### PR TITLE
[Config] Increase submit timeout

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -105,7 +105,7 @@ default_config = {
     # custom logger format, workes only with log_formatter: custom
     # Note that your custom format must include those 4 fields - timestamp, level, message and more
     "log_format_override": None,
-    "submit_timeout": "180",  # timeout when submitting a new k8s resource
+    "submit_timeout": "280",  # timeout when submitting a new k8s resource
     # runtimes cleanup interval in seconds
     "runtimes_cleanup_interval": "300",
     "monitoring": {


### PR DESCRIPTION
Submitting a job sets the timeout to 200 seconds - 180(config value) + 20.
Some MPI jobs take more than 200 seconds to complete, so increasing the config timeout to 280 - resulting with a total of 5 minutes.

https://iguazio.atlassian.net/browse/ML-9072