### PR TITLE
[SDK] Remove unused deprecated parameters

### DIFF
--- a/docs/change-log/index.md
+++ b/docs/change-log/index.md
@@ -1172,12 +1172,11 @@ with a drill-down to view the steps and their details. [Tech Preview]
 | v1.8.0       |v1.6.0    |Feature store: `preview`                                                             |`FeatureSet.preview()`|
 | v1.8.0       |v1.6.0    |Feature store: `ingest`                                                              |`FeatureSet.ingest()`|
 | v1.8.0       |v1.6.0    |Artifacts: `uid` parameter of `store_artifact`                                       | `tree` parameter of `store_artifact` (artifact uid is generated in the backend)|
-| v1.8.0       |v1.6.0    |Runtimes: `with_requirements` &mdash; `requirements` param as a requirements file    |`requirements_file` param  |
 
 ### Removed APIs
 
 | Version|API                                                                                                                                                                                                                                                                                                 |Use instead                                                                  |
-|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|
 | v1.7.0 |Function: `mlrun.utils.helpers.parse_versioned_object_uri`                                  |`mlrun.common.helpers.parse_versioned_object_uri`         |
 | v1.7.0 |`func_info`                                                                       |`ast_func_info`                                                |
 | v1.7.0 |Class: `MpiRuntimeV1Alpha1`                                                         |`MpiRuntimeV1`          |
@@ -1186,9 +1185,10 @@ with a drill-down to view the steps and their details. [Tech Preview]
 | v1.7.0 |API endpoint GET: `/files` and `/filestat`                                        |`/projects/{project}/filestat`                                                                                                                              |
 | v1.7.0 |`LegacyArtifact` and all legacy artifact types that inherit from it (`LegacyArtifact`, `LegacyDirArtifact`, `LegacyLinkArtifact`, `LegacyPlotArtifact`, `LegacyChartArtifact`, `LegacyTableArtifact`, `LegacyModelArtifact`, `LegacyDatasetArtifact`, `LegacyPlotlyArtifact`, `LegacyBokehArtifact`, `BokehArtifact`, `LegacyArtifact`)|`Artifact` or other artifact classes that inherit from it                    |
 | v1.7.0 |Parameter of mlrun.feature_store.feature_set.FeatureSet.set_targets `default_final_state`   |`default_final_step`                                                                                                                                          |
-| v1.6.2  |`dashboard` parameter of the RemoteRuntime `invoke`                             |NA. The parameter was ignored. |
+| v1.6.2 |`dashboard` parameter of the RemoteRuntime `invoke`                             |NA. The parameter was ignored. |
 | v1.6.0 |`dashboard` parameter of `project.deploy_function`, `RemoteRuntime.deploy`, `RemoteRuntime.get_nuclio_deploy_status`, `ServingRuntime.with_secrets`| NA. The parameter was ignored.         |
 | v1.6.0 |`MLRunProject.clear_context()`                                                      |NA |
+|v1.6.0  |Runtimes: `with_requirements` &mdash; `requirements` param as a requirements file    |`requirements_file` param  |
 | v1.6.0 |MLRunProject object legacy parameters                                              |metadata and spec                                                                                                                                           |
 | v1.6.0 |`BaseRuntime.with_commands` and `KubejobRuntime.build_config` `verify_base_image` param|`prepare_image_for_deploy`                                                                                                                                 |
 | v1.6.0 |`run_local`                                                                          |`function.run(local=True)`                                                                                                                                   |

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -149,7 +149,13 @@ class RunDBInterface(ABC):
 
     @abstractmethod
     def store_artifact(
-        self, key, artifact, uid=None, iter=None, tag="", project="", tree=None
+        self,
+        key,
+        artifact,
+        iter=None,
+        tag="",
+        project="",
+        tree=None,
     ):
         pass
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -899,7 +899,6 @@ class HTTPRunDB(RunDBInterface):
         ] = None,  # Backward compatibility
         states: typing.Optional[list[mlrun.common.runtimes.constants.RunStates]] = None,
         sort: bool = True,
-        last: int = 0,
         iter: bool = False,
         start_time_from: Optional[datetime] = None,
         start_time_to: Optional[datetime] = None,
@@ -946,7 +945,6 @@ class HTTPRunDB(RunDBInterface):
         :param states: List only runs whose state is one of the provided states.
         :param sort: Whether to sort the result according to their start time. Otherwise, results will be
             returned by their internal order in the DB (order will not be guaranteed).
-        :param last: Deprecated - currently not used (will be removed in 1.8.0).
         :param iter: If ``True`` return runs from all iterations. Otherwise, return only runs whose ``iter`` is 0.
         :param start_time_from: Filter by run start time in ``[start_time_from, start_time_to]``.
         :param start_time_to: Filter by run start time in ``[start_time_from, start_time_to]``.
@@ -974,7 +972,6 @@ class HTTPRunDB(RunDBInterface):
             state=state,
             states=states,
             sort=sort,
-            last=last,
             iter=iter,
             start_time_from=start_time_from,
             start_time_to=start_time_to,
@@ -1093,8 +1090,6 @@ class HTTPRunDB(RunDBInterface):
         self,
         key,
         artifact,
-        # TODO: deprecated, remove in 1.8.0
-        uid=None,
         iter=None,
         tag=None,
         project="",
@@ -1104,8 +1099,6 @@ class HTTPRunDB(RunDBInterface):
 
         :param key: Identifying key of the artifact.
         :param artifact: The :py:class:`~mlrun.artifacts.Artifact` to store.
-        :param uid: A unique ID for this specific version of the artifact
-                    (deprecated, artifact uid is generated in the backend use `tree` instead)
         :param iter: The task iteration which generated this artifact. If ``iter`` is not ``None`` the iteration will
             be added to the key provided to generate a unique key for the artifact of the specific iteration.
         :param tag: Tag of the artifact.
@@ -1113,15 +1106,6 @@ class HTTPRunDB(RunDBInterface):
         :param tree: The tree (producer id) which generated this artifact.
         :returns: The stored artifact dictionary.
         """
-        if uid:
-            warnings.warn(
-                "'uid' is deprecated in 1.6.0 and will be removed in 1.8.0, use 'tree' instead.",
-                # TODO: Remove this in 1.8.0
-                FutureWarning,
-            )
-
-        # we do this because previously the 'uid' name was used for the 'tree' parameter
-        tree = tree or uid
         project = project or mlrun.mlconf.default_project
         endpoint_path = f"projects/{project}/artifacts/{key}"
 
@@ -5198,7 +5182,6 @@ class HTTPRunDB(RunDBInterface):
         ] = None,  # Backward compatibility
         states: typing.Optional[list[mlrun.common.runtimes.constants.RunStates]] = None,
         sort: bool = True,
-        last: int = 0,
         iter: bool = False,
         start_time_from: Optional[datetime] = None,
         start_time_to: Optional[datetime] = None,
@@ -5230,13 +5213,6 @@ class HTTPRunDB(RunDBInterface):
                 "using the `with_notifications` flag."
             )
 
-        if last:
-            # TODO: Remove this in 1.8.0
-            warnings.warn(
-                "'last' is deprecated and will be removed in 1.8.0.",
-                FutureWarning,
-            )
-
         if state:
             # TODO: Remove this in 1.9.0
             warnings.warn(
@@ -5252,7 +5228,6 @@ class HTTPRunDB(RunDBInterface):
             and not labels
             and not state
             and not states
-            and not last
             and not start_time_from
             and not start_time_to
             and not last_update_time_from

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -175,7 +175,13 @@ class NopDB(RunDBInterface):
         pass
 
     def store_artifact(
-        self, key, artifact, uid=None, iter=None, tag="", project="", tree=None
+        self,
+        key,
+        artifact,
+        iter=None,
+        tag="",
+        project="",
+        tree=None,
     ):
         pass
 

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -229,18 +229,23 @@ class SQLRunDB(RunDBInterface):
         )
 
     def store_artifact(
-        self, key, artifact, uid=None, iter=None, tag="", project="", tree=None
+        self,
+        key,
+        artifact,
+        iter=None,
+        tag="",
+        project="",
+        tree=None,
     ):
         return self._transform_db_error(
             services.api.crud.Artifacts().store_artifact,
             self.session,
             key,
             artifact,
-            uid,
-            iter,
-            tag,
-            project,
-            tree,
+            tag=tag,
+            iter=iter,
+            project=project,
+            producer_id=tree,
         )
 
     def read_artifact(

--- a/tests/integration/sdk_api/artifacts/test_artifact_tags.py
+++ b/tests/integration/sdk_api/artifacts/test_artifact_tags.py
@@ -53,14 +53,14 @@ class TestArtifactTags(tests.integration.sdk_api.base.TestMLRunIntegration):
         mlrun.get_run_db().store_artifact(
             model_key,
             model_artifact.to_dict(),
-            model_tree,
+            tree=model_tree,
             tag=model_tag,
             project=project_name,
         )
         mlrun.get_run_db().store_artifact(
             model_key,
             model_artifact.to_dict(),
-            model_tree_2,
+            tree=model_tree_2,
             tag=model_tag_2,
             project=project_name,
         )

--- a/tests/integration/sdk_api/projects/test_project.py
+++ b/tests/integration/sdk_api/projects/test_project.py
@@ -111,7 +111,6 @@ class TestProject(tests.integration.sdk_api.base.TestMLRunIntegration):
             db.store_artifact(
                 artifact_key,
                 artifact_instance,
-                "some_uid",
                 tag="some-tag",
                 project=project.metadata.name,
             )


### PR DESCRIPTION
Removed:
1. HTTPDB: `last` parameter of `list_runs`
2. Artifacts: `uid` parameter of `store_artifact`

Fixed documentation: `with_requirements` - `requirements` param as a requirements file - was removed in 1.6

https://iguazio.atlassian.net/browse/ML-9365