### PR TITLE
[Model Monitoring] Support Nuclio annotations in Kafka datastore profile

### DIFF
--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -236,9 +236,11 @@ class KafkaParameters:
             "partitions": "",
             "sasl": "",
             "worker_allocation_mode": "",
-            "tls_enable": "",  # for Nuclio with Confluent Kafka (Sarama client)
+            # for Nuclio with Confluent Kafka
+            "tls_enable": "",
             "tls": "",
             "new_topic": "",
+            "nuclio_annotations": "",
         }
         self._reference_dicts = (
             self._custom_attributes,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3855,7 +3855,8 @@ class MlrunProject(ModelObj):
             )
 
         The replication factor and timeout configuration might need to be adjusted according to your Confluent cluster
-        type and settings.
+        type and settings. Nuclio annotations for the model monitoring infrastructure and application functions are
+        supported through ``kwargs_public={"nuclio_annotations": {...}, ...}``.
 
         :param tsdb_profile_name:         The datastore profile name of the time-series database to be used in model
                                           monitoring. The supported profiles are:

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -29,7 +29,6 @@ import kafka.errors
 import nuclio
 import sqlalchemy.orm
 import v3io.dataplane
-import v3io.dataplane.response
 from fastapi import BackgroundTasks
 from fastapi.concurrency import run_in_threadpool
 
@@ -395,6 +394,13 @@ class MonitoringDeployment:
                 raise exc
 
         function = stream_source.add_nuclio_trigger(function)
+        if nuclio_annotations := profile_attributes.get("nuclio_annotations"):
+            if not isinstance(nuclio_annotations, dict):
+                raise mlrun.errors.MLRunInvalidArgumentTypeError(
+                    "The Kafka datastore profile includes an invalid `nuclio_annotations` configuration. "
+                    f"Expected a dictionary or `None`, but received: {nuclio_annotations = }"
+                )
+            function.with_annotations(nuclio_annotations)
         function.spec.min_replicas = stream_args.kafka.min_replicas
         function.spec.max_replicas = stream_args.kafka.max_replicas
 

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -23,6 +23,7 @@ import taosws
 
 import mlrun.common.schemas
 import mlrun.runtimes
+from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
 
 import services.api
 import services.api.crud.model_monitoring.deployment as mm_dep
@@ -163,3 +164,62 @@ class TestAppDeployment:
             )
 
             secrets = monitoring_deployment._get_monitoring_mandatory_project_secrets()
+
+
+@pytest.mark.parametrize(
+    "nuclio_annotations",
+    [
+        {
+            "nuclio.io/kafka-metadata-retry-max": "10000",
+            "nuclio.io/kafka-metadata-timeout": "1200s",
+        },
+        None,
+    ],
+)
+@patch("mlrun.datastore.sources.KafkaSource.create_topics")
+def test_apply_and_create_kafka_source(
+    create_topics_mock: Mock,
+    nuclio_annotations: typing.Optional[dict[str, str]],
+    monitoring_deployment: mm_dep.MonitoringDeployment,
+) -> None:
+    """Test that the Kafka trigger is set correctly"""
+    replication_factor = 3
+
+    kafka_profile = DatastoreProfileKafkaSource(
+        name="test-kafka-profile",
+        brokers=["sub.confluent.cloud:9092"],
+        topics=[],
+        sasl_user="usr1",
+        sasl_pass="pass123",
+        kwargs_public={
+            "security_protocol": "SASL_SSL",
+            "api_version_auto_timeout_ms": 15_000,
+            "tls": {"enable": True},
+            "new_topic": {"replication_factor": replication_factor},
+            **(
+                {"nuclio_annotations": nuclio_annotations} if nuclio_annotations else {}
+            ),
+        },
+    )
+
+    fn = mlrun.runtimes.ServingRuntime()
+    monitoring_deployment._apply_and_create_kafka_source(
+        kafka_profile=kafka_profile,
+        function=fn,
+        function_name="test-confluent-trigger",
+        stream_args=mlrun.mlconf.model_endpoint_monitoring.serving_stream,
+        ignore_stream_already_exists_failure=True,
+    )
+
+    create_topics_mock.assert_called_once_with(
+        num_partitions=8, replication_factor=replication_factor
+    )
+
+    kafka_trigger_conf = fn.spec.config.get("spec.triggers.kafka")
+    assert kafka_trigger_conf, "Expected a Kafka trigger"
+    assert (
+        kafka_trigger_conf.get("kind") == "kafka-cluster"
+    ), "Expected `kafka-cluster` kind"
+    assert (
+        fn.spec.base_spec.get("metadata", {}).get("annotations") == nuclio_annotations
+    ), "The set annotations are different than expected"


### PR DESCRIPTION
Fixes [ML-10166](https://iguazio.atlassian.net/browse/ML-10166).
Allow passing extra annotations to Nuclio functions through `DatastoreProfileKafkaSource`.

I tested it works with a system test and added a unit test.

[ML-10166]: https://iguazio.atlassian.net/browse/ML-10166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ