### PR TITLE
[Bugfix] Properly serialize datetime when sending webbook notifications [1.9.x]

### DIFF
--- a/mlrun/utils/notifications/notification/webhook.py
+++ b/mlrun/utils/notifications/notification/webhook.py
@@ -16,6 +16,7 @@ import re
 import typing
 
 import aiohttp
+import orjson
 
 import mlrun.common.schemas
 import mlrun.lists
@@ -79,6 +80,13 @@ class WebhookNotification(NotificationBase):
         if override_body:
             request_body = self._serialize_runs_in_request_body(override_body, runs)
 
+        request_body = orjson.dumps(
+            request_body,
+            option=orjson.OPT_NAIVE_UTC
+            | orjson.OPT_SERIALIZE_NUMPY
+            | orjson.OPT_NON_STR_KEYS
+            | orjson.OPT_SORT_KEYS,
+        ).decode()
         # Specify the `verify_ssl` parameter value only for HTTPS urls.
         # The `ClientSession` allows using `ssl=None` for the default SSL check,
         # and `ssl=False` to skip SSL certificate validation.

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -16,18 +16,23 @@ import asyncio
 import builtins
 import unittest.mock
 from contextlib import nullcontext as does_not_raise
-from typing import Optional
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Optional
 
 import aiohttp
+import orjson
 import pytest
 import tabulate
 
 import mlrun.common.runtimes.constants as runtimes_constants
+import mlrun.common.schemas
 import mlrun.common.schemas.notification
+import mlrun.utils
+import mlrun.utils.helpers
 import mlrun.utils.notifications
 import mlrun.utils.notifications.notification.mail as mail
-from mlrun.utils import logger
-from mlrun.utils.notifications.notification.webhook import WebhookNotification
+import mlrun.utils.notifications.notification.webhook
 
 
 @pytest.mark.parametrize(
@@ -552,13 +557,15 @@ async def test_webhook_override_body_job_succeed(monkeypatch, override_body):
     run = _generate_run_result(
         state=runtimes_constants.RunStates.completed, results={"return": 1}
     )
-    await WebhookNotification(
+    await mlrun.utils.notifications.notification.webhook.WebhookNotification(
         params={"override_body": override_body, "url": "http://test.com"}
     ).push("test-message", "info", [run])
-    expected_body = {
-        "message": "runs: [{'project': 'test-remote-workflow', 'name': 'func-func', "
-        "'status': {'state': 'completed', 'results': {'return': 1}}, 'host': 'func-func-8lvl8'}]"
-    }
+    expected_body = orjson.dumps(
+        {
+            "message": "runs: [{'project': 'test-remote-workflow', 'name': 'func-func', "
+            "'status': {'state': 'completed', 'results': {'return': 1}}, 'host': 'func-func-8lvl8'}]"
+        }
+    ).decode()
     requests_mock.assert_called_once_with(
         "http://test.com", headers={}, json=expected_body, ssl=None
     )
@@ -611,13 +618,15 @@ async def test_webhook_override_body_job_failed(monkeypatch, override_body):
     run = _generate_run_result(
         state=runtimes_constants.RunStates.error, error="some_error"
     )
-    await WebhookNotification(
+    await mlrun.utils.notifications.notification.webhook.WebhookNotification(
         params={"override_body": override_body, "url": "http://test.com"}
     ).push("test-message", "info", [run])
-    expected_body = {
-        "message": "runs: [{'project': 'test-remote-workflow', 'name': 'func-func', "
-        "'status': {'state': 'error', 'error': 'some_error'}, 'host': 'func-func-8lvl8'}]"
-    }
+    expected_body = orjson.dumps(
+        {
+            "message": "runs: [{'project': 'test-remote-workflow', 'name': 'func-func', "
+            "'status': {'state': 'error', 'error': 'some_error'}, 'host': 'func-func-8lvl8'}]"
+        }
+    ).decode()
     requests_mock.assert_called_once_with(
         "http://test.com", headers={}, json=expected_body, ssl=None
     )
@@ -835,11 +844,17 @@ async def test_webhook_notification(monkeypatch, test_method):
     requests_mock.assert_called_once_with(
         test_url,
         headers=test_headers,
-        json={
-            "message": test_message,
-            "severity": test_severity,
-            "runs": test_runs_info,
-        },
+        json=orjson.dumps(
+            {
+                "message": test_message,
+                "severity": test_severity,
+                "runs": test_runs_info,
+            },
+            option=orjson.OPT_NAIVE_UTC
+            | orjson.OPT_SERIALIZE_NUMPY
+            | orjson.OPT_NON_STR_KEYS
+            | orjson.OPT_SORT_KEYS,
+        ).decode(),
         ssl=None,
     )
 
@@ -850,7 +865,13 @@ async def test_webhook_notification(monkeypatch, test_method):
     requests_mock.assert_called_with(
         test_url,
         headers=test_headers,
-        json=test_override_body,
+        json=orjson.dumps(
+            test_override_body,
+            option=orjson.OPT_NAIVE_UTC
+            | orjson.OPT_SERIALIZE_NUMPY
+            | orjson.OPT_NON_STR_KEYS
+            | orjson.OPT_SORT_KEYS,
+        ).decode(),
         ssl=None,
     )
 
@@ -994,11 +1015,11 @@ def test_notification_validation_defaults(monkeypatch):
         "name": "",
     }
 
-    for field, expected_value in notification_fields.items():
-        value = getattr(notification, field)
+    for notification_field, expected_value in notification_fields.items():
+        value = getattr(notification, notification_field)
         assert (
             value == expected_value
-        ), f"{field} field value is {value}, expected {expected_value}"
+        ), f"{notification_field} field value is {value}, expected {expected_value}"
 
 
 @pytest.mark.parametrize(
@@ -1547,7 +1568,7 @@ class TestMailNotification:
         ],
     )
     def test_enrich_default_params(self, name, params, expected_params):
-        logger.debug(f"Testing {name}")
+        mlrun.utils.logger.debug(f"Testing {name}")
         enriched_params = mail.MailNotification.enrich_default_params(
             params, TestMailNotification.DEFAULT_PARAMS
         )
@@ -1584,10 +1605,254 @@ class TestMailNotification:
         ],
     )
     async def test_push(self, name, params, message, severity, expected):
-        logger.debug(f"Testing {name}")
+        mlrun.utils.logger.debug(f"Testing {name}")
         notification = mail.MailNotification(params=params)
         notification._send_email = unittest.mock.AsyncMock()
         notification._get_html = unittest.mock.MagicMock(return_value=self.MOCKED_HTML)
         await notification.push(message, severity, [])
         assert notification.params["subject"] == expected["subject"]
         assert notification.params["body"] == expected["body"]
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.status: int = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.request_args: Optional[dict[str, Any]] = None
+
+    async def post(
+        self,
+        url: str,
+        headers: Optional[dict[str, str]] = None,
+        json: Any = None,
+        ssl: Optional[bool] = None,
+    ) -> DummyResponse:
+        self.request_args = {
+            "method": "post",
+            "url": url,
+            "headers": headers,
+            "json": json,
+            "ssl": ssl,
+        }
+        return DummyResponse()
+
+    async def put(
+        self,
+        url: str,
+        headers: Optional[dict[str, str]] = None,
+        json: Any = None,
+        ssl: Optional[bool] = None,
+    ) -> DummyResponse:
+        self.request_args = {
+            "method": "put",
+            "url": url,
+            "headers": headers,
+            "json": json,
+            "ssl": ssl,
+        }
+        return DummyResponse()
+
+
+class DummySessionContext:
+    dummy_session_holder: dict[str, DummySession] = {}
+
+    def __init__(self) -> None:
+        self._session = DummySession()
+
+    async def __aenter__(self) -> DummySession:
+        self.dummy_session_holder["session"] = self._session
+        return self._session
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def client_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Patch aiohttp.ClientSession only for the tests that need it.
+    """
+    monkeypatch.setattr(
+        mlrun.utils.notifications.notification.webhook.aiohttp,
+        "ClientSession",
+        DummySessionContext,
+    )
+
+
+@dataclass
+class DummyRun:
+    project: str = "proj"
+    name: str = "run1"
+    host: Optional[str] = None
+    state: str = "s"
+    error: Optional[str] = None
+    results: Optional[list[Any]] = None
+    metadata: dict[str, Any] = field(init=False)
+    status: dict[str, Any] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.metadata = {"project": self.project, "name": self.name, "labels": {}}
+        if self.host:
+            self.metadata["labels"]["host"] = self.host
+        self.status = {"state": self.state}
+        if self.error:
+            self.status["error"] = self.error
+        elif self.results is not None:
+            self.status["results"] = self.results
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"metadata": self.metadata, "status": self.status}
+
+
+@dataclass
+class DummyAlert:
+    name: str
+    project: str
+    severity: str
+    summary: Optional[str] = None
+
+
+@dataclass
+class DummyEntity:
+    ids: list[Any]
+
+
+@dataclass
+class DummyEvent:
+    value_dict: dict[str, Any]
+    ids: list[Any]
+    entity: DummyEntity = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.entity = DummyEntity(self.ids)
+
+
+@pytest.mark.asyncio
+async def test_push_full_payload(client_session: Any) -> None:
+    runs: list[DummyRun] = [
+        DummyRun(
+            project="p", name="n", host="h", state="running", error="err"
+        ).to_dict()
+    ]
+    alert = DummyAlert("alertName", "alertProj", "alertSeverity", summary="summaryText")
+    event = DummyEvent({"key": "val"}, ["id1", "id2"])
+    custom_html = "<b>html</b>"
+
+    notif = mlrun.utils.notifications.notification.webhook.WebhookNotification(
+        params={
+            "url": "https://example.com/hook",
+            "method": "PUT",
+            "headers": {"H": "v"},
+        }
+    )
+    await notif.push(
+        message="hello",
+        severity="origSeverity",
+        runs=runs,
+        custom_html=custom_html,
+        alert=alert,
+        event_data=event,
+    )
+
+    session = DummySessionContext.dummy_session_holder["session"]
+    args = session.request_args or {}
+    assert args["method"] == "put"
+    assert args["url"] == "https://example.com/hook"
+    assert args["headers"] == {"H": "v"}
+
+    payload = orjson.loads(args["json"])
+    assert payload["message"] == "hello"
+    assert payload["severity"] == alert.severity
+    assert payload["runs"] == runs
+    assert payload["name"] == alert.name
+    assert payload["project"] == alert.project
+    assert payload["summary"] == "summaryText"
+    assert payload["value"] == {"key": "val"}
+    assert payload["id"] == "id1"
+    assert payload["custom_html"] == custom_html
+    assert args["ssl"] is None
+
+
+@pytest.mark.asyncio
+async def test_override_list_passthrough(client_session: Any) -> None:
+    override_body = ["a", "b"]
+    notif = mlrun.utils.notifications.notification.webhook.WebhookNotification(
+        params={
+            "url": "http://example.com",
+            "override_body": override_body,
+            "verify_ssl": True,
+        },
+    )
+    await notif.push("ignored")
+    session = DummySessionContext.dummy_session_holder["session"]
+    assert (
+        session.request_args
+        and orjson.loads(session.request_args["json"]) == override_body
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "override_body, runs, key, expected",
+    [
+        (
+            {"dict": {"x": datetime(2025, 1, 1, 0, 0, 0)}},
+            None,
+            "dict",
+            {"x": "2025-01-01T00:00:00+00:00"},
+        ),
+        ({"float": 1.23}, None, "float", 1.23),
+        ({"bool": True}, None, "bool", True),
+        ({"none": None}, None, "none", None),
+        ({"list": [1, 2, "a"]}, None, "list", [1, 2, "a"]),
+        ({"mixed": "val{{ runs }}end"}, [], "mixed", "val[]end"),
+    ],
+)
+async def test_override_values(
+    client_session: Any,
+    override_body: dict[str, Any],
+    runs: Optional[list[Any]],
+    key: str,
+    expected: Any,
+) -> None:
+    notif = mlrun.utils.notifications.notification.webhook.WebhookNotification(
+        params={
+            "url": "http://example.com",
+            "override_body": override_body.copy(),
+        }
+    )
+    await notif.push("ignored", runs=runs)
+    sent = DummySessionContext.dummy_session_holder["session"].request_args["json"]
+    assert orjson.loads(sent)[key] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url, verify_ssl, expected_ssl",
+    [
+        ("https://example.com", None, None),
+        ("https://example.com", False, False),
+        ("http://example.com", True, None),
+    ],
+)
+async def test_ssl_logic(
+    client_session: Any,
+    url: str,
+    verify_ssl: Optional[bool],
+    expected_ssl: Optional[bool],
+) -> None:
+    params: dict[str, Any] = {"url": url}
+    if verify_ssl is not None:
+        params["verify_ssl"] = verify_ssl
+    notification = mlrun.utils.notifications.notification.webhook.WebhookNotification(
+        params=params
+    )
+    await notification.push("ignored")
+    ssl_arg = DummySessionContext.dummy_session_holder["session"].request_args["ssl"]
+    assert ssl_arg is expected_ssl


### PR DESCRIPTION
(cherry picked from commit b78f04a1bc946abecee0cfd9d5c08383dbfce919)