### PR TITLE
[Tests] Limit vizro version due to pydantic upgrade [1.8.x]

### DIFF
--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -187,7 +187,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         function = self.project.set_function(
             name=name,
             kind="application",
-            requirements=["vizro", "gunicorn", "Werkzeug==2.2.2"],
+            requirements=["vizro<0.1.32", "gunicorn", "Werkzeug==2.2.2"],
             with_repo=with_repo,
         )
         function.set_internal_application_port(8050)


### PR DESCRIPTION
(cherry picked from commit 91ea5ae24a8b3fd1cacf61a98c093a50367fc870)