### PR TITLE
[Nuclio] Remove deprecated code from `_configure_serving_spec()`

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -393,24 +393,10 @@ def _configure_serving_spec(
     client_version, env_dict, function, project, serving_spec, serving_spec_volume, tag
 ):
     if serving_spec is not None:
-        # To keep backward compatability, allow passing service spec
-        # via Config Map only for client version higher then 1.7.0
-        # TODO: remove in 1.9.0.
-        can_pass_via_cm = (
-            not client_version
-            or (
-                semver.Version.parse(client_version)
-                >= semver.Version.parse("1.7.0-rc30")
-            )
-            or "unstable" in client_version
-        )
         # since environment variables have a limited size,
         # large serving specs are stored in config maps that are mounted to the pod
         serving_spec_len = len(serving_spec.encode("utf-8"))
-        if (
-            can_pass_via_cm
-            and serving_spec_len >= mlrun.mlconf.httpdb.nuclio.serving_spec_env_cutoff
-        ):
+        if serving_spec_len >= mlrun.mlconf.httpdb.nuclio.serving_spec_env_cutoff:
             if serving_spec_len >= SERVING_SPEC_MAX_LENGTH:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"The serving spec length exceeds the limit of {SERVING_SPEC_MAX_LENGTH}. "
@@ -471,12 +457,6 @@ def _configure_serving_spec(
                 "volumeMount": volume_mount,
             }
         else:
-            if not can_pass_via_cm:
-                logger.debug(
-                    "Client version does not support passing serving spec via ConfigMap",
-                    client_version=client_version,
-                    serving_spec_length=len(serving_spec),
-                )
             env_dict["SERVING_SPEC_ENV"] = serving_spec
     return serving_spec_volume
 


### PR DESCRIPTION
[ML-9706](https://iguazio.atlassian.net/browse/ML-9706)

[ML-9706]: https://iguazio.atlassian.net/browse/ML-9706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ