### PR TITLE
[Model Monitoring] Reuse the existing MM application `kafka topic` if it already exists

### DIFF
--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -575,6 +575,7 @@ def _deploy_nuclio_runtime(
                 function=fn,
                 function_name=fn.metadata.name,
                 stream_args=config.model_endpoint_monitoring.application_stream_args,
+                ignore_stream_already_exists_failure=True,
             )
 
         if serving_to_monitor:


### PR DESCRIPTION
When the user redeploy the model monitoring app and the topic is already exists (e.g., was generated in a previous deployment which eventually failed), we will reuse the existing topic with the `earliest` policy. This means the app pod will consume all data pushed during the "pre-deployment" period within the retention window once it starts.

https://iguazio.atlassian.net/browse/ML-9470