### PR TITLE
[Datastore] Handle 'ds://' URLs when generating ipython links [1.8.x]

### DIFF
--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -111,7 +111,7 @@ def schema_to_store(schema):
 
 def uri_to_ipython(link):
     schema, endpoint, parsed_url = parse_url(link)
-    if schema in [DB_SCHEMA, "memory"]:
+    if schema in [DB_SCHEMA, "memory", "ds"]:
         return ""
     return schema_to_store(schema).uri_to_ipython(endpoint, parsed_url.path)
 


### PR DESCRIPTION
Backport of #7774.

https://iguazio.atlassian.net/browse/ML-9906