### PR TITLE
[Model Monitoring] Connect evaluate to the writer

### DIFF
--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import collections
-import json
 import traceback
 from collections import OrderedDict
 from datetime import datetime
@@ -23,10 +22,12 @@ import mlrun.common.schemas
 import mlrun.common.schemas.alert as alert_objects
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.model_monitoring.helpers
+import mlrun.platforms.iguazio
 from mlrun.serving import GraphContext
 from mlrun.serving.utils import StepToDict
 from mlrun.utils import logger
 
+from .base import _serialize_context_and_result
 from .context import MonitoringApplicationContext
 from .results import (
     ModelMonitoringApplicationMetric,
@@ -45,7 +46,7 @@ class _PushToMonitoringWriter(StepToDict):
         :param project: Project name.
         """
         self.project = project
-        self.output_stream = None
+        self._output_stream = None
 
     def do(
         self,
@@ -65,48 +66,31 @@ class _PushToMonitoringWriter(StepToDict):
 
         :param event: Monitoring result(s) to push and the original event from the controller.
         """
-        self._lazy_init()
         application_results, application_context = event
-        writer_event = {
-            mm_constants.WriterEvent.ENDPOINT_NAME: application_context.endpoint_name,
-            mm_constants.WriterEvent.APPLICATION_NAME: application_context.application_name,
-            mm_constants.WriterEvent.ENDPOINT_ID: application_context.endpoint_id,
-            mm_constants.WriterEvent.START_INFER_TIME: application_context.start_infer_time.isoformat(
-                sep=" ", timespec="microseconds"
-            ),
-            mm_constants.WriterEvent.END_INFER_TIME: application_context.end_infer_time.isoformat(
-                sep=" ", timespec="microseconds"
-            ),
-        }
-        for result in application_results:
-            data = result.to_dict()
-            if isinstance(result, ModelMonitoringApplicationResult):
-                writer_event[mm_constants.WriterEvent.EVENT_KIND] = (
-                    mm_constants.WriterEventKind.RESULT
-                )
-            elif isinstance(result, _ModelMonitoringApplicationStats):
-                writer_event[mm_constants.WriterEvent.EVENT_KIND] = (
-                    mm_constants.WriterEventKind.STATS
-                )
-            else:
-                writer_event[mm_constants.WriterEvent.EVENT_KIND] = (
-                    mm_constants.WriterEventKind.METRIC
-                )
-            writer_event[mm_constants.WriterEvent.DATA] = json.dumps(data)
-            logger.debug(
-                "Pushing data to output stream", writer_event=str(writer_event)
-            )
-            self.output_stream.push(
-                [writer_event], partition_key=application_context.endpoint_id
-            )
-            logger.debug("Pushed data to output stream successfully")
 
-    def _lazy_init(self):
-        if self.output_stream is None:
-            self.output_stream = mlrun.model_monitoring.helpers.get_output_stream(
+        writer_events = [
+            _serialize_context_and_result(context=application_context, result=result)
+            for result in application_results
+        ]
+
+        logger.debug("Pushing data to output stream", writer_events=str(writer_events))
+        self.output_stream.push(
+            writer_events, partition_key=application_context.endpoint_id
+        )
+        logger.debug("Pushed data to output stream successfully")
+
+    @property
+    def output_stream(
+        self,
+    ) -> Union[
+        mlrun.platforms.iguazio.OutputStream, mlrun.platforms.iguazio.KafkaOutputStream
+    ]:
+        if self._output_stream is None:
+            self._output_stream = mlrun.model_monitoring.helpers.get_output_stream(
                 project=self.project,
                 function_name=mm_constants.MonitoringFunctionNames.WRITER,
             )
+        return self._output_stream
 
 
 class _PrepareMonitoringEvent(StepToDict):

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -15,7 +15,9 @@
 import json
 import socket
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Any, Optional, Union, cast
 
@@ -24,10 +26,12 @@ import pandas as pd
 import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
+import mlrun.datastore.datastore_profile as ds_profile
 import mlrun.errors
 import mlrun.model_monitoring.api as mm_api
 import mlrun.model_monitoring.applications.context as mm_context
 import mlrun.model_monitoring.applications.results as mm_results
+import mlrun.model_monitoring.helpers as mm_helpers
 from mlrun.serving.utils import MonitoringApplicationToDict
 from mlrun.utils import logger
 
@@ -161,6 +165,43 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             ]
         return result
 
+    @staticmethod
+    @contextmanager
+    def _push_to_writer(
+        *,
+        write_output: bool,
+        stream_profile: Optional[ds_profile.DatastoreProfile],
+    ) -> Iterator[dict[str, list[tuple]]]:
+        endpoints_output: dict[str, list[tuple]] = defaultdict(list)
+        try:
+            yield endpoints_output
+        finally:
+            if write_output:
+                logger.debug(
+                    "Pushing model monitoring application job data to the writer stream",
+                    passed_stream_profile=str(stream_profile),
+                )
+                project_name = (
+                    mlrun.mlconf.active_project or mlrun.get_current_project().name
+                )
+                writer_stream = mm_helpers.get_output_stream(
+                    project=project_name,
+                    function_name=mm_constants.MonitoringFunctionNames.WRITER,
+                    profile=stream_profile,
+                )
+                for endpoint_id, outputs in endpoints_output.items():
+                    writer_stream.push(
+                        [
+                            _serialize_context_and_result(context=ctx, result=res)
+                            for ctx, res in outputs
+                        ],
+                        partition_key=endpoint_id,
+                    )
+                logger.debug(
+                    "Pushed the data to all the relevant model endpoints successfully",
+                    endpoints_output=endpoints_output,
+                )
+
     def _handler(
         self,
         context: "mlrun.MLClientCtx",
@@ -170,6 +211,8 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         start: Optional[str] = None,
         end: Optional[str] = None,
         base_period: Optional[int] = None,
+        write_output: bool = False,
+        stream_profile: Optional[ds_profile.DatastoreProfile] = None,
     ):
         """
         A custom handler that wraps the application's logic implemented in
@@ -177,46 +220,69 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         for an MLRun job.
         This method should not be called directly.
         """
+
+        if write_output and (
+            not endpoints or sample_data is not None or reference_data is not None
+        ):
+            raise mlrun.errors.MLRunValueError(
+                "Writing the results of an application to the TSDB is possible only when "
+                "working with endpoints, without any custom data-frame input"
+            )
+
         feature_stats = (
             mm_api.get_sample_set_statistics(reference_data)
             if reference_data is not None
             else None
         )
 
-        def call_do_tracking(event: Optional[dict] = None):
-            if event is None:
-                event = {}
-            monitoring_context = mm_context.MonitoringApplicationContext._from_ml_ctx(
-                event=event,
-                application_name=self.__class__.__name__,
-                context=context,
-                sample_df=sample_data,
-                feature_stats=feature_stats,
-            )
-            return self.do_tracking(monitoring_context)
+        with self._push_to_writer(
+            write_output=write_output, stream_profile=stream_profile
+        ) as endpoints_output:
 
-        if endpoints is not None:
-            for window_start, window_end in self._window_generator(
-                start, end, base_period
-            ):
-                for endpoint_name, endpoint_id in endpoints:
-                    result = call_do_tracking(
-                        event={
-                            mm_constants.ApplicationEvent.ENDPOINT_NAME: endpoint_name,
-                            mm_constants.ApplicationEvent.ENDPOINT_ID: endpoint_id,
-                            mm_constants.ApplicationEvent.START_INFER_TIME: window_start,
-                            mm_constants.ApplicationEvent.END_INFER_TIME: window_end,
-                        }
-                    )
-                    result_key = (
-                        f"{endpoint_name}-{endpoint_id}_{window_start.isoformat()}_{window_end.isoformat()}"
-                        if window_start and window_end
-                        else f"{endpoint_name}-{endpoint_id}"
-                    )
+            def call_do_tracking(event: Optional[dict] = None):
+                nonlocal endpoints_output
 
-                    context.log_result(result_key, self._flatten_data_result(result))
-        else:
-            return self._flatten_data_result(call_do_tracking())
+                if event is None:
+                    event = {}
+                monitoring_context = (
+                    mm_context.MonitoringApplicationContext._from_ml_ctx(
+                        event=event,
+                        application_name=self.__class__.__name__,
+                        context=context,
+                        sample_df=sample_data,
+                        feature_stats=feature_stats,
+                    )
+                )
+                result = self.do_tracking(monitoring_context)
+                endpoints_output[monitoring_context.endpoint_id].append(
+                    (monitoring_context, result)
+                )
+                return result
+
+            if endpoints is not None:
+                for window_start, window_end in self._window_generator(
+                    start, end, base_period
+                ):
+                    for endpoint_name, endpoint_id in endpoints:
+                        result = call_do_tracking(
+                            event={
+                                mm_constants.ApplicationEvent.ENDPOINT_NAME: endpoint_name,
+                                mm_constants.ApplicationEvent.ENDPOINT_ID: endpoint_id,
+                                mm_constants.ApplicationEvent.START_INFER_TIME: window_start,
+                                mm_constants.ApplicationEvent.END_INFER_TIME: window_end,
+                            }
+                        )
+                        result_key = (
+                            f"{endpoint_name}-{endpoint_id}_{window_start.isoformat()}_{window_end.isoformat()}"
+                            if window_start and window_end
+                            else f"{endpoint_name}-{endpoint_id}"
+                        )
+
+                        context.log_result(
+                            result_key, self._flatten_data_result(result)
+                        )
+            else:
+                return self._flatten_data_result(call_do_tracking())
 
     @staticmethod
     def _handle_endpoints_type_evaluate(
@@ -381,6 +447,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         * ``start``, ``datetime``
         * ``end``, ``datetime``
         * ``base_period``, ``int``
+        * ``write_output``, ``bool``
 
         For Git sources, add the source archive to the returned job and change the handler:
 
@@ -463,6 +530,8 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
         base_period: Optional[int] = None,
+        write_output: bool = False,
+        stream_profile: Optional[ds_profile.DatastoreProfile] = None,
     ) -> "mlrun.RunObject":
         """
         Call this function to run the application's
@@ -513,6 +582,11 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                                   ..., (\\operatorname{start} +
                                   m\\cdot\\operatorname{base\\_period}, \\operatorname{end}]`,
                                   where :math:`m` is some positive integer.
+        :param write_output:      Whether to write the results and metrics to the time-series DB. Can be ``True`` only
+                                  if ``endpoints`` are passed.
+                                  Note: the model monitoring infrastructure must be up for the writing to work.
+        :param stream_profile:    The stream profile, relevant only when running locally (``run_local=True``) and
+                                  ``write_output`` is ``True``.
 
         :returns: The output of the
                   :py:meth:`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.do_tracking`
@@ -550,9 +624,24 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 )
                 params["end"] = end.isoformat() if isinstance(end, datetime) else end
                 params["base_period"] = base_period
+                params["write_output"] = write_output
+                if stream_profile:
+                    if not run_local:
+                        raise mlrun.errors.MLRunValueError(
+                            "Passing a `stream_profile` is relevant only when running locally"
+                        )
+                    if not write_output:
+                        raise mlrun.errors.MLRunValueError(
+                            "Passing a `stream_profile` is relevant only when writing the outputs"
+                        )
+                params["stream_profile"] = stream_profile
         elif start or end or base_period:
             raise mlrun.errors.MLRunValueError(
                 "Custom `start` and `end` times or base_period are supported only with endpoints data"
+            )
+        elif write_output or stream_profile:
+            raise mlrun.errors.MLRunValueError(
+                "Writing the application output or passing `stream_profile` are supported only with endpoints data"
             )
 
         inputs: dict[str, str] = {}

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -585,8 +585,11 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         :param write_output:      Whether to write the results and metrics to the time-series DB. Can be ``True`` only
                                   if ``endpoints`` are passed.
                                   Note: the model monitoring infrastructure must be up for the writing to work.
-        :param stream_profile:    The stream profile, relevant only when running locally (``run_local=True``) and
-                                  ``write_output`` is ``True``.
+        :param stream_profile:    The stream datastore profile. It should be provided only when running locally and
+                                  writing the outputs to the database (i.e., when both ``run_local`` and
+                                  ``write_output`` are set to ``True``).
+                                  For more details on configuring the stream profile, see
+                                  :py:meth:`~mlrun.projects.MlrunProject.set_model_monitoring_credentials`.
 
         :returns: The output of the
                   :py:meth:`~mlrun.model_monitoring.applications.ModelMonitoringApplicationBase.do_tracking`

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import socket
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -29,6 +30,48 @@ import mlrun.model_monitoring.applications.context as mm_context
 import mlrun.model_monitoring.applications.results as mm_results
 from mlrun.serving.utils import MonitoringApplicationToDict
 from mlrun.utils import logger
+
+
+def _serialize_context_and_result(
+    *,
+    context: mm_context.MonitoringApplicationContext,
+    result: Union[
+        mm_results.ModelMonitoringApplicationResult,
+        mm_results.ModelMonitoringApplicationMetric,
+        mm_results._ModelMonitoringApplicationStats,
+    ],
+) -> dict[mm_constants.WriterEvent, str]:
+    """
+    Serialize the returned result from a model monitoring application and its context
+    for the writer.
+    """
+    writer_event = {
+        mm_constants.WriterEvent.ENDPOINT_NAME: context.endpoint_name,
+        mm_constants.WriterEvent.APPLICATION_NAME: context.application_name,
+        mm_constants.WriterEvent.ENDPOINT_ID: context.endpoint_id,
+        mm_constants.WriterEvent.START_INFER_TIME: context.start_infer_time.isoformat(
+            sep=" ", timespec="microseconds"
+        ),
+        mm_constants.WriterEvent.END_INFER_TIME: context.end_infer_time.isoformat(
+            sep=" ", timespec="microseconds"
+        ),
+    }
+
+    if isinstance(result, mm_results.ModelMonitoringApplicationResult):
+        writer_event[mm_constants.WriterEvent.EVENT_KIND] = (
+            mm_constants.WriterEventKind.RESULT
+        )
+    elif isinstance(result, mm_results._ModelMonitoringApplicationStats):
+        writer_event[mm_constants.WriterEvent.EVENT_KIND] = (
+            mm_constants.WriterEventKind.STATS
+        )
+    else:
+        writer_event[mm_constants.WriterEvent.EVENT_KIND] = (
+            mm_constants.WriterEventKind.METRIC
+        )
+    writer_event[mm_constants.WriterEvent.DATA] = json.dumps(result.to_dict())
+
+    return writer_event
 
 
 class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -22,14 +22,11 @@ import numpy as np
 import pandas as pd
 
 import mlrun
-import mlrun.artifacts
 import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.data_types.infer
 import mlrun.datastore.datastore_profile
-import mlrun.model_monitoring
 import mlrun.platforms.iguazio
-import mlrun.utils.helpers
 from mlrun.common.schemas import ModelEndpoint
 from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointMonitoringMetric,

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -25,6 +25,7 @@ import pytest
 
 import mlrun
 from mlrun.common.schemas.model_monitoring import ResultKindApp, ResultStatusApp
+from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
 from mlrun.model_monitoring.applications import (
     ModelMonitoringApplicationBase,
     ModelMonitoringApplicationMetric,
@@ -178,6 +179,67 @@ class TestEvaluate:
         assert (
             "Read the sample data" in captured.out
         ), "The expected log message was not found in the captured output"
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("endpoints", "start", "end", "run_local", "write_output", "error_msg"),
+        [
+            (
+                [("ep-name", "ep-uid")],
+                datetime(2025, 5, 3),
+                datetime(2025, 5, 4),
+                False,
+                True,
+                "`stream_profile` is relevant only when running locally",
+            ),
+            (
+                [("ep-name", "ep-uid")],
+                datetime(2025, 5, 3),
+                datetime(2025, 5, 4),
+                True,
+                False,
+                "`stream_profile` is relevant only when writing the outputs",
+            ),
+            (
+                None,
+                datetime(2025, 5, 3),
+                datetime(2025, 5, 4),
+                False,
+                True,
+                "Custom `start` and `end` times .+ supported only with endpoints data",
+            ),
+            (
+                None,
+                None,
+                None,
+                False,
+                False,
+                "or passing `stream_profile` are supported only with endpoints data",
+            ),
+        ],
+    )
+    def test_invalid_params(
+        endpoints: Optional[list[tuple[str, str]]],
+        start: Optional[datetime],
+        end: Optional[datetime],
+        run_local: bool,
+        write_output: bool,
+        error_msg: str,
+    ) -> None:
+        with pytest.raises(mlrun.errors.MLRunValueError, match=error_msg):
+            ModelEndpointAccessApp.evaluate(
+                func_path=__file__,
+                endpoints=endpoints,
+                start=start,
+                end=end,
+                run_local=run_local,
+                write_output=write_output,
+                stream_profile=DatastoreProfileKafkaSource(
+                    name="should-not-be-passed-on-remote",
+                    brokers=["broker-address:9092"],
+                    topics=[],
+                ),
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -43,6 +43,10 @@ import mlrun.feature_store
 import mlrun.feature_store as fstore
 import mlrun.model_monitoring
 import mlrun.model_monitoring.api
+from mlrun.common.schemas.model_monitoring import ResultKindApp
+from mlrun.common.schemas.model_monitoring.model_endpoints import (
+    ModelEndpointMonitoringMetric,
+)
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
     DatastoreProfileKafkaSource,
@@ -1545,7 +1549,8 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
             executor.submit(self._deploy_model_serving)
 
     @pytest.mark.parametrize("run_local", [False, True])
-    def test_count_app(self, run_local: bool) -> None:
+    @pytest.mark.parametrize("write_output", [True])
+    def test_count_app(self, run_local: bool, write_output: bool) -> None:
         # Set up the serving function with a model endpoint, and the necessary infrastructure
         self._setup_resources()
 
@@ -1596,6 +1601,7 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
                 model_endpoint.metadata.name,
             ],
         ]
+
         for i, endpoints in enumerate(endpoints_params):
             run_result = CountApp.evaluate(
                 func_path=str(Path(__file__).parent / "assets/application.py"),
@@ -1606,6 +1612,10 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
                 run_local=run_local,
                 image=self.image,
                 base_period=1,
+                write_output=write_output,
+                stream_profile=(
+                    self.mm_stream_profile if run_local and write_output else None
+                ),
             )
 
             # Test the state
@@ -1640,6 +1650,32 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
                     "result_extra_data": "{}",
                 },
             ], "The outputs are different than expected"
+
+            if write_output:
+                # Test that the outputs were written in the database
+                db = typing.cast(mlrun.db.httpdb.HTTPRunDB, mlrun.get_run_db())
+                # Wait for the writer to get the data and write it
+                time.sleep(5)
+                metrics = db.get_model_endpoint_monitoring_metrics(
+                    project=self.project_name, endpoint_id=model_endpoint.metadata.uid
+                )
+                assert metrics == [
+                    ModelEndpointMonitoringMetric(
+                        project=self.project_name,
+                        app="CountApp",
+                        type="result",
+                        name="count",
+                        full_name=f"{self.project_name}.CountApp.result.count",
+                        kind=ResultKindApp.model_performance,
+                    ),
+                    ModelEndpointMonitoringMetric(
+                        project=self.project_name,
+                        app="mlrun-infra",
+                        type="metric",
+                        name="invocations",
+                        full_name=f"{self.project_name}.mlrun-infra.metric.invocations",
+                    ),
+                ], "The metrics from the database are different than expected"
 
 
 class TestBatchServingWithSampling(TestMLRunSystemModelMonitoring):


### PR DESCRIPTION
Implements [ML-10152](https://iguazio.atlassian.net/browse/ML-10152).

This PR connects the model monitoring application `evaluate` (and the underlying job) to the relevant databases.

When the `write_output` argument is set to `True`, the job sends the results to the writer.
The stream profile and secrets are fetched from the environment variables and k8s secrets in a remote job, or can be passed with the `stream_profile` parameter when running locally.

Note: the credentials and infrastructure resources have to be set and enabled for this to work.

Upcoming PRs will improve the support with regard to more sophisticated aspects and error handling.

The tests and the extended system test cover the new functionality.

[ML-10152]: https://iguazio.atlassian.net/browse/ML-10152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ