### PR TITLE
[Artifacts] Fix Artifact Deletion by UID [1.9.x]

### DIFF
--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -401,7 +401,7 @@ class ArtifactManager:
         self.artifact_db.del_artifact(
             key=item.db_key,
             project=item.project,
-            tag=item.tag,
+            # tag=item.tag,
             tree=item.tree,
             uid=item.uid,
             iter=item.iter,

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -401,7 +401,6 @@ class ArtifactManager:
         self.artifact_db.del_artifact(
             key=item.db_key,
             project=item.project,
-            # tag=item.tag,
             tree=item.tree,
             uid=item.uid,
             iter=item.iter,

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -403,6 +403,7 @@ class ArtifactManager:
             project=item.project,
             tag=item.tag,
             tree=item.tree,
+            uid=item.uid,
             iter=item.iter,
             deletion_strategy=deletion_strategy,
             secrets=secrets,

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -173,14 +173,15 @@ class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
         # verify that the temp path was deleted after the import
         assert not os.path.exists(temp_local_path)
 
-    def test_retrieve_an_artifact_with_no_tag(self):
+    def test_artifact_retrieval_and_deletion_without_tag(self):
         """
-        Test artifact retrieval when no tag is explicitly set.
+        Test artifact retrieval and deletion when logging models without explicitly setting a tag.
         Verifies:
         1. The first artifact has no tag.
         2. The second artifact is tagged as 'latest'.
         3. Attempting to retrieve the untagged artifact using its URI without the UID raises an error.
         4. The artifact with no tag can be retrieved successfully using its full URI.
+        5. Deleting the untagged artifact removes it while the tagged one remains.
         """
         project = mlrun.new_project("log-mod")
 
@@ -214,9 +215,11 @@ class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
         # Ensure we can retrieve the untagged artifact by its URI
         assert project.get_store_resource(artifacts[1].uri)
 
-        # Delete the artifact without a tag
+        # Delete the untagged artifact
+        uid0 = artifacts[0].metadata.uid
         project.delete_artifact(artifacts[1])
 
-        # Ensure only the tagged artifact remains
+        # Only the tagged artifact should remain
         artifacts = project.list_artifacts().to_objects()
         assert len(artifacts) == 1, f"Expected 1 artifacts, found {len(artifacts)}"
+        assert artifacts[0].metadata.uid == uid0

--- a/tests/integration/sdk_api/artifacts/test_artifacts.py
+++ b/tests/integration/sdk_api/artifacts/test_artifacts.py
@@ -213,3 +213,10 @@ class TestArtifacts(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # Ensure we can retrieve the untagged artifact by its URI
         assert project.get_store_resource(artifacts[1].uri)
+
+        # Delete the artifact without a tag
+        project.delete_artifact(artifacts[1])
+
+        # Ensure only the tagged artifact remains
+        artifacts = project.list_artifacts().to_objects()
+        assert len(artifacts) == 1, f"Expected 1 artifacts, found {len(artifacts)}"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1218,6 +1218,33 @@ def test_delete_artifacts_with_iteration(rundb_mock):
     assert len(artifacts) == 2
 
 
+def test_delete_artifacts_with_different_uid_without_tag(rundb_mock):
+    project_name = "my-project"
+    project = mlrun.new_project(project_name, save=False)
+
+    artifact_key = "my-artifact"
+
+    for uid in range(1, 4):
+        artifact = mlrun.artifacts.Artifact(
+            metadata=mlrun.artifacts.ArtifactMetadata(key=artifact_key, project=project_name, uid=uid),
+            body="123",
+        )
+        artifact.db_key = artifact_key
+        rundb_mock.store_artifact(artifact_key, artifact.to_dict())
+
+    artifacts = project.list_artifacts().to_objects()
+    assert len(artifacts) == 3
+
+    # deleting artifact with the same project, key and uid without specifying the tag (tag is None)
+    artifact = mlrun.artifacts.Artifact(
+        metadata= mlrun.artifacts.ArtifactMetadata(project=project_name, key=artifact_key, uid=artifacts[1]["metadata"]["uid"])
+    )
+    project.delete_artifact(artifact)
+
+    artifacts = project.list_artifacts()
+    assert len(artifacts) == 2
+
+
 @pytest.mark.parametrize(
     "relative_artifact_path,project_context,expected_path,expected_in_context",
     [

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1218,33 +1218,6 @@ def test_delete_artifacts_with_iteration(rundb_mock):
     assert len(artifacts) == 2
 
 
-def test_delete_artifacts_with_different_uid_without_tag(rundb_mock):
-    project_name = "my-project"
-    project = mlrun.new_project(project_name, save=False)
-
-    artifact_key = "my-artifact"
-
-    for uid in range(1, 4):
-        artifact = mlrun.artifacts.Artifact(
-            metadata=mlrun.artifacts.ArtifactMetadata(key=artifact_key, project=project_name, uid=uid),
-            body="123",
-        )
-        artifact.db_key = artifact_key
-        rundb_mock.store_artifact(artifact_key, artifact.to_dict())
-
-    artifacts = project.list_artifacts().to_objects()
-    assert len(artifacts) == 3
-
-    # deleting artifact with the same project, key and uid without specifying the tag (tag is None)
-    artifact = mlrun.artifacts.Artifact(
-        metadata= mlrun.artifacts.ArtifactMetadata(project=project_name, key=artifact_key, uid=artifacts[1]["metadata"]["uid"])
-    )
-    project.delete_artifact(artifact)
-
-    artifacts = project.list_artifacts()
-    assert len(artifacts) == 2
-
-
 @pytest.mark.parametrize(
     "relative_artifact_path,project_context,expected_path,expected_in_context",
     [


### PR DESCRIPTION
When deleting an artifact, we expect it to be deleted by its UID. However, `manager.delete_artifact` was not passing `item.uid` to `httpdb.del_artifact`. As a result, when attempting to delete an artifact with the same key and project but with a different UID, it would delete all artifacts matching the key and project, ignoring the UID.

To fix this, I passed the UID explicitly. I also removed the tag parameter, since the db layer does not support receiving both tag and uid simultaneously. Besides, we're deleting a specific artifact, not an artifact tag. 
https://iguazio.atlassian.net/browse/ML-10296