### PR TITLE
[Datastore] Rename store_manager to remote_item_manager

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
     "v3io_cred",
     "auto_mount",
     "VolumeMount",
-    "remote_client_manager"
+    "remote_client_manager",
 ]
 
 from os import environ, path

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "v3io_cred",
     "auto_mount",
     "VolumeMount",
+    "remote_client_manager"
 ]
 
 from os import environ, path
@@ -32,7 +33,7 @@ from typing import Optional
 import dotenv
 
 from .config import config as mlconf
-from .datastore import DataItem, store_manager
+from .datastore import DataItem, remote_client_manager
 from .db import get_run_db
 from .errors import MLRunInvalidArgumentError, MLRunNotFoundError
 from .execution import MLClientCtx

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -24,7 +24,7 @@ __all__ = [
     "v3io_cred",
     "auto_mount",
     "VolumeMount",
-    "remote_client_manager",
+    "remote_item_manager",
 ]
 
 from os import environ, path
@@ -33,7 +33,7 @@ from typing import Optional
 import dotenv
 
 from .config import config as mlconf
-from .datastore import DataItem, remote_client_manager
+from .datastore import DataItem, remote_item_manager
 from .db import get_run_db
 from .errors import MLRunInvalidArgumentError, MLRunNotFoundError
 from .execution import MLClientCtx

--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -412,7 +412,7 @@ class Artifact(ModelObj):
             self.metadata.hash = body_hash or calculate_blob_hash(body)
         self.spec.size = len(body)
 
-        mlrun.datastore.remote_client_manager.object(
+        mlrun.datastore.remote_item_manager.object(
             url=target or self.spec.target_path
         ).put(body)
 
@@ -436,7 +436,7 @@ class Artifact(ModelObj):
             self.metadata.hash = file_hash or calculate_local_file_hash(source_path)
         self.spec.size = os.stat(source_path).st_size
 
-        mlrun.datastore.remote_client_manager.object(
+        mlrun.datastore.remote_item_manager.object(
             url=target_path or self.spec.target_path
         ).upload(source_path)
 
@@ -713,7 +713,7 @@ class DirArtifact(Artifact):
                     "set to False"
                 )
 
-            mlrun.datastore.remote_client_manager.object(url=target_path).upload(
+            mlrun.datastore.remote_item_manager.object(url=target_path).upload(
                 file_path
             )
             # add files of the directory to the extra data of the artifact with value of the target path
@@ -803,7 +803,7 @@ def upload_extra_data(
                     item, artifact_path=artifact_path
                 )
 
-            mlrun.datastore.remote_client_manager.object(url=target).put(item)
+            mlrun.datastore.remote_item_manager.object(url=target).put(item)
             artifact.extra_data[prefix + key] = target
             continue
 
@@ -820,7 +820,7 @@ def upload_extra_data(
                 _, target = artifact.resolve_file_target_hash_path(
                     src_path, artifact_path=artifact_path
                 )
-            mlrun.datastore.remote_client_manager.object(url=target).upload(src_path)
+            mlrun.datastore.remote_item_manager.object(url=target).upload(src_path)
             artifact.extra_data[prefix + key] = target
             continue
 
@@ -841,12 +841,12 @@ def get_artifact_meta(artifact):
         artifact = artifact.artifact_url
 
     if mlrun.datastore.is_store_uri(artifact):
-        artifact_spec, target = (
-            mlrun.datastore.remote_client_manager.get_store_artifact(artifact)
+        artifact_spec, target = mlrun.datastore.remote_item_manager.get_store_artifact(
+            artifact
         )
 
     elif artifact.lower().endswith(".yaml"):
-        data = mlrun.datastore.remote_client_manager.object(url=artifact).get()
+        data = mlrun.datastore.remote_item_manager.object(url=artifact).get()
         spec = yaml.load(data, Loader=yaml.FullLoader)
         artifact_spec = mlrun.artifacts.dict_to_artifact(spec)
 
@@ -855,7 +855,7 @@ def get_artifact_meta(artifact):
 
     extra_dataitems = {}
     for k, v in artifact_spec.extra_data.items():
-        extra_dataitems[k] = mlrun.datastore.remote_client_manager.object(v, key=k)
+        extra_dataitems[k] = mlrun.datastore.remote_item_manager.object(v, key=k)
 
     return artifact_spec, extra_dataitems
 

--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -412,9 +412,9 @@ class Artifact(ModelObj):
             self.metadata.hash = body_hash or calculate_blob_hash(body)
         self.spec.size = len(body)
 
-        mlrun.datastore.remote_client_manager.object(url=target or self.spec.target_path).put(
-            body
-        )
+        mlrun.datastore.remote_client_manager.object(
+            url=target or self.spec.target_path
+        ).put(body)
 
     def _upload_file(
         self,
@@ -713,7 +713,9 @@ class DirArtifact(Artifact):
                     "set to False"
                 )
 
-            mlrun.datastore.remote_client_manager.object(url=target_path).upload(file_path)
+            mlrun.datastore.remote_client_manager.object(url=target_path).upload(
+                file_path
+            )
             # add files of the directory to the extra data of the artifact with value of the target path
             self.spec.extra_data[file_name] = target_path
 
@@ -839,8 +841,8 @@ def get_artifact_meta(artifact):
         artifact = artifact.artifact_url
 
     if mlrun.datastore.is_store_uri(artifact):
-        artifact_spec, target = mlrun.datastore.remote_client_manager.get_store_artifact(
-            artifact
+        artifact_spec, target = (
+            mlrun.datastore.remote_client_manager.get_store_artifact(artifact)
         )
 
     elif artifact.lower().endswith(".yaml"):

--- a/mlrun/artifacts/base.py
+++ b/mlrun/artifacts/base.py
@@ -412,7 +412,7 @@ class Artifact(ModelObj):
             self.metadata.hash = body_hash or calculate_blob_hash(body)
         self.spec.size = len(body)
 
-        mlrun.datastore.store_manager.object(url=target or self.spec.target_path).put(
+        mlrun.datastore.remote_client_manager.object(url=target or self.spec.target_path).put(
             body
         )
 
@@ -436,7 +436,7 @@ class Artifact(ModelObj):
             self.metadata.hash = file_hash or calculate_local_file_hash(source_path)
         self.spec.size = os.stat(source_path).st_size
 
-        mlrun.datastore.store_manager.object(
+        mlrun.datastore.remote_client_manager.object(
             url=target_path or self.spec.target_path
         ).upload(source_path)
 
@@ -713,7 +713,7 @@ class DirArtifact(Artifact):
                     "set to False"
                 )
 
-            mlrun.datastore.store_manager.object(url=target_path).upload(file_path)
+            mlrun.datastore.remote_client_manager.object(url=target_path).upload(file_path)
             # add files of the directory to the extra data of the artifact with value of the target path
             self.spec.extra_data[file_name] = target_path
 
@@ -801,7 +801,7 @@ def upload_extra_data(
                     item, artifact_path=artifact_path
                 )
 
-            mlrun.datastore.store_manager.object(url=target).put(item)
+            mlrun.datastore.remote_client_manager.object(url=target).put(item)
             artifact.extra_data[prefix + key] = target
             continue
 
@@ -818,7 +818,7 @@ def upload_extra_data(
                 _, target = artifact.resolve_file_target_hash_path(
                     src_path, artifact_path=artifact_path
                 )
-            mlrun.datastore.store_manager.object(url=target).upload(src_path)
+            mlrun.datastore.remote_client_manager.object(url=target).upload(src_path)
             artifact.extra_data[prefix + key] = target
             continue
 
@@ -839,12 +839,12 @@ def get_artifact_meta(artifact):
         artifact = artifact.artifact_url
 
     if mlrun.datastore.is_store_uri(artifact):
-        artifact_spec, target = mlrun.datastore.store_manager.get_store_artifact(
+        artifact_spec, target = mlrun.datastore.remote_client_manager.get_store_artifact(
             artifact
         )
 
     elif artifact.lower().endswith(".yaml"):
-        data = mlrun.datastore.store_manager.object(url=artifact).get()
+        data = mlrun.datastore.remote_client_manager.object(url=artifact).get()
         spec = yaml.load(data, Loader=yaml.FullLoader)
         artifact_spec = mlrun.artifacts.dict_to_artifact(spec)
 
@@ -853,7 +853,7 @@ def get_artifact_meta(artifact):
 
     extra_dataitems = {}
     for k, v in artifact_spec.extra_data.items():
-        extra_dataitems[k] = mlrun.datastore.store_manager.object(v, key=k)
+        extra_dataitems[k] = mlrun.datastore.remote_client_manager.object(v, key=k)
 
     return artifact_spec, extra_dataitems
 

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -423,7 +423,7 @@ def update_dataset_meta(
     if isinstance(artifact, DatasetArtifact):
         artifact_spec = artifact
     elif mlrun.datastore.is_store_uri(artifact):
-        artifact_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(
+        artifact_spec, _ = mlrun.datastore.remote_item_manager.get_store_artifact(
             artifact
         )
     else:
@@ -471,7 +471,7 @@ def upload_dataframe(
     df, target_path, format, src_path=None, **kw
 ) -> tuple[Optional[int], Optional[str]]:
     if src_path and os.path.isfile(src_path):
-        mlrun.datastore.remote_client_manager.object(url=target_path).upload(src_path)
+        mlrun.datastore.remote_item_manager.object(url=target_path).upload(src_path)
         return (
             os.stat(src_path).st_size,
             mlrun.utils.helpers.calculate_local_file_hash(src_path),
@@ -481,7 +481,7 @@ def upload_dataframe(
         return None, None
 
     if target_path.startswith("memory://"):
-        mlrun.datastore.remote_client_manager.object(target_path).put(df)
+        mlrun.datastore.remote_item_manager.object(target_path).put(df)
         return None, None
 
     if format in ["csv", "parquet"]:

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -423,7 +423,9 @@ def update_dataset_meta(
     if isinstance(artifact, DatasetArtifact):
         artifact_spec = artifact
     elif mlrun.datastore.is_store_uri(artifact):
-        artifact_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(artifact)
+        artifact_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(
+            artifact
+        )
     else:
         raise ValueError("model path must be a model store object/URL/DataItem")
 

--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -423,7 +423,7 @@ def update_dataset_meta(
     if isinstance(artifact, DatasetArtifact):
         artifact_spec = artifact
     elif mlrun.datastore.is_store_uri(artifact):
-        artifact_spec, _ = mlrun.datastore.store_manager.get_store_artifact(artifact)
+        artifact_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(artifact)
     else:
         raise ValueError("model path must be a model store object/URL/DataItem")
 
@@ -469,7 +469,7 @@ def upload_dataframe(
     df, target_path, format, src_path=None, **kw
 ) -> tuple[Optional[int], Optional[str]]:
     if src_path and os.path.isfile(src_path):
-        mlrun.datastore.store_manager.object(url=target_path).upload(src_path)
+        mlrun.datastore.remote_client_manager.object(url=target_path).upload(src_path)
         return (
             os.stat(src_path).st_size,
             mlrun.utils.helpers.calculate_local_file_hash(src_path),
@@ -479,7 +479,7 @@ def upload_dataframe(
         return None, None
 
     if target_path.startswith("memory://"):
-        mlrun.datastore.store_manager.object(target_path).put(df)
+        mlrun.datastore.remote_client_manager.object(target_path).put(df)
         return None, None
 
     if format in ["csv", "parquet"]:

--- a/mlrun/artifacts/document.py
+++ b/mlrun/artifacts/document.py
@@ -374,7 +374,7 @@ class DocumentArtifact(Artifact):
         loader_spec = DocumentLoaderSpec.from_dict(self.spec.document_loader)
         if loader_spec.download_object and self.get_target_path():
             with tempfile.NamedTemporaryFile() as tmp_file:
-                mlrun.datastore.store_manager.object(
+                mlrun.datastore.remote_client_manager.object(
                     url=self.get_target_path()
                 ).download(tmp_file.name)
                 loader = loader_spec.make_loader(tmp_file.name)

--- a/mlrun/artifacts/document.py
+++ b/mlrun/artifacts/document.py
@@ -374,7 +374,7 @@ class DocumentArtifact(Artifact):
         loader_spec = DocumentLoaderSpec.from_dict(self.spec.document_loader)
         if loader_spec.download_object and self.get_target_path():
             with tempfile.NamedTemporaryFile() as tmp_file:
-                mlrun.datastore.remote_client_manager.object(
+                mlrun.datastore.remote_item_manager.object(
                     url=self.get_target_path()
                 ).download(tmp_file.name)
                 loader = loader_spec.make_loader(tmp_file.name)

--- a/mlrun/artifacts/llm_prompt.py
+++ b/mlrun/artifacts/llm_prompt.py
@@ -128,7 +128,7 @@ class LLMPromptArtifact(Artifact):
             return self.spec._model_artifact
         if self.spec.model_uri:
             self.spec._model_artifact, target = (
-                mlrun.datastore.remote_client_manager.get_store_artifact(
+                mlrun.datastore.remote_item_manager.get_store_artifact(
                     self.spec.model_uri
                 )
             )
@@ -142,7 +142,7 @@ class LLMPromptArtifact(Artifact):
         if self.spec.prompt_string:
             return self.spec.prompt_string
         if self.spec.target_path:
-            with mlrun.datastore.remote_client_manager.object(
+            with mlrun.datastore.remote_item_manager.object(
                 url=self.spec.target_path
             ).open(mode="r") as p_file:
                 return p_file.read()

--- a/mlrun/artifacts/llm_prompt.py
+++ b/mlrun/artifacts/llm_prompt.py
@@ -128,7 +128,7 @@ class LLMPromptArtifact(Artifact):
             return self.spec._model_artifact
         if self.spec.model_uri:
             self.spec._model_artifact, target = (
-                mlrun.datastore.store_manager.get_store_artifact(self.spec.model_uri)
+                mlrun.datastore.remote_client_manager.get_store_artifact(self.spec.model_uri)
             )
             return self.spec._model_artifact
         return None
@@ -140,7 +140,7 @@ class LLMPromptArtifact(Artifact):
         if self.spec.prompt_string:
             return self.spec.prompt_string
         if self.spec.target_path:
-            with mlrun.datastore.store_manager.object(url=self.spec.target_path).open(
+            with mlrun.datastore.remote_client_manager.object(url=self.spec.target_path).open(
                 mode="r"
             ) as p_file:
                 return p_file.read()

--- a/mlrun/artifacts/llm_prompt.py
+++ b/mlrun/artifacts/llm_prompt.py
@@ -128,7 +128,9 @@ class LLMPromptArtifact(Artifact):
             return self.spec._model_artifact
         if self.spec.model_uri:
             self.spec._model_artifact, target = (
-                mlrun.datastore.remote_client_manager.get_store_artifact(self.spec.model_uri)
+                mlrun.datastore.remote_client_manager.get_store_artifact(
+                    self.spec.model_uri
+                )
             )
             return self.spec._model_artifact
         return None
@@ -140,9 +142,9 @@ class LLMPromptArtifact(Artifact):
         if self.spec.prompt_string:
             return self.spec.prompt_string
         if self.spec.target_path:
-            with mlrun.datastore.remote_client_manager.object(url=self.spec.target_path).open(
-                mode="r"
-            ) as p_file:
+            with mlrun.datastore.remote_client_manager.object(
+                url=self.spec.target_path
+            ).open(mode="r") as p_file:
                 return p_file.read()
 
     def before_log(self):

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -413,7 +413,9 @@ class ModelArtifact(Artifact):
         spec_target_path = spec_target_path or path.join(
             self.spec.target_path, model_spec_filename
         )
-        mlrun.datastore.remote_client_manager.object(url=spec_target_path).put(spec_body)
+        mlrun.datastore.remote_client_manager.object(url=spec_target_path).put(
+            spec_body
+        )
 
     def _upload_body_or_file(
         self,
@@ -515,8 +517,8 @@ def get_model(
     )
     if is_store_uri or isinstance(model_dir, ModelArtifact):
         if is_store_uri:
-            model_spec, target = mlrun.datastore.remote_client_manager.get_store_artifact(
-                model_dir
+            model_spec, target = (
+                mlrun.datastore.remote_client_manager.get_store_artifact(model_dir)
             )
         else:
             model_spec, target = model_dir, model_dir.get_target_path()
@@ -614,7 +616,9 @@ def update_model(
     if isinstance(model_artifact, ModelArtifact):
         model_spec = model_artifact
     elif mlrun.datastore.is_store_uri(model_artifact):
-        model_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(model_artifact)
+        model_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(
+            model_artifact
+        )
     else:
         raise ValueError("model path must be a model store object/URL/DataItem")
 

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -413,7 +413,7 @@ class ModelArtifact(Artifact):
         spec_target_path = spec_target_path or path.join(
             self.spec.target_path, model_spec_filename
         )
-        mlrun.datastore.store_manager.object(url=spec_target_path).put(spec_body)
+        mlrun.datastore.remote_client_manager.object(url=spec_target_path).put(spec_body)
 
     def _upload_body_or_file(
         self,
@@ -515,7 +515,7 @@ def get_model(
     )
     if is_store_uri or isinstance(model_dir, ModelArtifact):
         if is_store_uri:
-            model_spec, target = mlrun.datastore.store_manager.get_store_artifact(
+            model_spec, target = mlrun.datastore.remote_client_manager.get_store_artifact(
                 model_dir
             )
         else:
@@ -541,7 +541,7 @@ def get_model(
         model_file = model_dir
     else:
         suffix = suffix or default_suffix
-        dirobj = mlrun.datastore.store_manager.object(url=model_dir)
+        dirobj = mlrun.datastore.remote_client_manager.object(url=model_dir)
         model_dir_list = dirobj.listdir()
         if model_spec_filename in model_dir_list:
             model_spec = _load_model_spec(path.join(model_dir, model_spec_filename))
@@ -558,7 +558,7 @@ def get_model(
     if not model_file:
         raise ValueError(f"cant resolve model file for {model_dir} suffix{suffix}")
 
-    obj = mlrun.datastore.store_manager.object(url=model_file)
+    obj = mlrun.datastore.remote_client_manager.object(url=model_file)
     if obj.kind == "file":
         return model_file, model_spec, extra_dataitems
 
@@ -614,7 +614,7 @@ def update_model(
     if isinstance(model_artifact, ModelArtifact):
         model_spec = model_artifact
     elif mlrun.datastore.is_store_uri(model_artifact):
-        model_spec, _ = mlrun.datastore.store_manager.get_store_artifact(model_artifact)
+        model_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(model_artifact)
     else:
         raise ValueError("model path must be a model store object/URL/DataItem")
 
@@ -649,7 +649,7 @@ def update_model(
     if write_spec_copy:
         spec_path = path.join(model_spec.target_path, model_spec_filename)
         model_spec_yaml = _sanitize_and_serialize_model_spec_yaml(model_spec)
-        mlrun.datastore.store_manager.object(url=spec_path).put(model_spec_yaml)
+        mlrun.datastore.remote_client_manager.object(url=spec_path).put(model_spec_yaml)
 
     model_spec.db_key = model_spec.db_key or model_spec.key
     if store_object:
@@ -668,7 +668,7 @@ def _get_src_path(model_spec: ModelArtifact, filename: str) -> str:
 
 
 def _load_model_spec(spec_path) -> ModelArtifact:
-    data = mlrun.datastore.store_manager.object(url=spec_path).get()
+    data = mlrun.datastore.remote_client_manager.object(url=spec_path).get()
     spec = yaml.load(data, Loader=yaml.FullLoader)
     return ModelArtifact.from_dict(spec)
 
@@ -684,7 +684,7 @@ def _get_file_path(base_path: str, name: str, isdir: bool = False) -> str:
 def _get_extra(target: str, extra_data: dict, is_dir: bool = False) -> dict:
     extra_dataitems = {}
     for k, v in extra_data.items():
-        extra_dataitems[k] = mlrun.datastore.store_manager.object(
+        extra_dataitems[k] = mlrun.datastore.remote_client_manager.object(
             url=_get_file_path(target, v, isdir=is_dir), key=k
         )
     return extra_dataitems

--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -413,9 +413,7 @@ class ModelArtifact(Artifact):
         spec_target_path = spec_target_path or path.join(
             self.spec.target_path, model_spec_filename
         )
-        mlrun.datastore.remote_client_manager.object(url=spec_target_path).put(
-            spec_body
-        )
+        mlrun.datastore.remote_item_manager.object(url=spec_target_path).put(spec_body)
 
     def _upload_body_or_file(
         self,
@@ -517,8 +515,8 @@ def get_model(
     )
     if is_store_uri or isinstance(model_dir, ModelArtifact):
         if is_store_uri:
-            model_spec, target = (
-                mlrun.datastore.remote_client_manager.get_store_artifact(model_dir)
+            model_spec, target = mlrun.datastore.remote_item_manager.get_store_artifact(
+                model_dir
             )
         else:
             model_spec, target = model_dir, model_dir.get_target_path()
@@ -543,7 +541,7 @@ def get_model(
         model_file = model_dir
     else:
         suffix = suffix or default_suffix
-        dirobj = mlrun.datastore.remote_client_manager.object(url=model_dir)
+        dirobj = mlrun.datastore.remote_item_manager.object(url=model_dir)
         model_dir_list = dirobj.listdir()
         if model_spec_filename in model_dir_list:
             model_spec = _load_model_spec(path.join(model_dir, model_spec_filename))
@@ -560,7 +558,7 @@ def get_model(
     if not model_file:
         raise ValueError(f"cant resolve model file for {model_dir} suffix{suffix}")
 
-    obj = mlrun.datastore.remote_client_manager.object(url=model_file)
+    obj = mlrun.datastore.remote_item_manager.object(url=model_file)
     if obj.kind == "file":
         return model_file, model_spec, extra_dataitems
 
@@ -616,7 +614,7 @@ def update_model(
     if isinstance(model_artifact, ModelArtifact):
         model_spec = model_artifact
     elif mlrun.datastore.is_store_uri(model_artifact):
-        model_spec, _ = mlrun.datastore.remote_client_manager.get_store_artifact(
+        model_spec, _ = mlrun.datastore.remote_item_manager.get_store_artifact(
             model_artifact
         )
     else:
@@ -653,7 +651,7 @@ def update_model(
     if write_spec_copy:
         spec_path = path.join(model_spec.target_path, model_spec_filename)
         model_spec_yaml = _sanitize_and_serialize_model_spec_yaml(model_spec)
-        mlrun.datastore.remote_client_manager.object(url=spec_path).put(model_spec_yaml)
+        mlrun.datastore.remote_item_manager.object(url=spec_path).put(model_spec_yaml)
 
     model_spec.db_key = model_spec.db_key or model_spec.key
     if store_object:
@@ -672,7 +670,7 @@ def _get_src_path(model_spec: ModelArtifact, filename: str) -> str:
 
 
 def _load_model_spec(spec_path) -> ModelArtifact:
-    data = mlrun.datastore.remote_client_manager.object(url=spec_path).get()
+    data = mlrun.datastore.remote_item_manager.object(url=spec_path).get()
     spec = yaml.load(data, Loader=yaml.FullLoader)
     return ModelArtifact.from_dict(spec)
 
@@ -688,7 +686,7 @@ def _get_file_path(base_path: str, name: str, isdir: bool = False) -> str:
 def _get_extra(target: str, extra_data: dict, is_dir: bool = False) -> dict:
     extra_dataitems = {}
     for k, v in extra_data.items():
-        extra_dataitems[k] = mlrun.datastore.remote_client_manager.object(
+        extra_dataitems[k] = mlrun.datastore.remote_item_manager.object(
             url=_get_file_path(target, v, isdir=is_dir), key=k
         )
     return extra_dataitems

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "get_stream_pusher",
     "ConfigProfile",
     "VectorStoreCollection",
+    "remote_client_manager"
 ]
 
 from urllib.parse import urlparse
@@ -94,7 +95,7 @@ del fsspec  # clear the module namespace
 
 
 def set_in_memory_item(key, value):
-    item = store_manager.object(f"memory://{key}")
+    item = remote_client_manager.object(f"memory://{key}")
     item.put(value)
     return item
 

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -32,7 +32,7 @@ __all__ = [
     "get_stream_pusher",
     "ConfigProfile",
     "VectorStoreCollection",
-    "remote_client_manager"
+    "remote_client_manager",
 ]
 
 from urllib.parse import urlparse

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -32,7 +32,7 @@ __all__ = [
     "get_stream_pusher",
     "ConfigProfile",
     "VectorStoreCollection",
-    "remote_client_manager",
+    "remote_item_manager",
 ]
 
 from urllib.parse import urlparse
@@ -55,7 +55,7 @@ from mlrun.platforms.iguazio import (
 from ..utils import logger
 from .base import DataItem
 from .dbfs_store import DatabricksFileBugFixed, DatabricksFileSystemDisableCache
-from .remote_manager import RemoteClientManager, in_memory_store, uri_to_ipython
+from .remote_manager import RemoteItemManager, in_memory_store, uri_to_ipython
 from .s3 import parse_s3_bucket_and_key
 from .sources import (
     BigQuerySource,
@@ -74,7 +74,7 @@ from .store_resources import (
 from .targets import CSVTarget, NoSqlTarget, ParquetTarget, StreamTarget
 from .utils import get_kafka_brokers_from_dict, parse_kafka_url
 
-remote_client_manager = RemoteClientManager()
+remote_item_manager = RemoteItemManager()
 
 if hasattr(fsspec, "register_implementation"):
     fsspec.register_implementation(
@@ -94,7 +94,7 @@ del fsspec  # clear the module namespace
 
 
 def set_in_memory_item(key, value):
-    item = remote_client_manager.object(f"memory://{key}")
+    item = remote_item_manager.object(f"memory://{key}")
     item.put(value)
     return item
 

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -37,7 +37,6 @@ __all__ = [
 from urllib.parse import urlparse
 
 import fsspec
-from mergedeep import merge
 
 import mlrun.datastore.wasbfs
 from mlrun.datastore.datastore_profile import (
@@ -54,8 +53,8 @@ from mlrun.platforms.iguazio import (
 
 from ..utils import logger
 from .base import DataItem
-from .datastore import StoreManager, in_memory_store, uri_to_ipython
 from .dbfs_store import DatabricksFileBugFixed, DatabricksFileSystemDisableCache
+from .remote_manager import RemoteClientManager, in_memory_store, uri_to_ipython
 from .s3 import parse_s3_bucket_and_key
 from .sources import (
     BigQuerySource,
@@ -74,7 +73,8 @@ from .store_resources import (
 from .targets import CSVTarget, NoSqlTarget, ParquetTarget, StreamTarget
 from .utils import get_kafka_brokers_from_dict, parse_kafka_url
 
-store_manager = StoreManager()
+remote_client_manager = RemoteClientManager()
+store_manager = remote_client_manager
 
 if hasattr(fsspec, "register_implementation"):
     fsspec.register_implementation(

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -75,7 +75,6 @@ from .targets import CSVTarget, NoSqlTarget, ParquetTarget, StreamTarget
 from .utils import get_kafka_brokers_from_dict, parse_kafka_url
 
 remote_client_manager = RemoteClientManager()
-store_manager = remote_client_manager
 
 if hasattr(fsspec, "register_implementation"):
     fsspec.register_implementation(

--- a/mlrun/datastore/remote_manager.py
+++ b/mlrun/datastore/remote_manager.py
@@ -116,7 +116,7 @@ def uri_to_ipython(link):
     return schema_to_store(schema).uri_to_ipython(endpoint, parsed_url.path)
 
 
-class StoreManager:
+class RemoteClientManager:
     def __init__(self, secrets=None, db=None):
         self._stores = {}
         self._secrets = secrets or {}

--- a/mlrun/datastore/remote_manager.py
+++ b/mlrun/datastore/remote_manager.py
@@ -116,7 +116,7 @@ def uri_to_ipython(link):
     return schema_to_store(schema).uri_to_ipython(endpoint, parsed_url.path)
 
 
-class RemoteClientManager:
+class RemoteItemManager:
     def __init__(self, secrets=None, db=None):
         self._stores = {}
         self._secrets = secrets or {}

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -114,7 +114,7 @@ class BaseSourceDriver(DataSource):
         mlrun.utils.helpers.additional_filters_warning(
             additional_filters, self.__class__
         )
-        return mlrun.remote_client_manager.object(url=self.path).as_df(
+        return mlrun.remote_item_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
             start_time=start_time or self.start_time,
@@ -206,8 +206,8 @@ class CSVSource(BaseSourceDriver):
         if time_field and time_field not in parse_dates:
             parse_dates.append(time_field)
 
-        data_item = mlrun.remote_client_manager.object(self.path)
-        store, path, url = mlrun.remote_client_manager.get_or_create_store(self.path)
+        data_item = mlrun.remote_item_manager.object(self.path)
+        store, path, url = mlrun.remote_item_manager.get_or_create_store(self.path)
 
         return storey.CSVSource(
             paths=url,  # unlike self.path, it already has store:// replaced
@@ -219,7 +219,7 @@ class CSVSource(BaseSourceDriver):
         )
 
     def get_spark_options(self):
-        store, path, _ = mlrun.remote_client_manager.get_or_create_store(self.path)
+        store, path, _ = mlrun.remote_item_manager.get_or_create_store(self.path)
         spark_options = store.get_spark_options()
         spark_options.update(
             {
@@ -261,7 +261,7 @@ class CSVSource(BaseSourceDriver):
             additional_filters, self.__class__
         )
         reader_args = self.attributes.get("reader_args", {})
-        return mlrun.remote_client_manager.object(url=self.path).as_df(
+        return mlrun.remote_item_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
             format="csv",
@@ -380,8 +380,8 @@ class ParquetSource(BaseSourceDriver):
         if context:
             attributes["context"] = context
         additional_filters = transform_list_filters_to_tuple(additional_filters)
-        data_item = mlrun.remote_client_manager.object(self.path)
-        store, path, url = mlrun.remote_client_manager.get_or_create_store(self.path)
+        data_item = mlrun.remote_item_manager.object(self.path)
+        store, path, url = mlrun.remote_item_manager.get_or_create_store(self.path)
         return storey.ParquetSource(
             paths=url,  # unlike self.path, it already has store:// replaced
             key_field=self.key_field or key_field,
@@ -406,7 +406,7 @@ class ParquetSource(BaseSourceDriver):
         return new_obj
 
     def get_spark_options(self):
-        store, path, _ = mlrun.remote_client_manager.get_or_create_store(self.path)
+        store, path, _ = mlrun.remote_item_manager.get_or_create_store(self.path)
         spark_options = store.get_spark_options()
         spark_options.update(
             {
@@ -428,7 +428,7 @@ class ParquetSource(BaseSourceDriver):
     ):
         reader_args = self.attributes.get("reader_args", {})
         additional_filters = transform_list_filters_to_tuple(additional_filters)
-        return mlrun.remote_client_manager.object(url=self.path).as_df(
+        return mlrun.remote_item_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
             start_time=start_time or self.start_time,
@@ -1018,7 +1018,7 @@ class StreamSource(OnlineSource):
         super().__init__(name, attributes=attrs, **kwargs)
 
     def add_nuclio_trigger(self, function):
-        store, _, url = mlrun.remote_client_manager.get_or_create_store(self.path)
+        store, _, url = mlrun.remote_item_manager.get_or_create_store(self.path)
         if store.kind != "v3io":
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Only profiles that reference the v3io datastore can be used with StreamSource"

--- a/mlrun/datastore/sources.py
+++ b/mlrun/datastore/sources.py
@@ -114,7 +114,7 @@ class BaseSourceDriver(DataSource):
         mlrun.utils.helpers.additional_filters_warning(
             additional_filters, self.__class__
         )
-        return mlrun.store_manager.object(url=self.path).as_df(
+        return mlrun.remote_client_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
             start_time=start_time or self.start_time,
@@ -206,8 +206,8 @@ class CSVSource(BaseSourceDriver):
         if time_field and time_field not in parse_dates:
             parse_dates.append(time_field)
 
-        data_item = mlrun.store_manager.object(self.path)
-        store, path, url = mlrun.store_manager.get_or_create_store(self.path)
+        data_item = mlrun.remote_client_manager.object(self.path)
+        store, path, url = mlrun.remote_client_manager.get_or_create_store(self.path)
 
         return storey.CSVSource(
             paths=url,  # unlike self.path, it already has store:// replaced
@@ -219,7 +219,7 @@ class CSVSource(BaseSourceDriver):
         )
 
     def get_spark_options(self):
-        store, path, _ = mlrun.store_manager.get_or_create_store(self.path)
+        store, path, _ = mlrun.remote_client_manager.get_or_create_store(self.path)
         spark_options = store.get_spark_options()
         spark_options.update(
             {
@@ -261,7 +261,7 @@ class CSVSource(BaseSourceDriver):
             additional_filters, self.__class__
         )
         reader_args = self.attributes.get("reader_args", {})
-        return mlrun.store_manager.object(url=self.path).as_df(
+        return mlrun.remote_client_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
             format="csv",
@@ -380,8 +380,8 @@ class ParquetSource(BaseSourceDriver):
         if context:
             attributes["context"] = context
         additional_filters = transform_list_filters_to_tuple(additional_filters)
-        data_item = mlrun.store_manager.object(self.path)
-        store, path, url = mlrun.store_manager.get_or_create_store(self.path)
+        data_item = mlrun.remote_client_manager.object(self.path)
+        store, path, url = mlrun.remote_client_manager.get_or_create_store(self.path)
         return storey.ParquetSource(
             paths=url,  # unlike self.path, it already has store:// replaced
             key_field=self.key_field or key_field,
@@ -406,7 +406,7 @@ class ParquetSource(BaseSourceDriver):
         return new_obj
 
     def get_spark_options(self):
-        store, path, _ = mlrun.store_manager.get_or_create_store(self.path)
+        store, path, _ = mlrun.remote_client_manager.get_or_create_store(self.path)
         spark_options = store.get_spark_options()
         spark_options.update(
             {
@@ -428,7 +428,7 @@ class ParquetSource(BaseSourceDriver):
     ):
         reader_args = self.attributes.get("reader_args", {})
         additional_filters = transform_list_filters_to_tuple(additional_filters)
-        return mlrun.store_manager.object(url=self.path).as_df(
+        return mlrun.remote_client_manager.object(url=self.path).as_df(
             columns=columns,
             df_module=df_module,
             start_time=start_time or self.start_time,
@@ -1018,7 +1018,7 @@ class StreamSource(OnlineSource):
         super().__init__(name, attributes=attrs, **kwargs)
 
     def add_nuclio_trigger(self, function):
-        store, _, url = mlrun.store_manager.get_or_create_store(self.path)
+        store, _, url = mlrun.remote_client_manager.get_or_create_store(self.path)
         if store.kind != "v3io":
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Only profiles that reference the v3io datastore can be used with StreamSource"

--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -188,5 +188,5 @@ def get_store_resource(
             return mlrun.artifacts.dict_to_artifact(resource)
 
     else:
-        stores = mlrun.store_manager.set(secrets, db=db)
+        stores = mlrun.remote_client_manager.set(secrets, db=db)
         return stores.object(url=uri, secrets=data_store_secrets)

--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -188,5 +188,5 @@ def get_store_resource(
             return mlrun.artifacts.dict_to_artifact(resource)
 
     else:
-        stores = mlrun.remote_client_manager.set(secrets, db=db)
+        stores = mlrun.remote_item_manager.set(secrets, db=db)
         return stores.object(url=uri, secrets=data_store_secrets)

--- a/mlrun/datastore/storeytargets.py
+++ b/mlrun/datastore/storeytargets.py
@@ -39,7 +39,9 @@ To avoid passing it openly within the graph, we use wrapper classes.
 
 
 def get_url_and_storage_options(path, external_storage_options=None):
-    store, resolved_store_path, url = mlrun.remote_client_manager.get_or_create_store(path)
+    store, resolved_store_path, url = mlrun.remote_client_manager.get_or_create_store(
+        path
+    )
     storage_options = store.get_storage_options()
     if storage_options and external_storage_options:
         # merge external storage options with the store's storage options. storage_options takes precedence

--- a/mlrun/datastore/storeytargets.py
+++ b/mlrun/datastore/storeytargets.py
@@ -39,7 +39,7 @@ To avoid passing it openly within the graph, we use wrapper classes.
 
 
 def get_url_and_storage_options(path, external_storage_options=None):
-    store, resolved_store_path, url = mlrun.store_manager.get_or_create_store(path)
+    store, resolved_store_path, url = mlrun.remote_client_manager.get_or_create_store(path)
     storage_options = store.get_storage_options()
     if storage_options and external_storage_options:
         # merge external storage options with the store's storage options. storage_options takes precedence

--- a/mlrun/datastore/storeytargets.py
+++ b/mlrun/datastore/storeytargets.py
@@ -39,7 +39,7 @@ To avoid passing it openly within the graph, we use wrapper classes.
 
 
 def get_url_and_storage_options(path, external_storage_options=None):
-    store, resolved_store_path, url = mlrun.remote_client_manager.get_or_create_store(
+    store, resolved_store_path, url = mlrun.remote_item_manager.get_or_create_store(
         path
     )
     storage_options = store.get_storage_options()

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -450,8 +450,8 @@ class BaseStoreTarget(DataTargetBase):
         )
 
     def _get_store_and_path(self):
-        store, resolved_store_path, url = mlrun.remote_client_manager.get_or_create_store(
-            self.get_target_path()
+        store, resolved_store_path, url = (
+            mlrun.remote_client_manager.get_or_create_store(self.get_target_path())
         )
         return store, resolved_store_path, url
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -450,8 +450,8 @@ class BaseStoreTarget(DataTargetBase):
         )
 
     def _get_store_and_path(self):
-        store, resolved_store_path, url = (
-            mlrun.remote_client_manager.get_or_create_store(self.get_target_path())
+        store, resolved_store_path, url = mlrun.remote_item_manager.get_or_create_store(
+            self.get_target_path()
         )
         return store, resolved_store_path, url
 

--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -450,7 +450,7 @@ class BaseStoreTarget(DataTargetBase):
         )
 
     def _get_store_and_path(self):
-        store, resolved_store_path, url = mlrun.store_manager.get_or_create_store(
+        store, resolved_store_path, url = mlrun.remote_client_manager.get_or_create_store(
             self.get_target_path()
         )
         return store, resolved_store_path, url

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -63,7 +63,7 @@ def upload_tarball(source_dir, target, secrets=None):
     with tempfile.NamedTemporaryFile(suffix=".tar.gz") as temp_fh:
         with tarfile.open(mode="w:gz", fileobj=temp_fh) as tar:
             tar.add(source_dir, arcname="")
-        stores = mlrun.datastore.store_manager.set(secrets)
+        stores = mlrun.datastore.remote_client_manager.set(secrets)
         datastore, subpath, url = stores.get_or_create_store(target)
         datastore.upload(subpath, temp_fh.name)
 

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -63,7 +63,7 @@ def upload_tarball(source_dir, target, secrets=None):
     with tempfile.NamedTemporaryFile(suffix=".tar.gz") as temp_fh:
         with tarfile.open(mode="w:gz", fileobj=temp_fh) as tar:
             tar.add(source_dir, arcname="")
-        stores = mlrun.datastore.remote_client_manager.set(secrets)
+        stores = mlrun.datastore.remote_item_manager.set(secrets)
         datastore, subpath, url = stores.get_or_create_store(target)
         datastore.upload(subpath, temp_fh.name)
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -38,7 +38,7 @@ from mlrun.datastore.store_resources import get_store_resource
 from mlrun.errors import MLRunInvalidArgumentError
 
 from .artifacts.manager import ArtifactManager, dict_to_artifact, extend_artifact_path
-from .datastore import store_manager
+from .datastore import remote_client_manager
 from .features import Feature
 from .model import HyperParamOptions
 from .secrets import SecretsStore
@@ -1369,7 +1369,7 @@ class MLClientCtx:
                 self._rundb = rundb
         else:
             self._rundb = mlrun.get_run_db()
-        self._data_stores = store_manager.set(self._secrets_manager, db=self._rundb)
+        self._data_stores = remote_client_manager.set(self._secrets_manager, db=self._rundb)
         self._artifacts_manager = ArtifactManager(db=self._rundb)
 
     def _load_project_object(self) -> Optional["mlrun.MlrunProject"]:

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -1369,7 +1369,9 @@ class MLClientCtx:
                 self._rundb = rundb
         else:
             self._rundb = mlrun.get_run_db()
-        self._data_stores = remote_client_manager.set(self._secrets_manager, db=self._rundb)
+        self._data_stores = remote_client_manager.set(
+            self._secrets_manager, db=self._rundb
+        )
         self._artifacts_manager = ArtifactManager(db=self._rundb)
 
     def _load_project_object(self) -> Optional["mlrun.MlrunProject"]:

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -38,7 +38,7 @@ from mlrun.datastore.store_resources import get_store_resource
 from mlrun.errors import MLRunInvalidArgumentError
 
 from .artifacts.manager import ArtifactManager, dict_to_artifact, extend_artifact_path
-from .datastore import remote_client_manager
+from .datastore import remote_item_manager
 from .features import Feature
 from .model import HyperParamOptions
 from .secrets import SecretsStore
@@ -1369,7 +1369,7 @@ class MLClientCtx:
                 self._rundb = rundb
         else:
             self._rundb = mlrun.get_run_db()
-        self._data_stores = remote_client_manager.set(
+        self._data_stores = remote_item_manager.set(
             self._secrets_manager, db=self._rundb
         )
         self._artifacts_manager = ArtifactManager(db=self._rundb)

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -381,7 +381,7 @@ def _ingest(
         )
 
     if isinstance(source, str):
-        source = mlrun.remote_client_manager.object(url=source).as_df()
+        source = mlrun.remote_item_manager.object(url=source).as_df()
 
     schema_options = InferOptions.get_common_options(
         infer_options, InferOptions.schema()
@@ -452,7 +452,7 @@ def _preview(
 
     if isinstance(source, str):
         # if source is a path/url convert to DataFrame
-        source = mlrun.remote_client_manager.object(url=source).as_df()
+        source = mlrun.remote_item_manager.object(url=source).as_df()
 
     verify_feature_set_permissions(
         featureset, mlrun.common.schemas.AuthorizationAction.update

--- a/mlrun/feature_store/api.py
+++ b/mlrun/feature_store/api.py
@@ -381,7 +381,7 @@ def _ingest(
         )
 
     if isinstance(source, str):
-        source = mlrun.store_manager.object(url=source).as_df()
+        source = mlrun.remote_client_manager.object(url=source).as_df()
 
     schema_options = InferOptions.get_common_options(
         infer_options, InferOptions.schema()
@@ -452,7 +452,7 @@ def _preview(
 
     if isinstance(source, str):
         # if source is a path/url convert to DataFrame
-        source = mlrun.store_manager.object(url=source).as_df()
+        source = mlrun.remote_client_manager.object(url=source).as_df()
 
     verify_feature_set_permissions(
         featureset, mlrun.common.schemas.AuthorizationAction.update

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -127,7 +127,7 @@ class MonitoringApplicationContext:
         self._feature_set: Optional[fs.FeatureSet] = (
             feature_sets_dict.get(self.endpoint_id) if feature_sets_dict else None
         )
-        store, _, _ = mlrun.remote_client_manager.get_or_create_store(
+        store, _, _ = mlrun.remote_item_manager.get_or_create_store(
             mlrun.mlconf.artifact_path
         )
         self.storage_options = store.get_storage_options()

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -127,7 +127,7 @@ class MonitoringApplicationContext:
         self._feature_set: Optional[fs.FeatureSet] = (
             feature_sets_dict.get(self.endpoint_id) if feature_sets_dict else None
         )
-        store, _, _ = mlrun.store_manager.get_or_create_store(
+        store, _, _ = mlrun.remote_client_manager.get_or_create_store(
             mlrun.mlconf.artifact_path
         )
         self.storage_options = store.get_storage_options()

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -259,7 +259,7 @@ class MonitoringApplicationController:
 
         self.model_monitoring_access_key = self._get_model_monitoring_access_key()
         self.v3io_access_key = mlrun.mlconf.get_v3io_access_key()
-        store, _, _ = mlrun.store_manager.get_or_create_store(
+        store, _, _ = mlrun.remote_client_manager.get_or_create_store(
             mlrun.mlconf.artifact_path
         )
         self.storage_options = store.get_storage_options()

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -259,7 +259,7 @@ class MonitoringApplicationController:
 
         self.model_monitoring_access_key = self._get_model_monitoring_access_key()
         self.v3io_access_key = mlrun.mlconf.get_v3io_access_key()
-        store, _, _ = mlrun.remote_client_manager.get_or_create_store(
+        store, _, _ = mlrun.remote_item_manager.get_or_create_store(
             mlrun.mlconf.artifact_path
         )
         self.storage_options = store.get_storage_options()

--- a/mlrun/model_monitoring/db/_schedules.py
+++ b/mlrun/model_monitoring/db/_schedules.py
@@ -232,7 +232,7 @@ def delete_model_monitoring_schedules_folder(project: str) -> None:
     folder = mlrun.model_monitoring.helpers._get_monitoring_schedules_folder_path(
         project
     )
-    fs = mlrun.datastore.store_manager.object(folder).store.filesystem
+    fs = mlrun.datastore.remote_client_manager.object(folder).store.filesystem
     if fs and fs.exists(folder):
         logger.debug("Deleting model monitoring schedules folder", folder=folder)
         fs.rm(folder, recursive=True)

--- a/mlrun/model_monitoring/db/_schedules.py
+++ b/mlrun/model_monitoring/db/_schedules.py
@@ -232,7 +232,7 @@ def delete_model_monitoring_schedules_folder(project: str) -> None:
     folder = mlrun.model_monitoring.helpers._get_monitoring_schedules_folder_path(
         project
     )
-    fs = mlrun.datastore.remote_client_manager.object(folder).store.filesystem
+    fs = mlrun.datastore.remote_item_manager.object(folder).store.filesystem
     if fs and fs.exists(folder):
         logger.debug("Deleting model monitoring schedules folder", folder=folder)
         fs.rm(folder, recursive=True)

--- a/mlrun/model_monitoring/db/_stats.py
+++ b/mlrun/model_monitoring/db/_stats.py
@@ -179,7 +179,7 @@ class ModelMonitoringDriftMeasuresFile(ModelMonitoringStatsFile):
 def delete_model_monitoring_stats_folder(project: str) -> None:
     """Delete the model monitoring schedules folder of the project"""
     folder = get_monitoring_stats_directory_path(project)
-    fs = mlrun.datastore.remote_client_manager.object(folder).store.filesystem
+    fs = mlrun.datastore.remote_item_manager.object(folder).store.filesystem
     if fs and fs.exists(folder):
         logger.debug("Deleting model monitoring stats folder", folder=folder)
         fs.rm(folder, recursive=True)

--- a/mlrun/model_monitoring/db/_stats.py
+++ b/mlrun/model_monitoring/db/_stats.py
@@ -179,7 +179,7 @@ class ModelMonitoringDriftMeasuresFile(ModelMonitoringStatsFile):
 def delete_model_monitoring_stats_folder(project: str) -> None:
     """Delete the model monitoring schedules folder of the project"""
     folder = get_monitoring_stats_directory_path(project)
-    fs = mlrun.datastore.store_manager.object(folder).store.filesystem
+    fs = mlrun.datastore.remote_client_manager.object(folder).store.filesystem
     if fs and fs.exists(folder):
         logger.debug("Deleting model monitoring stats folder", folder=folder)
         fs.rm(folder, recursive=True)

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -475,7 +475,7 @@ class V3IOTSDBConnector(TSDBConnector):
         # Final cleanup of tsdb path
         tsdb_path = self._get_v3io_source_directory()
         tsdb_path.replace("://u", ":///u")
-        store, _, _ = mlrun.store_manager.get_or_create_store(tsdb_path)
+        store, _, _ = mlrun.remote_client_manager.get_or_create_store(tsdb_path)
         store.rm(tsdb_path, recursive=True)
 
     def delete_tsdb_records(

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -475,7 +475,7 @@ class V3IOTSDBConnector(TSDBConnector):
         # Final cleanup of tsdb path
         tsdb_path = self._get_v3io_source_directory()
         tsdb_path.replace("://u", ":///u")
-        store, _, _ = mlrun.remote_client_manager.get_or_create_store(tsdb_path)
+        store, _, _ = mlrun.remote_item_manager.get_or_create_store(tsdb_path)
         store.rm(tsdb_path, recursive=True)
 
     def delete_tsdb_records(

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -220,7 +220,7 @@ def get_monitoring_current_stats_data(project: str, endpoint_id: str) -> "DataIt
     :param endpoint_id: endpoint id str
     :return: DataItem
     """
-    return mlrun.datastore.store_manager.object(
+    return mlrun.datastore.remote_client_manager.object(
         _get_monitoring_current_stats_file_path(
             project=project, endpoint_id=endpoint_id
         )
@@ -234,7 +234,7 @@ def get_monitoring_drift_measures_data(project: str, endpoint_id: str) -> "DataI
     :param endpoint_id: endpoint id str
     :return: DataItem
     """
-    return mlrun.datastore.store_manager.object(
+    return mlrun.datastore.remote_client_manager.object(
         _get_monitoring_drift_measures_file_path(
             project=project, endpoint_id=endpoint_id
         )
@@ -563,7 +563,7 @@ def get_monitoring_schedules_endpoint_data(
     """
     Get the model monitoring schedules' data item of the project's model endpoint.
     """
-    return mlrun.datastore.store_manager.object(
+    return mlrun.datastore.remote_client_manager.object(
         _get_monitoring_schedules_file_endpoint_path(
             project=project, endpoint_id=endpoint_id
         )
@@ -577,7 +577,7 @@ def get_monitoring_schedules_chief_data(
     """
     Get the model monitoring schedules' data item of the project's model endpoint.
     """
-    return mlrun.datastore.store_manager.object(
+    return mlrun.datastore.remote_client_manager.object(
         _get_monitoring_schedules_file_chief_path(project=project)
     )
 

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -220,7 +220,7 @@ def get_monitoring_current_stats_data(project: str, endpoint_id: str) -> "DataIt
     :param endpoint_id: endpoint id str
     :return: DataItem
     """
-    return mlrun.datastore.remote_client_manager.object(
+    return mlrun.datastore.remote_item_manager.object(
         _get_monitoring_current_stats_file_path(
             project=project, endpoint_id=endpoint_id
         )
@@ -234,7 +234,7 @@ def get_monitoring_drift_measures_data(project: str, endpoint_id: str) -> "DataI
     :param endpoint_id: endpoint id str
     :return: DataItem
     """
-    return mlrun.datastore.remote_client_manager.object(
+    return mlrun.datastore.remote_item_manager.object(
         _get_monitoring_drift_measures_file_path(
             project=project, endpoint_id=endpoint_id
         )
@@ -563,7 +563,7 @@ def get_monitoring_schedules_endpoint_data(
     """
     Get the model monitoring schedules' data item of the project's model endpoint.
     """
-    return mlrun.datastore.remote_client_manager.object(
+    return mlrun.datastore.remote_item_manager.object(
         _get_monitoring_schedules_file_endpoint_path(
             project=project, endpoint_id=endpoint_id
         )
@@ -577,7 +577,7 @@ def get_monitoring_schedules_chief_data(
     """
     Get the model monitoring schedules' data item of the project's model endpoint.
     """
-    return mlrun.datastore.remote_client_manager.object(
+    return mlrun.datastore.remote_item_manager.object(
         _get_monitoring_schedules_file_chief_path(project=project)
     )
 

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -275,7 +275,9 @@ class PackagersManager:
         # Try to get the notes and instructions (can be found only in artifacts but data item may be a simple path/url):
         if data_item.get_artifact_type():
             # Get the artifact object in the data item:
-            artifact, _ = remote_client_manager.get_store_artifact(url=data_item.artifact_url)
+            artifact, _ = remote_client_manager.get_store_artifact(
+                url=data_item.artifact_url
+            )
             # Get the key from the artifact's metadata and instructions from the artifact's spec:
             artifact_key = artifact.metadata.key
             packaging_instructions = artifact.spec.unpackaging_instructions

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -21,7 +21,7 @@ from typing import Any, Optional, Union
 
 import mlrun.errors
 from mlrun.artifacts import Artifact
-from mlrun.datastore import DataItem, get_store_resource, remote_client_manager
+from mlrun.datastore import DataItem, get_store_resource, remote_item_manager
 from mlrun.errors import MLRunInvalidArgumentError
 from mlrun.utils import logger
 
@@ -275,7 +275,7 @@ class PackagersManager:
         # Try to get the notes and instructions (can be found only in artifacts but data item may be a simple path/url):
         if data_item.get_artifact_type():
             # Get the artifact object in the data item:
-            artifact, _ = remote_client_manager.get_store_artifact(
+            artifact, _ = remote_item_manager.get_store_artifact(
                 url=data_item.artifact_url
             )
             # Get the key from the artifact's metadata and instructions from the artifact's spec:

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -21,7 +21,7 @@ from typing import Any, Optional, Union
 
 import mlrun.errors
 from mlrun.artifacts import Artifact
-from mlrun.datastore import DataItem, get_store_resource, store_manager
+from mlrun.datastore import DataItem, get_store_resource, remote_client_manager
 from mlrun.errors import MLRunInvalidArgumentError
 from mlrun.utils import logger
 
@@ -275,7 +275,7 @@ class PackagersManager:
         # Try to get the notes and instructions (can be found only in artifacts but data item may be a simple path/url):
         if data_item.get_artifact_type():
             # Get the artifact object in the data item:
-            artifact, _ = store_manager.get_store_artifact(url=data_item.artifact_url)
+            artifact, _ = remote_client_manager.get_store_artifact(url=data_item.artifact_url)
             # Get the key from the artifact's metadata and instructions from the artifact's spec:
             artifact_key = artifact.metadata.key
             packaging_instructions = artifact.spec.unpackaging_instructions

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -87,7 +87,7 @@ from ..artifacts import (
 )
 from ..artifacts.manager import ArtifactManager, dict_to_artifact, extend_artifact_path
 from ..common.runtimes.constants import RunStates
-from ..datastore import store_manager
+from ..datastore import remote_client_manager
 from ..features import Feature
 from ..model import EntrypointParam, ImageBuilder, ModelObj
 from ..run import code_to_function, get_object, import_function, new_function
@@ -1557,7 +1557,7 @@ class MlrunProject(ModelObj):
         if self._artifact_manager:
             return self._artifact_manager
         db = mlrun.db.get_run_db(secrets=self._secrets)
-        store_manager.set(self._secrets, db)
+        remote_client_manager.set(self._secrets, db)
         self._artifact_manager = ArtifactManager(db)
         return self._artifact_manager
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -87,7 +87,7 @@ from ..artifacts import (
 )
 from ..artifacts.manager import ArtifactManager, dict_to_artifact, extend_artifact_path
 from ..common.runtimes.constants import RunStates
-from ..datastore import remote_client_manager
+from ..datastore import remote_item_manager
 from ..features import Feature
 from ..model import EntrypointParam, ImageBuilder, ModelObj
 from ..run import code_to_function, get_object, import_function, new_function
@@ -1557,7 +1557,7 @@ class MlrunProject(ModelObj):
         if self._artifact_manager:
             return self._artifact_manager
         db = mlrun.db.get_run_db(secrets=self._secrets)
-        remote_client_manager.set(self._secrets, db)
+        remote_item_manager.set(self._secrets, db)
         self._artifact_manager = ArtifactManager(db)
         return self._artifact_manager
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -41,7 +41,7 @@ from mlrun_pipelines.common.ops import format_summary_from_kfp_run, show_kfp_run
 
 from .common.helpers import parse_versioned_object_uri
 from .config import config as mlconf
-from .datastore import store_manager
+from .datastore import remote_client_manager
 from .errors import MLRunInvalidArgumentError, MLRunTimeoutError
 from .execution import MLClientCtx
 from .model import RunObject, RunTemplate
@@ -1142,19 +1142,19 @@ def list_pipelines(
 
 def get_object(url, secrets=None, size=None, offset=0, db=None):
     """get mlrun dataitem body (from path/url)"""
-    stores = store_manager.set(secrets, db=db)
+    stores = remote_client_manager.set(secrets, db=db)
     return stores.object(url=url).get(size, offset)
 
 
 def get_dataitem(url, secrets=None, db=None) -> "DataItem":
     """get mlrun dataitem object (from path/url)"""
-    stores = store_manager.set(secrets, db=db)
+    stores = remote_client_manager.set(secrets, db=db)
     return stores.object(url=url)
 
 
 def download_object(url, target, secrets=None):
     """download mlrun dataitem (from path/url to target path)"""
-    stores = store_manager.set(secrets)
+    stores = remote_client_manager.set(secrets)
     stores.object(url=url).download(target_path=target)
 
 

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -41,7 +41,7 @@ from mlrun_pipelines.common.ops import format_summary_from_kfp_run, show_kfp_run
 
 from .common.helpers import parse_versioned_object_uri
 from .config import config as mlconf
-from .datastore import remote_client_manager
+from .datastore import remote_item_manager
 from .errors import MLRunInvalidArgumentError, MLRunTimeoutError
 from .execution import MLClientCtx
 from .model import RunObject, RunTemplate
@@ -1142,19 +1142,19 @@ def list_pipelines(
 
 def get_object(url, secrets=None, size=None, offset=0, db=None):
     """get mlrun dataitem body (from path/url)"""
-    stores = remote_client_manager.set(secrets, db=db)
+    stores = remote_item_manager.set(secrets, db=db)
     return stores.object(url=url).get(size, offset)
 
 
 def get_dataitem(url, secrets=None, db=None) -> "DataItem":
     """get mlrun dataitem object (from path/url)"""
-    stores = remote_client_manager.set(secrets, db=db)
+    stores = remote_item_manager.set(secrets, db=db)
     return stores.object(url=url)
 
 
 def download_object(url, target, secrets=None):
     """download mlrun dataitem (from path/url to target path)"""
-    stores = remote_client_manager.set(secrets)
+    stores = remote_item_manager.set(secrets)
     stores.object(url=url).download(target_path=target)
 
 

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -45,7 +45,7 @@ from mlrun.utils.helpers import generate_object_uri, verify_field_regex
 from mlrun_pipelines.common.ops import mlrun_op
 
 from ..config import config
-from ..datastore import store_manager
+from ..datastore import remote_client_manager
 from ..errors import err_to_str
 from ..lists import RunList
 from ..utils import (
@@ -886,7 +886,7 @@ class BaseRuntime(ModelObj):
             data = dict_to_yaml(struct)
         else:
             data = dict_to_json(struct)
-        stores = store_manager.set(secrets)
+        stores = remote_client_manager.set(secrets)
         target = target or "function.yaml"
         datastore, subpath, url = stores.get_or_create_store(target)
         datastore.put(subpath, data)

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -45,7 +45,7 @@ from mlrun.utils.helpers import generate_object_uri, verify_field_regex
 from mlrun_pipelines.common.ops import mlrun_op
 
 from ..config import config
-from ..datastore import remote_client_manager
+from ..datastore import remote_item_manager
 from ..errors import err_to_str
 from ..lists import RunList
 from ..utils import (
@@ -886,7 +886,7 @@ class BaseRuntime(ModelObj):
             data = dict_to_yaml(struct)
         else:
             data = dict_to_json(struct)
-        stores = remote_client_manager.set(secrets)
+        stores = remote_item_manager.set(secrets)
         target = target or "function.yaml"
         datastore, subpath, url = stores.get_or_create_store(target)
         datastore.put(subpath, data)

--- a/server/py/services/api/api/endpoints/files.py
+++ b/server/py/services/api/api/endpoints/files.py
@@ -21,7 +21,7 @@ from fastapi.concurrency import run_in_threadpool
 
 import mlrun
 import mlrun.common.schemas
-from mlrun.datastore import store_manager
+from mlrun.datastore import remote_client_manager
 from mlrun.errors import err_to_str
 from mlrun.utils import logger
 
@@ -135,7 +135,7 @@ def _get_files(
 
     body = None
     try:
-        obj = store_manager.object(url=objpath, secrets=secrets, project=project)
+        obj = remote_client_manager.object(url=objpath, secrets=secrets, project=project)
         if objpath.endswith("/"):
             listdir = obj.listdir()
             return {

--- a/server/py/services/api/api/endpoints/files.py
+++ b/server/py/services/api/api/endpoints/files.py
@@ -21,7 +21,7 @@ from fastapi.concurrency import run_in_threadpool
 
 import mlrun
 import mlrun.common.schemas
-from mlrun.datastore import remote_client_manager
+from mlrun.datastore import remote_item_manager
 from mlrun.errors import err_to_str
 from mlrun.utils import logger
 
@@ -135,9 +135,7 @@ def _get_files(
 
     body = None
     try:
-        obj = remote_client_manager.object(
-            url=objpath, secrets=secrets, project=project
-        )
+        obj = remote_item_manager.object(url=objpath, secrets=secrets, project=project)
         if objpath.endswith("/"):
             listdir = obj.listdir()
             return {

--- a/server/py/services/api/api/endpoints/files.py
+++ b/server/py/services/api/api/endpoints/files.py
@@ -135,7 +135,9 @@ def _get_files(
 
     body = None
     try:
-        obj = remote_client_manager.object(url=objpath, secrets=secrets, project=project)
+        obj = remote_client_manager.object(
+            url=objpath, secrets=secrets, project=project
+        )
         if objpath.endswith("/"):
             listdir = obj.listdir()
             return {

--- a/server/py/services/api/crud/files.py
+++ b/server/py/services/api/crud/files.py
@@ -83,7 +83,9 @@ class Files(
         enriched_secrets = self._enrich_secrets_with_auth_info(auth_info, secrets)
         stat = None
         try:
-            stat = remote_client_manager.object(url=path, secrets=enriched_secrets).stat()
+            stat = remote_client_manager.object(
+                url=path, secrets=enriched_secrets
+            ).stat()
         except FileNotFoundError as exc:
             framework.api.utils.log_and_raise(
                 HTTPStatus.NOT_FOUND.value, path=path, err=err_to_str(exc)
@@ -111,7 +113,9 @@ class Files(
         path = self._resolve_obj_path(schema, path, user)
         enriched_secrets = self._enrich_secrets_with_auth_info(auth_info, secrets)
 
-        obj = remote_client_manager.object(url=path, secrets=enriched_secrets, project=project)
+        obj = remote_client_manager.object(
+            url=path, secrets=enriched_secrets, project=project
+        )
         obj.delete()
 
     @staticmethod

--- a/server/py/services/api/crud/files.py
+++ b/server/py/services/api/crud/files.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 import mlrun.common.schemas
 import mlrun.utils.singleton
-from mlrun import remote_client_manager
+from mlrun import remote_item_manager
 from mlrun.errors import err_to_str
 from mlrun.utils import logger
 
@@ -83,9 +83,7 @@ class Files(
         enriched_secrets = self._enrich_secrets_with_auth_info(auth_info, secrets)
         stat = None
         try:
-            stat = remote_client_manager.object(
-                url=path, secrets=enriched_secrets
-            ).stat()
+            stat = remote_item_manager.object(url=path, secrets=enriched_secrets).stat()
         except FileNotFoundError as exc:
             framework.api.utils.log_and_raise(
                 HTTPStatus.NOT_FOUND.value, path=path, err=err_to_str(exc)
@@ -113,7 +111,7 @@ class Files(
         path = self._resolve_obj_path(schema, path, user)
         enriched_secrets = self._enrich_secrets_with_auth_info(auth_info, secrets)
 
-        obj = remote_client_manager.object(
+        obj = remote_item_manager.object(
             url=path, secrets=enriched_secrets, project=project
         )
         obj.delete()

--- a/server/py/services/api/crud/files.py
+++ b/server/py/services/api/crud/files.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 import mlrun.common.schemas
 import mlrun.utils.singleton
-from mlrun import store_manager
+from mlrun import remote_client_manager
 from mlrun.errors import err_to_str
 from mlrun.utils import logger
 
@@ -83,7 +83,7 @@ class Files(
         enriched_secrets = self._enrich_secrets_with_auth_info(auth_info, secrets)
         stat = None
         try:
-            stat = store_manager.object(url=path, secrets=enriched_secrets).stat()
+            stat = remote_client_manager.object(url=path, secrets=enriched_secrets).stat()
         except FileNotFoundError as exc:
             framework.api.utils.log_and_raise(
                 HTTPStatus.NOT_FOUND.value, path=path, err=err_to_str(exc)
@@ -111,7 +111,7 @@ class Files(
         path = self._resolve_obj_path(schema, path, user)
         enriched_secrets = self._enrich_secrets_with_auth_info(auth_info, secrets)
 
-        obj = store_manager.object(url=path, secrets=enriched_secrets, project=project)
+        obj = remote_client_manager.object(url=path, secrets=enriched_secrets, project=project)
         obj.delete()
 
     @staticmethod

--- a/server/py/services/api/crud/hub.py
+++ b/server/py/services/api/crud/hub.py
@@ -23,7 +23,7 @@ import mlrun.errors
 import mlrun.utils.helpers
 import mlrun.utils.singleton
 from mlrun.config import config
-from mlrun.datastore import store_manager
+from mlrun.datastore import remote_client_manager
 
 import framework.utils.singletons.db
 import framework.utils.singletons.k8s
@@ -153,7 +153,7 @@ class Hub(metaclass=mlrun.utils.singleton.Singleton):
             )
 
         if url.endswith("/"):
-            obj = store_manager.object(url=url, secrets=credentials)
+            obj = remote_client_manager.object(url=url, secrets=credentials)
             listdir = obj.listdir()
             return {
                 "listdir": listdir,

--- a/server/py/services/api/crud/hub.py
+++ b/server/py/services/api/crud/hub.py
@@ -23,7 +23,7 @@ import mlrun.errors
 import mlrun.utils.helpers
 import mlrun.utils.singleton
 from mlrun.config import config
-from mlrun.datastore import remote_client_manager
+from mlrun.datastore import remote_item_manager
 
 import framework.utils.singletons.db
 import framework.utils.singletons.k8s
@@ -153,7 +153,7 @@ class Hub(metaclass=mlrun.utils.singleton.Singleton):
             )
 
         if url.endswith("/"):
-            obj = remote_client_manager.object(url=url, secrets=credentials)
+            obj = remote_item_manager.object(url=url, secrets=credentials)
             listdir = obj.listdir()
             return {
                 "listdir": listdir,

--- a/server/py/services/api/tests/unit/api/test_files.py
+++ b/server/py/services/api/tests/unit/api/test_files.py
@@ -61,14 +61,14 @@ class DatastoreObjectMock:
 
 @pytest.fixture
 def files_mock():
-    old_object = mlrun.remote_client_manager.object
-    mlrun.remote_client_manager.object = unittest.mock.Mock(
+    old_object = mlrun.remote_item_manager.object
+    mlrun.remote_item_manager.object = unittest.mock.Mock(
         return_value=DatastoreObjectMock()
     )
 
-    yield mlrun.remote_client_manager.object
+    yield mlrun.remote_item_manager.object
 
-    mlrun.remote_client_manager.object = old_object
+    mlrun.remote_item_manager.object = old_object
 
 
 def test_files(db: Session, client: TestClient, files_mock, k8s_secrets_mock) -> None:

--- a/server/py/services/api/tests/unit/api/test_files.py
+++ b/server/py/services/api/tests/unit/api/test_files.py
@@ -62,7 +62,9 @@ class DatastoreObjectMock:
 @pytest.fixture
 def files_mock():
     old_object = mlrun.remote_client_manager.object
-    mlrun.remote_client_manager.object = unittest.mock.Mock(return_value=DatastoreObjectMock())
+    mlrun.remote_client_manager.object = unittest.mock.Mock(
+        return_value=DatastoreObjectMock()
+    )
 
     yield mlrun.remote_client_manager.object
 

--- a/server/py/services/api/tests/unit/api/test_files.py
+++ b/server/py/services/api/tests/unit/api/test_files.py
@@ -61,12 +61,12 @@ class DatastoreObjectMock:
 
 @pytest.fixture
 def files_mock():
-    old_object = mlrun.store_manager.object
-    mlrun.store_manager.object = unittest.mock.Mock(return_value=DatastoreObjectMock())
+    old_object = mlrun.remote_client_manager.object
+    mlrun.remote_client_manager.object = unittest.mock.Mock(return_value=DatastoreObjectMock())
 
-    yield mlrun.store_manager.object
+    yield mlrun.remote_client_manager.object
 
-    mlrun.store_manager.object = old_object
+    mlrun.remote_client_manager.object = old_object
 
 
 def test_files(db: Session, client: TestClient, files_mock, k8s_secrets_mock) -> None:

--- a/server/py/services/api/tests/unit/crud/test_files.py
+++ b/server/py/services/api/tests/unit/crud/test_files.py
@@ -63,7 +63,7 @@ def test_delete_artifact_data(
     k8s_secrets_mock.store_project_secrets(project, project_secrets)
 
     with unittest.mock.patch(
-        "mlrun.datastore.remote_client_manager.object"
+        "mlrun.datastore.remote_item_manager.object"
     ) as store_manager_object_mock:
         services.api.crud.Files().delete_artifact_data(
             auth_info, project, path, secrets=user_secrets

--- a/server/py/services/api/tests/unit/crud/test_files.py
+++ b/server/py/services/api/tests/unit/crud/test_files.py
@@ -63,7 +63,7 @@ def test_delete_artifact_data(
     k8s_secrets_mock.store_project_secrets(project, project_secrets)
 
     with unittest.mock.patch(
-        "mlrun.datastore.store_manager.object"
+        "mlrun.datastore.remote_client_manager.object"
     ) as store_manager_object_mock:
         services.api.crud.Files().delete_artifact_data(
             auth_info, project, path, secrets=user_secrets

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -79,8 +79,8 @@ def config_test_base():
     # remove the run db cache, so it won't pass between tests
     mlrun.db._run_db = None
     mlrun.db._last_db_url = None
-    mlrun.datastore.remote_client_manager._db = None
-    mlrun.datastore.remote_client_manager._stores = {}
+    mlrun.datastore.remote_item_manager._db = None
+    mlrun.datastore.remote_item_manager._stores = {}
 
     # no need to raise error when using nop_db
     mlrun.mlconf.httpdb.nop_db.raise_error = False

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -79,8 +79,8 @@ def config_test_base():
     # remove the run db cache, so it won't pass between tests
     mlrun.db._run_db = None
     mlrun.db._last_db_url = None
-    mlrun.datastore.store_manager._db = None
-    mlrun.datastore.store_manager._stores = {}
+    mlrun.datastore.remote_client_manager._db = None
+    mlrun.datastore.remote_client_manager._stores = {}
 
     # no need to raise error when using nop_db
     mlrun.mlconf.httpdb.nop_db.raise_error = False

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -222,7 +222,9 @@ def test_as_df_time_filters(start_time_tz, end_time_tz, df_tz):
             full_df[time_column] = full_df[time_column].dt.tz_localize("UTC")
         full_df.to_parquet(parquet_file.name)
 
-        data_item = mlrun.datastore.remote_client_manager.object(f"file://{parquet_file.name}")
+        data_item = mlrun.datastore.remote_client_manager.object(
+            f"file://{parquet_file.name}"
+        )
 
         start_time = None
         tzinfo = pytz.UTC if start_time_tz == "with_tz" else None

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -40,21 +40,21 @@ from mlrun.datastore.v3io import V3ioStore
 
 
 def test_http_fs_parquet_as_df():
-    data_item = mlrun.datastore.store_manager.object(
+    data_item = mlrun.datastore.remote_client_manager.object(
         "https://s3.wasabisys.com/iguazio/data/market-palce/aggregate/metrics.pq"
     )
     data_item.as_df()
 
 
 def test_http_fs_parquet_with_params_as_df():
-    data_item = mlrun.datastore.store_manager.object(
+    data_item = mlrun.datastore.remote_client_manager.object(
         "https://s3.wasabisys.com/iguazio/data/market-palce/aggregate/metrics.pq?param1=1&param2=2"
     )
     data_item.as_df()
 
 
 def test_s3_fs_parquet_as_df():
-    data_item = mlrun.datastore.store_manager.object(
+    data_item = mlrun.datastore.remote_client_manager.object(
         "s3://aws-public-blockchain/v1.0/btc/blocks/date=2023-02-27/"
         "part-00000-7de4c87e-242f-4568-b5d7-aae4cc75e9ad-c000.snappy.parquet"
     )
@@ -222,7 +222,7 @@ def test_as_df_time_filters(start_time_tz, end_time_tz, df_tz):
             full_df[time_column] = full_df[time_column].dt.tz_localize("UTC")
         full_df.to_parquet(parquet_file.name)
 
-        data_item = mlrun.datastore.store_manager.object(f"file://{parquet_file.name}")
+        data_item = mlrun.datastore.remote_client_manager.object(f"file://{parquet_file.name}")
 
         start_time = None
         tzinfo = pytz.UTC if start_time_tz == "with_tz" else None

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -29,12 +29,12 @@ from mlrun import MLRunInvalidArgumentError, new_function
 from mlrun.datastore import KafkaSource
 from mlrun.datastore.azure_blob import AzureBlobStore
 from mlrun.datastore.base import HttpStore
-from mlrun.datastore.datastore import schema_to_store
 from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
 from mlrun.datastore.dbfs_store import DBFSStore
 from mlrun.datastore.filestore import FileStore
 from mlrun.datastore.google_cloud_storage import GoogleCloudStorageStore
 from mlrun.datastore.redis import RedisStore
+from mlrun.datastore.remote_manager import schema_to_store
 from mlrun.datastore.s3 import S3Store
 from mlrun.datastore.v3io import V3ioStore
 

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -40,21 +40,21 @@ from mlrun.datastore.v3io import V3ioStore
 
 
 def test_http_fs_parquet_as_df():
-    data_item = mlrun.datastore.remote_client_manager.object(
+    data_item = mlrun.datastore.remote_item_manager.object(
         "https://s3.wasabisys.com/iguazio/data/market-palce/aggregate/metrics.pq"
     )
     data_item.as_df()
 
 
 def test_http_fs_parquet_with_params_as_df():
-    data_item = mlrun.datastore.remote_client_manager.object(
+    data_item = mlrun.datastore.remote_item_manager.object(
         "https://s3.wasabisys.com/iguazio/data/market-palce/aggregate/metrics.pq?param1=1&param2=2"
     )
     data_item.as_df()
 
 
 def test_s3_fs_parquet_as_df():
-    data_item = mlrun.datastore.remote_client_manager.object(
+    data_item = mlrun.datastore.remote_item_manager.object(
         "s3://aws-public-blockchain/v1.0/btc/blocks/date=2023-02-27/"
         "part-00000-7de4c87e-242f-4568-b5d7-aae4cc75e9ad-c000.snappy.parquet"
     )
@@ -222,7 +222,7 @@ def test_as_df_time_filters(start_time_tz, end_time_tz, df_tz):
             full_df[time_column] = full_df[time_column].dt.tz_localize("UTC")
         full_df.to_parquet(parquet_file.name)
 
-        data_item = mlrun.datastore.remote_client_manager.object(
+        data_item = mlrun.datastore.remote_item_manager.object(
             f"file://{parquet_file.name}"
         )
 

--- a/tests/datastore/test_datastores.py
+++ b/tests/datastore/test_datastores.py
@@ -106,7 +106,7 @@ def test_file(rundb_mock, tmpdir: Path) -> None:
 def test_parse_url_preserve_case():
     url = "store://Hedi/mlrun-dbd7ef-training_mymodel#a5dc8e34a46240bb9a07cd9deb3609c7"
     expected_endpoint = "Hedi"
-    _, endpoint, _ = mlrun.datastore.datastore.parse_url(url)
+    _, endpoint, _ = mlrun.datastore.remote_client_manager.parse_url(url)
     assert expected_endpoint, endpoint
 
 
@@ -262,7 +262,7 @@ def test_get_store_resource_with_linked_artifacts():
 
 @pytest.mark.usefixtures("patch_file_forbidden")
 def test_forbidden_file_access():
-    store = mlrun.datastore.datastore.StoreManager(
+    store = mlrun.datastore.remote_manager.RemoteClientManager(
         secrets={"V3IO_ACCESS_KEY": "some-access-key"}
     )
 
@@ -289,7 +289,7 @@ def test_verify_data_stores_are_not_cached_in_api_when_not_needed():
     user2_objpath = "v3io://some-system/some-dir/user2"
 
     user3_objpath = "v3io://some-system/some-dir/user3"
-    store = mlrun.datastore.datastore.StoreManager(
+    store = mlrun.datastore.remote_manager.RemoteClientManager(
         secrets={"V3IO_ACCESS_KEY": "api-access-key"}
     )
     obj = store.object(url=user1_objpath, secrets=user1_secrets)
@@ -313,7 +313,7 @@ def test_verify_data_stores_are_cached_when_not_api():
     user2_objpath = "v3io://some-system/some-dir/user2"
 
     user3_objpath = "v3io://some-system/some-dir/user3"
-    store = mlrun.datastore.datastore.StoreManager(
+    store = mlrun.datastore.remote_manager.RemoteClientManager(
         secrets={"V3IO_ACCESS_KEY": "api-access-key"}
     )
     # if secrets provided then store is not cached
@@ -343,7 +343,7 @@ def test_verify_data_stores_are_cached_when_not_api():
 
 def test_object_from_empty_url():
     user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
-    store = mlrun.datastore.datastore.StoreManager(
+    store = mlrun.datastore.remote_manager.RemoteClientManager(
         secrets={"V3IO_ACCESS_KEY": "api-access-key"}
     )
     data_item = store.object(url="", secrets=user1_secrets)

--- a/tests/datastore/test_datastores.py
+++ b/tests/datastore/test_datastores.py
@@ -106,7 +106,7 @@ def test_file(rundb_mock, tmpdir: Path) -> None:
 def test_parse_url_preserve_case():
     url = "store://Hedi/mlrun-dbd7ef-training_mymodel#a5dc8e34a46240bb9a07cd9deb3609c7"
     expected_endpoint = "Hedi"
-    _, endpoint, _ = mlrun.datastore.remote_client_manager.parse_url(url)
+    _, endpoint, _ = mlrun.datastore.remote_item_manager.parse_url(url)
     assert expected_endpoint, endpoint
 
 
@@ -262,7 +262,7 @@ def test_get_store_resource_with_linked_artifacts():
 
 @pytest.mark.usefixtures("patch_file_forbidden")
 def test_forbidden_file_access():
-    store = mlrun.datastore.remote_manager.RemoteClientManager(
+    store = mlrun.datastore.remote_manager.RemoteItemManager(
         secrets={"V3IO_ACCESS_KEY": "some-access-key"}
     )
 
@@ -289,7 +289,7 @@ def test_verify_data_stores_are_not_cached_in_api_when_not_needed():
     user2_objpath = "v3io://some-system/some-dir/user2"
 
     user3_objpath = "v3io://some-system/some-dir/user3"
-    store = mlrun.datastore.remote_manager.RemoteClientManager(
+    store = mlrun.datastore.remote_manager.RemoteItemManager(
         secrets={"V3IO_ACCESS_KEY": "api-access-key"}
     )
     obj = store.object(url=user1_objpath, secrets=user1_secrets)
@@ -313,7 +313,7 @@ def test_verify_data_stores_are_cached_when_not_api():
     user2_objpath = "v3io://some-system/some-dir/user2"
 
     user3_objpath = "v3io://some-system/some-dir/user3"
-    store = mlrun.datastore.remote_manager.RemoteClientManager(
+    store = mlrun.datastore.remote_manager.RemoteItemManager(
         secrets={"V3IO_ACCESS_KEY": "api-access-key"}
     )
     # if secrets provided then store is not cached
@@ -343,7 +343,7 @@ def test_verify_data_stores_are_cached_when_not_api():
 
 def test_object_from_empty_url():
     user1_secrets = {"V3IO_ACCESS_KEY": "user1-access-key"}
-    store = mlrun.datastore.remote_manager.RemoteClientManager(
+    store = mlrun.datastore.remote_manager.RemoteItemManager(
         secrets={"V3IO_ACCESS_KEY": "api-access-key"}
     )
     data_item = store.object(url="", secrets=user1_secrets)
@@ -354,7 +354,7 @@ def test_object_from_empty_url():
 
 
 def test_fsspec(tmpdir: Path) -> None:
-    store, _, _ = mlrun.remote_client_manager.get_or_create_store(str(tmpdir))
+    store, _, _ = mlrun.remote_item_manager.get_or_create_store(str(tmpdir))
     file_system = store.filesystem
     with store.open(tmpdir / "1x.txt", "w") as fp:
         fp.write("123")

--- a/tests/datastore/test_datastores.py
+++ b/tests/datastore/test_datastores.py
@@ -354,7 +354,7 @@ def test_object_from_empty_url():
 
 
 def test_fsspec(tmpdir: Path) -> None:
-    store, _, _ = mlrun.store_manager.get_or_create_store(str(tmpdir))
+    store, _, _ = mlrun.remote_client_manager.get_or_create_store(str(tmpdir))
     file_system = store.filesystem
     with store.open(tmpdir / "1x.txt", "w") as fp:
         fp.write("123")

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -27,7 +27,7 @@ from botocore.exceptions import ClientError
 
 import mlrun
 import mlrun.errors
-from mlrun.datastore import remote_client_manager
+from mlrun.datastore import remote_item_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileS3,
     register_temporary_client_datastore_profile,
@@ -92,7 +92,7 @@ class TestAwsS3:
             logger.debug("test directory has been deleted.")
 
     def setup_method(self, method):
-        remote_client_manager.reset_secrets()
+        remote_item_manager.reset_secrets()
         self.profile = DatastoreProfileS3(
             name=self.profile_name,
             access_key_id=self.access_key_id,
@@ -106,7 +106,7 @@ class TestAwsS3:
 
     @pytest.fixture(autouse=True)
     def setup_before_each_test(self, use_datastore_profile):
-        mlrun.datastore.remote_client_manager.reset_secrets()
+        mlrun.datastore.remote_item_manager.reset_secrets()
 
         # We give priority to profiles, then to secrets, and finally to environment variables.
         # We want to ensure that we test these priorities in the correct order.

--- a/tests/integration/aws_s3/test_aws_s3.py
+++ b/tests/integration/aws_s3/test_aws_s3.py
@@ -27,7 +27,7 @@ from botocore.exceptions import ClientError
 
 import mlrun
 import mlrun.errors
-from mlrun.datastore import store_manager
+from mlrun.datastore import remote_client_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileS3,
     register_temporary_client_datastore_profile,
@@ -92,7 +92,7 @@ class TestAwsS3:
             logger.debug("test directory has been deleted.")
 
     def setup_method(self, method):
-        store_manager.reset_secrets()
+        remote_client_manager.reset_secrets()
         self.profile = DatastoreProfileS3(
             name=self.profile_name,
             access_key_id=self.access_key_id,
@@ -106,7 +106,7 @@ class TestAwsS3:
 
     @pytest.fixture(autouse=True)
     def setup_before_each_test(self, use_datastore_profile):
-        mlrun.datastore.store_manager.reset_secrets()
+        mlrun.datastore.remote_client_manager.reset_secrets()
 
         # We give priority to profiles, then to secrets, and finally to environment variables.
         # We want to ensure that we test these priorities in the correct order.

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -28,7 +28,7 @@ from azure.core.exceptions import ClientAuthenticationError
 
 import mlrun
 import mlrun.errors
-from mlrun.datastore import store_manager
+from mlrun.datastore import remote_client_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileAzureBlob,
     register_temporary_client_datastore_profile,
@@ -119,7 +119,7 @@ class TestAzureBlob:
 
     @classmethod
     def teardown_class(cls):
-        store_manager.reset_secrets()
+        remote_client_manager.reset_secrets()
         pop_env()
         test_dir = f"{cls.bucket_name}/{cls.test_dir}"
         if not cls._azure_fs:
@@ -146,7 +146,7 @@ class TestAzureBlob:
         self.object_url = f"{self.run_dir_url}{self.object_file}"
 
     def setup_before_test(self, use_datastore_profile, auth_method, fake_secrets=False):
-        store_manager.reset_secrets()
+        remote_client_manager.reset_secrets()
         self.storage_options = {}
         pop_env()
         self.build_object_url(use_datastore_profile)
@@ -455,17 +455,17 @@ class TestAnonymousAccessAzureBlob:
     @pytest.fixture(autouse=True)
     def setup_before_each_test(self):
         pop_env()
-        store_manager.reset_secrets()
+        remote_client_manager.reset_secrets()
         os.environ["AZURE_STORAGE_ACCOUNT_NAME"] = self.account_name
 
     def teardown_class(self):
-        store_manager.reset_secrets()
+        remote_client_manager.reset_secrets()
         pop_env()
 
     def test_load_object_into_dask_dataframe(self):
         # Load a parquet file from Azure Open Datasets
 
-        data_item = mlrun.datastore.store_manager.object(
+        data_item = mlrun.datastore.remote_client_manager.object(
             "az://public/curated/covid-19/ecdc_cases/latest/ecdc_cases.parquet"
         )
         ddf = data_item.as_df(df_module=dd)

--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -28,7 +28,7 @@ from azure.core.exceptions import ClientAuthenticationError
 
 import mlrun
 import mlrun.errors
-from mlrun.datastore import remote_client_manager
+from mlrun.datastore import remote_item_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileAzureBlob,
     register_temporary_client_datastore_profile,
@@ -119,7 +119,7 @@ class TestAzureBlob:
 
     @classmethod
     def teardown_class(cls):
-        remote_client_manager.reset_secrets()
+        remote_item_manager.reset_secrets()
         pop_env()
         test_dir = f"{cls.bucket_name}/{cls.test_dir}"
         if not cls._azure_fs:
@@ -146,7 +146,7 @@ class TestAzureBlob:
         self.object_url = f"{self.run_dir_url}{self.object_file}"
 
     def setup_before_test(self, use_datastore_profile, auth_method, fake_secrets=False):
-        remote_client_manager.reset_secrets()
+        remote_item_manager.reset_secrets()
         self.storage_options = {}
         pop_env()
         self.build_object_url(use_datastore_profile)
@@ -455,17 +455,17 @@ class TestAnonymousAccessAzureBlob:
     @pytest.fixture(autouse=True)
     def setup_before_each_test(self):
         pop_env()
-        remote_client_manager.reset_secrets()
+        remote_item_manager.reset_secrets()
         os.environ["AZURE_STORAGE_ACCOUNT_NAME"] = self.account_name
 
     def teardown_class(self):
-        remote_client_manager.reset_secrets()
+        remote_item_manager.reset_secrets()
         pop_env()
 
     def test_load_object_into_dask_dataframe(self):
         # Load a parquet file from Azure Open Datasets
 
-        data_item = mlrun.datastore.remote_client_manager.object(
+        data_item = mlrun.datastore.remote_item_manager.object(
             "az://public/curated/covid-19/ecdc_cases/latest/ecdc_cases.parquet"
         )
         ddf = data_item.as_df(df_module=dd)

--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -31,7 +31,7 @@ from google.auth.exceptions import DefaultCredentialsError, RefreshError
 
 import mlrun
 import mlrun.errors
-from mlrun.datastore import remote_client_manager
+from mlrun.datastore import remote_item_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileGCS,
     register_temporary_client_datastore_profile,
@@ -114,7 +114,7 @@ class TestGoogleCloudStorage:
 
     @pytest.fixture(autouse=True)
     def setup_before_each_test(self, use_datastore_profile):
-        remote_client_manager.reset_secrets()
+        remote_item_manager.reset_secrets()
         object_file = f"/file_{uuid.uuid4()}.txt"
         self._object_path = f"{self.run_dir}{object_file}"
         os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)

--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -31,7 +31,7 @@ from google.auth.exceptions import DefaultCredentialsError, RefreshError
 
 import mlrun
 import mlrun.errors
-from mlrun.datastore import store_manager
+from mlrun.datastore import remote_client_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileGCS,
     register_temporary_client_datastore_profile,
@@ -114,7 +114,7 @@ class TestGoogleCloudStorage:
 
     @pytest.fixture(autouse=True)
     def setup_before_each_test(self, use_datastore_profile):
-        store_manager.reset_secrets()
+        remote_client_manager.reset_secrets()
         object_file = f"/file_{uuid.uuid4()}.txt"
         self._object_path = f"{self.run_dir}{object_file}"
         os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)

--- a/tests/integration/redis/test_redis.py
+++ b/tests/integration/redis/test_redis.py
@@ -60,7 +60,7 @@ class TestRedisDataStore:
 
     def test_redis_put_get_object(self, use_datastore_profile):
         self.setup_before_test(use_datastore_profile)
-        data_item = mlrun.datastore.remote_client_manager.object(self.object_url)
+        data_item = mlrun.datastore.remote_item_manager.object(self.object_url)
 
         data_item.delete()
 
@@ -107,7 +107,7 @@ class TestRedisDataStore:
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=True) as temp_file:
             with open(temp_file.name, "w") as f:
                 f.write(expected)
-            data_item = mlrun.datastore.remote_client_manager.object(self.object_url)
+            data_item = mlrun.datastore.remote_item_manager.object(self.object_url)
             data_item.delete()
 
             data_item.upload(temp_file.name)
@@ -125,14 +125,14 @@ class TestRedisDataStore:
         for depth in range(5):
             dir_path = dir_path + f"/dir-{depth}"
             obj_path = dir_path + f"/obj-{depth}"
-            data_item = mlrun.datastore.remote_client_manager.object(obj_path)
+            data_item = mlrun.datastore.remote_item_manager.object(obj_path)
             data_item.delete()
             data_item.put("abcde")
             # list_dir skips the first object
             if depth > 0:
                 expected.append(obj_path[len(self.test_endpoint) :])
 
-        dir_item = mlrun.datastore.remote_client_manager.object(list_dir)
+        dir_item = mlrun.datastore.remote_item_manager.object(list_dir)
         actual = dir_item.listdir()
         assert set(expected) == set(
             actual

--- a/tests/integration/redis/test_redis.py
+++ b/tests/integration/redis/test_redis.py
@@ -60,7 +60,7 @@ class TestRedisDataStore:
 
     def test_redis_put_get_object(self, use_datastore_profile):
         self.setup_before_test(use_datastore_profile)
-        data_item = mlrun.datastore.store_manager.object(self.object_url)
+        data_item = mlrun.datastore.remote_client_manager.object(self.object_url)
 
         data_item.delete()
 
@@ -107,7 +107,7 @@ class TestRedisDataStore:
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=True) as temp_file:
             with open(temp_file.name, "w") as f:
                 f.write(expected)
-            data_item = mlrun.datastore.store_manager.object(self.object_url)
+            data_item = mlrun.datastore.remote_client_manager.object(self.object_url)
             data_item.delete()
 
             data_item.upload(temp_file.name)
@@ -125,14 +125,14 @@ class TestRedisDataStore:
         for depth in range(5):
             dir_path = dir_path + f"/dir-{depth}"
             obj_path = dir_path + f"/obj-{depth}"
-            data_item = mlrun.datastore.store_manager.object(obj_path)
+            data_item = mlrun.datastore.remote_client_manager.object(obj_path)
             data_item.delete()
             data_item.put("abcde")
             # list_dir skips the first object
             if depth > 0:
                 expected.append(obj_path[len(self.test_endpoint) :])
 
-        dir_item = mlrun.datastore.store_manager.object(list_dir)
+        dir_item = mlrun.datastore.remote_client_manager.object(list_dir)
         actual = dir_item.listdir()
         assert set(expected) == set(
             actual

--- a/tests/integration/test_dbfs_store/test_dbfs_store.py
+++ b/tests/integration/test_dbfs_store/test_dbfs_store.py
@@ -27,7 +27,7 @@ from fsspec.implementations.dbfs import DatabricksException
 # from databricks.sdk.errors.mapping import PermissionDenied, Unauthenticated
 import mlrun
 import mlrun.errors
-from mlrun.datastore import store_manager
+from mlrun.datastore import remote_client_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileDBFS,
     register_temporary_client_datastore_profile,
@@ -98,7 +98,7 @@ class TestDBFSStore:
         register_temporary_client_datastore_profile(self.profile)
         os.environ["DATABRICKS_TOKEN"] = self.token
         os.environ["DATABRICKS_HOST"] = self.host
-        store_manager.reset_secrets()
+        remote_client_manager.reset_secrets()
 
     @classmethod
     def teardown_class(cls):

--- a/tests/integration/test_dbfs_store/test_dbfs_store.py
+++ b/tests/integration/test_dbfs_store/test_dbfs_store.py
@@ -27,7 +27,7 @@ from fsspec.implementations.dbfs import DatabricksException
 # from databricks.sdk.errors.mapping import PermissionDenied, Unauthenticated
 import mlrun
 import mlrun.errors
-from mlrun.datastore import remote_client_manager
+from mlrun.datastore import remote_item_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileDBFS,
     register_temporary_client_datastore_profile,
@@ -98,7 +98,7 @@ class TestDBFSStore:
         register_temporary_client_datastore_profile(self.profile)
         os.environ["DATABRICKS_TOKEN"] = self.token
         os.environ["DATABRICKS_HOST"] = self.host
-        remote_client_manager.reset_secrets()
+        remote_item_manager.reset_secrets()
 
     @classmethod
     def teardown_class(cls):

--- a/tests/system/datastore/test_v3io.py
+++ b/tests/system/datastore/test_v3io.py
@@ -89,7 +89,7 @@ class TestV3ioDataStore(TestMLRunSystem):
         prefix_path = (
             f"ds://{self.profile_name}" if use_datastore_profile else "v3io://"
         )
-        mlrun.datastore.remote_client_manager.reset_secrets()
+        mlrun.datastore.remote_item_manager.reset_secrets()
         self.run_dir_url = f"{prefix_path}{self.run_dir}"
         object_file = f"/file_{uuid.uuid4()}.txt"
         self.object_url = f"{self.run_dir_url}{object_file}"
@@ -271,12 +271,12 @@ class TestV3ioDataStore(TestMLRunSystem):
         assert stat.size == len(self.test_string)
 
     def test_list_dir(self):
-        dir_base_item = mlrun.datastore.remote_client_manager.object(self.run_dir_url)
+        dir_base_item = mlrun.datastore.remote_item_manager.object(self.run_dir_url)
         filename = f"test_file_{uuid.uuid4()}.txt"
-        file_item = mlrun.datastore.remote_client_manager.object(
+        file_item = mlrun.datastore.remote_item_manager.object(
             f"{self.run_dir_url}/{filename}"
         )
-        file_item_deep = mlrun.datastore.remote_client_manager.object(
+        file_item_deep = mlrun.datastore.remote_item_manager.object(
             f"{self.run_dir_url}/test_dir/test_file_{uuid.uuid4()}.txt"
         )
         file_item.put("test")

--- a/tests/system/datastore/test_v3io.py
+++ b/tests/system/datastore/test_v3io.py
@@ -89,7 +89,7 @@ class TestV3ioDataStore(TestMLRunSystem):
         prefix_path = (
             f"ds://{self.profile_name}" if use_datastore_profile else "v3io://"
         )
-        mlrun.datastore.store_manager.reset_secrets()
+        mlrun.datastore.remote_client_manager.reset_secrets()
         self.run_dir_url = f"{prefix_path}{self.run_dir}"
         object_file = f"/file_{uuid.uuid4()}.txt"
         self.object_url = f"{self.run_dir_url}{object_file}"
@@ -271,12 +271,12 @@ class TestV3ioDataStore(TestMLRunSystem):
         assert stat.size == len(self.test_string)
 
     def test_list_dir(self):
-        dir_base_item = mlrun.datastore.store_manager.object(self.run_dir_url)
+        dir_base_item = mlrun.datastore.remote_client_manager.object(self.run_dir_url)
         filename = f"test_file_{uuid.uuid4()}.txt"
-        file_item = mlrun.datastore.store_manager.object(
+        file_item = mlrun.datastore.remote_client_manager.object(
             f"{self.run_dir_url}/{filename}"
         )
-        file_item_deep = mlrun.datastore.store_manager.object(
+        file_item_deep = mlrun.datastore.remote_client_manager.object(
             f"{self.run_dir_url}/test_dir/test_file_{uuid.uuid4()}.txt"
         )
         file_item.put("test")

--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -40,7 +40,7 @@ class TestHorovodTFv2(TestDemo):
         self._logger.debug("Uploading training file")
         trainer_src_path = str(self.assets_path / "horovod_training.py")
         trainer_dest_path = pathlib.Path("/assets/horovod_training.py")
-        stores = mlrun.datastore.store_manager.set()
+        stores = mlrun.datastore.remote_client_manager.set()
         datastore, subpath, _ = stores.get_or_create_store(
             self._get_v3io_user_store_path(trainer_dest_path)
         )

--- a/tests/system/demos/horovod/test_horovod.py
+++ b/tests/system/demos/horovod/test_horovod.py
@@ -40,7 +40,7 @@ class TestHorovodTFv2(TestDemo):
         self._logger.debug("Uploading training file")
         trainer_src_path = str(self.assets_path / "horovod_training.py")
         trainer_dest_path = pathlib.Path("/assets/horovod_training.py")
-        stores = mlrun.datastore.remote_client_manager.set()
+        stores = mlrun.datastore.remote_item_manager.set()
         datastore, subpath, _ = stores.get_or_create_store(
             self._get_v3io_user_store_path(trainer_dest_path)
         )

--- a/tests/system/feature_store/spark_hadoop_test_base.py
+++ b/tests/system/feature_store/spark_hadoop_test_base.py
@@ -20,7 +20,7 @@ import pytest
 
 import mlrun
 import mlrun.feature_store as fstore
-from mlrun import remote_client_manager
+from mlrun import remote_item_manager
 from mlrun.datastore.sources import ParquetSource
 from mlrun.datastore.targets import (
     ParquetTarget,
@@ -125,7 +125,7 @@ class SparkHadoopTestBase(TestMLRunSystem):
         )
 
     def ds_upload_src(self, ds_profile, bucket):
-        store, _, _ = remote_client_manager.get_or_create_store(
+        store, _, _ = remote_item_manager.get_or_create_store(
             f"ds://{ds_profile.name}/{bucket}"
         )
         store.upload(

--- a/tests/system/feature_store/spark_hadoop_test_base.py
+++ b/tests/system/feature_store/spark_hadoop_test_base.py
@@ -20,7 +20,7 @@ import pytest
 
 import mlrun
 import mlrun.feature_store as fstore
-from mlrun import store_manager
+from mlrun import remote_client_manager
 from mlrun.datastore.sources import ParquetSource
 from mlrun.datastore.targets import (
     ParquetTarget,
@@ -125,7 +125,7 @@ class SparkHadoopTestBase(TestMLRunSystem):
         )
 
     def ds_upload_src(self, ds_profile, bucket):
-        store, _, _ = store_manager.get_or_create_store(
+        store, _, _ = remote_client_manager.get_or_create_store(
             f"ds://{ds_profile.name}/{bucket}"
         )
         store.upload(

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -530,7 +530,7 @@ class TestFeatureStore(TestMLRunSystem):
         if should_succeed:
             fset.ingest(source=stocks, targets=[target])
             if fset.get_target_path().endswith(fset.status.targets[0].run_id + "/"):
-                store, _, _ = mlrun.remote_client_manager.get_or_create_store(
+                store, _, _ = mlrun.remote_item_manager.get_or_create_store(
                     fset.get_target_path()
                 )
                 v3io = store.filesystem
@@ -570,7 +570,7 @@ class TestFeatureStore(TestMLRunSystem):
         if should_succeed:
             fset.ingest(source=source, targets=[target])
             if fset.get_target_path().endswith(fset.status.targets[0].run_id + "/"):
-                store, _, _ = mlrun.remote_client_manager.get_or_create_store(
+                store, _, _ = mlrun.remote_item_manager.get_or_create_store(
                     fset.get_target_path()
                 )
                 v3io = store.filesystem

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -530,7 +530,7 @@ class TestFeatureStore(TestMLRunSystem):
         if should_succeed:
             fset.ingest(source=stocks, targets=[target])
             if fset.get_target_path().endswith(fset.status.targets[0].run_id + "/"):
-                store, _, _ = mlrun.store_manager.get_or_create_store(
+                store, _, _ = mlrun.remote_client_manager.get_or_create_store(
                     fset.get_target_path()
                 )
                 v3io = store.filesystem
@@ -570,7 +570,7 @@ class TestFeatureStore(TestMLRunSystem):
         if should_succeed:
             fset.ingest(source=source, targets=[target])
             if fset.get_target_path().endswith(fset.status.targets[0].run_id + "/"):
-                store, _, _ = mlrun.store_manager.get_or_create_store(
+                store, _, _ = mlrun.remote_client_manager.get_or_create_store(
                     fset.get_target_path()
                 )
                 v3io = store.filesystem

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -169,7 +169,9 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         from mlrun.run import new_function
         from mlrun.runtimes import RemoteSparkRuntime
 
-        store, _, _ = remote_client_manager.get_or_create_store(cls.get_remote_pq_source_path())
+        store, _, _ = remote_client_manager.get_or_create_store(
+            cls.get_remote_pq_source_path()
+        )
         store.upload(
             cls.get_remote_pq_source_path(without_prefix=True),
             cls.get_local_pq_source_path(),

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -30,7 +30,7 @@ from storey import EmitEveryEvent
 import mlrun
 import mlrun.datastore.utils
 import mlrun.feature_store as fstore
-from mlrun import code_to_function, store_manager
+from mlrun import code_to_function, remote_client_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileHdfs,
     DatastoreProfileS3,
@@ -169,12 +169,12 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         from mlrun.run import new_function
         from mlrun.runtimes import RemoteSparkRuntime
 
-        store, _, _ = store_manager.get_or_create_store(cls.get_remote_pq_source_path())
+        store, _, _ = remote_client_manager.get_or_create_store(cls.get_remote_pq_source_path())
         store.upload(
             cls.get_remote_pq_source_path(without_prefix=True),
             cls.get_local_pq_source_path(),
         )
-        store, _, _ = store_manager.get_or_create_store(
+        store, _, _ = remote_client_manager.get_or_create_store(
             cls.get_remote_csv_source_path()
         )
         store.upload(
@@ -1474,7 +1474,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             )
 
             if fset.get_target_path().endswith(fset.status.targets[0].run_id + "/"):
-                store, _, _ = mlrun.store_manager.get_or_create_store(
+                store, _, _ = mlrun.remote_client_manager.get_or_create_store(
                     fset.get_target_path()
                 )
                 v3io = store.filesystem

--- a/tests/system/feature_store/test_spark_engine.py
+++ b/tests/system/feature_store/test_spark_engine.py
@@ -30,7 +30,7 @@ from storey import EmitEveryEvent
 import mlrun
 import mlrun.datastore.utils
 import mlrun.feature_store as fstore
-from mlrun import code_to_function, remote_client_manager
+from mlrun import code_to_function, remote_item_manager
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileHdfs,
     DatastoreProfileS3,
@@ -169,14 +169,14 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
         from mlrun.run import new_function
         from mlrun.runtimes import RemoteSparkRuntime
 
-        store, _, _ = remote_client_manager.get_or_create_store(
+        store, _, _ = remote_item_manager.get_or_create_store(
             cls.get_remote_pq_source_path()
         )
         store.upload(
             cls.get_remote_pq_source_path(without_prefix=True),
             cls.get_local_pq_source_path(),
         )
-        store, _, _ = remote_client_manager.get_or_create_store(
+        store, _, _ = remote_item_manager.get_or_create_store(
             cls.get_remote_csv_source_path()
         )
         store.upload(
@@ -1476,7 +1476,7 @@ class TestFeatureStoreSparkEngine(TestMLRunSystem):
             )
 
             if fset.get_target_path().endswith(fset.status.targets[0].run_id + "/"):
-                store, _, _ = mlrun.remote_client_manager.get_or_create_store(
+                store, _, _ = mlrun.remote_item_manager.get_or_create_store(
                     fset.get_target_path()
                 )
                 v3io = store.filesystem

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -209,7 +209,7 @@ def test_context_inputs(rundb_mock, is_api):
         # 'store-input' is a store artifact, store it in the db before getting it
         artifact = mlrun.artifacts.Artifact(key, b"123")
         rundb_mock.store_artifact(key, artifact.to_dict(), uid="123")
-        mlrun.datastore.store_manager.object(
+        mlrun.datastore.remote_client_manager.object(
             url,
             key,
             project=run_dict["metadata"]["project"],

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -209,7 +209,7 @@ def test_context_inputs(rundb_mock, is_api):
         # 'store-input' is a store artifact, store it in the db before getting it
         artifact = mlrun.artifacts.Artifact(key, b"123")
         rundb_mock.store_artifact(key, artifact.to_dict(), uid="123")
-        mlrun.datastore.remote_client_manager.object(
+        mlrun.datastore.remote_item_manager.object(
             url,
             key,
             project=run_dict["metadata"]["project"],


### PR DESCRIPTION
For a more generic approach with remote items, the functions, class names, and modules in store_manager need to be decoupled from the datastore-specific syntax.

[ML-10347](https://iguazio.atlassian.net/browse/ML-10347)

[ML-10347]: https://iguazio.atlassian.net/browse/ML-10347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ