### PR TITLE
[Tests] Explicitly set project in cli build system tests

### DIFF
--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -533,6 +533,8 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
             "--name",
             "test",
             function,
+            "--project",
+            self.project_name,
         ]
         out, _, _ = exec_cli(args, action="build")
         assert "Function built, state=ready" in out
@@ -546,6 +548,8 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
             "test",
             "--runtime",
             json.dumps(runtime),
+            "--project",
+            self.project_name,
         ]
         out, _, _ = exec_cli(args, action="build")
         assert "Function built, state=ready" in out


### PR DESCRIPTION
Removed reliance on the default project in couple of system tests by explicitly passing the project name, ensuring the test passes after the default project removal.


As part of: 
https://iguazio.atlassian.net/browse/ML-9836