### PR TITLE
[Pipelines] Config Pipelines days back for project summary [1.8.x]

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -547,6 +547,10 @@ default_config = {
                 "max_size": 10000,
             },
         },
+        "pipelines": {
+            # Number of days back to include when calculating the project pipeline summary.
+            "days_back_for_project_counters": 7,
+        },
     },
     "model_endpoint_monitoring": {
         # Scaling Rule

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -486,6 +486,10 @@ default_config = {
             "iguazio_client_job_cache_ttl": "20 minutes",
             "nuclio_project_deletion_verification_timeout": "300 seconds",
             "nuclio_project_deletion_verification_interval": "5 seconds",
+            "summaries": {
+                # Number of days back to include when calculating the project pipeline summary.
+                "list_pipelines_time_period_in_days": 7,
+            },
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",
@@ -546,10 +550,6 @@ default_config = {
                 "ttl": 3600,
                 "max_size": 10000,
             },
-        },
-        "pipelines": {
-            # Number of days back to include when calculating the project pipeline summary.
-            "days_back_for_project_counters": 7,
         },
     },
     "model_endpoint_monitoring": {

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -544,7 +544,7 @@ class Projects(
             str(
                 datetime.datetime.now()
                 - datetime.timedelta(
-                    days=mlrun.mlconf.httpdb.pipelines.days_back_for_project_counters
+                    days=mlrun.mlconf.httpdb.projects.summaries.list_pipelines_time_period_in_days
                 )
             )
         )

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -539,9 +539,14 @@ class Projects(
                 project_to_running_pipelines_count,
             )
 
-        # include pipelines created in the past 3 days.
+        # include pipelines created in the past x days.
         start_date = mlrun.utils.validate_and_convert_date(
-            str(datetime.datetime.now() - datetime.timedelta(days=3))
+            str(
+                datetime.datetime.now()
+                - datetime.timedelta(
+                    days=mlrun.mlconf.httpdb.pipelines.days_back_for_project_counters
+                )
+            )
         )
         try:
             next_page_token = ""


### PR DESCRIPTION
Create a new config key `mlrun.mlconf.httpdb.projects.summaries.list_pipelines_time_period_in_days` to configure the number of days to look back when calculating the project pipeline summary. Also, set the default to 7 days.

https://iguazio.atlassian.net/browse/ML-9716
Related PR: https://github.com/mlrun/mlrun/pull/7595