### PR TITLE
[Docker] Compile Python bytecode in `uv pip install` / `sync`

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -72,7 +72,7 @@ RUN /usr/local/bin/python -m pip install --upgrade setuptools pip~=${MLRUN_PIP_V
     conda install -y python=${MLRUN_PYTHON_VERSION} pip~=${MLRUN_PIP_VERSION} && \
     conda clean -aqy
 
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 
 # do not require hashes as PyHive is installed via remote repo
 # and do not have a hash set in the locked-requirements.txt

--- a/dockerfiles/gpu/Dockerfile
+++ b/dockerfiles/gpu/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /mlrun
 # non-recursive chmod for the run to be able to create the handler file with any security context
 RUN chmod 777 /mlrun
 
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 
 # do not require hashes as PyHive is installed via remote repo
 # and do not have a hash set in the locked-requirements.txt

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -69,7 +69,7 @@ COPY --chown=$NB_UID:$NB_GID ./dockerfiles/jupyter/README.ipynb $HOME
 COPY --chown=$NB_UID:$NB_GID ./dockerfiles/jupyter/mlrun.env $HOME
 COPY --chown=$NB_UID:$NB_GID ./dockerfiles/jupyter/mlce-start.sh /usr/local/bin/mlce-start.sh
 
-ENV UV_LINK_MODE=copy
+ENV UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 
 # removing unsupported files
 RUN rm -rf $HOME/tutorials/genai-02-model-monitor-llm.ipynb $HOME/tutorials/genai_01_basic_tutorial.ipynb

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # Remove system ensurepip from Python
 RUN rm -rf /usr/local/lib/python${MLRUN_PYTHON_VERSION}/ensurepip
 
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 
 WORKDIR /mlrun
 

--- a/dockerfiles/mlrun-kfp/Dockerfile
+++ b/dockerfiles/mlrun-kfp/Dockerfile
@@ -37,7 +37,7 @@ RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}
 
 WORKDIR /mlrun
 
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -79,7 +79,7 @@ RUN /usr/local/bin/python -m pip install --upgrade setuptools pip~=${MLRUN_PIP_V
 # see https://iguazio.atlassian.net/browse/ML-8712 for example
 # where 'tqdm' is given by conda env but will get remove if we omit the `--no-deps`.
 # TODO: move tqdm to image requirements
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=dockerfiles/mlrun/locked-requirements.txt,target=locked-requirements.txt \

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/
 
 WORKDIR /tmp/mlrun
 
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=dockerfiles/test-system/locked-requirements.txt,target=locked-requirements.txt \

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -52,7 +52,7 @@ RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}
 
 WORKDIR /mlrun
 
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 ARG MLRUN_PYTHON_VERSION=3.9
 # explicitly set the python version to ensure uv installs the correct version
 # as per the python version or we will handle situtations where python 3.11 tries to install


### PR DESCRIPTION
Back in #6677, I replaced `pip install` with `uv pip install`/`uv pip sync`. We had some unexplained 68% reduction in the `mlrun-api` image size.
After talking with uv authors at PyCon US 2025, I understood this "improvement" in the image size is due to missing bytecode compiled files (`.pyc` in `__pycache__`).

The change in this PR is setting the `UV_COMPILE_BYTECODE=1` env var, as recommended in Docker files:
https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode

The previous behavior compiled the `.py` files on the go when they were first called.

See also:

* https://docs.astral.sh/uv/pip/compatibility/#bytecode-compilation
* https://docs.astral.sh/uv/configuration/environment/#uv_compile_bytecode