### PR TITLE
[Tests] Support list/dict in env.yml

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -261,7 +261,7 @@ class TestMLRunSystem:
         # Set the environment variable
         if isinstance(value, bool):
             os.environ[key] = "true" if value else "false"
-        elif value is not None:
+        elif value is not None and not isinstance(value, (list, dict)):
             os.environ[key] = value
 
     @classmethod


### PR DESCRIPTION
Support (ie ignore) list/dict in system tests env.yml (useful for merging `env.yml` with patch_remote `patch_env.yml`)