### PR TITLE
[Model endpoints] Fix model endpoint uid parse as hex back from db

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6210,7 +6210,9 @@ class SQLDB(DBInterface):
         model_endpoint_full_dict[ModelEndpointSchema.CREATED] = (
             model_endpoint_record.created
         )
-        model_endpoint_full_dict[ModelEndpointSchema.UID] = model_endpoint_record.uid.hex
+        model_endpoint_full_dict[ModelEndpointSchema.UID] = (
+            model_endpoint_record.uid.hex
+        )
 
         model_endpoint_full_dict = self._fill_model_endpoint_with_function_data(
             model_endpoint_record,

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6210,9 +6210,8 @@ class SQLDB(DBInterface):
         model_endpoint_full_dict[ModelEndpointSchema.CREATED] = (
             model_endpoint_record.created
         )
-        model_endpoint_full_dict[ModelEndpointSchema.UID] = str(
-            model_endpoint_record.uid
-        )
+        model_endpoint_full_dict[ModelEndpointSchema.UID] = model_endpoint_record.uid.hex
+
         model_endpoint_full_dict = self._fill_model_endpoint_with_function_data(
             model_endpoint_record,
             model_endpoint_full_dict,

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -8008,7 +8008,7 @@ class SQLDB(DBInterface):
             obj_name_attribute=["name"],
             obj_name_suffix=obj_name_suffix,
         )
-        return str(mep.uid)
+        return mep.uid.hex
 
     def _get_mep_function(
         self, session, function_name, function_tag, project

--- a/server/py/services/api/tests/unit/db/test_model_endpoint.py
+++ b/server/py/services/api/tests/unit/db/test_model_endpoint.py
@@ -231,10 +231,7 @@ class TestModelEndpoint(TestDatabaseBase):
         )
         assert model_endpoint_from_db.metadata.name == "model-endpoint-1"
         assert model_endpoint_from_db.metadata.project == "project-1"
-        assert (
-            model_endpoint_from_db.metadata.uid
-            == "5cfeed6672cc4d978ff9b7b06ebe77f2"
-        )
+        assert model_endpoint_from_db.metadata.uid == "5cfeed6672cc4d978ff9b7b06ebe77f2"
 
         # assert model_endpoint_from_db.status.monitoring_mode == "disabled"
 
@@ -247,10 +244,7 @@ class TestModelEndpoint(TestDatabaseBase):
         )
         assert model_endpoint_from_db.metadata.name == "model-endpoint-2"
         assert model_endpoint_from_db.metadata.project == "project-1"
-        assert (
-            model_endpoint_from_db.metadata.uid
-            == "2127986e91f544af9be31250295f03b6"
-        )
+        assert model_endpoint_from_db.metadata.uid == "2127986e91f544af9be31250295f03b6"
 
         assert model_endpoint_from_db.spec.model_class == "new_class"
 

--- a/server/py/services/api/tests/unit/db/test_model_endpoint.py
+++ b/server/py/services/api/tests/unit/db/test_model_endpoint.py
@@ -171,7 +171,7 @@ class TestModelEndpoint(TestDatabaseBase):
             metadata={
                 "name": "model-endpoint-1",
                 "project": "project-1",
-                "uid": "5cfeed66-72cc-4d97-8ff9-b7b06ebe77f2",
+                "uid": "5cfeed6672cc4d978ff9b7b06ebe77f2",
             },
             spec={
                 "function_name": "function-1",
@@ -185,7 +185,7 @@ class TestModelEndpoint(TestDatabaseBase):
             metadata={
                 "name": "model-endpoint-2",
                 "project": "project-1",
-                "uid": "2127986e-91f5-44af-9be3-1250295f03b6",
+                "uid": "2127986e91f544af9be31250295f03b6",
             },
             spec={
                 "function_name": "function-1",
@@ -213,10 +213,10 @@ class TestModelEndpoint(TestDatabaseBase):
             self._db_session,
             "project-1",
             {
-                uuid.UUID("5cfeed66-72cc-4d97-8ff9-b7b06ebe77f2"): {
+                uuid.UUID("5cfeed66-72cc4d978ff9b7b06ebe77f2"): {
                     "monitoring_mode": ModelMonitoringMode.disabled
                 },
-                uuid.UUID("2127986e-91f5-44af-9be3-1250295f03b6"): {
+                uuid.UUID("2127986e91f544af9be31250295f03b6"): {
                     "model_class": "new_class"
                 },
             },
@@ -233,7 +233,7 @@ class TestModelEndpoint(TestDatabaseBase):
         assert model_endpoint_from_db.metadata.project == "project-1"
         assert (
             model_endpoint_from_db.metadata.uid
-            == "5cfeed66-72cc-4d97-8ff9-b7b06ebe77f2"
+            == "5cfeed6672cc4d978ff9b7b06ebe77f2"
         )
 
         # assert model_endpoint_from_db.status.monitoring_mode == "disabled"
@@ -249,7 +249,7 @@ class TestModelEndpoint(TestDatabaseBase):
         assert model_endpoint_from_db.metadata.project == "project-1"
         assert (
             model_endpoint_from_db.metadata.uid
-            == "2127986e-91f5-44af-9be3-1250295f03b6"
+            == "2127986e91f544af9be31250295f03b6"
         )
 
         assert model_endpoint_from_db.spec.model_class == "new_class"
@@ -508,10 +508,10 @@ class TestModelEndpoint(TestDatabaseBase):
 
         # expecting two model endpoints that are the latest
         assert len(list_mep) == 2
-        assert list_mep[0].metadata.uid == "5cfeed66-72cc-4d97-8ff9-b7b06ebe77f2"
+        assert list_mep[0].metadata.uid == "5cfeed6672cc4d978ff9b7b06ebe77f2"
 
         # store another model endpoint with the same name but different uid
-        model_endpoint.metadata.uid = "2127986e-91f5-44af-9be3-1250295f03b6"
+        model_endpoint.metadata.uid = "2127986e91f544af9be31250295f03b6"
         self._db.store_model_endpoint(
             self._db_session,
             model_endpoint,
@@ -534,7 +534,7 @@ class TestModelEndpoint(TestDatabaseBase):
 
         # expecting two model endpoints that are the latest
         assert len(list_mep) == 2
-        assert list_mep[0].metadata.uid == "2127986e-91f5-44af-9be3-1250295f03b6"
+        assert list_mep[0].metadata.uid == "2127986e91f544af9be31250295f03b6"
 
         list_mep = self._db.list_model_endpoints(
             self._db_session,

--- a/server/py/services/api/tests/unit/db/test_model_endpoint.py
+++ b/server/py/services/api/tests/unit/db/test_model_endpoint.py
@@ -112,6 +112,9 @@ class TestModelEndpoint(TestDatabaseBase):
                 == f"project-1/function-1@{unversioned_tagged_object_uid_prefix}latest"
             )
             assert model_endpoint_from_db.spec.model_name == f"model-{i}"
+            assert is_hex(
+                model_endpoint_from_db.metadata.uid
+            ), "expected uid as hex value"
             uids.append(uid)
 
         model_endpoint_from_db = self._db.get_model_endpoint(
@@ -906,3 +909,11 @@ class TestModelEndpoint(TestDatabaseBase):
         ).endpoints
 
         assert len(endpoints) == 0
+
+
+def is_hex(s: str):
+    try:
+        int(s, 16)
+        return True
+    except (ValueError, TypeError):
+        return False


### PR DESCRIPTION
fix https://iguazio.atlassian.net/browse/ML-10292
parse uid as hex back from DB