### PR TITLE
[CI] Remove python 3.12 jobs [1.8.x]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up python ${{ matrix.python-version }}
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v4
 
@@ -127,7 +127,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9"]
 
     steps:
     - uses: actions/checkout@v4
@@ -280,7 +280,7 @@ jobs:
     strategy:
       matrix:
         # 3.9 is the current >= 1.3.0 python version
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up python ${{ matrix.python-version }}


### PR DESCRIPTION
Not needed anymore and holds runners