### PR TITLE
[Tests] Fix run updated time and end time verification (#8110)

### DIFF
--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -35,17 +35,13 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
                 with_notifications=True,
             )
             assert len(runs) == 1
-            # Verify that `last_update` and `end_time` are very close in time
-            # This ensures that the final update to the run status happens
-            # at most within 1 millisecond after the run actual end time.
             assert runs[0]["status"]["end_time"]
             assert runs[0]["status"]["last_update"]
             end_time = datetime.datetime.fromisoformat(runs[0]["status"]["end_time"])
             last_updated_time = datetime.datetime.fromisoformat(
                 runs[0]["status"]["last_update"]
             )
-            max_time_delta = datetime.timedelta(milliseconds=1)
-            assert last_updated_time - end_time < max_time_delta
+            assert last_updated_time >= end_time
 
             assert len(runs[0]["status"]["notifications"]) == 2
             for notification_name, notification in runs[0]["status"][


### PR DESCRIPTION
(cherry picked from commit da0b2aeda29ea09ac4befa3ddb91d5cd5f908a52)