### PR TITLE
[CI] Remove python 3.11 linter [1.9.x]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up python ${{ matrix.python-version }}


### PR DESCRIPTION
(cherry picked from commit ea4b013c33a5559dd59500fbd5365903bd77fe4a)