### PR TITLE
[Workflows] Avoid sending client side completion notifications

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -1139,6 +1139,11 @@ def load_and_run_workflow(
         if "running" in notification.when
     ]
 
+    # Prevent redundant notifications for run completion by ensuring that notifications are only triggered when the run
+    # reaches the "running" state, as the server already handles the completion notifications.
+    for notification in start_notifications:
+        notification.when = ["running"]
+
     workflow_log_message = workflow_name or workflow_path
     context.logger.info(f"Running workflow {workflow_log_message} from remote")
     run = project.run(


### PR DESCRIPTION
Ensure that the client side does not send redundant notifications when the run is completed. 
Previously, the client triggered a notification for both "running" and "completed" states, even though the server already handles the "completion" notifications. 
This fix updates the client to only send notifications when the run is in "running" state.

Jira:
https://iguazio.atlassian.net/browse/ML-8064