### PR TITLE
[Serving] Fix Nuclio serving spec breakage

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -347,7 +347,6 @@ def _compile_function_config(
         config,
         "spec.volumes",
         function.spec.generate_nuclio_volumes(),
-        append=True,
     )
     _resolve_and_set_base_image(function, config, client_version, client_python_version)
     _resolve_and_set_nuclio_runtime(

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -35,7 +35,7 @@ import mlrun.runtimes.utils
 import mlrun.utils
 import mlrun.utils.regex
 from mlrun.model import RunSpec, RunTemplate
-from mlrun.runtimes import KubejobRuntime
+from mlrun.runtimes import KubejobRuntime, RemoteRuntime
 
 import framework.api.utils
 import framework.utils.helpers
@@ -434,14 +434,14 @@ class ServerSideLauncher(launcher.BaseLauncher):
             ]
 
         serving_spec = getattr(runtime, "serving_spec", None)
-        if serving_spec:
+        if serving_spec and isinstance(runtime, (KubejobRuntime, RemoteRuntime)):
             serving_spec_volume = self._configure_serving_spec(
                 client_version=client_version,
                 function=runtime,
                 project=project.name,
                 serving_spec=serving_spec,
             )
-            if serving_spec_volume and isinstance(runtime, KubejobRuntime):
+            if serving_spec_volume:
                 runtime.spec.volumes = runtime.spec.volumes + [
                     serving_spec_volume["volume"]
                 ]


### PR DESCRIPTION
Following #8043. This fixes the following error:
```
  File "/opt/nuclio/v2_model_server.py", line 42, in init_context
    nuclio_init_hook(context, globals(), 'serving_v2')
  File "/opt/conda/lib/python3.11/site-packages/mlrun/runtimes/nuclio/nuclio.py", line 34, in nuclio_init_hook
    v2_serving_init(context, data)
  File "/opt/conda/lib/python3.11/site-packages/mlrun/serving/server.py", line 373, in v2_serving_init
    spec = mlrun.utils.get_serving_spec()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/mlrun/utils/helpers.py", line 1911, in get_serving_spec
    raise mlrun.errors.MLRunInvalidArgumentError(
mlrun.errors.MLRunInvalidArgumentError: Failed to find serving spec in env var or config file
```