### PR TITLE
[Nuclio] Mask trigger sensitive fields

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import json
 import typing
 import warnings
@@ -49,6 +50,19 @@ from mlrun.runtimes.pod import KubeResource, KubeResourceSpec
 from mlrun.runtimes.utils import get_item_name, log_std
 from mlrun.utils import get_in, logger, update_in
 from mlrun_pipelines.common.ops import deploy_op
+
+SENSITIVE_PATHS_IN_TRIGGER_CONFIG = {
+    "password",
+    "secret",
+    "attributes/password",
+    "attributes/accesskeyid",
+    "attributes/secretaccesskey",
+    "attributes/cacert",
+    "attributes/accesskey",
+    "attributes/accesscertificate",
+    "attributes/sasl/password",
+    "attributes/sasl/oauth/clientsecret",
+}
 
 
 def validate_nuclio_version_compatibility(*min_versions):
@@ -273,6 +287,37 @@ class RemoteRuntime(KubeResource):
     def pre_deploy_validation(self):
         if self.metadata.tag:
             mlrun.utils.validate_tag_name(self.metadata.tag, "function.metadata.tag")
+
+    def mask_sensitive_data_in_config(self):
+        if not self.spec.config:
+            return {}
+
+        raw_config = copy.deepcopy(self.spec.config)
+
+        for key, value in self.spec.config.items():
+            if key.startswith("spec.triggers"):
+                trigger_name = key.split(".")[-1]
+
+                for path in SENSITIVE_PATHS_IN_TRIGGER_CONFIG:
+                    # Handle nested keys
+                    nested_keys = path.split("/")
+                    target = value
+                    for sub_key in nested_keys[:-1]:
+                        target = target.get(sub_key, {})
+
+                    last_key = nested_keys[-1]
+                    if last_key in target:
+                        sensitive_field = target[last_key]
+                        if sensitive_field.startswith(
+                            mlrun.model.Credentials.secret_reference_prefix
+                        ):
+                            # already masked
+                            continue
+                        target[last_key] = (
+                            f"{mlrun.model.Credentials.secret_reference_prefix}/spec/triggers/{trigger_name}/{path}"
+                        )
+
+        return raw_config
 
     def set_config(self, key, value):
         self.spec.config[key] = value
@@ -1229,6 +1274,9 @@ class RemoteRuntime(KubeResource):
         for remote_env in remote_data.get("spec", {}).get("env", []):
             if remote_env.get("name") in credentials_env_var_names:
                 new_env.append(remote_env)
+
+        # update nuclio-specific credentials
+        self.mask_sensitive_data_in_config()
 
         self.spec.env = new_env
 

--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -517,9 +517,16 @@ def _deploy_function(
         launcher.enrich_runtime(runtime=fn, full=True)
 
         fn.pre_deploy_validation()
+        # before saving function to DB, we need to mask some nuclio-specific fields
+        # which later in Nuclio will be masked and saved to secrets
+        raw_config = fn.mask_sensitive_data_in_config()
+
+        # save the function to DB
         fn.save(versioned=False)
         fn.spec.model_endpoint_creation_task_name = model_endpoint_creation_task_name
 
+        # after saving function to DB, we need to restore the original config so that the sensitive data won't be stored
+        fn.spec.config = raw_config
         fn = _deploy_nuclio_runtime(
             auth_info,
             builder_env,
@@ -528,6 +535,8 @@ def _deploy_function(
             db_session,
             fn,
         )
+        # after deploying the function, we need to re-mask the sensitive data again and save to the db
+        fn.mask_sensitive_data_in_config()
         fn.save(versioned=False)
         logger.info("Resolved function", fn=fn.to_yaml())
     except Exception as err:
@@ -705,6 +714,7 @@ def _handle_nuclio_deploy_status(
             tag,
             versioned=versioned,
         )
+        logger.info("Updating function status", function=fn)
 
     return Response(
         content=text,

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1846,6 +1846,34 @@ class TestNuclioRuntime(TestRuntimeBase):
             nuclio.triggers.V3IOStreamTrigger(explicit_ack_mode="explicitOnly"),
         )
 
+    def test_masking_sensitive_fields(self):
+        function = self._generate_runtime(self.runtime_kind)
+
+        raw_password = "raw_password"
+        function.add_v3io_stream_trigger(
+            stream_path="test",
+            access_key=raw_password,
+            extra_attributes={"password": raw_password},
+        )
+        raw_config = function.mask_sensitive_data_in_config()
+
+        assert (
+            function.spec.config.get("spec.triggers.stream").get("password")
+            == "$ref:/spec/triggers/stream/password"
+        )
+        assert raw_config.get("spec.triggers.stream").get("password") == raw_password
+
+        assert (
+            function.spec.config.get("spec.triggers.stream")
+            .get("attributes", {})
+            .get("password")
+            == "$ref:/spec/triggers/stream/attributes/password"
+        )
+        assert (
+            raw_config.get("spec.triggers.stream").get("attributes", {}).get("password")
+            == raw_password
+        )
+
 
 # Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well
 class TestNuclioMLRunRuntime(TestNuclioRuntime):

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -252,6 +252,15 @@ class TestNuclioRuntimeWithStream(tests.system.base.TestMLRunSystem):
         self._logger.debug("Deploying nuclio function")
         url = function.deploy()
 
+        db_function = self.project.get_function(function.metadata.name)
+        nuclio_config = db_function.spec.config
+
+        for key, value in nuclio_config.items():
+            if key.startswith("spec.triggers"):
+                assert value.get("password", "").startswith(
+                    mlrun.model.Credentials.secret_reference_prefi
+                )
+
         self._logger.debug("Triggering nuclio function")
         resp = requests.post(url, json={"hello": "world"})
         assert resp.status_code == 200


### PR DESCRIPTION
The logic is that we send raw data to nuclio and after sending it, mask the fields by the same algorithms it is done in nuclio. 

List of fields to mask: https://github.com/nuclio/nuclio/blob/01b66be40410cb9827b3de0eb7c8628ade18911b/pkg/platformconfig/types.go#L319-L333. 

Jira - https://iguazio.atlassian.net/browse/ML-9443

![image](https://github.com/user-attachments/assets/06e26391-774b-4ab4-8e63-41d99a1fbac6)

