### PR TITLE
[Model Monitoring] Create the schemas for all V3IO tables during deployment

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -150,10 +150,14 @@ class V3IOTSDBConnector(TSDBConnector):
 
     def create_tables(self) -> None:
         """
-        Create the tables using the TSDB connector. The tables are being created in the V3IO TSDB and include:
+        Create the tables using the TSDB connector. These are the tables that are stored in the V3IO TSDB:
         - app_results: a detailed result that includes status, kind, extra data, etc.
         - metrics: a basic key value that represents a single numeric metric.
-        Note that the predictions table is automatically created by the model monitoring stream pod.
+        - events: A statistics table that includes pre-aggregated metrics (such as average latency over the
+        last 5 minutes) and data samples
+        - predictions: a detailed prediction that includes latency, request timestamp, etc.
+        - errors: a detailed error that includes error desc, error type, etc.
+
         """
 
         for table_name in self.tables:

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -155,11 +155,8 @@ class V3IOTSDBConnector(TSDBConnector):
         - metrics: a basic key value that represents a single numeric metric.
         Note that the predictions table is automatically created by the model monitoring stream pod.
         """
-        application_tables = [
-            mm_schemas.V3IOTSDBTables.APP_RESULTS,
-            mm_schemas.V3IOTSDBTables.METRICS,
-        ]
-        for table_name in application_tables:
+
+        for table_name in self.tables:
             logger.info("Creating table in V3IO TSDB", table_name=table_name)
             table = self.tables[table_name]
             self.frames_client.create(


### PR DESCRIPTION
Currently, we create only 2 out of the 5 V3IO tables during model monitoring infra deployment (`metrics` and `app-results`). The other 3 tables are generated only when the first relevant event is pushed to them. For example, the `errors` table is created only when the first error event occurs. As a result, when `framesd` tries to query these tables (e.g., during `list_model_endpoints` in each controller process), it gets an error about a missing TSDB schema file.

In this PR, we address this by generating all of the schemas during deployment. This ensures the schemas are available in advance and prevents the repeating `No TSDB schema file found` error in `framesd` logs."

https://iguazio.atlassian.net/browse/ML-9542