### PR TITLE
[KFP] Resolve kfp fixed image

### DIFF
--- a/server/py/services/api/api/endpoints/workflows.py
+++ b/server/py/services/api/api/endpoints/workflows.py
@@ -163,9 +163,9 @@ async def submit_workflow(
     updated_request.spec = workflow_spec
 
     client_image = services.api.utils.helpers.resolve_client_default_kfp_image(
+        project,
+        workflow_spec,
         client_version=client_version,
-        project=project,
-        workflow_spec=workflow_spec,
     )
 
     # This function is for loading the project and running workflow remotely.

--- a/server/py/services/api/api/endpoints/workflows.py
+++ b/server/py/services/api/api/endpoints/workflows.py
@@ -162,6 +162,12 @@ async def submit_workflow(
     updated_request = workflow_request.copy()
     updated_request.spec = workflow_spec
 
+    client_image = services.api.utils.helpers.resolve_client_default_kfp_image(
+        client_version=client_version,
+        project=project,
+        workflow_spec=workflow_spec,
+    )
+
     # This function is for loading the project and running workflow remotely.
     # In this way we can schedule workflows (by scheduling a job that runs the workflow)
     workflow_runner: mlrun.run.KubejobRuntime = await run_in_threadpool(
@@ -173,11 +179,7 @@ async def submit_workflow(
         project=project.metadata.name,
         db_session=db_session,
         auth_info=auth_info,
-        image=services.api.utils.helpers.resolve_client_default_kfp_image(
-            client_version=client_version,
-            project=project,
-            workflow_spec=workflow_spec,
-        ),
+        image=client_image,
     )
 
     logger.debug(

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -1730,42 +1730,42 @@ async def test_update_functions_with_deletion_info(db: sqlalchemy.orm.Session):
 @pytest.mark.parametrize(
     "project_image,workflow_image,client_version,expected_image",
     [
-        # (
-        #     "x",
-        #     "",
-        #     "1.8.0",
-        #     "x",
-        # ),
-        # (
-        #     "x",
-        #     "y",
-        #     "1.8.0",
-        #     "y",
-        # ),
-        # (
-        #     "",
-        #     "y",
-        #     "1.8.0",
-        #     "y",
-        # ),
-        # (
-        #     "",
-        #     "",
-        #     "1.8.0",
-        #     "mlrun/mlrun-kfp",
-        # ),
-        # (
-        #     "",
-        #     "",
-        #     "",
-        #     "mlrun/mlrun-kfp",
-        # ),
-        # (
-        #     "",
-        #     "",
-        #     "1.8.0-rc1",
-        #     "mlrun/mlrun-kfp",
-        # ),
+        (
+            "x",
+            "",
+            "1.8.0",
+            "x",
+        ),
+        (
+            "x",
+            "y",
+            "1.8.0",
+            "y",
+        ),
+        (
+            "",
+            "y",
+            "1.8.0",
+            "y",
+        ),
+        (
+            "",
+            "",
+            "1.8.0",
+            "mlrun/mlrun-kfp",
+        ),
+        (
+            "",
+            "",
+            "",
+            "mlrun/mlrun-kfp",
+        ),
+        (
+            "",
+            "",
+            "1.8.0-rc1",
+            "mlrun/mlrun-kfp",
+        ),
         (
             "",
             "",

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -1730,47 +1730,47 @@ async def test_update_functions_with_deletion_info(db: sqlalchemy.orm.Session):
 @pytest.mark.parametrize(
     "project_image,workflow_image,client_version,expected_image",
     [
-        (
-            "x",
-            "",
-            "1.8.0",
-            "x",
-        ),
-        (
-            "x",
-            "y",
-            "1.8.0",
-            "y",
-        ),
-        (
-            "",
-            "y",
-            "1.8.0",
-            "y",
-        ),
-        (
-            "",
-            "",
-            "1.8.0",
-            "mlrun/mlrun-kfp",
-        ),
-        (
-            "",
-            "",
-            "",
-            "mlrun/mlrun-kfp",
-        ),
-        (
-            "",
-            "",
-            "1.8.0-rc1",
-            "mlrun/mlrun-kfp",
-        ),
+        # (
+        #     "x",
+        #     "",
+        #     "1.8.0",
+        #     "x",
+        # ),
+        # (
+        #     "x",
+        #     "y",
+        #     "1.8.0",
+        #     "y",
+        # ),
+        # (
+        #     "",
+        #     "y",
+        #     "1.8.0",
+        #     "y",
+        # ),
+        # (
+        #     "",
+        #     "",
+        #     "1.8.0",
+        #     "mlrun/mlrun-kfp",
+        # ),
+        # (
+        #     "",
+        #     "",
+        #     "",
+        #     "mlrun/mlrun-kfp",
+        # ),
+        # (
+        #     "",
+        #     "",
+        #     "1.8.0-rc1",
+        #     "mlrun/mlrun-kfp",
+        # ),
         (
             "",
             "",
             "1.7.0",
-            "mlrun/mlrun",
+            "mlrun/mlrun:1.7.0",
         ),
     ],
 )

--- a/server/py/services/api/utils/helpers.py
+++ b/server/py/services/api/utils/helpers.py
@@ -24,8 +24,8 @@ from mlrun.utils import logger
 
 
 def resolve_client_default_kfp_image(
-    project: typing.Optional[ProjectOut] = None,
-    workflow_spec: typing.Optional[WorkflowSpec] = None,
+    project: ProjectOut,
+    workflow_spec: WorkflowSpec,
     client_version: typing.Optional[str] = None,
 ) -> str:
     if workflow_spec and workflow_spec.image:
@@ -65,7 +65,7 @@ def resolve_client_default_kfp_image(
 
     logger.debug(
         "Resolved KFP image for workflow",
-        project=project,
+        project_name=project.metadata.name,
         client_version=client_version,
         workflow_spec_image=workflow_spec.image,
         project_spec_default_image=project.spec.default_image,

--- a/server/py/services/api/utils/helpers.py
+++ b/server/py/services/api/utils/helpers.py
@@ -36,9 +36,9 @@ def resolve_client_default_kfp_image(
         must_use_mlrun_image = False
         if client_version and "unstable" not in client_version:
             try:
-                # client is olden than (<) 1.8, must use mlrun image for kfp
+                # client is older than (<) 1.8, must use mlrun image for kfp
                 if semver.Version.parse(client_version) < semver.Version.parse(
-                    "1.7.9999"
+                    "1.8.0-rc0"
                 ):
                     must_use_mlrun_image = True
             except ValueError:
@@ -55,7 +55,7 @@ def resolve_client_default_kfp_image(
                     image, client_version=client_version
                 )
                 logger.debug(
-                    "Ensure KFP image has fixed client version",
+                    "Ensuring KFP image has fixed client version",
                     enriched_image=enriched_image,
                     image=image,
                 )

--- a/server/py/services/api/utils/helpers.py
+++ b/server/py/services/api/utils/helpers.py
@@ -36,9 +36,10 @@ def resolve_client_default_kfp_image(
         must_use_mlrun_image = False
         if client_version and "unstable" not in client_version:
             try:
-                client_version = semver.Version.parse(client_version)
                 # client is olden than (<) 1.8, must use mlrun image for kfp
-                if client_version < semver.Version.parse("1.7.9999"):
+                if semver.Version.parse(client_version) < semver.Version.parse(
+                    "1.7.9999"
+                ):
                     must_use_mlrun_image = True
             except ValueError:
                 # client version is not semver, pass
@@ -46,15 +47,28 @@ def resolve_client_default_kfp_image(
 
         if must_use_mlrun_image:
             image = mlrun.mlconf.default_base_image
+            if ":" not in image:
+                # enrich the image with the client version to ensure that
+                # client < 1.8 will use the correct mlrun image and version.
+                # https://iguazio.atlassian.net/browse/ML-9292
+                enriched_image = mlrun.utils.enrich_image_url(
+                    image, client_version=client_version
+                )
+                logger.debug(
+                    "Ensure KFP image has fixed client version",
+                    enriched_image=enriched_image,
+                    image=image,
+                )
+                image = enriched_image
         else:
             image = mlrun.mlconf.kfp_image
 
-        logger.debug(
-            "Resolved KFP image for workflow",
-            project=project,
-            client_version=client_version,
-            workflow_spec_image=workflow_spec.image,
-            project_spec_default_image=project.spec.default_image,
-            resolved_image=image,
-        )
+    logger.debug(
+        "Resolved KFP image for workflow",
+        project=project,
+        client_version=client_version,
+        workflow_spec_image=workflow_spec.image,
+        project_spec_default_image=project.spec.default_image,
+        resolved_image=image,
+    )
     return image


### PR DESCRIPTION
Ensure remote workflow pipeline has its client version fixed in so that when enrichment happen (later on) it won't set it to newer server version.
The flow is as such

1. workflow image is set (via `resolve_client_default_kfp_image`)
2. the remote workflow function is saved
3. its run is created
4. its image is enriched with server version

so, if client 1.7 is running, it needs the `mlrun/mlrun` with version 1.7 to ensure code is compatible with client env.
if client wants to get newer version of remote workflow, it needs to have newer client version.

Important to note, that on 1.8 we have removed `kfp` from `mlrun/mlrun` image and thus, for <1.8 we pick `mlrun/mlrun` and for >= 1.8 we pick `mlrun/mlrun-kfp`.

https://iguazio.atlassian.net/browse/ML-9292