### PR TITLE
[Python] Remove distutils references

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -30,7 +30,6 @@ import typing
 import warnings
 from collections.abc import Mapping
 from datetime import timedelta
-from distutils.util import strtobool
 from os.path import expanduser
 from threading import Lock
 
@@ -1471,17 +1470,6 @@ def _convert_resources_to_str(config: typing.Optional[dict] = None):
             if value is None:
                 continue
             resource_requirement[resource_type] = str(value)
-
-
-def _convert_str(value, typ):
-    if typ in (str, _none_type):
-        return value
-
-    if typ is bool:
-        return strtobool(value)
-
-    # e.g. int('8080') → 8080
-    return typ(value)
 
 
 def _configure_ssl_verification(verify_ssl: bool) -> None:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1463,6 +1463,16 @@ def str_to_timestamp(time_str: str, now_time: Timestamp = None):
     return Timestamp(time_str)
 
 
+def str_to_bool(value: str) -> bool:
+    """Convert a string to a boolean value."""
+    value = value.lower()
+    if value in ("true", "1", "t", "y", "yes", "on"):
+        return True
+    if value in ("false", "0", "f", "n", "no", "off"):
+        return False
+    raise ValueError(f"invalid boolean value: {value}")
+
+
 def is_link_artifact(artifact):
     if isinstance(artifact, dict):
         return (

--- a/server/py/services/api/api/endpoints/functions.py
+++ b/server/py/services/api/api/endpoints/functions.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import traceback
-from distutils.util import strtobool
 from http import HTTPStatus
 from typing import Optional
 
@@ -335,7 +334,7 @@ async def build_function(
     if isinstance(data.get("with_mlrun"), bool):
         with_mlrun = data.get("with_mlrun")
     else:
-        with_mlrun = strtobool(data.get("with_mlrun", "on"))
+        with_mlrun = mlrun.utils.str_to_bool(data.get("with_mlrun", "on"))
     skip_deployed = data.get("skip_deployed", False)
     force_build = data.get("force_build", False)
     mlrun_version_specifier = data.get("mlrun_version_specifier")

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -989,6 +989,40 @@ def test_get_pretty_types_names():
         assert pretty_result == expected
 
 
+@pytest.mark.parametrize(
+    "value, expected, exception",
+    [
+        # True values
+        ("y", True, does_not_raise()),
+        ("yes", True, does_not_raise()),
+        ("t", True, does_not_raise()),
+        ("true", True, does_not_raise()),
+        ("on", True, does_not_raise()),
+        ("1", True, does_not_raise()),
+        # False values
+        ("n", False, does_not_raise()),
+        ("no", False, does_not_raise()),
+        ("f", False, does_not_raise()),
+        ("false", False, does_not_raise()),
+        ("off", False, does_not_raise()),
+        ("0", False, does_not_raise()),
+        # Invalid values
+        ("maybe", None, pytest.raises(ValueError)),
+        ("2", None, pytest.raises(ValueError)),
+        ("", None, pytest.raises(ValueError)),
+        (" ", None, pytest.raises(ValueError)),
+        # Case insensitivity
+        ("Y", True, does_not_raise()),
+        ("nO", False, does_not_raise()),
+        ("TrUe", True, does_not_raise()),
+        ("FaLsE", False, does_not_raise()),
+    ],
+)
+def test_str_to_bool(value, expected, exception):
+    with exception:
+        assert mlrun.utils.str_to_bool(value) == expected
+
+
 def test_str_to_timestamp():
     now_time = Timestamp("2021-01-01 00:01:00")
     cases = [


### PR DESCRIPTION
distutils is deprecated since python 3.12
we currently get it by having setuptools but needlessly as this is a single functionality that can be part of mlrun utls
https://iguazio.atlassian.net/browse/ML-5438