### PR TITLE
[Model Monitoring] Fix TDEngine precision - support microsecond [1.8.x]

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -77,7 +77,7 @@ def extra_requirements() -> dict[str, list[str]]:
             'distributed~=2023.12.1; python_version < "3.11"',
         ],
         "alibaba-oss": ["ossfs==2023.12.0", "oss2==2.18.1"],
-        "tdengine": ["taos-ws-py==0.3.2", "taoswswrap~=0.3.4"],
+        "tdengine": ["taos-ws-py==0.3.2", "taoswswrap~=0.3.5"],
         "snowflake": ["snowflake-connector-python~=3.7"],
     }
 

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -51,5 +51,5 @@ distributed~=2023.12.1; python_version < "3.11"
 dask~=2024.12.1; python_version >= "3.11"
 distributed~=2024.12.1; python_version >= "3.11"
 taos-ws-py==0.3.2
-taoswswrap~=0.3.4
+taoswswrap~=0.3.5
 snowflake-connector-python~=3.7

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -200,6 +200,7 @@ class TDEngineConnector(TSDBConnector):
             columns=columns,
             subtable=table_name,
             values=event,
+            timestamp_precision=self._timestamp_precision,
         )
 
         self.connection.run(

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import asyncio
 from datetime import datetime, timedelta
 from threading import Lock
-from typing import Callable, Literal, Optional, Union
+from typing import Callable, Final, Literal, Optional, Union
 
 import pandas as pd
 import taosws
@@ -24,6 +25,7 @@ from taoswswrap.tdengine_connection import (
 )
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
+import mlrun.common.types
 import mlrun.model_monitoring.db.tsdb.tdengine.schemas as tdengine_schemas
 import mlrun.model_monitoring.db.tsdb.tdengine.stream_graph_steps
 from mlrun.datastore.datastore_profile import DatastoreProfile
@@ -33,6 +35,19 @@ from mlrun.utils import logger
 
 _connection = None
 _connection_lock = Lock()
+
+
+class TDEngineTimestampPrecision(mlrun.common.types.StrEnum):
+    """
+    The timestamp precision for the TDEngine database.
+    For more information, see:
+    https://docs.tdengine.com/tdengine-reference/sql-manual/data-types/#timestamp
+    https://docs.tdengine.com/tdengine-reference/sql-manual/manage-databases/#create-database
+    """
+
+    MILLISECOND = "ms"  # TDEngine's default
+    MICROSECOND = "us"  # MLRun's default
+    NANOSECOND = "ns"
 
 
 class TDEngineConnector(TSDBConnector):
@@ -47,11 +62,16 @@ class TDEngineConnector(TSDBConnector):
         self,
         project: str,
         profile: DatastoreProfile,
+        timestamp_precision: TDEngineTimestampPrecision = TDEngineTimestampPrecision.MICROSECOND,
         **kwargs,
     ):
         super().__init__(project=project)
 
         self._tdengine_connection_profile = profile
+
+        self._timestamp_precision: Final = (  # cannot be changed after initialization
+            timestamp_precision
+        )
 
         self._init_super_tables()
 
@@ -105,7 +125,7 @@ class TDEngineConnector(TSDBConnector):
         """Create the database if it does not exist."""
         self.connection.prefix_statements = []
         self.connection.run(
-            statements=f"CREATE DATABASE IF NOT EXISTS {self.database}",
+            statements=f"CREATE DATABASE IF NOT EXISTS {self.database} PRECISION '{self._timestamp_precision}'",
             timeout=self._timeout,
             retries=self._retries,
         )

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1505,8 +1505,8 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
     def _setup_resources(self) -> None:
         self.set_mm_credentials()
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            executor.submit(self._deploy_model_serving)
             executor.submit(self._set_infra)
+            executor.submit(self._deploy_model_serving)
 
     @pytest.mark.parametrize("run_local", [False, True])
     def test_count_app(self, run_local: bool) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -147,7 +147,7 @@ class _V3IORecordsChecker:
             lr_tsdb = cls._tsdb_storage.get_last_request(endpoint_ids=ep_id)
             if isinstance(lr_tsdb, pd.DataFrame):
                 cls._check_valid_tsdb_result(
-                    lr_tsdb, ep_id, "last_request", last_request
+                    lr_tsdb, ep_id, "last_request", pd.Timestamp(last_request)
                 )
             else:
                 cls._check_last_request_dict(
@@ -167,19 +167,9 @@ class _V3IORecordsChecker:
         assert (
             df.endpoint_id == ep_id
         ).all(), "The endpoint IDs are different than expected"
-        if isinstance(result_value, datetime) or isinstance(result_value, pd.Timestamp):
-            # Note: We check for differences in time is less than 1 ms because this is the highest resolution we get
-            # from TDEngine
-            assert abs(
-                df[df["endpoint_id"] == ep_id][result_name].item() - result_value
-            ) < np.timedelta64(1, "ms"), (
-                f"The {result_name} is different than expected for {ep_id}, "
-                f"for timestamp we use TDEngine resolution that is 1 ms"
-            )
-        else:
-            assert (
-                df[df["endpoint_id"] == ep_id][result_name].item() == result_value
-            ), f"The {result_name} is different than expected for {ep_id}"
+        assert (
+            df[df["endpoint_id"] == ep_id][result_name].item() == result_value
+        ), f"The {result_name} is different than expected for {ep_id}"
 
     @classmethod
     def _check_last_request_dict(
@@ -1561,8 +1551,7 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
         # To include the first request, make a small offset
         start = model_endpoint.status.first_request - timedelta(microseconds=1)
 
-        # Adjust the end time - ML-9067
-        end = model_endpoint.status.last_request + timedelta(milliseconds=3)
+        end = model_endpoint.status.last_request
 
         endpoints_params = [
             [(model_endpoint.metadata.name, model_endpoint.metadata.uid)],


### PR DESCRIPTION
Resolves [ML-9067](https://iguazio.atlassian.net/browse/ML-9067).
For the motivation - see https://github.com/mlrun/storey/pull/555 and the comments in the ticket.
In short, microsecond is the natural `datetime.datetime` precision in Python.

See also https://github.com/gtopper/taos-ws-py-wrapper/pull/8.

The `taoswswrap` upgrade in the lock-files happened in #7563.

[ML-9067]: https://iguazio.atlassian.net/browse/ML-9067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9691]: https://iguazio.atlassian.net/browse/ML-9691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ