### PR TITLE
[MPA] Fix no-op pipeline compile [1.8.x]

### DIFF
--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -69,3 +69,8 @@ RUN rm -rf ./server/go
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install .[complete] --python-version ${MLRUN_PYTHON_VERSION}
+
+
+RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
+    uv pip install ./pipeline-adapters/mlrun-pipelines-kfp-common && \
+    uv pip install ./pipeline-adapters/mlrun-pipelines-kfp-v1-8

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2234,7 +2234,7 @@ class HTTPRunDB(RunDBInterface):
         with open(pipe_file, "rb") as fp:
             data = fp.read()
             if not data:
-                raise ValueError(f"File {pipe_file} is empty")
+                raise ValueError("The compiled pipe file is empty")
         if not isinstance(pipeline, str):
             remove(pipe_file)
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -2221,18 +2221,20 @@ class HTTPRunDB(RunDBInterface):
         elif pipe_file.endswith(".zip"):
             headers = {"content-type": "application/zip"}
         else:
-            raise ValueError("pipeline file must be .yaml or .zip")
+            raise ValueError("'pipeline' file must be .yaml or .zip")
         if arguments:
             if not isinstance(arguments, dict):
-                raise ValueError("arguments must be dict type")
+                raise ValueError("'arguments' must be dict type")
             headers[mlrun.common.schemas.HeaderNames.pipeline_arguments] = str(
                 arguments
             )
 
         if not path.isfile(pipe_file):
-            raise OSError(f"file {pipe_file} doesnt exist")
+            raise OSError(f"File {pipe_file} doesnt exist")
         with open(pipe_file, "rb") as fp:
             data = fp.read()
+            if not data:
+                raise ValueError(f"File {pipe_file} is empty")
         if not isinstance(pipeline, str):
             remove(pipe_file)
 

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.3.13",
+    version="0.3.14",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
@@ -68,8 +68,8 @@ class DummyCompiler:
 
         def compile(
             self,
-            pipeline_func: Callable[..., Any] = None,
-            package_path: str = None,
+            pipeline_func: Optional[Callable[..., Any]] = None,
+            package_path: Optional[str] = None,
             **kwargs: Any,
         ) -> None:
             self._warn_once_about_kfp()

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
@@ -66,7 +66,12 @@ class DummyCompiler:
                 logger.warning("KFP is not installed; using a no-op compiler.")
                 self._has_warned = True
 
-        def compile(self, pipeline_func: Callable[..., Any], package_path: str) -> None:
+        def compile(
+            self,
+            pipeline_func: Callable[..., Any] = None,
+            package_path: str = None,
+            **kwargs: Any,
+        ) -> None:
             self._warn_once_about_kfp()
             logger.debug(
                 f"[NoOp] Compiling pipeline for func '{pipeline_func}' -> '{package_path}'"

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
@@ -76,6 +76,11 @@ class DummyCompiler:
             self._warn_once_about_kfp()
             logger.debug("[NoOp] _create_workflow called.")
 
+        def __call__(
+            self, pipeline_func: Callable[..., Any], package_path: str
+        ) -> None:
+            raise NotImplementedError("KFP is not installed, cannot compile pipeline.")
+
 
 class DummyRunPipelineResult:
     def get_output_file(self, op_name: str, output: Optional[str] = None) -> str:

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/imports.py
@@ -76,10 +76,8 @@ class DummyCompiler:
             self._warn_once_about_kfp()
             logger.debug("[NoOp] _create_workflow called.")
 
-        def __call__(
-            self, pipeline_func: Callable[..., Any], package_path: str
-        ) -> None:
-            raise NotImplementedError("KFP is not installed, cannot compile pipeline.")
+        def __call__(self) -> "DummyCompiler.Compiler":
+            return self
 
 
 class DummyRunPipelineResult:

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/tests/test_imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/tests/test_imports.py
@@ -19,3 +19,4 @@ def test_dummy_compiler_calls():
     expected_compiler = container.Compiler()
     result_compiler = expected_compiler()
     assert expected_compiler == result_compiler
+    result_compiler.compile(a="test")

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/tests/test_imports.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/tests/test_imports.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mlrun_pipelines.common.imports
+
+
+def test_dummy_compiler_calls():
+    container = mlrun_pipelines.common.imports.DummyCompiler()
+    expected_compiler = container.Compiler()
+    result_compiler = expected_compiler()
+    assert expected_compiler == result_compiler


### PR DESCRIPTION
When KFP is not installed no-op adapter should not explode.
Before sending the pipeline to the server - verify it is not empty.
Install local MPAs in test image to enable CI test without releasing.

https://iguazio.atlassian.net/browse/ML-9943