### PR TITLE
[Model Monitoring] Store `last_request` value in V3IO KV

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -281,6 +281,7 @@ class FileTargetKind:
     MONITORING_APPLICATION = "monitoring_application"
     ERRORS = "errors"
     STATS = "stats"
+    LAST_REQUEST = "last_request"
 
 
 class ModelMonitoringMode(StrEnum):

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -210,8 +210,7 @@ class TSDBConnector(ABC):
         endpoint_ids: Union[str, list[str]],
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
-        get_raw: bool = False,
-    ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
+    ) -> Union[pd.DataFrame, dict[str, float]]:
         """
         Fetches data from the predictions TSDB table and returns the most recent request
         timestamp for each specified endpoint.
@@ -219,11 +218,11 @@ class TSDBConnector(ABC):
         :param endpoint_ids:    A list of model endpoint identifiers.
         :param start:           The start time for the query.
         :param end:             The end time for the query.
-        :param get_raw:         Whether to return the request as raw frames rather than a pandas dataframe. Defaults
-          to False. This can greatly improve performance when a dataframe isn't needed.
 
-        :return: A pd.DataFrame containing the columns [endpoint_id, last_request, last_latency].
-        If an endpoint has not been invoked within the specified time range, it will not appear in the result.
+        :return: A pd.DataFrame containing the columns [endpoint_id, last_request, last_latency] or a dictionary
+        containing the endpoint_id as the key and the last request timestamp as the value.
+        if an endpoint has not been invoked within the specified time range, it will not appear in the result (relevant
+        only to non-v3io connector).
         """
 
     @abstractmethod

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -668,7 +668,6 @@ class TDEngineConnector(TSDBConnector):
         endpoint_ids: Union[str, list[str]],
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
-        get_raw: bool = False,
     ) -> pd.DataFrame:
         filter_query = self._get_endpoint_filter(endpoint_id=endpoint_ids)
         start, end = self._get_start_end(start, end)

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from io import StringIO
 from typing import Callable, Literal, Optional, Union
 
@@ -72,6 +72,15 @@ class V3IOTSDBConnector(TSDBConnector):
         self._frames_client: Optional[v3io_frames.client.ClientBase] = None
         self._init_tables_path()
         self._create_table = create_table
+        self._v3io_client = None
+
+    @property
+    def v3io_client(self):
+        if not self._v3io_client:
+            self._v3io_client = mlrun.utils.v3io_clients.get_v3io_client(
+                endpoint=mlrun.mlconf.v3io_api, access_key=self._v3io_access_key
+            )
+        return self._v3io_client
 
     @property
     def frames_client(self) -> v3io_frames.client.ClientBase:
@@ -146,6 +155,21 @@ class V3IOTSDBConnector(TSDBConnector):
             monitoring_predictions_full_path
         )
         self.tables[mm_schemas.V3IOTSDBTables.PREDICTIONS] = monitoring_predictions_path
+
+        # initialize kv table
+        last_request_full_table_path = (
+            mlrun.mlconf.get_model_monitoring_file_target_path(
+                project=self.project,
+                kind=mm_schemas.FileTargetKind.LAST_REQUEST,
+            )
+        )
+        (
+            _,
+            _,
+            self.last_request_table,
+        ) = mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
+            last_request_full_table_path
+        )
 
     def create_tables(self) -> None:
         """
@@ -250,6 +274,16 @@ class V3IOTSDBConnector(TSDBConnector):
             max_events=tsdb_batching_max_events,
             flush_after_seconds=tsdb_batching_timeout_secs,
             key=mm_schemas.EventFieldType.ENDPOINT_ID,
+        )
+
+        # Write last request timestamp to KV table
+        graph.add_step(
+            "storey.NoSqlTarget",
+            name="KVLastRequest",
+            after="tsdb_predictions",
+            table=f"v3io:///users/{self.last_request_table}",
+            columns=[EventFieldType.LAST_REQUEST_TIMESTAMP],
+            index_cols=[EventFieldType.ENDPOINT_ID],
         )
 
         # Emits the event in window size of events based on sample_window size (10 by default)
@@ -458,11 +492,30 @@ class V3IOTSDBConnector(TSDBConnector):
                         error=mlrun.errors.err_to_str(e),
                         project=self.project,
                     )
+
+        # Clean the last request records from the KV table
+        self._delete_last_request_records(endpoint_ids=endpoint_ids)
+
         logger.debug(
             "Deleted all model endpoint resources using the V3IO connector",
             project=self.project,
             number_of_endpoints_to_delete=len(endpoint_ids),
         )
+
+    def _delete_last_request_records(self, endpoint_ids: list[str]):
+        for endpoint_id in endpoint_ids:
+            try:
+                self.v3io_client.kv.delete(
+                    container=self.container,
+                    table=self.last_request_table,
+                    key=endpoint_id,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to delete last request record for endpoint '{endpoint_id}'",
+                    error=mlrun.errors.err_to_str(e),
+                    project=self.project,
+                )
 
     def get_model_endpoint_real_time_metrics(
         self, endpoint_id: str, metrics: list[str], start: str, end: str
@@ -826,41 +879,34 @@ class V3IOTSDBConnector(TSDBConnector):
         endpoint_ids: Union[str, list[str]],
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
-        get_raw: bool = False,
-    ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
-        filter_query = self._get_endpoint_filter(endpoint_id=endpoint_ids)
-        start, end = self._get_start_end(start, end)
-
-        res = self._get_records(
-            table=mm_schemas.V3IOTSDBTables.PREDICTIONS,
-            start=start,
-            end=end,
-            filter_query=filter_query,
-            agg_funcs=["last"],
-            get_raw=get_raw,
-        )
-
-        if get_raw:
-            return res
-
-        df = res
-        if not df.empty:
-            df.rename(
-                columns={
-                    f"last({mm_schemas.EventFieldType.LAST_REQUEST_TIMESTAMP})": mm_schemas.EventFieldType.LAST_REQUEST,
-                    f"last({mm_schemas.EventFieldType.LATENCY})": f"last_{mm_schemas.EventFieldType.LATENCY}",
-                },
-                inplace=True,
-            )
-            df[mm_schemas.EventFieldType.LAST_REQUEST] = df[
-                mm_schemas.EventFieldType.LAST_REQUEST
-            ].map(
-                lambda last_request: datetime.fromtimestamp(
-                    last_request, tz=timezone.utc
-                )
+    ) -> dict[str, float]:
+        if isinstance(endpoint_ids, str):
+            filter_expression = f"__name=='{endpoint_ids}'"
+        else:
+            filter_expression = " OR ".join(
+                [f"__name=='{endpoint_id}'" for endpoint_id in endpoint_ids]
             )
 
-        return df.reset_index(drop=True)
+        # Get the last request timestamp for each endpoint from the KV table.
+        # The result of the query is a list of dictionaries,
+        # each dictionary contains the endpoint id and the last request timestamp.
+
+        try:
+            res = self.v3io_client.kv.new_cursor(
+                container=self.container,
+                table_path=self.last_request_table,
+                filter_expression=filter_expression,
+            ).all()
+        except Exception as e:
+            logger.warning(
+                "Failed to get last request timestamp from V3IO KV table.",
+                err=mlrun.errors.err_to_str(e),
+                project=self.project,
+                table=self.last_request_table,
+            )
+            return {}
+
+        return {d["__name"]: d["last_request_timestamp"] for d in res}
 
     def get_drift_status(
         self,
@@ -1037,7 +1083,6 @@ class V3IOTSDBConnector(TSDBConnector):
             model_endpoint_objects_by_uid[uid] = model_endpoint_object
 
         error_count_res = self.get_error_count(endpoint_ids=uids, get_raw=True)
-        last_request_res = self.get_last_request(endpoint_ids=uids, get_raw=True)
         avg_latency_res = self.get_avg_latency(endpoint_ids=uids, get_raw=True)
         drift_status_res = self.get_drift_status(endpoint_ids=uids, get_raw=True)
 
@@ -1060,11 +1105,7 @@ class V3IOTSDBConnector(TSDBConnector):
             "count(error_count)",
             error_count_res,
         )
-        add_metric(
-            "last_request",
-            "last(last_request_timestamp)",
-            last_request_res,
-        )
+
         add_metric(
             "avg_latency",
             "avg(latency)",
@@ -1075,4 +1116,19 @@ class V3IOTSDBConnector(TSDBConnector):
             "max(result_status)",
             drift_status_res,
         )
+
+        self._enrich_mep_with_last_request(
+            model_endpoint_objects_by_uid=model_endpoint_objects_by_uid
+        )
+
         return list(model_endpoint_objects_by_uid.values())
+
+    def _enrich_mep_with_last_request(
+        self,
+        model_endpoint_objects_by_uid: dict[str, mlrun.common.schemas.ModelEndpoint],
+    ):
+        last_request_dictionary = self.get_last_request(
+            endpoint_ids=list(model_endpoint_objects_by_uid.keys())
+        )
+        for uid, mep in model_endpoint_objects_by_uid.items():
+            mep.status.last_request = last_request_dictionary.get(uid)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -145,7 +145,14 @@ class _V3IORecordsChecker:
         if last_request:
             cls._logger.debug("Checking the MEP last_request")
             lr_tsdb = cls._tsdb_storage.get_last_request(endpoint_ids=ep_id)
-            cls._check_valid_tsdb_result(lr_tsdb, ep_id, "last_request", last_request)
+            if isinstance(lr_tsdb, pd.DataFrame):
+                cls._check_valid_tsdb_result(
+                    lr_tsdb, ep_id, "last_request", last_request
+                )
+            else:
+                cls._check_last_request_dict(
+                    lr_tsdb, ep_id, "last_request", last_request
+                )
 
         if error_count:
             cls._logger.debug("Checking the MEP error_count")
@@ -173,6 +180,22 @@ class _V3IORecordsChecker:
             assert (
                 df[df["endpoint_id"] == ep_id][result_name].item() == result_value
             ), f"The {result_name} is different than expected for {ep_id}"
+
+    @classmethod
+    def _check_last_request_dict(
+        cls,
+        data: dict[str, float],
+        ep_id: str,
+        result_name: str,
+        result_value: datetime,
+    ):
+        assert data, "No last request data"
+        assert (
+            list(data.keys())[0] == ep_id
+        ), "The endpoint IDs are different than expected"
+        assert (
+            data[ep_id] == result_value.timestamp()
+        ), f"The {result_name} is different than expected for {ep_id}"
 
     @classmethod
     def _test_predictions_table(cls, ep_id: str, should_be_empty: bool = False) -> None:


### PR DESCRIPTION
Add a new target to the model monitoring stream graph that stores the `last_request` value for each model endpoint in a new table: `v3io:///users/pipelines/<'project_name'>/model-endpoints/last_request`. We will manage one table per project, where the key is the `endpoint_id` and it contains a single attribute - `last_request_timestamp`.

This PR also resolves https://iguazio.atlassian.net/browse/ML-9527 where instead of calculating the `last_request` value from the `V3IO TSDB`, we will now retrieve it from the `V3IO KV` table. Note that we only store the latest value in this table, making retrieval significantly faster compared to loading data from the TSDB using `framesd` and searching for the most recent record.


