### PR TITLE
[Remote] Fix trigger nuclio version validation for `unstable`

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -306,9 +306,12 @@ class RemoteRuntime(KubeResource):
     def _validate_triggers(self, spec):
         # ML-7763 / NUC-233
         min_nuclio_version = "1.13.12"
-        if mlconf.nuclio_version and semver.VersionInfo.parse(
+        if (
             mlconf.nuclio_version
-        ) < semver.VersionInfo.parse(min_nuclio_version):
+            and mlconf.nuclio_version != "unstable"
+            and semver.VersionInfo.parse(mlconf.nuclio_version)
+            < semver.VersionInfo.parse(min_nuclio_version)
+        ):
             explicit_ack_enabled = False
             num_triggers = 0
             trigger_name = spec.get("name", "UNKNOWN")

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1827,8 +1827,15 @@ class TestNuclioRuntime(TestRuntimeBase):
                 nuclio.triggers.V3IOStreamTrigger(explicit_ack_mode="explicitOnly"),
             )
 
-    def test_multiple_stream_triggers_new_nuclio_explicit_ack(self):
-        mlconf.nuclio_version = "1.13.12"
+    @pytest.mark.parametrize(
+        "nuclio_version",
+        [
+            "1.13.12",
+            "unstable",
+        ],
+    )
+    def test_multiple_stream_triggers_new_nuclio_explicit_ack(self, nuclio_version):
+        mlconf.nuclio_version = nuclio_version
         function = self._generate_runtime(self.runtime_kind)
         function.add_trigger(
             "stream1",


### PR DESCRIPTION
When Nuclio version is `unstable`, don't break on semver parsing and assume version > 1.13.12 (The min version that doesn't require validation).