### PR TITLE
[Notifications] Fix stuck pending notifications

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -304,8 +304,13 @@ class SQLDB(DBInterface):
             run.state in mlrun.common.runtimes.constants.RunStates.terminal_states()
             and not run.end_time
         ):
-            end_time = run_end_time(struct)
-            self._update_run_end_time(run, struct, now=end_time)
+            self._update_run_end_time(run, struct, now=datetime.now(timezone.utc))
+        elif (
+            run.state not in mlrun.common.runtimes.constants.RunStates.terminal_states()
+        ):
+            # Ensure end time is not set if the run is not in a terminal state
+            run.end_time = None
+            struct.setdefault("status", {}).pop("end_time", None)
 
         # Update the labels only if the run updates contains labels
         if run_labels(updates):
@@ -571,6 +576,13 @@ class SQLDB(DBInterface):
         ):
             end_time = run_end_time(run_data)
             self._update_run_end_time(run, run_data, now=end_time)
+        elif (
+            run.state not in mlrun.common.runtimes.constants.RunStates.terminal_states()
+        ):
+            # Ensure end time is not set if the run is not in a terminal state
+            run.end_time = None
+            run_data.setdefault("status", {}).pop("end_time", None)
+
         run.struct = run_data
 
     def _add_run_name_query(self, query, name):

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -300,17 +300,7 @@ class SQLDB(DBInterface):
         if start_time:
             run.start_time = start_time
 
-        if (
-            run.state in mlrun.common.runtimes.constants.RunStates.terminal_states()
-            and not run.end_time
-        ):
-            self._update_run_end_time(run, struct, now=datetime.now(timezone.utc))
-        elif (
-            run.state not in mlrun.common.runtimes.constants.RunStates.terminal_states()
-        ):
-            # Ensure end time is not set if the run is not in a terminal state
-            run.end_time = None
-            struct.setdefault("status", {}).pop("end_time", None)
+        self._update_run_end_time(run, struct)
 
         # Update the labels only if the run updates contains labels
         if run_labels(updates):
@@ -570,18 +560,7 @@ class SQLDB(DBInterface):
         run_data.setdefault("status", {})["start_time"] = start_time.isoformat()
         run.start_time = start_time
         self._update_run_updated_time(run, run_data, now=now)
-        if (
-            run.state in mlrun.common.runtimes.constants.RunStates.terminal_states()
-            and not run.end_time
-        ):
-            end_time = run_end_time(run_data)
-            self._update_run_end_time(run, run_data, now=end_time)
-        elif (
-            run.state not in mlrun.common.runtimes.constants.RunStates.terminal_states()
-        ):
-            # Ensure end time is not set if the run is not in a terminal state
-            run.end_time = None
-            run_data.setdefault("status", {}).pop("end_time", None)
+        self._update_run_end_time(run, run_data, end_time=run_end_time(run_data))
 
         run.struct = run_data
 
@@ -602,6 +581,23 @@ class SQLDB(DBInterface):
             )
 
     @staticmethod
+    def _update_run_end_time(run: Run, run_dict: dict, end_time: Optional[str] = None):
+        if (
+            run.state in mlrun.common.runtimes.constants.RunStates.terminal_states()
+            and not run.end_time
+        ):
+            if end_time is None:
+                end_time = datetime.now(timezone.utc)
+            run.end_time = end_time
+            run_dict.setdefault("status", {})["end_time"] = end_time.isoformat()
+        elif (
+            run.state not in mlrun.common.runtimes.constants.RunStates.terminal_states()
+        ):
+            # Ensure end time is not set if the run is not in a terminal state
+            run.end_time = None
+            run_dict.setdefault("status", {}).pop("end_time", None)
+
+    @staticmethod
     def _update_run_updated_time(
         run_record: Run, run_dict: dict, now: typing.Optional[datetime] = None
     ):
@@ -609,15 +605,6 @@ class SQLDB(DBInterface):
             now = datetime.now(timezone.utc)
         run_record.updated = now
         run_dict.setdefault("status", {})["last_update"] = now.isoformat()
-
-    @staticmethod
-    def _update_run_end_time(
-        run_record: Run, run_dict: dict, now: typing.Optional[datetime] = None
-    ):
-        if now is None:
-            now = datetime.now(timezone.utc)
-        run_record.end_time = now
-        run_dict.setdefault("status", {})["end_time"] = now.isoformat()
 
     @staticmethod
     def _update_run_state(run_record: Run, run_dict: dict):

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -582,6 +582,13 @@ class SQLDB(DBInterface):
 
     @staticmethod
     def _update_run_end_time(run: Run, run_dict: dict, end_time: Optional[str] = None):
+        """
+        Update the run's end time if the run is in a terminal state and the end time is not set.
+        If the run is in terminal state and the end time is set then keep the end time as is.
+        :param run: The run object
+        :param run_dict: The run dict
+        :param end_time: The end time to set - used when in 'store' flow to set the end time
+        """
         if (
             run.state in mlrun.common.runtimes.constants.RunStates.terminal_states()
             and not run.end_time

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -100,7 +100,6 @@ class TimeWindowTracker:
 
 
 async def run_with_time_window_tracker(
-    db_session: sqlalchemy.orm.Session,
     key: TimeWindowTrackerKeys,
     max_window_size_seconds: int,
     ensure_window_update: bool,
@@ -121,18 +120,8 @@ async def run_with_time_window_tracker(
         framework.db.session.run_function_with_new_db_session, cycle_tracker.get_window
     )
     now = datetime.datetime.now(datetime.timezone.utc)
-    if ensure_window_update:
-        try:
-            await framework.utils.asyncio.maybe_coroutine(
-                callback(db_session, last_update_time, *args, **kwargs)
-            )
-        finally:
-            await run_in_threadpool(
-                framework.db.session.run_function_with_new_db_session,
-                cycle_tracker.update_window,
-                now,
-            )
-    else:
+    db_session = await run_in_threadpool(framework.db.create_session)
+    try:
         await framework.utils.asyncio.maybe_coroutine(
             callback(db_session, last_update_time, *args, **kwargs)
         )
@@ -141,3 +130,12 @@ async def run_with_time_window_tracker(
             cycle_tracker.update_window,
             now,
         )
+        ensure_window_update = False
+    finally:
+        await run_in_threadpool(framework.db.close_session, db_session)
+        if ensure_window_update:
+            await run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
+                cycle_tracker.update_window,
+                now,
+            )

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -130,10 +130,12 @@ async def run_with_time_window_tracker(
             cycle_tracker.update_window,
             now,
         )
+        # The window update succeeded above, no need to ensure it
         ensure_window_update = False
     finally:
         await run_in_threadpool(framework.db.close_session, db_session)
         if ensure_window_update:
+            # Sessions are not thread-safe, so we need to create a new one
             await run_in_threadpool(
                 framework.db.session.run_function_with_new_db_session,
                 cycle_tracker.update_window,

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -43,7 +43,6 @@ import framework.utils.time_window_tracker
 import services.alerts.crud
 import services.alerts.initial_data
 import services.api.crud
-from framework.db.session import close_session, create_session
 from framework.routers import (
     alert_activations,
     alert_template,
@@ -604,10 +603,8 @@ class Service(framework.service.Service):
             )
 
     async def _generate_events(self):
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
         try:
             await framework.utils.time_window_tracker.run_with_time_window_tracker(
-                db_session=db_session,
                 key=framework.utils.time_window_tracker.TimeWindowTrackerKeys.events_generation,
                 max_window_size_seconds=int(
                     # TODO: This needs to be aligned with chief
@@ -621,8 +618,6 @@ class Service(framework.service.Service):
                 "Failed generating events. Ignoring",
                 exc=mlrun.errors.err_to_str(exc),
             )
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
     @staticmethod
     def _get_authorization_resource_for_alert_template():

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -241,23 +241,18 @@ class Service(framework.service.Service):
         collect logs.
         :param start_logs_limit: Semaphore which limits the number of concurrent log collection tasks
         """
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-        try:
-            await framework.utils.time_window_tracker.run_with_time_window_tracker(
-                db_session,
-                key=framework.utils.time_window_tracker.TimeWindowTrackerKeys.log_collection,
-                # If the API was down for more than the grace period, we will only collect logs for runs which reached
-                # terminal state within the grace period and not since the API actually went down.
-                max_window_size_seconds=min(
-                    int(mlconf.log_collector.api_downtime_grace_period),
-                    int(mlconf.runtime_resources_deletion_grace_period),
-                ),
-                ensure_window_update=True,
-                callback=self._verify_log_collection_started,
-                start_logs_limit=start_logs_limit,
-            )
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
+        await framework.utils.time_window_tracker.run_with_time_window_tracker(
+            key=framework.utils.time_window_tracker.TimeWindowTrackerKeys.log_collection,
+            # If the API was down for more than the grace period, we will only collect logs for runs which reached
+            # terminal state within the grace period and not since the API actually went down.
+            max_window_size_seconds=min(
+                int(mlconf.log_collector.api_downtime_grace_period),
+                int(mlconf.runtime_resources_deletion_grace_period),
+            ),
+            ensure_window_update=True,
+            callback=self._verify_log_collection_started,
+            start_logs_limit=start_logs_limit,
+        )
 
     async def _verify_log_collection_started(
         self, db_session, last_update_time: datetime.datetime, start_logs_limit
@@ -724,7 +719,6 @@ class Service(framework.service.Service):
                 )
         try:
             await framework.utils.time_window_tracker.run_with_time_window_tracker(
-                db_session,
                 key=framework.utils.time_window_tracker.TimeWindowTrackerKeys.run_monitoring,
                 max_window_size_seconds=int(
                     mlconf.runtime_resources_deletion_grace_period

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -425,6 +425,46 @@ class TestRuns(TestDatabaseBase):
             assert run["status"]["end_time"] is not None
             assert update_labels_mock.call_count == 0
 
+    def test_store_and_update_run_from_terminal_state_to_non_terminal_state(self):
+        project, name, uid, iteration, run = self._create_new_run(
+            state=mlrun.common.runtimes.constants.RunStates.completed
+        )
+        run = self._db.read_run(self._db_session, uid, project, iteration)
+
+        # Store completed expected to fill end time
+        initial_end_time = run["status"]["end_time"]
+        assert initial_end_time is not None
+
+        self._create_new_run(state=mlrun.common.runtimes.constants.RunStates.running)
+        run = self._db.read_run(self._db_session, uid, project, iteration)
+
+        # Store running expected to remove end time
+        assert "end_time" not in run["status"]
+
+        self._db.update_run(
+            self._db_session,
+            {"status.state": mlrun.common.runtimes.constants.RunStates.completed},
+            uid,
+            project,
+            iteration,
+        )
+        run = self._db.read_run(self._db_session, uid, project, iteration)
+
+        # Update completed expected to fill end time
+        assert run["status"]["end_time"] > initial_end_time
+
+        self._db.update_run(
+            self._db_session,
+            {"status.state": mlrun.common.runtimes.constants.RunStates.running},
+            uid,
+            project,
+            iteration,
+        )
+        run = self._db.read_run(self._db_session, uid, project, iteration)
+
+        # Update running expected to remove end time
+        assert "end_time" not in run["status"]
+
     def test_run_iter(self):
         uid, prj = "uid39", "lemon"
         run = new_run("s1", {"l1": "v1", "l2": "v2"}, x=1)

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 import unittest.mock
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import pytest
 
@@ -559,29 +559,25 @@ class TestRuns(TestDatabaseBase):
         assert not run["status"].get("end_time")
 
         # update the run's end_time
-        end_time = datetime.now(timezone.utc)
-        end_time_iso = end_time.isoformat()
         updates = {
             "status.state": "completed",
-            "status.end_time": end_time_iso,
         }
         self._db.update_run(self._db_session, updates, run_uid, project)
 
         # fetch the run and verify the end_time
         run = self._db.read_run(self._db_session, run_uid, project, iteration)
         assert run["status"].get("end_time")
-        assert run["status"]["end_time"] == end_time_iso
+        end_time = datetime.fromisoformat(run["status"]["end_time"])
 
         # list runs with end_time filter
         runs = self._db.list_runs(
             self._db_session,
             project=project,
-            end_time_from=end_time - timedelta(milliseconds=100),
+            end_time_from=end_time,
         )
         assert len(runs) == 1
         stored_run = runs[0]
         assert stored_run["metadata"]["uid"] == run_uid
-        assert stored_run["status"]["end_time"] == end_time_iso
         assert stored_run["status"]["end_time"] > stored_run["status"]["start_time"]
 
     @staticmethod

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -435,6 +435,7 @@ class TestRuns(TestDatabaseBase):
         initial_end_time = run["status"]["end_time"]
         assert initial_end_time is not None
 
+        # Update the run using `store` to running state to test the store flow as well
         self._create_new_run(state=mlrun.common.runtimes.constants.RunStates.running)
         run = self._db.read_run(self._db_session, uid, project, iteration)
 
@@ -464,6 +465,26 @@ class TestRuns(TestDatabaseBase):
 
         # Update running expected to remove end time
         assert "end_time" not in run["status"]
+
+    def test_consecutive_completed_update_requests(self):
+        project, name, uid, iteration, run = self._create_new_run(
+            state=mlrun.common.runtimes.constants.RunStates.completed
+        )
+        run = self._db.read_run(self._db_session, uid, project, iteration)
+
+        # Store completed expected to fill end time
+        initial_end_time = run["status"]["end_time"]
+        assert initial_end_time is not None
+
+        self._db.update_run(
+            self._db_session,
+            {"status.state": mlrun.common.runtimes.constants.RunStates.completed},
+            uid,
+            project,
+            iteration,
+        )
+        run = self._db.read_run(self._db_session, uid, project, iteration)
+        assert run["status"]["end_time"] == initial_end_time
 
     def test_run_iter(self):
         uid, prj = "uid39", "lemon"


### PR DESCRIPTION
Some notifications may be stuck on pending and never be sent although the run has completed due to db session isolation level. Fix is to start a new session.
This also fixes a situation where the server sets a run to running although it is completed without removing the `end_time`. This can happen if the pod didn't terminate but the client updated the run to completed.

https://iguazio.atlassian.net/browse/ML-9432