### PR TITLE
[Deprecations] Change functionality of `allow_cross_project` in `mlrun.load_project`

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -23,6 +23,7 @@ from ast import literal_eval
 from base64 import b64decode
 from os import environ, path, remove
 from pprint import pprint
+from typing import Optional
 
 import click
 import dotenv
@@ -202,6 +203,7 @@ def main():
 @click.option(
     "--allow-cross-project",
     is_flag=True,
+    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )
@@ -505,6 +507,7 @@ def run(
 @click.option(
     "--allow-cross-project",
     is_flag=True,
+    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )
@@ -663,6 +666,7 @@ def build(
 @click.option(
     "--allow-cross-project",
     is_flag=True,
+    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )
@@ -998,6 +1002,7 @@ def logs(uid, project, offset, db):
 @click.option(
     "--allow-cross-project",
     is_flag=True,
+    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )
@@ -1370,7 +1375,9 @@ def dict_to_str(struct: dict):
 
 
 def func_url_to_runtime(
-    func_url, ensure_project: bool = False, allow_cross_project: bool = None
+    func_url,
+    ensure_project: bool = False,
+    allow_cross_project: Optional[bool] = None,
 ):
     try:
         if func_url.startswith("db://"):

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -199,6 +199,12 @@ def main():
     multiple=True,
     help="Logging configurations for the handler's returning values",
 )
+@click.option(
+    "--allow-cross-project",
+    is_flag=True,
+    help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
+    "as a baseline for a new project with a different name",
+)
 def run(
     url,
     param,
@@ -242,6 +248,7 @@ def run(
     run_args,
     ensure_project,
     returns,
+    allow_cross_project,
 ):
     """Execute a task and inject parameters."""
 
@@ -293,10 +300,11 @@ def run(
         mlrun.get_or_create_project(
             name=project,
             context="./",
+            allow_cross_project=allow_cross_project,
         )
     if func_url or kind:
         if func_url:
-            runtime = func_url_to_runtime(func_url, ensure_project)
+            runtime = func_url_to_runtime(func_url, ensure_project, allow_cross_project)
             kind = get_in(runtime, "kind", kind or "job")
             if runtime is None:
                 exit(1)
@@ -494,6 +502,12 @@ def run(
     default="/tmp/fullimage",
     help="path to file with full image data",
 )
+@click.option(
+    "--allow-cross-project",
+    is_flag=True,
+    help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
+    "as a baseline for a new project with a different name",
+)
 def build(
     func_url,
     name,
@@ -516,6 +530,7 @@ def build(
     state_file_path,
     image_file_path,
     full_image_file_path,
+    allow_cross_project,
 ):
     """Build a container image from code and requirements."""
 
@@ -591,6 +606,7 @@ def build(
         mlrun.get_or_create_project(
             name=project,
             context="./",
+            allow_cross_project=allow_cross_project,
         )
 
     if hasattr(func, "deploy"):
@@ -644,6 +660,12 @@ def build(
     is_flag=True,
     help="ensure the project exists, if not, create project",
 )
+@click.option(
+    "--allow-cross-project",
+    is_flag=True,
+    help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
+    "as a baseline for a new project with a different name",
+)
 def deploy(
     spec,
     source,
@@ -656,6 +678,7 @@ def deploy(
     verbose,
     env_file,
     ensure_project,
+    allow_cross_project,
 ):
     """Deploy model or function"""
     if env_file:
@@ -665,10 +688,11 @@ def deploy(
         mlrun.get_or_create_project(
             name=project,
             context="./",
+            allow_cross_project=allow_cross_project,
         )
 
     if func_url:
-        runtime = func_url_to_runtime(func_url, ensure_project)
+        runtime = func_url_to_runtime(func_url, ensure_project, allow_cross_project)
         if runtime is None:
             exit(1)
     elif spec:
@@ -971,6 +995,12 @@ def logs(uid, project, offset, db):
     "destination define: file=notification.json or a "
     'dictionary configuration e.g \'{"slack":{"webhook":"<webhook>"}}\'',
 )
+@click.option(
+    "--allow-cross-project",
+    is_flag=True,
+    help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
+    "as a baseline for a new project with a different name",
+)
 def project(
     context,
     name,
@@ -998,6 +1028,7 @@ def project(
     notifications,
     save_secrets,
     save,
+    allow_cross_project,
 ):
     """load and/or run a project"""
     if env_file:
@@ -1024,6 +1055,7 @@ def project(
         clone=clone,
         save=save,
         parameters=parameters,
+        allow_cross_project=allow_cross_project,
     )
     url_str = " from " + url if url else ""
     print(f"Loading project {proj.name}{url_str} into {context}:\n")
@@ -1337,7 +1369,9 @@ def dict_to_str(struct: dict):
     return ",".join([f"{k}={v}" for k, v in struct.items()])
 
 
-def func_url_to_runtime(func_url, ensure_project: bool = False):
+def func_url_to_runtime(
+    func_url, ensure_project: bool = False, allow_cross_project: bool = None
+):
     try:
         if func_url.startswith("db://"):
             func_url = func_url[5:]
@@ -1348,7 +1382,9 @@ def func_url_to_runtime(func_url, ensure_project: bool = False):
             func_url = "function.yaml" if func_url == "." else func_url
             runtime = import_function_to_dict(func_url, {})
         else:
-            mlrun_project = load_project(".", save=ensure_project)
+            mlrun_project = load_project(
+                ".", save=ensure_project, allow_cross_project=allow_cross_project
+            )
             function = mlrun_project.get_function(func_url, enrich=True)
             if function.kind == "local":
                 command, function = load_func_code(function)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -757,14 +757,7 @@ def _project_instance_from_struct(struct, name, allow_cross_project):
             "3. Use different project context dir."
         )
 
-        if allow_cross_project is None:
-            # TODO: Remove this warning in version 1.10.0 and also fix cli to support allow_cross_project
-            warnings.warn(
-                f"Project {name=} is different than specified on the context's project yaml. "
-                "This behavior is deprecated and will not be supported from version 1.10.0."
-            )
-            logger.warn(error_message)
-        elif allow_cross_project:
+        if allow_cross_project:
             logger.debug(
                 "Project name is different than specified on the context's project yaml. Overriding.",
                 existing_name=name_from_struct,

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -101,7 +101,7 @@ class TestEvaluate:
     @staticmethod
     @pytest.fixture(autouse=True)
     def _set_project() -> Iterator[None]:
-        project = mlrun.get_or_create_project("test")
+        project = mlrun.get_or_create_project("test", allow_cross_project=True)
         with patch("mlrun.db.nopdb.NopDB.get_project", Mock(return_value=project)):
             yield
 

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -41,7 +41,7 @@ assets_folder = Path(__file__).parent / "assets"
 
 @pytest.fixture
 def project(tmp_path: Path) -> mlrun.MlrunProject:
-    project = mlrun.get_or_create_project("temp")
+    project = mlrun.get_or_create_project("temp", allow_cross_project=True)
     project.artifact_path = str(tmp_path)
     return project
 

--- a/tests/model_monitoring/test_monitoring_api.py
+++ b/tests/model_monitoring/test_monitoring_api.py
@@ -168,7 +168,7 @@ def _get_metrics(
 def test_project_create_model_monitoring_alert_configs() -> None:
     db_mock = Mock(spec=RunDBInterface)
     db_mock.get_metrics_by_multiple_endpoints.side_effect = _get_metrics
-    project = mlrun.get_or_create_project("mm-project")
+    project = mlrun.get_or_create_project("mm-project", allow_cross_project=True)
 
     notification = Notification(
         kind=NotificationKind.mail,

--- a/tests/model_monitoring/test_stream_processing.py
+++ b/tests/model_monitoring/test_stream_processing.py
@@ -47,7 +47,7 @@ def test_plot_monitoring_serving_graph(
     tsdb_profile: DatastoreProfile, stream_profile: DatastoreProfile
 ) -> None:
     project_name = "test-stream-processing"
-    project = mlrun.get_or_create_project(project_name)
+    project = mlrun.get_or_create_project(project_name, allow_cross_project=True)
 
     processor = EventStreamProcessor(project_name, 1000, 10, "mytarget")
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -252,8 +252,8 @@ def test_build_project_from_minimal_dict():
             3,
             True,
             "",
-            False,
-            "",
+            True,
+            "Project name mismatch",
         ),
         (
             pathlib.Path(tests.conftest.tests_root_directory)

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -314,7 +314,7 @@ def test_get_or_create_ctx_run_kind():
 
 
 def test_get_or_create_ctx_run_kind_local_from_function():
-    project = mlrun.get_or_create_project("dummy-project")
+    project = mlrun.get_or_create_project("dummy-project", allow_cross_project=True)
     project.set_function(
         name="func",
         func=f"{assets_path}/simple.py",

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -333,7 +333,7 @@ def test_deploy_reverse_proxy_image(rundb_mock, igz_version_mock):
 
 
 def test_application_from_local_file_validation():
-    project = mlrun.get_or_create_project("test-application")
+    project = mlrun.get_or_create_project("test-application", allow_cross_project=True)
     func_path = assets_path / "sample_function.py"
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,

--- a/tests/serving/test_tracking.py
+++ b/tests/serving/test_tracking.py
@@ -190,7 +190,7 @@ def rec_to_data(rec):
 
 @pytest.fixture
 def project() -> mlrun.MlrunProject:
-    return mlrun.get_or_create_project("test-tracking")
+    return mlrun.get_or_create_project("test-tracking", allow_cross_project=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
 Project name differs from the name specified in the context's project YAML.
This functionality is no longer supported. If you want to enable this behavior, you can take one of the following actions:

1. Set `allow_cross_project=True` when loading the project.
2. Delete the existing project YAML, or ensure its name field matches the actual project name.
3. Use a different project context directory.

Previously, when `allow_cross_project` was not set (None), it implicitly behaved as if it were True, with a warning. Now, if you want this functionality, you must explicitly set `allow_cross_project=True`.

Also, added support for `allow_cross_project` in the CLI with default as true.

https://iguazio.atlassian.net/browse/ML-10062