### PR TITLE
[Logs] Handle log collection per attempt [feature/retry-job]

### DIFF
--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -62,6 +62,7 @@ class MLRunInternalLabels:
     scrape_metrics = f"{MLRUN_LABEL_PREFIX}scrape-metrics"
     tag = f"{MLRUN_LABEL_PREFIX}tag"
     uid = f"{MLRUN_LABEL_PREFIX}uid"
+    retry = f"{MLRUN_LABEL_PREFIX}retry-attempt"
     username = f"{MLRUN_LABEL_PREFIX}username"
     username_domain = f"{MLRUN_LABEL_PREFIX}username_domain"
     task_name = f"{MLRUN_LABEL_PREFIX}task-name"

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -44,7 +44,7 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def get_log(self, uid, project="", offset=0, size=0):
+    def get_log(self, uid, project="", offset=0, size=0, attempt=None):
         pass
 
     @abstractmethod

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -608,7 +608,7 @@ class HTTPRunDB(RunDBInterface):
         error = f"store log {project}/{uid}"
         self.api_call("POST", path, error, params, body)
 
-    def get_log(self, uid, project="", offset=0, size=None):
+    def get_log(self, uid, project="", offset=0, size=None, attempt=None):
         """Retrieve 1 MB data of log.
 
         :param uid: Log unique ID
@@ -616,6 +616,7 @@ class HTTPRunDB(RunDBInterface):
         :param offset: Retrieve partial log, get up to ``size`` bytes starting at offset ``offset``
             from beginning of log (must be >= 0)
         :param size: If set to ``-1`` will retrieve and print all data to end of the log by chunks of 1MB each.
+        :param attempt: For retriable runs, the attempt number to retrieve the log for. 0 is the initial attempt.
         :returns: The following objects:
 
             - state - The state of the runtime object which generates this log, if it exists. In case no known state
@@ -636,6 +637,8 @@ class HTTPRunDB(RunDBInterface):
             return state, offset
 
         params = {"offset": offset, "size": size}
+        if attempt:
+            params["attempt"] = attempt
         path = self._path_of("logs", project, uid)
         error = f"get log {project}/{uid}"
         resp = self.api_call("GET", path, error, params=params)
@@ -658,7 +661,7 @@ class HTTPRunDB(RunDBInterface):
         resp = self.api_call("GET", path, error)
         return resp.json()["size"]
 
-    def watch_log(self, uid, project="", watch=True, offset=0):
+    def watch_log(self, uid, project="", watch=True, offset=0, attempt=None):
         """Retrieve logs of a running process by chunks of 1MB, and watch the progress of the execution until it
         completes. This method will print out the logs and continue to periodically poll for, and print,
         new logs as long as the state of the runtime which generates this log is either ``pending`` or ``running``.
@@ -668,10 +671,11 @@ class HTTPRunDB(RunDBInterface):
         :param watch: If set to ``True`` will continue tracking the log as described above. Otherwise this function
             is practically equivalent to the :py:func:`~get_log` function.
         :param offset: Minimal offset in the log to watch.
+        :param attempt: For retriable runs, the attempt number to retrieve the log for. 0 is the initial attempt.
         :returns: The final state of the log being watched and the final offset.
         """
 
-        state, text = self.get_log(uid, project, offset=offset)
+        state, text = self.get_log(uid, project, offset=offset, attempt=attempt)
         if text:
             print(text.decode(errors=mlrun.mlconf.httpdb.logs.decode.errors))
         nil_resp = 0
@@ -687,7 +691,7 @@ class HTTPRunDB(RunDBInterface):
                         mlrun.mlconf.httpdb.logs.pull_logs_backoff_no_logs_default_interval
                     )
                 )
-            state, text = self.get_log(uid, project, offset=offset)
+            state, text = self.get_log(uid, project, offset=offset, attempt=attempt)
             if text:
                 nil_resp = 0
                 print(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -672,7 +672,7 @@ class HTTPRunDB(RunDBInterface):
         :param watch: If set to ``True`` will continue tracking the log as described above. Otherwise this function
             is practically equivalent to the :py:func:`~get_log` function.
         :param offset: Minimal offset in the log to watch.
-        :param attempt: For retriable runs, the attempt number to retrieve the log for. 0 is the initial attempt.
+        :param attempt: For retriable runs, the attempt number to retrieve the log for. 1 is the initial attempt.
         :returns: The final state of the log being watched and the final offset.
         """
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -616,7 +616,8 @@ class HTTPRunDB(RunDBInterface):
         :param offset: Retrieve partial log, get up to ``size`` bytes starting at offset ``offset``
             from beginning of log (must be >= 0)
         :param size: If set to ``-1`` will retrieve and print all data to end of the log by chunks of 1MB each.
-        :param attempt: For retriable runs, the attempt number to retrieve the log for. 0 is the initial attempt.
+        :param attempt: For retriable runs, the attempt number to retrieve the log for.
+            1 is the initial attempt.
         :returns: The following objects:
 
             - state - The state of the runtime object which generates this log, if it exists. In case no known state

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -63,7 +63,7 @@ class NopDB(RunDBInterface):
     def store_log(self, uid, project="", body=None, append=False):
         pass
 
-    def get_log(self, uid, project="", offset=0, size=0):
+    def get_log(self, uid, project="", offset=0, size=0, attempt=None):
         pass
 
     def store_run(self, struct, uid, project="", iter=0):

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -18,6 +18,7 @@ import os
 import uuid
 from typing import Any, Callable, Optional, Union
 
+import mlrun.common.constants
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.config
@@ -366,12 +367,6 @@ class BaseLauncher(abc.ABC):
         )
         run.spec.state_thresholds = state_thresholds or run.spec.state_thresholds
         run.spec.retry = retry or run.spec.retry
-        if run.status.state == mlrun.common.runtimes.constants.RunStates.pending_retry:
-            run.status.state = mlrun.common.runtimes.constants.RunStates.running
-            run.status.retry_count = run.status.retry_count or 0  # in case it is none
-            run.status.retry_count += 1  # increment by one
-            # TODO: Maintain start time of each retry ML-10169
-            run.status.start_time = None
         return run
 
     @staticmethod

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -73,15 +73,9 @@ class SQLRunDB(RunDBInterface):
             append,
         )
 
-    def get_log(self, uid, project="", offset=0, size=0):
-        # TODO: this is method which is not being called through the API (only through the SDK), but due to changes in
-        #  the API we changed the get_log method to async so we cannot call it here, and in this PR we won't change the
-        #  SDK to run async, we will use the legacy method for now, and later when we will have a better solution
-        #  we will change it.
+    def get_log(self, uid, project="", offset=0, size=0, attempt=None):
         raise NotImplementedError(
-            "This should be changed to async call, if you are running in the API, use `services.api.crud.get_log`"
-            " method directly instead and not through the get_db().get_log() method. "
-            "This will be removed in 1.5.0",
+            "Use `services.api.crud.get_log`method directly instead and not through the get_db().get_log() method. "
         )
 
     def store_run(self, struct, uid, project="", iter=0):

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -75,7 +75,7 @@ class SQLRunDB(RunDBInterface):
 
     def get_log(self, uid, project="", offset=0, size=0, attempt=None):
         raise NotImplementedError(
-            "Use `services.api.crud.get_log`method directly instead and not through the get_db().get_log() method. "
+            "Use `services.api.crud.get_log` method directly instead, and not through the get_db().get_log() method."
         )
 
     def store_run(self, struct, uid, project="", iter=0):

--- a/server/py/services/api/api/endpoints/logs.py
+++ b/server/py/services/api/api/endpoints/logs.py
@@ -83,10 +83,8 @@ async def get_log(
         )
     )
 
-    if attempt:
-        uid = f"{uid}-attempt-{attempt}"
     run_state, log_stream = await services.api.crud.Logs().get_logs(
-        db_session, project, uid, size, offset
+        db_session, project, uid, size, offset, attempt=attempt
     )
     headers = {
         "x-mlrun-run-state": run_state,
@@ -117,7 +115,7 @@ async def get_log_size(
         )
     )
 
-    if attempt:
+    if attempt and attempt > 1:
         uid = f"{uid}-attempt-{attempt}"
     log_file_size = await services.api.crud.Logs().get_log_size(project, uid)
     return {

--- a/server/py/services/api/api/endpoints/logs.py
+++ b/server/py/services/api/api/endpoints/logs.py
@@ -61,6 +61,7 @@ async def get_log(
     uid: str,
     size: int = -1,
     offset: int = 0,
+    attempt: int = 0,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         framework.api.deps.authenticate_request
     ),
@@ -81,6 +82,9 @@ async def get_log(
             auth_info,
         )
     )
+
+    if attempt:
+        uid = f"{uid}-attempt-{attempt}"
     run_state, log_stream = await services.api.crud.Logs().get_logs(
         db_session, project, uid, size, offset
     )
@@ -98,6 +102,7 @@ async def get_log(
 async def get_log_size(
     project: str,
     uid: str,
+    attempt: int = 0,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         framework.api.deps.authenticate_request
     ),
@@ -111,6 +116,9 @@ async def get_log_size(
             auth_info,
         )
     )
+
+    if attempt:
+        uid = f"{uid}-attempt-{attempt}"
     log_file_size = await services.api.crud.Logs().get_log_size(project, uid)
     return {
         "size": log_file_size,

--- a/server/py/services/api/common/runtime_handlers.py
+++ b/server/py/services/api/common/runtime_handlers.py
@@ -22,12 +22,13 @@ def get_resource_labels(function, run=None, scrape_metrics=None):
     scrape_metrics = (
         scrape_metrics if scrape_metrics is not None else mlconf.scrape_metrics
     )
-    run_uid, run_name, run_project, run_owner = None, None, None, None
+    run_uid, run_name, run_project, run_owner, run_attempt = [None] * 5
     if run:
         run_uid = run.metadata.uid
         run_name = run.metadata.name
         run_project = run.metadata.project
         run_owner = run.metadata.labels.get(mlrun_constants.MLRunInternalLabels.owner)
+        run_attempt = run.metadata.labels.get(mlrun_constants.MLRunInternalLabels.retry)
     labels = copy.deepcopy(function.metadata.labels)
     labels[mlrun_constants.MLRunInternalLabels.mlrun_class] = function.kind
     labels[mlrun_constants.MLRunInternalLabels.project] = (
@@ -51,5 +52,8 @@ def get_resource_labels(function, run=None, scrape_metrics=None):
             run_owner, domain = run_owner.split("@")
             labels[mlrun_constants.MLRunInternalLabels.mlrun_owner] = run_owner
             labels[mlrun_constants.MLRunInternalLabels.owner_domain] = domain
+
+    if run_attempt:
+        labels[mlrun_constants.MLRunInternalLabels.retry] = run_attempt
 
     return labels

--- a/server/py/services/api/crud/logs.py
+++ b/server/py/services/api/crud/logs.py
@@ -138,6 +138,7 @@ class Logs(
         size: int = -1,
         offset: int = 0,
         source: LogSources = LogSources.AUTO,
+        attempt: int = 0,
     ) -> tuple[str, typing.AsyncIterable[bytes]]:
         """
         Get logs
@@ -149,11 +150,16 @@ class Logs(
         :param source: log source (default auto) Relevant only for legacy log_collector mode
           if auto, it will use the mode configured in `mlrun.mlconf.log_collector.mode`
           if other than auto, it will fall back to legacy log_collector mode
+        :param attempt: for retriable runs, the attempt number to get logs for
         :return: run state and logs
         """
         run = await self._get_run_for_log(db_session, project, uid)
         run_state = run.get("status", {}).get("state", "")
         log_stream = None
+        if attempt and attempt > 1:
+            # if attempt is specified, we need to get the logs for the specific attempt
+            uid = f"{uid}-attempt-{attempt}"
+
         if (
             mlrun.mlconf.log_collector.mode
             == mlrun.common.schemas.LogsCollectorMode.best_effort

--- a/server/py/services/api/crud/runs.py
+++ b/server/py/services/api/crud/runs.py
@@ -21,6 +21,7 @@ from fastapi.concurrency import run_in_threadpool
 
 import mlrun.artifacts
 import mlrun.common.constants as mlrun_constants
+import mlrun.common.formatters
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.config

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -243,8 +243,9 @@ class ServerSideLauncher(launcher.BaseLauncher):
             return
 
         run.status.state = mlrun.common.runtimes.constants.RunStates.running
-        run.status.retry_count = run.status.retry_count or 0  # in case it is none
-        run.status.retry_count += 1  # increment by one
+        # retry_count may be None on first run attempt
+        run.status.retry_count = run.status.retry_count or 0
+        run.status.retry_count += 1
         # TODO: Maintain start time of each retry ML-10169
         run.status.start_time = None
         # The combination of retry attempt label and requested logs `False` is required for the log collector to

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -39,13 +39,11 @@ from mlrun.model import RunSpec, RunTemplate
 from mlrun.runtimes import KubejobRuntime, RemoteRuntime
 
 import framework.api.utils
+import framework.db.session
 import framework.utils.helpers
+import framework.utils.singletons.db
 import services.api.crud
 import services.api.runtime_handlers
-from framework.db.sqldb.sql_session import create_session
-
-# Configmap objects on Kubernetes have 10Mb size limit
-SERVING_SPEC_MAX_LENGTH = 10485760
 
 # Configmap objects on Kubernetes have 10Mb size limit
 SERVING_SPEC_MAX_LENGTH = 10485760
@@ -154,6 +152,7 @@ class ServerSideLauncher(launcher.BaseLauncher):
 
         # post verifications, store execution in db and run pre run hooks
         execution.store_run()
+        self._configure_attempt_for_logging(run)
         runtime._pre_run(run, execution)  # hook for runtime specific prep
 
         last_err = None
@@ -234,8 +233,37 @@ class ServerSideLauncher(launcher.BaseLauncher):
             retry=retry,
         )
 
+        self._handle_retry(run)
         run = self._pre_run_image_pull_secret_enrichment(run)
         return self._pre_run_scheduling_constraints_enrichment(runtime, run)
+
+    @staticmethod
+    def _handle_retry(run: mlrun.run.RunObject):
+        if run.status.state != mlrun.common.runtimes.constants.RunStates.pending_retry:
+            return
+
+        run.status.state = mlrun.common.runtimes.constants.RunStates.running
+        run.status.retry_count = run.status.retry_count or 0  # in case it is none
+        run.status.retry_count += 1  # increment by one
+        # TODO: Maintain start time of each retry ML-10169
+        run.status.start_time = None
+        # The combination of retry attempt label and requested logs `False` is required for the log collector to
+        # collect logs from the current run attempt.
+        run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] = str(
+            run.status.retry_count
+        )
+
+    @staticmethod
+    def _configure_attempt_for_logging(run: mlrun.run.RunObject):
+        if not run.status.retry_count:
+            # Run is not a retry, continue
+            return
+
+        framework.db.session.run_function_with_new_db_session(
+            framework.utils.singletons.db.get_db().update_runs_requested_logs,
+            uids=[run.metadata.uid],
+            requested_logs=False,
+        )
 
     def _pre_run_scheduling_constraints_enrichment(
         self,
@@ -485,9 +513,8 @@ class ServerSideLauncher(launcher.BaseLauncher):
 
         # If in the api server, we can assume that watch=False, so we save notification
         # configs to the DB, for the run monitor to later pick up and push.
-        session = create_session()
-        services.api.crud.Notifications().store_run_notifications(
-            session,
+        framework.db.session.run_function_with_new_db_session(
+            services.api.crud.Notifications().store_run_notifications,
             runobj.spec.notifications,
             runobj.metadata.uid,
             runobj.metadata.project,

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -516,6 +516,7 @@ class Service(framework.service.Service):
                 if retry_count:
                     # Adding the attempt number to the run uid since the log collector does not support multiple pods
                     # per run uid. This separates the attempts so that each attempt has its own logs file.
+                    # Incrementing the retry count by 1 since the first retry is the 2nd attempt and so on.
                     logs_run_uid = f"{run_uid}-attempt-{int(retry_count)+1}"
                 success, _ = await logs_collector_client.start_logs(
                     run_uid=logs_run_uid,

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -512,10 +512,13 @@ class Service(framework.service.Service):
                     with_main_runtime_resource_label_selector=True,
                     retry_count=retry_count,
                 )
+                logs_run_uid = run_uid
+                if retry_count:
+                    # Adding the attempt number to the run uid since the log collector does not support multiple pods
+                    # per run uid. This separates the attempts so that each attempt has its own logs file.
+                    logs_run_uid = f"{run_uid}-attempt-{int(retry_count)+1}"
                 success, _ = await logs_collector_client.start_logs(
-                    run_uid=run_uid
-                    if not retry_count
-                    else f"{run_uid}-attempt-{retry_count}",
+                    run_uid=logs_run_uid,
                     selector=label_selector,
                     project=project_name,
                     best_effort=best_effort,

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -489,6 +489,7 @@ class Service(framework.service.Service):
             run_kind = run.get("metadata", {}).get("labels", {}).get("kind", None)
             project_name = run.get("metadata", {}).get("project", None)
             run_uid = run.get("metadata", {}).get("uid", None)
+            retry_count = run.get("status", {}).get("retry_count", None)
 
             # information for why runtime isn't log collectable is inside the method
             if not mlrun.runtimes.RuntimeKinds.is_log_collectable_runtime(run_kind):
@@ -509,9 +510,12 @@ class Service(framework.service.Service):
                     # runtimes that the user will create with hundreds of resources (e.g mpi job can have multiple
                     # workers which aren't really important for log collection
                     with_main_runtime_resource_label_selector=True,
+                    retry_count=retry_count,
                 )
                 success, _ = await logs_collector_client.start_logs(
-                    run_uid=run_uid,
+                    run_uid=run_uid
+                    if not retry_count
+                    else f"{run_uid}-attempt-{retry_count}",
                     selector=label_selector,
                     project=project_name,
                     best_effort=best_effort,
@@ -528,6 +532,7 @@ class Service(framework.service.Service):
                 self._logger.warning(
                     "Failed to start logs for run",
                     run_uid=run_uid,
+                    retry_count=retry_count,
                     exc=mlrun.errors.err_to_str(exc),
                 )
                 return None

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -241,6 +241,7 @@ class BaseRuntimeHandler(ABC):
         label_selector: Optional[str] = None,
         class_mode: Union[RuntimeClassMode, str] = None,
         with_main_runtime_resource_label_selector: bool = False,
+        retry_count: Optional[int] = None,
     ) -> str:
         default_label_selector = self._get_default_label_selector(class_mode=class_mode)
 
@@ -269,6 +270,15 @@ class BaseRuntimeHandler(ABC):
                 label_selector = ",".join(
                     [label_selector, main_runtime_resource_label_selector]
                 )
+
+        if retry_count is not None:
+            # If retry attempt is provided, add it to the label selector to avoid conflicts with previous runs
+            label_selector = ",".join(
+                [
+                    label_selector,
+                    f"{mlrun_constants.MLRunInternalLabels.retry}={retry_count}",
+                ]
+            )
 
         return label_selector
 

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import pathlib
 import re
 import unittest.mock
@@ -21,6 +20,7 @@ import pytest
 import sqlalchemy.orm
 from fastapi.testclient import TestClient
 
+import mlrun.common.constants
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.launcher.base
@@ -299,3 +299,46 @@ def test_validate_run_retry_runtime_kind():
         ),
     ):
         launcher._validate_run(runtime, run)
+
+
+def test_run_status_retry_updates():
+    """
+    Test that the run status is updated when a retry is triggered.
+    The test simulates a run that is in the pending_retry state and checks that the retry count is incremented
+    and the state is updated to running when the run is enriched again.
+    """
+    runtime = mlrun.code_to_function(
+        name="test", kind="job", filename=str(func_path), handler="raise_func"
+    )
+    run = mlrun.run.RunObject(
+        spec=mlrun.model.RunSpec(
+            retry={
+                "count": 10,
+            },
+        ),
+        status=mlrun.model.RunStatus(
+            state=mlrun.common.runtimes.constants.RunStates.pending_retry,
+        ),
+    )
+
+    launcher = services.api.launcher.ServerSideLauncher()
+    enriched_run = launcher._enrich_run(runtime=runtime, run=run)
+    assert (
+        enriched_run.status.state == mlrun.common.runtimes.constants.RunStates.running
+    )
+    assert enriched_run.status.start_time is None
+    assert enriched_run.status.retry_count == 1, "Expected retry count to be 1"
+    assert run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] == str(
+        enriched_run.status.retry_count
+    )
+
+    enriched_run.status.state = mlrun.common.runtimes.constants.RunStates.pending_retry
+    enriched_run_2 = launcher._enrich_run(runtime=runtime, run=enriched_run)
+    assert (
+        enriched_run_2.status.state == mlrun.common.runtimes.constants.RunStates.running
+    )
+    assert enriched_run_2.status.start_time is None
+    assert enriched_run_2.status.retry_count == 2, "Expected retry count to be 2"
+    assert run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] == str(
+        enriched_run_2.status.retry_count
+    )

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
-import datetime
 import io
 import pathlib
 import sys
@@ -396,7 +395,6 @@ def test_code_to_function_file_include_invalid_handler_name_for_nuclio_mlrun_run
 def test_run_status_retry_updates(rundb_mock):
     """
     Test that the run status is updated to pending_retry when the run fails
-    and the retry count is incremented when the run is retried.
     """
     function = new_function(command=f"{assets_path}/kwargs.py")
     with pytest.raises(mlrun.runtimes.RunError) as exc:
@@ -413,7 +411,6 @@ def test_run_status_retry_updates(rundb_mock):
         == mlrun.common.runtimes.constants.RunStates.pending_retry
     ), "Expected run state to be pending_retry"
 
-    start_time_1 = result["status"]["start_time"]
     with pytest.raises(mlrun.runtimes.RunError) as exc:
         function.run(
             runspec=result,
@@ -426,11 +423,3 @@ def test_run_status_retry_updates(rundb_mock):
         result["status"]["state"]
         == mlrun.common.runtimes.constants.RunStates.pending_retry
     ), "Expected run state to be pending_retry"
-    assert result["status"]["retry_count"] == 1, "Expected retry count to be 1"
-
-    start_time_2 = result["status"]["start_time"]
-    assert datetime.datetime.fromisoformat(
-        start_time_1
-    ) < datetime.datetime.fromisoformat(
-        start_time_2
-    ), "Expected start time to be updated on retry"

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -753,7 +753,7 @@ def print_df(df):
                 run.status.retry_count == 3
             ), f"Expected retry_count=3, got {run.status.retry_count}"
             assert run.status.state == mlrun.common.runtimes.constants.RunStates.error
-            assert run.status.status_text == f"Run failed after {max_attempts} attempts"
+            assert f"Run failed after {max_attempts} attempts" in run.status.status_text
 
         mlrun.utils.retry_until_successful(
             1,
@@ -762,3 +762,11 @@ def print_df(df):
             True,
             _assert_retry_count,
         )
+
+        state, content = self._run_db.get_log(
+            run.metadata.uid, project=self.project_name, attempt=1
+        )
+        assert state == mlrun.common.runtimes.constants.RunStates.error
+        assert "Retrying run - attempt: 1" in str(
+            content
+        ), "Expected logs to contain retry attempt message"

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -764,9 +764,9 @@ def print_df(df):
         )
 
         state, content = self._run_db.get_log(
-            run.metadata.uid, project=self.project_name, attempt=1
+            run.metadata.uid, project=self.project_name, attempt=2
         )
         assert state == mlrun.common.runtimes.constants.RunStates.error
-        assert "Retrying run - attempt: 1" in str(
+        assert "Retrying run - attempt: 2" in str(
             content
         ), "Expected logs to contain retry attempt message"


### PR DESCRIPTION
Send a start logs request per each attempt differentiating the logs by including the attempt in the "run uid" forwarded to the log collector.
Small gap that this solution has is if the log collector is down for a long period of time, we might skip collecting logs for attempts.

https://iguazio.atlassian.net/browse/ML-10346