### PR TITLE
[CI] Fix system test failures on missing _sessionstarttime [1.9.x]

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -64,7 +64,12 @@ def post_report_session_finish_to_slack(
     reporter: TerminalReporter = session.config.pluginmanager.get_plugin(
         "terminalreporter"
     )
-    test_duration = time.time() - reporter._sessionstarttime
+
+    # pytest < 8.4
+    if hasattr(reporter, "_sessionstarttime"):
+        test_duration = time.time() - reporter._sessionstarttime
+    else:
+        test_duration = reporter._session_start.elapsed()
     mlrun_version = os.getenv("MLRUN_VERSION", "")
     mlrun_current_branch = os.getenv("MLRUN_SYSTEM_TESTS_BRANCH", "")
     mlrun_system_tests_component = os.getenv("MLRUN_SYSTEM_TESTS_COMPONENT", "")


### PR DESCRIPTION
(cherry picked from commit 942c3e74cd8aa27aab0f75cd5e9ddda1d1015aa3)