### PR TITLE
[Tests] Fix vectordb and alarms system tests

### DIFF
--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -31,7 +31,9 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointList,
 )
 from mlrun.datastore import get_stream_pusher
-from mlrun.datastore.datastore_profile import DatastoreProfileV3io
+from mlrun.datastore.datastore_profile import (
+    register_temporary_client_datastore_profile,
+)
 from mlrun.model_monitoring.helpers import get_stream_path
 from tests.system.base import TestMLRunSystem
 from tests.system.model_monitoring import TestMLRunSystemModelMonitoring
@@ -162,11 +164,13 @@ class TestAlerts(TestMLRunSystem):
         tsdb_profile = TestMLRunSystemModelMonitoring.get_tsdb_profile(
             self.mm_tsdb_profile_data
         )
+        register_temporary_client_datastore_profile(tsdb_profile)
         self.project.register_datastore_profile(tsdb_profile)
 
         stream_profile = TestMLRunSystemModelMonitoring.get_stream_profile(
             self.mm_stream_profile_data
         )
+        register_temporary_client_datastore_profile(stream_profile)
         self.project.register_datastore_profile(stream_profile)
 
         self.project.set_model_monitoring_credentials(
@@ -195,7 +199,7 @@ class TestAlerts(TestMLRunSystem):
         stream_uri = get_stream_path(
             project=self.project.metadata.name,
             function_name=mm_constants.MonitoringFunctionNames.WRITER,
-            profile=DatastoreProfileV3io(name="tmp"),
+            profile=stream_profile,
         )
         output_stream = get_stream_pusher(stream_uri)
 

--- a/tests/system/datastore/test_vectorstore.py
+++ b/tests/system/datastore/test_vectorstore.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+# Check if langchain_community is available
+import importlib.util
 import os
 import random
 import string
@@ -28,6 +30,17 @@ from mlrun.datastore.datastore_profile import (
     register_temporary_client_datastore_profile,
 )
 from tests.system.base import TestMLRunSystem
+
+LANGCHAIN_AVAILABLE = (
+    importlib.util.find_spec("langchain") is not None
+    and importlib.util.find_spec("langchain_community") is not None
+)
+
+# Skip all tests in this module if langchain_community is not installed
+pytestmark = pytest.mark.skipif(
+    not LANGCHAIN_AVAILABLE,
+    reason="langchain or langchain_community package is not installed",
+)
 
 here = os.path.dirname(__file__)
 config_file_path = os.path.join(here, "../env.yml")

--- a/tests/system/datastore/test_vectorstore.py
+++ b/tests/system/datastore/test_vectorstore.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-# Check if langchain_community is available
 import importlib.util
 import os
 import random


### PR DESCRIPTION
- Checks if LangChain is not installed before running vectordb tests
- Fixes the alarm system tests to support the latest model monitoring datastore profile convention