### PR TITLE
[Automation] Fix package test by further restricting pip version used [1.9.x]

### DIFF
--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -272,7 +272,7 @@ class PackageTester:
             extra=extra,
         )
         self._run_command(
-            "python -m pip install --upgrade pip~=25.0",
+            "python -m pip install --upgrade pip~=25.0.0",
             run_in_venv=True,
         )
 


### PR DESCRIPTION
… (#7742)

(cherry picked from commit 185fd9288b612130457f0732382bfe6655bcbf94)