### PR TITLE
[Deprecations] Remove `uid` param in GET and DELETE artifact

### DIFF
--- a/server/py/services/api/api/endpoints/artifacts_v2.py
+++ b/server/py/services/api/api/endpoints/artifacts_v2.py
@@ -248,13 +248,6 @@ async def get_artifact(
     tag: Optional[str] = None,
     iter: Optional[int] = None,
     object_uid: str = Query(None, alias="object-uid"),
-    # TODO: remove deprecated uid parameter in 1.10.0
-    # we support both uid and object-uid for backward compatibility
-    uid: str = Query(
-        None,
-        deprecated=True,
-        description="Use object-uid instead, will be removed in the 1.10.0",
-    ),
     format_: str = Query(mlrun.common.formatters.ArtifactFormat.full, alias="format"),
     auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
     db_session: Session = Depends(deps.get_db_session),
@@ -291,7 +284,7 @@ async def get_artifact(
         project,
         format_,
         producer_id=tree,
-        object_uid=object_uid or uid,
+        object_uid=object_uid,
     )
     return artifact
 
@@ -303,13 +296,6 @@ async def delete_artifact(
     tree: Optional[str] = None,
     tag: Optional[str] = None,
     object_uid: str = Query(None, alias="object-uid"),
-    # TODO: remove deprecated uid parameter in 1.10.0
-    # we support both uid and object-uid for backward compatibility
-    uid: str = Query(
-        None,
-        deprecated=True,
-        description="Use object-uid instead, will be removed in the 1.10.0",
-    ),
     iteration: int = Query(None, alias="iter"),
     deletion_strategy: ArtifactsDeletionStrategies = ArtifactsDeletionStrategies.metadata_only,
     secrets: Optional[dict] = None,
@@ -324,7 +310,7 @@ async def delete_artifact(
         producer_id=tree,
         deletion_strategy=deletion_strategy,
         iteration=iteration,
-        object_uid=object_uid or uid,
+        object_uid=object_uid,
     )
 
     await (
@@ -342,7 +328,7 @@ async def delete_artifact(
         key=key,
         tag=tag,
         project=project,
-        object_uid=object_uid or uid,
+        object_uid=object_uid,
         producer_id=tree,
         deletion_strategy=deletion_strategy,
         secrets=secrets,


### PR DESCRIPTION
deprecated in 1.7.0 removed in 1.10 
1. DELETE `/projects/{project}/artifacts/{key:path}?uid`  - Use `object-uid` instead
2. GET `/projects/{project}/artifacts/{key:path}?uid` - Use `object-uid` instead
https://iguazio.atlassian.net/browse/ML-10046

