### PR TITLE
[Labels] Validate labels

### DIFF
--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -63,7 +63,7 @@ def run_state(run):
     )
 
 
-def update_labels(obj, labels: dict):
+def update_labels(obj, labels: dict[str, str]):
     old = {label.name: label for label in obj.labels}
     obj.labels.clear()
     for name, value in labels.items():

--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -63,7 +63,7 @@ def run_state(run):
     )
 
 
-def update_labels(obj, labels: dict[str, str]):
+def update_labels(obj, labels: dict[str, typing.Union[str, int]]):
     if not isinstance(labels, dict):
         raise mlrun.errors.MLRunInvalidArgumentError("Labels must be a dictionary.")
 
@@ -175,22 +175,29 @@ def ensure_max_length(string: str):
     return string
 
 
+def _validate_label(name: str, value: typing.Union[str, int]):
+    if not isinstance(name, str):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "The name in the label must be a string."
+        )
+
+    if not isinstance(value, (str, int)):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "The value in the label must be a string or an integer."
+        )
+
+    value = str(value)
+
+    _validate_label_length(label_type="Name", label_name=name, validate_element=name)
+    _validate_label_length(label_type="Value", label_name=name, validate_element=value)
+
+
 def _validate_label_length(label_type: str, label_name: str, validate_element: str):
     """Validates the length of a label name or value and raises an error if it exceeds max_length."""
     if len(validate_element) > max_str_length:
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"{label_type} of `{label_name}` label is too long. Maximum allowed length is {max_str_length} characters."
         )
-
-
-def _validate_label(name: str, value: str):
-    if not isinstance(name, str) or not isinstance(value, str):
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            "Both the keys and values in the labels must be strings."
-        )
-
-    _validate_label_length(label_type="Name", label_name=name, validate_element=name)
-    _validate_label_length(label_type="Value", label_name=name, validate_element=value)
 
 
 class MemoizationCache:

--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -64,13 +64,13 @@ def run_state(run):
 
 
 def update_labels(obj, labels: dict[str, str]):
+    if not isinstance(labels, dict):
+        raise mlrun.errors.MLRunInvalidArgumentError("Labels must be a dictionary.")
+
     old = {label.name: label for label in obj.labels}
     obj.labels.clear()
     for name, value in labels.items():
-        validate_label_length(label_type="Name", label_name=name, validate_element=name)
-        validate_label_length(
-            label_type="Value", label_name=name, validate_element=value
-        )
+        _validate_label(name, value)
         if name in old:
             old[name].value = value
             obj.labels.append(old[name])
@@ -175,12 +175,22 @@ def ensure_max_length(string: str):
     return string
 
 
-def validate_label_length(label_type: str, label_name: str, validate_element: str):
+def _validate_label_length(label_type: str, label_name: str, validate_element: str):
     """Validates the length of a label name or value and raises an error if it exceeds max_length."""
-    if len(str(validate_element)) > max_str_length:
+    if len(validate_element) > max_str_length:
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"{label_type} of `{label_name}` label is too long. Maximum allowed length is {max_str_length} characters."
         )
+
+
+def _validate_label(name: str, value: str):
+    if not isinstance(name, str) or not isinstance(value, str):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Both the keys and values in the labels must be strings."
+        )
+
+    _validate_label_length(label_type="Name", label_name=name, validate_element=name)
+    _validate_label_length(label_type="Value", label_name=name, validate_element=value)
 
 
 class MemoizationCache:

--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -67,11 +67,11 @@ def update_labels(obj, labels: dict):
     old = {label.name: label for label in obj.labels}
     obj.labels.clear()
     for name, value in labels.items():
+        error_msg = f" of `{name}` label is too long. Maximum allowed length is {max_str_length} characters."
+        if len(str(name)) > max_str_length:
+            raise mlrun.errors.MLRunInvalidArgumentError("Name" + error_msg)
         if len(str(value)) > max_str_length:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Value of `{name}` label is too long. "
-                f"Maximum allowed length is {max_str_length} characters."
-            )
+            raise mlrun.errors.MLRunInvalidArgumentError("Value" + error_msg)
         if name in old:
             old[name].value = value
             obj.labels.append(old[name])

--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -67,11 +67,10 @@ def update_labels(obj, labels: dict):
     old = {label.name: label for label in obj.labels}
     obj.labels.clear()
     for name, value in labels.items():
-        error_msg = f" of `{name}` label is too long. Maximum allowed length is {max_str_length} characters."
-        if len(str(name)) > max_str_length:
-            raise mlrun.errors.MLRunInvalidArgumentError("Name" + error_msg)
-        if len(str(value)) > max_str_length:
-            raise mlrun.errors.MLRunInvalidArgumentError("Value" + error_msg)
+        validate_label_length(label_type="Name", label_name=name, validate_element=name)
+        validate_label_length(
+            label_type="Value", label_name=name, validate_element=value
+        )
         if name in old:
             old[name].value = value
             obj.labels.append(old[name])
@@ -174,6 +173,14 @@ def ensure_max_length(string: str):
     if string and len(string) > max_str_length:
         string = string[:max_str_length]
     return string
+
+
+def validate_label_length(label_type: str, label_name: str, validate_element: str):
+    """Validates the length of a label name or value and raises an error if it exceeds max_length."""
+    if len(validate_element) > max_str_length:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"{label_type} of `{label_name}` label is too long. Maximum allowed length is {max_str_length} characters."
+        )
 
 
 class MemoizationCache:

--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -177,7 +177,7 @@ def ensure_max_length(string: str):
 
 def validate_label_length(label_type: str, label_name: str, validate_element: str):
     """Validates the length of a label name or value and raises an error if it exceeds max_length."""
-    if len(validate_element) > max_str_length:
+    if len(str(validate_element)) > max_str_length:
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"{label_type} of `{label_name}` label is too long. Maximum allowed length is {max_str_length} characters."
         )

--- a/server/py/services/api/tests/unit/db/test_helpers.py
+++ b/server/py/services/api/tests/unit/db/test_helpers.py
@@ -1,0 +1,41 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import mlrun.errors
+
+import framework.db.sqldb.helpers
+import framework.db.sqldb.models
+from framework.tests.unit.db.common_fixtures import TestDatabaseBase
+
+
+class TestHelpers(TestDatabaseBase):
+    @pytest.mark.parametrize(
+        "labels",
+        [
+            ("my-str"),
+            ([]),
+            (None),
+            ({"a": [{"b": "c"}]}),
+            ({1: "a"}),
+            ({"a": 1}),
+            ({"a" * 256: "b"}),
+            ({"a": "b" * 256}),
+        ],
+    )
+    def test_update_labels_invalid(self, labels):
+        obj = framework.db.sqldb.models.ArtifactV2()
+        obj.labels = []
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+            framework.db.sqldb.helpers.update_labels(obj, labels)

--- a/server/py/services/api/tests/unit/db/test_helpers.py
+++ b/server/py/services/api/tests/unit/db/test_helpers.py
@@ -29,7 +29,6 @@ class TestHelpers(TestDatabaseBase):
             (None),
             ({"a": [{"b": "c"}]}),
             ({1: "a"}),
-            ({"a": 1}),
             ({"a" * 256: "b"}),
             ({"a": "b" * 256}),
         ],

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -524,6 +524,22 @@ class TestRuns(TestDatabaseBase):
                 iteration,
             )
 
+        label_key = "a" * 256
+        run["metadata"]["labels"] = {label_key: "b"}
+        # too long name
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match=f"Name of `{label_key}` label is too long. "
+            "Maximum allowed length is 255 characters.",
+        ):
+            self._db.update_run(
+                self._db_session,
+                run,
+                uid,
+                project,
+                iteration,
+            )
+
     def test_store_and_update_run_update_name_failure(self):
         project, name, uid, iteration, run = self._create_new_run()
 


### PR DESCRIPTION
Adding validation to verify that labels are a dictionary of strings.

Additionally, the maximum length for the label key is 255 characters.
[Here](https://github.com/mlrun/mlrun/pull/7149), we validate the label value, but not the label key.
This causes the error: `Failed committing changes to DB`.

These bugs are relevant for all resources that have labels stored in a different table:

- Artifact
- Run
- Schedule
- Function
- Project
- Feature
- Entity
- FeatureSet
- FeatureVector
- ModelEndpoint

https://iguazio.atlassian.net/browse/ML-9632
https://iguazio.atlassian.net/browse/ML-9599