### PR TITLE
[Project] Skip source archive setup when source is db

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4269,11 +4269,17 @@ class MlrunProject(ModelObj):
         function = mlrun.new_function("mlrun--project--image--builder", kind="job")
 
         if self.spec.source and not self.spec.load_source_on_run:
-            function.with_source_archive(
-                source=self.spec.source,
-                target_dir=target_dir,
-                pull_at_runtime=False,
-            )
+            if self.spec.source.startswith("db://"):
+                logger.debug(
+                    "Project source is 'db://', which refers to metadata stored in the MLRun DB."
+                    " Skipping source archive setup for image build"
+                )
+            else:
+                function.with_source_archive(
+                    source=self.spec.source,
+                    target_dir=target_dir,
+                    pull_at_runtime=False,
+                )
 
         build = self.spec.build
         result = self.build_function(

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2339,6 +2339,7 @@ def test_set_source():
             "/target/path/for/source",
         ),
         ("git://some/repo", True, None, ".some-image", "/target/path"),
+        ("db://project-name", None, None, ".some-image", None),
     ],
 )
 def test_project_build_image(
@@ -2365,9 +2366,15 @@ def test_project_build_image(
         assert build_config.source is None
         assert source_code_target_dir is None
     else:
-        assert not build_config.load_source_on_run
-        assert build_config.source == source_url
-        assert source_code_target_dir == target_dir
+        if source_url and source_url.startswith("db://"):
+            # db:// is metadata-only, not an actual build source
+            assert build_config.source is None
+            assert source_code_target_dir is None
+            assert build_config.load_source_on_run is None
+        else:
+            assert not build_config.load_source_on_run
+            assert build_config.source == source_url
+            assert source_code_target_dir == target_dir
 
     assert build_config.image == image_name
     # If no base image was used, then mlrun/mlrun is expected


### PR DESCRIPTION
This PR fixes an issue where attempting to build an image for a project with a non-archive source (e.g., a source not pointing to a file path, Git repo, or archive) would result in an error.
MLRun previously tried to set the project source as a source archive unconditionally during `build_image`, which fails for certain valid source types.

The fix ensures that if the project source is not intended to be archived (e.g., managed elsewhere or not relevant to the build), the image build process will skip setting a source archive.

Jira:
https://iguazio.atlassian.net/browse/ML-10178