### PR TITLE
[Tests] Fix feature store system tests [1.8.x]

### DIFF
--- a/tests/system/feature_store/assets/sample_function.py
+++ b/tests/system/feature_store/assets/sample_function.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mlrun
+
+mlrun.mlconf.feature_store.flush_interval = None
+
+
+def test_func(context, p1):
+    return p1 + 1

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -40,7 +40,6 @@ import mlrun
 import mlrun.datastore.utils
 import mlrun.feature_store as fstore
 import mlrun.runtimes.mounts
-import tests.conftest
 from mlrun.config import config
 from mlrun.data_types.data_types import InferOptions, ValueType
 from mlrun.datastore.datastore_profile import (
@@ -2596,13 +2595,7 @@ class TestFeatureStore(TestMLRunSystem):
         )
         myset.ingest(quotes)
         source = StreamSource(key_field="ticker")
-        filename = str(
-            pathlib.Path(tests.conftest.tests_root_directory)
-            / "api"
-            / "runtimes"
-            / "assets"
-            / "sample_function.py"
-        )
+        filename = str(pathlib.Path(__file__).parent / "assets" / "sample_function.py")
 
         function = mlrun.code_to_function(
             "ingest_transactions", kind="serving", filename=filename
@@ -2912,13 +2905,7 @@ class TestFeatureStore(TestMLRunSystem):
             entity_columns=["ticker"],
         )
 
-        filename = str(
-            pathlib.Path(tests.conftest.tests_root_directory)
-            / "api"
-            / "runtimes"
-            / "assets"
-            / "sample_function.py"
-        )
+        filename = str(pathlib.Path(__file__).parent / "assets" / "sample_function.py")
 
         function = mlrun.code_to_function(
             "ingest_transactions", kind="serving", filename=filename
@@ -3128,13 +3115,7 @@ class TestFeatureStore(TestMLRunSystem):
             fset.set_targets(feature_set_targets, with_defaults=False)
         fset.ingest(quotes)
         source = StreamSource(key_field="ticker")
-        filename = str(
-            pathlib.Path(tests.conftest.tests_root_directory)
-            / "api"
-            / "runtimes"
-            / "assets"
-            / "sample_function.py"
-        )
+        filename = str(pathlib.Path(__file__).parent / "assets" / "sample_function.py")
 
         function = mlrun.code_to_function(
             "ingest_transactions", kind="serving", filename=filename


### PR DESCRIPTION
Backport of #7670.

Fixes the following system tests that broke following #6615:
```
TestFeatureStore::test_stream_source
TestFeatureStore::test_preview_saves_changes
TestFeatureStore::test_deploy_ingestion_service_with_different_targets
```