### PR TITLE
[Datastore] Fix S3 profile with bucket as part of the url

### DIFF
--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -223,7 +223,7 @@ class DatastoreProfileS3(DatastoreProfile):
     assume_role_arn: typing.Optional[str] = None
     access_key_id: typing.Optional[str] = None
     secret_key: typing.Optional[str] = None
-    bucket: str
+    bucket: typing.Optional[str] = None
 
     def secrets(self) -> dict:
         res = {}

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -178,16 +178,7 @@ class TestAwsS3:
             os.environ.pop(SecretsStore.k8s_env_variable_name_for_secret(param))
 
     def test_using_env_variables(self):
-        # Use "naked" env variables, useful in client-side sdk.
-        for param in credential_params:
-            os.environ[param] = self.env[param]
-            os.environ.pop(SecretsStore.k8s_env_variable_name_for_secret(param), None)
-
         self._perform_aws_s3_tests()
-
-        # cleanup
-        for param in credential_params:
-            os.environ.pop(param)
 
     def test_using_dataitem_secrets(
         self,


### PR DESCRIPTION
1) Bucket can be retrieved from the url, not only from profile.
2) `test_using_env_variables` did not take under consideration that the prefix can be empty ("").


[ML-10182](https://iguazio.atlassian.net/browse/ML-10182)

[ML-10182]: https://iguazio.atlassian.net/browse/ML-10182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ