### PR TITLE
[Nuclio] Update client-side with server-side spec changes after deployment

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -652,7 +652,7 @@ class RemoteRuntime(KubeResource):
         logger.info("Starting remote function deploy")
         data = db.deploy_nuclio_function(func=self, builder_env=builder_env)
         self.status = data["data"].get("status")
-        self.spec = merge(self.spec.to_dict(), data["data"].get("spec"))
+        self.spec = merge(self.spec.to_dict(), data["data"].get("spec") or {})
 
         self._update_credentials_from_remote_build(data["data"])
 

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -27,7 +27,6 @@ import requests
 import semver
 from aiohttp.client import ClientSession
 from kubernetes import client
-from mergedeep import merge
 from nuclio.deploy import find_dashboard_url, get_deploy_status
 from nuclio.triggers import V3IOStreamTrigger
 
@@ -652,7 +651,10 @@ class RemoteRuntime(KubeResource):
         logger.info("Starting remote function deploy")
         data = db.deploy_nuclio_function(func=self, builder_env=builder_env)
         self.status = data["data"].get("status")
-        self.spec = merge(self.spec.to_dict(), data["data"].get("spec") or {})
+
+        # Extract the spec to avoid overwriting server-side updates during the later save in
+        # _enrich_command_from_status.
+        self.spec = data["data"].get("spec")
 
         self._update_credentials_from_remote_build(data["data"])
 

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -651,6 +651,8 @@ class RemoteRuntime(KubeResource):
         logger.info("Starting remote function deploy")
         data = db.deploy_nuclio_function(func=self, builder_env=builder_env)
         self.status = data["data"].get("status")
+        self.spec = data["data"].get("spec")
+
         self._update_credentials_from_remote_build(data["data"])
 
         # when a function is deployed, we wait for it to be ready by default

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -27,6 +27,7 @@ import requests
 import semver
 from aiohttp.client import ClientSession
 from kubernetes import client
+from mergedeep import merge
 from nuclio.deploy import find_dashboard_url, get_deploy_status
 from nuclio.triggers import V3IOStreamTrigger
 
@@ -651,7 +652,7 @@ class RemoteRuntime(KubeResource):
         logger.info("Starting remote function deploy")
         data = db.deploy_nuclio_function(func=self, builder_env=builder_env)
         self.status = data["data"].get("status")
-        self.spec = data["data"].get("spec")
+        self.spec = merge(self.spec.to_dict(), data["data"].get("spec"))
 
         self._update_credentials_from_remote_build(data["data"])
 

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -809,13 +809,32 @@ class RemoteBuilderMock(RunDBMock):
         ):
             # Need to fill in clone_target_dir in the response since the code is copying it back to the function, so
             # it overrides the mock args - this way the value will remain as it was.
+            image = f".mlrun/func-{func.metadata.project}-{func.metadata.name}:latest"
             return {
                 "ready": True,
                 "data": {
                     "spec": {
                         "clone_target_dir": func.spec.clone_target_dir,
                         "build": {
-                            "image": f".mlrun/func-{func.metadata.project}-{func.metadata.name}:latest",
+                            "image": image,
+                        },
+                        "env": [
+                            {"name": "SIDECAR_PORT", "value": "8050"},
+                        ],
+                        "config": {
+                            "spec.sidecars": [
+                                {
+                                    "image": image,
+                                    "name": "application-test-sidecar",
+                                    "ports": [
+                                        {
+                                            "containerPort": 8050,
+                                            "name": "application-t-0",
+                                            "protocol": "TCP",
+                                        }
+                                    ],
+                                }
+                            ],
                         },
                     },
                     "status": {

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -802,6 +802,7 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
             **self.app_data.kwargs,
         )
         self.project.deploy_function(fn)
+        return fn
 
     def _record_results(self) -> str:
         model_endpoint = mlrun.model_monitoring.api.record_results(
@@ -823,12 +824,25 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
             **({} if self.image is None else {"image": self.image}),
         )
 
+    @staticmethod
+    def _assert_replicas(fn):
+        """
+        Validate that the 'min_replicas' and 'max_replicas' values in the function's spec are correct after deployment.
+        This check ensures that the replica settings, which are modified on the server side during deployment, are
+        properly reflected on the client side.
+        """
+        assert fn.spec.min_replicas == 1
+        assert fn.spec.max_replicas == 1
+
     def test_inference_feature_set(self) -> None:
         self._log_model()
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            executor.submit(self._deploy_monitoring_app)
+            monitoring_app = executor.submit(self._deploy_monitoring_app)
             executor.submit(self._deploy_monitoring_infra)
+
+        fn = monitoring_app.result()
+        self._assert_replicas(fn)
 
         endpoint_id = self._record_results()
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -824,16 +824,6 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
             **({} if self.image is None else {"image": self.image}),
         )
 
-    @staticmethod
-    def _assert_replicas(fn):
-        """
-        Validate that the 'min_replicas' and 'max_replicas' values in the function's spec are correct after deployment.
-        This check ensures that the replica settings, which are modified on the server side during deployment, are
-        properly reflected on the client side.
-        """
-        assert fn.spec.min_replicas == 1
-        assert fn.spec.max_replicas == 1
-
     def test_inference_feature_set(self) -> None:
         self._log_model()
 
@@ -859,6 +849,16 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
             mep.metadata.uid, inputs=set(self.columns), outputs=set(self.y_name)
         )
         self._test_predictions_table(mep.metadata.uid, should_be_empty=True)
+
+    @staticmethod
+    def _assert_replicas(fn):
+        """
+        Validate that the 'min_replicas' and 'max_replicas' values in the function's spec are correct after deployment.
+        This check ensures that the replica settings, which are modified on the server side during deployment, are
+        properly reflected on the client side.
+        """
+        assert fn.spec.min_replicas == 1
+        assert fn.spec.max_replicas == 1
 
 
 @TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured


### PR DESCRIPTION
This PR fixes an issue where replica values (`min_replicas` and `max_replicas`) in the function spec were incorrect after deployment.

The cause of this is that after deploying a function, we call `_enrich_command_from_status`, which saved the outdated client-side function object. This overwrote server-side updates, causing inconsistencies in the function's spec.

So we now update the function’s spec from the server-side deployment response (similar to how we already update the status). This ensures that all server-side changes, including replica settings, are correctly reflected on the client side.

Jira:
https://iguazio.atlassian.net/browse/ML-9725