### PR TITLE
[Artifacts] Fix Migration Bug in "Latest" Tag Creation for Artifact

### DIFF
--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -1062,7 +1062,7 @@ def _ensure_latest_tag_for_artifacts(
                 obj_id=artifact_id,
                 obj_name=key,
             )
-            for artifact_id, project, key in artifacts_to_tag
+            for artifact_id, key, project in artifacts_to_tag
         ]
 
         logger.info(

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -530,6 +530,17 @@ def test_ensure_latest_tag_for_artifacts():
         len(artifacts) == 3
     ), f"Expected 3 artifacts with latest tag, found {len(artifacts)}"
 
+    # Ensure the tag was created correctly for the second artifact
+    artifacts = db.list_artifacts(
+        db_session, project=project1, name=key1, iter=1, as_records=True
+    )
+    assert len(artifacts) == 1
+    assert len(artifacts[0].tags) == 1
+    assert artifacts[0].tags[0].name == "latest"
+    assert artifacts[0].tags[0].project == project1
+    assert artifacts[0].tags[0].obj_name == key1
+    assert artifacts[0].tags[0].obj_id == artifact_2_id
+
 
 def _initialize_db_without_migrations() -> (
     tuple[framework.db.sqldb.db.SQLDB, sqlalchemy.orm.Session]


### PR DESCRIPTION
This PR addresses a migration issue that occurred during the creation of the "latest" tag for an artifact. After the migration, the tag creation logic was incorrect, resulting in tags being associated with the wrong artifact. 
Specifically:
1. The artifact's tag obj_name was mistakenly used as the project in the tags table, instead of using the artifact key.
2. The artifact's tag project was used as the artifact key.

As a result, tags were created for the wrong artifact, leading to incorrect tag associations.
https://iguazio.atlassian.net/browse/ML-9235