### PR TITLE
[Artifacts] Ensure 'latest' tag appears first when listing artifacts [1.8.x]

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1763,7 +1763,9 @@ class SQLDB(DBInterface):
             # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
             query = self._paginate_query(
                 query.order_by(
-                    ArtifactV2.updated.desc(), ArtifactV2.id.desc(), ArtifactV2.Tag.id
+                    ArtifactV2.updated.desc(),
+                    ArtifactV2.id.desc(),
+                    ArtifactV2.Tag.id.desc(),
                 ),
                 offset,
                 limit,
@@ -1783,7 +1785,7 @@ class SQLDB(DBInterface):
         # If the updated fields are the same, we need a secondary field to sort by.
         # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
         outer_query = outer_query.order_by(
-            ArtifactV2.updated.desc(), ArtifactV2.id.desc(), ArtifactV2.Tag.id
+            ArtifactV2.updated.desc(), ArtifactV2.id.desc(), ArtifactV2.Tag.id.desc()
         )
 
         if not limit:
@@ -5574,7 +5576,7 @@ class SQLDB(DBInterface):
         # If the updated fields are the same, we need a secondary field to sort by.
         # Third sort by tag ID to ensure consistent ordering when a function has multiple tags.
         query = query.order_by(
-            Function.updated.desc(), Function.id.desc(), Function.Tag.id
+            Function.updated.desc(), Function.id.desc(), Function.Tag.id.desc()
         )
 
         query = self._paginate_query(query, offset, limit)

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1657,6 +1657,8 @@ class SQLDB(DBInterface):
             logger.warning(message, kind=kind, category=category)
             raise ValueError(message)
 
+        tag_id_alias = "tag_id"
+
         # create a sub query that gets only the artifact IDs
         # apply all filters and limits
         query = session.query(ArtifactV2).with_entities(
@@ -1664,7 +1666,7 @@ class SQLDB(DBInterface):
             ArtifactV2.Tag.name,
             # Include tag ID (as 'tag_id') to enable sorting by tag creation order DESC.
             # The alias is required to reference it later in subqueries and outer queries.
-            ArtifactV2.Tag.id.label("tag_id"),
+            ArtifactV2.Tag.id.label(tag_id_alias),
         )
 
         # If the query matches the default UI list artifacts request, we bypass the DB optimizer and use the index
@@ -1768,8 +1770,10 @@ class SQLDB(DBInterface):
                 query.order_by(
                     ArtifactV2.updated.desc(),
                     ArtifactV2.id.desc(),
-                    # Use alias for sorting
-                    text("tag_id DESC"),
+                    # Use raw SQL text to refer to the "tag_id" alias we defined earlier.
+                    # This is necessary because SQLAlchemy does not allow direct reference
+                    # to aliased columns (like "tag_id") in order_by() using ORM column objects.
+                    text(f"{tag_id_alias} DESC"),
                 ),
                 offset,
                 limit,
@@ -1792,7 +1796,7 @@ class SQLDB(DBInterface):
             ArtifactV2.updated.desc(),
             ArtifactV2.id.desc(),
             # Safe ordering by tag_id alias
-            subquery.c.tag_id.desc(),
+            subquery.c[tag_id_alias].desc(),
         )
 
         if not limit:

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1760,8 +1760,11 @@ class SQLDB(DBInterface):
             # Order the results before applying the limit to ensure that the limit is applied to the correctly
             # ordered results.
             # If the updated fields are the same, we need a secondary field to sort by.
+            # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
             query = self._paginate_query(
-                query.order_by(ArtifactV2.updated.desc(), ArtifactV2.id.desc()),
+                query.order_by(
+                    ArtifactV2.updated.desc(), ArtifactV2.id.desc(), ArtifactV2.Tag.id
+                ),
                 offset,
                 limit,
             )
@@ -1778,8 +1781,9 @@ class SQLDB(DBInterface):
 
         # join may lose order, make sure order is applied on outer as well
         # If the updated fields are the same, we need a secondary field to sort by.
+        # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
         outer_query = outer_query.order_by(
-            ArtifactV2.updated.desc(), ArtifactV2.id.desc()
+            ArtifactV2.updated.desc(), ArtifactV2.id.desc(), ArtifactV2.Tag.id
         )
 
         if not limit:
@@ -5568,7 +5572,10 @@ class SQLDB(DBInterface):
         query = self._add_labels_filter(session, query, Function, labels)
 
         # If the updated fields are the same, we need a secondary field to sort by.
-        query = query.order_by(Function.updated.desc(), Function.id.desc())
+        # Third sort by tag ID to ensure consistent ordering when a function has multiple tags.
+        query = query.order_by(
+            Function.updated.desc(), Function.id.desc(), Function.Tag.id
+        )
 
         query = self._paginate_query(query, offset, limit)
         return query

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1662,6 +1662,7 @@ class SQLDB(DBInterface):
         query = session.query(ArtifactV2).with_entities(
             ArtifactV2.id,
             ArtifactV2.Tag.name,
+            ArtifactV2.Tag.id.label("tag_id"),  # Include tag_id for ordering
         )
 
         # If the query matches the default UI list artifacts request, we bypass the DB optimizer and use the index
@@ -1765,7 +1766,7 @@ class SQLDB(DBInterface):
                 query.order_by(
                     ArtifactV2.updated.desc(),
                     ArtifactV2.id.desc(),
-                    ArtifactV2.Tag.id.desc(),
+                    text("tag_id DESC"),  # Use alias for sorting
                 ),
                 offset,
                 limit,
@@ -1785,7 +1786,9 @@ class SQLDB(DBInterface):
         # If the updated fields are the same, we need a secondary field to sort by.
         # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
         outer_query = outer_query.order_by(
-            ArtifactV2.updated.desc(), ArtifactV2.id.desc(), ArtifactV2.Tag.id.desc()
+            ArtifactV2.updated.desc(),
+            ArtifactV2.id.desc(),
+            subquery.c.tag_id.desc(),  # Safe ordering by tag_id alias
         )
 
         if not limit:

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1764,10 +1764,16 @@ class SQLDB(DBInterface):
             # ordered results.
             # If the updated fields are the same, we need a secondary field to sort by.
             # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
+            # Put "latest" tag first, then others by tag_id desc
+            latest_first_case = case(
+                (ArtifactV2.Tag.name == "latest", 0),
+                else_=1,
+            )
             query = self._paginate_query(
                 query.order_by(
                     ArtifactV2.updated.desc(),
                     ArtifactV2.id.desc(),
+                    latest_first_case,
                     # Use alias for sorting
                     text("tag_id DESC"),
                 ),
@@ -1785,12 +1791,19 @@ class SQLDB(DBInterface):
 
         outer_query = outer_query.join(subquery, ArtifactV2.id == subquery.c.id)
 
+        # Put "latest" tag first, then others by tag_id desc
+        latest_first_case = case(
+            (subquery.c.name == "latest", 0),
+            else_=1,
+        )
+
         # join may lose order, make sure order is applied on outer as well
         # If the updated fields are the same, we need a secondary field to sort by.
         # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
         outer_query = outer_query.order_by(
             ArtifactV2.updated.desc(),
             ArtifactV2.id.desc(),
+            latest_first_case,
             # Safe ordering by tag_id alias
             subquery.c.tag_id.desc(),
         )

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1662,7 +1662,9 @@ class SQLDB(DBInterface):
         query = session.query(ArtifactV2).with_entities(
             ArtifactV2.id,
             ArtifactV2.Tag.name,
-            ArtifactV2.Tag.id.label("tag_id"),  # Include tag_id for ordering
+            # Include tag ID (as 'tag_id') to enable sorting by tag creation order DESC.
+            # The alias is required to reference it later in subqueries and outer queries.
+            ArtifactV2.Tag.id.label("tag_id"),
         )
 
         # If the query matches the default UI list artifacts request, we bypass the DB optimizer and use the index
@@ -1766,7 +1768,8 @@ class SQLDB(DBInterface):
                 query.order_by(
                     ArtifactV2.updated.desc(),
                     ArtifactV2.id.desc(),
-                    text("tag_id DESC"),  # Use alias for sorting
+                    # Use alias for sorting
+                    text("tag_id DESC"),
                 ),
                 offset,
                 limit,
@@ -1788,7 +1791,8 @@ class SQLDB(DBInterface):
         outer_query = outer_query.order_by(
             ArtifactV2.updated.desc(),
             ArtifactV2.id.desc(),
-            subquery.c.tag_id.desc(),  # Safe ordering by tag_id alias
+            # Safe ordering by tag_id alias
+            subquery.c.tag_id.desc(),
         )
 
         if not limit:

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -4469,7 +4469,8 @@ class SQLDB(DBInterface):
         # Retrieve only the ID from the subquery to minimize the inner table,
         # in the final step we inner join the inner table with the full table.
         query = query.with_entities(
-            cls.id, cls.Tag.name if with_tagged else None
+            cls.id,
+            *(cls.Tag.name, cls.Tag.id.label("tag_id")) if with_tagged else (),
         ).add_column(row_number_column)
         if max_partitions > 0:
             max_partition_value = (
@@ -4487,7 +4488,10 @@ class SQLDB(DBInterface):
         if max_partitions == 0:
             result_query = session.query(cls)
             if with_tagged:
-                result_query = result_query.add_column(subquery.c.name)
+                result_query = result_query.add_columns(
+                    subquery.c.name,
+                    subquery.c.tag_id,
+                )
             result_query = result_query.join(subquery, cls.id == subquery.c.id).filter(
                 subquery.c.row_number <= rows_per_partition
             )

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -1640,6 +1640,59 @@ class TestArtifacts(TestDatabaseBase):
                 artifact_name == expected_name
             ), f"Expected {expected_name}, got {artifact_name}"
 
+    @pytest.mark.parametrize("limit", [None, 3])
+    def test_list_artifacts_orders_by_tag_id(self, limit):
+        # This test verifies that when an artifact has multiple tags, the returned list is ordered by tag ID descending.
+
+        project = "artifact_project"
+        artifact_key = "dummy-artifact"
+
+        artifact_body = self._generate_artifact(
+            key=artifact_key,
+            project=project,
+        )
+
+        number_of_tags = 5
+        for counter in range(number_of_tags):
+            self._db.store_artifact(
+                self._db_session,
+                artifact_key,
+                artifact_body,
+                project=project,
+                tag=f"v{counter}",
+            )
+
+        artifacts = self._db.list_artifacts(
+            self._db_session, project=project, limit=limit
+        )
+
+        expected_count = limit or (number_of_tags + 1)  # one more for latest tag
+        assert (
+            len(artifacts) == expected_count
+        ), f"Expected {expected_count} results, got {len(artifacts)}"
+
+        # Extract the tags from returned artifacts
+        returned_tags = [artifact["metadata"]["tag"] for artifact in artifacts]
+
+        # Build the expected sorted tag list (v4 to v0)
+        sorted_tags = [f"v{i}" for i in reversed(range(number_of_tags))]
+
+        if limit is None:
+            non_latest_tags = [tag for tag in returned_tags if tag != "latest"]
+            assert non_latest_tags == sorted_tags
+            assert "latest" in returned_tags
+        else:
+            # Ensure returned tags are in correct descending order (including "latest" if present)
+            sorted_with_latest = sorted_tags + ["latest"]
+            assert returned_tags == sorted_with_latest[:limit]
+
+        # Verify the case of listing artifacts by a specific tag, which should result in an inner join and
+        # return only the matching tagged artifact
+        artifacts = self._db.list_artifacts(
+            self._db_session, project=project, limit=limit, tag="v3"
+        )
+        assert len(artifacts) == 1
+
     def test_list_artifacts_producer_uri(self):
         project = "artifact_project"
         artifact_key = "dummy-artifact"

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -737,11 +737,11 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 3
-        assert artifacts[0]["metadata"]["tag"] == "v2"
         assert (
-            artifacts[1]["metadata"]["tag"]
+            artifacts[0]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
+        assert artifacts[1]["metadata"]["tag"] == "v2"
         assert artifacts[2]["metadata"]["tag"] == "v1"
 
         # Step 2: Overwrite artifact with tag "v3"
@@ -755,11 +755,11 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 2
-        assert artifacts[0]["metadata"]["tag"] == "v3"
         assert (
-            artifacts[1]["metadata"]["tag"]
+            artifacts[0]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
+        assert artifacts[1]["metadata"]["tag"] == "v3"
 
         # Step 3: Append tag "v4"
         self._db.append_tag_to_artifacts(
@@ -771,12 +771,12 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 3
-        assert artifacts[0]["metadata"]["tag"] == "v4"
-        assert artifacts[1]["metadata"]["tag"] == "v3"
         assert (
-            artifacts[2]["metadata"]["tag"]
+            artifacts[0]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
+        assert artifacts[1]["metadata"]["tag"] == "v4"
+        assert artifacts[2]["metadata"]["tag"] == "v3"
 
         # Step 4: Delete tag "v3"
         self._db.delete_tag_from_artifacts(
@@ -788,11 +788,11 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 2
-        assert artifacts[0]["metadata"]["tag"] == "v4"
         assert (
-            artifacts[1]["metadata"]["tag"]
+            artifacts[0]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
+        assert artifacts[1]["metadata"]["tag"] == "v4"
 
     def test_delete_artifacts_tag_filter(self):
         artifact_1_key = "artifact_key_1"
@@ -1642,7 +1642,8 @@ class TestArtifacts(TestDatabaseBase):
 
     @pytest.mark.parametrize("limit", [None, 3])
     def test_list_artifacts_orders_by_tag_id(self, limit):
-        # This test verifies that when an artifact has multiple tags, the returned list is ordered by tag ID descending.
+        # This test verifies that when an artifact has multiple tags, the returned list is ordered with 'latest'
+        # first and the rest by tag ID descending.
 
         project = "artifact_project"
         artifact_key = "dummy-artifact"
@@ -1667,24 +1668,15 @@ class TestArtifacts(TestDatabaseBase):
         )
 
         expected_count = limit or (number_of_tags + 1)  # one more for latest tag
+
+        # Build expected tag order with "latest" first
+        expected_tags = ["latest"] + [f"v{i}" for i in reversed(range(number_of_tags))]
+        expected_tags = expected_tags[:expected_count]
+
+        actual_tags = [artifact["metadata"]["tag"] for artifact in artifacts]
         assert (
-            len(artifacts) == expected_count
-        ), f"Expected {expected_count} results, got {len(artifacts)}"
-
-        # Extract the tags from returned artifacts
-        returned_tags = [artifact["metadata"]["tag"] for artifact in artifacts]
-
-        # Build the expected sorted tag list (v4 to v0)
-        sorted_tags = [f"v{i}" for i in reversed(range(number_of_tags))]
-
-        if limit is None:
-            non_latest_tags = [tag for tag in returned_tags if tag != "latest"]
-            assert non_latest_tags == sorted_tags
-            assert "latest" in returned_tags
-        else:
-            # Ensure returned tags are in correct descending order (including "latest" if present)
-            sorted_with_latest = sorted_tags + ["latest"]
-            assert returned_tags == sorted_with_latest[:limit]
+            actual_tags == expected_tags
+        ), f"Expected tags {expected_tags}, got {actual_tags}"
 
         # Verify the case of listing artifacts by a specific tag, which should result in an inner join and
         # return only the matching tagged artifact

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -737,12 +737,12 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 3
+        assert artifacts[0]["metadata"]["tag"] == "v2"
         assert (
-            artifacts[0]["metadata"]["tag"]
+            artifacts[1]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
-        assert artifacts[1]["metadata"]["tag"] == "v1"
-        assert artifacts[2]["metadata"]["tag"] == "v2"
+        assert artifacts[2]["metadata"]["tag"] == "v1"
 
         # Step 2: Overwrite artifact with tag "v3"
         identifier = mlrun.common.schemas.ArtifactIdentifier(key=artifact_key)
@@ -755,11 +755,11 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 2
+        assert artifacts[0]["metadata"]["tag"] == "v3"
         assert (
-            artifacts[0]["metadata"]["tag"]
+            artifacts[1]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
-        assert artifacts[1]["metadata"]["tag"] == "v3"
 
         # Step 3: Append tag "v4"
         self._db.append_tag_to_artifacts(
@@ -771,12 +771,12 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 3
+        assert artifacts[0]["metadata"]["tag"] == "v4"
+        assert artifacts[1]["metadata"]["tag"] == "v3"
         assert (
-            artifacts[0]["metadata"]["tag"]
+            artifacts[2]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
-        assert artifacts[1]["metadata"]["tag"] == "v3"
-        assert artifacts[2]["metadata"]["tag"] == "v4"
 
         # Step 4: Delete tag "v3"
         self._db.delete_tag_from_artifacts(
@@ -788,11 +788,11 @@ class TestArtifacts(TestDatabaseBase):
             self._db_session, project=project, name=artifact_key
         )
         assert len(artifacts) == 2
+        assert artifacts[0]["metadata"]["tag"] == "v4"
         assert (
-            artifacts[0]["metadata"]["tag"]
+            artifacts[1]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         )
-        assert artifacts[1]["metadata"]["tag"] == "v4"
 
     def test_delete_artifacts_tag_filter(self):
         artifact_1_key = "artifact_key_1"

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -1678,12 +1678,18 @@ class TestArtifacts(TestDatabaseBase):
         sorted_tags = [f"v{i}" for i in reversed(range(number_of_tags))]
 
         if limit is None:
-            non_latest_tags = [tag for tag in returned_tags if tag != "latest"]
+            non_latest_tags = [
+                tag
+                for tag in returned_tags
+                if tag != mlrun.common.constants.RESERVED_TAG_NAME_LATEST
+            ]
             assert non_latest_tags == sorted_tags
-            assert "latest" in returned_tags
+            assert mlrun.common.constants.RESERVED_TAG_NAME_LATEST in returned_tags
         else:
             # Ensure returned tags are in correct descending order (including "latest" if present)
-            sorted_with_latest = sorted_tags + ["latest"]
+            sorted_with_latest = sorted_tags + [
+                mlrun.common.constants.RESERVED_TAG_NAME_LATEST
+            ]
             assert returned_tags == sorted_with_latest[:limit]
 
         # Verify the case of listing artifacts by a specific tag, which should result in an inner join and

--- a/server/py/services/api/tests/unit/db/test_functions.py
+++ b/server/py/services/api/tests/unit/db/test_functions.py
@@ -747,6 +747,36 @@ class TestFunctions(TestDatabaseBase):
                 function_name == expected_name
             ), f"Expected {expected_name}, got {function_name}"
 
+    def test_list_functions_orders_by_tag_id(self):
+        # This test verifies that when a function has multiple tags, the returned list is ordered by tag ID descending.
+
+        number_of_tags = 5
+        function = self._generate_function()
+
+        for counter in range(number_of_tags):
+            tag = f"v{counter}"
+            self._db.store_function(
+                self._db_session,
+                function.to_dict(),
+                function.metadata.name,
+                versioned=False,
+                tag=tag,
+            )
+
+        functions = self._db.list_functions(self._db_session)
+
+        assert (
+            len(functions) == number_of_tags
+        ), f"Expected {number_of_tags} results, got {len(functions)}"
+
+        # Extract the tags from returned functions
+        returned_tags = [function["metadata"]["tag"] for function in functions]
+
+        # Build the expected sorted tag list (v4 to v0)
+        sorted_tags = [f"v{i}" for i in reversed(range(number_of_tags))]
+
+        assert returned_tags == sorted_tags
+
     def test_list_functions_with_missing_milliseconds_in_timestamp(self):
         function = self._generate_function()
         tag = "some_tag"


### PR DESCRIPTION
When listing artifacts, if an artifact has multiple tags, the tags should be ordered with the 'latest' tag first, followed by the rest of the tags ordered by tag ID in descending order.

https://iguazio.atlassian.net/browse/ML-9522