### PR TITLE
[Deprecations] Add deprecation msg to RunLabels class [1.8.x]

### DIFF
--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -17,6 +17,7 @@ import typing
 
 import mlrun.common.constants as mlrun_constants
 import mlrun_pipelines.common.models
+from deprecated import deprecated
 
 
 class PodPhases:
@@ -238,6 +239,11 @@ class RunStates:
 
 
 # TODO: remove this class in 1.10.0 - use only MlrunInternalLabels
+@deprecated(
+    version="1.7.0",
+    reason="This class is deprecated and will be removed in 1.10.0. Use MLRunInternalLabels instead.",
+    category=FutureWarning,
+)
 class RunLabels(enum.Enum):
     owner = mlrun_constants.MLRunInternalLabels.owner
     v3io_user = mlrun_constants.MLRunInternalLabels.v3io_user


### PR DESCRIPTION
This class was already deprecated in version 1.7.x and was documented in [this ticket](https://iguazio.atlassian.net/browse/ML-5948) and in the changelog. However, a deprecation error was not raised for this class. 
A fix was already introduced in [this PR](https://github.com/mlrun/mlrun/pull/7814), but with the wrong version