### PR TITLE
[Deprecations] Remove `labels` param in `list_schedules`

### DIFF
--- a/server/py/services/api/api/endpoints/schedules.py
+++ b/server/py/services/api/api/endpoints/schedules.py
@@ -106,13 +106,6 @@ async def update_schedule(
 async def list_schedules(
     project: str,
     name: Optional[str] = None,
-    # TODO: Remove _labels in 1.10.0
-    _labels: str = fastapi.Query(
-        None,
-        alias="labels",
-        deprecated=True,
-        description="Use 'label' instead, will be removed in the 1.10.0",
-    ),
     labels: list[str] = fastapi.Query([], alias="label"),
     kind: mlrun.common.schemas.ScheduleKinds = None,
     include_last_run: bool = False,
@@ -138,7 +131,7 @@ async def list_schedules(
         project=allowed_project_names,
         name=name,
         kind=kind,
-        labels=labels or _labels,
+        labels=labels,
         include_last_run=include_last_run,
         include_credentials=include_credentials,
         next_run_time_since=next_run_time_since,

--- a/server/py/services/api/tests/unit/api/test_schedules.py
+++ b/server/py/services/api/tests/unit/api/test_schedules.py
@@ -90,13 +90,13 @@ def test_list_schedules(
         )
 
         _get_and_assert_single_schedule(
-            client, {"labels": "label1"}, schedule_name, project
+            client, {"label": "label1"}, schedule_name, project
         )
         _get_and_assert_single_schedule(
             client, {"label": "label1"}, schedule_name, project
         )
         _get_and_assert_single_schedule(
-            client, {"labels": "label2"}, schedule_name_2, project
+            client, {"label": "label2"}, schedule_name_2, project
         )
         _get_and_assert_single_schedule(
             client, {"label": ["label2"]}, schedule_name_2, project
@@ -105,10 +105,10 @@ def test_list_schedules(
             client, {"label": ["label2", "label3"]}, schedule_name_2, project
         )
         _get_and_assert_single_schedule(
-            client, {"labels": "label1=value1"}, schedule_name, project
+            client, {"label": "label1=value1"}, schedule_name, project
         )
         _get_and_assert_single_schedule(
-            client, {"labels": "label2=value2"}, schedule_name_2, project
+            client, {"label": "label2=value2"}, schedule_name_2, project
         )
         _get_and_assert_single_schedule(
             client, {"label": "label2=value2"}, schedule_name_2, project
@@ -118,13 +118,13 @@ def test_list_schedules(
         )
         _get_and_assert_single_schedule(
             client,
-            {"labels": ["label2=value2", "label3=value3"]},
+            {"label": ["label2=value2", "label3=value3"]},
             schedule_name_2,
             project,
         )
 
     # Validate multi-project query
-    resp = client.get("projects/*/schedules", params={"labels": "label1"})
+    resp = client.get("projects/*/schedules", params={"label": "label1"})
     assert resp.status_code == http.HTTPStatus.OK.value, "status"
     result = resp.json()["schedules"]
     assert len(result) == len(project_names)


### PR DESCRIPTION
`labels` in `GET /projects/{project}/schedules?labels` is deprecated in 1.7.0
Use `label` instead which is an array of strings
https://iguazio.atlassian.net/browse/ML-10045