### PR TITLE
[Functions] Handle null function state in build status

### DIFF
--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -47,6 +47,7 @@ class FunctionState:
 
     # for pipeline steps
     skipped = "skipped"
+    initialized = "initialized"
 
     @classmethod
     def get_function_state_from_pod_state(cls, pod_state: str):

--- a/server/py/services/api/api/endpoints/functions.py
+++ b/server/py/services/api/api/endpoints/functions.py
@@ -458,7 +458,9 @@ def _handle_job_deploy_status(
 ):
     # job deploy status
     response_headers = {}
-    function_state = get_in(fn, "status.state", "")
+    function_state = (
+        get_in(fn, "status.state", "") or mlrun.common.schemas.FunctionState.initialized
+    )
     pod = get_in(fn, "status.build_pod", "")
     image = get_in(fn, "spec.build.image", "")
     out = b""

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -50,6 +50,7 @@ from services.api.daemon import daemon
 PROJECT = "project-name"
 ORIGINAL_VERSIONED_API_PREFIX = daemon.service.base_versioned_service_prefix
 FUNCTIONS_API = "projects/{project}/functions/{name}"
+BUILD_STATUS_API = "build/status"
 
 
 def test_build_status_pod_not_found(
@@ -80,7 +81,7 @@ def test_build_status_pod_not_found(
         ),
     ):
         response = client.get(
-            "build/status",
+            BUILD_STATUS_API,
             params={
                 "project": function["metadata"]["project"],
                 "name": function["metadata"]["name"],
@@ -88,6 +89,53 @@ def test_build_status_pod_not_found(
             },
         )
         assert response.status_code == HTTPStatus.NOT_FOUND.value
+
+
+def test_build_status_with_missing_state(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+):
+    # Test that a function without status.state returns 'initialized' in build/status
+    services.api.tests.unit.api.utils.create_project(client, PROJECT)
+    function = {
+        "kind": "job",
+        "metadata": {
+            "name": "function-name",
+            "project": PROJECT,
+            "tag": "latest",
+        },
+        "spec": {
+            "build": {"image": "some-image"},
+        },
+    }
+
+    client.post(
+        FUNCTIONS_API.format(
+            project=function["metadata"]["project"], name=function["metadata"]["name"]
+        ),
+        json=function,
+    )
+    response = client.get(
+        FUNCTIONS_API.format(
+            project=function["metadata"]["project"],
+            name=function["metadata"]["name"],
+        ),
+    )
+    assert response.status_code == HTTPStatus.OK.value
+    assert response.json().get("status", {}).get("state") is None
+
+    response = client.get(
+        BUILD_STATUS_API,
+        params={
+            "project": function["metadata"]["project"],
+            "name": function["metadata"]["name"],
+            "tag": function["metadata"]["tag"],
+        },
+    )
+    assert response.status_code == HTTPStatus.OK.value
+    assert (
+        response.headers["function_status"]
+        == mlrun.common.schemas.FunctionState.initialized
+    )
 
 
 @pytest.mark.asyncio
@@ -1066,7 +1114,7 @@ def test_build_status_events_and_logs(
         ),
     ):
         response = client.get(
-            "build/status",
+            BUILD_STATUS_API,
             params={
                 "project": function["metadata"]["project"],
                 "name": function["metadata"]["name"],
@@ -1099,7 +1147,7 @@ def test_build_status_events_and_logs(
         ),
     ):
         response = client.get(
-            "build/status",
+            BUILD_STATUS_API,
             params={
                 "project": function["metadata"]["project"],
                 "name": function["metadata"]["name"],


### PR DESCRIPTION
This PR introduces a mitigation for cases where a function's `status.state` is null in the DB, which causes encoding issues when querying the `/build/status` endpoint.

To ensure a valid and consistent API response, a new function state `initialized` was added, so when a function has no state, the build status response returns `initialized`, preventing encoding errors in the response headers.

A more robust solution would be to ensure a default state is set during function storage (store_function), which requires more work and can be handled later.

Jira:
https://iguazio.atlassian.net/browse/ML-10175