### PR TITLE
[Tutorials] Add a workaround for wrong aws url key name (#8027)

### DIFF
--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -47,6 +47,7 @@
    "outputs": [],
    "source": [
     "import mlrun\n",
+    "import os\n",
     "\n",
     "# Install and use a version of evidently that was tested to be working with mlrun\n",
     "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION\n",
@@ -68,7 +69,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = mlrun.get_or_create_project(\"tutorial\", context=\"./\", user_project=True)"
+    "project = mlrun.get_or_create_project(\"tutorial\", context=\"./\", user_project=True)\n",
+    "\n",
+    "# Needed when using S3/minio until AWS_ENDPOINT_URL_S3 env-var is adopted in mlrun\n",
+    "aws_url = os.environ.get(\"S3_ENDPOINT_URL\")\n",
+    "if aws_url:\n",
+    "    os.environ[\"AWS_ENDPOINT_URL_S3\"] = aws_url\n",
+    "    project.set_secrets({\"AWS_ENDPOINT_URL_S3\": aws_url})"
    ]
   },
   {


### PR DESCRIPTION
[ML-10129](https://iguazio.atlassian.net/browse/ML-10129)

[ML-10129]: https://iguazio.atlassian.net/browse/ML-10129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ