### PR TITLE
[CI] Bump release-required dependencies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,8 +158,8 @@ jobs:
           # TODO: move to a separated requirements file
           python -m pip install \
             build~=1.2 \
-            wheel~=0.43 \
-            twine~=5.1
+            wheel~=0.45 \
+            twine~=6.1
       - name: Build & push to pypi
         if: github.event.inputs.skip_publish_pypi != 'true'
         run: |


### PR DESCRIPTION
There is an issue with `pkginfo` which was a dependency of twine but is not anymore.
```
Uploading distributions to https://upload.pypi.org/legacy/
ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.                                                    
make: *** [Makefile:507: publish-package] Error 1
```