### PR TITLE
[Alerts] Increased limit of alerts up to 20k and make cache size configurable

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -811,14 +811,14 @@ default_config = {
         "mode": "enabled",
         # maximum number of alerts we allow to be configured.
         # user will get an error when exceeding this
-        "max_allowed": 10000,
+        "max_allowed": 20000,
         # maximum allowed value for count in criteria field inside AlertConfig
         "max_criteria_count": 100,
         # interval for periodic events generation job
         "events_generation_interval": 30,  # seconds
         # maximum allowed alert config cache size in alert's CRUD
         # for the best performance, it is recommended to set this value to the maximum number of alerts
-        "max_allowed_cache_size": 10000,
+        "max_allowed_cache_size": 20000,
     },
     "auth_with_client_id": {
         "enabled": False,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -816,6 +816,9 @@ default_config = {
         "max_criteria_count": 100,
         # interval for periodic events generation job
         "events_generation_interval": 30,  # seconds
+        # maximum allowed alert config cache size in alert's CRUD
+        # for the best performance, it is recommended to set this value to the maximum number of alerts
+        "max_allowed_cache_size": 10000,
     },
     "auth_with_client_id": {
         "enabled": False,

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -332,7 +332,7 @@ class Alerts(
         if not cls._alert_cache:
             cls._alert_cache = framework.utils.lru_cache.LRUCache(
                 framework.utils.singletons.db.get_db().get_alert_by_id,
-                maxsize=10000,
+                maxsize=mlconfig.alerts.max_allowed,
                 ignore_args_for_hash=[0],
             )
 
@@ -343,7 +343,7 @@ class Alerts(
         if not cls._alert_state_cache:
             cls._alert_state_cache = framework.utils.lru_cache.LRUCache(
                 framework.utils.singletons.db.get_db().get_alert_state_dict,
-                maxsize=10000,
+                maxsize=mlconfig.alerts.max_allowed,
                 ignore_args_for_hash=[0],
             )
         return cls._alert_state_cache

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -332,7 +332,7 @@ class Alerts(
         if not cls._alert_cache:
             cls._alert_cache = framework.utils.lru_cache.LRUCache(
                 framework.utils.singletons.db.get_db().get_alert_by_id,
-                maxsize=mlconfig.alerts.max_allowed,
+                maxsize=mlconfig.alerts.max_allowed_cache_size,
                 ignore_args_for_hash=[0],
             )
 
@@ -343,7 +343,7 @@ class Alerts(
         if not cls._alert_state_cache:
             cls._alert_state_cache = framework.utils.lru_cache.LRUCache(
                 framework.utils.singletons.db.get_db().get_alert_state_dict,
-                maxsize=mlconfig.alerts.max_allowed,
+                maxsize=mlconfig.alerts.max_allowed_cache_size,
                 ignore_args_for_hash=[0],
             )
         return cls._alert_state_cache


### PR DESCRIPTION
Makes maximum cache size configurable depending on `max_allowed_cache_size`. Also, increases both `max_allowed` and `max_allowed_cache_size` up to 20k. 
 
Jira - https://iguazio.atlassian.net/browse/ML-9341