### PR TITLE
[Serving] Explicitly set async as the default since it aligns with the actual default behavior for flow topology

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -272,7 +272,7 @@ class ServingRuntime(RemoteRuntime):
 
           flow   - workflow (DAG) with a chain of states
                    flow supports both "sync" and "async" engines, with "async" being the default.
-                   branches are not allowed in sync mode
+                   Branches are not allowed in sync mode.
                    when using async mode calling state.respond() will mark the state as the
                    one which generates the (REST) call response
 

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -300,7 +300,7 @@ class ServingRuntime(RemoteRuntime):
                 step = RouterStep(class_name=class_name, class_args=class_args)
             self.spec.graph = step
         elif topology == StepKinds.flow:
-            self.spec.graph = RootFlowStep(engine=engine)
+            self.spec.graph = RootFlowStep(engine=engine or "async")
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"unsupported topology {topology}, use 'router' or 'flow'"

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -271,7 +271,8 @@ class ServingRuntime(RemoteRuntime):
                    can specify special router class and router arguments
 
           flow   - workflow (DAG) with a chain of states
-                   flow support "sync" and "async" engines, branches are not allowed in sync mode
+                   flow supports both "sync" and "async" engines, with "async" being the default.
+                   branches are not allowed in sync mode
                    when using async mode calling state.respond() will mark the state as the
                    one which generates the (REST) call response
 


### PR DESCRIPTION
When configuring a stream trigger for a serving function, we check the engine and determine whether to set explicit ack accordingly. To ensure this works correctly, the engine must be explicitly set to async by default.