### PR TITLE
[Serving] Fix check engine attribute in graph when creating nuclio stream

### DIFF
--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -974,8 +974,7 @@ class OnlineSource(BaseSourceDriver):
         if (
             function.spec
             and hasattr(function.spec, "graph")
-            and function.spec.graph
-            and function.spec.graph.engine
+            and hasattr(function.spec.graph, "engine")
         ):
             engine = function.spec.graph.engine
         if mlrun.mlconf.is_explicit_ack_enabled() and engine == "async":

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -971,12 +971,8 @@ class OnlineSource(BaseSourceDriver):
     def set_explicit_ack_mode(function: Function, **extra_arguments) -> dict[str, Any]:
         extra_arguments = extra_arguments or {}
         engine = "sync"
-        if (
-            function.spec
-            and hasattr(function.spec, "graph")
-            and hasattr(function.spec.graph, "engine")
-        ):
-            engine = function.spec.graph.engine
+        if function.spec and hasattr(function.spec, "graph"):
+            engine = getattr(function.spec.graph, "engine", None) or engine
         if mlrun.mlconf.is_explicit_ack_enabled() and engine == "async":
             extra_arguments["explicit_ack_mode"] = extra_arguments.get(
                 "explicit_ack_mode", "explicitOnly"

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -577,12 +577,9 @@ class RemoteRuntime(KubeResource):
             access_key = self._resolve_v3io_access_key()
         engine = "sync"
         explicit_ack_mode = kwargs.pop("explicit_ack_mode", None)
-        if (
-            self.spec
-            and hasattr(self.spec, "graph")
-            and hasattr(self.spec.graph, "engine")
-        ):
-            engine = self.spec.graph.engine
+        if self.spec and hasattr(self.spec, "graph"):
+            engine = getattr(self.spec.graph, "engine", None) or engine
+
         if mlrun.mlconf.is_explicit_ack_enabled() and engine == "async":
             explicit_ack_mode = explicit_ack_mode or "explicitOnly"
 

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -580,8 +580,7 @@ class RemoteRuntime(KubeResource):
         if (
             self.spec
             and hasattr(self.spec, "graph")
-            and self.spec.graph
-            and self.spec.graph.engine
+            and hasattr(self.spec.graph, "engine")
         ):
             engine = self.spec.graph.engine
         if mlrun.mlconf.is_explicit_ack_enabled() and engine == "async":


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-9756
Added check `getattr(function.spec.graph, "engine", None)` for assignment of engine, preventing the explicit_ack_mode check fail on RouterStep topology graph