### PR TITLE
[Runs] Fix end time fsp

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -602,7 +602,8 @@ class SQLDB(DBInterface):
             and not run.end_time
         ):
             if end_time is None:
-                end_time = func.now()
+                # Ensures fsp 6 for MySQL NOW() to includes microseconds
+                end_time = func.now(6)
             run.end_time = end_time
         elif (
             run.state not in mlrun.common.runtimes.constants.RunStates.terminal_states()

--- a/tests/integration/sdk_api/httpdb/runs/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/runs/test_runs.py
@@ -227,7 +227,8 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         project_name = "project-1"
         mlrun.new_project(project_name)
         # Create 5 runs with different states
-        # Runs 1, 2, 3 are completed and end in that order
+        # Runs 1, is completed, runs 2 and 3 start as running and moves to completed
+        updated_to_completed_uids = []
         statuses = [
             {
                 "state": mlrun.common.runtimes.constants.RunStates.completed,
@@ -237,22 +238,19 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
                 - datetime.timedelta(hours=5),
             },
             {
-                "state": mlrun.common.runtimes.constants.RunStates.completed,
+                "state": mlrun.common.runtimes.constants.RunStates.running,
                 "start_time": datetime.datetime.now(datetime.timezone.utc)
                 - datetime.timedelta(hours=5),
-                "end_time": datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(hours=1),
-            },
-            {
-                "state": mlrun.common.runtimes.constants.RunStates.completed,
-                "start_time": datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(days=1),
-                "end_time": datetime.datetime.now(datetime.timezone.utc),
             },
             {
                 "state": mlrun.common.runtimes.constants.RunStates.running,
                 "start_time": datetime.datetime.now(datetime.timezone.utc)
                 - datetime.timedelta(days=1),
+            },
+            {
+                "state": mlrun.common.runtimes.constants.RunStates.running,
+                "start_time": datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(hours=5),
             },
             {
                 "state": mlrun.common.runtimes.constants.RunStates.pending,
@@ -269,6 +267,19 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
                 "status": status,
             }
             mlrun.get_run_db().store_run(run, run["metadata"]["uid"], project_name)
+
+        # Move 2nd and 3rd run to completed
+        updates = {
+            "status.state": mlrun.common.runtimes.constants.RunStates.completed,
+        }
+        for i in range(1, 3):
+            uid = f"run-name-{i}-uid"
+            mlrun.get_run_db().update_run(
+                updates=updates,
+                uid=uid,
+                project=project_name,
+            )
+            updated_to_completed_uids.append(uid)
 
         run_1_start_time = statuses[0]["start_time"]
         run_2_start_time = statuses[1]["start_time"]
@@ -288,18 +299,12 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         stored_run = runs[0]
         assert stored_run["status"]["end_time"] > stored_run["status"]["start_time"]
         assert stored_run["status"]["end_time"].endswith("+00:00")
-        # Assert fsp 6
-        assert any(
-            datetime.datetime.fromisoformat(run["status"]["end_time"]).microsecond
-            for run in runs[:3]
-        )
+
         # 2nd run is 1st in order because it started last
         assert runs[0]["metadata"]["name"] == "run-name-1"
-        assert runs[0]["status"]["end_time"] == statuses[1]["end_time"].isoformat()
         assert runs[1]["metadata"]["name"] == "run-name-0"
         assert runs[1]["status"]["end_time"] == statuses[0]["end_time"].isoformat()
         assert runs[2]["metadata"]["name"] == "run-name-2"
-        assert runs[2]["status"]["end_time"] == statuses[2]["end_time"].isoformat()
 
         _list_and_assert_objects(
             expected_number_of_runs=1,
@@ -315,6 +320,30 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         )
         assert runs[0]["metadata"]["name"] == "run-name-1"
         assert runs[1]["metadata"]["name"] == "run-name-2"
+
+        updates = {
+            "status.state": mlrun.common.runtimes.constants.RunStates.completed,
+        }
+        uid = "run-name-4-uid"
+        mlrun.get_run_db().update_run(
+            updates=updates,
+            uid=uid,
+            project=project_name,
+        )
+        updated_to_completed_uids.append(uid)
+
+        # Assert fsp 6 for updated runs (uses `NOW()` in DB for end_time)
+        runs = _list_and_assert_objects(
+            expected_number_of_runs=5,
+            project=project_name,
+        )
+        # Assert with any for the slight chance that some may have been saved at a round second
+        assert any(
+            datetime.datetime.fromisoformat(run["status"]["end_time"]).microsecond
+            if run["metadata"]["uid"] in updated_to_completed_uids
+            else False
+            for run in runs
+        )
 
 
 def _list_and_assert_objects(expected_number_of_runs: int, **kwargs):


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-9572

Integration test was not using "update" so the `now` func was not used.

`func.now` does no accept fsp as kwarg