### PR TITLE
[Artifacts] Ensure order on list_artifacts

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1654,12 +1654,11 @@ class SQLDB(DBInterface):
 
         outer_query = outer_query.join(subquery, ArtifactV2.id == subquery.c.id)
 
+        # join may lose order, make sure order is applied on outer as well
+        outer_query = outer_query.order_by(ArtifactV2.updated.desc())
+
         if not limit:
-            # When a limit is applied, the results are ordered before limiting, so no additional ordering is needed.
-            # If no limit is specified, ensure the results are ordered after all filtering and joins have been applied.
-            outer_query = self._paginate_query(
-                outer_query.order_by(ArtifactV2.updated.desc()), offset, limit=None
-            )
+            outer_query = self._paginate_query(outer_query, offset, limit=None)
 
         results = outer_query.all()
         if not attach_tags:

--- a/server/py/services/api/tests/unit/crud/test_artifacts.py
+++ b/server/py/services/api/tests/unit/crud/test_artifacts.py
@@ -1,0 +1,96 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import time
+import uuid
+
+import sqlalchemy.orm
+
+import mlrun.common.schemas.artifact
+
+import services.api.crud
+
+
+class TestArtifacts:
+    def test_list_artifacts(
+        self,
+        db: sqlalchemy.orm.Session,
+    ):
+        tree, key = "tree", "key"
+        project = "project-name"
+        artifact = self._generate_artifact(project, tree, key)
+        services.api.crud.Artifacts().store_artifact(
+            db,
+            artifact["spec"]["db_key"],
+            artifact,
+            project=project,
+        )
+        artifacts = services.api.crud.Artifacts().list_artifacts(
+            db, project, tag="*", limit=100
+        )
+        assert len(artifacts) == 1, "bad number of artifacts"
+
+        artifact_kinds = [
+            artifact_category.value
+            for artifact_category in mlrun.common.schemas.artifact.ArtifactCategories.all()
+        ]
+        for artifact_kind in artifact_kinds:
+            artifact = self._generate_artifact(project, tree, key, kind=artifact_kind)
+            time.sleep(0.01)
+            services.api.crud.Artifacts().store_artifact(
+                db,
+                artifact["spec"]["db_key"],
+                artifact,
+                project=project,
+            )
+
+        expected_length = len(artifact_kinds) + 1
+        artifacts = services.api.crud.Artifacts().list_artifacts(db, project, tag="*")
+        assert len(artifacts) == expected_length, "bad number of artifacts"
+
+        # validate ordering by checking that the first artifact is the latest one
+        assert artifacts[0]["kind"] == artifact_kinds[-1], "bad ordering"
+
+        # validate ordering by checking that list of returned artifacts is sorted
+        # by updated time in descending order
+        for i in range(1, len(artifacts)):
+            assert (
+                artifacts[i]["metadata"]["updated"]
+                <= artifacts[i - 1]["metadata"]["updated"]
+            ), "bad ordering"
+
+    @staticmethod
+    def _generate_artifact(
+        project,
+        tree,
+        key,
+        kind="artifact",
+        iter=None,
+    ):
+        artifact = {
+            "kind": kind,
+            "metadata": {
+                "key": key,
+                "tree": tree,
+                "uid": str(uuid.uuid4()),
+                "project": project,
+                "iter": iter or 0,
+                "tag": "latest",
+            },
+            "spec": {
+                "db_key": key,
+            },
+            "status": {},
+        }
+        return artifact

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -1557,12 +1557,16 @@ class TestArtifacts(TestDatabaseBase):
     @pytest.mark.parametrize("limit", [None, 6])
     def test_list_artifacts_returns_elements_by_order_updated_field(self, limit):
         project = "artifact_project"
+        artifact_kinds = ArtifactCategories.all()
 
         # Create artifacts
         number_of_artifacts = 10
         for counter in range(number_of_artifacts):
+            next_cyclic_item = artifact_kinds[counter % len(artifact_kinds)]
             artifact_key = f"artifact-{counter}"
-            artifact_body = self._generate_artifact(artifact_key, project=project)
+            artifact_body = self._generate_artifact(
+                artifact_key, project=project, kind=next_cyclic_item
+            )
             self._db.store_artifact(
                 self._db_session, artifact_key, artifact_body, project=project
             )
@@ -2605,6 +2609,7 @@ class TestArtifacts(TestDatabaseBase):
                 name=project_name,
             ),
             spec=mlrun.common.schemas.ProjectSpec(description="some-description"),
+            kind=mlrun.common.schemas.ObjectKind.project,
         )
         self._db.create_project(self._db_session, project)
 

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -203,8 +203,8 @@ class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
         artifacts = project.list_artifacts().to_objects()
         assert len(artifacts) == 2, f"Expected 2 artifacts, found {len(artifacts)}"
 
-        assert artifacts[1].tag == "latest"
-        assert artifacts[0].tag is None
+        assert artifacts[0].tag == "latest"
+        assert artifacts[1].tag is None
 
         # Assert attempting to retrieve an artifact with a URI missing the UID raises the expected error
         uri_without_uid = artifacts[0].uri.split("^")[0]

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -207,9 +207,9 @@ class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
         assert artifacts[1].tag is None
 
         # Assert attempting to retrieve an artifact with a URI missing the UID raises the expected error
-        uri_without_uid = artifacts[0].uri.split("^")[0]
+        uri_without_uid = artifacts[1].uri.split("^")[0]
         with pytest.raises(mlrun.errors.MLRunNotFoundError):
             project.get_store_resource(uri_without_uid)
 
         # Ensure we can retrieve the untagged artifact by its URI
-        assert project.get_store_resource(artifacts[0].uri)
+        assert project.get_store_resource(artifacts[1].uri)

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -15,6 +15,7 @@
 import os
 import pathlib
 import shutil
+import time
 import unittest.mock
 
 import pandas
@@ -39,9 +40,22 @@ class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
         artifact = mlrun.artifacts.Artifact(key, body, target_path="/a.txt")
 
         db.store_artifact(key, artifact, tree=tree, project=prj)
+        # to ensure order on updated_at field
+        time.sleep(0.01)
         db.store_artifact(key, artifact, tree=tree, project=prj, iter=42)
         artifacts = db.list_artifacts(project=prj, tag="*", tree=tree)
         assert len(artifacts) == 2, "bad number of artifacts"
+
+        # validate ordering by checking that list of returned artifacts is sorted
+        # by updated time in descending order
+        artifacts = db.list_artifacts(project=prj)
+        assert len(artifacts) == 2, "bad number of artifacts"
+        for i in range(1, len(artifacts)):
+            assert (
+                artifacts[i]["metadata"]["updated"]
+                <= artifacts[i - 1]["metadata"]["updated"]
+            ), "bad ordering"
+
         assert artifacts.to_objects()[0].key == key, "not a valid artifact object"
         assert artifacts.dataitems()[0].url, "not a valid artifact dataitem"
 


### PR DESCRIPTION
The list artifacts is compiled of 2 queries `SELECTS`.
- The `inner` one - which filters on the artifact table and returns only artifact id
- The `outer` one - which joins on the inner and returns the entire artifact row(s)

note: The reason we have both inner/outer is to optimize the amount of "data" being loading during the list_artifacts so we can scan the artifact table while keep memory footprint low

the bug is that the `outer` query loses the order during the `join` - the fix is to ensure the `order by` on the results

https://iguazio.atlassian.net/browse/ML-9408

