### PR TITLE
[Workflows] Fix condition for remote file validation

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -5266,7 +5266,7 @@ class MlrunProject(ModelObj):
             )
 
         # if engine is remote then skip the local file validation
-        if engine and not engine.startswith("remote"):
+        if engine and engine.startswith("remote"):
             return
 
         code_path = self.spec.get_code_path()

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1565,9 +1565,9 @@ def test_run_function_passes_project_artifact_path(rundb_mock):
             None,
         ),
         # relative path with engine="remote", should not raise an error since the file does not need to exist locally
-        ("./workflow.py", does_not_raise(), "remote"),
-        ("./workflow.py", does_not_raise(), "remote:local"),
-        ("./workflow.py", does_not_raise(), "remote:kfp"),
+        ("./remote_workflow.py", does_not_raise(), "remote"),
+        ("./remote_workflow.py", does_not_raise(), "remote:local"),
+        ("./remote_workflow.py", does_not_raise(), "remote:kfp"),
     ],
 )
 def test_set_workflow_path_validation(


### PR DESCRIPTION
Corrected the logic to properly skip file validation for **remote** engines, as the previous condition incorrectly applied the opposite behavior.
The existing test did not catch this because the workflow path is used in the test existed locally. 
To properly test the fix, the path was changed to something that does not exist locally.

https://iguazio.atlassian.net/browse/ML-9442