### PR TITLE
[Tutorials] Add a workaround for wrong aws url key name

### DIFF
--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -48,6 +48,7 @@
    "source": [
     "import mlrun\n",
     "import os\n",
+    "\n",
     "# Install and use a version of evidently that was tested to be working with mlrun\n",
     "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION\n",
     "\n",
@@ -74,7 +75,7 @@
     "aws_url = os.environ.get(\"S3_ENDPOINT_URL\")\n",
     "if aws_url:\n",
     "    os.environ[\"AWS_ENDPOINT_URL_S3\"] = aws_url\n",
-    "    project.set_secrets({\"AWS_ENDPOINT_URL_S3\":aws_url})"
+    "    project.set_secrets({\"AWS_ENDPOINT_URL_S3\": aws_url})"
    ]
   },
   {

--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "project = mlrun.get_or_create_project(\"tutorial\", context=\"./\", user_project=True)\n",
     "\n",
-    "# Workaround in place until AWS key name update in a future version\n",
+    "# Needed when using S3/minio until AWS_ENDPOINT_URL_S3 env-var is adopted in mlrun\n",
     "aws_url = os.environ.get(\"S3_ENDPOINT_URL\")\n",
     "if aws_url:\n",
     "    os.environ[\"AWS_ENDPOINT_URL_S3\"] = aws_url\n",

--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "import mlrun\n",
-    "\n",
+    "import os\n",
     "# Install and use a version of evidently that was tested to be working with mlrun\n",
     "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION\n",
     "\n",
@@ -68,7 +68,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = mlrun.get_or_create_project(\"tutorial\", context=\"./\", user_project=True)"
+    "project = mlrun.get_or_create_project(\"tutorial\", context=\"./\", user_project=True)\n",
+    "\n",
+    "# Workaround in place until AWS key name update in a future version\n",
+    "aws_url = os.environ.get(\"S3_ENDPOINT_URL\")\n",
+    "if aws_url and mlrun.mlconf.is_ce_mode():\n",
+    "    os.environ[\"AWS_ENDPOINT_URL_S3\"] = aws_url\n",
+    "    project.set_secrets({\"AWS_ENDPOINT_URL_S3\":aws_url})"
    ]
   },
   {

--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "# Workaround in place until AWS key name update in a future version\n",
     "aws_url = os.environ.get(\"S3_ENDPOINT_URL\")\n",
-    "if aws_url and mlrun.mlconf.is_ce_mode():\n",
+    "if aws_url:\n",
     "    os.environ[\"AWS_ENDPOINT_URL_S3\"] = aws_url\n",
     "    project.set_secrets({\"AWS_ENDPOINT_URL_S3\":aws_url})"
    ]


### PR DESCRIPTION
Mlrun need to align the S3 AWS URL key name with the one used by the boto3 client, which fsspec also relies on.

This PR is a quick fix — we'll gradually update the credentials handling in 1.10 in deprecation mode, aiming for full replacement by version 1.12.

`S3_ENDPOINT_URL` -> `AWS_ENDPOINT_URL_S3`


[ML-10129](https://iguazio.atlassian.net/browse/ML-10129)

[ML-10129]: https://iguazio.atlassian.net/browse/ML-10129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ