### PR TITLE
[Deprecations] Revert warning type for Artifact constructor parameters [1.8.x]

### DIFF
--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -237,7 +237,7 @@ class Artifact(ModelObj):
             warnings.warn(
                 "Artifact constructor parameters are deprecated in 1.7.0 and will be removed in 1.10.0. "
                 "Use the metadata and spec parameters instead.",
-                FutureWarning,
+                DeprecationWarning,
             )
 
         self._metadata = None
@@ -766,7 +766,7 @@ class LinkArtifact(Artifact):
             warnings.warn(
                 "Artifact constructor parameters are deprecated in 1.7.0 and will be removed in 1.10.0. "
                 "Use the metadata and spec parameters instead.",
-                FutureWarning,
+                DeprecationWarning,
             )
         super().__init__(
             key, target_path=target_path, project=project, metadata=metadata, spec=spec

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -165,7 +165,7 @@ class DatasetArtifact(Artifact):
             warnings.warn(
                 "Artifact constructor parameters are deprecated in 1.7.0 and will be removed in 1.10.0. "
                 "Use the metadata and spec parameters instead.",
-                FutureWarning,
+                DeprecationWarning,
             )
 
         format = (format or "").lower()

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -154,7 +154,7 @@ class ModelArtifact(Artifact):
             warnings.warn(
                 "Artifact constructor parameters are deprecated in 1.7.0 and will be removed in 1.10.0. "
                 "Use the metadata and spec parameters instead.",
-                FutureWarning,
+                DeprecationWarning,
             )
         super().__init__(key, body, format=format, target_path=target_path, **kwargs)
         model_file = str(model_file or "")

--- a/mlrun/artifacts/plots.py
+++ b/mlrun/artifacts/plots.py
@@ -39,7 +39,7 @@ class PlotArtifact(Artifact):
             warnings.warn(
                 "Artifact constructor parameters are deprecated in 1.7.0 and will be removed in 1.10.0. "
                 "Use the metadata and spec parameters instead.",
-                FutureWarning,
+                DeprecationWarning,
             )
         super().__init__(key, body, format="html", target_path=target_path)
         self.metadata.description = title
@@ -98,7 +98,7 @@ class PlotlyArtifact(Artifact):
             warnings.warn(
                 "Artifact constructor parameters are deprecated in 1.7.0 and will be removed in 1.10.0. "
                 "Use the metadata and spec parameters instead.",
-                FutureWarning,
+                DeprecationWarning,
             )
         # Validate the plotly package:
         try:

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-common",
-    version="0.3.14",
+    version="0.3.15",
     description="MLRun Pipelines package for providing KFP common functionality",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
@@ -178,7 +178,7 @@ def mlrun_op(
         warnings.warn(
             "rundb parameter is deprecated in 1.7.0 and will be removed in 1.10.0. "
             "use 'MLRUN_DBPATH' env instead.",
-            FutureWarning,
+            DeprecationWarning,
         )
 
     secrets = [] if secrets is None else secrets


### PR DESCRIPTION
Change the warning type to `DeprecationWarning` instead of `FutureWarning`.

This means users will not see the warning in their Jupyter notebooks by default.
So we need to handle the deprecation properly in our code for newer versions, because the deprecation likely started after 1.8.x, and users may be unaware of it.

https://iguazio.atlassian.net/browse/ML-9988