### PR TITLE
[Scheduler] Fix uninitialized scheduler shutdown

### DIFF
--- a/server/py/services/api/utils/scheduler.py
+++ b/server/py/services/api/utils/scheduler.py
@@ -83,6 +83,9 @@ class Scheduler:
 
     async def stop(self):
         logger.info("Stopping scheduler")
+        if not self._scheduler.running:
+            # https://github.com/agronholm/apscheduler/issues/1019 mitigation
+            return
         self._scheduler.shutdown()
         # the scheduler shutdown and start operation are not fully async compatible yet -
         # https://github.com/agronholm/apscheduler/issues/360 - this sleep make them work


### PR DESCRIPTION
When the scheduler is not initialized (on API workers) the shutdown fails with:
```
AttributeError: 'NoneType' object has no attribute 'call_soon_threadsafe'
```
This skips the shutdown if the scheduler is not running.
It is aligned with the fix for https://github.com/agronholm/apscheduler/issues/1019

Raised by https://iguazio.atlassian.net/browse/ML-9318