### PR TITLE
[Pipeline-adapters] Properly handle multiple parameter workflows in retry [1.9.x]

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/setup.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/setup.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("mlrun-kfp-setup")
 
 setup(
     name="mlrun-pipelines-kfp-v1-8",
-    version="0.4.1",
+    version="0.4.2",
     description="MLRun Pipelines package for providing KFP 1.8 compatibility",
     author="Yaron Haviv",
     author_email="yaronh@iguazio.com",

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
@@ -603,9 +603,12 @@ class Client(
                 workflow_manifest_path = temp_file.name
 
         # KFP server API may return pipeline parameters as a list containing a single dict
-        pipeline_parameters: Any = pipeline_spec.parameters
-        if isinstance(pipeline_parameters, list) and pipeline_parameters:
-            pipeline_parameters = pipeline_parameters[0]
+        pipeline_parameters = pipeline_spec.parameters
+        if isinstance(pipeline_spec.parameters, list):
+            pipeline_parameters = {
+                getattr(param, "name"): getattr(param, "value")
+                for param in pipeline_spec.parameters
+            }
 
         current_name: str = existing_run_details.name.strip()
         desired_prefix: str = f"{project}-Retry of "


### PR DESCRIPTION
(cherry picked from commit c126f75ff1c70519c3de9e20f2456abd35f06a08)