### PR TITLE
[Launcher] Strip run start time upon retry [feature/retry-job]

### DIFF
--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -370,6 +370,8 @@ class BaseLauncher(abc.ABC):
             run.status.state = mlrun.common.runtimes.constants.RunStates.running
             run.status.retry_count = run.status.retry_count or 0  # in case it is none
             run.status.retry_count += 1  # increment by one
+            # TODO: Maintain start time of each retry ML-10169
+            run.status.start_time = None
         return run
 
     @staticmethod

--- a/server/py/services/api/tests/unit/test_service.py
+++ b/server/py/services/api/tests/unit/test_service.py
@@ -118,8 +118,6 @@ class TestService(TestAPIBase):
         count: int = 3,
         retry_count: int = 0,
     ):
-        import uuid
-
         return {
             "metadata": {
                 "name": "test-job",

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import datetime
 import io
 import pathlib
 import sys
@@ -411,6 +412,8 @@ def test_run_status_retry_updates(rundb_mock):
         result["status"]["state"]
         == mlrun.common.runtimes.constants.RunStates.pending_retry
     ), "Expected run state to be pending_retry"
+
+    start_time_1 = result["status"]["start_time"]
     with pytest.raises(mlrun.runtimes.RunError) as exc:
         function.run(
             runspec=result,
@@ -424,3 +427,10 @@ def test_run_status_retry_updates(rundb_mock):
         == mlrun.common.runtimes.constants.RunStates.pending_retry
     ), "Expected run state to be pending_retry"
     assert result["status"]["retry_count"] == 1, "Expected retry count to be 1"
+
+    start_time_2 = result["status"]["start_time"]
+    assert datetime.datetime.fromisoformat(
+        start_time_1
+    ) < datetime.datetime.fromisoformat(
+        start_time_2
+    ), "Expected start time to be updated on retry"


### PR DESCRIPTION
Strip the start time to make sure we update to start time of current attempt