### PR TITLE
[Artifacts] Handle Iterations When Ensuring the Latest Tag During Migration

### DIFF
--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -1041,7 +1041,7 @@ def _ensure_latest_tag_for_artifacts(
     )
 
     # Collecting the two sets of (project, key) tuples
-    project_key_iter_0 = (
+    project_key_iter_0 = set(
         latest_with_iter_0.with_entities(
             subquery_filtered.c.project, subquery_filtered.c.key
         )
@@ -1049,17 +1049,13 @@ def _ensure_latest_tag_for_artifacts(
         .all()
     )
 
-    project_key_iter_gt_0 = (
+    project_key_iter_gt_0 = set(
         latest_with_iter_gt_0.with_entities(
             subquery_filtered.c.project, subquery_filtered.c.key
         )
         .distinct()
         .all()
     )
-
-    # Sets for checking intersection
-    set_iter_0 = set(project_key_iter_0)
-    set_iter_gt_0 = set(project_key_iter_gt_0)
 
     # Create an alias for the Tag table for the NOT EXISTS condition
     tag_alias = sqlalchemy.orm.aliased(framework.db.sqldb.models.ArtifactV2.Tag)
@@ -1073,56 +1069,42 @@ def _ensure_latest_tag_for_artifacts(
         )
     ).distinct()
 
-    artifacts_to_tag = query.limit(chunk_size).all()
-
-    if not artifacts_to_tag:
-        logger.info(
-            "No artifacts without 'latest' were found",
-            model=framework.db.sqldb.models.ArtifactV2.Tag,
-        )
-        return
-
-    logger.info(
-        "Starting artifacts without 'latest' tag migration",
-        model=framework.db.sqldb.models.ArtifactV2.Tag,
-        count=len(artifacts_to_tag),
-    )
-
     processed_artifacts = set()
 
-    while artifacts_to_tag:
+    while True:
+        # Filter artifacts that have already been processed, as there are artifacts that were processed but not tagged.
+        artifacts_to_tag = (
+            query.filter(~subquery_filtered.c.id.in_(processed_artifacts))
+            .limit(chunk_size)
+            .all()
+        )
+
+        if not artifacts_to_tag:
+            logger.info(
+                "No artifacts without 'latest' were found",
+                model=framework.db.sqldb.models.ArtifactV2.Tag,
+            )
+            break
+
+        logger.info(
+            "Starting artifacts without 'latest' tag migration",
+            model=framework.db.sqldb.models.ArtifactV2.Tag,
+            count=len(artifacts_to_tag),
+        )
+
         new_tags = []
         for artifact_id, key, project, iteration in artifacts_to_tag:
-            # in the scenario where the same project+key were created from both a hyper-param run and single run,
-            # and the user removed the latest tag from everything. In that case we'll assign latest to either the
-            # hyper-param items or the single run item, depending on which item we run into first when iterating
-            # over the results, and it may not necessarily be really the latest. Still, it will handle the
-            # more common case.
+            new_tag = _tag_artifact(
+                artifact_id,
+                key,
+                project,
+                iteration,
+                project_key_iter_0,
+                project_key_iter_gt_0,
+            )
 
-
-            # If iteration is 0, ensure it does not exist in set_iter_gt_0
-            if iteration == 0:
-                if (project, key) not in set_iter_gt_0:
-                    new_tags.append(
-                        framework.db.sqldb.models.ArtifactV2.Tag(
-                            project=project,
-                            name="latest",
-                            obj_id=artifact_id,
-                            obj_name=key,
-                        )
-                    )
-                    set_iter_0.add((project, key))  # Add to iter=0 set
-            else:  # If iteration > 0, ensure it does not exist in set_iter_0
-                if (project, key) not in set_iter_0:
-                    new_tags.append(
-                        framework.db.sqldb.models.ArtifactV2.Tag(
-                            project=project,
-                            name="latest",
-                            obj_id=artifact_id,
-                            obj_name=key,
-                        )
-                    )
-                    set_iter_gt_0.add((project, key))  # Add to iter>0 set
+            if new_tag:
+                new_tags.append(new_tag)
 
             processed_artifacts.add(artifact_id)
 
@@ -1135,15 +1117,39 @@ def _ensure_latest_tag_for_artifacts(
             db_session.add_all(new_tags)
             db_session.commit()
 
-        artifacts_to_tag = (
-            query.filter(~subquery_filtered.c.id.in_(processed_artifacts))
-            .limit(chunk_size)
-            .all()
-        )
+    logger.info("No more artifacts to migrate.")
 
-    logger.info(
-        "No more artifacts to migrate",
-    )
+
+def _tag_artifact(
+    artifact_id, key, project, iteration, project_key_iter_0, project_key_iter_gt_0
+):
+    """Tags an artifact as 'latest' depending on its iteration and project+key set."""
+
+    # In cases where the same project and key were created from both a hyper-params run and a single run, and the
+    # user removed the 'latest' tag from all items, we will assign the 'latest' tag to either the hyper-params items
+    # or the single run items. This will depend on which item we encounter first when iterating over the results.
+    # Although it may not necessarily reflect the true latest item, it will handle the more common scenario
+
+    new_tag = None
+
+    if iteration == 0 and (project, key) not in project_key_iter_gt_0:
+        new_tag = framework.db.sqldb.models.ArtifactV2.Tag(
+            project=project,
+            name="latest",
+            obj_id=artifact_id,
+            obj_name=key,
+        )
+        project_key_iter_0.add((project, key))  # Add to iter=0 set
+    elif iteration > 0 and (project, key) not in project_key_iter_0:
+        new_tag = framework.db.sqldb.models.ArtifactV2.Tag(
+            project=project,
+            name="latest",
+            obj_id=artifact_id,
+            obj_name=key,
+        )
+        project_key_iter_gt_0.add((project, key))  # Add to iter>0 set
+
+    return new_tag
 
 
 def _create_project_summaries(db, db_session):

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -994,6 +994,7 @@ def _ensure_latest_tag_for_artifacts(
         framework.db.sqldb.models.ArtifactV2.id,
         framework.db.sqldb.models.ArtifactV2.key,
         framework.db.sqldb.models.ArtifactV2.project,
+        framework.db.sqldb.models.ArtifactV2.iteration,
         sqlalchemy.func.row_number()
         .over(
             partition_by=[
@@ -1012,6 +1013,7 @@ def _ensure_latest_tag_for_artifacts(
             subquery.c.id,
             subquery.c.key,
             subquery.c.project,
+            subquery.c.iteration,
         )
         .filter(subquery.c.row_number == 1)  # Get only the latest for each combination
         .subquery()
@@ -1022,15 +1024,47 @@ def _ensure_latest_tag_for_artifacts(
         subquery_filtered.c.id,
         subquery_filtered.c.key,
         subquery_filtered.c.project,
+        subquery_filtered.c.iteration,
     ).outerjoin(
         framework.db.sqldb.models.ArtifactV2.Tag,
         framework.db.sqldb.models.ArtifactV2.Tag.obj_id == subquery_filtered.c.id,
     )
 
+    # Step 4: Collect project+key pairs for iteration 0 and >0
+    latest_with_iter_0 = query.filter(
+        framework.db.sqldb.models.ArtifactV2.Tag.name == "latest",
+        subquery_filtered.c.iteration == 0,
+    )
+    latest_with_iter_gt_0 = query.filter(
+        framework.db.sqldb.models.ArtifactV2.Tag.name == "latest",
+        subquery_filtered.c.iteration > 0,
+    )
+
+    # Collecting the two sets of (project, key) tuples
+    project_key_iter_0 = (
+        latest_with_iter_0.with_entities(
+            subquery_filtered.c.project, subquery_filtered.c.key
+        )
+        .distinct()
+        .all()
+    )
+
+    project_key_iter_gt_0 = (
+        latest_with_iter_gt_0.with_entities(
+            subquery_filtered.c.project, subquery_filtered.c.key
+        )
+        .distinct()
+        .all()
+    )
+
+    # Sets for checking intersection
+    set_iter_0 = set(project_key_iter_0)
+    set_iter_gt_0 = set(project_key_iter_gt_0)
+
     # Create an alias for the Tag table for the NOT EXISTS condition
     tag_alias = sqlalchemy.orm.aliased(framework.db.sqldb.models.ArtifactV2.Tag)
 
-    # Step 4: Filter out artifacts that already have the "latest" tag
+    # Step 5: Collect all artifacts that need to be tagged, filter out artifacts that already have the "latest" tag
     query = query.filter(
         ~sqlalchemy.exists().where(
             sqlalchemy.and_(
@@ -1054,26 +1088,58 @@ def _ensure_latest_tag_for_artifacts(
         count=len(artifacts_to_tag),
     )
 
+    processed_artifacts = set()
+
     while artifacts_to_tag:
-        new_tags = [
-            framework.db.sqldb.models.ArtifactV2.Tag(
-                project=project,
-                name="latest",
-                obj_id=artifact_id,
-                obj_name=key,
+        new_tags = []
+        for artifact_id, key, project, iteration in artifacts_to_tag:
+            # in the scenario where the same project+key were created from both a hyper-param run and single run,
+            # and the user removed the latest tag from everything. In that case we'll assign latest to either the
+            # hyper-param items or the single run item, depending on which item we run into first when iterating
+            # over the results, and it may not necessarily be really the latest. Still, it will handle the
+            # more common case.
+
+
+            # If iteration is 0, ensure it does not exist in set_iter_gt_0
+            if iteration == 0:
+                if (project, key) not in set_iter_gt_0:
+                    new_tags.append(
+                        framework.db.sqldb.models.ArtifactV2.Tag(
+                            project=project,
+                            name="latest",
+                            obj_id=artifact_id,
+                            obj_name=key,
+                        )
+                    )
+                    set_iter_0.add((project, key))  # Add to iter=0 set
+            else:  # If iteration > 0, ensure it does not exist in set_iter_0
+                if (project, key) not in set_iter_0:
+                    new_tags.append(
+                        framework.db.sqldb.models.ArtifactV2.Tag(
+                            project=project,
+                            name="latest",
+                            obj_id=artifact_id,
+                            obj_name=key,
+                        )
+                    )
+                    set_iter_gt_0.add((project, key))  # Add to iter>0 set
+
+            processed_artifacts.add(artifact_id)
+
+        if new_tags:
+            logger.info(
+                "Committing migrated records",
+                model=framework.db.sqldb.models.ArtifactV2.Tag,
+                count=len(new_tags),
             )
-            for artifact_id, key, project in artifacts_to_tag
-        ]
+            db_session.add_all(new_tags)
+            db_session.commit()
 
-        logger.info(
-            "Committing migrated records",
-            model=framework.db.sqldb.models.ArtifactV2.Tag,
-            count=len(new_tags),
+        artifacts_to_tag = (
+            query.filter(~subquery_filtered.c.id.in_(processed_artifacts))
+            .limit(chunk_size)
+            .all()
         )
-        db_session.add_all(new_tags)
-        db_session.commit()
-
-        artifacts_to_tag = query.limit(chunk_size).all()
 
     logger.info(
         "No more artifacts to migrate",

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -989,6 +989,9 @@ def _ensure_latest_tag_for_artifacts(
 ):
     chunk_size = chunk_size or config.artifacts.artifact_migration_v9_batch_size
 
+    # Note: when logging the same artifact and spawning tags in version < 1.8  and then migrating to 1.8,
+    # two artifacts should remain at the end
+
     # Step 1: Get the latest artifact row for each combination of project, key, and iteration
     subquery = db_session.query(
         framework.db.sqldb.models.ArtifactV2.id,
@@ -1125,10 +1128,9 @@ def _tag_artifact(
 ):
     """Tags an artifact as 'latest' depending on its iteration and project+key set."""
 
-    # In cases where the same project and key were created from both a hyper-params run and a single run, and the
+    # Note: In cases where the same project and key were created from both a hyper-params run and a single run, and the
     # user removed the 'latest' tag from all items, we will assign the 'latest' tag to either the hyper-params items
     # or the single run items. This will depend on which item we encounter first when iterating over the results.
-    # Although it may not necessarily reflect the true latest item, it will handle the more common scenario
 
     new_tag = None
 

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -551,7 +551,8 @@ def test_ensure_latest_tag_for_artifacts():
     artifact_3_id = artifact3.id
     artifact_4_id = artifact4.id
 
-    # Step 3: Delete the "latest" tags manually from the second artifact and the forth artifact (artifact_2_id, artifact_4_id)
+    # Step 3: Delete the "latest" tags manually from the second artifact and the forth artifact
+    # (artifact_2_id, artifact_4_id)
     db._delete(
         db_session,
         framework.db.sqldb.db.ArtifactV2.Tag,

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -421,12 +421,17 @@ def test_init_system_id(
 def test_ensure_latest_tag_for_artifacts():
     # This test verifies that the migration to ensure the "latest" tag is assigned correctly to artifacts works as
     # expected. The test creates a set of artifacts with different iteration numbers and tags:
-    # - project1 + key1 + iteration 0 -> 3 tags (v1, v2, latest)
-    # - project1 + key1 + iteration 1 -> 1 tag (latest)
-    # - project1 + key1 + iteration 2 -> 2 tags (v1, latest)
-    # - project2 + key1 + iteration 0 -> 1 tag (latest)
-    # - project2 + key2 + iteration 0 -> 1 tag (latest)
-    # The test then deletes the "latest" tags from the first two artifacts and verifies that only one artifact has the
+
+    # 1. project1 + key1 + iteration 0 (run1) -> 2 tags (v1, v2)
+
+    # 2. project1 + key1 + iteration 1 (run2) -> 1 tag (latest)
+    # 3. project1 + key1 + iteration 2 (run2) -> 2 tags (v1, latest)
+    # 4. project1 + key1 + iteration 3 (run2) -> 2 tags (v1, latest)
+
+    # 5. project2 + key1 + iteration 0 -> 1 tag (latest)
+    # 6. project2 + key2 + iteration 0 -> 1 tag (latest)
+
+    # The test then deletes the "latest" tags from the second artifact and verifies that only 2 artifacts have the
     # "latest" tag left. After performing the migration, the test verifies that the correct artifacts are tagged as
     # "latest".
 
@@ -435,46 +440,95 @@ def test_ensure_latest_tag_for_artifacts():
     project1 = "project1"
     key2 = "key2"
     project2 = "project2"
+    tree1 = "tree1"
+    tree2 = "tree2"
 
-    artifact = {
-        "kind": "artifact",
-    }
+    def generate_artifact(key, tree=None):
+        artifact = {
+            "metadata": {"key": key},
+            "kind": "artifact",
+        }
+        if tree:
+            artifact["metadata"]["tree"] = tree
+        return artifact
 
     # Step 1: Create artifacts with different iteration numbers and tags
-    # project1 + key1 + iteration 0 -> 3 tags (v1, v2, latest)
+
+    # Create artifact for project1 + key1 + iteration 0 (run1) -> 3 tags (v1, v2, latest)
     artifact_1_uid = db.store_artifact(
-        db_session, key=key1, project=project1, iter=0, artifact=artifact, tag="v1"
+        db_session,
+        key=key1,
+        project=project1,
+        iter=0,
+        artifact=generate_artifact(key1, tree1),
+        tag="v1",
     )
     db.store_artifact(
-        db_session, key=key1, project=project1, iter=0, artifact=artifact, tag="v2"
+        db_session,
+        key=key1,
+        project=project1,
+        iter=0,
+        artifact=generate_artifact(key1, tree1),
+        tag="v2",
     )
 
-    # project1 + key1 + iteration 1 -> 1 tag (latest)
+    # Create 2 artifacts with hyperparameters, each will receive the 'latest' tag
+    # and the 'latest' tag is removed from the artifact from the previous run (run1)
+
+    # project1 + key1 + iteration 1 (run2) -> 1 tag (latest)
     artifact_2_uid = db.store_artifact(
-        db_session, key=key1, project=project1, iter=1, artifact=artifact
+        db_session,
+        key=key1,
+        project=project1,
+        iter=1,
+        artifact=generate_artifact(key1, tree2),
     )
 
-    # project1 + key1 + iteration 2 -> 2 tags (v1, latest)
+    # project1 + key1 + iteration 2 (run2) -> 2 tags (v1, latest)
     artifact_3_uid = db.store_artifact(
-        db_session, key=key1, project=project1, iter=2, artifact=artifact, tag="v1"
+        db_session,
+        key=key1,
+        project=project1,
+        iter=2,
+        artifact=generate_artifact(key1, tree2),
+        tag="v1",
+    )
+
+    # project1 + key1 + iteration 3 (run2) -> 2 tags (v1, latest)
+    artifact_4_uid = db.store_artifact(
+        db_session,
+        key=key1,
+        project=project1,
+        iter=3,
+        artifact=generate_artifact(key1, tree2),
+        tag="v1",
     )
 
     # project2 + key1 + iteration 0 -> 1 tag (latest)
-    db.store_artifact(
+    artifact_5_uid = db.store_artifact(
         db_session,
         key=key1,
         project=project2,
         iter=0,
-        artifact=artifact,
+        artifact=generate_artifact(key1),
     )
 
     # project2 + key2 + iteration 0 -> 1 tag (latest)
-    db.store_artifact(
+    artifact_6_uid = db.store_artifact(
         db_session,
         key=key2,
         project=project2,
         iter=0,
-        artifact=artifact,
+        artifact=generate_artifact(key2),
+    )
+
+    assert (
+        artifact_1_uid
+        != artifact_2_uid
+        != artifact_3_uid
+        != artifact_4_uid
+        != artifact_5_uid
+        != artifact_6_uid
     )
 
     # Step 2: List the artifacts for project1, key1, and the "latest" tag
@@ -484,30 +538,30 @@ def test_ensure_latest_tag_for_artifacts():
     assert len(artifacts) == 3
 
     # Read the artifacts that were stored to get their IDs
-    artifact1 = db.read_artifact(
-        db_session, key=key1, project=project1, uid=artifact_1_uid, as_record=True
-    )
     artifact2 = db.read_artifact(
-        db_session, key=key1, project=project1, uid=artifact_2_uid, as_record=True
+        db_session, project=project1, key=key1, uid=artifact_2_uid, as_record=True
     )
     artifact3 = db.read_artifact(
-        db_session, key=key1, project=project1, uid=artifact_3_uid, as_record=True
+        db_session, project=project1, key=key1, uid=artifact_3_uid, as_record=True
     )
-    artifact_1_id = artifact1.id
+    artifact4 = db.read_artifact(
+        db_session, project=project1, key=key1, uid=artifact_4_uid, as_record=True
+    )
     artifact_2_id = artifact2.id
     artifact_3_id = artifact3.id
+    artifact_4_id = artifact4.id
 
-    # Step 3: Delete the "latest" tags manually from the first two artifacts (artifact_1_id, artifact_2_id)
+    # Step 3: Delete the "latest" tags manually from the second artifact and the forth artifact (artifact_2_id, artifact_4_id)
     db._delete(
         db_session,
         framework.db.sqldb.db.ArtifactV2.Tag,
-        obj_id=artifact_1_id,
+        obj_id=artifact_2_id,
         name="latest",
     )
     db._delete(
         db_session,
         framework.db.sqldb.db.ArtifactV2.Tag,
-        obj_id=artifact_2_id,
+        obj_id=artifact_4_id,
         name="latest",
     )
     db_session.flush()
@@ -530,16 +584,19 @@ def test_ensure_latest_tag_for_artifacts():
         len(artifacts) == 3
     ), f"Expected 3 artifacts with latest tag, found {len(artifacts)}"
 
+    # Verify that artifact from the previous run (run1) wasn't tagged as latest
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        db.read_artifact(db_session, project=project1, key=key1, tag="latest", iter=0)
+
     # Ensure the tag was created correctly for the second artifact
-    artifacts = db.list_artifacts(
-        db_session, project=project1, name=key1, iter=1, as_records=True
+    artifact = db.read_artifact(
+        db_session, project=project1, key=key1, tag="latest", iter=1, as_record=True
     )
-    assert len(artifacts) == 1
-    assert len(artifacts[0].tags) == 1
-    assert artifacts[0].tags[0].name == "latest"
-    assert artifacts[0].tags[0].project == project1
-    assert artifacts[0].tags[0].obj_name == key1
-    assert artifacts[0].tags[0].obj_id == artifact_2_id
+    assert len(artifact.tags) == 1
+    assert artifact.tags[0].name == "latest"
+    assert artifact.tags[0].project == project1
+    assert artifact.tags[0].obj_name == key1
+    assert artifact.tags[0].obj_id == artifact_2_id
 
 
 def _initialize_db_without_migrations() -> (


### PR DESCRIPTION
This PR addresses the issue of correctly assigning the "latest" tag during data migration, specifically separating the logic for artifacts with iter == 0 and iter != 0. Previously, the "latest" tag assignment did not account for distinguishing between these two cases.

**_Changes:_**

To implement this, we have separated the artifacts into two sets of (project, key) tuples:
- One set for artifacts with iter == 0 and the "latest" tag.
- Another set for artifacts with iter > 0 and the "latest" tag.

During the migration process, when iterating over all artifacts that do not have the "latest" tag, the following checks are performed:

1. For artifacts with iter == 0:
Mark as "latest" only if the project's key combination does not already exist in the set of iter > 0 "latest" items.
Once marked as "latest", add the (project, key) to the iter == 0 set.

1. For artifacts with iter > 0:
Mark as "latest" only if the project's key combination does not already exist in the set of iter == 0 "latest" items.
After marking, add the (project, key) to the iter > 0 set.

_**Note:**_ 
In cases where the same project and key were created from both a hyper-params run and a single run, and the user removed the 'latest' tag from all items, we will assign the 'latest' tag to either the hyper-params items or the single run items. This will depend on which item we encounter first when iterating over the results, and it may not necessarily be really the latest.

https://iguazio.atlassian.net/browse/ML-9285