### PR TITLE
[Deprecations] Remove delete_function v1 endpoint

### DIFF
--- a/server/py/services/api/api/endpoints/functions.py
+++ b/server/py/services/api/api/endpoints/functions.py
@@ -59,7 +59,6 @@ from services.api.api.endpoints.nuclio import (
     _get_api_gateways_urls_for_function,
     _handle_nuclio_deploy_status,
 )
-from services.api.utils.singletons.scheduler import get_scheduler
 
 router = APIRouter()
 
@@ -144,68 +143,6 @@ async def get_function(
     return {
         "func": func,
     }
-
-
-# TODO: Remove in 1.10.0
-@router.delete(
-    "/projects/{project}/functions/{name}",
-    status_code=HTTPStatus.NO_CONTENT.value,
-    deprecated=True,
-    description="'/v1/projects/{project}/functions/{name}' will be removed in 1.10.0, "
-    "use '/v2/projects/{project}/functions/{name}' instead.",
-)
-async def delete_function(
-    request: Request,
-    project: str,
-    name: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(deps.authenticate_request),
-    db_session: Session = Depends(deps.get_db_session),
-):
-    await (
-        framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
-            mlrun.common.schemas.AuthorizationResourceTypes.function,
-            project,
-            name,
-            mlrun.common.schemas.AuthorizationAction.delete,
-            auth_info,
-        )
-    )
-    #  If the requested function has a schedule, we must delete it before deleting the function
-    try:
-        function_schedule = await run_in_threadpool(
-            get_scheduler().get_schedule,
-            db_session,
-            project,
-            name,
-        )
-    except mlrun.errors.MLRunNotFoundError:
-        function_schedule = None
-
-    if function_schedule:
-        # when deleting a function, we should also delete its schedules if exists
-        # schedules are only supposed to be run by the chief, therefore, if the function has a schedule,
-        # and we are running in worker, we send the request to the chief client
-        if (
-            mlrun.mlconf.httpdb.clusterization.role
-            != mlrun.common.schemas.ClusterizationRole.chief
-        ):
-            logger.info(
-                "Function has a schedule, deleting",
-                function=name,
-                project=project,
-            )
-            chief_client = framework.utils.clients.chief.Client()
-            await chief_client.delete_schedule(
-                project=project, name=name, request=request
-            )
-        else:
-            await run_in_threadpool(
-                get_scheduler().delete_schedule, db_session, project, name
-            )
-    await run_in_threadpool(
-        services.api.crud.Functions().delete_function, db_session, project, name
-    )
-    return Response(status_code=HTTPStatus.NO_CONTENT.value)
 
 
 @router.get("/projects/{project}/functions")

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -333,10 +333,6 @@ async def test_list_functions_filter_by_states(db, async_client):
         "remote",
     ],
 )
-@pytest.mark.parametrize(
-    "function_deletion_endpoint_prefix, expected_status",
-    [("v1/", HTTPStatus.NO_CONTENT.value), ("v2/", HTTPStatus.ACCEPTED.value)],
-)
 @unittest.mock.patch.object(framework.utils.clients.async_nuclio, "Client")
 @unittest.mock.patch.object(
     framework.utils.clients.async_nuclio.Client, "delete_function"
@@ -347,8 +343,6 @@ def test_delete_function(
     db: sqlalchemy.orm.Session,
     unversioned_client: fastapi.testclient.TestClient,
     kind,
-    function_deletion_endpoint_prefix,
-    expected_status,
 ):
     patched_nuclio_client.return_value = fastapi.testclient.TestClient
     patched_delete_nuclio_function.return_value.return_value = None
@@ -380,10 +374,8 @@ def test_delete_function(
     hash_key = function.json()["hash_key"]
 
     # delete the function and assert that it has been removed, as has its schedule if created
-    response = unversioned_client.delete(
-        f"{function_deletion_endpoint_prefix}{function_endpoint}"
-    )
-    assert response.status_code == expected_status
+    response = unversioned_client.delete(f"v2/{function_endpoint}")
+    assert response.status_code == HTTPStatus.ACCEPTED.value
 
     response = unversioned_client.get(
         f"{endpoint_prefix}{function_endpoint}", params={"hash_key": hash_key}


### PR DESCRIPTION
`/v1/projects/{project}/functions/{name}` deprecated in 1.7.0 use `/v2/projects/{project}/functions/{name}` instead
https://iguazio.atlassian.net/browse/ML-10047