### PR TITLE
[Model Monitoring] Improve the error message when accessing `sample_df`

### DIFF
--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -60,7 +60,6 @@ class MonitoringApplicationContext:
         sample_df: Optional[pd.DataFrame] = None,
         feature_stats: Optional[FeatureStats] = None,
         feature_sets_dict: Optional[dict[str, FeatureSet]] = None,
-        ml_ctx_generated: bool = False,
     ) -> None:
         """
         The :code:`MonitoringApplicationContext` object holds all the relevant information for the
@@ -129,8 +128,6 @@ class MonitoringApplicationContext:
             feature_sets_dict.get(self.endpoint_id) if feature_sets_dict else None
         )
 
-        self._ml_ctx_generated = ml_ctx_generated
-
     @classmethod
     def _from_ml_ctx(
         cls,
@@ -160,7 +157,6 @@ class MonitoringApplicationContext:
             artifacts_logger=artifacts_logger,
             sample_df=sample_df,
             feature_stats=feature_stats,
-            ml_ctx_generated=True,
         )
 
     @classmethod
@@ -211,11 +207,11 @@ class MonitoringApplicationContext:
     @property
     def sample_df(self) -> pd.DataFrame:
         if self._sample_df is None:
-            if self._ml_ctx_generated and not (
-                self.endpoint_name
-                and self.endpoint_id
-                and self.start_infer_time
-                and self.end_infer_time
+            if (
+                self.endpoint_name is None
+                or self.endpoint_id is None
+                or pd.isnull(self.start_infer_time)
+                or pd.isnull(self.end_infer_time)
             ):
                 raise mlrun.errors.MLRunValueError(
                     "You have tried to access `monitoring_context.sample_df`, but have not provided it directly "

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -60,6 +60,7 @@ class MonitoringApplicationContext:
         sample_df: Optional[pd.DataFrame] = None,
         feature_stats: Optional[FeatureStats] = None,
         feature_sets_dict: Optional[dict[str, FeatureSet]] = None,
+        ml_ctx_generated: bool = False,
     ) -> None:
         """
         The :code:`MonitoringApplicationContext` object holds all the relevant information for the
@@ -76,7 +77,6 @@ class MonitoringApplicationContext:
         :param sample_df:               (pd.DataFrame) The new sample DataFrame.
         :param start_infer_time:        (pd.Timestamp) Start time of the monitoring schedule.
         :param end_infer_time:          (pd.Timestamp) End time of the monitoring schedule.
-        :param latest_request:          (pd.Timestamp) Timestamp of the latest request on this endpoint_id.
         :param endpoint_id:             (str) ID of the monitored model endpoint
         :param feature_set:              (FeatureSet) the model endpoint feature set
         :param endpoint_name:           (str) Name of the monitored model endpoint
@@ -129,6 +129,8 @@ class MonitoringApplicationContext:
             feature_sets_dict.get(self.endpoint_id) if feature_sets_dict else None
         )
 
+        self._ml_ctx_generated = ml_ctx_generated
+
     @classmethod
     def _from_ml_ctx(
         cls,
@@ -158,6 +160,7 @@ class MonitoringApplicationContext:
             artifacts_logger=artifacts_logger,
             sample_df=sample_df,
             feature_stats=feature_stats,
+            ml_ctx_generated=True,
         )
 
     @classmethod
@@ -208,6 +211,20 @@ class MonitoringApplicationContext:
     @property
     def sample_df(self) -> pd.DataFrame:
         if self._sample_df is None:
+            if self._ml_ctx_generated and not (
+                self.endpoint_name
+                and self.endpoint_id
+                and self.start_infer_time
+                and self.end_infer_time
+            ):
+                raise mlrun.errors.MLRunValueError(
+                    "You have tried to access `monitoring_context.sample_df`, but have not provided it directly "
+                    "through `sample_data`, nor have you provided the model endpoint's name, ID, and the start and "
+                    f"end times: `endpoint_name`={self.endpoint_name}, `endpoint_uid`={self.endpoint_id}, "
+                    f"`start`={self.start_infer_time}, and `end`={self.end_infer_time}. "
+                    "You can either provide the sample dataframe directly, the model endpoint's details and times, "
+                    "or adapt the application's logic to not access the sample dataframe."
+                )
             feature_set = self.feature_set
             features = [f"{feature_set.metadata.name}.*"]
             vector = fstore.FeatureVector(

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Optional, Union
 from unittest.mock import Mock, patch
 
+import pandas as pd
 import pytest
 
 import mlrun
@@ -77,6 +78,19 @@ class ModelEndpointAccessApp(ModelMonitoringApplicationBase):
         )
 
 
+class SampleDFAccessApp(ModelMonitoringApplicationBase):
+    def do_tracking(self, monitoring_context: MonitoringApplicationContext) -> None:
+        monitoring_context.logger.info(
+            "Accessing the model endpoint's sample data",
+            project=monitoring_context.project_name,
+        )
+        sample_df = monitoring_context.sample_df
+        monitoring_context.logger.info(
+            "Read the sample data",
+            sample_df=sample_df,
+        )
+
+
 @pytest.mark.filterwarnings("error")
 def test_no_deprecation_instantiation() -> None:
     NoOpApp()
@@ -119,6 +133,40 @@ class TestEvaluate:
             "but you have tried to access `monitoring_context.model_endpoint`"
             in captured.out
         ), "The error message is different than expected or was not captured"
+
+    @staticmethod
+    def test_invalid_sample_df_access(capsys: pytest.CaptureFixture) -> None:
+        """Test that the logs contain the error message about sample data access"""
+        run = SampleDFAccessApp.evaluate(func_path=__file__)
+        assert run.state() == "created"  # Should be "error", see ML-8507
+        captured = capsys.readouterr()
+        assert (
+            "You have tried to access `monitoring_context.sample_df`, but have not provided it directly"
+            in captured.out
+        ), "The error message is different than expected or was not captured"
+
+    @staticmethod
+    def test_valid_sample_df_access(
+        tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        project = mlrun.get_or_create_project(
+            "local-test-sample-df", context=str(tmp_path)
+        )
+        project.artifact_path = str(tmp_path)
+        sample_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        ds_artifact = project.log_dataset("sample-df", df=sample_df)
+        job = SampleDFAccessApp.to_job(func_path=__file__)
+        run = job.run(local=True, inputs={"sample_data": ds_artifact.target_path})
+        assert run.state() == "completed"
+        captured = capsys.readouterr()
+        assert (
+            "You have tried to access `monitoring_context.sample_df`, but have not provided it directly"
+            not in captured.out
+        ), "The captured error was not expected"
+
+        assert (
+            "Read the sample data" in captured.out
+        ), "The expected log message was not found in the captured output"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes [ML-8730](https://iguazio.atlassian.net/browse/ML-8730).
Improve the error message when a user tries to access `monitoring_context.sample_df`, but does not provide:

1. `sample_data`, or
2. Model endpoint details: `[(endpoint_name, endpoint_uid)]`, and `start` and `end` times.

[ML-8730]: https://iguazio.atlassian.net/browse/ML-8730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ