### PR TITLE
[Model Monitoring] Support Confluent Cloud

### DIFF
--- a/docs/model-monitoring/index.md
+++ b/docs/model-monitoring/index.md
@@ -74,7 +74,7 @@ Model monitoring supports Kafka or V3IO as streaming platforms, and TDEngine or 
 We recommend the following versions:
 
 - TDEngine: `3.3.2.0`.
-- Kafka: `3.9.0` self-hosted, or Confluent Kafka `7.9`.
+- Kafka: `3.9.0` self-hosted, or Confluent Cloud (tested against `7.9`).
 
 Before you deploy the model monitoring or serving function, you need to {py:meth}`set the credentials <mlrun.projects.MlrunProject.set_model_monitoring_credentials>`.
 

--- a/docs/model-monitoring/index.md
+++ b/docs/model-monitoring/index.md
@@ -71,9 +71,10 @@ For example:
 
 Model monitoring supports Kafka or V3IO as streaming platforms, and TDEngine or V3IO TSDB platforms.
 
-Recommended versions:
-- TDEngine: `3.3.2.0`
-- Kafka: `3.9.0`
+We recommend the following versions:
+
+- TDEngine: `3.3.2.0`.
+- Kafka: `3.9.0` self-hosted, or Confluent Kafka `7.9`.
 
 Before you deploy the model monitoring or serving function, you need to {py:meth}`set the credentials <mlrun.projects.MlrunProject.set_model_monitoring_credentials>`.
 

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import json
 import operator
 import os
@@ -18,7 +19,7 @@ import warnings
 from base64 import b64encode
 from copy import copy
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import pandas as pd
 import semver
@@ -1063,16 +1064,17 @@ class KafkaSource(OnlineSource):
 
     def __init__(
         self,
-        brokers=None,
-        topics=None,
-        group="serving",
-        initial_offset="earliest",
-        partitions=None,
-        sasl_user=None,
-        sasl_pass=None,
-        attributes=None,
+        brokers: Optional[list[str]] = None,
+        topics: Optional[list[str]] = None,
+        group: str = "serving",
+        initial_offset: Literal["earliest", "latest"] = "earliest",
+        partitions: Optional[list[int]] = None,
+        sasl_user: Optional[str] = None,
+        sasl_pass: Optional[str] = None,
+        tls_enable: Optional[bool] = None,
+        attributes: Optional[dict] = None,
         **kwargs,
-    ):
+    ) -> None:
         """Sets kafka source for the flow
 
         :param brokers: list of broker IP addresses
@@ -1082,6 +1084,7 @@ class KafkaSource(OnlineSource):
         :param partitions: Optional, A list of partitions numbers for which the function receives events.
         :param sasl_user: Optional, user name to use for sasl authentications
         :param sasl_pass: Optional, password to use for sasl authentications
+        :param tls_enable: Optional, if set - whether to enable TLS or not.
         :param attributes: Optional, extra attributes to be passed to kafka trigger
         """
         if isinstance(topics, str):
@@ -1095,10 +1098,15 @@ class KafkaSource(OnlineSource):
         attributes["initial_offset"] = initial_offset
         if partitions is not None:
             attributes["partitions"] = partitions
-        if sasl := mlrun.datastore.utils.KafkaParameters(attributes).sasl(
-            usr=sasl_user, pwd=sasl_pass
-        ):
+
+        kafka_params = mlrun.datastore.utils.KafkaParameters(attributes)
+
+        if sasl := kafka_params.sasl(usr=sasl_user, pwd=sasl_pass):
             attributes["sasl"] = sasl
+
+        if tls := kafka_params.tls(tls_enable=tls_enable):
+            attributes["tls"] = tls
+
         super().__init__(attributes=attributes, **kwargs)
 
     def to_dataframe(

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -270,7 +270,9 @@ class KafkaParameters:
         }
         if sasl := self._kwargs.get("sasl"):
             res |= {
-                "security_protocol": "SASL_PLAINTEXT",
+                "security_protocol": self._kwargs.get(
+                    "security_protocol", "SASL_PLAINTEXT"
+                ),
                 "sasl_mechanism": sasl["mechanism"],
                 "sasl_plain_username": sasl["user"],
                 "sasl_plain_password": sasl["password"],

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -246,6 +246,8 @@ class KafkaParameters:
             "partitions": "",
             "sasl": "",
             "worker_allocation_mode": "",
+            "tls_enable": "",  # for Nuclio with Confluent Kafka (Sarama client)
+            "tls": "",
         }
         self._reference_dicts = (
             self._custom_attributes,

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -302,6 +302,15 @@ class KafkaParameters:
             res["handshake"] = self._kwargs.get("sasl_handshake", True)
         return res
 
+    def tls(self, *, tls_enable: typing.Optional[bool] = None) -> dict[str, bool]:
+        res = self._kwargs.get("tls", {})
+        tls_enable = (
+            tls_enable if tls_enable is not None else self._kwargs.get("tls_enable")
+        )
+        if tls_enable:
+            res["enable"] = tls_enable
+        return res
+
     def valid_entries_only(self, input_dict: dict) -> dict:
         valid_keys = set()
         for ref_dict in self._reference_dicts:

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -288,15 +288,16 @@ class KafkaParameters:
 
     def sasl(
         self, *, usr: typing.Optional[str] = None, pwd: typing.Optional[str] = None
-    ) -> dict:
-        usr = usr or self._kwargs.get("sasl_plain_username", None)
-        pwd = pwd or self._kwargs.get("sasl_plain_password", None)
+    ) -> dict[str, typing.Union[str, bool]]:
         res = self._kwargs.get("sasl", {})
+        usr = usr or self._kwargs.get("sasl_plain_username")
+        pwd = pwd or self._kwargs.get("sasl_plain_password")
         if usr and pwd:
             res["enable"] = True
             res["user"] = usr
             res["password"] = pwd
             res["mechanism"] = self._kwargs.get("sasl_mechanism", "PLAIN")
+            res["handshake"] = self._kwargs.get("sasl_handshake", True)
         return res
 
     def valid_entries_only(self, input_dict: dict) -> dict:

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -248,6 +248,7 @@ class KafkaParameters:
             "worker_allocation_mode": "",
             "tls_enable": "",  # for Nuclio with Confluent Kafka (Sarama client)
             "tls": "",
+            "new_topic": "",
         }
         self._reference_dicts = (
             self._custom_attributes,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3981,6 +3981,7 @@ class HTTPRunDB(RunDBInterface):
                 "deploy_histogram_data_drift_app": deploy_histogram_data_drift_app,
                 "fetch_credentials_from_sys_config": fetch_credentials_from_sys_config,
             },
+            timeout=300,  # 5 minutes
         )
 
     def disable_model_monitoring(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3695,7 +3695,7 @@ class MlrunProject(ModelObj):
                 brokers=["<kafka-broker-ip-address>:9094"],
                 topics=[],  # Keep the topics list empty
                 ## SASL is supported
-                # sasl_user="user1",
+                # sasl_user="<kafka-sasl-user>",
                 # sasl_pass="<kafka-sasl-password>",
             )
             project.register_datastore_profile(stream_profile)
@@ -3727,6 +3727,29 @@ class MlrunProject(ModelObj):
             project.register_datastore_profile(stream_profile)
 
         In the V3IO datastore, you must provide an explicit access key to the stream, but not to the TSDB.
+
+        An external Confluent Kafka stream is also supported. Here is an example:
+
+        .. code-block:: python
+
+            from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
+
+            stream_profile = DatastoreProfileKafkaSource(
+                name="confluent-kafka",
+                brokers=["<server-domain-start>.confluent.cloud:9092"],
+                topics=[],
+                sasl_user="<API-key>",
+                sasl_pass="<API-secret>",
+                kwargs_public={
+                    "security_protocol": "SASL_SSL",
+                    "api_version_auto_timeout_ms": 20_000,  # 20 seconds
+                    "tls": {"enable": True},
+                    "new_topic": {"replication_factor": 3},
+                },
+            )
+
+        The replication factor and timeout configuration might need to be adjusted according to your Confluent cluster
+        type and settings.
 
         :param tsdb_profile_name:         The datastore profile name of the time-series database to be used in model
                                           monitoring. The supported profiles are:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3742,7 +3742,7 @@ class MlrunProject(ModelObj):
                 sasl_pass="<API-secret>",
                 kwargs_public={
                     "security_protocol": "SASL_SSL",
-                    "api_version_auto_timeout_ms": 10_000,  # 10 seconds
+                    "api_version_auto_timeout_ms": 15_000,  # 15 seconds
                     "tls": {"enable": True},
                     "new_topic": {"replication_factor": 3},
                 },

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3742,7 +3742,7 @@ class MlrunProject(ModelObj):
                 sasl_pass="<API-secret>",
                 kwargs_public={
                     "security_protocol": "SASL_SSL",
-                    "api_version_auto_timeout_ms": 20_000,  # 20 seconds
+                    "api_version_auto_timeout_ms": 10_000,  # 10 seconds
                     "tls": {"enable": True},
                     "new_topic": {"replication_factor": 3},
                 },

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -218,9 +218,7 @@ class MonitoringDeployment:
                 f"Deploying {mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER} function",
                 project=self.project,
             )
-            fn = self._get_model_monitoring_controller_function(
-                image=controller_image, ignore_stream_already_exists_failure=overwrite
-            )
+            fn = self._get_model_monitoring_controller_function(image=controller_image)
             minutes = base_period
             hours = days = 0
             batch_dict = {
@@ -512,16 +510,12 @@ class MonitoringDeployment:
 
         return function
 
-    def _get_model_monitoring_controller_function(
-        self, image: str, ignore_stream_already_exists_failure: bool
-    ):
+    def _get_model_monitoring_controller_function(self, image: str):
         """
         Initialize model monitoring controller function.
 
-        :param image:                               Base docker image to use for building the function container.
-        :param ignore_stream_already_exists_failure: If True, ignores `TopicAlreadyExistsError` error on
-                                                     MM-infra-functions deployment when using kafka.
-        :return:                                    A function object from a mlrun runtime class.
+        :param image: Base docker image to use for building the function container.
+        :return:      A function object from a mlrun runtime class.
         """
         # Create job function runtime for the controller
         function = mlrun.code_to_function(
@@ -544,7 +538,7 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
             stream_args=config.model_endpoint_monitoring.controller_stream_args,
-            ignore_stream_already_exists_failure=ignore_stream_already_exists_failure,
+            ignore_stream_already_exists_failure=True,
         )
 
         function = self._apply_access_key_and_mount_function(

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -167,12 +167,8 @@ class MonitoringDeployment:
         :param overwrite:                   If true, overwrite the existing model monitoring stream. Default is False.
         """
 
-        if (
-            overwrite
-            or self._get_function_state(
-                function_name=mm_constants.MonitoringFunctionNames.STREAM,
-            )
-            != "ready"
+        if overwrite or self._should_deploy_function(
+            function_name=mm_constants.MonitoringFunctionNames.STREAM
         ):
             logger.info(
                 f"Deploying {mm_constants.MonitoringFunctionNames.STREAM} function",
@@ -215,12 +211,8 @@ class MonitoringDeployment:
         :param overwrite:                   If true, overwrite the existing model monitoring controller.
                                             By default, False.
         """
-        if (
-            overwrite
-            or self._get_function_state(
-                function_name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
-            )
-            != "ready"
+        if overwrite or self._should_deploy_function(
+            function_name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER
         ):
             logger.info(
                 f"Deploying {mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER} function",
@@ -269,12 +261,8 @@ class MonitoringDeployment:
         :param overwrite:                   If true, overwrite the existing model monitoring writer. Default is False.
         """
 
-        if (
-            overwrite
-            or self._get_function_state(
-                function_name=mm_constants.MonitoringFunctionNames.WRITER,
-            )
-            != "ready"
+        if overwrite or self._should_deploy_function(
+            function_name=mm_constants.MonitoringFunctionNames.WRITER
         ):
             logger.info(
                 f"Deploying {mm_constants.MonitoringFunctionNames.WRITER} function",
@@ -658,14 +646,10 @@ class MonitoringDeployment:
 
         return function
 
-    def _get_function_state(
-        self,
-        function_name: str,
-    ) -> typing.Optional[str]:
+    def _get_function_state(self, function_name: str) -> typing.Optional[str]:
         """
-        :param function_name:   The name of the function to check.
-
-        :return:                Function state if deployed, else None.
+        :param function_name: The name of the function to check.
+        :return:              Function state if deployed, else None.
         """
         logger.info(
             f"Checking if {function_name} is already deployed",
@@ -690,6 +674,16 @@ class MonitoringDeployment:
         except mlrun.errors.MLRunNotFoundError:
             pass
 
+    def _should_deploy_function(self, function_name: str) -> bool:
+        """
+        :param function_name: The name of the function to check.
+        :return:              False if the function is deployed/deploying, True otherwise.
+        """
+        return self._get_function_state(function_name) not in (
+            mlrun.common.schemas.FunctionState.ready,
+            "building",  # see ML-9903
+        )
+
     def deploy_histogram_data_drift_app(
         self, image: str, overwrite: bool = False
     ) -> None:
@@ -699,12 +693,8 @@ class MonitoringDeployment:
         :param image:       The image on with the function will run.
         :param overwrite:   If True, the function will be overwritten.
         """
-        if (
-            overwrite
-            or self._get_function_state(
-                function_name=mm_constants.HistogramDataDriftApplicationConstants.NAME,
-            )
-            != "ready"
+        if overwrite or self._should_deploy_function(
+            function_name=mm_constants.HistogramDataDriftApplicationConstants.NAME
         ):
             logger.info("Preparing the histogram data drift function")
             func = mlrun.model_monitoring.api._create_model_monitoring_function_base(

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -368,7 +368,7 @@ class MonitoringDeployment:
         topic = mlrun.common.model_monitoring.helpers.get_kafka_topic(
             project=self.project, function_name=function_name
         )
-
+        profile_attributes = kafka_profile.attributes()
         stream_source = mlrun.datastore.sources.KafkaSource(
             brokers=kafka_profile.brokers,
             topics=[topic],
@@ -379,12 +379,18 @@ class MonitoringDeployment:
                 "max_workers": stream_args.kafka.num_workers,
                 "worker_allocation_mode": "static",
             }
-            | kafka_profile.attributes(),
+            | profile_attributes,
+        )
+        new_topic_profile_config = profile_attributes.get("new_topic", {})
+        num_partitions = new_topic_profile_config.get(
+            "num_partitions", stream_args.kafka.partition_count
+        )
+        replication_factor = new_topic_profile_config.get(
+            "replication_factor", stream_args.kafka.replication_factor
         )
         try:
             stream_source.create_topics(
-                num_partitions=stream_args.kafka.partition_count,
-                replication_factor=stream_args.kafka.replication_factor,
+                num_partitions=num_partitions, replication_factor=replication_factor
             )
         except kafka.errors.TopicAlreadyExistsError as exc:
             if ignore_stream_already_exists_failure:

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -218,7 +218,9 @@ class MonitoringDeployment:
                 f"Deploying {mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER} function",
                 project=self.project,
             )
-            fn = self._get_model_monitoring_controller_function(image=controller_image)
+            fn = self._get_model_monitoring_controller_function(
+                image=controller_image, ignore_stream_already_exists_failure=overwrite
+            )
             minutes = base_period
             hours = days = 0
             batch_dict = {
@@ -510,12 +512,16 @@ class MonitoringDeployment:
 
         return function
 
-    def _get_model_monitoring_controller_function(self, image: str):
+    def _get_model_monitoring_controller_function(
+        self, image: str, ignore_stream_already_exists_failure: bool
+    ):
         """
         Initialize model monitoring controller function.
 
-        :param image: Base docker image to use for building the function container.
-        :return:      A function object from a mlrun runtime class.
+        :param image:                               Base docker image to use for building the function container.
+        :param ignore_stream_already_exists_failure: If True, ignores `TopicAlreadyExistsError` error on
+                                                     MM-infra-functions deployment when using kafka.
+        :return:                                    A function object from a mlrun runtime class.
         """
         # Create job function runtime for the controller
         function = mlrun.code_to_function(
@@ -538,7 +544,7 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
             stream_args=config.model_endpoint_monitoring.controller_stream_args,
-            ignore_stream_already_exists_failure=True,
+            ignore_stream_already_exists_failure=ignore_stream_already_exists_failure,
         )
 
         function = self._apply_access_key_and_mount_function(

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -375,11 +375,11 @@ class MonitoringDeployment:
             group=kafka_profile.group,
             initial_offset=kafka_profile.initial_offset,
             partitions=kafka_profile.partitions,
-            attributes=kafka_profile.attributes()
-            | {
+            attributes={
                 "max_workers": stream_args.kafka.num_workers,
                 "worker_allocation_mode": "static",
-            },
+            }
+            | kafka_profile.attributes(),
         )
         try:
             stream_source.create_topics(

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1061,7 +1061,10 @@ class MonitoringDeployment:
                     client_id=client_id,
                     **kafka_admin_client_kwargs,
                 )
-                kafka_client.delete_topics(topics)
+                try:
+                    kafka_client.delete_topics(topics)
+                finally:
+                    kafka_client.close()
                 logger.debug("Deleted kafka topics", topics=topics)
             except Exception as exc:
                 # Raise an error that will be caught by the caller and skip the deletion of the stream

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -176,6 +176,7 @@ def test_kafka_source_without_attributes():
     assert attributes["consumerGroup"] == "mygroup"
     assert attributes["sasl"] == {
         "enable": True,
+        "handshake": True,
         "user": "myuser",
         "password": "mypassword",
         "mechanism": "PLAIN",

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -106,7 +106,7 @@ mlrun_model_monitoring_stream_profile:
   # For Confluent Kafka:
   # kwargs_public:
   #   security_protocol: SASL_SSL
-  #   api_version_auto_timeout_ms: 10_000
+  #   api_version_auto_timeout_ms: 15_000
   #   tls:
   #     enable: true
   #   new_topic:

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -106,7 +106,7 @@ mlrun_model_monitoring_stream_profile:
   # For Confluent Kafka:
   # kwargs_public:
   #   security_protocol: SASL_SSL
-  #   api_version_auto_timeout_ms: 20000
+  #   api_version_auto_timeout_ms: 10_000
   #   tls:
   #     enable: true
   #   new_topic:

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -100,8 +100,17 @@ mlrun_model_monitoring_stream_profile:
   # type: kafka_source
   # brokers: # <host>:<port>
   # topics: []
+  # With SASL:
   # sasl_user:
   # sasl_pass:
+  # For Confluent Kafka:
+  # kwargs_public:
+  #   security_protocol: SASL_SSL
+  #   api_version_auto_timeout_ms: 20000
+  #   tls:
+  #     enable: true
+  #   new_topic:
+  #     replication_factor: 3
 
 # Controls whether the client verifies the server's TLS certificate.
 # Set to `True` to enable TLS verification.

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -699,10 +699,11 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         )
 
         self._infer_with_error(serving_fn, with_training_set=with_training_set)
-        # mark the first window as "done" with another request
+        # wait for the NO-OP event to close the window
         time.sleep(
             2 * self.app_interval_seconds
             + mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
+            + 90  # external Confluent Kafka degrades the streams latency
         )
 
         mep = mlrun.db.get_run_db().get_model_endpoint(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -388,7 +388,9 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         self._external_stream_delay = 0
         if isinstance(
             self.mm_stream_profile, DatastoreProfileKafkaSource
-        ) and self.mm_stream_profile.brokers[0].endswith(".confluent.cloud:9092"):
+        ) and self.mm_stream_profile.attributes()["brokers"][0].endswith(
+            ".confluent.cloud:9092"
+        ):
             # external Confluent Cloud degrades the streams latency
             self._external_stream_delay = 90  # seconds
         super(TestMLRunSystem, self).custom_setup(project_name=self.project_name)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -386,6 +386,12 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
 
     def custom_setup(self) -> None:
         self.set_mm_credentials()
+        self._external_stream_delay = 0
+        if isinstance(
+            self.mm_stream_profile, DatastoreProfileKafkaSource
+        ) and self.mm_stream_profile.brokers[0].endswith(".confluent.cloud:9092"):
+            # external Confluent Cloud degrades the streams latency
+            self._external_stream_delay = 90  # seconds
         super(TestMLRunSystem, self).custom_setup(project_name=self.project_name)
 
     def custom_teardown(self) -> None:
@@ -703,7 +709,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         time.sleep(
             2 * self.app_interval_seconds
             + mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
-            + 90  # external Confluent Kafka degrades the streams latency
+            + self._external_stream_delay
         )
 
         mep = mlrun.db.get_run_db().get_model_endpoint(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -43,7 +43,6 @@ import mlrun.feature_store
 import mlrun.feature_store as fstore
 import mlrun.model_monitoring
 import mlrun.model_monitoring.api
-import mlrun.model_monitoring.applications.histogram_data_drift
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
     DatastoreProfileKafkaSource,

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -703,7 +703,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         time.sleep(
             2 * self.app_interval_seconds
             + mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
-            + 60  # external Confluent Kafka degrades the streams latency
+            + 90  # external Confluent Kafka degrades the streams latency
         )
 
         mep = mlrun.db.get_run_db().get_model_endpoint(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -714,11 +714,15 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
             tsdb_metrics=True,
         )
 
+        assert (
+            mep.status.last_request == last_request
+        ), "The saved `last_request` in the model endpoint is different than the last result timestamp"
+
         self._test_v3io_records(
             ep_id=mep.metadata.uid,
             inputs=inputs,
             outputs=outputs,
-            last_request=last_request,
+            last_request=mep.status.last_request,
             error_count=self.error_count,
         )
         self._test_predictions_table(mep.metadata.uid)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -703,7 +703,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         time.sleep(
             2 * self.app_interval_seconds
             + mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
-            + 90  # external Confluent Kafka degrades the streams latency
+            + 60  # external Confluent Kafka degrades the streams latency
         )
 
         mep = mlrun.db.get_run_db().get_model_endpoint(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -421,7 +421,13 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
                 )
 
         elif isinstance(stream_profile, DatastoreProfileKafkaSource):
-            consumer = kafka.KafkaConsumer(bootstrap_servers=stream_profile.brokers)
+            kafka_profile_attributes = stream_profile.attributes()
+            kafka_consumer_kwargs = mlrun.datastore.utils.KafkaParameters(
+                kafka_profile_attributes
+            ).consumer()
+            consumer = kafka.KafkaConsumer(
+                bootstrap_servers=stream_profile.brokers, **kafka_consumer_kwargs
+            )
             topics = consumer.topics()
 
             project_topics_list = [


### PR DESCRIPTION
Implements [ML-9895](https://iguazio.atlassian.net/browse/ML-9895) - support Confluent Cloud.

As a part of the changes, I noticed we send multiple API requests for `enable_model_monitoring`, as the default request timeout is 45 seconds, and there are a few retries. Sending multiple requests while the Nuclio functions are being deployed with a Confluent Cloud trigger causes a failure.

In addition, I changed `ignore_stream_already_exists_failure` for the controller to be `True`, as `enable_model_monitoring` didn't work without it.

### Documentation

- Update the mentioned model monitoring streaming platforms - add "Confluent Cloud".
- Add an example in `project.set_model_monitoring_credentials` API reference.

### Tests

I updated the system test to support `"kafka_source"` stream profile with Confluent Cloud credentials.
The main MM system test passed: `"tests/system/model_monitoring/test_app.py::TestMonitoringAppFlow::test_app_flow[True]"`.
I used both "basic" and "standard" cluster types. The "basic" type is less performant, and requires waiting more time and longer timeouts.

Some untested features of Confluent Cloud: **service account** API key.
This requires more advanced [ACLs security configuration](https://docs.confluent.io/cloud/current/security/access-control/rbac/use-acls-with-rbac.html#use-acls-with-rbac-on-ccloud).

Tested with Nuclio 1.13.13.

[ML-9895]: https://iguazio.atlassian.net/browse/ML-9895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ