### PR TITLE
[Model Monitoring] Create TDEngine DB if not exists each time we create the infra STABLES

### DIFF
--- a/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
+++ b/tests/model_monitoring/db/tsdb/tdengine/test_tdengine_connector.py
@@ -80,7 +80,6 @@ def test_write_application_event(
         "result_extra_data": """{"question": "Who wrote 'To Kill a Mockingbird'?"}""",
         "result_value": result_value,
     }
-    connector._create_connection()  # Recreate the connection to verify that the database exists
     connector.create_tables()
     connector.write_application_event(data)
     read_data_kwargs = {


### PR DESCRIPTION
Following #7331 we drop the TDEngine db if it's empty, which in other words means that we deleted a project with tsdb data and there are no more monitored projects in this db. Now, if the user would try to recreate a new project afterwards, he might face an issue which the DB doesn't exist (https://iguazio.atlassian.net/browse/ML-9436) because we use the same connection.
In this PR we address this issue by recreating the db if it doesn't exist each time we call `create_tables` instead of doing it once on the connection initialization. Note that this operation only occurs once during the project cycle when we set the credentials.
