### PR TITLE
[Package] Improve the build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,15 +144,8 @@ jobs:
     needs: [ prepare-inputs, trigger-and-wait-for-ui-image-building, trigger-and-wait-for-mlrun-image-building ]
     steps:
       - uses: actions/checkout@v4
-      - name: Get uv version
-        id: uv-version
-        run: |
-          version=$(grep "^MLRUN_UV_VERSION ?= " Makefile | cut -d' ' -f3)
-          echo "version=$(version)" >> $GITHUB_OUTPUT
       - name: Set up uv
         uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # 6.3.1
-        with:
-          version: ${{ steps.uv-version.outputs.version }}
       - name: Build & push to PyPI
         if: github.event.inputs.skip_publish_pypi != 'true'
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,8 @@ jobs:
         if: github.event.inputs.skip_publish_pypi != 'true'
         env:
           MLRUN_VERSION: ${{ needs.prepare-inputs.outputs.version }}
+          UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: uv run --no-project --with packaging~=25.0 make publish-package
 
   create-releases:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,8 +150,6 @@ jobs:
         if: github.event.inputs.skip_publish_pypi != 'true'
         env:
           MLRUN_VERSION: ${{ needs.prepare-inputs.outputs.version }}
-          UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: uv run --no-project --with packaging~=25.0 make publish-package
 
   create-releases:

--- a/.github/workflows/upgrade-lock.yaml
+++ b/.github/workflows/upgrade-lock.yaml
@@ -31,14 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Get uv version from the Makefile
-      id: uv-version
-      run: |
-        version=$(grep "MLRUN_UV_VERSION ?=" Makefile | cut -d' ' -f3)
-        echo version=$version >> "$GITHUB_OUTPUT"
     - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # 6.3.1
-      with:
-        version: ${{ steps.uv-version.outputs.version }}
 
     - name: Upgrade dependencies in the lock file with uv
       run: make upgrade-mlrun-deps-lock

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ PYTHON_VERSION ?= $(shell python --version)
 MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=
 MLRUN_PIP_VERSION ?= 25.0.0
-MLRUN_UV_VERSION ?= 0.7.12
+MLRUN_UV_VERSION ?= 0.7.14
 MLRUN_UV_IMAGE ?= ghcr.io/astral-sh/uv:$(MLRUN_UV_VERSION)
 MLRUN_CACHE_DATE ?= $(shell date +%s)
 # empty by default, can be set to something like "tag-name" which will cause to:
@@ -936,19 +936,9 @@ ifdef MLRUN_DOCKER_CACHE_FROM_TAG
 	done;
 endif
 
-.PHONY: verify-uv-version
-verify-uv-version:
-	@{ \
-	uv_version=$$(uv self version | cut -d' ' -f2); \
-	result=$$(python -m semver compare $$uv_version $(MLRUN_UV_VERSION)); \
-	if [ "$$result" -eq -1 ]; then \
-	  echo "Error: The running uv version ($$uv_version) is outdated. Upgrade uv to version $(MLRUN_UV_VERSION)."; \
-	  exit 1; \
-	fi; \
-	}
 
 .PHONY: upgrade-mlrun-api-deps-lock
-upgrade-mlrun-api-deps-lock: verify-uv-version ## Upgrade mlrun-api locked requirements file
+upgrade-mlrun-api-deps-lock: ## Upgrade mlrun-api locked requirements file
 	uv pip compile \
 		requirements.txt \
 		extras-requirements.txt \
@@ -958,7 +948,7 @@ upgrade-mlrun-api-deps-lock: verify-uv-version ## Upgrade mlrun-api locked requi
 		--output-file dockerfiles/mlrun-api/locked-requirements.txt
 
 .PHONY: upgrade-mlrun-mlrun-deps-lock
-upgrade-mlrun-mlrun-deps-lock: verify-uv-version ## Upgrade mlrun-mlrun locked requirements file
+upgrade-mlrun-mlrun-deps-lock: ## Upgrade mlrun-mlrun locked requirements file
 	uv pip compile \
 		requirements.txt \
 		extras-requirements.txt \
@@ -967,7 +957,7 @@ upgrade-mlrun-mlrun-deps-lock: verify-uv-version ## Upgrade mlrun-mlrun locked r
 		--output-file dockerfiles/mlrun/locked-requirements.txt
 
 .PHONY: upgrade-mlrun-gpu-deps-lock
-upgrade-mlrun-gpu-deps-lock: verify-uv-version ## Upgrade mlrun-gpu locked requirements file
+upgrade-mlrun-gpu-deps-lock: ## Upgrade mlrun-gpu locked requirements file
 	uv pip compile \
 		requirements.txt \
 		extras-requirements.txt \
@@ -976,7 +966,7 @@ upgrade-mlrun-gpu-deps-lock: verify-uv-version ## Upgrade mlrun-gpu locked requi
 		--output-file dockerfiles/gpu/locked-requirements.txt
 
 .PHONY: upgrade-mlrun-jupyter-deps-lock
-upgrade-mlrun-jupyter-deps-lock: verify-uv-version ## Upgrade mlrun-jupyter locked requirements file
+upgrade-mlrun-jupyter-deps-lock: ## Upgrade mlrun-jupyter locked requirements file
 	uv pip compile \
 		requirements.txt \
 		extras-requirements.txt \
@@ -986,7 +976,7 @@ upgrade-mlrun-jupyter-deps-lock: verify-uv-version ## Upgrade mlrun-jupyter lock
 		--output-file dockerfiles/jupyter/locked-requirements.txt
 
 .PHONY: upgrade-mlrun-test-deps-lock
-upgrade-mlrun-test-deps-lock: verify-uv-version ## Upgrade mlrun test locked requirements file
+upgrade-mlrun-test-deps-lock: ## Upgrade mlrun test locked requirements file
 	uv pip compile \
 		requirements.txt \
 		extras-requirements.txt \
@@ -997,7 +987,7 @@ upgrade-mlrun-test-deps-lock: verify-uv-version ## Upgrade mlrun test locked req
 		--output-file dockerfiles/test/locked-requirements.txt
 
 .PHONY: upgrade-mlrun-system-test-deps-lock
-upgrade-mlrun-system-test-deps-lock: verify-uv-version ## Upgrade mlrun system test locked requirements file
+upgrade-mlrun-system-test-deps-lock: ## Upgrade mlrun system test locked requirements file
 	uv pip compile \
 		requirements.txt \
 		extras-requirements.txt \
@@ -1007,8 +997,7 @@ upgrade-mlrun-system-test-deps-lock: verify-uv-version ## Upgrade mlrun system t
 		$(MLRUN_UV_UPGRADE_FLAG) \
 		--output-file dockerfiles/test-system/locked-requirements.txt
 
-
-upgrade-mlrun-kfp-deps-lock: verify-uv-version ## Upgrade mlrun-kfp locked requirements file
+upgrade-mlrun-kfp-deps-lock: ## Upgrade mlrun-kfp locked requirements file
 	uv pip compile \
 		requirements.txt \
 		dockerfiles/mlrun-kfp/requirements.txt \
@@ -1017,7 +1006,7 @@ upgrade-mlrun-kfp-deps-lock: verify-uv-version ## Upgrade mlrun-kfp locked requi
 		--output-file dockerfiles/mlrun-kfp/locked-requirements.txt
 
 .PHONY: upgrade-mlrun-deps-lock
-upgrade-mlrun-deps-lock: verify-uv-version ## Upgrade mlrun-* locked requirements file
+upgrade-mlrun-deps-lock: ## Upgrade mlrun-* locked requirements file
 	@$(MAKE) -j \
 		upgrade-mlrun-mlrun-deps-lock \
 		upgrade-mlrun-api-deps-lock \
@@ -1026,6 +1015,7 @@ upgrade-mlrun-deps-lock: verify-uv-version ## Upgrade mlrun-* locked requirement
 		upgrade-mlrun-kfp-deps-lock \
 		upgrade-mlrun-test-deps-lock \
 		upgrade-mlrun-system-test-deps-lock
+
 
 .PHONY: coverage-combine
 coverage-combine: ## Combine all coverage reports, ignoring errors like missing or corrupted source files

--- a/dependencies.py
+++ b/dependencies.py
@@ -19,10 +19,6 @@ def base_requirements() -> list[str]:
     return list(_load_dependencies_from_file("requirements.txt"))
 
 
-def dev_requirements() -> list[str]:
-    return list(_load_dependencies_from_file("dev-requirements.txt"))
-
-
 def extra_requirements() -> dict[str, list[str]]:
     # NOTE:
     #     - These are tested in `automation/package_test/test.py`. If you modify these, make sure to change the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ author = "Iguazio"
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.uv]
+required-version = ">=0.7.14"
+
 [tool.uv.pip]
 python-version = "3.9"  # TODO: change to 3.11 when 3.9 is no longer supported
 generate-hashes = true

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
     ],
     python_requires=">=3.9, <3.12",
     install_requires=dependencies.base_requirements(),
-    tests_require=dependencies.dev_requirements(),
     extras_require=dependencies.extra_requirements(),
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",


### PR DESCRIPTION
Continue the work from #8100:

- Add the required uv version and upgrade uv
  https://docs.astral.sh/uv/reference/settings/#required-version
  Remove the `verify-uv-version` target.
- Package build:
  - Remove the deprecated tests_require package input
    https://setuptools.pypa.io/en/latest/deprecated/changed_keywords.html#new-and-changed-setup-keywords
  - Remove the deprecated license classifier 
    https://packaging.python.org/en/latest/specifications/pyproject-toml/#classifiers