### PR TITLE
[Tests] Fix MM env preparation for system tests

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -399,16 +399,28 @@ class SystemTestPreparer:
         self._env_config["V3IO_API"] = f"https://{v3io_api_host}"
         self._env_config["MLRUN_DBPATH"] = f"https://{mlrun_api_url}"
 
-        self._env_config["mlrun_model_monitoring_tsdb_profile"] = {
-            "type": "v3io",
-            "name": "mm-tsdb-profile",
-            "v3io_access_key": None,
-        }
-        self._env_config["mlrun_model_monitoring_stream_profile"] = {
-            "type": "v3io",
-            "name": "mm-stream-profile",
-            "v3io_access_key": self._env_config["V3IO_ACCESS_KEY"],
-        }
+        # Since the prepare script is shared across branches, two MM configs are set.
+        # Remove the deprecated config when we stop testing 1.7.x.
+
+        # MM infra for < 1.8.0
+        self._env_config["MLRUN_MODEL_ENDPOINT_MONITORING__TSDB_CONNECTION"] = "v3io"
+        self._env_config["MLRUN_MODEL_ENDPOINT_MONITORING__STREAM_CONNECTION"] = "v3io"
+
+        # MM infra for >= 1.8.0
+        self._env_config["mlrun_model_monitoring_tsdb_profile"] = json.dumps(
+            {
+                "type": "v3io",
+                "name": "mm-tsdb-profile",
+                "v3io_access_key": None,
+            }
+        )
+        self._env_config["mlrun_model_monitoring_stream_profile"] = json.dumps(
+            {
+                "type": "v3io",
+                "name": "mm-stream-profile",
+                "v3io_access_key": self._env_config["V3IO_ACCESS_KEY"],
+            }
+        )
 
     def _install_dev_utilities(self):
         list_uninstall = [

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import json
 import os
 import pathlib
 import sys
@@ -75,8 +76,12 @@ class TestMLRunSystem:
         cls._logger = logger.get_child(cls.__name__.lower())
         cls.project: typing.Optional[mlrun.projects.MlrunProject] = None
 
-        cls.mm_tsdb_profile_data = env.get("mlrun_model_monitoring_tsdb_profile")
-        cls.mm_stream_profile_data = env.get("mlrun_model_monitoring_stream_profile")
+        cls.mm_tsdb_profile_data = cls._get_mm_data(
+            env, "mlrun_model_monitoring_tsdb_profile"
+        )
+        cls.mm_stream_profile_data = cls._get_mm_data(
+            env, "mlrun_model_monitoring_stream_profile"
+        )
 
         cls.uploaded_code = False
 
@@ -90,6 +95,15 @@ class TestMLRunSystem:
         # so even though we set the env var, we still need to directly configure
         # it in mlconf.
         mlconf.dbpath = cls._test_env["MLRUN_DBPATH"]
+
+    @staticmethod
+    def _get_mm_data(
+        env: dict[str, typing.Any], key: str
+    ) -> typing.Optional[dict[str, typing.Any]]:
+        data = env.get(key)
+        if isinstance(data, str):
+            data = json.loads(data)
+        return data
 
     @classmethod
     def custom_setup_class(cls):


### PR DESCRIPTION
Following #7250, the following workflow:
https://github.com/mlrun/mlrun/actions/workflows/system-tests-enterprise.yml
Fails on 1.7.x, e.g.: https://github.com/mlrun/mlrun/actions/runs/13231699922/job/36929984760#step:9:311

The reason is that the same development version of the preparation script is used for all the tested branches.