### PR TITLE
[Pipeline-adapters] Properly handle multiple parameter workflows in retry

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.5.2"
+version = "0.5.3"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
@@ -621,9 +621,12 @@ class Client(
                 workflow_manifest_path = temp_file.name
 
         # KFP server API may return pipeline parameters as a list containing a single dict
-        pipeline_parameters: Any = pipeline_spec.parameters
-        if isinstance(pipeline_parameters, list) and pipeline_parameters:
-            pipeline_parameters = pipeline_parameters[0]
+        pipeline_parameters = pipeline_spec.parameters
+        if isinstance(pipeline_spec.parameters, list):
+            pipeline_parameters = {
+                getattr(param, "name"): getattr(param, "value")
+                for param in pipeline_spec.parameters
+            }
 
         current_name: str = existing_run_details.name.strip()
         desired_prefix: str = f"{project}-Retry of "


### PR DESCRIPTION

(cherry picked from commit c126f75ff1c70519c3de9e20f2456abd35f06a08)
(cherry picked from commit 7988a8acbbd2e6a2608121b52f4c3e0a13c461a8)