### PR TITLE
[Deprecations] Remove `rundb` param in `mlrun.runtimes.base.mlrun_op`

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-common"
-version = "0.5.4"
+version = "0.5.5"
 description = "MLRun Pipelines adapter package for providing KFP common functionality"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
@@ -22,7 +22,6 @@ import io
 import json
 import multiprocessing
 import os
-import warnings
 import zipfile
 from ast import literal_eval
 from copy import deepcopy
@@ -78,7 +77,6 @@ def mlrun_op(
     outputs: typing.Optional[list] = None,
     in_path: str = "",
     out_path: str = "",
-    rundb: str = "",
     mode: str = "",
     handler: str = "",
     more_args: typing.Optional[list] = None,
@@ -119,7 +117,6 @@ def mlrun_op(
                      omitted the path will be the out_path/key.
     :param in_path:  default input path/url (prefix) for inputs
     :param out_path: default output path/url (prefix) for artifacts
-    :param rundb:    Deprecated. use 'MLRUN_DBPATH' env instead.
     :param mode:     run mode, e.g. 'pass' for using the command without mlrun wrapper
     :param handler   code entry-point/handler name
     :param job_image name of the image user for the job
@@ -174,14 +171,6 @@ def mlrun_op(
 
     """
     from mlrun_pipelines.ops import generate_pipeline_node
-
-    # TODO: remove in 1.10.0
-    if rundb:
-        warnings.warn(
-            "rundb parameter is deprecated in 1.7.0 and will be removed in 1.10.0. "
-            "use 'MLRUN_DBPATH' env instead.",
-            DeprecationWarning,
-        )
 
     secrets = [] if secrets is None else secrets
     params = {} if params is None else params


### PR DESCRIPTION
`rundb` in `mlrun.runtimes.base.mlrun_op`  is deprecated in 1.7.0 use `MLRUN_DBPATH` environment variable instead
https://iguazio.atlassian.net/browse/ML-10051