### PR TITLE
[DB] Fix Handling of Timestamps Without Milliseconds [1.8.x]

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -537,7 +537,11 @@ class SQLDB(DBInterface):
             ("last_update", "updated"),
         ]:
             if field_value := getattr(run, struct_field, None):
-                status[status_field] = self._add_utc_timezone(field_value).isoformat()
+                # Handle cases where milliseconds/microseconds are missing in timestamp, because isoformat by default
+                # ignores them if they are zero
+                status[status_field] = self._add_utc_timezone(field_value).isoformat(
+                    timespec="microseconds"
+                )
 
         if with_notifications:
             self._fill_run_struct_with_notifications(run.notifications, run_struct)
@@ -2660,9 +2664,11 @@ class SQLDB(DBInterface):
         # the column (not from the struct) to ensure the ordering is correct.
         # In SQLite, the updated column return timestamps with fsp=6.
         if field_value := getattr(function, "updated", None):
+            # Handle cases where milliseconds/microseconds are missing in timestamp, because isoformat by default
+            # ignores them if they are zero
             function_struct["metadata"]["updated"] = self._add_utc_timezone(
                 field_value
-            ).isoformat()
+            ).isoformat(timespec="microseconds")
 
     def _delete_project_functions(self, session: Session, project: str):
         logger.debug("Removing project functions from db", project=project)
@@ -8092,3 +8098,23 @@ class SQLDB(DBInterface):
                 as_record=True,
             )
             mep_record.model_id = db_artifact.id
+
+    def update_db_object(self, session, model, filters=None, **fields):
+        """Helper function to update fields of a database object and commit the changes."""
+        query = self._query(session, model)
+
+        # Apply filters if provided
+        if filters:
+            query = query.filter_by(**filters)
+
+        db_object = query.one_or_none()
+
+        if not db_object:
+            raise ValueError(f"No record found for model {model.__name__}")
+
+        for field, value in fields.items():
+            setattr(db_object, field, value)
+
+        session.add(db_object)
+        self._commit(session, db_object)
+        session.flush()

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -1612,13 +1612,12 @@ class TestArtifacts(TestDatabaseBase):
             )
 
             # Set the same `updated` timestamp for all artifacts
-            db_artifact = self._db._query(
-                self._db_session, ArtifactV2, key=artifact_key
-            ).one_or_none()
-            db_artifact.updated = t1
-            self._db_session.add(db_artifact)
-            self._db._commit(self._db_session, db_artifact)
-            self._db_session.flush()
+            self._db.update_db_object(
+                self._db_session,
+                framework.db.sqldb.models.ArtifactV2,
+                filters={"key": artifact_key},
+                updated=t1,
+            )
 
         artifacts = self._db.list_artifacts(
             self._db_session, project=project, limit=limit

--- a/server/py/services/api/tests/unit/db/test_functions.py
+++ b/server/py/services/api/tests/unit/db/test_functions.py
@@ -21,6 +21,7 @@ import pytest
 import mlrun.common.schemas
 import mlrun.errors
 
+import framework.db.sqldb.models
 from framework.db.sqldb.db import unversioned_tagged_object_uid_prefix
 from framework.db.sqldb.models import Function
 from framework.tests.unit.db.common_fixtures import TestDatabaseBase
@@ -723,13 +724,12 @@ class TestFunctions(TestDatabaseBase):
             )
 
             # Set the same `updated` timestamp for all functions
-            db_function = self._db._query(
-                self._db_session, Function, name=function_name
-            ).one_or_none()
-            db_function.updated = t1
-            self._db_session.add(db_function)
-            self._db._commit(self._db_session, db_function)
-            self._db_session.flush()
+            self._db.update_db_object(
+                self._db_session,
+                framework.db.sqldb.models.Function,
+                filters={"name": function_name},
+                updated=t1,
+            )
 
         functions = self._db.list_functions(self._db_session)
 
@@ -746,6 +746,30 @@ class TestFunctions(TestDatabaseBase):
             assert (
                 function_name == expected_name
             ), f"Expected {expected_name}, got {function_name}"
+
+    def test_list_functions_with_missing_milliseconds_in_timestamp(self):
+        function = self._generate_function()
+        tag = "some_tag"
+        self._db.store_function(
+            self._db_session,
+            function.to_dict(),
+            function.metadata.name,
+            versioned=False,
+            tag=tag,
+        )
+
+        # Set the `updated` timestamp without microseconds
+        t1 = datetime.datetime.now().replace(microsecond=0)
+        self._db.update_db_object(
+            self._db_session,
+            framework.db.sqldb.models.Function,
+            updated=t1,
+        )
+
+        functions = self._db.list_functions(self._db_session)
+        assert len(functions) == 1
+
+        assert functions[0]["metadata"]["updated"].endswith(".000000+00:00")
 
     def test_delete_functions(self):
         names = ["some_name", "some_name2", "some_name3"]

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -608,13 +608,12 @@ class TestRuns(TestDatabaseBase):
             )
 
             # Set the same `start_time` timestamp for all runs
-            db_run = self._db._query(
-                self._db_session, framework.db.sqldb.models.Run, name=run_name
-            ).one_or_none()
-            db_run.start_time = t1
-            self._db_session.add(db_run)
-            self._db._commit(self._db_session, db_run)
-            self._db_session.flush()
+            self._db.update_db_object(
+                self._db_session,
+                framework.db.sqldb.models.Run,
+                filters={"name": run_name},
+                start_time=t1,
+            )
 
         runs = self._db.list_runs(
             self._db_session,
@@ -631,6 +630,22 @@ class TestRuns(TestDatabaseBase):
             assert (
                 run_name == expected_name
             ), f"Expected {expected_name}, got {run_name}"
+
+    def test_list_runs_with_missing_milliseconds_in_timestamp(self):
+        self._create_new_run(project="my-project")
+
+        t1 = datetime.now().replace(microsecond=0)
+
+        # Set the `start_time` and `end_time` timestamps without microseconds
+        self._db.update_db_object(
+            self._db_session, framework.db.sqldb.models.Run, start_time=t1, end_time=t1
+        )
+
+        runs = self._db.list_runs(self._db_session, project="my-project")
+        assert len(runs) == 1
+
+        assert runs[0]["status"]["start_time"].endswith(".000000+00:00")
+        assert runs[0]["status"]["end_time"].endswith(".000000+00:00")
 
     @staticmethod
     def _change_run_record_to_before_align_runs_migration(run, time_before_creation):


### PR DESCRIPTION
(cherry picked from commit 023366f06bb2c539549adca8b8b9ceb41d046fe9)