### PR TITLE
[Model Monitoring] Fix delete V3IO TSDB tables using `framesd`  (#7788) [1.9.x]

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -455,12 +455,20 @@ class V3IOTSDBConnector(TSDBConnector):
             # Delete all tables
             tables = mm_schemas.V3IOTSDBTables.list()
         for table_to_delete in tables:
-            try:
-                self.frames_client.delete(backend=_TSDB_BE, table=table_to_delete)
-            except v3io_frames.DeleteError as e:
+            if table_to_delete in self.tables:
+                try:
+                    self.frames_client.delete(
+                        backend=_TSDB_BE, table=self.tables[table_to_delete]
+                    )
+                except v3io_frames.DeleteError as e:
+                    logger.warning(
+                        f"Failed to delete TSDB table '{table_to_delete}'",
+                        err=mlrun.errors.err_to_str(e),
+                    )
+            else:
                 logger.warning(
-                    f"Failed to delete TSDB table '{table}'",
-                    err=mlrun.errors.err_to_str(e),
+                    f"Skipping deletion: table '{table_to_delete}' is not among the initialized tables.",
+                    initialized_tables=list(self.tables.keys()),
                 )
 
         # Final cleanup of tsdb path


### PR DESCRIPTION
Fix an issue where the paths of V3IO TSDB tables were incorrectly resolved during the cleanup TSDB resources as part of the project deletion process.
As a result, the API warns that it `Failed to delete TSDB table`. Note that even with the warning the resources were eventually deleted following a recursive cleanup process using `V3ioStore`, which correctly targets the project's root directory.

cherry pick:
- #7788 

https://iguazio.atlassian.net/browse/ML-9912