### PR TITLE
[Scripts] Configurable namespace in patch_remote

### DIFF
--- a/automation/patch_igz/patch_env_template.yml
+++ b/automation/patch_igz/patch_env_template.yml
@@ -51,3 +51,6 @@ DB_USER:
 # Optional - relevant when working with multiple DATA_NODES and iguazio datanode registry
 # set to "true" if you want the image to be pushed only to a single registry specified in DOCKER_REGISTRY
 SKIP_MULTI_NODE_PUSH:
+
+# Optional - if no given the "default-tenant" namespace will be used
+NAMESPACE:

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -44,6 +44,7 @@ class Constants:
     mlrun = "mlrun"
     mlrun_kfp = "mlrun-kfp"
     log_collector = "log-collector"
+    default_namespace = "default-tenant"
     targets_to_image_name = {
         api: api_container,
         mlrun: mlrun,
@@ -65,6 +66,7 @@ class MLRunPatcher:
         patch_alerts: bool,
         no_build: bool,
         no_push: bool,
+        namespace: str,
     ):
         self._config = yaml.safe_load(conf_file)
         patch_yaml_data = yaml.safe_load(patch_file)
@@ -78,6 +80,7 @@ class MLRunPatcher:
         self._patch_alerts = patch_alerts
         self._no_build = no_build
         self._no_push = no_push
+        self._namespace = self._resolve_namespace(namespace)
 
         if self._skip_patch_api and self._patch_alerts:
             raise ValueError("Cannot skip api and patch alerts at the same time")
@@ -144,7 +147,7 @@ class MLRunPatcher:
             finally:
                 # Check status of pods after deployment
                 out = self._exec_remote(
-                    ["kubectl", "-n", "default-tenant", "get", "pods"]
+                    ["kubectl", "-n", self._namespace, "get", "pods"]
                 )
                 for line in out.splitlines():
                     if (
@@ -307,7 +310,7 @@ class MLRunPatcher:
                 [
                     "kubectl",
                     "-n",
-                    "default-tenant",
+                    self._namespace,
                     "patch",
                     "deployment",
                     deployment,
@@ -330,7 +333,7 @@ class MLRunPatcher:
                 [
                     "kubectl",
                     "-n",
-                    "default-tenant",
+                    self._namespace,
                     "set",
                     "image",
                     f"deployment/{deployment}",
@@ -345,7 +348,7 @@ class MLRunPatcher:
                 [
                     "kubectl",
                     "-n",
-                    "default-tenant",
+                    self._namespace,
                     "rollout",
                     "restart",
                     f"deployment/{deployment}",
@@ -359,7 +362,7 @@ class MLRunPatcher:
                 [
                     "kubectl",
                     "-n",
-                    "default-tenant",
+                    self._namespace,
                     "rollout",
                     "status",
                     "deployment",
@@ -387,7 +390,7 @@ class MLRunPatcher:
                     [
                         "kubectl",
                         "-n",
-                        "default-tenant",
+                        self._namespace,
                         "wait",
                         "pods",
                         "-l",
@@ -416,7 +419,7 @@ class MLRunPatcher:
                 [
                     "kubectl",
                     "-n",
-                    "default-tenant",
+                    self._namespace,
                     "get",
                     "deployments",
                     "--selector",
@@ -442,7 +445,7 @@ class MLRunPatcher:
             [
                 "kubectl",
                 "-n",
-                "default-tenant",
+                self._namespace,
                 "scale",
                 "deploy",
                 "--selector",
@@ -455,7 +458,7 @@ class MLRunPatcher:
             [
                 "kubectl",
                 "-n",
-                "default-tenant",
+                self._namespace,
                 "wait",
                 "--for=delete",
                 "--timeout=300s",
@@ -471,7 +474,7 @@ class MLRunPatcher:
             [
                 "kubectl",
                 "-n",
-                "default-tenant",
+                self._namespace,
                 "exec",
                 "-it",
                 "deployment/mlrun-db",
@@ -495,7 +498,7 @@ class MLRunPatcher:
                 [
                     "kubectl",
                     "-n",
-                    "default-tenant",
+                    self._namespace,
                     "scale",
                     "deploy",
                     deployment,
@@ -566,6 +569,11 @@ class MLRunPatcher:
 
         return docker_registry, overwrite_registry
 
+    def _resolve_namespace(self, namespace: str = "") -> str:
+        if namespace:
+            return namespace
+        return self._config.get("NAMESPACE", Constants.default_namespace)
+
 
 @click.command(help="mlrun-api deployer to remote system")
 @click.option("-v", "--verbose", is_flag=True, help="Print what we are doing")
@@ -629,6 +637,12 @@ class MLRunPatcher:
     is_flag=True,
     help="Skip pushing the image",
 )
+@click.option(
+    "-n",
+    "--namespace",
+    default="",
+    help="Kubernetes namespace to deploy to. If not set, defaults to 'default-tenant'.",
+)
 def main(
     verbose: bool,
     config: str,
@@ -641,6 +655,7 @@ def main(
     alerts: bool,
     no_build: bool,
     no_push: bool,
+    namespace: str,
 ):
     if verbose:
         coloredlogs.set_level(logging.DEBUG)
@@ -656,6 +671,7 @@ def main(
         patch_alerts=alerts,
         no_build=no_build,
         no_push=no_push,
+        namespace=namespace,
     ).patch()
 
 


### PR DESCRIPTION
Support patching MLRun in namespaces other than `default-tenant`.
Namespace can be either passed in the `patch_env.yaml` or as a flag, with precedence to the flag.
If not configured at all - defaults to `default-tenant`.