### PR TITLE
[Evidently] Fix evidently Json config + evidently classes import 1.8.x

### DIFF
--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -327,13 +327,16 @@
     "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION\n",
     "from src.evidently_app_setup import setup_evidently_project\n",
     "\n",
-    "evidently_workspace_path=os.path.join(\n",
-    "        mlrun.mlconf.artifact_path.replace(\"{{run.project}}\", project.name),\n",
-    "        \"evidently_workspace\",\n",
-    "    )\n",
+    "evidently_workspace_path = os.path.join(\n",
+    "    mlrun.mlconf.artifact_path.replace(\"{{run.project}}\", project.name),\n",
+    "    \"evidently_workspace\",\n",
+    ")\n",
     "\n",
-    "evidently_project_id=str(uuid.uuid4())\n",
-    "setup_evidently_project(evidently_project_id=evidently_project_id, evidently_workspace_path=evidently_workspace_path)"
+    "evidently_project_id = str(uuid.uuid4())\n",
+    "setup_evidently_project(\n",
+    "    evidently_project_id=evidently_project_id,\n",
+    "    evidently_workspace_path=evidently_workspace_path,\n",
+    ")"
    ]
   },
   {

--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -322,7 +322,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION"
+    "import os\n",
+    "import uuid\n",
+    "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION\n",
+    "from src.evidently_app_setup import setup_evidently_project\n",
+    "\n",
+    "evidently_workspace_path=os.path.join(\n",
+    "        mlrun.mlconf.artifact_path.replace(\"{{run.project}}\", project.name),\n",
+    "        \"evidently_workspace\",\n",
+    "    )\n",
+    "\n",
+    "evidently_project_id=str(uuid.uuid4())\n",
+    "setup_evidently_project(evidently_project_id=evidently_project_id, evidently_workspace_path=evidently_workspace_path)"
    ]
   },
   {
@@ -358,8 +369,6 @@
    ],
    "source": [
     "# register the second app named \"evidently_app\"\n",
-    "import os\n",
-    "import uuid\n",
     "\n",
     "my_evidently_app = project.set_model_monitoring_function(\n",
     "    func=\"src/evidently_app.py\",\n",
@@ -369,11 +378,8 @@
     "    ],\n",
     "    name=\"MyEvidentlyApp\",\n",
     "    application_class=\"DemoEvidentlyMonitoringApp\",\n",
-    "    evidently_workspace_path=os.path.join(\n",
-    "        mlrun.mlconf.artifact_path.replace(\"{{run.project}}\", project.name),\n",
-    "        \"evidently_workspace\",\n",
-    "    ),\n",
-    "    evidently_project_id=str(uuid.uuid4()),\n",
+    "    evidently_workspace_path=evidently_workspace_path,\n",
+    "    evidently_project_id=evidently_project_id,\n",
     ")\n",
     "\n",
     "project.deploy_function(my_evidently_app)"

--- a/docs/tutorials/src/evidently_app.py
+++ b/docs/tutorials/src/evidently_app.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from typing import Optional
-from uuid import UUID
 
 import pandas as pd
 from sklearn.datasets import load_iris
@@ -34,83 +33,13 @@ if _HAS_EVIDENTLY:
     from evidently.core.report import Report, Snapshot
     from evidently.metrics import DatasetMissingValueCount, ValueDrift
     from evidently.presets import DataDriftPreset, DataSummaryPreset
-    from evidently.sdk.models import PanelMetric
-    from evidently.sdk.panels import DashboardPanelPlot
     from evidently.ui.workspace import (
         STR_UUID,
         OrgID,
-        Project,
-        ProjectModel,
-        WorkspaceBase,
     )
 
     _PROJECT_NAME = "Iris Monitoring"
     _PROJECT_DESCRIPTION = "Test project using iris dataset"
-
-    def _create_evidently_project(
-        workspace: WorkspaceBase,
-        id: Optional[UUID] = None,
-        org_id: Optional[OrgID] = None,
-    ) -> Project:
-        if id:
-            project = ProjectModel(
-                name=_PROJECT_NAME, description=_PROJECT_DESCRIPTION, id=id
-            )
-            project = workspace.add_project(project, org_id=org_id)
-        else:
-            project = workspace.create_project(_PROJECT_NAME, org_id=org_id)
-        project.description = _PROJECT_DESCRIPTION
-        project.dashboard.add_panel(
-            DashboardPanelPlot(
-                title="Income Dataset (iris)",
-                subtitle="The iris dataset.",
-                size="half",
-                values=[PanelMetric(legend="Row count", metric="RowCount")],
-                plot_params={"plot_type": "counter", "aggregation": "sum"},
-            ),
-            tab="tab 0",
-        )
-        project.dashboard.add_panel(
-            DashboardPanelPlot(
-                title="Model Calls",
-                subtitle="Total number of predictions over time.",
-                size="half",
-                values=[PanelMetric(legend="count", metric="DatasetMissingValueCount")],
-                plot_params={"plot_type": "counter", "aggregation": "sum"},
-            ),
-            tab="tab 0",
-        )
-        project.dashboard.add_panel(
-            DashboardPanelPlot(
-                title="Share of Drifted Features",
-                subtitle="Measure the drift of the features.",
-                size="full",
-                values=[PanelMetric(metric="DataDriftPreset", legend="share")],
-                plot_params={"plot_type": "counter", "aggregation": "last"},
-            ),
-            tab="tab 0",
-        )
-        project.dashboard.add_panel(
-            DashboardPanelPlot(
-                title="Dataset Quality",
-                subtitle="",
-                size="full",
-                values=[
-                    PanelMetric(
-                        metric="DataDriftPreset",
-                        legend="Drift Share",
-                    ),
-                    PanelMetric(
-                        metric="DatasetMissingValuesMetric",
-                        legend="Missing Values Share",
-                    ),
-                ],
-                plot_params={"plot_type": "line"},
-            ),
-            tab="tab 0",
-        )
-        project.save()
-        return project
 
 
 class DemoEvidentlyMonitoringApp(EvidentlyModelMonitoringApplicationBase):
@@ -135,14 +64,6 @@ class DemoEvidentlyMonitoringApp(EvidentlyModelMonitoringApplicationBase):
         iris = load_iris()
         self.columns = [norm_column_name(col) for col in iris.feature_names]
         self.train_set = pd.DataFrame(iris.data, columns=self.columns)
-
-    def load_project(self) -> None:
-        if isinstance(self.evidently_project_id, str):
-            self.evidently_project_id = UUID(self.evidently_project_id)
-        self.evidently_project = _create_evidently_project(
-            self.evidently_workspace, self.evidently_project_id, org_id=self.org_id
-        )
-        self.evidently_project_id = self.evidently_project.id
 
     def do_tracking(
         self, monitoring_context: mm_context.MonitoringApplicationContext

--- a/docs/tutorials/src/evidently_app_setup.py
+++ b/docs/tutorials/src/evidently_app_setup.py
@@ -22,11 +22,10 @@ if _HAS_EVIDENTLY:
     from evidently.sdk.panels import DashboardPanelPlot
     from evidently.ui.workspace import (
         STR_UUID,
-        Project,
+        OrgID,
         ProjectModel,
         Workspace,
         WorkspaceBase,
-        OrgID
     )
 
 _PROJECT_NAME = "Iris Monitoring"

--- a/docs/tutorials/src/evidently_app_setup.py
+++ b/docs/tutorials/src/evidently_app_setup.py
@@ -26,6 +26,7 @@ if _HAS_EVIDENTLY:
         ProjectModel,
         Workspace,
         WorkspaceBase,
+        OrgID
     )
 
 _PROJECT_NAME = "Iris Monitoring"
@@ -35,14 +36,15 @@ _PROJECT_DESCRIPTION = "Test project using iris dataset"
 def create_evidently_project(
     workspace: WorkspaceBase,
     id: Optional[UUID] = None,
-) -> Project:
+    org_id: Optional[OrgID] = None,
+):
     if id:
         project = ProjectModel(
             name=_PROJECT_NAME, description=_PROJECT_DESCRIPTION, id=id
         )
-        project = workspace.add_project(project)
+        project = workspace.add_project(project, org_id=org_id)
     else:
-        project = workspace.create_project(_PROJECT_NAME)
+        project = workspace.create_project(_PROJECT_NAME, org_id=org_id)
     project.description = _PROJECT_DESCRIPTION
     project.dashboard.add_panel(
         DashboardPanelPlot(

--- a/docs/tutorials/src/evidently_app_setup.py
+++ b/docs/tutorials/src/evidently_app_setup.py
@@ -102,9 +102,11 @@ def get_local_workspace(evidently_workspace_path: str) -> "Workspace":
 
 
 def setup_evidently_project(
-    evidently_project_id: "STR_UUID", evidently_workspace_path: str
+    evidently_project_id: "STR_UUID",
+    evidently_workspace_path: str,
+    org_id: Optional[OrgID] = None,
 ) -> None:
     if isinstance(evidently_project_id, str):
         evidently_project_id = UUID(evidently_project_id)
     workspace = get_local_workspace(evidently_workspace_path)
-    create_evidently_project(workspace, evidently_project_id)
+    create_evidently_project(workspace, evidently_project_id, org_id=org_id)

--- a/docs/tutorials/src/evidently_app_setup.py
+++ b/docs/tutorials/src/evidently_app_setup.py
@@ -100,10 +100,10 @@ def get_local_workspace(evidently_workspace_path: str) -> "Workspace":
     return Workspace.create(evidently_workspace_path)
 
 
-def setup_evidently_project(evidently_project_id: "STR_UUID", evidently_workspace_path: str) -> None:
+def setup_evidently_project(
+    evidently_project_id: "STR_UUID", evidently_workspace_path: str
+) -> None:
     if isinstance(evidently_project_id, str):
         evidently_project_id = UUID(evidently_project_id)
     workspace = get_local_workspace(evidently_workspace_path)
-    create_evidently_project(
-        workspace, evidently_project_id
-    )
+    create_evidently_project(workspace, evidently_project_id)

--- a/docs/tutorials/src/evidently_app_setup.py
+++ b/docs/tutorials/src/evidently_app_setup.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+from uuid import UUID
+
+from mlrun.model_monitoring.applications.evidently import _HAS_EVIDENTLY
+
+if _HAS_EVIDENTLY:
+    from evidently.sdk.models import PanelMetric
+    from evidently.sdk.panels import DashboardPanelPlot
+    from evidently.ui.workspace import (
+        STR_UUID,
+        Project,
+        ProjectModel,
+        Workspace,
+        WorkspaceBase,
+    )
+
+_PROJECT_NAME = "Iris Monitoring"
+_PROJECT_DESCRIPTION = "Test project using iris dataset"
+
+
+def create_evidently_project(
+    workspace: WorkspaceBase,
+    id: Optional[UUID] = None,
+) -> Project:
+    if id:
+        project = ProjectModel(
+            name=_PROJECT_NAME, description=_PROJECT_DESCRIPTION, id=id
+        )
+        project = workspace.add_project(project)
+    else:
+        project = workspace.create_project(_PROJECT_NAME)
+    project.description = _PROJECT_DESCRIPTION
+    project.dashboard.add_panel(
+        DashboardPanelPlot(
+            title="Income Dataset (iris)",
+            subtitle="The iris dataset.",
+            size="half",
+            values=[PanelMetric(legend="Row count", metric="RowCount")],
+            plot_params={"plot_type": "counter", "aggregation": "sum"},
+        ),
+        tab="tab 0",
+    )
+    project.dashboard.add_panel(
+        DashboardPanelPlot(
+            title="Model Calls",
+            subtitle="Total number of predictions over time.",
+            size="half",
+            values=[PanelMetric(legend="count", metric="DatasetMissingValueCount")],
+            plot_params={"plot_type": "counter", "aggregation": "sum"},
+        ),
+        tab="tab 0",
+    )
+    project.dashboard.add_panel(
+        DashboardPanelPlot(
+            title="Share of Drifted Features",
+            subtitle="Measure the drift of the features.",
+            size="full",
+            values=[PanelMetric(metric="DataDriftPreset", legend="share")],
+            plot_params={"plot_type": "counter", "aggregation": "last"},
+        ),
+        tab="tab 0",
+    )
+    project.dashboard.add_panel(
+        DashboardPanelPlot(
+            title="Dataset Quality",
+            subtitle="",
+            size="full",
+            values=[
+                PanelMetric(
+                    metric="DataDriftPreset",
+                    legend="Drift Share",
+                ),
+                PanelMetric(
+                    metric="DatasetMissingValuesMetric",
+                    legend="Missing Values Share",
+                ),
+            ],
+            plot_params={"plot_type": "line"},
+        ),
+        tab="tab 0",
+    )
+    project.save()
+
+
+def get_local_workspace(evidently_workspace_path: str) -> "Workspace":
+    return Workspace.create(evidently_workspace_path)
+
+
+def setup_evidently_project(evidently_project_id: "STR_UUID", evidently_workspace_path: str) -> None:
+    if isinstance(evidently_project_id, str):
+        evidently_project_id = UUID(evidently_project_id)
+    workspace = get_local_workspace(evidently_workspace_path)
+    create_evidently_project(
+        workspace, evidently_project_id
+    )

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -108,7 +108,6 @@ class EvidentlyModelMonitoringApplicationBase(
     def get_workspace(self) -> "WorkspaceBase":
         """Get the Evidently workspace. Override this method for customize access to the workspace."""
         if self.evidently_workspace_path:
-            self._log_location(self.evidently_workspace_path)
             return Workspace.create(self.evidently_workspace_path)
         else:
             raise MLRunValueError(
@@ -120,40 +119,6 @@ class EvidentlyModelMonitoringApplicationBase(
     def get_cloud_workspace(self) -> "CloudWorkspace":
         """Load the Evidently cloud workspace according to the `EVIDENTLY_API_KEY` environment variable."""
         return CloudWorkspace()
-
-    @staticmethod
-    def _log_location(evidently_workspace_path):
-        # TODO remove function + usage after solving issue ML-9530
-        location = FSLocation(base_path=evidently_workspace_path)
-        location.invalidate_cache("")
-        paths = [p for p in location.listdir("") if location.isdir(p)]
-
-        for path in paths:
-            metadata_path = posixpath.join(path, METADATA_PATH)
-            full_path = posixpath.join(location.path, metadata_path)
-            print(f"evidently json issue, working on path: {full_path}")
-            try:
-                with location.open(metadata_path) as f:
-                    content = json.load(f)
-                    print(
-                        f"evidently json issue, successful load path: {full_path}, content: {content}"
-                    )
-            except FileNotFoundError:
-                print(f"evidently json issue, path not found: {full_path}")
-                continue
-            except json.decoder.JSONDecodeError as json_error:
-                print(
-                    f"evidently json issue, path got json error, path:{full_path}, error: {json_error}"
-                )
-                print("evidently json issue, file content:")
-                with location.open(metadata_path) as f:
-                    print(f.read())
-                continue
-            except Exception as error:
-                print(
-                    f"evidently json issue, path got general error, path:{full_path}, error: {error}"
-                )
-                continue
 
     @staticmethod
     def log_evidently_object(

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -101,11 +101,11 @@ class EvidentlyModelMonitoringApplicationBase(
         self.evidently_project_id = evidently_project_id
         self.evidently_project = self.load_project()
 
-    def load_project(self) -> Project:
+    def load_project(self) -> "Project":
         """Load the Evidently project."""
         return self.evidently_workspace.get_project(self.evidently_project_id)
 
-    def get_workspace(self) -> WorkspaceBase:
+    def get_workspace(self) -> "WorkspaceBase":
         """Get the Evidently workspace. Override this method for customize access to the workspace."""
         if self.evidently_workspace_path:
             self._log_location(self.evidently_workspace_path)
@@ -117,7 +117,7 @@ class EvidentlyModelMonitoringApplicationBase(
                 "`EVIDENTLY_API_KEY` environment variable. In other cases, override this method."
             )
 
-    def get_cloud_workspace(self) -> CloudWorkspace:
+    def get_cloud_workspace(self) -> "CloudWorkspace":
         """Load the Evidently cloud workspace according to the `EVIDENTLY_API_KEY` environment variable."""
         return CloudWorkspace()
 

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import posixpath
-import uuid
 import warnings
 from abc import ABC
 from tempfile import NamedTemporaryFile
@@ -61,7 +58,6 @@ except ModuleNotFoundError:
 
 if _HAS_EVIDENTLY:
     from evidently.core.report import Snapshot
-    from evidently.legacy.ui.storage.local.base import METADATA_PATH, FSLocation
     from evidently.ui.workspace import (
         STR_UUID,
         CloudWorkspace,

--- a/mlrun/model_monitoring/applications/evidently/base.py
+++ b/mlrun/model_monitoring/applications/evidently/base.py
@@ -14,6 +14,7 @@
 
 import json
 import posixpath
+import uuid
 import warnings
 from abc import ABC
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
Fix 3 bugs in evidently usage:

Evidently json issue
The default number of workers in model monitoring app is 4.
When the project is created inside the application, multiple workers may conflict by overwriting the same configuration files.(metadata.json and dashboard.json).

If the client does not have evidently installed, calling evidently application creation will raise an error when attempting to use evidently classes as return type hints.

To avoid this, we wrap the return type hint in quotes (e.g., -> "Project"), which delays the evaluation of the type and prevents import-time errors.

[ML-9530](https://iguazio.atlassian.net/browse/ML-9530)
[ML-9989](https://iguazio.atlassian.net/browse/ML-9989)
[ML-9996](https://iguazio.atlassian.net/browse/ML-9996)

[ML-9530]: https://iguazio.atlassian.net/browse/ML-9530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9989]: https://iguazio.atlassian.net/browse/ML-9989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9996]: https://iguazio.atlassian.net/browse/ML-9996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ