### PR TITLE
[Requirements] Temporarily pin storey version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2023.9.2, <2024.7
 v3iofs~=0.1.17
-storey~=1.10.2
+storey==1.10.4
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -122,7 +122,7 @@ def test_requirement_specifiers_convention():
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
         "aiobotocore": {">=2.5.0,<2.16"},
-        "storey": {"~=1.10.2"},
+        "storey": {"==1.10.4"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "scipy": {"~=1.13.0"},


### PR DESCRIPTION
To introduce https://github.com/mlrun/storey/pull/573 in storey v1.10.5 without breaking mlrun CI. To be unpinned in #8172.