### PR TITLE
[System id] Generate system ID using only lowercase letters and digits

### DIFF
--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -1140,17 +1140,7 @@ def _generate_system_id() -> str:
     valid_chars = string.ascii_lowercase + string.digits
     system_id_len = 6
 
-    while True:
-        system_id = "".join(random.choices(valid_chars, k=system_id_len))
-
-        # validate the result against the qualified_name regex
-        try:
-            mlrun.utils.helpers.verify_field_regex(
-                "system_id", system_id, mlrun.utils.regex.qualified_name
-            )
-            return system_id
-        except mlrun.errors.MLRunInvalidArgumentError:
-            continue
+    return "".join(random.choices(valid_chars, k=system_id_len))
 
 
 def main() -> None:

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import base64
 import datetime
 import json
 import os
 import pathlib
 import random
+import string
 import typing
 
 import dateutil.parser
@@ -1136,21 +1136,19 @@ def _get_configured_system_id() -> typing.Optional[str]:
 
 
 def _generate_system_id() -> str:
-    # Generate a random 32-bit unsigned integer and encode as a URL-safe Base64 string without padding
-    while True:
-        random_number = random.getrandbits(32)
-        random_bytes = random_number.to_bytes(4, "big")
-        base64_str = base64.urlsafe_b64encode(random_bytes).decode("utf-8").rstrip("=")
+    # Generate a 6-character alphanumeric ID using lowercase letters and digits only
+    valid_chars = string.ascii_lowercase + string.digits
+    system_id_len = 6
 
-        # convert to lowercase and remove underscores for compatibility with Kubernetes names
-        sanitized_str = base64_str.lower().replace("_", "-")
+    while True:
+        system_id = "".join(random.choices(valid_chars, k=system_id_len))
 
         # validate the result against the qualified_name regex
         try:
             mlrun.utils.helpers.verify_field_regex(
-                "system_id", sanitized_str, mlrun.utils.regex.qualified_name
+                "system_id", system_id, mlrun.utils.regex.qualified_name
             )
-            return sanitized_str
+            return system_id
         except mlrun.errors.MLRunInvalidArgumentError:
             continue
 

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import string
 import typing
 import unittest.mock
 
@@ -405,8 +406,10 @@ def test_init_system_id(
     assert system_id is not None
 
     if system_id_source == "random":
-        # ensure that the generated id has the correct length (6 characters, as it is base64 encoded without padding)
+        # ensure the generated id has the correct length
         assert len(system_id) == 6
+        # ensure the generated id contains only alphanumeric characters
+        assert all(char in string.ascii_lowercase + string.digits for char in system_id)
     else:
         assert system_id == expected_system_id
 


### PR DESCRIPTION
This PR updates the system ID generation to ensure it follows stricter naming rules. 
The previous system ID generation involved using a URL-safe Base64 encoding, which could include special characters like `-` . 
The new approach generates a 6-character system ID using only lowercase letters (a-z) and digits (0-9), ensuring it remains alphanumeric and compatible with Kubernetes resource naming conventions.

Jira:
https://iguazio.atlassian.net/browse/ML-9239