### PR TITLE
[Model Monitoring] Fix `last_request` enrichment in controller for batch model endpoints

### DIFF
--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -732,7 +732,9 @@ class MonitoringApplicationController:
                     last_request = last_request_dict.get(endpoint.metadata.uid, None)
                     if isinstance(last_request, float):
                         last_request = pd.to_datetime(last_request, unit="s", utc=True)
-                    endpoint.status.last_request = last_request or endpoint.status.last_request
+                    endpoint.status.last_request = (
+                        last_request or endpoint.status.last_request
+                    )
                     futures = {
                         pool.submit(
                             self.endpoint_to_regular_event,

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -732,7 +732,7 @@ class MonitoringApplicationController:
                     last_request = last_request_dict.get(endpoint.metadata.uid, None)
                     if isinstance(last_request, float):
                         last_request = pd.to_datetime(last_request, unit="s", utc=True)
-                    endpoint.status.last_request = last_request
+                    endpoint.status.last_request = last_request or endpoint.status.last_request
                     futures = {
                         pool.submit(
                             self.endpoint_to_regular_event,


### PR DESCRIPTION
When generating a mep using batch infer, the `last_request` value is stored in the mep table in the mlrundb, rather than in the last_request kv table. 

As a result, and due to recent changes in the controller where we now enrich the `last_request` directly from the KV store (https://github.com/mlrun/mlrun/pull/7811), the controller tries to retrieve this value from the KV table, which doesn't exist for batch meps. Therefore, the app wasn’t triggered, and no artifacts were logged.

In this PR we fix that issue by setting the `last_request` value from the mlrundb when it’s not found in the KV table. 

https://iguazio.atlassian.net/browse/ML-9983