### PR TITLE
[Functions] Change tag computation when the function is unversioned

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2508,7 +2508,7 @@ class SQLDB(DBInterface):
                 raise mlrun.errors.MLRunNotFoundError(
                     f"Function tag not found {function_uri}"
                 )
-        return tag_function_uid
+            return tag_function_uid
 
     @staticmethod
     def _compute_function_tag(tag: str, hash_key: str):

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2512,7 +2512,7 @@ class SQLDB(DBInterface):
 
     @staticmethod
     def _compute_function_tag(tag: str, hash_key: str):
-        if unversioned_tagged_object_uid_prefix in hash_key:
+        if hash_key and unversioned_tagged_object_uid_prefix in hash_key:
             computed_tag = tag or hash_key.split("-", maxsplit=1)[1]
             tag = computed_tag
         else:

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2457,7 +2457,7 @@ class SQLDB(DBInterface):
         format_: str = mlrun.common.formatters.FunctionFormat.full,
     ):
         project = project or config.default_project
-        computed_tag = tag or mlrun.common.constants.RESERVED_TAG_NAME_LATEST
+        tag, computed_tag = self._compute_function_tag(tag, hash_key)
 
         obj, uid = self._get_function_db_object(session, name, project, tag, hash_key)
         tag_function_uid = None if not tag and hash_key else uid
@@ -2496,7 +2496,7 @@ class SQLDB(DBInterface):
     def _get_function_uid(
         self, session, name: str, tag: str, hash_key: str, project: str
     ):
-        computed_tag = tag or mlrun.common.constants.RESERVED_TAG_NAME_LATEST
+        tag, computed_tag = self._compute_function_tag(tag, hash_key)
         if not tag and hash_key:
             return hash_key
         else:
@@ -2508,7 +2508,16 @@ class SQLDB(DBInterface):
                 raise mlrun.errors.MLRunNotFoundError(
                     f"Function tag not found {function_uri}"
                 )
-            return tag_function_uid
+        return tag_function_uid
+
+    @staticmethod
+    def _compute_function_tag(tag: str, hash_key: str):
+        if unversioned_tagged_object_uid_prefix in hash_key:
+            computed_tag = tag or hash_key.split("-", maxsplit=1)[1]
+            tag = computed_tag
+        else:
+            computed_tag = tag or mlrun.common.constants.RESERVED_TAG_NAME_LATEST
+        return tag, computed_tag
 
     def _delete_project_functions(self, session: Session, project: str):
         logger.debug("Removing project functions from db", project=project)

--- a/server/py/services/api/tests/unit/db/test_functions.py
+++ b/server/py/services/api/tests/unit/db/test_functions.py
@@ -18,6 +18,7 @@ import time
 import pytest
 
 import mlrun.errors
+from framework.db.sqldb.db import unversioned_tagged_object_uid_prefix
 
 from framework.db.sqldb.models import Function
 from framework.tests.unit.db.common_fixtures import TestDatabaseBase
@@ -103,6 +104,12 @@ class TestFunctions(TestDatabaseBase):
         )
         assert function_result_1 is not None
         assert function_result_1["metadata"]["tag"] == "latest"
+
+        function_result_2 = self._db.get_function(
+            self._db_session, function_1.metadata.name, hash_key=f"{unversioned_tagged_object_uid_prefix}latest"
+        )
+        assert function_result_2 is not None
+        assert function_result_2["metadata"]["tag"] == "latest"
 
         # not versioned so not queryable by hash key
         with pytest.raises(mlrun.errors.MLRunNotFoundError):

--- a/server/py/services/api/tests/unit/db/test_functions.py
+++ b/server/py/services/api/tests/unit/db/test_functions.py
@@ -18,8 +18,8 @@ import time
 import pytest
 
 import mlrun.errors
-from framework.db.sqldb.db import unversioned_tagged_object_uid_prefix
 
+from framework.db.sqldb.db import unversioned_tagged_object_uid_prefix
 from framework.db.sqldb.models import Function
 from framework.tests.unit.db.common_fixtures import TestDatabaseBase
 
@@ -106,7 +106,9 @@ class TestFunctions(TestDatabaseBase):
         assert function_result_1["metadata"]["tag"] == "latest"
 
         function_result_2 = self._db.get_function(
-            self._db_session, function_1.metadata.name, hash_key=f"{unversioned_tagged_object_uid_prefix}latest"
+            self._db_session,
+            function_1.metadata.name,
+            hash_key=f"{unversioned_tagged_object_uid_prefix}latest",
         )
         assert function_result_2 is not None
         assert function_result_2["metadata"]["tag"] == "latest"


### PR DESCRIPTION
In order to get the tag and the uid correctly when the retrieved function is unversioned , relevant to model endpoint.

related to https://iguazio.atlassian.net/browse/ML-9394