### PR TITLE
[Runs] Fix rendering runs table links [1.8.x]

### DIFF
--- a/mlrun/render.py
+++ b/mlrun/render.py
@@ -361,9 +361,6 @@ def get_tblframe(df, display, classes=None):
     return ipython_display(html, display)
 
 
-uid_template = '<div title="{}"><a href="{}/{}/{}/jobs/monitor/{}/overview" target="_blank" >...{}</a></div>'
-
-
 def runs_to_html(
     df: pd.DataFrame,
     display: bool = True,
@@ -379,15 +376,14 @@ def runs_to_html(
     df["results"] = df["results"].apply(dict_html)
     df["start"] = df["start"].apply(time_str)
     df["parameters"] = df["parameters"].apply(dict_html)
+    uid_template = '<div title="{}"><a href="{}" target="_blank" >...{}</a></div>'
+
     if config.resolve_ui_url():
         df["uid"] = df.apply(
             lambda x: uid_template.format(
-                x.uid,
-                config.resolve_ui_url(),
-                config.ui.projects_prefix,
-                x.project,
-                x.uid,
-                x.uid[-8:],
+                x["uid"],
+                mlrun.utils.get_run_url(x["project"], x["uid"], x["name"]),
+                x["uid"][-8:],
             ),
             axis=1,
         )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -52,6 +52,7 @@ def test_list_runs(rundb_mock, generate_artifact_hash_mode, expected_target_path
     mlrun.mlconf.artifacts.generate_target_path_from_artifact_hash = (
         generate_artifact_hash_mode
     )
+    mlrun.mlconf.ui.url = "http://mlrun-ui:8080"
     func = mlrun.code_to_function(
         filename=function_path, kind="job", handler="log_dataset"
     )
@@ -60,6 +61,15 @@ def test_list_runs(rundb_mock, generate_artifact_hash_mode, expected_target_path
     # Verify target path in enriched run list
     runs = mlrun.lists.RunList([run.to_dict()])
     html = runs.show(display=False)
+    assert (
+        f"{mlrun.mlconf.ui.url}/"
+        f"projects/"
+        f"{run.metadata.project}/"
+        f"jobs/monitor-jobs/"
+        f"{run.metadata.name}/"
+        f"{run.metadata.uid}/"
+        f"overview" in html
+    )
     for expected_target_path in expected_target_paths:
         expected_link, _ = mlrun.render.link_to_ipython(expected_target_path)
         assert expected_link in html
@@ -72,17 +82,3 @@ def test_list_runs(rundb_mock, generate_artifact_hash_mode, expected_target_path
     dataset_0_uri = list(runs[0]["status"]["artifact_uris"].values())[0]
     assert dataset_0_uri
     assert dataset_0_uri in html
-
-
-# FIXME: this test was counting on the fact it's running after some test (I think test_httpdb) which leaves runs and
-#  artifacts in the `results` dir, it should generate its own stuff, skipping for now
-@pytest.mark.skip("FIX_ME")
-def test_list_artifacts():
-    db = get_db()
-    artifacts = db.list_artifacts()
-    assert artifacts, "empty artifacts result"
-
-    html = artifacts.show(display=False)
-
-    with open(f"{results}/artifacts.html", "w") as fp:
-        fp.write(html)


### PR DESCRIPTION
looks like a breakage that was never fixed for ui - https://iguazio.atlassian.net/browse/ML-9937
the side effect is that mlrun ui cannot fallback to use the proper view as the link generated is old