### PR TITLE
[Alerts] Add limit to list alert configs

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -822,6 +822,8 @@ default_config = {
         # maximum allowed alert config cache size in alert's CRUD
         # for the best performance, it is recommended to set this value to the maximum number of alerts
         "max_allowed_cache_size": 20000,
+        # default limit for listing alert configs
+        "default_list_alert_configs_limit": 100,
     },
     "auth_with_client_id": {
         "enabled": False,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -823,7 +823,7 @@ default_config = {
         # for the best performance, it is recommended to set this value to the maximum number of alerts
         "max_allowed_cache_size": 20000,
         # default limit for listing alert configs
-        "default_list_alert_configs_limit": 100,
+        "default_list_alert_configs_limit": 2000,
     },
     "auth_with_client_id": {
         "enabled": False,

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -889,7 +889,9 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def list_alerts_configs(self, project=""):
+    def list_alerts_configs(
+        self, project="", limit: Optional[int] = None, offset: Optional[int] = None
+    ):
         pass
 
     @abstractmethod

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4826,6 +4826,7 @@ class HTTPRunDB(RunDBInterface):
 
         :param project: The project name.
         :param limit: The maximum number of alerts to return.
+            Defaults to `mlconf.alerts.default_list_alert_configs_limit` if not provided.
         :param offset: The number of alerts to skip.
 
         :returns: All the alerts objects of the project.
@@ -4834,7 +4835,7 @@ class HTTPRunDB(RunDBInterface):
         endpoint_path = f"projects/{project}/alerts"
         error_message = f"get alerts {project}/alerts"
         params = {}
-        # TODO: remove limit and offset when pagination is implemented
+        # TODO: Deprecate limit and offset when pagination is implemented
         if limit:
             params["page-size"] = limit
         if offset:
@@ -4843,7 +4844,7 @@ class HTTPRunDB(RunDBInterface):
             "GET", endpoint_path, error_message, params=params
         ).json()
         results = []
-        for item in response:
+        for item in response.get("alerts", []):
             results.append(AlertConfig(**item))
         return results
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4818,18 +4818,30 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", endpoint_path, error_message)
         return AlertConfig.from_dict(response.json())
 
-    def list_alerts_configs(self, project="") -> list[AlertConfig]:
+    def list_alerts_configs(
+        self, project="", limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> list[AlertConfig]:
         """
         Retrieve list of alerts of a project.
 
         :param project: The project name.
+        :param limit: The maximum number of alerts to return.
+        :param offset: The number of alerts to skip.
 
         :returns: All the alerts objects of the project.
         """
         project = project or config.default_project
         endpoint_path = f"projects/{project}/alerts"
         error_message = f"get alerts {project}/alerts"
-        response = self.api_call("GET", endpoint_path, error_message).json()
+        params = {}
+        # TODO: remove limit and offset when pagination is implemented
+        if limit:
+            params["page-size"] = limit
+        if offset:
+            params["offset"] = offset
+        response = self.api_call(
+            "GET", endpoint_path, error_message, params=params
+        ).json()
         results = []
         for item in response:
             results.append(AlertConfig(**item))

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -5041,6 +5041,7 @@ class MlrunProject(ModelObj):
         Retrieve list of alerts of a project.
 
         :param limit: The maximum number of alerts to return.
+            Defaults to `mlconf.alerts.default_list_alert_configs_limit` if not provided.
         :param offset: The number of alerts to skip before starting to collect alerts.
 
         :return: All the alerts objects of the project.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -5034,14 +5034,19 @@ class MlrunProject(ModelObj):
         db = mlrun.db.get_run_db(secrets=self._secrets)
         return db.get_alert_config(alert_name, self.metadata.name)
 
-    def list_alerts_configs(self) -> list[AlertConfig]:
+    def list_alerts_configs(
+        self, limit: Optional[int] = None, offset: Optional[int] = None
+    ) -> list[AlertConfig]:
         """
         Retrieve list of alerts of a project.
+
+        :param limit: The maximum number of alerts to return.
+        :param offset: The number of alerts to skip before starting to collect alerts.
 
         :return: All the alerts objects of the project.
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)
-        return db.list_alerts_configs(self.metadata.name)
+        return db.list_alerts_configs(self.metadata.name, limit=limit, offset=offset)
 
     def delete_alert_config(
         self, alert_data: AlertConfig = None, alert_name: Optional[str] = None

--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -933,6 +933,8 @@ class DBInterface(ABC):
         session,
         project: typing.Optional[typing.Union[str, list[str]]] = None,
         exclude_updated: bool = False,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
     ) -> list[mlrun.common.schemas.AlertConfig]:
         pass
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6266,6 +6266,7 @@ class SQLDB(DBInterface):
         ).add_entity(AlertState)
 
         query = self._filter_query_by_resource_project(query, AlertConfig, project)
+        query = query.order_by(AlertConfig.id.desc())
         query = self._paginate_query(query, offset, limit)
 
         results = query.all()

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6247,6 +6247,8 @@ class SQLDB(DBInterface):
         session,
         project: typing.Optional[typing.Union[str, list[str]]] = None,
         exclude_updated: bool = False,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
     ) -> list[mlrun.common.schemas.AlertConfig]:
         query = self._query(session, AlertConfig)
 
@@ -6256,6 +6258,8 @@ class SQLDB(DBInterface):
         ).add_entity(AlertState)
 
         query = self._filter_query_by_resource_project(query, AlertConfig, project)
+        query = self._paginate_query(query, offset, limit)
+
         results = query.all()
 
         # Process each result, transforming and enriching the AlertConfig objects

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6266,7 +6266,7 @@ class SQLDB(DBInterface):
         ).add_entity(AlertState)
 
         query = self._filter_query_by_resource_project(query, AlertConfig, project)
-        query = query.order_by(AlertConfig.id.desc())
+        query = query.order_by(AlertConfig.id.asc())
         query = self._paginate_query(query, offset, limit)
 
         results = query.all()

--- a/server/py/framework/routers/alerts.py
+++ b/server/py/framework/routers/alerts.py
@@ -82,7 +82,7 @@ async def get_alert(
 
 @router.get(
     "",
-    response_model=list[mlrun.common.schemas.AlertConfig],
+    response_model=dict[str, list[mlrun.common.schemas.AlertConfig]],
     response_model_exclude_none=True,
 )
 @inject

--- a/server/py/framework/routers/alerts.py
+++ b/server/py/framework/routers/alerts.py
@@ -16,7 +16,7 @@
 from http import HTTPStatus
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
@@ -89,6 +89,8 @@ async def get_alert(
 async def list_alerts(
     request: Request,
     project: str,
+    page_size: int = Query(None, alias="page-size", gt=0),
+    offset: int = Query(None),
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
     service: framework.service.Service = Depends(
@@ -99,6 +101,8 @@ async def list_alerts(
         "list_alerts",
         request,
         project,
+        page_size,
+        offset,
         auth_info,
         db_session,
     )

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -1310,7 +1310,9 @@ class SQLRunDB(RunDBInterface):
     def get_alert_config(self, alert_name: str, project=""):
         pass
 
-    def list_alerts_configs(self, project=""):
+    def list_alerts_configs(
+        self, project="", limit: Optional[int] = None, offset: Optional[int] = None
+    ):
         pass
 
     def delete_alert_config(self, alert_name, project=""):

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -121,7 +121,7 @@ class Alerts(
                 )
 
         framework.utils.singletons.db.get_db().enrich_alert(
-            session, new_alert, state=existing_alert_state
+            session=session, alert=new_alert, state=existing_alert_state
         )
 
         logger.debug("Stored alert", alert=new_alert)
@@ -133,10 +133,16 @@ class Alerts(
         session: sqlalchemy.orm.Session,
         project: typing.Optional[typing.Union[str, list[str]]] = None,
         exclude_updated: bool = False,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
     ) -> list[mlrun.common.schemas.AlertConfig]:
         project = project or mlrun.mlconf.default_project
         return framework.utils.singletons.db.get_db().list_alerts(
-            session, project, exclude_updated
+            session=session,
+            project=project,
+            exclude_updated=exclude_updated,
+            limit=limit,
+            offset=offset,
         )
 
     def get_alert(
@@ -147,7 +153,7 @@ class Alerts(
         exclude_updated: bool = False,
     ):
         alert, state = framework.utils.singletons.db.get_db().get_alert(
-            session, project, name, with_state=True
+            session=session, project=project, name=name, with_state=True
         )
         if alert is None:
             raise mlrun.errors.MLRunNotFoundError(
@@ -177,7 +183,11 @@ class Alerts(
                 project, kind, alert.id, alert.entities.ids[0]
             )
 
-        framework.utils.singletons.db.get_db().delete_alert(session, project, name)
+        framework.utils.singletons.db.get_db().delete_alert(
+            session=session,
+            project=project,
+            name=name,
+        )
         self._clear_alert_states(alert.id)
         self._clear_caches(alert.id)
 
@@ -191,7 +201,7 @@ class Alerts(
         services.alerts.crud.Events().delete_project_alert_events(project)
 
         alert_ids = framework.utils.singletons.db.get_db().delete_project_alerts(
-            session, project
+            session=session, project=project
         )
         if not alert_ids:
             return

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -146,7 +146,7 @@ class Service(framework.service.Service):
         self,
         request: fastapi.Request,
         project: str,
-        page_size: int,
+        page_size: typing.Optional[int],
         offset: typing.Optional[int],
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import datetime
 import http
+import typing
 from typing import Optional, Union
 
 import fastapi
@@ -145,6 +146,8 @@ class Service(framework.service.Service):
         self,
         request: fastapi.Request,
         project: str,
+        page_size: int,
+        offset: typing.Optional[int],
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
     ) -> list[mlrun.common.schemas.AlertConfig]:
@@ -164,11 +167,18 @@ class Service(framework.service.Service):
         )
 
         exclude_updated = self._should_exclude_updated(request)
+
+        # TODO: Remove this when implementing pagination for alert configs
+        #  page_size is used for the limit in the query, but we don't have pagination yet
+        limit = page_size or mlconf.alerts.default_list_alert_configs_limit
+
         alerts = await run_in_threadpool(
             services.alerts.crud.Alerts().list_alerts,
             db_session,
             project=allowed_project_names,
             exclude_updated=exclude_updated,
+            offset=offset,
+            limit=limit,
         )
 
         alerts = await framework.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -150,7 +150,7 @@ class Service(framework.service.Service):
         offset: typing.Optional[int],
         auth_info: mlrun.common.schemas.AuthInfo,
         db_session: sqlalchemy.orm.Session = None,
-    ) -> list[mlrun.common.schemas.AlertConfig]:
+    ) -> dict[str, list[mlrun.common.schemas.AlertConfig]]:
         if project != "*":
             # TODO: When alerts is a different service and not in Hydra mode, we need to send the request to the API and
             #  not access it directly (ML-8565)
@@ -191,7 +191,9 @@ class Service(framework.service.Service):
             auth_info,
         )
 
-        return alerts
+        return {
+            "alerts": alerts,
+        }
 
     async def delete_alert(
         self,

--- a/server/py/services/alerts/tests/unit/api/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/api/test_alerts.py
@@ -16,6 +16,7 @@ import datetime
 import unittest
 from http import HTTPStatus
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -29,6 +30,30 @@ import services.api.tests.unit.api.utils
 
 ALERTS_PATH = "projects/{project}/alerts"
 STORE_ALERTS_PATH = "projects/{project}/alerts/{name}"
+
+
+@pytest.fixture
+def setup_alerts(db: Session, client: TestClient, k8s_secrets_mock):
+    project = "test-alerts"
+    num_alerts = 10
+    TestAlerts._create_project(db, project)
+
+    for i in range(num_alerts):
+        alert_name = f"alert-name-{i}"
+        alert_config = services.alerts.tests.unit.crud.utils.generate_alert_data(
+            project=project,
+            name=alert_name,
+            entity=services.alerts.tests.unit.crud.utils.generate_alert_entity(
+                project=project
+            ),
+        )
+        resp = client.put(
+            STORE_ALERTS_PATH.format(project=project, name=alert_name),
+            json=alert_config.dict(),
+        )
+        assert resp.status_code == HTTPStatus.OK.value
+
+    yield project
 
 
 class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
@@ -198,51 +223,29 @@ class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
         result = client.delete(f"projects/{project_name}/alerts")
         assert result.status_code == 204
 
+    @pytest.mark.parametrize(
+        "params, expected_length",
+        [
+            ({"page-size": 5}, 5),
+            ({"page-size": 5, "offset": 2}, 5),
+            ({"page-size": 5, "offset": 8}, 2),
+            ({}, 8),
+            ({"offset": 3}, 7),
+        ],
+    )
     def test_list_alert_configs_with_limits(
-        self,
-        db: Session,
-        client: TestClient,
-        k8s_secrets_mock,
+        self, setup_alerts, client: TestClient, params, expected_length
     ):
-        project = "test-alerts"
-        self._create_project(db, project)
-
         # for the sake of the test, set the limit to 8
         mlrun.mlconf.alerts.default_list_alert_configs_limit = 8
 
-        for i in range(10):
-            alert_name = f"alert-name-{i}"
-            alert_config = services.alerts.tests.unit.crud.utils.generate_alert_data(
-                project=project,
-                name=alert_name,
-                entity=services.alerts.tests.unit.crud.utils.generate_alert_entity(
-                    project=project
-                ),
-            )
-            resp = client.put(
-                STORE_ALERTS_PATH.format(project=project, name=alert_name),
-                json=alert_config.dict(),
-            )
-            assert resp.status_code == HTTPStatus.OK.value
-
-        for params, expected_length in [
-            # limit to 5
-            ({"page-size": 5}, 5),
-            # limit to 5, offset 2
-            ({"page-size": 5, "offset": 2}, 5),
-            # limit to 5, offset 6 - not enough alerts
-            ({"page-size": 5, "offset": 8}, 2),
-            # no limit at all
-            ({}, 8),
-            # only offset
-            ({"offset": 3}, 7),
-        ]:
-            resp = client.get(ALERTS_PATH.format(project=project), params=params)
-            assert resp.status_code == HTTPStatus.OK.value
-            alerts = resp.json().get("alerts", [])
-            assert (
-                len(alerts) == expected_length
-            ), f"Unexpected number of alerts for params: {params}"
+        project = setup_alerts
+        resp = client.get(ALERTS_PATH.format(project=project), params=params)
+        assert resp.status_code == HTTPStatus.OK.value
+        alerts = resp.json().get("alerts", [])
+        assert (
+            len(alerts) == expected_length
+        ), f"Unexpected number of alerts for params: {params}"
 
     # TODO: Move to test utils framework
     @staticmethod

--- a/server/py/services/alerts/tests/unit/api/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/api/test_alerts.py
@@ -53,7 +53,7 @@ class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
             ALERTS_PATH.format(project=project),
         )
         assert resp.status_code == HTTPStatus.OK.value
-        alerts = resp.json()
+        alerts = resp.json().get("alerts", [])
         assert len(alerts) == 1
         assert alerts[0]["name"] == alert_name
 
@@ -82,7 +82,7 @@ class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
             ALERTS_PATH.format(project="*"),
         )
         assert resp.status_code == HTTPStatus.OK.value
-        alerts = resp.json()
+        alerts = resp.json().get("alerts", [])
         assert len(alerts) == 2
 
         # list alerts for a specific project
@@ -90,7 +90,7 @@ class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
             ALERTS_PATH.format(project="test-alerts-0"),
         )
         assert resp.status_code == HTTPStatus.OK.value
-        alerts = resp.json()
+        alerts = resp.json().get("alerts", [])
         assert len(alerts) == 1
 
         # list alerts for a non-existing project
@@ -239,7 +239,7 @@ class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
         ]:
             resp = client.get(ALERTS_PATH.format(project=project), params=params)
             assert resp.status_code == HTTPStatus.OK.value
-            alerts = resp.json()
+            alerts = resp.json().get("alerts", [])
             assert (
                 len(alerts) == expected_length
             ), f"Unexpected number of alerts for params: {params}"

--- a/server/py/services/alerts/tests/unit/api/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/api/test_alerts.py
@@ -226,10 +226,15 @@ class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
     @pytest.mark.parametrize(
         "params, expected_length",
         [
+            # limit to 5
             ({"page-size": 5}, 5),
+            # limit to 5, offset 2
             ({"page-size": 5, "offset": 2}, 5),
+            # limit to 5, offset 8 - not enough alerts
             ({"page-size": 5, "offset": 8}, 2),
+            # no explicit limit, should return default limit (8)
             ({}, 8),
+            # only offset
             ({"offset": 3}, 7),
         ],
     )

--- a/server/py/services/alerts/tests/unit/api/test_alerts.py
+++ b/server/py/services/alerts/tests/unit/api/test_alerts.py
@@ -198,6 +198,52 @@ class TestAlerts(services.alerts.tests.unit.conftest.TestAlertsBase):
         result = client.delete(f"projects/{project_name}/alerts")
         assert result.status_code == 204
 
+    def test_list_alert_configs_with_limits(
+        self,
+        db: Session,
+        client: TestClient,
+        k8s_secrets_mock,
+    ):
+        project = "test-alerts"
+        self._create_project(db, project)
+
+        # for the sake of the test, set the limit to 8
+        mlrun.mlconf.alerts.default_list_alert_configs_limit = 8
+
+        for i in range(10):
+            alert_name = f"alert-name-{i}"
+            alert_config = services.alerts.tests.unit.crud.utils.generate_alert_data(
+                project=project,
+                name=alert_name,
+                entity=services.alerts.tests.unit.crud.utils.generate_alert_entity(
+                    project=project
+                ),
+            )
+            resp = client.put(
+                STORE_ALERTS_PATH.format(project=project, name=alert_name),
+                json=alert_config.dict(),
+            )
+            assert resp.status_code == HTTPStatus.OK.value
+
+        for params, expected_length in [
+            # limit to 5
+            ({"page-size": 5}, 5),
+            # limit to 5, offset 2
+            ({"page-size": 5, "offset": 2}, 5),
+            # limit to 5, offset 6 - not enough alerts
+            ({"page-size": 5, "offset": 8}, 2),
+            # no limit at all
+            ({}, 8),
+            # only offset
+            ({"offset": 3}, 7),
+        ]:
+            resp = client.get(ALERTS_PATH.format(project=project), params=params)
+            assert resp.status_code == HTTPStatus.OK.value
+            alerts = resp.json()
+            assert (
+                len(alerts) == expected_length
+            ), f"Unexpected number of alerts for params: {params}"
+
     # TODO: Move to test utils framework
     @staticmethod
     def _create_project(session: Session, project_name: str):


### PR DESCRIPTION
When we have many (~20k) alert configs in the system, listing them all causes the API behave unexpectedly.
While we will want to implement pagination for alert configs, as a current mitigation this PR adds a default limit to the list alert configs endpoint - 2k .

To avoid adding a query param to the endpoint that will be deprecated when pagination is implemented, the new param `page-size` is basically implementing the `limit` param.
On the client-side, we still use `limit` and `offset` arguments, that are translated to `page-size` and `offset`.

The 2k limit is configurable via the mlrun config.

Additionally, change the `list_alert_configs` response to return a dictionary that contains a list, instead of only a list, to prepare for pagination.

https://iguazio.atlassian.net/browse/ML-9576