### PR TITLE
[Model Monitoring] Add evidently logs in json load

### DIFF
--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -109,7 +109,9 @@ class EvidentlyModelMonitoringApplicationBase(
             except FileNotFoundError:
                 print(f"evidently json issue, path not found: {full_path}")
             except json.decoder.JSONDecodeError as json_error:
-                print(f"evidently json issue, path got json error, path:{full_path}, error:")
+                print(
+                    f"evidently json issue, path got json error, path:{full_path}, error:"
+                )
                 traceback.print_exception(
                     type(json_error), json_error, json_error.__traceback__
                 )

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import posixpath
+import traceback
 import uuid
 import warnings
 from abc import ABC
 
 import pandas as pd
 import semver
+from evidently.ui.storage.local.base import METADATA_PATH, FSLocation
 
 import mlrun.model_monitoring.applications.base as mm_base
 import mlrun.model_monitoring.applications.context as mm_context
@@ -81,11 +85,36 @@ class EvidentlyModelMonitoringApplicationBase(
         # TODO : more then one project (mep -> project)
         if not _HAS_EVIDENTLY:
             raise ModuleNotFoundError("Evidently is not installed - the app cannot run")
+        self._log_location(evidently_workspace_path)
         self.evidently_workspace = Workspace.create(evidently_workspace_path)
         self.evidently_project_id = evidently_project_id
         self.evidently_project = self.evidently_workspace.get_project(
             evidently_project_id
         )
+
+    @staticmethod
+    def _log_location(evidently_workspace_path):
+        location = FSLocation(base_path=evidently_workspace_path)
+        location.invalidate_cache("")
+        # projects = [load_project(location, p) for p in location.listdir("") if location.isdir(p)]
+        paths = [p for p in location.listdir("") if location.isdir(p)]
+
+        for path in paths:
+            metadata_path = posixpath.join(path, METADATA_PATH)
+            full_path = posixpath.join(location.path, metadata_path)
+            try:
+                with location.open(metadata_path) as f:
+                    return json.load(f)
+            except FileNotFoundError:
+                print(f"path not found: {full_path}")
+            except json.decoder.JSONDecodeError as json_error:
+                print(f"path got json error, path:{full_path}, error:")
+                traceback.print_exception(
+                    type(json_error), json_error, json_error.__traceback__
+                )
+                print("file content:")
+                with location.open(metadata_path) as f:
+                    print(f.read())
 
     @staticmethod
     def log_evidently_object(

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -102,17 +102,18 @@ class EvidentlyModelMonitoringApplicationBase(
         for path in paths:
             metadata_path = posixpath.join(path, METADATA_PATH)
             full_path = posixpath.join(location.path, metadata_path)
+            print(f"evidently json issue, working on path: {full_path}")
             try:
                 with location.open(metadata_path) as f:
                     return json.load(f)
             except FileNotFoundError:
-                print(f"path not found: {full_path}")
+                print(f"evidently json issue, path not found: {full_path}")
             except json.decoder.JSONDecodeError as json_error:
-                print(f"path got json error, path:{full_path}, error:")
+                print(f"evidently json issue, path got json error, path:{full_path}, error:")
                 traceback.print_exception(
                     type(json_error), json_error, json_error.__traceback__
                 )
-                print("file content:")
+                print("evidently json issue, file content:")
                 with location.open(metadata_path) as f:
                     print(f.read())
 

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -14,7 +14,6 @@
 
 import json
 import posixpath
-import traceback
 import uuid
 import warnings
 from abc import ABC
@@ -105,19 +104,21 @@ class EvidentlyModelMonitoringApplicationBase(
             print(f"evidently json issue, working on path: {full_path}")
             try:
                 with location.open(metadata_path) as f:
-                    return json.load(f)
+                    content = json.load(f)
+                    print(
+                        f"evidently json issue, successful load path: {full_path}, content: {content}"
+                    )
             except FileNotFoundError:
                 print(f"evidently json issue, path not found: {full_path}")
+                continue
             except json.decoder.JSONDecodeError as json_error:
                 print(
-                    f"evidently json issue, path got json error, path:{full_path}, error:"
-                )
-                traceback.print_exception(
-                    type(json_error), json_error, json_error.__traceback__
+                    f"evidently json issue, path got json error, path:{full_path}, error: {json_error}"
                 )
                 print("evidently json issue, file content:")
                 with location.open(metadata_path) as f:
                     print(f.read())
+                continue
 
     @staticmethod
     def log_evidently_object(

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -94,9 +94,9 @@ class EvidentlyModelMonitoringApplicationBase(
 
     @staticmethod
     def _log_location(evidently_workspace_path):
+        # TODO remove function + usage after solving issue ML-9530
         location = FSLocation(base_path=evidently_workspace_path)
         location.invalidate_cache("")
-        # projects = [load_project(location, p) for p in location.listdir("") if location.isdir(p)]
         paths = [p for p in location.listdir("") if location.isdir(p)]
 
         for path in paths:

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -119,6 +119,11 @@ class EvidentlyModelMonitoringApplicationBase(
                 with location.open(metadata_path) as f:
                     print(f.read())
                 continue
+            except Exception as error:
+                print(
+                    f"evidently json issue, path got general error, path:{full_path}, error: {error}"
+                )
+                continue
 
     @staticmethod
     def log_evidently_object(


### PR DESCRIPTION
Evidently, json.load `metadata.json` is not reproduced in a regular `05-model-monitoring.ipynb` run on the Jupyter service on iguazio setup.

This bug is transient, so logs were added in case it occurs again during QA tests.

[ML-9530](https://iguazio.atlassian.net/browse/ML-9530)

[ML-9530]: https://iguazio.atlassian.net/browse/ML-9530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Attention! These logs are temporary and will be removed once we solve/close the issue.