### PR TITLE
[Go] Bump to 1.23.8

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -512,7 +512,7 @@ default_config = {
             # git+https://github.com/mlrun/mlrun@development. by default uses the version
             "mlrun_version_specifier": "",
             "kaniko_image": "gcr.io/kaniko-project/executor:v1.23.2",  # kaniko builder image
-            "kaniko_init_container_image": "alpine:3.18",
+            "kaniko_init_container_image": "alpine:3.20",
             # image for kaniko init container when docker registry is ECR
             "kaniko_aws_cli_image": "amazon/aws-cli:2.17.16",
             # kaniko sometimes fails to get filesystem from image, this is a workaround to retry the process

--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/mlrun
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
remedying vulnerability as per https://go.dev/doc/devel/release#go1.23.minor:~:text=tracker%20for%20details.-,go1.23.8,-(released%202025%2D04