### PR TITLE
[Model Monitoring] Remove deprecated set credentials arguments

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 
 import datetime
 import json
@@ -24,6 +24,7 @@ import sys
 import time
 import typing
 import urllib.parse
+from typing import Union
 
 import click
 import paramiko
@@ -110,7 +111,7 @@ class SystemTestPreparer:
         self._ssh_client: typing.Optional[paramiko.SSHClient] = None
         self._mlrun_dbpath = mlrun_dbpath
 
-        self._env_config = {
+        self._env_config: dict[str, Union[str, None, dict]] = {
             "MLRUN_DBPATH": mlrun_dbpath,
             "V3IO_USERNAME": username,
             "V3IO_ACCESS_KEY": access_key,
@@ -397,8 +398,17 @@ class SystemTestPreparer:
         )
         self._env_config["V3IO_API"] = f"https://{v3io_api_host}"
         self._env_config["MLRUN_DBPATH"] = f"https://{mlrun_api_url}"
-        self._env_config["MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"] = "v3io"
-        self._env_config["MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"] = "v3io"
+
+        self._env_config["mlrun_model_monitoring_tsdb_profile"] = {
+            "type": "v3io",
+            "name": "mm-tsdb-profile",
+            "v3io_access_key": None,
+        }
+        self._env_config["mlrun_model_monitoring_stream_profile"] = {
+            "type": "v3io",
+            "name": "mm-stream-profile",
+            "v3io_access_key": self._env_config["V3IO_ACCESS_KEY"],
+        }
 
     def _install_dev_utilities(self):
         list_uninstall = [

--- a/docs/feature-store/end-to-end-demo/03-deploy-serving-model.ipynb
+++ b/docs/feature-store/end-to-end-demo/03-deploy-serving-model.ipynb
@@ -431,6 +431,46 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enable model monitoring\n",
+    "serving_fn.set_tracking()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mlrun.datastore.datastore_profile import DatastoreProfileV3io\n",
+    "\n",
+    "tsdb_profile = DatastoreProfileV3io(name=\"v3io-tsdb-profile\")\n",
+    "project.register_datastore_profile(tsdb_profile)\n",
+    "\n",
+    "stream_profile = DatastoreProfileV3io(\n",
+    "    name=\"v3io-stream-profile\",\n",
+    "    v3io_access_key=mlrun.mlconf.get_v3io_access_key(),\n",
+    ")\n",
+    "project.register_datastore_profile(stream_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project.set_model_monitoring_credentials(\n",
+    "    tsdb_profile_name=tsdb_profile.name,\n",
+    "    stream_profile_name=stream_profile.name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
    "outputs": [
@@ -460,12 +500,6 @@
     }
    ],
    "source": [
-    "import os\n",
-    "\n",
-    "# Enable model monitoring\n",
-    "serving_fn.set_tracking()\n",
-    "project.set_model_monitoring_credentials(os.getenv(\"V3IO_ACCESS_KEY\"))\n",
-    "\n",
     "# Deploy the serving function\n",
     "serving_fn.deploy()"
    ]

--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -52,11 +52,38 @@
    ],
    "source": [
     "import mlrun\n",
-    "import os\n",
-    "import uuid\n",
+    "from mlrun.datastore.datastore_profile import DatastoreProfileV3io\n",
     "\n",
     "project_name = \"tutorial\"\n",
     "project = mlrun.get_or_create_project(project_name, \"./\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsdb_profile = DatastoreProfileV3io(name=\"v3io-tsdb-profile\")\n",
+    "project.register_datastore_profile(tsdb_profile)\n",
+    "\n",
+    "stream_profile = DatastoreProfileV3io(\n",
+    "    name=\"v3io-stream-profile\",\n",
+    "    v3io_access_key=mlrun.mlconf.get_v3io_access_key(),\n",
+    ")\n",
+    "project.register_datastore_profile(stream_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project.set_model_monitoring_credentials(\n",
+    "    tsdb_profile_name=tsdb_profile.name,\n",
+    "    stream_profile_name=stream_profile.name,\n",
+    ")"
    ]
   },
   {
@@ -73,7 +100,6 @@
     }
    ],
    "source": [
-    "project.set_model_monitoring_credentials(None, \"v3io\", \"v3io\")\n",
     "project.enable_model_monitoring(base_period=2)"
    ]
   },

--- a/docs/tutorials/06-batch-infer.ipynb
+++ b/docs/tutorials/06-batch-infer.ipynb
@@ -75,7 +75,8 @@
    "outputs": [],
    "source": [
     "import mlrun\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from mlrun.datastore.datastore_profile import DatastoreProfileV3io"
    ]
   },
   {
@@ -623,6 +624,36 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "fc2043db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsdb_profile = DatastoreProfileV3io(name=\"v3io-tsdb-profile\")\n",
+    "project.register_datastore_profile(tsdb_profile)\n",
+    "\n",
+    "stream_profile = DatastoreProfileV3io(\n",
+    "    name=\"v3io-stream-profile\",\n",
+    "    v3io_access_key=mlrun.mlconf.get_v3io_access_key(),\n",
+    ")\n",
+    "project.register_datastore_profile(stream_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8c47b9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project.set_model_monitoring_credentials(\n",
+    "    tsdb_profile_name=tsdb_profile.name,\n",
+    "    stream_profile_name=stream_profile.name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "id": "b14395bb-be2b-49f7-acf3-85387dbe29d9",
    "metadata": {},
@@ -663,7 +694,6 @@
     }
    ],
    "source": [
-    "project.set_model_monitoring_credentials(None, \"v3io\", \"v3io\")\n",
     "project.enable_model_monitoring(\n",
     "    base_period=1, wait_for_deployment=True, deploy_histogram_data_drift_app=True\n",
     ")"

--- a/docs/tutorials/genai-02-model-monitor-llm.ipynb
+++ b/docs/tutorials/genai-02-model-monitor-llm.ipynb
@@ -29,8 +29,8 @@
    "outputs": [],
    "source": [
     "import mlrun\n",
-    "import os\n",
-    "from mlrun.features import Feature"
+    "from mlrun.features import Feature\n",
+    "from mlrun.datastore.datastore_profile import DatastoreProfileV3io"
    ]
   },
   {
@@ -69,15 +69,31 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "54ca9b5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsdb_profile = DatastoreProfileV3io(name=\"v3io-tsdb-profile\")\n",
+    "project.register_datastore_profile(tsdb_profile)\n",
+    "\n",
+    "stream_profile = DatastoreProfileV3io(\n",
+    "    name=\"v3io-stream-profile\",\n",
+    "    v3io_access_key=mlrun.mlconf.get_v3io_access_key(),\n",
+    ")\n",
+    "project.register_datastore_profile(stream_profile)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 5,
    "id": "690aa9d5-9dd4-4dae-8a37-1d4ba305db63",
    "metadata": {},
    "outputs": [],
    "source": [
     "project.set_model_monitoring_credentials(\n",
-    "    os.environ[\"V3IO_ACCESS_KEY\"],\n",
-    "    \"v3io\",\n",
-    "    \"v3io\",\n",
+    "    tsdb_profile_name=tsdb_profile.name,\n",
+    "    stream_profile_name=stream_profile.name,\n",
     ")"
    ]
   },
@@ -105,7 +121,6 @@
    ],
    "source": [
     "project.enable_model_monitoring(\n",
-    "    image=\"mlrun/mlrun\",\n",
     "    base_period=2,  # frequency (in minutes) at which the monitoring applications are triggered\n",
     ")"
    ]

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -250,11 +250,6 @@ class TSDBTarget(MonitoringStrEnum):
     TDEngine = "tdengine"
 
 
-class DefaultProfileName(StrEnum):
-    STREAM = "mm-infra-stream"
-    TSDB = "mm-infra-tsdb"
-
-
 class ProjectSecretKeys:
     ACCESS_KEY = "MODEL_MONITORING_ACCESS_KEY"
     TSDB_PROFILE_NAME = "TSDB_PROFILE_NAME"

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import datetime
-import os
 import typing
 
 import storey
@@ -84,12 +83,10 @@ class EventStreamProcessor:
         self.v3io_framesd = v3io_framesd or mlrun.mlconf.v3io_framesd
         self.v3io_api = v3io_api or mlrun.mlconf.v3io_api
 
-        self.v3io_access_key = v3io_access_key or mlrun.get_secret_or_env(
-            "V3IO_ACCESS_KEY"
-        )
+        self.v3io_access_key = v3io_access_key or mlrun.mlconf.get_v3io_access_key()
         self.model_monitoring_access_key = (
             model_monitoring_access_key
-            or os.environ.get(ProjectSecretKeys.ACCESS_KEY)
+            or mlrun.get_secret_or_env(ProjectSecretKeys.ACCESS_KEY)
             or self.v3io_access_key
         )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -29,7 +29,6 @@ import zipfile
 from copy import deepcopy
 from os import environ, makedirs, path
 from typing import Callable, Optional, Union, cast
-from urllib.parse import urlparse
 
 import deprecated
 import dotenv
@@ -3671,44 +3670,77 @@ class MlrunProject(ModelObj):
 
     def set_model_monitoring_credentials(
         self,
-        stream_path: Optional[str] = None,  # Deprecated
-        tsdb_connection: Optional[str] = None,  # Deprecated
-        replace_creds: bool = False,
         *,
-        stream_profile_name: Optional[str] = None,
-        tsdb_profile_name: Optional[str] = None,
-    ):
+        tsdb_profile_name: str,
+        stream_profile_name: str,
+        replace_creds: bool = False,
+    ) -> None:
         """
-        Set the credentials that will be used by the project's model monitoring
-        infrastructure functions. Important to note that you have to set the credentials before deploying any
-        model monitoring or serving function.
+        Set the credentials that will be used by the project's model monitoring infrastructure functions.
+        Please note that you have to set the credentials before deploying any model monitoring application
+        or a tracked serving function.
 
-        :param stream_path:               (Deprecated) This argument is deprecated. Use ``stream_profile_name`` instead.
-                                          Path to the model monitoring stream. By default, None. Options:
+        For example, the full flow for enabling model monitoring infrastructure with **TDEngine** and **Kafka**, is:
 
-                                          * ``"v3io"`` - for v3io stream, pass ``"v3io"`` and the system will generate
-                                            the exact path.
-                                          * Kafka - for Kafka stream, provide the full connection string without acustom
-                                            topic, for example ``"kafka://<some_kafka_broker>:<port>"``.
-        :param tsdb_connection:           (Deprecated) Connection string to the time series database. By default, None.
-                                          Options:
+        .. code-block:: python
 
-                                          * v3io - for v3io stream, pass ``"v3io"`` and the system will generate the
-                                            exact path.
-                                          * TDEngine - for TDEngine tsdb, provide the full websocket connection URL,
-                                            for example ``"taosws://<username>:<password>@<host>:<port>"``.
-        :param replace_creds:             If True, will override the existing credentials.
-                                          Please keep in mind that if you already enabled model monitoring on
-                                          your project this action can cause data loose and will require redeploying
-                                          all model monitoring functions & model monitoring infra
-                                          & tracked model server.
-        :param stream_profile_name:       The datastore profile name of the stream to be used in model monitoring.
-                                          The supported profiles are:
+            import mlrun
+            from mlrun.datastore.datastore_profile import (
+                DatastoreProfileKafkaSource,
+                TDEngineDatastoreProfile,
+            )
 
-                                          * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileV3io`
-                                          * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource`
+            project = mlrun.get_or_create_project("mm-infra-setup")
 
-                                          You need to register one of them, and pass the profile's name.
+            # Create and register TSDB profile
+            tsdb_profile = TDEngineDatastoreProfile(
+                name="my-tdengine",
+                host="<tdengine-server-ip-address>",
+                port=6041,
+                user="username",
+                password="<tdengine-password>",
+            )
+            project.register_datastore_profile(tsdb_profile)
+
+            # Create and register stream profile
+            stream_profile = DatastoreProfileKafkaSource(
+                name="my-kafka",
+                brokers=["<kafka-broker-ip-address>:9094"],
+                topics=[],  # Keep the topics list empty
+                ## SASL is supported
+                # sasl_user="user1",
+                # sasl_pass="<kafka-sasl-password>",
+            )
+            project.register_datastore_profile(stream_profile)
+
+            # Set model monitoring credentials and enable the infrastructure
+            project.set_model_monitoring_credentials(
+                tsdb_profile_name=tsdb_profile.name,
+                stream_profile_name=stream_profile.name,
+            )
+            project.enable_model_monitoring()
+
+        Note that you will need to change the profiles if you want to use **V3IO** TSDB and stream:
+
+        .. code-block:: python
+
+            from mlrun.datastore.datastore_profile import DatastoreProfileV3io
+
+            # Create and register TSDB profile
+            tsdb_profile = DatastoreProfileV3io(
+                name="my-v3io-tsdb",
+            )
+            project.register_datastore_profile(tsdb_profile)
+
+            # Create and register stream profile
+            stream_profile = DatastoreProfileV3io(
+                name="my-v3io-stream",
+                v3io_access_key=mlrun.mlconf.get_v3io_access_key(),
+            )
+            project.register_datastore_profile(stream_profile)
+
+        In the V3IO datastore, you must provide an explicit access key to the stream, but not to the TSDB.
+
         :param tsdb_profile_name:         The datastore profile name of the time-series database to be used in model
                                           monitoring. The supported profiles are:
 
@@ -3716,76 +3748,24 @@ class MlrunProject(ModelObj):
                                           * :py:class:`~mlrun.datastore.datastore_profile.TDEngineDatastoreProfile`
 
                                           You need to register one of them, and pass the profile's name.
+        :param stream_profile_name:       The datastore profile name of the stream to be used in model monitoring.
+                                          The supported profiles are:
+
+                                          * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileV3io`
+                                          * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource`
+
+                                          You need to register one of them, and pass the profile's name.
+        :param replace_creds:             If True, will override the existing credentials.
+                                          Please keep in mind that if you already enabled model monitoring on
+                                          your project this action can cause data loose and will require redeploying
+                                          all model monitoring functions & model monitoring infra
+                                          & tracked model server.
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)
-
-        if tsdb_connection:
-            warnings.warn(
-                "The `tsdb_connection` argument is deprecated and will be removed in MLRun version 1.8.0. "
-                "Use `tsdb_profile_name` instead.",
-                FutureWarning,
-            )
-            if tsdb_profile_name:
-                raise mlrun.errors.MLRunValueError(
-                    "If you set `tsdb_profile_name`, you must not pass `tsdb_connection`."
-                )
-            if tsdb_connection == "v3io":
-                tsdb_profile = mlrun.datastore.datastore_profile.DatastoreProfileV3io(
-                    name=mm_constants.DefaultProfileName.TSDB
-                )
-            else:
-                parsed_url = urlparse(tsdb_connection)
-                if parsed_url.scheme != "taosws":
-                    raise mlrun.errors.MLRunValueError(
-                        f"Unsupported `tsdb_connection`: '{tsdb_connection}'."
-                    )
-                tsdb_profile = (
-                    mlrun.datastore.datastore_profile.TDEngineDatastoreProfile(
-                        name=mm_constants.DefaultProfileName.TSDB,
-                        user=parsed_url.username,
-                        password=parsed_url.password,
-                        host=parsed_url.hostname,
-                        port=parsed_url.port,
-                    )
-                )
-
-            self.register_datastore_profile(tsdb_profile)
-            tsdb_profile_name = tsdb_profile.name
-
-        if stream_path:
-            warnings.warn(
-                "The `stream_path` argument is deprecated and will be removed in MLRun version 1.8.0. "
-                "Use `stream_profile_name` instead.",
-                FutureWarning,
-            )
-            if stream_profile_name:
-                raise mlrun.errors.MLRunValueError(
-                    "If you set `stream_profile_name`, you must not pass `stream_path`."
-                )
-            if stream_path == "v3io":
-                stream_profile = mlrun.datastore.datastore_profile.DatastoreProfileV3io(
-                    name=mm_constants.DefaultProfileName.STREAM
-                )
-            else:
-                parsed_stream = urlparse(stream_path)
-                if parsed_stream.scheme != "kafka":
-                    raise mlrun.errors.MLRunValueError(
-                        f"Unsupported `stream_path`: '{stream_path}'."
-                    )
-                stream_profile = (
-                    mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource(
-                        name=mm_constants.DefaultProfileName.STREAM,
-                        brokers=[parsed_stream.netloc],
-                        topics=[],
-                    )
-                )
-            self.register_datastore_profile(stream_profile)
-            stream_profile_name = stream_profile.name
 
         db.set_model_monitoring_credentials(
             project=self.name,
             credentials={
-                "access_key": None,
                 "tsdb_profile_name": tsdb_profile_name,
                 "stream_profile_name": stream_profile_name,
             },

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3755,11 +3755,11 @@ class MlrunProject(ModelObj):
                                           * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource`
 
                                           You need to register one of them, and pass the profile's name.
-        :param replace_creds:             If True, will override the existing credentials.
-                                          Please keep in mind that if you already enabled model monitoring on
-                                          your project this action can cause data loose and will require redeploying
-                                          all model monitoring functions & model monitoring infra
-                                          & tracked model server.
+        :param replace_creds:             If ``True`` - override the existing credentials.
+                                          Please keep in mind that if you have already enabled model monitoring
+                                          on your project, replacing the credentials can cause data loss, and will
+                                          require redeploying all the model monitoring functions, model monitoring
+                                          infrastructure, and tracked model servers.
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)
 

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -358,14 +358,6 @@ async def delete_model_monitoring_function(
     return tasks
 
 
-# TODO: remove /projects/{project}/model-monitoring/set-model-monitoring-credentials in 1.8.0
-@router.post(
-    "/set-model-monitoring-credentials",
-    deprecated=True,
-    description="/projects/{project}/model-monitoring/set-model-monitoring-credentials "
-    "will be removed in 1.8.0, "
-    "use PUT /projects/{project}/model-monitoring/credentials instead",
-)
 @router.put("/credentials")
 def set_model_monitoring_credentials(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -369,9 +369,8 @@ async def delete_model_monitoring_function(
 @router.put("/credentials")
 def set_model_monitoring_credentials(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
-    access_key: Optional[str] = None,
-    tsdb_profile_name: Optional[str] = None,
-    stream_profile_name: Optional[str] = None,
+    tsdb_profile_name: str,
+    stream_profile_name: str,
     replace_creds: bool = False,
 ) -> None:
     """
@@ -379,7 +378,6 @@ def set_model_monitoring_credentials(
     infrastructure functions. Important to note that you have to set the credentials before deploying any
     model monitoring or serving function.
     :param commons:                   The common parameters of the request.
-    :param access_key:                Model Monitoring access key for managing user permissions.
     :param tsdb_profile_name:         TSDB datastore profile name.
     :param stream_profile_name:       Stream datastore profile name.
                                       The profile can be V3IO or KafkaSource.
@@ -391,7 +389,6 @@ def set_model_monitoring_credentials(
         db_session=commons.db_session,
         model_monitoring_access_key=commons.model_monitoring_access_key,
     ).set_credentials(
-        access_key=access_key,
         tsdb_profile_name=tsdb_profile_name,
         stream_profile_name=stream_profile_name,
         replace_creds=replace_creds,

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -411,7 +411,7 @@ class MonitoringDeployment:
         )
 
         access_key = (
-            v3io_profile.v3io_access_key or self.model_monitoring_access_key
+            v3io_profile.v3io_access_key
             if function_name
             != mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER
             else mlrun.mlconf.get_v3io_access_key()
@@ -805,7 +805,6 @@ class MonitoringDeployment:
                     auth_info=self.auth_info,
                     delete_app_stream_resources=function_name
                     != mm_constants.MonitoringFunctionNames.STREAM,
-                    access_key=self.model_monitoring_access_key,
                 )
                 tasks.append(task)
 
@@ -874,7 +873,6 @@ class MonitoringDeployment:
         function_name: str,
         auth_info: mlrun.common.schemas.AuthInfo,
         delete_app_stream_resources: bool,
-        access_key: str,
     ):
         background_task_name = str(uuid.uuid4())
 
@@ -892,7 +890,6 @@ class MonitoringDeployment:
             auth_info,
             background_task_name,
             delete_app_stream_resources,
-            access_key,
         )
 
     @staticmethod
@@ -903,7 +900,6 @@ class MonitoringDeployment:
         auth_info: mlrun.common.schemas.AuthInfo,
         background_task_name: str,
         delete_app_stream_resources: bool,
-        access_key: str,
     ) -> None:
         """
         Delete the model monitoring function and its resources.
@@ -928,8 +924,7 @@ class MonitoringDeployment:
                 MonitoringDeployment(
                     project=project
                 )._delete_model_monitoring_stream_resources(
-                    function_names=[function_name],
-                    access_key=access_key,
+                    function_names=[function_name]
                 )
             except mlrun.errors.MLRunStreamConnectionFailureError as e:
                 logger.warning(
@@ -945,12 +940,10 @@ class MonitoringDeployment:
         stream_profile: typing.Optional[
             mlrun.datastore.datastore_profile.DatastoreProfile
         ] = None,
-        access_key: typing.Optional[str] = None,
     ) -> None:
         """
         :param function_names: A list of functions that their resources should be deleted.
         :param stream_profile: An optional datastore profile for the stream.
-        :param access_key:     If the stream is V3IO, the access key is required.
         """
         logger.debug(
             "Deleting model monitoring stream resources deployment",
@@ -1029,7 +1022,7 @@ class MonitoringDeployment:
                         stream_path,
                         access_key=mlrun.mlconf.get_v3io_access_key()
                         if container.startswith("users")
-                        else profile.v3io_access_key or access_key,
+                        else profile.v3io_access_key,
                     )
                     logger.debug(
                         "Deleted v3io stream",

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1219,13 +1219,21 @@ class MonitoringDeployment:
     def _verify_v3io_access(
         self, v3io_profile: mlrun.datastore.datastore_profile.DatastoreProfileV3io
     ) -> None:
+        stream_access_key = v3io_profile.v3io_access_key
+        if not stream_access_key:
+            raise mlrun.errors.MLRunInvalidMMStoreTypeError(
+                "The model monitoring stream profile must be set with an explicit `v3io_access_key`. "
+                f"The passed profile '{v3io_profile.name}' has an empty access key. "
+                "You may register it again and set `v3io_access_key=mlrun.mlconf.get_v3io_access_key()`"
+            )
+
         stream_path = mlrun.model_monitoring.get_stream_path(
             project=self.project, profile=v3io_profile
         )
         container, path = split_path(stream_path)
 
         v3io_client = mlrun.utils.v3io_clients.get_v3io_client(
-            endpoint=mlrun.mlconf.v3io_api, access_key=v3io_profile.v3io_access_key
+            endpoint=mlrun.mlconf.v3io_api, access_key=stream_access_key
         )
         # We don't expect the stream to exist. The purpose is to make sure we have access.
         v3io_client.stream.describe(

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -297,9 +297,9 @@ class MonitoringDeployment:
     ) -> mlrun.runtimes.ServingRuntime:
         """
         Add stream source for the nuclio serving function. The function's stream trigger can be
-        either Kafka or V3IO, depends on the stream path schema that is defined by:
+        either Kafka or V3IO, depends on the stream profile defined by::
 
-            project.set_model_monitoring_credentials(..., stream_path="...")
+            project.set_model_monitoring_credentials(stream_profile_name="...", ...)
 
         Note: this method also disables the default HTTP trigger of the function, so it remains
         only with stream trigger(s).
@@ -1089,9 +1089,7 @@ class MonitoringDeployment:
 
         return credentials_dict
 
-    def check_if_credentials_are_set(
-        self,
-    ):
+    def check_if_credentials_are_set(self) -> None:
         """
         Check if the model monitoring credentials are set. If not, raise an error.
 
@@ -1099,7 +1097,7 @@ class MonitoringDeployment:
         """
 
         credentials_dict = self._get_monitoring_mandatory_project_secrets()
-        if all([val is not None for key, val in credentials_dict.items()]):
+        if all([val is not None for val in credentials_dict.values()]):
             return
 
         raise mlrun.errors.MLRunBadRequestError(

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1234,7 +1234,7 @@ class MonitoringDeployment:
 
     def set_credentials(
         self,
-        access_key: typing.Optional[str] = None,
+        *,
         tsdb_profile_name: typing.Optional[str] = None,
         stream_profile_name: typing.Optional[str] = None,
         replace_creds: bool = False,
@@ -1242,7 +1242,6 @@ class MonitoringDeployment:
         """
         Set the model monitoring credentials for the project. The credentials are stored in the project secrets.
 
-        :param access_key:                Model Monitoring access key for managing user permissions.
         :param tsdb_profile_name:         The TSDB profile name to be used in the project's model monitoring framework.
                                           Either V3IO or TDEngine profile.
         :param stream_profile_name:       The stream profile name to be used in the project's model monitoring
@@ -1272,12 +1271,6 @@ class MonitoringDeployment:
 
         secrets_dict = {}
         old_secrets_dict = self._get_monitoring_mandatory_project_secrets()
-        if access_key:
-            secrets_dict[
-                mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY
-            ] = access_key or old_secrets_dict.get(
-                mlrun.common.schemas.model_monitoring.ProjectSecretKeys.ACCESS_KEY
-            )
 
         stream_profile_name = stream_profile_name or old_secrets_dict.get(
             mlrun.common.schemas.model_monitoring.ProjectSecretKeys.STREAM_PROFILE_NAME

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1050,7 +1050,6 @@ class ModelEndpoints:
         cls._delete_model_monitoring_stream_resources(
             project_name=project_name,
             model_monitoring_applications=model_monitoring_applications,
-            model_monitoring_access_key=model_monitoring_access_key,
             stream_profile=stream_profile,
         )
         # Delete model monitoring stats folder.
@@ -1126,7 +1125,6 @@ class ModelEndpoints:
         project_name: str,
         model_monitoring_applications: typing.Optional[list[str]],
         stream_profile: mlrun.datastore.datastore_profile.DatastoreProfile,
-        model_monitoring_access_key: typing.Optional[str] = None,
     ) -> None:
         """
         Delete model monitoring stream resources.
@@ -1135,8 +1133,6 @@ class ModelEndpoints:
         :param model_monitoring_applications: A list of model monitoring applications that their resources should
                                               be deleted.
         :param stream_profile:                The datastore profile for the stream.
-        :param model_monitoring_access_key:   The access key for the model monitoring resources. Relevant only for
-                                              V3IO resources.
         """
         logger.debug(
             "Deleting model monitoring stream resources",
@@ -1155,7 +1151,6 @@ class ModelEndpoints:
                 project=project_name
             )._delete_model_monitoring_stream_resources(
                 function_names=model_monitoring_applications,
-                access_key=model_monitoring_access_key,
                 stream_profile=stream_profile,
             )
             logger.debug(

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 import base64
 import os
 import pathlib
@@ -53,9 +53,9 @@ class TestMLRunSystem:
         "MLRUN_SYSTEM_TESTS_DEFAULT_SPARK_SERVICE",
     ]
 
-    model_monitoring_mandatory_env_vars = [
-        "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION",
-        "MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION",
+    model_monitoring_mandatory_keys = [
+        "mlrun_model_monitoring_tsdb_profile",
+        "mlrun_model_monitoring_stream_profile",
     ]
 
     enterprise_configured = os.getenv("V3IO_API")
@@ -74,6 +74,10 @@ class TestMLRunSystem:
         cls.custom_setup_class()
         cls._logger = logger.get_child(cls.__name__.lower())
         cls.project: typing.Optional[mlrun.projects.MlrunProject] = None
+
+        cls.mm_tsdb_profile_data = env.get("mlrun_model_monitoring_tsdb_profile")
+        cls.mm_stream_profile_data = env.get("mlrun_model_monitoring_stream_profile")
+
         cls.uploaded_code = False
 
         if "MLRUN_IGUAZIO_API_URL" in env:
@@ -172,7 +176,7 @@ class TestMLRunSystem:
             else cls.mandatory_env_vars
         )
         if cls._has_marker(test, cls.model_monitoring_marker_name):
-            mandatory_env_vars += cls.model_monitoring_mandatory_env_vars
+            mandatory_env_vars += cls.model_monitoring_mandatory_keys
 
         missing_env_vars = []
         try:
@@ -226,6 +230,9 @@ class TestMLRunSystem:
 
         # Process keys
         for key, value in env.items():
+            if key in cls.model_monitoring_mandatory_keys:
+                # model monitoring profiles data is saved separately
+                continue
             cls._process_env_var(key, value)
 
         # Reload the config so changes to the env vars will take effect

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -78,14 +78,35 @@ SNOWFLAKE_SCHEMA:
 SNOWFLAKE_TABLE_NAME:
 SNOWFLAKE_WAREHOUSE:
 
-# model monitoring cred
-MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION:
-MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION:
+# model monitoring datastore profiles credentials
+mlrun_model_monitoring_tsdb_profile:
+  # name:  # choose, e.g.: my-mm-tsdb
+  # # now, choose either:
+  # type: v3io
+  # v3io_access_key: # can leave empty
+  # # or:
+  # type: taosws
+  # host:
+  # port: 6041
+  # user:
+  # password:
+
+mlrun_model_monitoring_stream_profile:
+  # name: # choose, e.g.: my-mm-stream
+  # # now, choose either:
+  # type: v3io
+  # v3io_access_key: # can leave empty
+  # # or:
+  # type: kafka_source
+  # brokers: # <host>:<port>
+  # topics: []
+  # sasl_user:
+  # sasl_pass:
 
 # Controls whether the client verifies the server's TLS certificate.
 # Set to `True` to enable TLS verification.
 # set to `False` when running in a lab environment where TLS verification may be disabled.
 MLRUN_HTTPDB__HTTP__VERIFY:
 
-MILVUS_HOST: 
-MILVUS_PORT: 
+MILVUS_HOST:
+MILVUS_PORT:

--- a/tests/system/model_monitoring/__init__.py
+++ b/tests/system/model_monitoring/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+from typing import Any
 
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,

--- a/tests/system/model_monitoring/__init__.py
+++ b/tests/system/model_monitoring/__init__.py
@@ -14,21 +14,82 @@
 
 from typing import Any
 
+import pytest
+from typing_extensions import TypeAlias
+
+import mlrun
+from mlrun import MlrunProject
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
+    DatastoreProfileKafkaSource,
     DatastoreProfileV3io,
     TDEngineDatastoreProfile,
 )
+from tests.system.base import TestMLRunSystem
+
+_ProfilesMap: TypeAlias = dict[str, type[DatastoreProfile]]
+
+_DS_TYPE_TO_DS_PROFILE: _ProfilesMap = {
+    "v3io": DatastoreProfileV3io,
+    "taosws": TDEngineDatastoreProfile,
+    "kafka_source": DatastoreProfileKafkaSource,
+}
 
 
-# TODO: Remove after ML-9020
-def get_tsdb_datastore_profile_from_env() -> DatastoreProfile:
-    tsdb_connection = os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION")
-    if tsdb_connection == "v3io":
-        return DatastoreProfileV3io(name="v3io-tsdb-profile")
-    elif tsdb_connection.startswith("taosws://"):
-        return TDEngineDatastoreProfile.from_dsn(
-            tsdb_connection, profile_name="tdengine-profile"
+@pytest.mark.model_monitoring
+class TestMLRunSystemModelMonitoring(TestMLRunSystem):
+    project: MlrunProject
+    mm_tsdb_profile: DatastoreProfile
+    mm_stream_profile: DatastoreProfile
+
+    @staticmethod
+    def _get_profile(profile_data: Any, profiles_map: _ProfilesMap) -> DatastoreProfile:
+        if isinstance(profile_data, dict):
+            ds_type = profile_data.get("type")
+            if ds_type in profiles_map:
+                return profiles_map[ds_type].parse_obj(profile_data)
+            raise ValueError(
+                f"Unsupported datastore type: '{ds_type}', expected one of {list(profiles_map)}"
+            )
+        raise ValueError("The model monitoring profile data is not a dictionary")
+
+    @classmethod
+    def get_tsdb_profile(cls, profile_data: dict[str, Any]) -> DatastoreProfile:
+        return cls._get_profile(
+            profile_data,
+            {type_: _DS_TYPE_TO_DS_PROFILE[type_] for type_ in ("v3io", "taosws")},
         )
-    else:
-        raise ValueError(f"Unsupported {tsdb_connection=}")
+
+    @classmethod
+    def get_stream_profile(cls, profile_data: dict[str, Any]) -> DatastoreProfile:
+        profile = cls._get_profile(
+            profile_data,
+            {
+                type_: _DS_TYPE_TO_DS_PROFILE[type_]
+                for type_ in ("v3io", "kafka_source")
+            },
+        )
+        if isinstance(profile, DatastoreProfileV3io):
+            # Populate the V3IO access key for the stream profile
+            profile.v3io_access_key = (
+                profile.v3io_access_key or mlrun.mlconf.get_v3io_access_key()
+            )
+        return profile
+
+    @classmethod
+    def set_mm_profiles(cls):
+        cls.mm_tsdb_profile = cls.get_tsdb_profile(cls.mm_tsdb_profile_data)
+        cls.mm_stream_profile = cls.get_stream_profile(cls.mm_stream_profile_data)
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.set_mm_profiles()
+
+    def set_mm_credentials(self) -> None:
+        self.project.register_datastore_profile(self.mm_tsdb_profile)
+        self.project.register_datastore_profile(self.mm_stream_profile)
+        self.project.set_model_monitoring_credentials(
+            tsdb_profile_name=self.mm_tsdb_profile.name,
+            stream_profile_name=self.mm_stream_profile.name,
+        )

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -41,15 +41,13 @@ import mlrun.runtimes.mounts
 import mlrun.runtimes.utils
 import mlrun.serving.routers
 import mlrun.utils
-from mlrun.datastore import get_stream_pusher
-from mlrun.datastore.datastore_profile import DatastoreProfileV3io
 from mlrun.model import BaseMetadata
-from mlrun.model_monitoring.helpers import get_result_instance_fqn, get_stream_path
+from mlrun.model_monitoring.helpers import get_output_stream, get_result_instance_fqn
 from mlrun.runtimes import BaseRuntime
 from mlrun.utils.v3io_clients import get_frames_client
 from tests.system.base import TestMLRunSystem
 
-from . import get_tsdb_datastore_profile_from_env
+from . import TestMLRunSystemModelMonitoring
 
 
 def mock_random_endpoint(
@@ -87,10 +85,9 @@ def mock_random_endpoint(
 
 
 # Marked as enterprise because of v3io mount and pipelines
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestModelEndpointsOperations(TestMLRunSystem):
+class TestModelEndpointsOperations(TestMLRunSystemModelMonitoring):
     """Applying basic model endpoint CRUD operations through MLRun API"""
 
     project_name = "mm-app-project"
@@ -99,12 +96,7 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         super().setup_method(method)
         if method.__name__ == "test_list_endpoints_without_creds":
             return
-        self.project.set_model_monitoring_credentials(
-            stream_path=os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"),
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-        )
+        self.set_mm_credentials()
 
     @pytest.mark.parametrize("by_uid", [True, False])
     def test_clear_endpoint(self, by_uid):
@@ -387,10 +379,9 @@ class TestModelEndpointsOperations(TestMLRunSystem):
         assert mep.status.current_stats_timestamp is not None
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestBasicModelMonitoring(TestMLRunSystem):
+class TestBasicModelMonitoring(TestMLRunSystemModelMonitoring):
     """Deploy and apply monitoring on a basic pre-trained model"""
 
     project_name = "pr-basic-model-monitoring"
@@ -408,13 +399,7 @@ class TestBasicModelMonitoring(TestMLRunSystem):
         # Deploy Model Servers
         project = self.project
 
-        project.set_model_monitoring_credentials(
-            stream_path=os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"),
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-            replace_creds=True,  # remove once ML-7501 is resolved
-        )
+        self.set_mm_credentials()
 
         iris = load_iris()
         train_set = pd.DataFrame(
@@ -950,10 +935,9 @@ class TestVotingModelMonitoring(TestMLRunSystem):
         assert fields_dict["active"] == "boolean"
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestBatchDrift(TestMLRunSystem):
+class TestBatchDrift(TestMLRunSystemModelMonitoring):
     """Record monitoring parquet results and trigger the monitoring batch drift job analysis. This flow tests
     the monitoring process of the batch infer job function that can be imported from the functions hub.
     """
@@ -1002,12 +986,7 @@ class TestBatchDrift(TestMLRunSystem):
         )
 
         # Deploy model monitoring infra
-        project.set_model_monitoring_credentials(
-            stream_path=os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"),
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-        )
+        self.set_mm_credentials()
         project.enable_model_monitoring(
             base_period=1,
             deploy_histogram_data_drift_app=True,
@@ -1069,10 +1048,9 @@ class TestBatchDrift(TestMLRunSystem):
         }
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestModelMonitoringKafka(TestMLRunSystem):
+class TestModelMonitoringKafka(TestMLRunSystemModelMonitoring):
     """Deploy a basic iris model configured with kafka stream"""
 
     brokers = (
@@ -1127,13 +1105,7 @@ class TestModelMonitoringKafka(TestMLRunSystem):
             ),
         )
 
-        project.set_model_monitoring_credentials(
-            stream_path=f"kafka://{self.brokers}",
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-        )
-
+        self.set_mm_credentials()
         # enable model monitoring
         serving_fn.set_tracking()
 
@@ -1189,10 +1161,9 @@ class TestModelMonitoringKafka(TestMLRunSystem):
         assert model_endpoint.status.metrics["generic"]["predictions_count_5m"] > 0
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestInferenceWithSpecialChars(TestMLRunSystem):
+class TestInferenceWithSpecialChars(TestMLRunSystemModelMonitoring):
     project_name = "pr-infer-special-chars"
     name_prefix = "infer-monitoring"
     # Set image to "<repo>/mlrun:<tag>" for local testing
@@ -1200,7 +1171,6 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
 
     @classmethod
     def custom_setup_class(cls) -> None:
-        # todo testsssss
         cls.classif = SVC()
         cls.model_name = "classif_model"
         cls.columns = ["feat 1", "b (C)", "Last   for df "]
@@ -1222,12 +1192,7 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
     def custom_setup(self) -> None:
         mlrun.runtimes.utils.global_context.set(None)
         # Set the model monitoring credentials
-        self.project.set_model_monitoring_credentials(
-            stream_path=os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"),
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-        )
+        self.set_mm_credentials()
 
     @classmethod
     def _generate_data(cls) -> list[Union[pd.DataFrame, pd.Series]]:
@@ -1304,10 +1269,9 @@ class TestInferenceWithSpecialChars(TestMLRunSystem):
         self._test_feature_names()
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestModelInferenceTSDBRecord(TestMLRunSystem):
+class TestModelInferenceTSDBRecord(TestMLRunSystemModelMonitoring):
     """
     Test that batch inference records results to V3IO TSDB when tracking is
     enabled and the selected model does not have a serving endpoint.
@@ -1350,7 +1314,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
     @classmethod
     def _test_v3io_tsdb_record(cls) -> None:
         tsdb_client = mlrun.model_monitoring.get_tsdb_connector(
-            project=cls.project_name, profile=get_tsdb_datastore_profile_from_env()
+            project=cls.project_name, profile=cls.mm_tsdb_profile
         )
 
         df: pd.DataFrame = tsdb_client._get_records(
@@ -1372,12 +1336,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
         }, "The result is different than expected"
 
     def test_record(self) -> None:
-        self.project.set_model_monitoring_credentials(
-            stream_path=os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"),
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-        )
+        self.set_mm_credentials()
         self.project.enable_model_monitoring(
             base_period=1,
             deploy_histogram_data_drift_app=True,
@@ -1401,10 +1360,9 @@ class TestModelInferenceTSDBRecord(TestMLRunSystem):
         self._test_v3io_tsdb_record()
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestModelEndpointWithManyFeatures(TestMLRunSystem):
+class TestModelEndpointWithManyFeatures(TestMLRunSystemModelMonitoring):
     """Log a model with 500 features and validate the model endpoint feature stats."""
 
     project_name = "pr-many-features-model-monitoring"
@@ -1412,12 +1370,7 @@ class TestModelEndpointWithManyFeatures(TestMLRunSystem):
     def test_model_endpoint_with_many_features(self) -> None:
         project = self.project
 
-        project.set_model_monitoring_credentials(
-            stream_path=os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"),
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-        )
+        self.set_mm_credentials()
 
         # Generate a model with 500 features
         x, y = make_classification(n_samples=1000, n_features=500, random_state=42)
@@ -1449,10 +1402,9 @@ class TestModelEndpointWithManyFeatures(TestMLRunSystem):
         assert len(model_endpoint.spec.feature_stats) == 501
 
 
-@TestMLRunSystem.skip_test_if_env_not_configured
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.model_monitoring
-class TestModelEndpointGetMetrics(TestMLRunSystem):
+class TestModelEndpointGetMetrics(TestMLRunSystemModelMonitoring):
     """Test get_model_endpoint_monitoring_metrics functionality."""
 
     project_name = "model-endpoint-get-metrics"
@@ -1495,12 +1447,7 @@ class TestModelEndpointGetMetrics(TestMLRunSystem):
         return data
 
     def test_get_model_endpoint_metrics(self):
-        self.project.set_model_monitoring_credentials(
-            stream_path=os.getenv("MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"),
-            tsdb_connection=os.getenv(
-                "MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"
-            ),
-        )
+        self.set_mm_credentials()
 
         self.project.enable_model_monitoring(image=self.image or "mlrun/mlrun")
         db = mlrun.get_run_db()
@@ -1520,12 +1467,11 @@ class TestModelEndpointGetMetrics(TestMLRunSystem):
         )
         writer._wait_for_function_deployment(db=writer._get_db())
 
-        stream_uri = get_stream_path(
+        output_stream = get_output_stream(
             project=self.project.metadata.name,
             function_name=mm_constants.MonitoringFunctionNames.WRITER,
-            profile=DatastoreProfileV3io(name="tmp"),
+            profile=self.mm_stream_profile,
         )
-        output_stream = get_stream_pusher(stream_uri)
 
         output_stream.push(
             self._generate_event(


### PR DESCRIPTION
Implements [ML-9020](https://iguazio.atlassian.net/browse/ML-9020), [ML-9058](https://iguazio.atlassian.net/browse/ML-9058), and fixes [ML-9042](https://iguazio.atlassian.net/browse/ML-9042).

This PR breaks the `project.set_model_monitoring_credentials` API.
Previously, one could pass the deprecated `tsdb_connection` and `stream_path` arguments to this API, and the datastore profiles were registered as a part of this method.
Now, one has to take care of the profiles outside of this method and pass to this method only their names: `tsdb_profile_name` and `stream_profile_name`.

The way to enable MM infrastructure is now documented in this method:

```py
import mlrun
from mlrun.datastore.datastore_profile import DatastoreProfileV3io

project = mlrun.get_or_create_project("mm-infra-setup")

# Create and register TSDB profile
tsdb_profile = DatastoreProfileV3io(
    name="my-v3io-tsdb",
)
project.register_datastore_profile(tsdb_profile)

# Create and register stream profile
stream_profile = DatastoreProfileV3io(
    name="my-v3io-stream",
    v3io_access_key=mlrun.mlconf.get_v3io_access_key(),
)
project.register_datastore_profile(stream_profile)

# Set model monitoring credentials and enable the infrastructure
project.set_model_monitoring_credentials(
    tsdb_profile_name=tsdb_profile.name,
    stream_profile_name=stream_profile.name,
)
project.enable_model_monitoring()
```

To configure the MM datastore for running system tests - see the updated `tests/system/env-template.yml`.
A valid V3IO configuration can be:

```yml
# tests/system/env-template.yml
mlrun_model_monitoring_tsdb_profile:
  name: my-mm-tsdb
  type: v3io

mlrun_model_monitoring_stream_profile:
  name: my-mm-stream
  type: v3io
```

The TSDB can be changed to be a `TDEngineDatastoreProfile`, and the stream can be changed to be a `DatastoreProfileKafkaSource`.

Update the usage of `project.set_model_monitoring_credentials` in the tutorials and system tests - use the relevant datastore profiles, register them, and pass their names to this method.
Specifically for the system tests, add a helper MM system test class - `TestMLRunSystemModelMonitoring`, which parses the profile data into a datastore profile object.

The backward compatibility test failed due to:

- Delete the deprecated `POST /api/v1/projects/{project}/model-monitoring/set-model-monitoring-credentials`
- Delete the deprecated `access_key` argument in `PUT /api/v1/projects/{project}/model-monitoring/credentials`.
  Require none-null `tsdb_profile_name` and `stream_profile_name`.

In addition, when using V3IO streams - use the profile's `v3io_access_key` instead of the internal `model_monitoring_access_key`.

[ML-9020]: https://iguazio.atlassian.net/browse/ML-9020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9058]: https://iguazio.atlassian.net/browse/ML-9058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9042]: https://iguazio.atlassian.net/browse/ML-9042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ