### PR TITLE
[Workflows] Fix set workflow to avoid looking for remote paths locally

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1412,7 +1412,9 @@ class MlrunProject(ModelObj):
         """
 
         # validate the provided workflow_path
-        self._validate_file_path(workflow_path, param_name="workflow_path")
+        self._validate_file_path(
+            workflow_path, param_name="workflow_path", engine=engine
+        )
 
         if engine and "local" in engine and schedule:
             raise ValueError("'schedule' argument is not supported for 'local' engine.")
@@ -5241,7 +5243,7 @@ class MlrunProject(ModelObj):
             if is_remote_enriched:
                 self.spec.repo.remotes[remote].set_url(clean_remote, enriched_remote)
 
-    def _validate_file_path(self, file_path: str, param_name: str):
+    def _validate_file_path(self, file_path: str, param_name: str, engine: str):
         """
         The function checks if the given file_path is a valid path.
         If the file_path is a relative path, it is completed by joining it with the self.spec.get_code_path()
@@ -5266,10 +5268,7 @@ class MlrunProject(ModelObj):
                 f"Invalid '{param_name}': '{file_path}'. Got a remote URL without a file suffix."
             )
 
-        _, in_context = self.get_item_absolute_path(file_path)
-
-        # if the file source is remote then skip the local file validation
-        if in_context and self.spec.source:
+        if engine and not engine.startswith("remote"):
             return
 
         code_path = self.spec.get_code_path()

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -5268,6 +5268,7 @@ class MlrunProject(ModelObj):
                 f"Invalid '{param_name}': '{file_path}'. Got a remote URL without a file suffix."
             )
 
+        # if engine is remote then skip the local file validation
         if engine and not engine.startswith("remote"):
             return
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -5266,6 +5266,12 @@ class MlrunProject(ModelObj):
                 f"Invalid '{param_name}': '{file_path}'. Got a remote URL without a file suffix."
             )
 
+        _, in_context = self.get_item_absolute_path(file_path)
+
+        # if the file source is remote then skip the local file validation
+        if in_context and self.spec.source:
+            return
+
         code_path = self.spec.get_code_path()
 
         # If the file path is a relative path, it is completed by joining it with the code_path.

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1502,7 +1502,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
 
 
 @pytest.mark.parametrize(
-    "workflow_path,exception",
+    "workflow_path,exception,engine",
     [
         (
             "./",
@@ -1515,6 +1515,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                     )
                 ),
             ),
+            None,
         ),
         (
             "https://test",
@@ -1526,6 +1527,7 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                     )
                 ),
             ),
+            None,
         ),
         (
             "",
@@ -1533,25 +1535,48 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
                 mlrun.errors.MLRunInvalidArgumentError,
                 match=str(re.escape("workflow_path must be provided.")),
             ),
+            None,
         ),
-        ("https://test.py", does_not_raise()),
+        ("https://test.py", does_not_raise(), None),
         # relative path
-        ("./workflow.py", does_not_raise()),
-        ("./assets/handler.py", does_not_raise()),
+        ("./workflow.py", does_not_raise(), None),
+        ("./assets/handler.py", does_not_raise(), None),
         # only file name
-        ("workflow.py", does_not_raise()),
-        ("assets/handler.py", does_not_raise()),
+        ("workflow.py", does_not_raise(), None),
+        ("assets/handler.py", does_not_raise(), None),
         # absolute path
         (
             str(pathlib.Path(__file__).parent / "assets" / "handler.py"),
             does_not_raise(),
+            None,
         ),
+        # absolute path that doesn't exist
+        (
+            str(pathlib.Path("/non_existing_file.py")),
+            pytest.raises(
+                mlrun.errors.MLRunInvalidArgumentError,
+                match=str(
+                    re.escape(
+                        "Invalid 'workflow_path': '/non_existing_file.py'. Got a path to a non-existing file. "
+                        "Path must be absolute or relative to the project code path i.e. "
+                        "<project.spec.get_code_path()>/<workflow_path>)."
+                    )
+                ),
+            ),
+            None,
+        ),
+        # relative path with engine="remote", should not raise an error since the file does not need to exist locally
+        ("./workflow.py", does_not_raise(), "remote"),
+        ("./workflow.py", does_not_raise(), "remote:local"),
+        ("./workflow.py", does_not_raise(), "remote:kfp"),
     ],
 )
-def test_set_workflow_path_validation(chdir_to_test_location, workflow_path, exception):
+def test_set_workflow_path_validation(
+    chdir_to_test_location, workflow_path, exception, engine
+):
     proj = mlrun.new_project("proj", save=False)
     with exception:
-        proj.set_workflow("main", workflow_path)
+        proj.set_workflow("main", workflow_path, engine=engine)
 
 
 def test_set_workflow_local_engine():

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1729,21 +1729,6 @@ class TestProject(TestMLRunSystem):
             len(notifications) == 2
         ), f"Expected 2 notifications, got {len(notifications)}"
 
-    def test_set_and_run_remote_workflow(self):
-        """
-        This test verifies that a workflow can be set and executed remotely when the project source
-        is a remote repository (e.g., a Git repository) and the function files are not present locally.
-        """
-        project_name = "my-project"
-        source = "git://github.com/mlrun/project-demo.git#main"
-        project = mlrun.new_project(project_name, overwrite=True)
-
-        project.set_source(source=source)
-        project.set_workflow(name="main", workflow_path="./kflow.py", engine="remote")
-        run = project.run("main", engine="remote", source=source)
-        mlrun.wait_for_pipeline_completion(run)
-        assert run.state == mlrun.run.RunStatuses.succeeded
-
     @staticmethod
     def _generate_pipeline_notifications(
         nuclio_function_url: str,

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1732,7 +1732,7 @@ class TestProject(TestMLRunSystem):
     def test_set_and_run_remote_workflow(self):
         """
         This test verifies that a workflow can be set and executed remotely when the project source
-        is a remote repository (e.g., a Git repository).
+        is a remote repository (e.g., a Git repository) and the function files are not present locally.
         """
         project_name = "my-project"
         source = "git://github.com/mlrun/project-demo.git#main"

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1735,11 +1735,12 @@ class TestProject(TestMLRunSystem):
         is a remote repository (e.g., a Git repository).
         """
         project_name = "my-project"
-        self.custom_project_names_to_delete.append(project_name)
-        project = self._load_remote_pipeline_project(name=project_name)
+        source = "git://github.com/mlrun/project-demo.git#main"
+        project = mlrun.new_project(project_name, overwrite=True)
 
+        project.set_source(source=source)
         project.set_workflow(name="main", workflow_path="./kflow.py", engine="remote")
-        run = project.run("main", engine="remote")
+        run = project.run("main", engine="remote", source=source)
         mlrun.wait_for_pipeline_completion(run)
         assert run.state == mlrun.run.RunStatuses.succeeded
 

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1729,6 +1729,20 @@ class TestProject(TestMLRunSystem):
             len(notifications) == 2
         ), f"Expected 2 notifications, got {len(notifications)}"
 
+    def test_set_and_run_remote_workflow(self):
+        """
+        This test verifies that a workflow can be set and executed remotely when the project source
+        is a remote repository (e.g., a Git repository).
+        """
+        project_name = "my-project"
+        self.custom_project_names_to_delete.append(project_name)
+        project = self._load_remote_pipeline_project(name=project_name)
+
+        project.set_workflow(name="main", workflow_path="./kflow.py", engine="remote")
+        run = project.run("main", engine="remote")
+        mlrun.wait_for_pipeline_completion(run)
+        assert run.state == mlrun.run.RunStatuses.succeeded
+
     @staticmethod
     def _generate_pipeline_notifications(
         nuclio_function_url: str,


### PR DESCRIPTION
This fix ensures that `set_workflow` does not look for the workflow file locally when the project source points to a remote source (e.g., Git). 
Previously, the workflow file was always expected to exist locally, causing failures when using remote sources.

Jira:
https://iguazio.atlassian.net/browse/ML-9442