### PR TITLE
[Python] Fix determining the image version to run [1.9.x]

### DIFF
--- a/server/py/framework/utils/helpers.py
+++ b/server/py/framework/utils/helpers.py
@@ -89,24 +89,23 @@ def time_string_to_seconds(time_str: str, min_seconds: int = 60) -> Optional[int
 
 
 def extract_image_tag(image_reference):
-    # This matches any word character,dots,hyphens after a colon (:) anchored to the end of the string
+    # Extracts the tag from an image reference (e.g. repo/image:tag)
     pattern = r"(?<=:)[\w.-]+$"
     match = re.search(pattern, image_reference)
-
     tag = None
-    is_semver = False
     has_py_package = False
     if match:
         tag = match.group()
-        is_semver = semver.Version.is_valid(tag)
-
-        if is_semver:
+        # Remove -pyXY suffix if present (e.g. 1.2.3-py39 -> 1.2.3)
+        tag = re.sub(r"-py\d+$", "", tag)
+        if semver.Version.is_valid(tag):
             version = semver.Version.parse(tag)
-            # If the version is a prerelease, and it has a hyphen, it means it's a feature branch build
-            has_py_package = (
-                not version.prerelease or version.prerelease.find("-") == -1
-            )
-
+            is_ga = not version.prerelease
+            if is_ga:
+                # GA version always has a python package
+                return tag, True
+            # Allow -rc suffix to indicate python package exists
+            has_py_package = re.search(r"-rc\d+$", tag) is not None
     return tag, has_py_package
 
 

--- a/server/py/services/api/tests/unit/utils/test_helpers.py
+++ b/server/py/services/api/tests/unit/utils/test_helpers.py
@@ -41,3 +41,23 @@ def test_validate_client_version(client_version, min_versions, expected_compatib
         framework.utils.helpers.validate_client_version(client_version, *min_versions)
         == expected_compatible
     )
+
+
+@pytest.mark.parametrize(
+    "image_reference,expected_tag,expected_has_py_package",
+    [
+        ("mlrun/mlrun:1.9.0", "1.9.0", True),
+        ("mlrun/mlrun:1.9.0-rc5", "1.9.0-rc5", True),
+        ("mlrun/mlrun:1.9.0-py39", "1.9.0", True),
+        ("mlrun/mlrun:1.9.0-rc1-py38", "1.9.0-rc1", True),
+        ("mlrun/mlrun:1.9.0-rc5-somefeature", "1.9.0-rc5-somefeature", False),
+        ("mlrun/mlrun:1.9.0-rc5-somefeature-py39", "1.9.0-rc5-somefeature", False),
+        ("mlrun/mlrun:latest", "latest", False),
+        ("mlrun/mlrun", None, False),
+        ("mlrun/mlrun:unstable", "unstable", False),
+    ],
+)
+def test_extract_image_tag(image_reference, expected_tag, expected_has_py_package):
+    tag, has_py_package = framework.utils.helpers.extract_image_tag(image_reference)
+    assert tag == expected_tag
+    assert has_py_package == expected_has_py_package

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -805,6 +805,7 @@ def add_mlrun_to_requirements(build, enriched_base_image, mlrun_version_specifie
         )
         mlrun.utils.logger.debug(
             "Enriching build requirements with mlrun package",
+            enriched_base_image=enriched_base_image,
             installed_mlrun_version_command=installed_mlrun_version_command,
             image_tag=image_tag,
             mlrun_version_specifier=mlrun_version_specifier,

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -803,6 +803,12 @@ def add_mlrun_to_requirements(build, enriched_base_image, mlrun_version_specifie
         installed_mlrun_version_command = resolve_mlrun_install_command_version(
             mlrun_version_specifier, client_version=image_tag
         )
+        mlrun.utils.logger.debug(
+            "Enriching build requirements with mlrun package",
+            installed_mlrun_version_command=installed_mlrun_version_command,
+            image_tag=image_tag,
+            mlrun_version_specifier=mlrun_version_specifier,
+        )
         build.requirements.insert(0, installed_mlrun_version_command)
 
     else:


### PR DESCRIPTION
Refines the image tag extraction process to better handle different tag formats, including those with `-pyXY` suffixes, which indicate a Python package.

The logic now correctly identifies and removes the `-pyXY` suffix to extract the base version. It also accurately determines if a python package exists, considering `-rc` suffixes.

Adds unit tests to validate the updated logic.

https://iguazio.atlassian.net/browse/ML-10326