### PR TITLE
[Deprications] Remove `auth_info` in `mlrun.runtimes.nuclio.function.RemoteRuntime.deploy`

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -272,7 +272,6 @@ class ApplicationRuntime(RemoteRuntime):
         project="",
         tag="",
         verbose=False,
-        auth_info: schemas.AuthInfo = None,
         builder_env: typing.Optional[dict] = None,
         force_build: bool = False,
         with_mlrun=None,
@@ -289,7 +288,6 @@ class ApplicationRuntime(RemoteRuntime):
         :param project:                     Project name
         :param tag:                         Function tag
         :param verbose:                     Set True for verbose logging
-        :param auth_info:                   Service AuthInfo (deprecated and ignored)
         :param builder_env:                 Env vars dict for source archive config/credentials
                                             e.g. builder_env={"GIT_TOKEN": token}
         :param force_build:                 Set True for force building the application image
@@ -330,7 +328,6 @@ class ApplicationRuntime(RemoteRuntime):
             project=project,
             tag=tag,
             verbose=verbose,
-            auth_info=auth_info,
             builder_env=builder_env,
         )
         logger.info(

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -16,7 +16,6 @@ import asyncio
 import copy
 import json
 import typing
-import warnings
 from datetime import datetime
 from time import sleep
 

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -607,7 +607,6 @@ class RemoteRuntime(KubeResource):
         project="",
         tag="",
         verbose=False,
-        auth_info: AuthInfo = None,
         builder_env: typing.Optional[dict] = None,
         force_build: bool = False,
     ):
@@ -616,16 +615,9 @@ class RemoteRuntime(KubeResource):
         :param project:    project name
         :param tag:        function tag
         :param verbose:    set True for verbose logging
-        :param auth_info:  service AuthInfo (deprecated and ignored)
         :param builder_env: env vars dict for source archive config/credentials e.g. builder_env={"GIT_TOKEN": token}
         :param force_build: set True for force building the image
         """
-        if auth_info:
-            # TODO: remove in 1.10.0
-            warnings.warn(
-                "'auth_info' is deprecated for nuclio runtimes in 1.7.0 and will be removed in 1.10.0",
-                FutureWarning,
-            )
 
         old_http_session = getattr(self, "_http_session", None)
         if old_http_session:

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -629,7 +629,6 @@ class ServingRuntime(RemoteRuntime):
         project="",
         tag="",
         verbose=False,
-        auth_info: schemas.AuthInfo = None,
         builder_env: Optional[dict] = None,
         force_build: bool = False,
     ):
@@ -638,8 +637,6 @@ class ServingRuntime(RemoteRuntime):
         :param project:   optional, override function specified project name
         :param tag:       specify unique function tag (a different function service is created for every tag)
         :param verbose:   verbose logging
-        :param auth_info: The auth info to use to communicate with the Nuclio dashboard, required only when providing
-                          dashboard
         :param builder_env: env vars dict for source archive config/credentials e.g. builder_env={"GIT_TOKEN": token}
         :param force_build: set True for force building the image
         """
@@ -684,7 +681,6 @@ class ServingRuntime(RemoteRuntime):
             project,
             tag,
             verbose,
-            auth_info,
             builder_env=builder_env,
             force_build=force_build,
         )


### PR DESCRIPTION
Deprecated in 1.7.0, removed in 1.10 
https://iguazio.atlassian.net/browse/ML-10052