### PR TITLE
[API] Paginate list runs on retry jobs periodic [feature/retry-job]

### DIFF
--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -934,6 +934,7 @@ class Service(framework.service.Service):
         """
         self._logger.debug("Retrying jobs with retry policy configured")
         db_session = await fastapi.concurrency.run_in_threadpool(create_session)
+        fetch_runs_limit = int(mlconf.monitoring.runs.retry.fetch_runs_limit)
         try:
             offset = 0
             while runs := await fastapi.concurrency.run_in_threadpool(
@@ -941,7 +942,7 @@ class Service(framework.service.Service):
                 db_session,
                 project="*",
                 states=[mlrun.common.runtimes.constants.RunStates.pending_retry],
-                limit=int(mlconf.monitoring.runs.retry.fetch_runs_limit),
+                limit=fetch_runs_limit,
                 offset=offset,
             ):
                 self._logger.debug(

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -935,72 +935,72 @@ class Service(framework.service.Service):
         self._logger.debug("Retrying jobs with retry policy configured")
         db_session = await fastapi.concurrency.run_in_threadpool(create_session)
         try:
-            runs = await fastapi.concurrency.run_in_threadpool(
+            offset = 0
+            while runs := await fastapi.concurrency.run_in_threadpool(
                 get_db().list_runs,
                 db_session,
                 project="*",
                 states=[mlrun.common.runtimes.constants.RunStates.pending_retry],
-                limit=mlconf.monitoring.runs.retry.fetch_runs_limit,
-            )
-            if not runs:
-                return
+                limit=int(mlconf.monitoring.runs.retry.fetch_runs_limit),
+                offset=offset,
+            ):
+                self._logger.debug(
+                    "Found runs to retry", runs_count=len(runs), offset=offset
+                )
+                offset = offset + len(runs)
 
-            self._logger.debug(
-                "Found runs to retry",
-                runs_count=len(runs),
-            )
-            futures = []
-            for run_dict in runs:
-                run = mlrun.RunObject.from_dict(run_dict)
-                if run.metadata.uid in self._retry_in_progress_run_uids:
-                    self._logger.debug(
-                        "Run is already being retried, skipping",
-                        run_uid=run.metadata.uid,
-                    )
-                    continue
-
-                # retry_count may be None on the first attempt
-                run.status.retry_count = run.status.retry_count or 0
-                # sanity
-                if not run.status.retry_count < run.spec.retry.count:
-                    self._logger.warn(
-                        "Run has reached max retry count, skipping",
-                        run_uid=run.metadata.uid,
-                        retry_count=run.status.retry_count,
-                        max_retry_count=run.spec.retry.count,
-                    )
-                    futures.append(
-                        fastapi.concurrency.run_in_threadpool(
-                            framework.db.session.run_function_with_new_db_session,
-                            get_db().update_run,
-                            updates={
-                                "status.state": mlrun.common.runtimes.constants.RunStates.error,
-                                "status.status_text": "Run retries exhausted",
-                            },
-                            uid=run.metadata.uid,
-                            project=run.metadata.project,
+                futures = []
+                for run_dict in runs:
+                    run = mlrun.RunObject.from_dict(run_dict)
+                    if run.metadata.uid in self._retry_in_progress_run_uids:
+                        self._logger.debug(
+                            "Run is already being retried, skipping",
+                            run_uid=run.metadata.uid,
                         )
-                    )
-                    continue
+                        continue
 
-                try:
-                    self._submit_run_for_retry(run)
-                except Exception as exc:
-                    self._logger.warning(
-                        "Failed retrying run",
-                        run_uid=run.metadata.uid,
-                        exc=err_to_str(exc),
-                        traceback=traceback.format_exc(),
-                    )
+                    # retry_count may be None on the first attempt
+                    run.status.retry_count = run.status.retry_count or 0
+                    # sanity
+                    if not run.status.retry_count < run.spec.retry.count:
+                        self._logger.warn(
+                            "Run has reached max retry count, skipping",
+                            run_uid=run.metadata.uid,
+                            retry_count=run.status.retry_count,
+                            max_retry_count=run.spec.retry.count,
+                        )
+                        futures.append(
+                            fastapi.concurrency.run_in_threadpool(
+                                framework.db.session.run_function_with_new_db_session,
+                                get_db().update_run,
+                                updates={
+                                    "status.state": mlrun.common.runtimes.constants.RunStates.error,
+                                    "status.status_text": "Run retries exhausted",
+                                },
+                                uid=run.metadata.uid,
+                                project=run.metadata.project,
+                            )
+                        )
+                        continue
 
-            if futures:
-                exceptions = await asyncio.gather(*futures, return_exceptions=True)
-                for exception in exceptions:
-                    if isinstance(exception, Exception):
+                    try:
+                        self._submit_run_for_retry(run)
+                    except Exception as exc:
                         self._logger.warning(
-                            "Failed task in retry job",
-                            exc=err_to_str(exception),
+                            "Failed retrying run",
+                            run_uid=run.metadata.uid,
+                            exc=err_to_str(exc),
+                            traceback=traceback.format_exc(),
                         )
+
+                if futures:
+                    exceptions = await asyncio.gather(*futures, return_exceptions=True)
+                    for exception in exceptions:
+                        if isinstance(exception, Exception):
+                            self._logger.warning(
+                                "Failed task in retry job",
+                                exc=err_to_str(exception),
+                            )
 
         except Exception as exc:
             self._logger.warning(

--- a/server/py/services/api/tests/unit/test_service.py
+++ b/server/py/services/api/tests/unit/test_service.py
@@ -15,6 +15,7 @@ import asyncio
 import datetime
 import typing
 import unittest.mock
+import uuid
 
 from sqlalchemy.orm import Session
 
@@ -80,6 +81,34 @@ class TestService(TestAPIBase):
             await asyncio.sleep(1)
             mock_submit_run_sync.assert_called_once()
             assert not self._service._retry_in_progress_run_uids
+
+    async def test_retry_job_paginated_list_runs(self, db: Session):
+        mlrun.mlconf.monitoring.runs.retry.fetch_runs_limit = 3
+        mlrun.mlconf.function.spec.retry.backoff.min_base_delay = "0s"
+        run_uids = [str(uuid.uuid4()) for _ in range(10)]
+        for run_uid in run_uids:
+            run = self._generate_retry_job(uid=run_uid)
+            mlrun.db.get_run_db().store_run(
+                struct=run, uid=run_uid, project=self._project
+            )
+
+        # Create a running job - should be filtered out
+        running_run_uid = "running_run"
+        run = self._generate_retry_job(
+            uid=running_run_uid, state=mlrun.common.runtimes.constants.RunStates.running
+        )
+        mlrun.db.get_run_db().store_run(
+            struct=run, uid=running_run_uid, project=self._project
+        )
+
+        # There seems to be some OS level caching that prevents the new db session from seeing the new runs immediately.
+        # Also, waiting less than a second does not work.
+        await asyncio.sleep(1)
+        with unittest.mock.patch(
+            "framework.api.utils.submit_run_sync", return_value=unittest.mock.Mock()
+        ) as mock_submit_run_sync:
+            await self._service._retry_jobs()
+            assert mock_submit_run_sync.call_count == 10
 
     def _generate_retry_job(
         self,


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-10253

Having weird issues with the unit tests not being able to see the runs with new session for a second after commit.
Also tried auxiliary function to poll the runs every 0.1 seconds but it returns immediately even with new session on a different thread.