### PR TITLE
[Docs] Fix broken CI [1.9.x]

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,3 +15,7 @@ sphinx_design~=0.4.1
 sphinx-reredirects~=0.1.2
 sphinx-version-warning~=1.1
 sphinxcontrib-mermaid~=0.9.2
+
+# snowballstemmer==3.0.0, which was released with breaking changes and removed the 'porter' algorithm, leading to
+# the error 'Stemming algorithm 'porter' not found'
+snowballstemmer!=3.0.0

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -159,6 +159,7 @@ def test_requirement_specifiers_convention():
         },
         "v3io-frames": {'>=0.13.0; python_version >= "3.11"'},
         "grpcio": {"~=1.70.0"},
+        "snowballstemmer": {"!=3.0.0"},
     }
 
     for (


### PR DESCRIPTION
fixing ci - https://github.com/mlrun/mlrun/actions/runs/14905616200/job/41867155912
```
  File "/opt/hostedtoolcache/Python/3.9.22/x64/lib/python3.9/site-packages/snowballstemmer/__init__.py", line 27, in stemmer
    raise KeyError("Stemming algorithm '%s' not found" % lang)
KeyError: "Stemming algorithm 'porter' not found"
```
https://github.com/snowballstem/snowball/issues/229