### PR TITLE
[Notifications] Fix push notifications session [1.8.x]

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2124,9 +2124,7 @@ class Workflow:
 
                 _run = _runs[0]
             except IndexError:
-                logger.warning(
-                    "No run found for step", step=_step.to_dict()
-                )
+                logger.warning("No run found for step", step=_step.to_dict())
                 _run = {
                     "metadata": {
                         "name": _step.display_name,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2088,7 +2088,9 @@ def join_urls(base_url: Optional[str], path: Optional[str]) -> str:
 
 class Workflow:
     @staticmethod
-    def get_workflow_steps(db, workflow_id: str, project: str) -> list:
+    def get_workflow_steps(
+        db: "mlrun.db.RunDBInterface", workflow_id: str, project: str
+    ) -> list:
         steps = []
 
         def _add_run_step(_step: mlrun_pipelines.models.PipelineStep):
@@ -2106,8 +2108,8 @@ class Workflow:
                     node_name_initials, node_name_generated_id = _step.node_name.rsplit(
                         "-", 1
                     )
-                    # x-y, Z, N -> x-y-Z-N
-                    # runner_pod = x-y-Z-N
+                    # compile the expected runner pod hostname as per kfp >= 2.4
+                    # x-y, Z, N -> runner_pod = x-y-Z-N
                     runner_pod_value = "-".join(
                         [node_name_initials, _step.display_name, node_name_generated_id]
                     )

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2088,9 +2088,7 @@ def join_urls(base_url: Optional[str], path: Optional[str]) -> str:
 
 class Workflow:
     @staticmethod
-    def get_workflow_steps(
-        db, workflow_id: str, project: str
-    ) -> list:
+    def get_workflow_steps(db, workflow_id: str, project: str) -> list:
         steps = []
 
         def _add_run_step(_step: mlrun_pipelines.models.PipelineStep):

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2092,7 +2092,7 @@ class Workflow:
         steps = []
 
         def _add_run_step(_step: mlrun_pipelines.models.PipelineStep):
-            # on kfp 1.8 argo sets the pod hostname differentaly than what we have with kfp 2.5
+            # on kfp 1.8 argo sets the pod hostname differently than what we have with kfp 2.5
             # therefor, the heuristic needs to change. what we do here is first trying against 1.8 conventions
             # and if we can't find it then falling back to 2.5
             try:
@@ -2106,8 +2106,8 @@ class Workflow:
                     node_name_initials, node_name_generated_id = _step.node_name.rsplit(
                         "-", 1
                     )
-                    # x-y, Y, N -> x-y-Y-N
-                    # runner_pod = x-y-Y-N
+                    # x-y, Z, N -> x-y-Z-N
+                    # runner_pod = x-y-Z-N
                     runner_pod_value = "-".join(
                         [node_name_initials, _step.display_name, node_name_generated_id]
                     )

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2124,7 +2124,9 @@ class Workflow:
 
                 _run = _runs[0]
             except IndexError:
-                logger.warn("No run found for step", step_external_Data=_step.to_dict())
+                logger.warning(
+                    "No run found for step", step_external_Data=_step.to_dict()
+                )
                 _run = {
                     "metadata": {
                         "name": _step.display_name,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2219,9 +2219,9 @@ class Workflow:
     ) -> typing.Optional[mlrun_pipelines.models.PipelineManifest]:
         kfp_client = mlrun_pipelines.utils.get_client(mlrun.mlconf.kfp_url)
 
-        # arbitrary timeout of 60 seconds, the workflow should be done by now, however sometimes kfp takes a few
+        # arbitrary timeout of 30 seconds, the workflow should be done by now, however sometimes kfp takes a few
         # seconds to update the workflow status
-        kfp_run = kfp_client.wait_for_run_completion(workflow_id, 60)
+        kfp_run = kfp_client.wait_for_run_completion(workflow_id, 30)
         if not kfp_run:
             return None
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2092,17 +2092,43 @@ class Workflow:
         steps = []
 
         def _add_run_step(_step: mlrun_pipelines.models.PipelineStep):
+            # on kfp 1.8 argo sets the pod hostname differentaly than what we have with kfp 2.5
+            # therefor, the heuristic needs to change. what we do here is first trying against 1.8 conventions
+            # and if we can't find it then falling back to 2.5
             try:
-                _run = db.list_runs(
+                # runner_pod = x-y-N
+                _runs = db.list_runs(
                     project=project,
                     labels=f"{mlrun_constants.MLRunInternalLabels.runner_pod}={_step.node_name}",
-                )[0]
+                )
+                if not _runs:
+                    # x-y-N -> x-y, N
+                    node_name_initials, node_name_generated_id = _step.node_name.rsplit(
+                        "-", 1
+                    )
+                    # x-y, Y, N -> x-y-Y-N
+                    # runner_pod = x-y-Y-N
+                    runner_pod_value = "-".join(
+                        [node_name_initials, _step.display_name, node_name_generated_id]
+                    )
+                    logger.debug(
+                        "No run found for step, trying with different node name",
+                        step_node_name=runner_pod_value,
+                    )
+                    _runs = db.list_runs(
+                        project=project,
+                        labels=f"{mlrun_constants.MLRunInternalLabels.runner_pod}={runner_pod_value}",
+                    )
+
+                _run = _runs[0]
             except IndexError:
+                logger.warn("No run found for step", step_external_Data=_step.to_dict())
                 _run = {
                     "metadata": {
                         "name": _step.display_name,
                         "project": project,
                     },
+                    "status": {},
                 }
             _run["step_kind"] = _step.step_type
             if _step.skipped:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2104,15 +2104,26 @@ class Workflow:
                     labels=f"{mlrun_constants.MLRunInternalLabels.runner_pod}={_step.node_name}",
                 )
                 if not _runs:
-                    # x-y-N -> x-y, N
-                    node_name_initials, node_name_generated_id = _step.node_name.rsplit(
-                        "-", 1
-                    )
+                    try:
+                        # x-y-N -> x-y, N
+                        node_name_initials, node_name_generated_id = (
+                            _step.node_name.rsplit("-", 1)
+                        )
+
+                    except ValueError:
+                        # defensive programming, if the node name is not in the expected format
+                        node_name_initials = _step.node_name
+                        node_name_generated_id = ""
+
                     # compile the expected runner pod hostname as per kfp >= 2.4
                     # x-y, Z, N -> runner_pod = x-y-Z-N
                     runner_pod_value = "-".join(
-                        [node_name_initials, _step.display_name, node_name_generated_id]
-                    )
+                        [
+                            node_name_initials,
+                            _step.display_name,
+                            node_name_generated_id,
+                        ]
+                    ).rstrip("-")
                     logger.debug(
                         "No run found for step, trying with different node name",
                         step_node_name=runner_pod_value,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2088,9 +2088,10 @@ def join_urls(base_url: Optional[str], path: Optional[str]) -> str:
 
 class Workflow:
     @staticmethod
-    def get_workflow_steps(workflow_id: str, project: str) -> list:
+    def get_workflow_steps(
+        db, workflow_id: str, project: str
+    ) -> list:
         steps = []
-        db = mlrun.get_run_db()
 
         def _add_run_step(_step: mlrun_pipelines.models.PipelineStep):
             try:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2095,7 +2095,7 @@ class Workflow:
 
         def _add_run_step(_step: mlrun_pipelines.models.PipelineStep):
             # on kfp 1.8 argo sets the pod hostname differently than what we have with kfp 2.5
-            # therefor, the heuristic needs to change. what we do here is first trying against 1.8 conventions
+            # therefore, the heuristic needs to change. what we do here is first trying against 1.8 conventions
             # and if we can't find it then falling back to 2.5
             try:
                 # runner_pod = x-y-N

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2125,7 +2125,7 @@ class Workflow:
                 _run = _runs[0]
             except IndexError:
                 logger.warning(
-                    "No run found for step", step_external_Data=_step.to_dict()
+                    "No run found for step", step=_step.to_dict()
                 )
                 _run = {
                     "metadata": {

--- a/mlrun/utils/notifications/notification/slack.py
+++ b/mlrun/utils/notifications/notification/slack.py
@@ -16,6 +16,7 @@ import typing
 
 import aiohttp
 
+import mlrun.common.runtimes.constants as runtimes_constants
 import mlrun.common.schemas
 import mlrun.lists
 import mlrun.utils.helpers
@@ -177,7 +178,10 @@ class SlackNotification(NotificationBase):
         # Only show the URL if the run is not a function (serving or mlrun function)
         kind = run.get("step_kind")
         state = run["status"].get("state", "")
-        if state != "skipped" and (url and not kind or kind == "run"):
+
+        if state != runtimes_constants.RunStates.skipped and (
+            url and not kind or kind == "run"
+        ):
             line = f'<{url}|*{meta.get("name")}*>'
         else:
             line = meta.get("name")

--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -287,7 +287,8 @@ class NotificationPusher(_NotificationPusherBase):
             )
             project = run.metadata.project
             workflow_id = run.status.results.get("workflow_id", None)
-            runs.extend(Workflow.get_workflow_steps(workflow_id, project))
+            db = mlrun.get_run_db()
+            runs.extend(Workflow.get_workflow_steps(db, workflow_id, project))
 
         message = (
             self.messages.get(run.state(), "").format(resource=resource)

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -18,6 +18,7 @@ import datetime
 import traceback
 import typing
 
+import sqlalchemy.orm
 from kubernetes.client import ApiException
 
 import mlrun.common.schemas
@@ -365,12 +366,14 @@ class AlertNotificationPusher(_NotificationPusherBase):
 class KFPNotificationPusher(NotificationPusher):
     def __init__(
         self,
+        db_session: sqlalchemy.orm.Session,
         project: str,
         workflow_id: str,
         notifications: list[mlrun.common.schemas.Notification],
         default_params: typing.Optional[dict] = None,
     ):
         self._project = project
+        self._db_session = db_session
         self._default_params = default_params or {}
         self._workflow_id = workflow_id
         self._notifications = notifications
@@ -509,7 +512,12 @@ class KFPNotificationPusher(NotificationPusher):
         )
 
         message = f" (workflow: {self._workflow_id}){custom_message}"
-        runs = Workflow.get_workflow_steps(self._workflow_id, self._project)
+        runs = Workflow.get_workflow_steps(
+            # sql session to rundb
+            framework.api.utils.get_run_db_instance(self._db_session),
+            self._workflow_id,
+            self._project,
+        )
 
         severity = (
             notification_object.severity

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -408,7 +408,9 @@ class KFPNotificationPusher(NotificationPusher):
                 )
 
     def push(self, sync_push_callback=None, async_push_callback=None):
-        def sync_push(runs_):
+        def sync_push(
+            runs_: typing.Optional[typing.Union[mlrun.lists.RunList, list]] = None,
+        ):
             for notification_data in self._sync_notifications:
                 try:
                     self._push_workflow_notification_sync(
@@ -422,7 +424,9 @@ class KFPNotificationPusher(NotificationPusher):
                         error=mlrun.errors.err_to_str(exc),
                     )
 
-        async def async_push(runs_):
+        async def async_push(
+            runs_: typing.Optional[typing.Union[mlrun.lists.RunList, list]] = None,
+        ):
             tasks = []
             for notification_data in self._async_notifications:
                 tasks.append(

--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -15,6 +15,7 @@
 import asyncio
 import collections
 import datetime
+import functools
 import traceback
 import typing
 
@@ -23,6 +24,7 @@ from kubernetes.client import ApiException
 
 import mlrun.common.schemas
 import mlrun.errors
+import mlrun.lists
 import mlrun.model
 import mlrun.utils.helpers
 import mlrun.utils.notifications.notification as notification_module
@@ -373,7 +375,12 @@ class KFPNotificationPusher(NotificationPusher):
         default_params: typing.Optional[dict] = None,
     ):
         self._project = project
-        self._db_session = db_session
+
+        # NOTE: do not access this parameter from event loop / many threads.
+        # this instance is not thread safe
+        self._run_db_instance = framework.api.utils.get_run_db_instance(db_session)
+        # eof NOTE
+
         self._default_params = default_params or {}
         self._workflow_id = workflow_id
         self._notifications = notifications
@@ -401,12 +408,13 @@ class KFPNotificationPusher(NotificationPusher):
                 )
 
     def push(self, sync_push_callback=None, async_push_callback=None):
-        def sync_push():
+        def sync_push(runs_):
             for notification_data in self._sync_notifications:
                 try:
                     self._push_workflow_notification_sync(
                         notification_data[0],
                         notification_data[1],
+                        runs_,
                     )
                 except Exception as exc:
                     logger.warning(
@@ -414,13 +422,14 @@ class KFPNotificationPusher(NotificationPusher):
                         error=mlrun.errors.err_to_str(exc),
                     )
 
-        async def async_push():
+        async def async_push(runs_):
             tasks = []
             for notification_data in self._async_notifications:
                 tasks.append(
                     self._push_workflow_notification_async(
                         notification_data[0],
                         notification_data[1],
+                        runs_,
                     )
                 )
 
@@ -438,14 +447,22 @@ class KFPNotificationPusher(NotificationPusher):
                         ),
                     )
 
-        super().push(sync_push, async_push)
+        runs = Workflow.get_workflow_steps(
+            self._run_db_instance,
+            self._workflow_id,
+            self._project,
+        )
+        super().push(
+            functools.partial(sync_push, runs), functools.partial(async_push, runs)
+        )
 
     def _push_workflow_notification_sync(
         self,
         notification: base.NotificationBase,
         notification_object: mlrun.common.schemas.Notification,
+        runs: typing.Optional[typing.Union[mlrun.lists.RunList, list]] = None,
     ):
-        message, severity, runs = self._prepare_workflow_notification_args(
+        message, severity = self._prepare_workflow_notification_args(
             notification_object
         )
 
@@ -453,6 +470,7 @@ class KFPNotificationPusher(NotificationPusher):
             "Pushing sync notification",
             notification=sanitize_notification(notification_object.dict()),
             workflow_id=self._workflow_id,
+            runs_len=len(runs),
         )
         try:
             notification.push(message, severity, runs)
@@ -475,8 +493,9 @@ class KFPNotificationPusher(NotificationPusher):
         self,
         notification: base.NotificationBase,
         notification_object: mlrun.common.schemas.Notification,
+        runs: typing.Optional[typing.Union[mlrun.lists.RunList, list]] = None,
     ):
-        message, severity, runs = self._prepare_workflow_notification_args(
+        message, severity = self._prepare_workflow_notification_args(
             notification_object
         )
 
@@ -484,6 +503,7 @@ class KFPNotificationPusher(NotificationPusher):
             "Pushing async notification",
             notification=sanitize_notification(notification_object.dict()),
             workflow_id=self._workflow_id,
+            runs_len=len(runs),
         )
         try:
             await notification.push(message, severity, runs)
@@ -510,17 +530,9 @@ class KFPNotificationPusher(NotificationPusher):
         custom_message = (
             f": {notification_object.message}" if notification_object.message else ""
         )
-
         message = f" (workflow: {self._workflow_id}){custom_message}"
-        runs = Workflow.get_workflow_steps(
-            # sql session to rundb
-            framework.api.utils.get_run_db_instance(self._db_session),
-            self._workflow_id,
-            self._project,
-        )
-
         severity = (
             notification_object.severity
             or mlrun.common.schemas.NotificationSeverity.INFO
         )
-        return message, severity, runs
+        return message, severity

--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -200,6 +200,7 @@ async def push_notifications(
         framework.utils.background_tasks.BackgroundTaskKinds.push_kfp_notification.format(
             project, run_id, time.time()
         ),
+        db_session,
         run_id,
         project,
         notifications,
@@ -357,7 +358,12 @@ def _try_resolve_project_from_body(
     )
 
 
-def _push_notifications(run_id, project, notifications):
+def _push_notifications(
+    db_session: Session,
+    run_id: str,
+    project: str,
+    notifications: typing.Optional[list[mlrun.common.schemas.Notification]] = None,
+):
     if not notifications:
         return
     unmasked_notifications = []
@@ -379,5 +385,5 @@ def _push_notifications(run_id, project, notifications):
     )
     default_params = run_notification_pusher.resolve_notifications_default_params()
     framework.utils.notifications.notification_pusher.KFPNotificationPusher(
-        project, run_id, unmasked_notifications, default_params
+        db_session, project, run_id, unmasked_notifications, default_params
     ).push()

--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -23,7 +23,6 @@ import fastapi.concurrency
 import sqlalchemy.orm
 import yaml
 from fastapi import BackgroundTasks, Depends
-from sqlalchemy.orm import Session
 
 import mlrun.common.formatters
 import mlrun.common.schemas
@@ -174,7 +173,7 @@ async def push_notifications(
     project: str,
     run_id: str,
     background_tasks: BackgroundTasks,
-    db_session: Session = Depends(framework.api.deps.get_db_session),
+    db_session: sqlalchemy.orm.Session = Depends(framework.api.deps.get_db_session),
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         framework.api.deps.authenticate_request
     ),
@@ -359,7 +358,7 @@ def _try_resolve_project_from_body(
 
 
 def _push_notifications(
-    db_session: Session,
+    db_session: sqlalchemy.orm.Session,
     run_id: str,
     project: str,
     notifications: typing.Optional[list[mlrun.common.schemas.Notification]] = None,

--- a/server/py/services/api/tests/unit/test_notifications.py
+++ b/server/py/services/api/tests/unit/test_notifications.py
@@ -130,11 +130,12 @@ def test_push_kfp_notification(monkeypatch):
         ),
     ]
 
-    kfp_notification_pusher = (
-        framework.utils.notifications.notification_pusher.KFPNotificationPusher(
-            unittest.mock.Mock(), project, run_id, notifications, {}
+    with unittest.mock.patch("framework.api.utils.get_run_db_instance"):
+        kfp_notification_pusher = (
+            framework.utils.notifications.notification_pusher.KFPNotificationPusher(
+                unittest.mock.Mock(), project, run_id, notifications, {}
+            )
         )
-    )
     kfp_notification_pusher._push_workflow_notification_async = (
         unittest.mock.AsyncMock()
     )
@@ -145,7 +146,6 @@ def test_push_kfp_notification(monkeypatch):
         unittest.mock.patch(
             "mlrun.utils.Workflow.get_workflow_steps"
         ) as get_workflow_steps_mock,
-        unittest.mock.patch("framework.api.utils.get_run_db_instance"),
         unittest.mock.patch("mlrun.config.is_running_as_api", return_value=False),
     ):
         kfp_notification_pusher.push()

--- a/server/py/services/api/tests/unit/test_notifications.py
+++ b/server/py/services/api/tests/unit/test_notifications.py
@@ -103,46 +103,54 @@ def test_notification_params_unmasking_on_run(monkeypatch):
     assert args[1][0].status == mlrun.common.schemas.NotificationStatus.ERROR
 
 
-class TestKFPNotificationPusher:
-    def test_push(self):
-        project = "test-project"
-        run_id = "test-run-id"
-        notifications = [
-            mlrun.common.schemas.Notification(
-                name="webhook-notification",
-                kind=mlrun.common.schemas.notification.NotificationKind.webhook,
-                message="test-message",
-                severity=mlrun.common.schemas.notification.NotificationSeverity.INFO,
-                when=[runtimes_constants.RunStates.completed],
-            ),
-            mlrun.common.schemas.Notification(
-                name="mail-notification",
-                kind=mlrun.common.schemas.notification.NotificationKind.mail,
-                message="test-message",
-                severity=mlrun.common.schemas.notification.NotificationSeverity.INFO,
-                when=[runtimes_constants.RunStates.completed],
-            ),
-            mlrun.common.schemas.Notification(
-                name="console-notification",
-                kind=mlrun.common.schemas.notification.NotificationKind.console,
-                message="test-message",
-                severity=mlrun.common.schemas.notification.NotificationSeverity.INFO,
-                when=[runtimes_constants.RunStates.completed],
-            ),
-        ]
+def test_push_kfp_notification(monkeypatch):
+    project = "test-project"
+    run_id = "test-run-id"
+    notifications = [
+        mlrun.common.schemas.Notification(
+            name="webhook-notification",
+            kind=mlrun.common.schemas.notification.NotificationKind.webhook,
+            message="test-message",
+            severity=mlrun.common.schemas.notification.NotificationSeverity.INFO,
+            when=[runtimes_constants.RunStates.completed],
+        ),
+        mlrun.common.schemas.Notification(
+            name="mail-notification",
+            kind=mlrun.common.schemas.notification.NotificationKind.mail,
+            message="test-message",
+            severity=mlrun.common.schemas.notification.NotificationSeverity.INFO,
+            when=[runtimes_constants.RunStates.completed],
+        ),
+        mlrun.common.schemas.Notification(
+            name="console-notification",
+            kind=mlrun.common.schemas.notification.NotificationKind.console,
+            message="test-message",
+            severity=mlrun.common.schemas.notification.NotificationSeverity.INFO,
+            when=[runtimes_constants.RunStates.completed],
+        ),
+    ]
 
-        kfp_notification_pusher = (
-            framework.utils.notifications.notification_pusher.KFPNotificationPusher(
-                None, project, run_id, notifications, {}
-            )
+    kfp_notification_pusher = (
+        framework.utils.notifications.notification_pusher.KFPNotificationPusher(
+            unittest.mock.Mock(), project, run_id, notifications, {}
         )
-        assert len(kfp_notification_pusher._sync_notifications) == 1
-        assert len(kfp_notification_pusher._async_notifications) == 2
-        with (
-            unittest.mock.patch(
-                "mlrun.utils.Workflow.get_workflow_steps"
-            ) as get_workflow_steps_mock,
-            unittest.mock.patch("mlrun.config.is_running_as_api", return_value=False),
-        ):
-            kfp_notification_pusher.push()
-            assert get_workflow_steps_mock.call_count == 3
+    )
+    kfp_notification_pusher._push_workflow_notification_async = (
+        unittest.mock.AsyncMock()
+    )
+    kfp_notification_pusher._push_workflow_notification_sync = unittest.mock.Mock()
+    assert len(kfp_notification_pusher._sync_notifications) == 1
+    assert len(kfp_notification_pusher._async_notifications) == 2
+    with (
+        unittest.mock.patch(
+            "mlrun.utils.Workflow.get_workflow_steps"
+        ) as get_workflow_steps_mock,
+        unittest.mock.patch("framework.api.utils.get_run_db_instance"),
+        unittest.mock.patch("mlrun.config.is_running_as_api", return_value=False),
+    ):
+        kfp_notification_pusher.push()
+
+        # get the workflow steps once, send notification many times
+        assert get_workflow_steps_mock.call_count == 1
+        assert kfp_notification_pusher._push_workflow_notification_async.call_count == 2
+        assert kfp_notification_pusher._push_workflow_notification_sync.call_count == 1

--- a/server/py/services/api/tests/unit/test_notifications.py
+++ b/server/py/services/api/tests/unit/test_notifications.py
@@ -17,6 +17,8 @@ import hashlib
 import json
 import unittest.mock
 
+import pytest
+
 import mlrun.common.runtimes.constants as runtimes_constants
 import mlrun.common.schemas.notification
 
@@ -103,7 +105,8 @@ def test_notification_params_unmasking_on_run(monkeypatch):
     assert args[1][0].status == mlrun.common.schemas.NotificationStatus.ERROR
 
 
-def test_push_kfp_notification():
+@pytest.mark.parametrize("running_from_api", [True, False])
+def test_push_kfp_notification(running_from_api):
     project = "test-project"
     run_id = "test-run-id"
     notifications = [
@@ -146,11 +149,67 @@ def test_push_kfp_notification():
         unittest.mock.patch(
             "mlrun.utils.Workflow.get_workflow_steps"
         ) as get_workflow_steps_mock,
-        unittest.mock.patch("mlrun.config.is_running_as_api", return_value=False),
+        unittest.mock.patch(
+            "mlrun.config.is_running_as_api", return_value=running_from_api
+        ),
     ):
         kfp_notification_pusher.push()
 
         # get the workflow steps once, send notification many times
         assert get_workflow_steps_mock.call_count == 1
         assert kfp_notification_pusher._push_workflow_notification_async.call_count == 2
-        assert kfp_notification_pusher._push_workflow_notification_sync.call_count == 1
+        assert (
+            kfp_notification_pusher._push_workflow_notification_sync.call_count == 0
+            if running_from_api
+            else 1
+        )
+
+
+def test_get_workflow_steps_called():
+    """Test that mlrun.utils.Workflow.get_workflow_steps is called and returns expected steps."""
+
+    db_mock = unittest.mock.Mock()
+    workflow_id = "workflow-123"
+    project = "test-project"
+
+    # Patch _get_workflow_manifest to return a mock with get_steps
+    class MockStep:
+        def __init__(self, display_name, step_type, skipped=False):
+            self.display_name = display_name
+            self.step_type = step_type
+            self.skipped = skipped
+            self.node_name = display_name
+            self.phase = "Succeeded"
+
+        def to_dict(self):
+            return {"display_name": self.display_name, "step_type": self.step_type}
+
+    class MockManifest:
+        def get_steps(self):
+            return [
+                MockStep("step1", "run"),
+            ]
+
+    db_mock.list_runs.side_effect = [
+        # no runs as label is incorrect
+        [],
+        # trying again yields it
+        [
+            {
+                "metadata": {"name": "step1", "project": project},
+                "status": {"state": "completed"},
+            }
+        ],
+    ]
+
+    with unittest.mock.patch(
+        "mlrun.utils.Workflow._get_workflow_manifest", return_value=MockManifest()
+    ):
+        steps = mlrun.utils.Workflow.get_workflow_steps(db_mock, workflow_id, project)
+
+    # TODO: change to 1 when deprecating kfp 1.8 server all together
+    assert (
+        db_mock.list_runs.call_count == 2
+    )  # called twice, first with no runs, then with the run
+    assert len(steps) == 1  # first step is the actual mlrun run
+    assert steps[0]["metadata"]["name"] == "step1"

--- a/server/py/services/api/tests/unit/test_notifications.py
+++ b/server/py/services/api/tests/unit/test_notifications.py
@@ -103,7 +103,7 @@ def test_notification_params_unmasking_on_run(monkeypatch):
     assert args[1][0].status == mlrun.common.schemas.NotificationStatus.ERROR
 
 
-def test_push_kfp_notification(monkeypatch):
+def test_push_kfp_notification():
     project = "test-project"
     run_id = "test-run-id"
     notifications = [

--- a/server/py/services/api/tests/unit/test_notifications.py
+++ b/server/py/services/api/tests/unit/test_notifications.py
@@ -133,7 +133,7 @@ class TestKFPNotificationPusher:
 
         kfp_notification_pusher = (
             framework.utils.notifications.notification_pusher.KFPNotificationPusher(
-                project, run_id, notifications, {}
+                None, project, run_id, notifications, {}
             )
         )
         assert len(kfp_notification_pusher._sync_notifications) == 1


### PR DESCRIPTION
Refactors the KFPNotificationPusher to receive a database session, enabling proper access to workflow steps. Also modifies Slack notification to use runtime constants.

addressing an issue where run retrieval for workflow step run is failing to be retrieved due to changes in pod hostname conventions between KFP versions

https://iguazio.atlassian.net/browse/ML-10086