### PR TITLE
[Artifacts] Allow logging with `None` values [1.8.x]

### DIFF
--- a/server/py/framework/db/sqldb/helpers.py
+++ b/server/py/framework/db/sqldb/helpers.py
@@ -175,7 +175,11 @@ def ensure_max_length(string: str):
     return string
 
 
-def _validate_label(name: str, value: typing.Union[str, int]):
+def _validate_label(name: str, value: typing.Optional[typing.Union[str, int]]):
+    # a backwards compatibility check for `None` key
+    if value is None:
+        return
+
     if not isinstance(name, str):
         raise mlrun.errors.MLRunInvalidArgumentError(
             "The name in the label must be a string."

--- a/server/py/services/api/tests/unit/db/test_helpers.py
+++ b/server/py/services/api/tests/unit/db/test_helpers.py
@@ -24,13 +24,14 @@ class TestHelpers(TestDatabaseBase):
     @pytest.mark.parametrize(
         "labels",
         [
-            ("my-str"),
-            ([]),
-            (None),
-            ({"a": [{"b": "c"}]}),
-            ({1: "a"}),
-            ({"a" * 256: "b"}),
-            ({"a": "b" * 256}),
+            ("my-str",),
+            ([],),
+            (None,),
+            ({"a": [{"b": "c"}]},),
+            ({1: "a"},),
+            ({"a": None},),
+            ({"a" * 256: "b"},),
+            ({"a": "b" * 256},),
         ],
     )
     def test_update_labels_invalid(self, labels):


### PR DESCRIPTION
(#7529)
(cherry picked from commit 953b58101962e640318e6449969abc2f6f221cdd)