### PR TITLE
[Config] Remove default project from config

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -94,7 +94,6 @@ default_config = {
     "default_base_image": "mlrun/mlrun",  # default base image when doing .deploy()
     # template for project default image name. Parameter {name} will be replaced with project name
     "default_project_image_name": ".mlrun-project-image-{name}",
-    "default_project": "default",  # default project name
     "active_project": "",  # active project name
     "default_archive": "",  # default remote archive URL (for build tar.gz)
     "mpijob_crd_version": "",  # mpijob crd version (e.g: "v1alpha1". must be in: mlrun.runtime.MPIJobCRDVersions)


### PR DESCRIPTION
This PR removes the default project from `config.py`, in alignment with previous changes to remove it from the API ( https://github.com/mlrun/mlrun/pull/7762 ) and SDK ( https://github.com/mlrun/mlrun/pull/7812 ).

Jira:
https://iguazio.atlassian.net/browse/ML-9881