### PR TITLE
[Tests] Server fixtures improvements

### DIFF
--- a/server/py/conftest.py
+++ b/server/py/conftest.py
@@ -15,5 +15,4 @@
 
 from tests.common_fixtures import (  # noqa: F401  # Linter incorrectly flags this as unused
     config_test_base,
-    rundb_mock,
 )

--- a/server/py/services/alerts/tests/unit/conftest.py
+++ b/server/py/services/alerts/tests/unit/conftest.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import pathlib
 
 import fastapi
@@ -26,14 +25,6 @@ from services.alerts.daemon import daemon
 
 tests_root_directory = pathlib.Path(__file__).absolute().parent
 assets_path = tests_root_directory.joinpath("assets")
-
-if str(tests_root_directory) in os.getcwd():
-    # If this is the top level conftest - we need to explicitly declare the base common fixtures to
-    # make pytest use them. If this is not the top level conftest (e.g. when running the tests from the project root)
-    # then providing pytest_plugins is not allowed.
-    pytest_plugins = [
-        "tests.common_fixtures",
-    ]
 
 
 class TestAlertsBase(TestServiceBase):

--- a/server/py/services/api/tests/unit/conftest.py
+++ b/server/py/services/api/tests/unit/conftest.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import pathlib
 import typing
 import unittest.mock
@@ -55,14 +54,6 @@ from services.api.daemon import daemon
 
 tests_root_directory = pathlib.Path(__file__).absolute().parent
 assets_path = tests_root_directory.joinpath("assets")
-
-if str(tests_root_directory) in os.getcwd():
-    # If this is the top level conftest - we need to explicitly declare the base common fixtures to
-    # make pytest use them. If this is not the top level conftest (e.g. when running the tests from the project root)
-    # then providing pytest_plugins is not allowed.
-    pytest_plugins = [
-        "tests.common_fixtures",
-    ]
 
 
 class TestAPIBase(TestServiceBase):

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -17,6 +17,7 @@ import unittest.mock
 from contextlib import nullcontext as does_not_raise
 
 import pytest
+import sqlalchemy.orm
 from fastapi.testclient import TestClient
 
 import mlrun.common.runtimes.constants
@@ -141,10 +142,15 @@ def test_validate_state_thresholds_failure(state_thresholds, expected_error):
     assert expected_error in str(exc.value)
 
 
-def test_new_function_args_with_default_image_pull_secret(rundb_mock):
+def test_new_function_args_with_default_image_pull_secret(
+    db: sqlalchemy.orm.Session, client: TestClient
+):
     assets_path = pathlib.Path(__file__).parent / "assets"
     func_path = assets_path / "sample_function.py"
     handler = "hello_word"
+    services.api.tests.unit.api.utils.create_project(
+        client, mlrun.mlconf.default_project
+    )
 
     mlrun.mlconf.function.spec.image_pull_secret = Config(
         {"default": "adam-docker-registry-auth"}
@@ -160,10 +166,14 @@ def test_new_function_args_with_default_image_pull_secret(rundb_mock):
         image="mlrun/mlrun",
     )
     uid = "123"
-    run = mlrun.run.RunObject(
-        metadata=mlrun.model.RunMetadata(uid=uid),
-    )
-    rundb_mock.store_run(run, uid)
+    run = {
+        "metadata": {
+            "uid": uid,
+            "name": "test",
+        },
+    }
+    rundb = mlrun.get_run_db()
+    rundb.store_run(run, uid)
     run = launcher._create_run_object(run)
 
     run = launcher._enrich_run(


### PR DESCRIPTION
pytest plugin hack is no longer needed after adding conftest
removed `rundb_mock` import as it is a client side mock