### PR TITLE
[Model Monitoring] Fix explicit ack on model monitoring stream

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -144,7 +144,7 @@ class EventStreamProcessor:
 
         graph = typing.cast(
             mlrun.serving.states.RootFlowStep,
-            fn.set_topology(mlrun.serving.states.StepKinds.flow),
+            fn.set_topology(mlrun.serving.states.StepKinds.flow, engine="async"),
         )
 
         # split the graph between event with error vs valid event


### PR DESCRIPTION
fix include calling `set_topology` with `engine="async"` in `EventStreamProcessor:apply_monitoring_serving_graph`