### PR TITLE
[Spark] Fix monitoring state race condition

### DIFF
--- a/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
@@ -528,7 +528,8 @@ with ctx:
             return
 
         run.setdefault("status", {})["ui_url"] = ui_url
-        db.store_run(db_session, run, uid, project)
+        run_updates = {"status.ui_url": ui_url}
+        db.update_run(db_session, run_updates, uid, project)
 
     @staticmethod
     def are_resources_coupled_to_run_object() -> bool:


### PR DESCRIPTION
Store run would update the state to whatever was in the run struct but it might have been changed to "completed" by then so this would override it to "running".

https://iguazio.atlassian.net/browse/ML-9694