### PR TITLE
[Workflows] Propagate GPU limits as zero in KFP and Kaniko pods to ensure toleration application [Part 2]

### DIFF
--- a/dockerfiles/base/locked-requirements.txt
+++ b/dockerfiles/base/locked-requirements.txt
@@ -2523,13 +2523,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via -r requirements.txt
 mpmath==1.3.0 \
     --hash=sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f \

--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -2531,13 +2531,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via -r requirements.txt
 mpi4py==3.1.6 \
     --hash=sha256:1de7f6bd22ea6c9b1d6cb42e9d8092217552ffc8267f81df884b61f46aef557c \

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -1912,13 +1912,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via -r requirements.txt
 msal==1.31.1 \
     --hash=sha256:11b5e6a3f802ffd3a72107203e20c4eac6ef53401961b880af2835b723d80578 \

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -1850,7 +1850,7 @@ markdown==3.7 \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
     # via mlflow
-markdown-it-py==3.0.0 ; sys_platform != 'win32' \
+markdown-it-py==3.0.0 ; python_full_version < '3.11' or sys_platform != 'win32' \
     --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
     --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
     # via

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -2078,13 +2078,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via
     #   -r dockerfiles/mlrun-api/requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -17,5 +17,5 @@ aiosmtplib~=3.0
 # until https://github.com/fastapi/fastapi/issues/10360 is solved
 pydantic>=1,<2
 # ensure kfp is installed
-mlrun-pipelines-kfp-v1-8[kfp]~=0.3.7; python_version < "3.11"
+mlrun-pipelines-kfp-v1-8[kfp]~=0.3.8; python_version < "3.11"
 grpcio~=1.70.0

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -1962,13 +1962,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via
     #   -r dockerfiles/mlrun-kfp/requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/mlrun-kfp/requirements.txt
+++ b/dockerfiles/mlrun-kfp/requirements.txt
@@ -1,2 +1,2 @@
 -r ../../extras-requirements.txt
-mlrun-pipelines-kfp-v1-8[kfp]~=0.3.7; python_version < "3.11"
+mlrun-pipelines-kfp-v1-8[kfp]~=0.3.8; python_version < "3.11"

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -1910,13 +1910,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via -r requirements.txt
 mpi4py==3.1.6 \
     --hash=sha256:1de7f6bd22ea6c9b1d6cb42e9d8092217552ffc8267f81df884b61f46aef557c \

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -2418,13 +2418,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via
     #   -r dockerfiles/mlrun-api/requirements.txt
     #   -r dockerfiles/mlrun-kfp/requirements.txt

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -2184,7 +2184,7 @@ markdown==3.7 \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
     # via mlflow
-markdown-it-py==3.0.0 ; sys_platform != 'win32' \
+markdown-it-py==3.0.0 \
     --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
     --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
     # via

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -2421,13 +2421,13 @@ mlflow-skinny==2.20.2 \
     --hash=sha256:b46400c84d97e2d33b9e5c4c9e12d30b30abc2ffd32a0b6a05d2ca9d0a8becde \
     --hash=sha256:f2335fb3f18298ff81507451883012735e4276a90bf11ba116734cfe7996955e
     # via mlflow
-mlrun-pipelines-kfp-common==0.3.11 \
-    --hash=sha256:60152c3c6a1d3c5839df101c23b39994570f0da47d708bab24dc34b0a9b9e608 \
-    --hash=sha256:768e93df50a92fa757b3779b65cfabd55cfa87625f3436a1e75d66457868d7e3
+mlrun-pipelines-kfp-common==0.3.12 \
+    --hash=sha256:52e0b8b1b7e5302493d8c7425a2c298f63393c5f728e73cf22adf4a13c5cb76c \
+    --hash=sha256:c958ae14c021293b42dcc9bb42c1da4b1574f2bf2edd0489dbde63aa23a5c61f
     # via -r requirements.txt
-mlrun-pipelines-kfp-v1-8==0.3.7 ; python_full_version < '3.11' \
-    --hash=sha256:87c02c7822b97097fdde6a97328c611c86c3d197ee8662a598eb3a1545881812 \
-    --hash=sha256:ed00d039b8b1a8fab97966019ec0fcd41aaea589286525b81f7b384838937d9f
+mlrun-pipelines-kfp-v1-8==0.3.8 ; python_full_version < '3.11' \
+    --hash=sha256:8d9d97640bd8021137c4a8f19349a72b94249d4462a136ee183d846cb59bd641 \
+    --hash=sha256:b5290a1829fb5f3a19991f63c9e548935011d95e172890403ec83a44717f4500
     # via
     #   -r dockerfiles/mlrun-api/requirements.txt
     #   -r dockerfiles/mlrun-kfp/requirements.txt

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -2187,7 +2187,7 @@ markdown==3.7 \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
     # via mlflow
-markdown-it-py==3.0.0 ; sys_platform != 'win32' \
+markdown-it-py==3.0.0 \
     --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
     --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,8 +39,8 @@ deprecated~=1.2
 jinja2~=3.1, >=3.1.3
 orjson>=3.9.15, <4
 # mlrun pipeline adapters
-mlrun-pipelines-kfp-common~=0.3.11
-mlrun-pipelines-kfp-v1-8~=0.3.7; python_version < "3.11"
+mlrun-pipelines-kfp-common~=0.3.12
+mlrun-pipelines-kfp-v1-8~=0.3.8; python_version < "3.11"
 # uncomment when we make the switch to mlrun 1.9
 # mlrun-pipelines-kfp-v2~=0.3.7; python_version >= "3.11"
 docstring_parser~=0.16

--- a/tests/projects/test_kfp.py
+++ b/tests/projects/test_kfp.py
@@ -233,8 +233,6 @@ def test_kfp_pod_sets_gpu_resources_to_zero_when_gpu_requested(
     )
     gpu_type = "nvidia.com/gpu"
     function.with_limits(gpus=1, gpu_type=gpu_type)
-
-    # TODO: uncomment when new adapters are released
-    # cop = function.as_step()
-    # assert gpu_type in cop.container.resources.limits
-    # assert cop.container.resources.limits[gpu_type] == 0
+    cop = function.as_step()
+    assert gpu_type in cop.container.resources.limits
+    assert cop.container.resources.limits[gpu_type] == 0


### PR DESCRIPTION
Now with released kfp adapters changes

continue of https://github.com/mlrun/mlrun/pull/7307
https://iguazio.atlassian.net/browse/ML-9216

https://iguazio.atlassian.net/browse/ML-9403