### PR TITLE
[Pipelines] Fix pipeline steps python version resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,6 @@ mlrun-kfp: update-version-file ## Build mlrun docker image with KFP
 	$(MLRUN_KFP_CACHE_IMAGE_PULL_COMMAND)
 	docker build \
 		--file dockerfiles/mlrun-kfp/Dockerfile \
-		--platform linux/amd64 \
 		--build-arg MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
 		--build-arg MLRUN_VERSION=$(MLRUN_VERSION) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ mlrun-kfp: update-version-file ## Build mlrun docker image with KFP
 	$(MLRUN_KFP_CACHE_IMAGE_PULL_COMMAND)
 	docker build \
 		--file dockerfiles/mlrun-kfp/Dockerfile \
+		--platform linux/amd64 \
 		--build-arg MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
 		--build-arg MLRUN_VERSION=$(MLRUN_VERSION) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \

--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -90,6 +90,13 @@ class MLRunInternalLabels:
             if not key.startswith("__") and isinstance(value, str)
         ]
 
+    @staticmethod
+    def default_run_labels_to_enrich():
+        return [
+            MLRunInternalLabels.owner,
+            MLRunInternalLabels.v3io_user,
+        ]
+
 
 class DeployStatusTextKind(mlrun.common.types.StrEnum):
     logs = "logs"

--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -15,6 +15,8 @@
 import enum
 import typing
 
+from deprecated import deprecated
+
 import mlrun.common.constants as mlrun_constants
 import mlrun_pipelines.common.models
 
@@ -237,7 +239,12 @@ class RunStates:
         }[pipeline_run_status]
 
 
-# TODO: remove this class in 1.9.0 - use only MlrunInternalLabels
+# TODO: remove this class in 1.11.0 - use only MLRunInternalLabels
+@deprecated(
+    version="1.9.0",
+    reason="This class is deprecated and will be removed in 1.11.0. Use MLRunInternalLabels instead.",
+    category=FutureWarning,
+)
 class RunLabels(enum.Enum):
     owner = mlrun_constants.MLRunInternalLabels.owner
     v3io_user = mlrun_constants.MLRunInternalLabels.v3io_user

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -72,7 +72,7 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
     ):
         run.metadata.labels[mlrun_constants.MLRunInternalLabels.kind] = runtime.kind
         mlrun.runtimes.utils.enrich_run_labels(
-            run.metadata.labels, [mlrun.common.runtimes.constants.RunLabels.owner]
+            run.metadata.labels, [mlrun_constants.MLRunInternalLabels.owner]
         )
         if run.spec.output_path:
             run.spec.output_path = run.spec.output_path.replace(

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -21,6 +21,7 @@ import typing
 import uuid
 
 import mlrun
+import mlrun.common.constants as mlrun_constants
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.common.schemas.function
@@ -1109,6 +1110,15 @@ def load_and_run_workflow(
     :param wait_for_completion: wait for workflow completion before returning
     :param project_context:     project context path (used for loading the project)
     """
+
+    logger.warning("ALON", labels=context.labels)
+    client_python_version = context.labels.get(
+        mlrun_constants.MLRunInternalLabels.client_python_version
+    )
+    if client_python_version:
+        db = mlrun.get_run_db()
+        db.python_version = client_python_version
+
     project_context = project_context or f"./{project_name}"
 
     # Load the project to fetch files which the runner needs, such as remote source files

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -499,7 +499,7 @@ class BaseRuntime(ModelObj):
     def _store_function(self, runspec, meta, db):
         meta.labels["kind"] = self.kind
         mlrun.runtimes.utils.enrich_run_labels(
-            meta.labels, [mlrun.common.runtimes.constants.RunLabels.owner]
+            meta.labels, [mlrun_constants.MLRunInternalLabels.owner]
         )
         if runspec.spec.output_path:
             runspec.spec.output_path = runspec.spec.output_path.replace(

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import enum
 import getpass
 import hashlib
 import json
@@ -28,7 +29,6 @@ import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 import mlrun.utils.regex
 from mlrun.artifacts import TableArtifact
-from mlrun.common.runtimes.constants import RunLabels
 from mlrun.config import config
 from mlrun.errors import err_to_str
 from mlrun.frameworks.parallel_coordinates import gen_pcp_plot
@@ -433,18 +433,39 @@ def enrich_function_from_dict(function, function_dict):
 
 def enrich_run_labels(
     labels: dict,
-    labels_to_enrich: Optional[list[RunLabels]] = None,
+    labels_to_enrich: Optional[list[mlrun_constants.MLRunInternalLabels]] = None,
+    labels_enrichment_extension: Optional[dict] = None,
 ):
+    """
+    Enrich the run labels with the internal labels and the labels enrichment extension
+    :param labels: The run labels dict
+    :param labels_to_enrich: The label keys to enrich from MLRunInternalLabels.default_run_labels_to_enrich
+    :param labels_enrichment_extension: Extra labels to enrich the run labels with
+    :return: The enriched labels dict
+    """
+    # Merge the labels with the labels enrichment extension
+    labels_enrichment_extension = labels_enrichment_extension or {}
     labels_enrichment = {
-        RunLabels.owner: os.environ.get("V3IO_USERNAME") or getpass.getuser(),
+        mlrun_constants.MLRunInternalLabels.owner: os.environ.get("V3IO_USERNAME")
+        or getpass.getuser(),
         # TODO: remove this in 1.9.0
-        RunLabels.v3io_user: os.environ.get("V3IO_USERNAME"),
-    }
-    labels_to_enrich = labels_to_enrich or RunLabels.all()
+        mlrun_constants.MLRunInternalLabels.v3io_user: os.environ.get("V3IO_USERNAME"),
+    } | labels_enrichment_extension
+
+    # Resolve which label keys to enrich
+    if labels_to_enrich is None:
+        labels_to_enrich = (
+            mlrun_constants.MLRunInternalLabels.default_run_labels_to_enrich()
+        )
+    labels_to_enrich += list(labels_enrichment_extension.keys())
+
+    # Enrich labels
     for label in labels_to_enrich:
+        if isinstance(label, enum.Enum):
+            label = label.value
         enrichment = labels_enrichment.get(label)
-        if label.value not in labels and enrichment:
-            labels[label.value] = enrichment
+        if label not in labels and enrichment:
+            labels[label] = enrichment
     return labels
 
 

--- a/server/py/services/api/api/endpoints/submit.py
+++ b/server/py/services/api/api/endpoints/submit.py
@@ -23,6 +23,7 @@ import mlrun.common.constants as mlrun_constants
 import mlrun.common.helpers
 import mlrun.common.schemas
 import mlrun.utils.helpers
+from mlrun.k8s_utils import sanitize_label_value
 from mlrun.utils import logger
 
 import framework.api.utils
@@ -120,20 +121,33 @@ async def submit_job(
             labels.setdefault(mlrun_constants.MLRunInternalLabels.v3io_user, username)
             labels.setdefault(mlrun_constants.MLRunInternalLabels.owner, username)
 
-    client_version = client_version or data["task"]["metadata"].get("labels", {}).get(
+    data["task"]["metadata"].setdefault("labels", {})
+    enrich_client_version_labels(
+        data["task"]["metadata"]["labels"], client_version, client_python_version
+    )
+    return await framework.api.utils.submit_run(db_session, auth_info, data)
+
+
+def enrich_client_version_labels(
+    labels: dict, client_version: Optional[str], client_python_version: Optional[str]
+):
+    """
+    Enriches the labels with the client version and python version if they are not already set.
+    :param labels: The object labels dict will be updated in-place
+    :param client_version: The client mlrun version
+    :param client_python_version: The client python version
+    """
+    client_version = client_version or labels.get(
         mlrun_constants.MLRunInternalLabels.client_version
     )
-    client_python_version = client_python_version or data["task"]["metadata"].get(
-        "labels", {}
-    ).get(mlrun_constants.MLRunInternalLabels.client_python_version)
+    client_python_version = client_python_version or labels.get(
+        mlrun_constants.MLRunInternalLabels.client_python_version
+    )
     if client_version is not None:
-        data["task"]["metadata"].setdefault("labels", {}).update(
-            {mlrun_constants.MLRunInternalLabels.client_version: client_version}
+        labels[mlrun_constants.MLRunInternalLabels.client_version] = (
+            sanitize_label_value(client_version)
         )
     if client_python_version is not None:
-        data["task"]["metadata"].setdefault("labels", {}).update(
-            {
-                mlrun_constants.MLRunInternalLabels.client_python_version: client_python_version
-            }
+        labels[mlrun_constants.MLRunInternalLabels.client_python_version] = (
+            sanitize_label_value(client_python_version)
         )
-    return await framework.api.utils.submit_run(db_session, auth_info, data)

--- a/server/py/services/api/api/endpoints/workflows.py
+++ b/server/py/services/api/api/endpoints/workflows.py
@@ -35,6 +35,7 @@ import framework.api.deps
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
 import framework.utils.singletons.project_member
+import services.api.api.endpoints.submit
 import services.api.crud
 import services.api.utils.helpers
 from framework.api.utils import log_and_raise
@@ -204,14 +205,11 @@ async def submit_workflow(
             ),
         }
     )
-    if client_version is not None:
-        workflow_runner.metadata.labels[
-            mlrun_constants.MLRunInternalLabels.client_version
-        ] = sanitize_label_value(client_version)
-    if client_python_version is not None:
-        workflow_runner.metadata.labels[
-            mlrun_constants.MLRunInternalLabels.client_python_version
-        ] = sanitize_label_value(client_python_version)
+    services.api.api.endpoints.submit.enrich_client_version_labels(
+        workflow_runner.metadata.labels,
+        client_version=client_version,
+        client_python_version=client_python_version,
+    )
     try:
         if workflow_spec.schedule:
             await run_in_threadpool(

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -106,7 +106,16 @@ class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
         :return: RunObject with run metadata, results, and status.
         """
         mlrun.runtimes.utils.enrich_run_labels(
-            labels, [mlrun.common.runtimes.constants.RunLabels.owner]
+            labels,
+            [mlrun_constants.MLRunInternalLabels.owner],
+            {
+                mlrun_constants.MLRunInternalLabels.client_version: runner.metadata.labels.get(
+                    mlrun_constants.MLRunInternalLabels.client_version
+                ),
+                mlrun_constants.MLRunInternalLabels.client_python_version: runner.metadata.labels.get(
+                    mlrun_constants.MLRunInternalLabels.client_python_version
+                ),
+            },
         )
 
         run_object = self._prepare_run_object(
@@ -255,7 +264,7 @@ class LoadRunner(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         :return: RunObject with run metadata, results, and status.
         """
         labels = {
-            "project": project.metadata.name,
+            mlrun_constants.MLRunInternalLabels.project: project.metadata.name,
             mlrun_constants.MLRunInternalLabels.job_type: JOB_TYPE_PROJECT_LOADER,
         }
 
@@ -356,6 +365,18 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
             mlrun_constants.MLRunInternalLabels.job_type: JOB_TYPE_WORKFLOW_RUNNER,
             mlrun_constants.MLRunInternalLabels.workflow: workflow_request.spec.name,
         }
+        mlrun.runtimes.utils.enrich_run_labels(
+            labels,
+            [mlrun_constants.MLRunInternalLabels.owner],
+            {
+                mlrun_constants.MLRunInternalLabels.client_version: runner.metadata.labels.get(
+                    mlrun_constants.MLRunInternalLabels.client_version
+                ),
+                mlrun_constants.MLRunInternalLabels.client_python_version: runner.metadata.labels.get(
+                    mlrun_constants.MLRunInternalLabels.client_python_version
+                ),
+            },
+        )
 
         # Generate unique UID
         meta_uid = uuid.uuid4().hex
@@ -416,7 +437,7 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         :return: RunObject with run metadata, results, and status.
         """
         labels = {
-            "project": project.metadata.name,
+            mlrun_constants.MLRunInternalLabels.project: project.metadata.name,
             mlrun_constants.MLRunInternalLabels.job_type: JOB_TYPE_WORKFLOW_RUNNER,
             mlrun_constants.MLRunInternalLabels.workflow: runner.metadata.name,
         }

--- a/tests/runtimes/test_utils.py
+++ b/tests/runtimes/test_utils.py
@@ -70,10 +70,11 @@ def test_add_code_metadata_stale_remote(repo):
 
 
 @pytest.mark.parametrize(
-    "labels, labels_to_enrich, expected_labels, env_vars_to_mock",
+    "labels, labels_to_enrich, labels_enrichment_extension, expected_labels, env_vars_to_mock",
     [
         (
             {},
+            None,
             None,
             {
                 mlrun_constants.MLRunInternalLabels.owner: mlrun_constants.MLRunInternalLabels.v3io_user,
@@ -83,13 +84,15 @@ def test_add_code_metadata_stale_remote(repo):
         ),
         (
             {},
-            {},
+            None,
+            None,
             {mlrun_constants.MLRunInternalLabels.owner: "test_user"},
             {"LOGNAME": "test_user", "V3IO_USERNAME": ""},
         ),
         (
             {mlrun_constants.MLRunInternalLabels.owner: "Mahatma"},
-            {},
+            None,
+            None,
             {
                 mlrun_constants.MLRunInternalLabels.owner: "Mahatma",
                 mlrun_constants.MLRunInternalLabels.v3io_user: mlrun_constants.MLRunInternalLabels.v3io_user,
@@ -101,7 +104,8 @@ def test_add_code_metadata_stale_remote(repo):
                 mlrun_constants.MLRunInternalLabels.owner: "Mahatma",
                 mlrun_constants.MLRunInternalLabels.v3io_user: "Gandhi",
             },
-            {},
+            [],
+            None,
             {
                 mlrun_constants.MLRunInternalLabels.owner: "Mahatma",
                 mlrun_constants.MLRunInternalLabels.v3io_user: "Gandhi",
@@ -110,7 +114,8 @@ def test_add_code_metadata_stale_remote(repo):
         ),
         (
             {"a": "A", "b": "B"},
-            {mlrun.common.runtimes.constants.RunLabels.owner},
+            [mlrun.common.runtimes.constants.RunLabels.owner],
+            None,
             {
                 "a": "A",
                 "b": "B",
@@ -118,9 +123,47 @@ def test_add_code_metadata_stale_remote(repo):
             },
             None,
         ),
+        (
+            {"a": "A", "b": "B"},
+            [],
+            {
+                mlrun_constants.MLRunInternalLabels.client_version: "1.9.0",
+                mlrun_constants.MLRunInternalLabels.client_python_version: "3.11",
+            },
+            {
+                "a": "A",
+                "b": "B",
+                mlrun_constants.MLRunInternalLabels.client_version: "1.9.0",
+                mlrun_constants.MLRunInternalLabels.client_python_version: "3.11",
+            },
+            None,
+        ),
+        (
+            {
+                mlrun_constants.MLRunInternalLabels.client_version: "1.8.0",
+                mlrun_constants.MLRunInternalLabels.client_python_version: "3.9",
+            },
+            [mlrun_constants.MLRunInternalLabels.owner],
+            {
+                mlrun_constants.MLRunInternalLabels.client_version: "1.9.0",
+                mlrun_constants.MLRunInternalLabels.client_python_version: "3.11",
+            },
+            {
+                mlrun_constants.MLRunInternalLabels.client_version: "1.8.0",
+                mlrun_constants.MLRunInternalLabels.client_python_version: "3.9",
+                mlrun_constants.MLRunInternalLabels.owner: "test_user",
+            },
+            {"V3IO_USERNAME": "test_user"},
+        ),
     ],
 )
-def test_enrich_run_labels(labels, labels_to_enrich, expected_labels, env_vars_to_mock):
+def test_enrich_run_labels(
+    labels,
+    labels_to_enrich,
+    labels_enrichment_extension,
+    expected_labels,
+    env_vars_to_mock,
+):
     env_vars_to_mock = env_vars_to_mock or {
         "V3IO_USERNAME": mlrun_constants.MLRunInternalLabels.v3io_user,
     }
@@ -128,12 +171,12 @@ def test_enrich_run_labels(labels, labels_to_enrich, expected_labels, env_vars_t
         os.environ,
         env_vars_to_mock,
     ):
-        enriched_labels = mlrun.runtimes.utils.enrich_run_labels(
-            labels, labels_to_enrich
+        mlrun.runtimes.utils.enrich_run_labels(
+            labels, labels_to_enrich, labels_enrichment_extension
         )
         assert (
             deepdiff.DeepDiff(
-                enriched_labels,
+                labels,
                 expected_labels,
                 ignore_order=True,
             )


### PR DESCRIPTION
Use client python version header to resolve the workflow version since the workflow runner is pinned to python 3.9 due to kfp 1.8 constraint.
The client python version is set on the run label and the workflow runner will override the request header value before submitting the pipeline.

https://iguazio.atlassian.net/browse/ML-9728