### PR TITLE
[Publishing] Use PyPI trusted publishers for `mlrun`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,6 +142,8 @@ jobs:
 
     # publishing to pypi is (kind of) irreversible, therefore do it only if both previous steps finished successfully
     needs: [ prepare-inputs, trigger-and-wait-for-ui-image-building, trigger-and-wait-for-mlrun-image-building ]
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up uv
@@ -150,8 +152,6 @@ jobs:
         if: github.event.inputs.skip_publish_pypi != 'true'
         env:
           MLRUN_VERSION: ${{ needs.prepare-inputs.outputs.version }}
-          UV_PUBLISH_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: uv run --no-project --with packaging~=25.0 make publish-package
 
   create-releases:


### PR DESCRIPTION
Remove PyPI username and password - use trusted publishers instead.
This PR continues the work from #8202.

See:
- https://docs.astral.sh/uv/guides/package/#publishing-your-package
- https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#defining-a-workflow-job-environment

TODO (together with @nashpaz123):
- [ ] Configure the trusted publishers on PyPI

After it is merged, we most probably can remove the `PYPI_USERNAME` and `PYPI_PASSWORD` secrets from GitHub and revoke the PyPI token.