### PR TITLE
[Alerts] Adjust timing in sliding window alert system test

### DIFF
--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -285,11 +285,8 @@ class TestAlerts(TestMLRunSystem):
             self.project.run_function(function_name)
 
         # wait for the periodic monitor runs function to run as it may take up to the maximum events_generation_interval
-        # to detect the event.
-        time.sleep(mlconf.alerts.events_generation_interval)
-
-        # Wait for more than half minute to simulate a delay that is slightly longer than the alert period
-        time.sleep(32)
+        # to detect the event + an extra 40s to simulate a delay that is slightly longer than the alert period
+        time.sleep(mlconf.alerts.events_generation_interval + 40)
 
         # this is the second failure
         with pytest.raises(Exception):

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -266,7 +266,7 @@ class TestAlerts(TestMLRunSystem):
         # create an alert with webhook notification that should trigger when the job fails twice in two minutes
         alert_name = "failure-webhook"
         alert_summary = "Job failed"
-        alert_criteria = alert_objects.AlertCriteria(period="1m", count=2)
+        alert_criteria = alert_objects.AlertCriteria(period="30s", count=2)
         run_id = f"{function_name}-handler"
         notifications = self._generate_failure_notifications(nuclio_function_url)
 
@@ -289,7 +289,7 @@ class TestAlerts(TestMLRunSystem):
         time.sleep(mlconf.alerts.events_generation_interval)
 
         # Wait for more than one minute to simulate a delay that is slightly longer than the alert period
-        time.sleep(62)
+        time.sleep(32)
 
         # this is the second failure
         with pytest.raises(Exception):
@@ -309,7 +309,7 @@ class TestAlerts(TestMLRunSystem):
         # validate that the alert was triggered and the notification was sent
         expected_notifications = ["notification failure"]
 
-        # wait since there is a might be a delay
+        # wait since there might be a delay
         mlrun.utils.retry_until_successful(
             3,
             10 * 3,

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -288,7 +288,7 @@ class TestAlerts(TestMLRunSystem):
         # to detect the event.
         time.sleep(mlconf.alerts.events_generation_interval)
 
-        # Wait for more than one minute to simulate a delay that is slightly longer than the alert period
+        # Wait for more than half minute to simulate a delay that is slightly longer than the alert period
         time.sleep(32)
 
         # this is the second failure

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -266,7 +266,7 @@ class TestAlerts(TestMLRunSystem):
         # create an alert with webhook notification that should trigger when the job fails twice in two minutes
         alert_name = "failure-webhook"
         alert_summary = "Job failed"
-        alert_criteria = alert_objects.AlertCriteria(period="2m", count=2)
+        alert_criteria = alert_objects.AlertCriteria(period="1m", count=2)
         run_id = f"{function_name}-handler"
         notifications = self._generate_failure_notifications(nuclio_function_url)
 
@@ -284,15 +284,16 @@ class TestAlerts(TestMLRunSystem):
         with pytest.raises(Exception):
             self.project.run_function(function_name)
 
-        # Wait for more than two minutes to simulate a delay that is slightly longer than the alert period
-        time.sleep(125)
+        # wait for the periodic monitor runs function to run as it may take up to the maximum events_generation_interval
+        # to detect the event.
+        time.sleep(mlconf.alerts.events_generation_interval)
+
+        # Wait for more than one minute to simulate a delay that is slightly longer than the alert period
+        time.sleep(62)
 
         # this is the second failure
         with pytest.raises(Exception):
             self.project.run_function(function_name)
-
-        # wait since there is a might be a delay
-        time.sleep(mlconf.alerts.events_generation_interval)
 
         # validate that no notifications were sent yet, as the two failures did not occur within the same period
         expected_notifications = []


### PR DESCRIPTION
This PR fixes a timing issue that occured in the `test_job_failure_alert_sliding_window` test to properly account for the periodic run monitor. 
The bug in the system test occurred because the test did not consider the delay introduced by the run monitor, which checks for job failures periodically. As a result, the second failure in the test was detected within the alert window, causing a  notification to be sent wrongly.

To fix this, the `time.sleep(mlconf.alerts.events_generation_interval)` was moved before the second failure, allowing the monitoring system sufficient time to detect the first failure. 
This ensures the alerting mechanism functions as expected and prevents false notifications.

Also, the alert period was minimized to 30 seconds to shorten the sleeps and the test duration.