### PR TITLE
[Model Monitoring] Check that the infra is up when writing in evaluate

### DIFF
--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -166,13 +166,29 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         return result
 
     @staticmethod
+    def _check_writer_is_up(project: "mlrun.MlrunProject") -> None:
+        try:
+            project.get_function(
+                mm_constants.MonitoringFunctionNames.WRITER, ignore_cache=True
+            )
+        except mlrun.errors.MLRunNotFoundError:
+            raise mlrun.errors.MLRunValueError(
+                "The model monitoring infrastructure was disabled - cannot write outputs to the databases.\n"
+                "To allow `write_output=True`, re-enable model monitoring with `project.enable_model_monitoring()`."
+            )
+
+    @classmethod
     @contextmanager
     def _push_to_writer(
+        cls,
         *,
         write_output: bool,
         stream_profile: Optional[ds_profile.DatastoreProfile],
+        project: "mlrun.MlrunProject",
     ) -> Iterator[dict[str, list[tuple]]]:
         endpoints_output: dict[str, list[tuple]] = defaultdict(list)
+        if write_output:
+            cls._check_writer_is_up(project)
         try:
             yield endpoints_output
         finally:
@@ -239,7 +255,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         )
 
         with self._push_to_writer(
-            write_output=write_output, stream_profile=stream_profile
+            write_output=write_output, stream_profile=stream_profile, project=project
         ) as endpoints_output:
 
             def call_do_tracking(event: Optional[dict] = None):

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -220,6 +220,9 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         for an MLRun job.
         This method should not be called directly.
         """
+        project = context.get_project_object()
+        if not project:
+            raise mlrun.errors.MLRunValueError("Could not load project from context")
 
         if write_output and (
             not endpoints or sample_data is not None or reference_data is not None
@@ -249,6 +252,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                         event=event,
                         application_name=self.__class__.__name__,
                         context=context,
+                        project=project,
                         sample_df=sample_data,
                         feature_stats=feature_stats,
                     )

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -173,8 +173,8 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             )
         except mlrun.errors.MLRunNotFoundError:
             raise mlrun.errors.MLRunValueError(
-                "The model monitoring infrastructure was disabled - cannot write outputs to the databases.\n"
-                "To allow `write_output=True`, re-enable model monitoring with `project.enable_model_monitoring()`."
+                "Writing outputs to the databases is blocked as the model monitoring infrastructure is disabled.\n"
+                "To unblock, enable model monitoring with `project.enable_model_monitoring()`."
             )
 
     @classmethod

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -137,13 +137,14 @@ class MonitoringApplicationContext:
         cls,
         context: "mlrun.MLClientCtx",
         *,
+        project: Optional["mlrun.MlrunProject"] = None,
         application_name: str,
         event: dict[str, Any],
         model_endpoint_dict: Optional[dict[str, ModelEndpoint]] = None,
         sample_df: Optional[pd.DataFrame] = None,
         feature_stats: Optional[FeatureStats] = None,
     ) -> "MonitoringApplicationContext":
-        project = context.get_project_object()
+        project = project or context.get_project_object()
         if not project:
             raise mlrun.errors.MLRunValueError("Could not load project from context")
         logger = context.logger

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -102,8 +102,11 @@ class TestEvaluate:
     @pytest.fixture(autouse=True)
     def _set_project() -> Iterator[None]:
         project = mlrun.get_or_create_project("test", allow_cross_project=True)
-        with patch("mlrun.db.nopdb.NopDB.get_project", Mock(return_value=project)):
-            yield
+        with patch.object(
+            project, "get_function", Mock(side_effect=mlrun.errors.MLRunNotFoundError)
+        ):
+            with patch("mlrun.db.nopdb.NopDB.get_project", Mock(return_value=project)):
+                yield
 
     @staticmethod
     def test_local_no_params() -> None:
@@ -239,6 +242,29 @@ class TestEvaluate:
                     topics=[],
                 ),
             )
+
+    @staticmethod
+    def test_invalid_infra(capsys: pytest.CaptureFixture) -> None:
+        ModelEndpointAccessApp.evaluate(
+            func_path=__file__,
+            endpoints=[("ep-name", "ep-uid")],
+            start=datetime(2025, 5, 3),
+            end=datetime(2025, 5, 4),
+            run_local=True,
+            write_output=True,
+            stream_profile=DatastoreProfileKafkaSource(
+                name="should-not-be-passed-on-remote",
+                brokers=["broker-address:9092"],
+                topics=[],
+            ),
+        )
+        captured = capsys.readouterr()
+        assert (
+            "mlrun.errors.MLRunValueError: The model monitoring infrastructure was disabled - cannot write outputs "
+            "to the databases.\n"
+            "To allow `write_output=True`, re-enable model monitoring with `project.enable_model_monitoring()`."
+            in captured.out
+        ), "The error message is different than expected or was not captured"
 
 
 @pytest.mark.parametrize(

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -260,9 +260,8 @@ class TestEvaluate:
         )
         captured = capsys.readouterr()
         assert (
-            "mlrun.errors.MLRunValueError: The model monitoring infrastructure was disabled - cannot write outputs "
-            "to the databases.\n"
-            "To allow `write_output=True`, re-enable model monitoring with `project.enable_model_monitoring()`."
+            "Writing outputs to the databases is blocked as the model monitoring infrastructure is disabled.\n"
+            "To unblock, enable model monitoring with `project.enable_model_monitoring()`."
             in captured.out
         ), "The error message is different than expected or was not captured"
 

--- a/tests/model_monitoring/test_features_drift_table.py
+++ b/tests/model_monitoring/test_features_drift_table.py
@@ -83,18 +83,15 @@ def plot_produce(context: mlrun.MLClientCtx):
             inputs=inputs,
         )
     )
-    with patch(
-        "mlrun.get_current_project",
-        Mock(return_value=Mock(spec=mlrun.projects.project.MlrunProject)),
-    ):
-        with mocked_graph_context_project():
-            monitoring_context = mm_context.MonitoringApplicationContext._from_ml_ctx(
-                application_name="histogram-data-drift",
-                event={},
-                context=context,
-            )
-            monitoring_context._feature_stats = inputs_statistics
-            monitoring_context._sample_df_stats = sample_data_statistics
+    with mocked_graph_context_project():
+        monitoring_context = mm_context.MonitoringApplicationContext._from_ml_ctx(
+            application_name="histogram-data-drift",
+            event={},
+            context=context,
+            project=Mock(spec=mlrun.projects.project.MlrunProject),
+        )
+        monitoring_context._feature_stats = inputs_statistics
+        monitoring_context._sample_df_stats = sample_data_statistics
     # Initialize the app
     application = histogram_data_drift.HistogramDataDriftApplication(
         produce_json_artifact=False, produce_plotly_artifact=True


### PR DESCRIPTION
Implements [ML-10263](https://iguazio.atlassian.net/browse/ML-10263).

Instead of sending the results to the writer stream when the MM infra is disabled, check it first, and raise an informative error message when it's the case.

[ML-10263]: https://iguazio.atlassian.net/browse/ML-10263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ