### PR TITLE
[Nuclio] Ensure project name on api put calls 

### DIFF
--- a/server/py/framework/utils/clients/nuclio.py
+++ b/server/py/framework/utils/clients/nuclio.py
@@ -61,7 +61,7 @@ class Client(
                 raise
             self._post_project_to_nuclio(body)
         else:
-            self._put_project_to_nuclio(body)
+            self._put_project_to_nuclio(name, body)
 
     def patch_project(
         self,
@@ -90,7 +90,7 @@ class Client(
             response_body.setdefault("spec", {})["description"] = project["spec"][
                 "description"
             ]
-        self._put_project_to_nuclio(response_body)
+        self._put_project_to_nuclio(name, response_body)
 
     def delete_project(
         self,
@@ -205,16 +205,18 @@ class Client(
         return self._send_request_to_api("GET", f"projects/{name}", auth_info=auth_info)
 
     def _post_project_to_nuclio(
-        self, body, auth_info: mlrun.common.schemas.AuthInfo = None
+        self, body: dict, auth_info: mlrun.common.schemas.AuthInfo = None
     ):
         return self._send_request_to_api(
             "POST", "projects", auth_info=auth_info, json=body
         )
 
     def _put_project_to_nuclio(
-        self, body, auth_info: mlrun.common.schemas.AuthInfo = None
+        self, name: str, body, auth_info: mlrun.common.schemas.AuthInfo = None
     ):
-        self._send_request_to_api("PUT", "projects", auth_info=auth_info, json=body)
+        self._send_request_to_api(
+            "PUT", f"projects/{name}", auth_info=auth_info, json=body
+        )
 
     def _send_request_to_api(
         self,

--- a/server/py/services/api/tests/unit/utils/clients/test_nuclio.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_nuclio.py
@@ -278,7 +278,9 @@ def test_store_project_update(
     requests_mock.get(
         f"{api_url}/api/projects/{project_name}", json=mocked_project_body
     )
-    requests_mock.put(f"{api_url}/api/projects", json=verify_store_update)
+    requests_mock.put(
+        f"{api_url}/api/projects/{project_name}", json=verify_store_update
+    )
     nuclio_client.store_project(
         None,
         project_name,
@@ -332,7 +334,7 @@ def test_patch_project(
     requests_mock.get(
         f"{api_url}/api/projects/{project_name}", json=mocked_project_body
     )
-    requests_mock.put(f"{api_url}/api/projects", json=verify_patch)
+    requests_mock.put(f"{api_url}/api/projects/{project_name}", json=verify_patch)
     nuclio_client.patch_project(
         None,
         project_name,
@@ -374,7 +376,7 @@ def test_patch_project_only_labels(
     requests_mock.get(
         f"{api_url}/api/projects/{project_name}", json=mocked_project_body
     )
-    requests_mock.put(f"{api_url}/api/projects", json=verify_patch)
+    requests_mock.put(f"{api_url}/api/projects/{project_name}", json=verify_patch)
     nuclio_client.patch_project(
         None,
         project_name,


### PR DESCRIPTION
Nuclio requires the project name as part of the update project request.

https://iguazio.atlassian.net/browse/ML-9410