### PR TITLE
Revert "[Config] Increasing project limit" [1.9.x]

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -482,7 +482,7 @@ default_config = {
             "project_owners_cache_ttl": "30 seconds",
             # access key to be used when the leader is iguazio and polling is done from it
             "iguazio_access_key": "",
-            "iguazio_list_projects_default_page_size": 500,
+            "iguazio_list_projects_default_page_size": 200,
             "iguazio_client_job_cache_ttl": "20 minutes",
             "nuclio_project_deletion_verification_timeout": "300 seconds",
             "nuclio_project_deletion_verification_interval": "5 seconds",


### PR DESCRIPTION
Reverts mlrun/mlrun#7927

Causing failures when mlrun tries to fetch projects from iguazio
```
Failed listing projects from Iguazio: [{'status': 400, 'detail': 'Requested page size (500) exceeds the maximum limit of 200'}]
```

https://iguazio.atlassian.net/browse/ML-10084
(cherry picked from commit 36edc88374b320efd30aa32c63e545a5a326a322)