### PR TITLE
[Model Monitoring] Support passing data items in `evaluate`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,8 @@ language = "en"
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    "_build",
+    "_build/**",
+    ".venv/**",
     "CONTRIBUTING.md",
 ]
 

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -409,8 +409,8 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         tag: Optional[str] = None,
         run_local: bool = True,
         auto_build: bool = True,
-        sample_data: Optional[pd.DataFrame] = None,
-        reference_data: Optional[pd.DataFrame] = None,
+        sample_data: Optional[Union[pd.DataFrame, str]] = None,
+        reference_data: Optional[Union[pd.DataFrame, str]] = None,
         image: Optional[str] = None,
         with_repo: Optional[bool] = False,
         class_handler: Optional[str] = None,
@@ -434,9 +434,11 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         :param tag:               Tag for the function.
         :param run_local:         Whether to run the function locally or remotely.
         :param auto_build:        Whether to auto build the function.
-        :param sample_data:       Pandas data-frame as the current dataset.
+        :param sample_data:       Pandas data-frame or :py:class:`~mlrun.artifacts.dataset.DatasetArtifact` URI as
+                                  the current dataset.
                                   When set, it replaces the data read from the model endpoint's offline source.
-        :param reference_data:    Pandas data-frame of the reference dataset.
+        :param reference_data:    Pandas data-frame or :py:class:`~mlrun.artifacts.dataset.DatasetArtifact` URI as
+                                  the reference dataset.
                                   When set, its statistics override the model endpoint's feature statistics.
         :param image:             Docker image to run the job on (when running remotely).
         :param with_repo:         Whether to clone the current repo to the build source.
@@ -515,7 +517,9 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             (sample_data, "sample_data"),
             (reference_data, "reference_data"),
         ]:
-            if data is not None:
+            if isinstance(data, str):
+                inputs[identifier] = data
+            elif data is not None:
                 key = f"{job.metadata.name}_{identifier}"
                 inputs[identifier] = project.log_dataset(
                     key,

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -85,6 +85,7 @@ class SampleDFAccessApp(ModelMonitoringApplicationBase):
             project=monitoring_context.project_name,
         )
         sample_df = monitoring_context.sample_df
+        assert sample_df is not None
         monitoring_context.logger.info(
             "Read the sample data",
             sample_df=sample_df,
@@ -146,17 +147,27 @@ class TestEvaluate:
         ), "The error message is different than expected or was not captured"
 
     @staticmethod
+    @pytest.mark.parametrize("method", ["to_job", "evaluate"])
     def test_valid_sample_df_access(
-        tmp_path: Path, capsys: pytest.CaptureFixture
+        method: str, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
         project = mlrun.get_or_create_project(
             "local-test-sample-df", context=str(tmp_path)
         )
         project.artifact_path = str(tmp_path)
         sample_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-        ds_artifact = project.log_dataset("sample-df", df=sample_df)
-        job = SampleDFAccessApp.to_job(func_path=__file__)
-        run = job.run(local=True, inputs={"sample_data": ds_artifact.target_path})
+        ds_artifact_path = project.log_dataset("sample-df", df=sample_df).target_path
+
+        if method == "to_job":
+            job = SampleDFAccessApp.to_job(func_path=__file__)
+            run = job.run(local=True, inputs={"sample_data": ds_artifact_path})
+        elif method == "evaluate":
+            run = SampleDFAccessApp.evaluate(
+                func_path=__file__, run_local=True, sample_data=ds_artifact_path
+            )
+        else:
+            raise NotImplementedError
+
         assert run.state() == "completed"
         captured = capsys.readouterr()
         assert (

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1415,12 +1415,15 @@ class TestAppJob(TestMLRunSystem):
         # Prepare the data
         sample_data = pd.DataFrame({"a": [9, 10, -2, 1], "b": [0.11, 2.03, 0.55, 0]})
         reference_data = pd.DataFrame({"a": [12, 13], "b": [3.12, 4.12]})
+        reference_data_uri = self.project.log_dataset(
+            "reference_data", reference_data
+        ).uri
 
         # Call `.evaluate(...)`
         run_result = histogram_app_with_artifacts.HistogramDataDriftApplicationWithArtifacts.evaluate(
             func_path=histogram_app_with_artifacts.__file__,
             sample_data=sample_data,
-            reference_data=reference_data,
+            reference_data=reference_data_uri,
             run_local=run_local,
             image=self.image,  # Relevant for remote runs only
         )


### PR DESCRIPTION
Implements [ML-10135](https://iguazio.atlassian.net/browse/ML-10135).

Adapt the tests to cover this case, and update the docstring.

In addition, fix the docs configuration to exclude irrelevant folders.

[ML-10135]: https://iguazio.atlassian.net/browse/ML-10135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ