### PR TITLE
[Nuclio] Fix spec enrichment if base_spec is not empty

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -340,7 +340,7 @@ def _compile_function_config(
             if not mlrun.utils.get_in(config, key):
                 mlrun.utils.update_in(config, key, {})
 
-        if not mlrun.utils.get_in(config,     "spec.handler"):
+        if not mlrun.utils.get_in(config, "spec.handler"):
             # if handler was not set, we set it to the default value
             mlrun.utils.update_in(config, "spec.handler", handler or "main:handler")
         config = nuclio.config.extend_config(

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -331,12 +331,21 @@ def _compile_function_config(
             # if base_spec was not set (when not using code_to_function) and we have base64 code
             # we create the base spec with essential attributes
             config = nuclio.config.new_config()
-            mlrun.utils.update_in(config, "spec.handler", handler or "main:handler")
 
+        # if base_spec comes from client side, make sure that labels and annotations exists in dictionary
+        for key in [
+            "metadata.labels",
+            "metadata.annotations",
+        ]:
+            if not mlrun.utils.get_in(config, key):
+                mlrun.utils.update_in(config, key, {})
+
+        if not mlrun.utils.get_in(config,     "spec.handler"):
+            # if handler was not set, we set it to the default value
+            mlrun.utils.update_in(config, "spec.handler", handler or "main:handler")
         config = nuclio.config.extend_config(
             config, nuclio_spec, tag, function.spec.build.code_origin
         )
-
         if (
             function.kind == mlrun.runtimes.RuntimeKinds.serving
             and not mlrun.utils.get_in(config, "spec.build.functionSourceCode")

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -332,13 +332,7 @@ def _compile_function_config(
             # we create the base spec with essential attributes
             config = nuclio.config.new_config()
 
-        # if base_spec comes from client side, make sure that labels and annotations exists in dictionary
-        for key in [
-            "metadata.labels",
-            "metadata.annotations",
-        ]:
-            if not mlrun.utils.get_in(config, key):
-                mlrun.utils.update_in(config, key, {})
+        _set_function_metadata(function, config)
 
         if not mlrun.utils.get_in(config, "spec.handler"):
             # if handler was not set, we set it to the default value
@@ -364,11 +358,11 @@ def _compile_function_config(
             kind=function.spec.function_kind,
             verbose=function.verbose,
         )
+        _set_function_metadata(function, config)
 
     mlrun.utils.update_in(
         config, "spec.volumes", function.spec.generate_nuclio_volumes()
     )
-    _set_function_metadata(function, config)
     _resolve_and_set_base_image(function, config, client_version, client_python_version)
     _resolve_and_set_nuclio_runtime(
         function, config, client_version, client_python_version
@@ -387,6 +381,14 @@ def _set_function_metadata(function, config):
     labels = function.metadata.labels or {}
     labels.update({mlrun_constants.MLRunInternalLabels.mlrun_class: function.kind})
     annotations = function.metadata.annotations or {}
+
+    # make sure that labels and annotations exists in dictionary
+    for key in [
+        "metadata.labels",
+        "metadata.annotations",
+    ]:
+        if not mlrun.utils.get_in(config, key):
+            mlrun.utils.update_in(config, key, {})
 
     _apply_escaped_config(config, "metadata.labels", labels)
     _apply_escaped_config(config, "metadata.annotations", annotations)

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -43,10 +43,11 @@ def test_compiled_function_config_nuclio_golang():
 
 def test_compiled_function_config_nuclio_python():
     name = f"{assets_path}/training.py"
-    fn = mlrun.code_to_function(
-        "nuclio", filename=name, kind="nuclio", handler="my_hand"
+    project = mlrun.get_or_create_project("test")
+    fn = project.set_function(
+        name, name="nuclio", kind="nuclio", handler="my_hand"
     )
-    fn.metadata.annotations = {"something": "somewhat"}
+    fn.with_annotations({"something": "somewhat"})
     (
         name,
         project,

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -44,9 +44,7 @@ def test_compiled_function_config_nuclio_golang():
 def test_compiled_function_config_nuclio_python():
     name = f"{assets_path}/training.py"
     project = mlrun.get_or_create_project("test")
-    fn = project.set_function(
-        name, name="nuclio", kind="nuclio", handler="my_hand"
-    )
+    fn = project.set_function(name, name="nuclio", kind="nuclio", handler="my_hand")
     fn.with_annotations({"something": "somewhat"})
     (
         name,


### PR DESCRIPTION
Jira - https://iguazio.atlassian.net/browse/ML-10206

Test doesn't work without fix. In general, it is better to use `set_function` in tests than `code_to_function` because their behaviour is different. 

The root cause is that if base_spec is not empty, then we do not get a basic config - https://github.com/nuclio/nuclio-jupyter/blob/21b122bf97b86e1926fd0a74b951f377da42f8bb/nuclio/config.py#L37-L54 and as a result, we fail on not having labels key here https://github.com/nuclio/nuclio-jupyter/blob/21b122bf97b86e1926fd0a74b951f377da42f8bb/nuclio/config.py#L391.

tested on a system:
![image](https://github.com/user-attachments/assets/03e404f5-4420-4615-a32b-12a55429a19e)
![image](https://github.com/user-attachments/assets/6f205d06-3816-4a5c-b162-327889a29da1)
