### PR TITLE
[Docs] Add instructions for formatting bulleted lists in docstrings and spaces at the end of lines in .md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,7 +327,7 @@ def function_name(parameter1, parameter2):
 	# Function implementation
 ```
 
-Bulleted lists in docstrings do not throw an error if they are incorrectly formatted. Publish the doc locally to 
+Bulleted lists in docstrings do not throw an error if they are incorrectly formatted. Build the doc locally to 
 check the formatting. The basic rules are:
 - Add a blank line before and after bulleted lines
 - Nested bulleted lists also need a blank line before and after

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,6 +327,31 @@ def function_name(parameter1, parameter2):
 	# Function implementation
 ```
 
+Bulleted lists in docstrings do not throw an error if they are incorrectly formatted. Publish the doc locally to 
+check the formatting. The basic rules are:
+- Add a blank line before and after bulleted lines
+- Nested bulleted lists also need a blank line before and after
+- If the text of the bullet exceeds one line, indent the second line by 2 spaces.
+Example:
+```
+        :param creation_strategy: Strategy for creating or updating the model endpoint:
+
+                           - **overwrite**:
+                           
+                           1. If model endpoints with the same name exist, delete the `latest` one.
+                           2. Create a new model endpoint entry and set it as `latest`.
+
+                           - **inplace** (default):
+                           
+                           1. If model endpoints with the same name exist, update the `latest` entry.
+                           2. Otherwise, create a new entry.
+
+        :param labels: Filter artifacts by label key-value pairs or key existence. This can be provided as:
+                       - A dictionary in the format `{"label": "value"}` to match specific label key-value pairs,
+                         or `{"label": None}` to check for key existence.
+                         
+        :param since: Not in use in :py:class:`HTTPRunDB`.					
+```
 15. When calling functions with multiple parameters, prefer using keyword arguments to improve readability and clarity.
 16. Logging: use structured variable instead of f-strings, for example: `logger.debug("Message", var1=var1, ...)`, and
 try to avoid logging large objects which are hard to decipher.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,6 +347,7 @@ Example:
                            2. Otherwise, create a new entry.
 
         :param labels: Filter artifacts by label key-value pairs or key existence. This can be provided as:
+
                        - A dictionary in the format `{"label": "value"}` to match specific label key-value pairs,
                          or `{"label": None}` to check for key existence.
                          

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,6 +35,14 @@ Ask @yaronha to add you to the project if you don't have access.
 
 The master file is `docs/contents.rst`
 
+## Spaces and line breaks
+- If there are 2 spaces at the end of a line, it breaks to the next line in the same paragraph.
+- If there is one space, the text just continues and the publishing creates the appropriate line break.
+
+## Lists
+- Use numbered lists for steps that are executed in a specific order.
+- Use bullets for lists that have no specific order.
+
 ## Language (usage) guidelines
 
 **One idea per sentence**<br>
@@ -67,10 +75,6 @@ It depends on your sentence. Use **which** after a comma.
 - Yes: There is also an open marketplace that stores many pre-developed functions for...
 - Yes: If you update the project object you need to run project.save(), which updates the project.yaml file....
 - No: There is also an open marketplace which stores many pre-developed functions for...
-
-**Lists**<br>
-- Use numbered lists for steps that are executed in a specific order.
-- Use bullets for lists that have no specific order.
 
 **Tense**<br>
 Use present, active tense.


### PR DESCRIPTION
Bulleted lists in docstrings that are not formatted correctly don't necessarily generate an error. But they publish as one sentence instead of a bulleted list, are hard to read, and do not give the correct visual indications of there choices an MLRun user can make. This PR adds an example of a well-formatted bulleted list and nested bulleted list.
The PR also adds a description of how spaces at the end of a line in .md files are interpreted during publishing