### PR TITLE
[System tests] Decouple dask system tests

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -33,6 +33,14 @@ import mlrun.launcher.factory
 import mlrun.utils.helpers
 import mlrun.utils.notifications
 import mlrun.utils.regex
+from mlrun.model import (
+    BaseMetadata,
+    HyperParamOptions,
+    ImageBuilder,
+    ModelObj,
+    RunObject,
+    RunTemplate,
+)
 from mlrun.utils.helpers import generate_object_uri, verify_field_regex
 from mlrun_pipelines.common.ops import mlrun_op
 
@@ -40,7 +48,6 @@ from ..config import config
 from ..datastore import store_manager
 from ..errors import err_to_str
 from ..lists import RunList
-from ..model import BaseMetadata, HyperParamOptions, ImageBuilder, ModelObj, RunObject
 from ..utils import (
     dict_to_json,
     dict_to_yaml,
@@ -668,7 +675,7 @@ class BaseRuntime(ModelObj):
 
     def as_step(
         self,
-        runspec: RunObject = None,
+        runspec: Union[RunObject, RunTemplate] = None,
         handler=None,
         name: str = "",
         project: str = "",

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -14,6 +14,8 @@
 #
 import datetime
 import os
+import random
+import string
 
 import kfp
 import kfp.compiler
@@ -40,7 +42,7 @@ class TestDask(TestMLRunSystem):
         self._logger.debug("Creating dask function")
 
     def test_dask(self):
-        dask_function = self._generate_dask_function("my-dask-1")
+        dask_function = self._generate_dask_function()
         run_object = dask_function.run(handler="main", params={"x": 12})
         self._logger.debug("Finished running task", run_object=run_object.to_dict())
 
@@ -73,7 +75,7 @@ class TestDask(TestMLRunSystem):
         assert run_object.state() == "completed"
 
     def test_run_pipeline(self):
-        dask_function = self._generate_dask_function("my-dask-2")
+        dask_function = self._generate_dask_function()
 
         @kfp.dsl.pipeline(name="dask_pipeline")
         def dask_pipe(x=1, y=10):
@@ -107,7 +109,7 @@ class TestDask(TestMLRunSystem):
         self._verify_run_metadata(
             run["metadata"],
             uid=run_uid,
-            name="my-dask-2-main",
+            name=f"{dask_function.metadata.name}-main",
             project=self.project_name,
             labels={
                 mlrun_constants.MLRunInternalLabels.v3io_user: self._test_env[
@@ -130,8 +132,7 @@ class TestDask(TestMLRunSystem):
         os.remove("daskpipe.yaml")
 
     def test_dask_close(self):
-        dask_function_name = "my-dask-3"
-        dask_function = self._generate_dask_function(dask_function_name)
+        dask_function = self._generate_dask_function()
         self._logger.info("Initializing dask cluster")
         cluster_start_time = datetime.datetime.now()
 
@@ -157,7 +158,7 @@ class TestDask(TestMLRunSystem):
             self._logger,
             True,
             self._wait_for_dask_cluster_to_shutdown,
-            dask_function_name,
+            dask_function.metadata.name,
         )
 
         # Client supposed to be closed
@@ -168,7 +169,10 @@ class TestDask(TestMLRunSystem):
         with pytest.raises(AttributeError):
             client.restart()
 
-    def _generate_dask_function(self, function_name: str):
+    def _generate_dask_function(self):
+        function_name = (
+            f"my-dask-{random.choices(string.ascii_letters + string.digits, k=4)}"
+        )
         dask_function = code_to_function(
             function_name,
             kind="dask",

--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -38,20 +38,10 @@ from tests.system.base import TestMLRunSystem
 class TestDask(TestMLRunSystem):
     def custom_setup(self):
         self._logger.debug("Creating dask function")
-        self.dask_function = code_to_function(
-            "mydask",
-            kind="dask",
-            filename=str(self.assets_path / "dask_function.py"),
-        ).apply(mount_v3io())
-
-        self.dask_function.spec.image = "mlrun/ml-base"
-        self.dask_function.spec.remote = True
-        self.dask_function.spec.replicas = 1
-        self.dask_function.spec.service_type = "NodePort"
-        self.dask_function.spec.command = str(self.assets_path / "dask_function.py")
 
     def test_dask(self):
-        run_object = self.dask_function.run(handler="main", params={"x": 12})
+        dask_function = self._generate_dask_function("my-dask-1")
+        run_object = dask_function.run(handler="main", params={"x": 12})
         self._logger.debug("Finished running task", run_object=run_object.to_dict())
 
         run_uid = run_object.uid()
@@ -83,10 +73,12 @@ class TestDask(TestMLRunSystem):
         assert run_object.state() == "completed"
 
     def test_run_pipeline(self):
+        dask_function = self._generate_dask_function("my-dask-2")
+
         @kfp.dsl.pipeline(name="dask_pipeline")
         def dask_pipe(x=1, y=10):
             # use_db option will use a function (DB) pointer instead of adding the function spec to the YAML
-            self.dask_function.as_step(
+            dask_function.as_step(
                 new_task(handler="main", name="dask_pipeline", params={"x": x, "y": y}),
                 use_db=True,
             )
@@ -115,7 +107,7 @@ class TestDask(TestMLRunSystem):
         self._verify_run_metadata(
             run["metadata"],
             uid=run_uid,
-            name="mydask-main",
+            name="my-dask-2-main",
             project=self.project_name,
             labels={
                 mlrun_constants.MLRunInternalLabels.v3io_user: self._test_env[
@@ -138,23 +130,25 @@ class TestDask(TestMLRunSystem):
         os.remove("daskpipe.yaml")
 
     def test_dask_close(self):
+        dask_function_name = "my-dask-3"
+        dask_function = self._generate_dask_function(dask_function_name)
         self._logger.info("Initializing dask cluster")
         cluster_start_time = datetime.datetime.now()
 
         # initialize the dask cluster and get its dashboard url
-        client = self.dask_function.client
+        client = dask_function.client
         time_took = (datetime.datetime.now() - cluster_start_time).seconds
         self._logger.info(
             "Dask cluster initialization completed", took_in_seconds=time_took
         )
 
         worker_start_time = datetime.datetime.now()
-        client.wait_for_workers(self.dask_function.spec.replicas)
+        client.wait_for_workers(dask_function.spec.replicas)
         time_took = (datetime.datetime.now() - worker_start_time).seconds
         self._logger.info("Workers initialization completed", took_in_seconds=time_took)
 
         self._logger.info("Shutting Down Cluster")
-        self.dask_function.close()
+        dask_function.close()
 
         # wait for the dask cluster to completely shut down
         mlrun.utils.retry_until_successful(
@@ -163,7 +157,7 @@ class TestDask(TestMLRunSystem):
             self._logger,
             True,
             self._wait_for_dask_cluster_to_shutdown,
-            "mydask",
+            dask_function_name,
         )
 
         # Client supposed to be closed
@@ -174,6 +168,20 @@ class TestDask(TestMLRunSystem):
         with pytest.raises(AttributeError):
             client.restart()
 
+    def _generate_dask_function(self, function_name: str):
+        dask_function = code_to_function(
+            function_name,
+            kind="dask",
+            filename=str(self.assets_path / "dask_function.py"),
+        ).apply(mount_v3io())
+
+        dask_function.spec.image = "mlrun/ml-base"
+        dask_function.spec.remote = True
+        dask_function.spec.replicas = 1
+        dask_function.spec.service_type = "NodePort"
+        dask_function.spec.command = str(self.assets_path / "dask_function.py")
+        return dask_function
+
     def _wait_for_dask_cluster_to_shutdown(self, dask_cluster_name):
         runtime_resources = mlrun.get_run_db().list_runtime_resources(
             project=self.project_name,
@@ -183,9 +191,12 @@ class TestDask(TestMLRunSystem):
         resources = runtime_resources[0].resources
         # Waiting for workers to be removed and scheduler status to completed
         if len(resources.pod_resources) > 1:
+            pod_resource_dicts = [
+                pod_resource.json() for pod_resource in resources.pod_resources
+            ]
             self._logger.info(
                 "Waiting for cluster to shut down",
-                pod_resources=resources.pod_resources,
+                pod_resource_dicts=pod_resource_dicts,
             )
             raise mlrun.errors.MLRunRuntimeError("Cluster did not completely clean up")
 


### PR DESCRIPTION
We see `tests_dask_close` keeps failing due to dask pipeline that failed with image pull backoff and kfp keeps retrying it automatically.
The test checks if there is more than 1 pod in the dask cluster and it gets more because of that pipeline from another test.
The following fixes should resolve the issue:
* Remove all dask pipeline runs from kfp so it will stop retiring it.
* Change the dask cluster name between tests to decouple them.