### PR TITLE
[Helpers] Convert timezone aware datetime to UTC

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1336,7 +1336,7 @@ def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
     if not time_obj:
         return
 
-    # if the datetime object has a timezone, convert it to UTC before formatting.
+    # if the datetime object has a timezone, convert it to UTC before formatting
     if time_obj.tzinfo:
         time_obj = time_obj.astimezone(timezone.utc)
     return time_obj.isoformat()

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1335,6 +1335,10 @@ def datetime_from_iso(time_str: str) -> Optional[datetime]:
 def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
     if not time_obj:
         return
+
+    # if the datetime object has a timezone, convert it to UTC before formatting.
+    if time_obj.tzinfo:
+        time_obj = time_obj.astimezone(timezone.utc)
     return time_obj.isoformat()
 
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1329,16 +1329,16 @@ def get_handler_extended(
 def datetime_from_iso(time_str: str) -> Optional[datetime]:
     if not time_str:
         return
-    return parser.isoparse(time_str)
+    dt = parser.isoparse(time_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    # ensure the datetime is in UTC, converting if necessary
+    return dt.astimezone(timezone.utc)
 
 
 def datetime_to_iso(time_obj: Optional[datetime]) -> Optional[str]:
     if not time_obj:
         return
-
-    # if the datetime object has a timezone, convert it to UTC before formatting
-    if time_obj.tzinfo:
-        time_obj = time_obj.astimezone(timezone.utc)
     return time_obj.isoformat()
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1392,7 +1392,7 @@ def test_join_urls(base_url, path, expected_result):
             datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone(Timedelta(hours=2))),
             "2025-01-15T09:00:00+00:00",
         ),
-        # Case 4: Already UTC datetime
+        # already in UTC
         (
             datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
             "2025-01-15T11:00:00+00:00",

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1386,18 +1386,18 @@ def test_join_urls(base_url, path, expected_result):
     [
         (None, None),
         # no timezone
-        (datetime(2025, 1, 15, 11, 0, 0), "2025-01-15T11:00:00"),
+        ("2025-01-15T11:00:00", datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone.utc)),
         # timezone-aware datetime (UTC+2), should convert to UTC
         (
-            datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone(Timedelta(hours=2))),
-            "2025-01-15T09:00:00+00:00",
+            "2025-01-15T11:00:00+02:00",
+            datetime(2025, 1, 15, 9, 0, 0, tzinfo=timezone.utc),
         ),
         # already in UTC
         (
-            datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
             "2025-01-15T11:00:00+00:00",
+            datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
         ),
     ],
 )
-def test_datetime_to_iso(input_time, expected_output):
-    assert mlrun.utils.helpers.datetime_to_iso(input_time) == expected_output
+def test_datetime_from_iso(input_time, expected_output):
+    assert mlrun.utils.helpers.datetime_from_iso(input_time) == expected_output

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1379,3 +1379,25 @@ def test_validate_single_def_handler_valid_handler(code):
 )
 def test_join_urls(base_url, path, expected_result):
     assert mlrun.utils.helpers.join_urls(base_url, path) == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_time, expected_output",
+    [
+        (None, None),
+        # no timezone
+        (datetime(2025, 1, 15, 11, 0, 0), "2025-01-15T11:00:00"),
+        # timezone-aware datetime (UTC+2), should convert to UTC
+        (
+            datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone(Timedelta(hours=2))),
+            "2025-01-15T09:00:00+00:00",
+        ),
+        # Case 4: Already UTC datetime
+        (
+            datetime(2025, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
+            "2025-01-15T11:00:00+00:00",
+        ),
+    ],
+)
+def test_datetime_to_iso(input_time, expected_output):
+    assert mlrun.utils.helpers.datetime_to_iso(input_time) == expected_output


### PR DESCRIPTION
The `datetime_from_iso` function has been updated to ensure that timezone-aware datetime objects are properly converted to UTC when parsed. This guarantees that all datetime values are stored and processed consistently in UTC at the backend level.

This issue was not limited to the alert activations SDK but also affected other SDK resources with list functions. Previously, these functions did not explicitly ensure that the `since` and `until` datetimes were in UTC, which could lead to inconsistencies in how dates and times were interpreted. 

Jira:
https://iguazio.atlassian.net/browse/ML-9128