### PR TITLE
[Depricatioins] Remove `labels` in `get_or_create_ctx`

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -21,7 +21,6 @@ import tempfile
 import time
 import typing
 import uuid
-import warnings
 from base64 import b64decode
 from copy import deepcopy
 from os import environ, makedirs, path
@@ -206,7 +205,6 @@ def get_or_create_ctx(
     rundb: Union[str, "mlrun.db.RunDBInterface"] = "",
     project: str = "",
     upload_artifacts: bool = False,
-    labels: Optional[dict] = None,
 ) -> MLClientCtx:
     """
     Called from within the user program to obtain a run context.
@@ -226,7 +224,6 @@ def get_or_create_ctx(
     :param project:  project to initiate the context in (by default `mlrun.mlconf.active_project`)
     :param upload_artifacts:  when using local context (not as part of a job/run), upload artifacts to the
                               system default artifact path location
-    :param labels: (deprecated - use spec instead) dict of the context labels.
     :return: execution context
 
     Examples::
@@ -259,21 +256,6 @@ def get_or_create_ctx(
         context.log_artifact("results.html", body=b"<b> Some HTML <b>", viewer="web-app")
 
     """
-    if labels:
-        warnings.warn(
-            "The `labels` argument is deprecated in 1.7.0 and will be removed in 1.10.0. "
-            "Please use `spec` instead, e.g.:\n"
-            "spec={'metadata': {'labels': {'key': 'value'}}}",
-            FutureWarning,
-        )
-        if spec is None:
-            spec = {}
-        if "metadata" not in spec:
-            spec["metadata"] = {}
-        if "labels" not in spec["metadata"]:
-            spec["metadata"]["labels"] = {}
-        spec["metadata"]["labels"].update(labels)
-
     if global_context.get() and not spec and not event:
         return global_context.get()
 


### PR DESCRIPTION
Deprecated in 1.7.0 
use `spec` instead  - `get_or_create_ctx(spec={'metadata': {'labels': {'key': 'value'}}})`
https://iguazio.atlassian.net/browse/ML-10043