### PR TITLE
[Deprecations] Legacy artifact postponed to 1.9

### DIFF
--- a/server/py/services/api/crud/artifacts.py
+++ b/server/py/services/api/crud/artifacts.py
@@ -63,7 +63,7 @@ class Artifacts(
         # calculate the size of the artifact
         self._resolve_artifact_size(artifact, auth_info)
 
-        # TODO: remove this in 1.8.0
+        # TODO: Remove once data migration v5 is obsolete
         if mlrun.utils.helpers.is_legacy_artifact(artifact):
             artifact = mlrun.artifacts.base.convert_legacy_artifact_to_new_format(
                 artifact


### PR DESCRIPTION
should not be removed in 1.8.0.
related to this pr https://github.com/mlrun/mlrun/pull/5891
postponed to 1.9.0 in this pr - https://github.com/mlrun/mlrun/pull/7363

https://iguazio.atlassian.net/browse/ML-9365