### PR TITLE
[Model Monitoring] Disable the Plotly artifact by default in the histogram app

### DIFF
--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -122,7 +122,10 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
     NAME: Final[str] = HistogramDataDriftApplicationConstants.NAME
 
     _REQUIRED_METRICS = {HellingerDistance, TotalVarianceDistance}
-    _STATS_TYPES: tuple[StatsKind] = (StatsKind.CURRENT_STATS, StatsKind.DRIFT_MEASURES)
+    _STATS_TYPES: tuple[StatsKind, StatsKind] = (
+        StatsKind.CURRENT_STATS,
+        StatsKind.DRIFT_MEASURES,
+    )
 
     metrics: list[type[HistogramDistanceMetric]] = [
         HellingerDistance,

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -102,10 +102,10 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
     Each metric is calculated over all the features individually and the mean is taken as the metric value.
     The average of Hellinger and total variance distance is taken as the result.
 
-    The application logs two artifacts:
+    The application can log two artifacts:
 
-    * A JSON with the general drift per feature.
-    * A plotly table different metrics per feature.
+    * JSON with the general drift value per feature, produced by default.
+    * Plotly table with the various metrics and histograms per feature, disabled by default due to performance issues.
 
     This application is deployed by default when calling:
 
@@ -114,6 +114,9 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         project.enable_model_monitoring()
 
     To avoid it, pass :code:`deploy_histogram_data_drift_app=False`.
+
+    If you want to change the application defaults, such as the classifier or which artifacts to produce, you
+    need to inherit from this class and deploy is as any other model monitoring application.
     """
 
     NAME: Final[str] = HistogramDataDriftApplicationConstants.NAME
@@ -127,7 +130,12 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         TotalVarianceDistance,
     ]
 
-    def __init__(self, value_classifier: Optional[ValueClassifier] = None) -> None:
+    def __init__(
+        self,
+        value_classifier: Optional[ValueClassifier] = None,
+        produce_json_artifact: bool = True,
+        produce_plotly_artifact: bool = False,
+    ) -> None:
         """
         :param value_classifier: Classifier object that adheres to the `ValueClassifier` protocol.
                                  If not provided, the default `DataDriftClassifier()` is used.
@@ -136,6 +144,9 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         assert self._REQUIRED_METRICS <= set(
             self.metrics
         ), "TVD and Hellinger distance are required for the general data drift result"
+
+        self._produce_json_artifact = produce_json_artifact
+        self._produce_plotly_artifact = produce_plotly_artifact
 
     def _compute_metrics_per_feature(
         self, monitoring_context: mm_context.MonitoringApplicationContext
@@ -310,25 +321,28 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         self,
         monitoring_context: mm_context.MonitoringApplicationContext,
         metrics_per_feature: DataFrame,
-        log_json_artifact: bool = True,
     ) -> None:
         """Log JSON and Plotly drift data per feature artifacts"""
+        if not self._produce_json_artifact and not self._produce_plotly_artifact:
+            return
+
         drift_per_feature_values = metrics_per_feature[
             [HellingerDistance.NAME, TotalVarianceDistance.NAME]
         ].mean(axis=1)
 
-        if log_json_artifact:
+        if self._produce_json_artifact:
             self._log_json_artifact(drift_per_feature_values, monitoring_context)
 
-        self._log_plotly_table_artifact(
-            sample_set_statistics=self._get_shared_features_sample_stats(
-                monitoring_context
-            ),
-            inputs_statistics=monitoring_context.feature_stats,
-            metrics_per_feature=metrics_per_feature,
-            drift_per_feature_values=drift_per_feature_values,
-            monitoring_context=monitoring_context,
-        )
+        if self._produce_plotly_artifact:
+            self._log_plotly_table_artifact(
+                sample_set_statistics=self._get_shared_features_sample_stats(
+                    monitoring_context
+                ),
+                inputs_statistics=monitoring_context.feature_stats,
+                metrics_per_feature=metrics_per_feature,
+                drift_per_feature_values=drift_per_feature_values,
+                monitoring_context=monitoring_context,
+            )
 
     def do_tracking(
         self, monitoring_context: mm_context.MonitoringApplicationContext

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -105,7 +105,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
     The application can log two artifacts:
 
     * JSON with the general drift value per feature, produced by default.
-    * Plotly table with the various metrics and histograms per feature, disabled by default due to performance issues.
+    * Plotly table with the various metrics and histograms per feature (disabled by default due to performance issues).
 
     This application is deployed by default when calling:
 
@@ -116,7 +116,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
     To avoid it, pass :code:`deploy_histogram_data_drift_app=False`.
 
     If you want to change the application defaults, such as the classifier or which artifacts to produce, you
-    need to inherit from this class and deploy is as any other model monitoring application.
+    need to inherit from this class and deploy it as any other model monitoring application.
     """
 
     NAME: Final[str] = HistogramDataDriftApplicationConstants.NAME

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -306,15 +306,15 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
             cast(str, key): (self._value_classifier.value_to_status(value), value)
             for key, value in drift_per_feature_values.items()
         }
-        monitoring_context.logger.debug("Logging plotly artifact")
-        monitoring_context.log_artifact(
-            mm_drift_table.FeaturesDriftTablePlot().produce(
-                sample_set_statistics=sample_set_statistics,
-                inputs_statistics=inputs_statistics,
-                metrics=metrics_per_feature.T.to_dict(),  # pyright: ignore[reportArgumentType]
-                drift_results=drift_results,
-            )
+        monitoring_context.logger.debug("Producing plotly artifact")
+        artifact = mm_drift_table.FeaturesDriftTablePlot().produce(
+            sample_set_statistics=sample_set_statistics,
+            inputs_statistics=inputs_statistics,
+            metrics=metrics_per_feature.T.to_dict(),  # pyright: ignore[reportArgumentType]
+            drift_results=drift_results,
         )
+        monitoring_context.logger.debug("Logging plotly artifact")
+        monitoring_context.log_artifact(artifact)
         monitoring_context.logger.debug("Logged plotly artifact successfully")
 
     def _log_drift_artifacts(

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -96,15 +96,15 @@ def plot_produce(context: mlrun.MLClientCtx):
             monitoring_context._feature_stats = inputs_statistics
             monitoring_context._sample_df_stats = sample_data_statistics
     # Initialize the app
-    application = histogram_data_drift.HistogramDataDriftApplication()
+    application = histogram_data_drift.HistogramDataDriftApplication(
+        produce_json_artifact=False, produce_plotly_artifact=True
+    )
     # Calculate drift
     metrics_per_feature = application._compute_metrics_per_feature(
         monitoring_context=monitoring_context,
     )
     application._log_drift_artifacts(
-        monitoring_context=monitoring_context,
-        metrics_per_feature=metrics_per_feature,
-        log_json_artifact=False,
+        monitoring_context=monitoring_context, metrics_per_feature=metrics_per_feature
     )
 
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -96,7 +96,7 @@ _DefaultDataDriftAppData = _AppData(
     deploy=False,
     results={"general_drift"},
     metrics={"hellinger_mean", "kld_mean", "tvd_mean"},
-    artifacts={"features_drift_results", "drift_table_plot"},
+    artifacts={"features_drift_results"},
 )
 
 

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1173,11 +1173,8 @@ class TestBatchDrift(TestMLRunSystemModelMonitoring):
                 "mlrun/endpoint-id": model_endpoint.metadata.uid,
             }
         )
-        assert len(artifacts) == 2
-        assert {art["metadata"]["key"] for art in artifacts} == {
-            "drift_table_plot",
-            "features_drift_results",
-        }
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["key"] == "features_drift_results"
 
 
 @TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured


### PR DESCRIPTION
Fixes [ML-9052](https://iguazio.atlassian.net/browse/ML-9052).

We found out that this artifact does not scale well for a large number of features, mainly due to the legacy `mlrun.model_monitoring.features_drift_table` module.
This PR disables producing this artifact by default and adapts the tests and documentation.

[ML-9052]: https://iguazio.atlassian.net/browse/ML-9052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ