### PR TITLE
[Model Monitoring] Revert #7419 to bring back parallel frames queries

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import math
 from datetime import datetime, timedelta
 from io import StringIO
@@ -1092,7 +1093,7 @@ class V3IOTSDBConnector(TSDBConnector):
         :param model_endpoint_objects: A list of `ModelEndpoint` objects that will
                                         be filled with the relevant basic metrics.
         :param project:                The name of the project.
-        :param run_in_threadpool:      Has no effect.
+        :param run_in_threadpool:      A function that runs another function in a thread pool.
 
         :return: A list of `ModelEndpointMonitoringMetric` objects.
         """
@@ -1104,9 +1105,29 @@ class V3IOTSDBConnector(TSDBConnector):
             uids.append(uid)
             model_endpoint_objects_by_uid[uid] = model_endpoint_object
 
-        error_count_res = self.get_error_count(endpoint_ids=uids, get_raw=True)
-        avg_latency_res = self.get_avg_latency(endpoint_ids=uids, get_raw=True)
-        drift_status_res = self.get_drift_status(endpoint_ids=uids, get_raw=True)
+        coroutines = [
+            run_in_threadpool(
+                self.get_error_count,
+                endpoint_ids=uids,
+                get_raw=True,
+            ),
+            run_in_threadpool(
+                self.get_avg_latency,
+                endpoint_ids=uids,
+                get_raw=True,
+            ),
+            run_in_threadpool(
+                self.get_drift_status,
+                endpoint_ids=uids,
+                get_raw=True,
+            ),
+        ]
+
+        (
+            error_count_res,
+            avg_latency_res,
+            drift_status_res,
+        ) = await asyncio.gather(*coroutines)
 
         def add_metric(
             metric: str,


### PR DESCRIPTION
Reverts #7419.

[ML-9651](https://iguazio.atlassian.net/browse/ML-9651)

[ML-9651]: https://iguazio.atlassian.net/browse/ML-9651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ