### PR TITLE
[Datastore] Support passing Kafka version in `DatastoreProfileKafkaSource`

### DIFF
--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -236,9 +236,11 @@ class KafkaParameters:
             "partitions": "",
             "sasl": "",
             "worker_allocation_mode": "",
-            "tls_enable": "",  # for Nuclio with Confluent Kafka (Sarama client)
+            # for Nuclio with Confluent Kafka (Sarama client)
+            "tls_enable": "",
             "tls": "",
             "new_topic": "",
+            "version": "",
         }
         self._reference_dicts = (
             self._custom_attributes,

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -28,7 +28,6 @@ import kafka.errors
 import nuclio
 import sqlalchemy.orm
 import v3io.dataplane
-import v3io.dataplane.response
 from fastapi import BackgroundTasks
 from fastapi.concurrency import run_in_threadpool
 


### PR DESCRIPTION
Fixes [ML-10102](https://iguazio.atlassian.net/browse/ML-10102).

Now, one can pass the minimal Kafka version for a proper handshake with Confluent Cloud.
Add to Confluent Cloud template here
https://docs.mlrun.org/en/latest/api/mlrun.projects/index.html#mlrun.projects.MlrunProject.set_model_monitoring_credentials
the following
```py
        "version": "3.9.0",
```
in the `kwargs_public` dictionary.

I verified it.

The user docs were not changed, as it is expected to be solved in Nuclio 1.14.7 in another way (see [NUC-450](https://iguazio.atlassian.net/browse/NUC-450), https://github.com/nuclio/nuclio/pull/3650).

[ML-10102]: https://iguazio.atlassian.net/browse/ML-10102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[NUC-450]: https://iguazio.atlassian.net/browse/NUC-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ