### PR TITLE
[CI] Fix failures intermediate failures

### DIFF
--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -165,14 +165,17 @@ def clone_git(url: str, context: str, secrets=None, clone: bool = True):
 
     branch = None
     tag = None
+    commit = None
     if url_obj.fragment:
         refs = url_obj.fragment
         if refs.startswith("refs/heads/"):
             branch = refs.replace("refs/heads/", "")
         elif refs.startswith("refs/tags/"):
             tag = refs.replace("refs/tags/", "")
+        elif refs.startswith("refs/commits/"):
+            commit = refs.replace("refs/commits/", "")
         else:
-            url = url.replace("#" + refs, f"#refs/heads/{refs}")
+            url = url.replace(f"#{refs}", f"#refs/heads/{refs}")
             branch = refs
 
     # when using the CLI and clone path was not enriched, username/password input will be requested via shell
@@ -182,8 +185,8 @@ def clone_git(url: str, context: str, secrets=None, clone: bool = True):
         # override enriched clone path for security reasons
         repo.remotes[0].set_url(clone_path, final_clone_path)
 
-    if tag:
-        repo.git.checkout(tag)
+    if tag_or_commit := tag or commit:
+        repo.git.checkout(tag_or_commit)
 
     return url, repo
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -286,7 +286,7 @@ def test_build_project_from_minimal_dict():
             "",
         ),
         (
-            "git://github.com/mlrun/project-demo.git#refs/heads/main",
+            "git://github.com/mlrun/project-demo.git#refs/commits/38699adc4016bf29d1f4ab11ddd70dcc4e569388",
             "pipe",
             ["prep_data.py", "project.yaml", "kflow.py", "newflow.py"],
             True,
@@ -356,7 +356,7 @@ def test_build_project_from_minimal_dict():
             "projects/assets/body.txt' already exists and is not an empty directory",
         ),
         (
-            "git://github.com/mlrun/project-demo.git#refs/heads/main",
+            "git://github.com/mlrun/project-demo.git#refs/commits/38699adc4016bf29d1f4ab11ddd70dcc4e569388",
             "pipe",
             ["prep_data.py", "project.yaml", "kflow.py", "newflow.py"],
             False,
@@ -565,29 +565,29 @@ def test_project_setup_must_return_project_object(
 
 
 @pytest.mark.parametrize(
-    "sync,expected_num_of_funcs, save",
+    "sync, has_functions, save",
     [
         (
             False,
-            0,
+            False,
             False,
         ),
         (
             True,
-            5,
+            True,
             False,
         ),
         (
             True,
-            5,
+            True,
             True,
         ),
     ],
 )
 def test_load_project_and_sync_functions(
-    context, rundb_mock, sync, expected_num_of_funcs, save
+    context, rundb_mock, sync, has_functions, save
 ):
-    url = "git://github.com/mlrun/project-demo.git"
+    url = "git://github.com/mlrun/project-demo.git#refs/commits/38699adc4016bf29d1f4ab11ddd70dcc4e569388"
     project = mlrun.load_project(
         context=str(context),
         url=url,
@@ -595,16 +595,15 @@ def test_load_project_and_sync_functions(
         save=save,
         allow_cross_project=True,
     )
-    assert len(project.spec._function_objects) == expected_num_of_funcs
+    assert has_functions == (len(project.spec._function_objects) > 0)
 
     if sync:
         function_names = project.spec._function_definitions.keys()
-        assert len(function_names) == expected_num_of_funcs
-        for func in function_names:
-            fn = project.get_function(func)
-            normalized_name = mlrun.utils.helpers.normalize_name(func)
+        assert has_functions == (len(function_names) > 0)
+        for function_name in function_names:
+            fn = project.get_function(function_name)
+            normalized_name = mlrun.utils.helpers.normalize_name(function_name)
             assert fn.metadata.name == normalized_name, "func did not return"
-
             if save:
                 assert normalized_name in rundb_mock._functions
 

--- a/tests/projects/test_project_create.py
+++ b/tests/projects/test_project_create.py
@@ -22,48 +22,48 @@ import pytest
 import mlrun
 from tests.conftest import out_path
 
-project_dir = f"{out_path}/project_dir"
-
 
 class TestNewProject:
-    def setup_method(self, method):
-        self.assets_path = (
-            pathlib.Path(sys.modules[self.__module__].__file__).absolute().parent
+    @classmethod
+    def setup_class(cls):
+        cls.assets_path = (
+            pathlib.Path(sys.modules[cls.__module__].__file__).absolute().parent
             / "assets"
         )
+        cls.project_dir = f"{out_path}/project_dir"
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.project_dir, ignore_errors=True)
 
     def test_yaml_template(self):
         project = mlrun.new_project(
             "newproj",
-            "./",
             from_template=str(self.assets_path / "project.yaml"),
             save=False,
         )
         assert project.spec.description == "test", "failed to load yaml template"
 
     def test_zip_template(self):
-        shutil.rmtree(project_dir, ignore_errors=True)
         project = mlrun.new_project(
             "newproj2",
-            project_dir,
+            self.project_dir,
             from_template=str(self.assets_path / "project.zip"),
             save=False,
         )
         assert project.spec.description == "test", "failed to load yaml template"
 
-        filepath = os.path.join(project_dir, "prep_data.py")
+        filepath = os.path.join(self.project_dir, "prep_data.py")
         assert os.path.isfile(filepath), "file not copied"
 
     @pytest.mark.skipif(os.name == "nt", reason="Does not work on Windows")
     def test_git_template(self):
-        shutil.rmtree(project_dir, ignore_errors=True)
         project = mlrun.new_project(
             "newproj3",
-            project_dir,
-            from_template="git://github.com/mlrun/project-demo.git",
+            self.project_dir,
+            from_template="git://github.com/mlrun/project-demo.git#refs/commits/38699adc4016bf29d1f4ab11ddd70dcc4e569388",
             save=False,
         )
         assert project.spec.description == "test", "failed to load yaml template"
 
-        filepath = os.path.join(project_dir, "prep_data.py")
+        filepath = os.path.join(self.project_dir, "prep_data.py")
         assert os.path.isfile(filepath), "file not copied"


### PR DESCRIPTION
following https://github.com/mlrun/project-demo/pull/20 merge there are few failing tests that assumes number of functions and having such functions on hub which the integration test did not rely on.

fixing those tests by checking to its previous commit (and adding the ability to checkout specific commit)