### PR TITLE
[System tests] Register artifacts before running pipeline

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -127,6 +127,7 @@ class TestProject(TestMLRunSystem):
             project=proj.to_yaml(),
         )
         proj.save()
+        proj.register_artifacts()
         return proj
 
     def test_project_persists_function_changes(self):


### PR DESCRIPTION
Since we are no longer reading the project yaml in a remote pipeline but rather get it from the DB, we also don't register the local artifacts. Therefore it is now required to register/save them before running the pipelines.

https://iguazio.atlassian.net/browse/ML-9474