### PR TITLE
[Artifacts] Update unit test for artifact deletion data failure

### DIFF
--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -293,6 +293,7 @@ class MLRunPatcher:
                     future.result()
                 except Exception as exc:
                     logger.error(f"Error pushing image {image}: {exc}")
+                    raise
 
     def _patch_deployment_from_file(self):
         for deployment in self._deployments:

--- a/server/py/services/api/tests/unit/api/test_artifacts.py
+++ b/server/py/services/api/tests/unit/api/test_artifacts.py
@@ -252,30 +252,45 @@ def test_delete_artifacts_after_storing_empty_dict(db: Session, client: TestClie
 
 
 @pytest.mark.parametrize(
-    "deletion_strategy, expected_status_code",
+    "deletion_strategy, expected_status_code, expected_status_code_for_getting_artifact",
     [
         (
             mlrun.common.schemas.artifact.ArtifactsDeletionStrategies.data_optional,
             HTTPStatus.NO_CONTENT.value,
+            # Artifact does not exist in DB after deleting data fails
+            HTTPStatus.NOT_FOUND.value,
         ),
         (
             mlrun.common.schemas.artifact.ArtifactsDeletionStrategies.data_force,
             HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            # Artifact exists in DB after deleting data fails
+            HTTPStatus.OK.value,
         ),
     ],
 )
-def test_fails_deleting_artifact_data(
-    deletion_strategy, expected_status_code, db: Session, unversioned_client: TestClient
+def test_delete_artifact_data_failure(
+    deletion_strategy,
+    expected_status_code,
+    expected_status_code_for_getting_artifact,
+    unversioned_client: TestClient,
 ):
     # This test attempts to delete the artifact data, but fails - the request should
     # be failed or succeeded by the deletion strategy.
     _create_project(unversioned_client)
-    artifact = mlrun.artifacts.Artifact(key=KEY, body="123", target_path="dummy-path")
 
+    # Generate artifact
+    artifact_data = _generate_artifact_body()
     resp = unversioned_client.post(
-        STORE_API_ARTIFACTS_PATH.format(project=PROJECT, uid=UID, key=KEY, tag=TAG),
-        data=artifact.to_json(),
+        STORE_API_ARTIFACTS_V2_PATH.format(project=PROJECT),
+        json=artifact_data,
     )
+    assert resp.status_code == HTTPStatus.CREATED.value
+    artifact_response = resp.json()
+    artifact_uid = artifact_response["metadata"]["uid"]
+
+    # Check if the artifact is created successfully
+    artifact_url = _get_artifact_url(uid=artifact_uid)
+    resp = unversioned_client.get(artifact_url)
     assert resp.status_code == HTTPStatus.OK.value
 
     url = DELETE_API_ARTIFACTS_V2_PATH.format(project=PROJECT, key=KEY)
@@ -289,6 +304,10 @@ def test_fails_deleting_artifact_data(
             url_with_deletion_strategy.format(deletion_strategy=deletion_strategy)
         )
     assert resp.status_code == expected_status_code
+
+    # Verify artifact exists in DB based on the deletion strategy
+    resp = unversioned_client.get(artifact_url)
+    assert resp.status_code == expected_status_code_for_getting_artifact
 
 
 def test_delete_artifact_data_default_deletion_strategy(


### PR DESCRIPTION
This fix is based on the comment from this PR: https://github.com/mlrun/mlrun/pull/7406#discussion_r1986399428, which mentioned missing unit tests to ensure that any changes in the code will fail in the CI.

The fix involves updating the unit test to verify the following scenarios when deleting an artifact, and the deletion of artifact data fails:

- If the `deletion_strategy` is data_force, the artifact should still exist in the database.
- If the `deletion_strategy` is data_optional, the artifact should not exist in the database.

Also, in this PR, I updated the `patch_remote` script so that if patching fails to push images, the patch will fail.