### PR TITLE
[Log collector] Delete logs by prefix [feature/retry-job]

### DIFF
--- a/server/go/services/logcollector/logcollector_test.go
+++ b/server/go/services/logcollector/logcollector_test.go
@@ -706,10 +706,17 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 			projectName := fmt.Sprintf("test-project-%d", projectCount)
 			projectCount++
 			var runUIDs []string
+			uid := uuid.New().String()
 			for i := 0; i < testCase.logsNumToCreate; i++ {
-				runUID := uuid.New().String()
+				runUID := uid
 				if testCase.deleteByPrefix {
-					runUID = fmt.Sprintf("run-prefix-%s", runUID)
+					if i > 0 {
+
+						// simulates runs with multiple attempts (retries)
+						runUID = fmt.Sprintf("%s-attempt-%d", runUID, i)
+					}
+				} else {
+					runUID = uuid.New().String()
 				}
 				runUIDs = append(runUIDs, runUID)
 				logFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
@@ -725,7 +732,9 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 
 			var runUIDsToDelete []string
 			if testCase.deleteByPrefix {
-				runUIDsToDelete = []string{"run-prefix-"}
+
+				// the 1st uid is the run uid that is also the prefix for all other files
+				runUIDsToDelete = runUIDs[:1]
 			} else {
 				runUIDsToDelete = runUIDs[testCase.expectedLogsNumLeft:]
 			}

--- a/server/go/services/logcollector/logcollector_test.go
+++ b/server/go/services/logcollector/logcollector_test.go
@@ -682,11 +682,17 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 		name                string
 		logsNumToCreate     int
 		expectedLogsNumLeft int
+		deleteByPrefix      bool
 	}{
 		{
 			name:                "Delete some logs",
 			logsNumToCreate:     5,
 			expectedLogsNumLeft: 2,
+		},
+		{
+			name:            "Delete some logs by prefix",
+			logsNumToCreate: 5,
+			deleteByPrefix:  true,
 		},
 		{
 			name:                "Delete all logs",
@@ -702,6 +708,9 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 			var runUIDs []string
 			for i := 0; i < testCase.logsNumToCreate; i++ {
 				runUID := uuid.New().String()
+				if testCase.deleteByPrefix {
+					runUID = fmt.Sprintf("run-prefix-%s", runUID)
+				}
 				runUIDs = append(runUIDs, runUID)
 				logFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
 				err := common.WriteToFile(logFilePath, []byte("some log"), false)
@@ -714,10 +723,17 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 			suite.Require().NoError(err, "Failed to read dir")
 			suite.Require().Equal(testCase.logsNumToCreate, len(dirEntries), "Expected logs to exist")
 
+			var runUIDsToDelete []string
+			if testCase.deleteByPrefix {
+				runUIDsToDelete = []string{"run-prefix-"}
+			} else {
+				runUIDsToDelete = runUIDs[testCase.expectedLogsNumLeft:]
+			}
+
 			// delete some logs
 			request := &protologcollector.StopLogsRequest{
 				Project: projectName,
-				RunUIDs: runUIDs[testCase.expectedLogsNumLeft:],
+				RunUIDs: runUIDsToDelete,
 			}
 			response, err := suite.logCollectorServer.DeleteLogs(suite.ctx, request)
 			suite.Require().NoError(err, "Failed to stop log")
@@ -726,7 +742,11 @@ func (suite *LogCollectorTestSuite) TestDeleteLogs() {
 			// verify files deleted
 			dirEntries, err = os.ReadDir(dirPath)
 			suite.Require().NoError(err, "Failed to read dir")
-			suite.Require().Equal(testCase.expectedLogsNumLeft, len(dirEntries), "Expected logs to be deleted")
+			if testCase.deleteByPrefix {
+				suite.Require().Equal(0, len(dirEntries), "Expected logs to be deleted")
+			} else {
+				suite.Require().Equal(testCase.expectedLogsNumLeft, len(dirEntries), "Expected logs to be deleted")
+			}
 		})
 	}
 }

--- a/server/go/services/logcollector/server.go
+++ b/server/go/services/logcollector/server.go
@@ -1243,8 +1243,14 @@ func (s *Server) successfulBaseResponse() *protologcollector.BaseResponse {
 
 func (s *Server) deleteRunLogFiles(ctx context.Context, runUID, project string) error {
 
-	// get all files that have the runUID as a prefix
-	pattern := path.Join(s.baseDir, project, runUID) + "*"
+	pattern := path.Join(s.baseDir, project, runUID)
+
+	// guard to not delete all project log files
+	if len(runUID) > 0 {
+
+		// get all files that have the runUID as a prefix
+		pattern += "*"
+	}
 	files, err := filepath.Glob(pattern)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get log files")

--- a/server/go/services/logcollector/server.go
+++ b/server/go/services/logcollector/server.go
@@ -1244,7 +1244,7 @@ func (s *Server) successfulBaseResponse() *protologcollector.BaseResponse {
 func (s *Server) deleteRunLogFiles(ctx context.Context, runUID, project string) error {
 
 	// get all files that have the runUID as a prefix
-	pattern := path.Join(s.baseDir, project, runUID)
+	pattern := path.Join(s.baseDir, project, runUID) + "*"
 	files, err := filepath.Glob(pattern)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get log files")


### PR DESCRIPTION
Remove all log files prefixed by run uid, this ensures cleanup of attempt logs

https://iguazio.atlassian.net/browse/ML-10381