### PR TITLE
[Dask] Raise on dask cluster start timeout

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -234,7 +234,10 @@ default_config = {
                 "model_endpoint_creation": "600",
                 "model_endpoint_tsdb_leftovers": "900",
             },
-            "runtimes": {"dask": "600"},
+            "runtimes": {
+                "dask": "600",
+                "dask_cluster_start": "300",
+            },
             "push_notifications": "60",
         },
     },

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -255,7 +255,11 @@ class DaskCluster(KubejobRuntime):
         background_task = db.start_function(func_url=self._function_uri())
         if watch:
             now = datetime.datetime.utcnow()
-            timeout = now + datetime.timedelta(minutes=10)
+            timeout = now + datetime.timedelta(
+                seconds=int(
+                    mlrun.mlconf.background_tasks.default_timeouts.runtimes.dask_cluster_start
+                )
+            )
             while now < timeout:
                 background_task = db.get_project_background_task(
                     background_task.metadata.project, background_task.metadata.name
@@ -282,6 +286,9 @@ class DaskCluster(KubejobRuntime):
                         return
                 time.sleep(5)
                 now = datetime.datetime.utcnow()
+            raise mlrun.errors.MLRunRuntimeError(
+                "Timeout waiting for Dask cluster to start"
+            )
 
     def close(self, running=True):
         from dask.distributed import default_client

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -286,7 +286,7 @@ class DaskCluster(KubejobRuntime):
                         return
                 time.sleep(5)
                 now = datetime.datetime.utcnow()
-            raise mlrun.errors.MLRunRuntimeError(
+            raise mlrun.errors.MLRunTimeoutError(
                 "Timeout waiting for Dask cluster to start"
             )
 


### PR DESCRIPTION
This PR fixes an issue where system tests using an invalid Dask image were incorrectly passing.

- Added a check to raise `MLRunRuntimeError` if the background task for starting the Dask cluster does not reach a terminal state before the timeout expires.
- This ensures that deployment failures (e.g., due to an invalid image) are properly detected and surfaced.
- Reduced the Dask cluster startup timeout from 10 minutes to 5 minutes to shorten feedback loops and avoid unnecessarily long waits during failures.

Jira :
https://iguazio.atlassian.net/browse/ML-10125