### PR TITLE
[Datastore] Handle 'ds://' URLs when generating ipython links [1.9.x]…

### DIFF
--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -111,7 +111,7 @@ def schema_to_store(schema):
 
 def uri_to_ipython(link):
     schema, endpoint, parsed_url = parse_url(link)
-    if schema in [DB_SCHEMA, "memory"]:
+    if schema in [DB_SCHEMA, "memory", "ds"]:
         return ""
     return schema_to_store(schema).uri_to_ipython(endpoint, parsed_url.path)
 


### PR DESCRIPTION
… (#7777)

(cherry picked from commit 61dbac0cd19c0a83f42ec0ba3e42b0563ec97883)