### PR TITLE
[Spark] Inform user about `deploy_default_image()` API change

### DIFF
--- a/docs/feature-store/using-spark-engine.md
+++ b/docs/feature-store/using-spark-engine.md
@@ -76,7 +76,10 @@ The following code should be executed only once to build the remote spark image 
 It may take a few minutes to prepare the image.
 
 ```python
+import mlrun
 from mlrun.runtimes import RemoteSparkRuntime
+
+mlrun.get_or_create_project("my-spark-project")
 
 RemoteSparkRuntime.deploy_default_image()
 ```
@@ -130,7 +133,10 @@ When running with a Spark operator, the MLRun execution details are returned, al
 The following code should be executed only once to build the spark job image before running the first ingest.
 It may take a few minutes to prepare the image.
 ```python
+import mlrun
 from mlrun.runtimes import Spark3Runtime
+
+mlrun.get_or_create_project("my-spark-project")
 
 Spark3Runtime.deploy_default_image()
 ```
@@ -222,7 +228,10 @@ feature set to S3 in the parquet format in a remote k8s job:
 One-time setup:
 1. Deploy the default image for your job (this takes several minutes but should be executed only once per cluster for any MLRun/Iguazio upgrade):
    ```python
+   import mlrun
    from mlrun.runtimes import RemoteSparkRuntime
+
+   mlrun.get_or_create_project("my-spark-project")
 
    RemoteSparkRuntime.deploy_default_image()
    ```

--- a/docs/runtimes/image-build.md
+++ b/docs/runtimes/image-build.md
@@ -229,6 +229,10 @@ with the correct versions of both products.
 To prepare this image, MLRun provides the following facilities:
 
 ```python
+import mlrun
+
+mlrun.get_or_create_project("my-spark-project")
+
 # For remote Spark
 from mlrun.runtimes import RemoteSparkRuntime
 

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -21,7 +21,6 @@ import mlrun.errors
 from mlrun.config import config
 from mlrun.runtimes.mounts import mount_v3io, mount_v3iod
 
-from ..errors import MLRunMissingProjectError
 from .kubejob import KubejobRuntime
 from .pod import KubeResourceSpec
 
@@ -105,7 +104,7 @@ class RemoteSparkRuntime(KubejobRuntime):
     @classmethod
     def deploy_default_image(cls):
         if not mlrun.get_current_project(silent=True):
-            raise MLRunMissingProjectError(
+            raise mlrun.errors.MLRunMissingProjectError(
                 "An active project is required to run deploy_default_image(). "
                 "This can be set by calling get_or_create_project()."
             )

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -106,7 +106,7 @@ class RemoteSparkRuntime(KubejobRuntime):
         if not mlrun.get_current_project(silent=True):
             raise mlrun.errors.MLRunMissingProjectError(
                 "An active project is required to run deploy_default_image(). "
-                "This can be set by calling get_or_create_project()."
+                "This can be set by calling get_or_create_project(), load_project(), or new_project()."
             )
 
         sj = mlrun.new_function(

--- a/mlrun/runtimes/remotesparkjob.py
+++ b/mlrun/runtimes/remotesparkjob.py
@@ -21,6 +21,7 @@ import mlrun.errors
 from mlrun.config import config
 from mlrun.runtimes.mounts import mount_v3io, mount_v3iod
 
+from ..errors import MLRunMissingProjectError
 from .kubejob import KubejobRuntime
 from .pod import KubeResourceSpec
 
@@ -103,6 +104,12 @@ class RemoteSparkRuntime(KubejobRuntime):
 
     @classmethod
     def deploy_default_image(cls):
+        if not mlrun.get_current_project(silent=True):
+            raise MLRunMissingProjectError(
+                "An active project is required to run deploy_default_image(). "
+                "This can be set by calling get_or_create_project()."
+            )
+
         sj = mlrun.new_function(
             kind="remote-spark", name="remote-spark-default-image-deploy-temp"
         )

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -25,6 +25,7 @@ from mlrun.runtimes.mounts import mount_v3io, mount_v3iod
 from ...execution import MLClientCtx
 from ...model import RunObject
 from ...utils import update_in, verify_field_regex
+from ..errors import MLRunMissingProjectError
 from ..kubejob import KubejobRuntime
 from ..pod import KubeResourceSpec
 from ..utils import (
@@ -804,6 +805,12 @@ class Spark3Runtime(KubejobRuntime):
 
     @classmethod
     def deploy_default_image(cls, with_gpu=False):
+        if not mlrun.get_current_project(silent=True):
+            raise MLRunMissingProjectError(
+                "An active project is required to run deploy_default_image(). "
+                "This can be set by calling get_or_create_project()."
+            )
+
         sj = mlrun.new_function(kind=cls.kind, name="spark-default-image-deploy-temp")
         sj.spec.build.image = cls._get_default_deployed_mlrun_image_name(with_gpu)
 

--- a/mlrun/runtimes/sparkjob/spark3job.py
+++ b/mlrun/runtimes/sparkjob/spark3job.py
@@ -25,7 +25,6 @@ from mlrun.runtimes.mounts import mount_v3io, mount_v3iod
 from ...execution import MLClientCtx
 from ...model import RunObject
 from ...utils import update_in, verify_field_regex
-from ..errors import MLRunMissingProjectError
 from ..kubejob import KubejobRuntime
 from ..pod import KubeResourceSpec
 from ..utils import (
@@ -806,7 +805,7 @@ class Spark3Runtime(KubejobRuntime):
     @classmethod
     def deploy_default_image(cls, with_gpu=False):
         if not mlrun.get_current_project(silent=True):
-            raise MLRunMissingProjectError(
+            raise mlrun.errors.MLRunMissingProjectError(
                 "An active project is required to run deploy_default_image(). "
                 "This can be set by calling get_or_create_project()."
             )


### PR DESCRIPTION
With an error message and documentation changes that clarify that an active project is required from 1.10.0 onward.

Following the removal of the default project in #7762.

[ML-10098](https://iguazio.atlassian.net/browse/ML-10098)

[ML-10098]: https://iguazio.atlassian.net/browse/ML-10098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ