### PR TITLE
[FeatureStore] Fix project creation in test_spark_engine.py

### DIFF
--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -185,7 +185,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         if not cls.spark_image_deployed:
             # TestMLRunSystem will create this project later in the initialization process, but we need it now
             # to avoid a "project does not exist" error because the default project was dropped in 1.8.0
-            mlrun.get_or_create_project(cls.project_name)
+            mlrun.get_or_create_project(cls.project_name, allow_cross_project=True)
 
             if not cls.test_branch:
                 RemoteSparkRuntime.deploy_default_image()


### PR DESCRIPTION
Due to https://github.com/mlrun/mlrun/pull/8085, If MLRun detects a conflict between the project YAML and the requested project, it will raise an error.

That's why in https://github.com/mlrun/mlrun/pull/5453, we use `allow_cross_project=True` in `TestMLRunSystem`.

[ML-10262](https://iguazio.atlassian.net/browse/ML-10262)

[ML-10262]: https://iguazio.atlassian.net/browse/ML-10262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ