### PR TITLE
[MPIJob] Modify server side polling for job startup

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -232,6 +232,11 @@ class MLClientCtx:
         """Dictionary with annotations (read-only)"""
         return deepcopy(self._annotations)
 
+    @property
+    def host(self):
+        """Execution host"""
+        return self._host
+
     def get_child_context(self, with_parent_params=False, **params):
         """Get child context (iteration)
 

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -63,17 +63,26 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             state = self._crd_state_to_run_state(status)
             launcher, _ = self._get_launcher(meta.name, meta.namespace)
             execution.set_hostname(launcher)
-            txt = f"MpiJob {meta.name} launcher pod {launcher} is in state {state}"
-            logger.info(txt)
+            status_text = (
+                f"MpiJob {meta.name} launcher pod {launcher} is in state {state}"
+            )
+            logger.info(
+                "MpiJob launcher pod state update",
+                name=meta.name,
+                launcher=launcher,
+                state=state,
+            )
         else:
             # no state yet, assume pending
             state = mlrun.run.RunStatuses.pending
-            txt = f"MpiJob {meta.name} pending - awaiting launcher pod startup"
-            logger.info(txt)
+            status_text = f"MpiJob {meta.name} pending - awaiting launcher pod startup"
+            logger.info(
+                "Waiting for MpiJob launcher pod to start", name=meta.name, state=state
+            )
 
         # update execution state and run status
         execution.set_state(state)
-        run.status.status_text = txt
+        run.status.status_text = status_text
 
     def get_pods(self, name=None, namespace=None, launcher=False):
         namespace = framework.utils.singletons.k8s.get_k8s_helper().resolve_namespace(

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-import time
+from typing import Optional
 
 from kubernetes import client
+from sqlalchemy.orm import Session
 
 import mlrun.k8s_utils
 import mlrun.utils.helpers
-from mlrun.config import config
 from mlrun.runtimes.base import RuntimeClassMode
 from mlrun.runtimes.mpijob import AbstractMPIJobRuntime
 from mlrun.utils import logger
 
 import framework.utils.singletons.k8s
+from framework.db.base import DBInterface
 from services.api.runtime_handlers import KubeRuntimeHandler
 
 
@@ -32,6 +33,9 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
     class_modes = {
         RuntimeClassMode.run: "mpijob",
     }
+
+    def __init__(self):
+        self._meta = None
 
     def run(
         self,
@@ -43,6 +47,7 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             runtime.store_run(run)
 
         meta = self._get_meta(runtime, run, True)
+        self._meta = meta
 
         self.add_secrets_to_spec_before_running(
             runtime, project_name=run.metadata.project
@@ -50,37 +55,28 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
 
         job = self._generate_mpi_job(runtime, run, execution, meta)
 
-        resp = self._submit_mpijob(job, meta.namespace)
+        self._submit_mpijob(job, meta.namespace)
 
-        state = None
-        timeout = int(config.submit_timeout) or 120
-        for _ in range(timeout):
-            resp = self.get_job(meta.name, meta.namespace)
-            state = self._get_job_launcher_status(resp)
-            if resp and state:
-                break
-            time.sleep(1)
+        # fetch the launcher pod status
+        resp = self.get_job(meta.name, meta.namespace)
+        status = self._get_job_launcher_status(resp)
 
-        if resp:
-            logger.info(f"MpiJob {meta.name} state={state or 'unknown'}")
-            if state:
-                state = self._crd_state_to_run_state(state)
-                launcher, _ = self._get_launcher(meta.name, meta.namespace)
-                execution.set_hostname(launcher)
-                execution.set_state(state)
-                txt = f"MpiJob {meta.name} launcher pod {launcher} state {state}"
-                logger.info(txt)
-                run.status.status_text = txt
+        if status:
+            # map the CRD state to run state and set hostname if launcher started
+            state = self._crd_state_to_run_state(status)
+            launcher, _ = self._get_launcher(meta.name, meta.namespace)
+            execution.set_hostname(launcher)
+            txt = f"MpiJob {meta.name} launcher pod {launcher} state {state}"
+            logger.info(txt)
+        else:
+            # no state yet, assume pending
+            state = mlrun.run.RunStatuses.pending
+            txt = f"MpiJob {meta.name} pending - awaiting launcher pod startup"
+            logger.info(txt)
 
-            else:
-                pods_phases = self.get_pods(meta.name, meta.namespace)
-                txt = f"MpiJob status unknown or failed, check pods: {pods_phases}"
-                logger.warning(
-                    "MpiJob status unknown or failed",
-                    pods_phases=pods_phases,
-                    resp_status=mlrun.utils.get_in(resp, "status"),
-                )
-                run.status.status_text = txt
+        # update execution state and run status
+        execution.set_state(state)
+        run.status.status_text = txt
 
     def get_pods(self, name=None, namespace=None, launcher=False):
         namespace = framework.utils.singletons.k8s.get_k8s_helper().resolve_namespace(
@@ -176,3 +172,49 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             "failed": mlrun.common.runtimes.constants.RunStates.error,
         }
         return mapping.get(state, state)
+
+    def _ensure_run_state(
+        self,
+        db: DBInterface,
+        db_session: Session,
+        project: str,
+        uid: str,
+        name: str,
+        run_state: str,
+        run: Optional[dict] = None,
+        search_run: bool = True,
+        runtime_resource: Optional[dict] = None,
+    ) -> tuple[bool, str, dict]:
+        # ensure run object is available
+        if not run:
+            run = db.read_run(db_session, uid, project)
+            if not run:
+                logger.warning(f"Run {uid} not found in project {project}")
+                return False, run_state, {}
+
+        execution = mlrun.execution.MLClientCtx.from_dict(run)
+
+        # ensure hostname is set if not already assigned
+        if self._meta and not execution.host:
+            launcher, _ = self._get_launcher(self._meta.name, self._meta.namespace)
+            execution.set_hostname(launcher)
+
+            # persist the hostname change in the DB
+            updates = {"status.host": launcher}
+            run = db.update_run(
+                db_session,
+                updates,
+                uid,
+                project,
+            )
+        return super()._ensure_run_state(
+            db,
+            db_session,
+            project,
+            uid,
+            name,
+            run_state,
+            run,
+            search_run,
+            runtime_resource,
+        )

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -17,6 +17,7 @@ from typing import Optional
 from kubernetes import client
 from sqlalchemy.orm import Session
 
+import mlrun.common.constants as mlrun_constants
 import mlrun.k8s_utils
 import mlrun.utils.helpers
 from mlrun.runtimes.base import RuntimeClassMode
@@ -34,9 +35,6 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
         RuntimeClassMode.run: "mpijob",
     }
 
-    def __init__(self):
-        self._meta = None
-
     def run(
         self,
         runtime: AbstractMPIJobRuntime,
@@ -47,7 +45,6 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             runtime.store_run(run)
 
         meta = self._get_meta(runtime, run, True)
-        self._meta = meta
 
         self.add_secrets_to_spec_before_running(
             runtime, project_name=run.metadata.project
@@ -198,10 +195,16 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
         )
 
         execution = mlrun.execution.MLClientCtx.from_dict(run, store_run=False)
+        pod_name = (
+            run["metadata"]
+            .get("labels", {})
+            .get(mlrun_constants.MLRunInternalLabels.job, "")
+        )
 
         # ensure hostname is set if not already assigned
-        if self._meta and not execution.host:
-            launcher, _ = self._get_launcher(self._meta.name, self._meta.namespace)
+        if pod_name and not execution.host:
+            namespace = mlrun.mlconf.namespace
+            launcher, _ = self._get_launcher(pod_name, namespace)
             execution.set_hostname(launcher)
 
             # persist the hostname change in the DB

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -66,7 +66,7 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             state = self._crd_state_to_run_state(status)
             launcher, _ = self._get_launcher(meta.name, meta.namespace)
             execution.set_hostname(launcher)
-            txt = f"MpiJob {meta.name} launcher pod {launcher} state {state}"
+            txt = f"MpiJob {meta.name} launcher pod {launcher} is in state {state}"
             logger.info(txt)
         else:
             # no state yet, assume pending

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -185,14 +185,19 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
         search_run: bool = True,
         runtime_resource: Optional[dict] = None,
     ) -> tuple[bool, str, dict]:
-        # ensure run object is available
-        if not run:
-            run = db.read_run(db_session, uid, project)
-            if not run:
-                logger.warning(f"Run {uid} not found in project {project}")
-                return False, run_state, {}
+        _, run_state, run = super()._ensure_run_state(
+            db,
+            db_session,
+            project,
+            uid,
+            name,
+            run_state,
+            run,
+            search_run,
+            runtime_resource,
+        )
 
-        execution = mlrun.execution.MLClientCtx.from_dict(run)
+        execution = mlrun.execution.MLClientCtx.from_dict(run, store_run=False)
 
         # ensure hostname is set if not already assigned
         if self._meta and not execution.host:
@@ -207,14 +212,4 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
                 uid,
                 project,
             )
-        return super()._ensure_run_state(
-            db,
-            db_session,
-            project,
-            uid,
-            name,
-            run_state,
-            run,
-            search_run,
-            runtime_resource,
-        )
+        return True, run_state, run

--- a/server/py/services/api/tests/unit/runtimes/test_mpijob.py
+++ b/server/py/services/api/tests/unit/runtimes/test_mpijob.py
@@ -53,19 +53,59 @@ class TestMpiV1Runtime(TestRuntimeBase):
 
             assert run.status.state == "running"
 
-    def _mock_get_namespaced_custom_object(self, workers=1):
+    def test_run_launcher_status_update(
+        self, db: Session, client: TestClient, k8s_secrets_mock
+    ):
+        self._mock_list_pods()
+        self._mock_create_namespaced_custom_object()
+
+        # case 1: launcher pod is active
+        self._mock_get_namespaced_custom_object(workers=1)
+
+        mpijob_function = self._generate_runtime(self.runtime_kind)
+        self.deploy(db, mpijob_function)
+        run = mpijob_function.run(
+            artifact_path="v3io:///mypath",
+            watch=False,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+        )
+
+        launcher_pod_name = get_k8s_helper().crdapi.get_namespaced_custom_object()[
+            "metadata"
+        ]["name"]
+        expected_prefix = f"launcher pod {launcher_pod_name} is in state running"
+        assert expected_prefix in run.status.status_text
+        assert run.status.state == "running"
+
+        # case 2: launcher pod has not started yet
+        self._mock_get_namespaced_custom_object(workers=1, active=False)
+
+        mpijob_function = self._generate_runtime(self.runtime_kind)
+        self.deploy(db, mpijob_function)
+        run = mpijob_function.run(
+            artifact_path="v3io:///mypath",
+            watch=False,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+        )
+
+        assert run.status.state == "pending"
+        assert "awaiting launcher pod startup" in run.status.status_text
+
+    def _mock_get_namespaced_custom_object(self, workers=1, active=True):
+        launcher_pod_name = f"{self.name}"
         get_k8s_helper().crdapi.get_namespaced_custom_object = unittest.mock.Mock(
             return_value={
                 "status": {
                     "replicaStatuses": {
                         "Launcher": {
-                            "active": 1,
+                            "active": active,
                         },
                         "Worker": {
                             "active": workers,
                         },
                     }
                 },
+                "metadata": {"name": launcher_pod_name},
             }
         )
 

--- a/tests/system/runtimes/test_mpijob.py
+++ b/tests/system/runtimes/test_mpijob.py
@@ -45,6 +45,7 @@ class TestMpiJobRuntime(tests.system.base.TestMLRunSystem):
 
         mpijob_run = mpijob_function.run(returns=["reduced_result", "rank_0_result"])
         assert mpijob_run.status.state == RunStates.completed
+        assert mpijob_run.status.host is not None
 
         reduced_result = mpijob_run.status.results["reduced_result"]
         rank_0_result = mpijob_run.status.results["rank_0_result"]


### PR DESCRIPTION
This PR refactors how MPIJob runs are handled by eliminating unnecessary server-side waiting for the job to start. Instead of blocking the request until the job transitions to a running state, the server now:
- Submits the MPIJob
- Fetches the launcher pod status once
- Sets the run state to "running" if the launcher pod has started, otherwise "pending".

This ensures the client is responsible for polling and detecting any failures

Jira:
https://iguazio.atlassian.net/browse/ML-5339