### PR TITLE
[Model Monitoring] Serialize the application results in evaluate

### DIFF
--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -26,6 +26,7 @@ import mlrun
 from mlrun.common.schemas.model_monitoring import ResultKindApp, ResultStatusApp
 from mlrun.model_monitoring.applications import (
     ModelMonitoringApplicationBase,
+    ModelMonitoringApplicationMetric,
     ModelMonitoringApplicationResult,
     MonitoringApplicationContext,
 )
@@ -83,6 +84,15 @@ class TestEvaluate:
         assert run.state() == "created"  # Should be "error", see ML-8507
         run = InProgressApp1.evaluate(func_path=__file__, func_name=func_name)
         assert run.state() == "completed"
+        assert run.status.results == {
+            "return": {
+                "result_name": "res0",
+                "result_value": 0.0,
+                "result_kind": 4,
+                "result_status": -1,
+                "result_extra_data": "{}",
+            }
+        }, "The run results are different than expected"
 
 
 @pytest.mark.parametrize(
@@ -197,6 +207,50 @@ def test_job_handler() -> None:
         )
         == "package.subpackage.module.AppClass::_handler"
     )
+
+
+@pytest.mark.parametrize(
+    ("result", "expected_flattened_result"),
+    [
+        (
+            ModelMonitoringApplicationMetric(name="m1", value=98),
+            {"metric_name": "m1", "metric_value": 98},
+        ),
+        (
+            [
+                ModelMonitoringApplicationMetric(name="m0", value=-2),
+                ModelMonitoringApplicationResult(
+                    name="r0",
+                    value=0,
+                    status=ResultStatusApp.no_detection,
+                    kind=ResultKindApp.mm_app_anomaly,
+                ),
+            ],
+            [
+                {"metric_name": "m0", "metric_value": -2},
+                {
+                    "result_name": "r0",
+                    "result_value": 0,
+                    "result_status": 0,
+                    "result_kind": 4,
+                    "result_extra_data": "{}",
+                },
+            ],
+        ),
+    ],
+)
+def test_flatten_data_result(
+    result: Union[
+        ModelMonitoringApplicationMetric,
+        ModelMonitoringApplicationResult,
+        list[Union[ModelMonitoringApplicationMetric, ModelMonitoringApplicationResult]],
+    ],
+    expected_flattened_result: Union[dict, list[dict]],
+) -> None:
+    assert (
+        ModelMonitoringApplicationBase._flatten_data_result(result)
+        == expected_flattened_result
+    ), "The flattened result is different than expected"
 
 
 class TestToJob:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1411,18 +1411,21 @@ class TestAppJob(TestMLRunSystem):
         # Test the results
         returned_results = run_result.output("return")
         assert returned_results, "No returned results"
-        assert {
-            "ModelMonitoringApplicationMetric(name='hellinger_mean', value=1.0)",
+        assert [
+            {"metric_name": "hellinger_mean", "metric_value": 1.0},
             # Ignore KLD due to varying numerical accuracy on different systems
-            # "ModelMonitoringApplicationMetric(name='kld_mean', value=8.517193191416238)",
-            "ModelMonitoringApplicationMetric(name='tvd_mean', value=0.5)",
-            (
-                "ModelMonitoringApplicationResult(name='general_drift', value=0.75, "
-                "kind=<ResultKindApp.data_drift: 0>, status=<ResultStatusApp.detected: 2>, extra_data={})"
-            ),
-        } <= set(
-            returned_results
-        ), "The returned metrics do not include the expected ones"
+            # {"metric_name": "kld_mean", "metric_value": 8.517193191416238},
+            {"metric_name": "tvd_mean", "metric_value": 0.5},
+            {
+                "result_name": "general_drift",
+                "result_value": 0.75,
+                "result_kind": 0,
+                "result_status": 2,
+                "result_extra_data": "{}",
+            },
+        ] == [returned_results[0]] + returned_results[
+            2:4
+        ], "The returned metrics are different than the expected ones"
         # Test the artifacts
         for artifact_name in _DefaultDataDriftAppData.artifacts:
             assert run_result.output(
@@ -1562,18 +1565,22 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
             assert (
                 len(outputs) == 2
             ), "The number of outputs is different than the number of windows"
-            assert set(outputs.values()) == {
-                (
-                    "ModelMonitoringApplicationResult(name='count', value=14.0, "
-                    "kind=<ResultKindApp.model_performance: 2>, status=<ResultStatusApp.no_detection: 0>, "
-                    "extra_data={})"
-                ),
-                (
-                    "ModelMonitoringApplicationResult(name='count', value=4.0, "
-                    "kind=<ResultKindApp.model_performance: 2>, status=<ResultStatusApp.no_detection: 0>, "
-                    "extra_data={})"
-                ),
-            }, "The outputs are different than expected"
+            assert list(outputs.values()) == [
+                {
+                    "result_name": "count",
+                    "result_value": 14.0,
+                    "result_kind": 2,
+                    "result_status": 0,
+                    "result_extra_data": "{}",
+                },
+                {
+                    "result_name": "count",
+                    "result_value": 4.0,
+                    "result_kind": 2,
+                    "result_status": 0,
+                    "result_extra_data": "{}",
+                },
+            ], "The outputs are different than expected"
 
 
 class TestBatchServingWithSampling(TestMLRunSystemModelMonitoring):


### PR DESCRIPTION
Fixes [ML-8734](https://iguazio.atlassian.net/browse/ML-8734) and [ML-8735](https://iguazio.atlassian.net/browse/ML-8735).

Instead of returning the result/metric Python object that is serialized to a string through the `__repr__` method - convert it to the dictionary representation.

Adapt the existing tests and cover the new functionality with a unit test.

[ML-8734]: https://iguazio.atlassian.net/browse/ML-8734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-8735]: https://iguazio.atlassian.net/browse/ML-8735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ