### PR TITLE
[Serving] Fix allow multiple deployment using copy in `ModelObj:from_dict`

### DIFF
--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -19,7 +19,7 @@ import re
 import time
 import typing
 from collections import OrderedDict
-from copy import deepcopy
+from copy import copy, deepcopy
 from datetime import datetime
 from os import environ
 from typing import Any, Optional, Union
@@ -228,7 +228,7 @@ class ModelObj:
         init_with_params: bool = False,
     ):
         """create an object from a python dictionary"""
-        struct = {} if struct is None else struct
+        struct = {} if struct is None else copy(struct)
         deprecated_fields = deprecated_fields or {}
         fields = fields or cls._dict_fields
         if not fields:

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1378,7 +1378,7 @@ class ModelRunnerStep(MonitoredStep):
         model_objects = []
         for model, model_params in models.values():
             model = get_class(model, namespace).from_dict(
-                model_params, init_with_params=True
+                deepcopy(model_params), init_with_params=True
             )
             model._raise_exception = False
             model_objects.append(model)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1378,7 +1378,7 @@ class ModelRunnerStep(MonitoredStep):
         model_objects = []
         for model, model_params in models.values():
             model = get_class(model, namespace).from_dict(
-                deepcopy(model_params), init_with_params=True
+                model_params, init_with_params=True
             )
             model._raise_exception = False
             model_objects.append(model)

--- a/tests/serving/test_tracking.py
+++ b/tests/serving/test_tracking.py
@@ -15,7 +15,7 @@
 import json
 import pathlib
 from collections.abc import Iterator
-from typing import cast
+from typing import Union, cast
 from unittest.mock import patch
 
 import numpy as np
@@ -31,7 +31,7 @@ from mlrun.datastore.datastore_profile import (
 )
 from mlrun.platforms.iguazio import KafkaOutputStream
 from mlrun.runtimes import ServingRuntime
-from mlrun.serving import Model, ModelRunnerStep
+from mlrun.serving import Model, ModelRunnerStep, ModelSelector
 from mlrun.serving.states import RootFlowStep
 from tests.serving.test_serving import _log_model
 
@@ -243,6 +243,13 @@ def test_tracking_datastore_profile(project: mlrun.MlrunProject) -> None:
     assert event["effective_sample_count"] == 2
     assert np.array_equal(event["request"]["inputs"], np.array([[0, -0.1], [0.4, 0]]))
     assert np.array_equal(event["resp"]["outputs"], np.array([0.0, 0.4 * 7]))
+
+
+class MyModelSelector(ModelSelector):
+    def select(
+        self, event, available_models: list[Model]
+    ) -> Union[list[str], list[Model]]:
+        return ["my_dict_model"]
 
 
 class MyModel(Model):
@@ -496,7 +503,9 @@ def test_set_untracked_with_model_runner():
 def test_tracked_multiple_to_mock_with_model_runner():
     function = mlrun.new_function("tests-1", kind="serving")
     graph = function.set_topology("flow", engine="async")
-    model_runner_step = ModelRunnerStep(name="my_model_runner", raise_exception=True)
+    model_runner_step = ModelRunnerStep(
+        name="my_model_runner", raise_exception=True, model_selector="MyModelSelector"
+    )
     model_runner_step.add_model(
         model_class="DictOutputModel",
         endpoint_name="my_dict_model",


### PR DESCRIPTION
Working on copy of struct allowing the call of ModelRunnerStep:init_object  take place multiple times while using pop inside `ModelObj:from_dict`