### PR TITLE
[Requirements] Bump storey

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2023.9.2, <2024.7
 v3iofs~=0.1.17
-storey~=1.8.9
+storey~=1.8.10
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -118,7 +118,7 @@ def test_requirement_specifiers_convention():
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "aiobotocore": {">=2.5.0,<2.16"},
-        "storey": {"~=1.8.9"},
+        "storey": {"~=1.8.10"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "sphinx-book-theme": {"~=1.0.1"},


### PR DESCRIPTION
Bump to the latest version - [v1.8.10](https://github.com/mlrun/storey/releases/tag/v1.8.10).
Related to [ML-9067](https://iguazio.atlassian.net/browse/ML-9067).

The lock files update has already happened in #7513:
https://github.com/mlrun/mlrun/blob/d61b4e2f37215ae9564aeb1dbbeee08c7f0c9d2c/dockerfiles/mlrun/locked-requirements.txt#L3493

So in this PR, we update only the manifest - the `requirements.txt` file, and a related test.

[ML-9067]: https://iguazio.atlassian.net/browse/ML-9067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ