### PR TITLE
[Deprecations] Remove Format classes

### DIFF
--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import enum
 import typing
 
 import mlrun.common.constants as mlrun_constants
@@ -235,19 +234,6 @@ class RunStates:
             mlrun_pipelines.common.models.RunStatuses.paused: RunStates.unknown,
             mlrun_pipelines.common.models.RunStatuses.unknown: RunStates.unknown,
         }[pipeline_run_status]
-
-
-# TODO: remove this class in 1.10.0 - use only MlrunInternalLabels
-class RunLabels(enum.Enum):
-    owner = mlrun_constants.MLRunInternalLabels.owner
-    v3io_user = mlrun_constants.MLRunInternalLabels.v3io_user
-
-    @staticmethod
-    def all():
-        return [
-            RunLabels.owner,
-            RunLabels.v3io_user,
-        ]
 
 
 class SparkApplicationStates:

--- a/mlrun/common/schemas/artifact.py
+++ b/mlrun/common/schemas/artifact.py
@@ -15,7 +15,6 @@
 import typing
 
 import pydantic.v1
-from deprecated import deprecated
 
 import mlrun.common.types
 
@@ -76,16 +75,6 @@ class ArtifactIdentifier(pydantic.v1.BaseModel):
     producer_id: typing.Optional[str]
     # TODO support hash once saved as a column in the artifacts table
     # hash: typing.Optional[str]
-
-
-@deprecated(
-    version="1.7.0",
-    reason="mlrun.common.schemas.ArtifactsFormat is deprecated and will be removed in 1.10.0. "
-    "Use mlrun.common.formatters.ArtifactFormat instead.",
-    category=FutureWarning,
-)
-class ArtifactsFormat(mlrun.common.types.StrEnum):
-    full = "full"
 
 
 class ArtifactMetadata(pydantic.v1.BaseModel):

--- a/mlrun/common/schemas/pipeline.py
+++ b/mlrun/common/schemas/pipeline.py
@@ -15,22 +15,6 @@
 import typing
 
 import pydantic.v1
-from deprecated import deprecated
-
-import mlrun.common.types
-
-
-@deprecated(
-    version="1.7.0",
-    reason="mlrun.common.schemas.PipelinesFormat is deprecated and will be removed in 1.10.0. "
-    "Use mlrun.common.formatters.PipelineFormat instead.",
-    category=FutureWarning,
-)
-class PipelinesFormat(mlrun.common.types.StrEnum):
-    full = "full"
-    metadata_only = "metadata_only"
-    summary = "summary"
-    name_only = "name_only"
 
 
 class PipelinesPagination(str):

--- a/mlrun/common/schemas/project.py
+++ b/mlrun/common/schemas/project.py
@@ -16,28 +16,11 @@ import datetime
 import typing
 
 import pydantic.v1
-from deprecated import deprecated
 
 import mlrun.common.types
 
 from .common import ImageBuilder
 from .object import ObjectKind, ObjectStatus
-
-
-@deprecated(
-    version="1.7.0",
-    reason="mlrun.common.schemas.ProjectsFormat is deprecated and will be removed in 1.10.0. "
-    "Use mlrun.common.formatters.ProjectFormat instead.",
-    category=FutureWarning,
-)
-class ProjectsFormat(mlrun.common.types.StrEnum):
-    full = "full"
-    name_only = "name_only"
-    # minimal format removes large fields from the response (e.g. functions, workflows, artifacts)
-    # and is used for faster response times (in the UI)
-    minimal = "minimal"
-    # internal - allowed only in follower mode, only for the leader for upgrade purposes
-    leader = "leader"
 
 
 class ProjectMetadata(pydantic.v1.BaseModel):

--- a/mlrun/common/schemas/runs.py
+++ b/mlrun/common/schemas/runs.py
@@ -15,26 +15,9 @@
 import typing
 
 import pydantic.v1
-from deprecated import deprecated
-
-import mlrun.common.types
 
 
 class RunIdentifier(pydantic.v1.BaseModel):
     kind: typing.Literal["run"] = "run"
     uid: typing.Optional[str]
     iter: typing.Optional[int]
-
-
-@deprecated(
-    version="1.7.0",
-    reason="mlrun.common.schemas.RunsFormat is deprecated and will be removed in 1.10.0. "
-    "Use mlrun.common.formatters.RunFormat instead.",
-    category=FutureWarning,
-)
-class RunsFormat(mlrun.common.types.StrEnum):
-    # No enrichment, data is pulled as-is from the database.
-    standard = "standard"
-
-    # Performs run enrichment, including the run's artifacts. Only available for the `get` run API.
-    full = "full"

--- a/tests/runtimes/test_utils.py
+++ b/tests/runtimes/test_utils.py
@@ -116,7 +116,7 @@ def test_add_code_metadata_stale_remote(repo):
         ),
         (
             {"a": "A", "b": "B"},
-            {mlrun.common.runtimes.constants.RunLabels.owner},
+            {mlrun_constants.MLRunInternalLabels.owner},
             {
                 "a": "A",
                 "b": "B",


### PR DESCRIPTION
Deprecated in 1.7.0 

- `mlrun.common.schemas.RunsFormat` use instead `mlrun.common.formatters.RunFormat`
- `mlrun.common.schemas.ArtifactsFormat` use instead `mlrun.common.formatters.ArtifactFormat`
- `mlrun.common.schemas.ProjectsFormat` use instead `mlrun.common.formatters.ProjectFormat`
- `mlrun.common.schemas.PipelinesFormat` use instead `mlrun.common.formatters.PipelineFormat`
- `mlrun.common.runtimes.constants.RunLabels` use instead `mlrun.common.constants.MLRunInternalLabels` (Because this class is used internally, a deprecation warning was not needed here)

https://iguazio.atlassian.net/browse/ML-10041
https://iguazio.atlassian.net/browse/ML-10044