### PR TITLE
[Model Monitoring] Disable logging the histogram's app JSON artifact

### DIFF
--- a/docs/model-monitoring/applications.md
+++ b/docs/model-monitoring/applications.md
@@ -50,15 +50,15 @@ To register and deploy the application see {ref}`register-model-monitoring-app`.
 ## Testing your application before deploying it
 
 You can run and debug your application as a job with data, but without a model endpoint or datastore profiles. This reduces
-the time required to refine your model before deploying. 
-The monitoring creates metrics that assist you in understanding and refining the model behavior. 
+the time required to refine your model before deploying.
+The monitoring creates metrics that assist you in understanding and refining the model behavior.
 You can use this flow for both local and remote jobs.
 
-Use {py:class}`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.evaluate` to test your code. 
-When you are satisfied with the application, deploy it with {py:class}`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.deploy`.
-
+Use {py:meth}`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.evaluate` to test your code.
+When you are satisfied with the application, deploy it with {py:meth}`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.deploy`.
 
 For example, import the source file:
+
 ```py
 # Myapp.py
 import mlrun
@@ -85,7 +85,9 @@ class MyApp(ModelMonitoringApplicationBase):
         ]
         return results
 ```
+
 Then, import the class and run `evaluate`.
+
 ```py
 from Myapp import MyApp
 
@@ -95,28 +97,30 @@ MyApp.evaluate(
     sample_data=pd.DataFrame({"col": [1, 2, 3, 4]}),
 )
 ```
+
 After you have fine-tuned the model monitoring application, deploy it with:
-```python
+
+```py
 MyApp.deploy(
     func_path="Myapp.py",
     func_name="run-me-in-wf",
 )
 ```
 
-
 ## Using the application context
 
-The `context` argument is a `MonitoringApplicationContext` object.
-It includes the current window data as a pandas data-frame: `context.sample_df`.
-The reference and current data is also available in raw format as `context.feature_stats`
-and `context.sample_df_stats`, respectively.
+The `monitoring_context` argument is a
+{py:class}`~mlrun.model_monitoring.applications.context.MonitoringApplicationContext` object.
+It includes the current window data as a pandas data-frame: `monitoring_context.sample_df`.
+The reference and current data is also available in raw format as `monitoring_context.feature_stats`
+and `monitoring_context.sample_df_stats`, respectively.
 
-The `context` provides also attributes and methods to log application messages or artifacts.
+The `monitoring_context` provides also attributes and methods to log application messages or artifacts.
 
 Logging a debug message:
 
 ```py
-context.logger.debug(
+monitoring_context.logger.debug(
     "Logging the current data of a specific endpoint",
     sample_df=context.sample_df.to_json(),
     endpoint_id=context.endpoint_id,
@@ -126,10 +130,17 @@ context.logger.debug(
 Logging an artifact:
 
 ```py
-context.log_artifact(
+monitoring_context.log_artifact(
     item=f"num_events_last_monitoring_window_{context.endpoint_id}",
     body=f"Number of events in the window: {len(context.sample_df)}",
 )
+```
+
+```{caution}
+Logging artifacts in every model monitoring window may cause scale issues.
+
+The `log_artifact` and `log_dataset` methods of the `monitoring_context` should be called on special occasions only.
+<!-- ML-9550, ML-7677 -->
 ```
 
 ## Evidently-based application

--- a/docs/tutorials/06-batch-infer.ipynb
+++ b/docs/tutorials/06-batch-infer.ipynb
@@ -684,6 +684,7 @@
     "    name=histogram_data_drift.HistogramDataDriftApplicationConstants.NAME,  # keep the default name\n",
     "    func=histogram_data_drift.__file__,\n",
     "    application_class=histogram_data_drift.HistogramDataDriftApplication.__name__,\n",
+    "    produce_json_artifact=True,\n",
     "    produce_plotly_artifact=True,\n",
     ")\n",
     "\n",

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -38,21 +38,30 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
 
     For example, :code:`MyApp` below is a simplistic custom application::
 
+        from mlrun.common.schemas.model_monitoring.constants import (
+            ResultKindApp,
+            ResultStatusApp,
+        )
+        from mlrun.model_monitoring.applications import (
+            ModelMonitoringApplicationBase,
+            ModelMonitoringApplicationResult,
+            MonitoringApplicationContext,
+        )
+
+
         class MyApp(ModelMonitoringApplicationBase):
             def do_tracking(
-                self,
-                monitoring_context: mm_context.MonitoringApplicationContext,
+                self, monitoring_context: MonitoringApplicationContext
             ) -> ModelMonitoringApplicationResult:
-                monitoring_context.log_artifact(
-                    TableArtifact(
-                        "sample_df_stats", df=self.dict_to_histogram(sample_df_stats)
-                    )
+                monitoring_context.logger.info(
+                    "Running application",
+                    application_name=monitoring_context.application_name,
                 )
                 return ModelMonitoringApplicationResult(
                     name="data_drift_test",
                     value=0.5,
-                    kind=mm_constant.ResultKindApp.data_drift,
-                    status=mm_constant.ResultStatusApp.detected,
+                    kind=ResultKindApp.data_drift,
+                    status=ResultStatusApp.detected,
                 )
     """
 

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -330,9 +330,17 @@ class MonitoringApplicationContext:
     ) -> Artifact:
         """
         Log an artifact.
-        See :func:`~mlrun.projects.MlrunProject.log_artifact` for the documentation.
-        :param unique_per_endpoint: by default True, we will log different artifact for each model endpoint,
-        set to False without changing item key will cause artifact override
+
+        .. caution::
+
+            Logging artifacts in every model monitoring window may cause scale issues.
+            This method should be called on special occasions only.
+
+        See :func:`~mlrun.projects.MlrunProject.log_artifact` for the full documentation, except for one
+        new argument:
+
+        :param unique_per_endpoint: by default ``True``, we will log different artifact for each model endpoint,
+                                    set to ``False`` without changing item key will cause artifact override.
         """
         labels = self._add_default_labels(labels)
         # By default, we want to log different artifact for each model endpoint
@@ -375,9 +383,17 @@ class MonitoringApplicationContext:
     ) -> DatasetArtifact:
         """
         Log a dataset artifact.
-        See :func:`~mlrun.projects.MlrunProject.log_dataset` for the documentation.
-        :param unique_per_endpoint: by default True, we will log different dataset for each model endpoint,
-        set to False without changing item key will cause dataset override
+
+        .. caution::
+
+            Logging datasets in every model monitoring window may cause scale issues.
+            This method should be called on special occasions only.
+
+        See :func:`~mlrun.projects.MlrunProject.log_dataset` for the full documentation, except for one
+        new argument:
+
+        :param unique_per_endpoint: by default ``True``, we will log different artifact for each model endpoint,
+                                    set to ``False`` without changing item key will cause artifact override.
         """
         labels = self._add_default_labels(labels)
         # By default, we want to log different artifact for each model endpoint

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -130,17 +130,28 @@ class EvidentlyModelMonitoringApplicationBase(
         monitoring_context: mm_context.MonitoringApplicationContext,
         evidently_object: "Display",
         artifact_name: str,
+        unique_per_endpoint: bool = True,
     ) -> None:
         """
-         Logs an Evidently report or suite as an artifact.
+        Logs an Evidently report or suite as an artifact.
+
+        .. caution::
+
+            Logging Evidently objects in every model monitoring window may cause scale issues.
+            This method should be called on special occasions only.
 
         :param monitoring_context:  (MonitoringApplicationContext) The monitoring context to process.
         :param evidently_object:    (Display) The Evidently display to log, e.g. a report or a test suite object.
         :param artifact_name:       (str) The name for the logged artifact.
+        :param unique_per_endpoint: by default ``True``, we will log different artifact for each model endpoint,
+                                    set to ``False`` without changing item key will cause artifact override.
         """
         evidently_object_html = evidently_object.get_html()
         monitoring_context.log_artifact(
-            artifact_name, body=evidently_object_html.encode("utf-8"), format="html"
+            artifact_name,
+            body=evidently_object_html.encode("utf-8"),
+            format="html",
+            unique_per_endpoint=unique_per_endpoint,
         )
 
     def log_project_dashboard(
@@ -149,14 +160,22 @@ class EvidentlyModelMonitoringApplicationBase(
         timestamp_start: pd.Timestamp,
         timestamp_end: pd.Timestamp,
         artifact_name: str = "dashboard",
+        unique_per_endpoint: bool = True,
     ) -> None:
         """
         Logs an Evidently project dashboard.
+
+        .. caution::
+
+            Logging Evidently dashboards in every model monitoring window may cause scale issues.
+            This method should be called on special occasions only.
 
         :param monitoring_context:  (MonitoringApplicationContext) The monitoring context to process.
         :param timestamp_start:     (pd.Timestamp) The start timestamp for the dashboard data.
         :param timestamp_end:       (pd.Timestamp) The end timestamp for the dashboard data.
         :param artifact_name:       (str) The name for the logged artifact.
+        :param unique_per_endpoint: by default ``True``, we will log different artifact for each model endpoint,
+                                    set to ``False`` without changing item key will cause artifact override.
         """
 
         dashboard_info = self.evidently_project.build_dashboard_info(
@@ -170,5 +189,8 @@ class EvidentlyModelMonitoringApplicationBase(
 
         dashboard_html = file_html_template(params=template_params)
         monitoring_context.log_artifact(
-            artifact_name, body=dashboard_html.encode("utf-8"), format="html"
+            artifact_name,
+            body=dashboard_html.encode("utf-8"),
+            format="html",
+            unique_per_endpoint=unique_per_endpoint,
         )

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -102,10 +102,10 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
     Each metric is calculated over all the features individually and the mean is taken as the metric value.
     The average of Hellinger and total variance distance is taken as the result.
 
-    The application can log two artifacts:
+    The application can log two artifacts (disabled by default due to performance issues):
 
-    * JSON with the general drift value per feature, produced by default.
-    * Plotly table with the various metrics and histograms per feature (disabled by default due to performance issues).
+    * JSON with the general drift value per feature.
+    * Plotly table with the various metrics and histograms per feature.
 
     This application is deployed by default when calling
     :py:func:`~mlrun.projects.MlrunProject.enable_model_monitoring`.
@@ -134,12 +134,14 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
     def __init__(
         self,
         value_classifier: Optional[ValueClassifier] = None,
-        produce_json_artifact: bool = True,
+        produce_json_artifact: bool = False,
         produce_plotly_artifact: bool = False,
     ) -> None:
         """
-        :param value_classifier: Classifier object that adheres to the :py:class:`~ValueClassifier` protocol.
-                                 If not provided, the default :py:class:`~DataDriftClassifier` is used.
+        :param value_classifier:        Classifier object that adheres to the :py:class:`~ValueClassifier` protocol.
+                                        If not provided, the default :py:class:`~DataDriftClassifier` is used.
+        :param produce_json_artifact:   Whether to produce the JSON artifact or not, ``False`` by default.
+        :param produce_plotly_artifact: Whether to produce the Plotly artifact or not, ``False`` by default.
         """
         self._value_classifier = value_classifier or DataDriftClassifier()
         assert self._REQUIRED_METRICS <= set(

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import logging
 from pathlib import Path
-from typing import Any
 from unittest.mock import Mock
 
 import pandas as pd
@@ -23,7 +21,6 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-import mlrun.artifacts.manager
 import mlrun.common.model_monitoring.helpers
 import mlrun.model_monitoring.applications
 import mlrun.model_monitoring.applications.context as mm_context
@@ -38,32 +35,28 @@ from mlrun.model_monitoring.applications.histogram_data_drift import (
     InvalidMetricValueError,
     InvalidThresholdValueError,
 )
-from mlrun.utils import Logger
 
 assets_folder = Path(__file__).parent / "assets"
 
 
 @pytest.fixture
+def project(tmp_path: Path) -> mlrun.MlrunProject:
+    project = mlrun.get_or_create_project("temp")
+    project.artifact_path = str(tmp_path)
+    return project
+
+
+@pytest.fixture
 def application() -> HistogramDataDriftApplication:
-    app = HistogramDataDriftApplication()
+    app = HistogramDataDriftApplication(
+        produce_json_artifact=True, produce_plotly_artifact=True
+    )
     return app
 
 
 @pytest.fixture
 def logger() -> mlrun.utils.Logger:
-    return mlrun.utils.Logger(level=logging.DEBUG, name=__name__)
-
-
-@pytest.fixture
-def monitoring_context() -> Mock:
-    mock_monitoring_context = Mock(spec=mm_context.MonitoringApplicationContext)
-    mock_monitoring_context.log_stream = Logger(
-        name="test_data_drift_app", level=logging.DEBUG
-    )
-    mock_monitoring_context._artifacts_manager = Mock(
-        spec=mlrun.artifacts.manager.ArtifactManager
-    )
-    return mock_monitoring_context
+    return mlrun.utils.Logger(level=logging.DEBUG, name="test_histogram_data_drift_app")
 
 
 class TestDataDriftClassifier:
@@ -177,40 +170,34 @@ class TestApplication:
 
     @staticmethod
     @pytest.fixture
-    def application_kwargs(
+    def monitoring_context(
         sample_df_stats: mlrun.common.model_monitoring.helpers.FeatureStats,
         feature_stats: mlrun.common.model_monitoring.helpers.FeatureStats,
         application: HistogramDataDriftApplication,
-        monitoring_context: Mock,
         logger: mlrun.utils.Logger,
-    ) -> dict[str, Any]:
-        kwargs = {}
-        kwargs["monitoring_context"] = monitoring_context
-        monitoring_context.application_name = application.NAME
-        monitoring_context.sample_df_stats = sample_df_stats
-        monitoring_context.feature_stats = feature_stats
-        monitoring_context.sample_df = Mock(spec=pd.DataFrame)
-        monitoring_context.start_infer_time = Mock(spec=pd.Timestamp)
-        monitoring_context.end_infer_time = Mock(spec=pd.Timestamp)
-        monitoring_context.latest_request = Mock(spec=pd.Timestamp)
-        monitoring_context.endpoint_id = Mock(spec=str)
-        monitoring_context.dict_to_histogram = (
-            mm_context.MonitoringApplicationContext.dict_to_histogram
+        project: mlrun.MlrunProject,
+    ) -> mm_context.MonitoringApplicationContext:
+        monitoring_context = mm_context.MonitoringApplicationContext(
+            application_name=application.NAME,
+            event={},
+            artifacts_logger=project,
+            logger=logger,
+            project=project,
+            nuclio_logger=logger,  # the wrong type but works here
         )
-        monitoring_context.logger = logger
-        assert (
-            kwargs.keys()
-            == inspect.signature(application.do_tracking).parameters.keys()
-        )
-        return kwargs
+        monitoring_context._sample_df_stats = sample_df_stats
+        monitoring_context._feature_stats = feature_stats
+
+        return monitoring_context
 
     @classmethod
     def test(
         cls,
         application: HistogramDataDriftApplication,
-        application_kwargs: dict[str, Any],
+        monitoring_context: mm_context.MonitoringApplicationContext,
+        project: mlrun.MlrunProject,
     ) -> None:
-        results = application.do_tracking(**application_kwargs)
+        results = application.do_tracking(monitoring_context)
         metrics = []
         assert len(results) == 6, "Expected four results & metrics % stats"
         for res in results:
@@ -233,6 +220,16 @@ class TestApplication:
             ):
                 metrics.append(res)
         assert len(metrics) == 3, "Expected three metrics"
+
+        # Check the artifacts
+        assert project._artifact_manager.artifact_uris.keys() == {
+            "features_drift_results",
+            "drift_table_plot",
+        }, "The artifacts in the artifact manager are different than expected"
+        assert {f.name for f in Path(project.artifact_path).glob("*")} == {
+            "drift_table_plot.html",
+            "features_drift_results.json",
+        }, "The artifact files were not found or are different than expected"
 
 
 class TestMetricsPerFeature:

--- a/tests/system/model_monitoring/assets/histogram_app_with_artifacts.py
+++ b/tests/system/model_monitoring/assets/histogram_app_with_artifacts.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mlrun.model_monitoring.applications.histogram_data_drift import (
+    HistogramDataDriftApplication,
+)
+
+
+class HistogramDataDriftApplicationWithArtifacts(HistogramDataDriftApplication):
+    """The same histogram application but with artifacts"""
+
+    def __init__(self) -> None:
+        super().__init__(produce_json_artifact=True, produce_plotly_artifact=True)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -60,6 +60,7 @@ from mlrun.utils.v3io_clients import get_v3io_client
 from tests.system.base import TestMLRunSystem
 
 from . import TestMLRunSystemModelMonitoring
+from .assets import histogram_app_with_artifacts
 from .assets.application import (
     EXPECTED_EVENTS_COUNT,
     CountApp,
@@ -96,7 +97,6 @@ _DefaultDataDriftAppData = _AppData(
     deploy=False,
     results={"general_drift"},
     metrics={"hellinger_mean", "kld_mean", "tvd_mean"},
-    artifacts={"features_drift_results"},
 )
 
 
@@ -1416,8 +1416,8 @@ class TestAppJob(TestMLRunSystem):
         reference_data = pd.DataFrame({"a": [12, 13], "b": [3.12, 4.12]})
 
         # Call `.evaluate(...)`
-        run_result = HistogramDataDriftApplication.evaluate(
-            func_path=mlrun.model_monitoring.applications.histogram_data_drift.__file__,
+        run_result = histogram_app_with_artifacts.HistogramDataDriftApplicationWithArtifacts.evaluate(
+            func_path=histogram_app_with_artifacts.__file__,
             sample_data=sample_data,
             reference_data=reference_data,
             run_local=run_local,
@@ -1452,7 +1452,7 @@ class TestAppJob(TestMLRunSystem):
             2:4
         ], "The returned metrics are different than the expected ones"
         # Test the artifacts
-        for artifact_name in _DefaultDataDriftAppData.artifacts:
+        for artifact_name in {"features_drift_results", "drift_table_plot"}:
             assert run_result.output(
                 artifact_name
             ), f"The artifact '{artifact_name}' is not listed in the run's output"

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1258,18 +1258,7 @@ class TestBatchDrift(TestMLRunSystemModelMonitoring):
         # Validate that model_uri is based on models prefix
         _validate_model_uri(model_obj=model, model_endpoint=model_endpoint_batch)
 
-        # Validate that the artifacts were logged in the project
-        artifacts = project.list_artifacts(
-            labels={
-                "mlrun/producer-type": "model-monitoring-app",
-                "mlrun/app-name": "histogram-data-drift",
-                "mlrun/endpoint-id": model_endpoint_batch.metadata.uid,
-            }
-        )
-
         assert model_endpoint_batch.status.result_status == 2  # drift detected
-        assert len(artifacts) == 1
-        assert artifacts[0]["metadata"]["key"] == "features_drift_results"
 
         model_endpoint_non_batch = (
             mlrun.model_monitoring.api.get_or_create_model_endpoint(


### PR DESCRIPTION
And add a warning to the docs.

Logging artifacts do not scale well, at least until we implement the `update_artifact` method.
For now, disable it and advise to use it with caution.

Adjust the docs, tutorial, and tests.

Resolves [ML-9761](https://iguazio.atlassian.net/browse/ML-9761) and [ML-9718](https://iguazio.atlassian.net/browse/ML-9718).

[ML-9761]: https://iguazio.atlassian.net/browse/ML-9761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9718]: https://iguazio.atlassian.net/browse/ML-9718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ