### PR TITLE
[Launcher] Skip retried runs that were aborted or deleted

### DIFF
--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -175,11 +175,6 @@ class ServerSideLauncher(launcher.BaseLauncher):
             try:
                 # Skip retried run if it was aborted or deleted
                 if self._should_skip_run(run):
-                    mlrun.utils.logger.info(
-                        "The pending retry run was aborted or deleted, skipping launch",
-                        uid=run.metadata.uid,
-                        project=run.metadata.project,
-                    )
                     run.status.state = mlrun.common.runtimes.constants.RunStates.aborted
 
                 else:
@@ -446,6 +441,11 @@ class ServerSideLauncher(launcher.BaseLauncher):
                 project=run.metadata.project,
             )
         except mlrun.errors.MLRunNotFoundError:
+            mlrun.utils.logger.info(
+                "Skipping retry for run - run was deleted",
+                uid=run.metadata.uid,
+                project=run.metadata.project,
+            )
             return True
 
         # check if it was aborted after the retry attempt
@@ -453,6 +453,11 @@ class ServerSideLauncher(launcher.BaseLauncher):
             db_run.get("status", {}).get("state")
             == mlrun.common.runtimes.constants.RunStates.aborted
         ):
+            mlrun.utils.logger.info(
+                "Skipping retry for run - run was aborted",
+                uid=run.metadata.uid,
+                project=run.metadata.project,
+            )
             return True
 
         return False

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -173,10 +173,19 @@ class ServerSideLauncher(launcher.BaseLauncher):
         else:
             # single run
             try:
-                runtime_handler = services.api.runtime_handlers.get_runtime_handler(
-                    runtime.kind
-                )
-                runtime_handler.run(runtime, run, execution)
+                if self._should_skip_run(run):
+                    mlrun.utils.logger.info(
+                        "Run was aborted or deleted, skipping launch",
+                        uid=run.metadata.uid,
+                        project=run.metadata.project,
+                    )
+                    run.status.state = mlrun.common.runtimes.constants.RunStates.aborted
+
+                else:
+                    runtime_handler = services.api.runtime_handlers.get_runtime_handler(
+                        runtime.kind
+                    )
+                    runtime_handler.run(runtime, run, execution)
             except mlrun.runtimes.utils.RunError as err:
                 last_err = err
 
@@ -416,6 +425,37 @@ class ServerSideLauncher(launcher.BaseLauncher):
             else:
                 function.spec.env["SERVING_SPEC_ENV"] = serving_spec
         return serving_spec_volume
+
+    @staticmethod
+    def _should_skip_run(run: mlrun.run.RunObject) -> bool:
+        """
+        Determine whether a retried run should be skipped based on its state.
+        A run should be skipped if it is in 'pending_retry' state and was either aborted or deleted after being
+        scheduled for retry.
+        """
+        # if the retry was not scheduled for retry, then skip the checks
+        if run.status.state != mlrun.common.runtimes.constants.RunStates.pending_retry:
+            return False
+
+        # fetch the run from the db to check if it was deleted after the retry attempt
+        db = framework.utils.singletons.db.get_db()
+        try:
+            db_run = framework.db.session.run_function_with_new_db_session(
+                db.read_run,
+                uid=run.metadata.uid,
+                project=run.metadata.project,
+            )
+        except mlrun.errors.MLRunNotFoundError:
+            # Run was deleted after being scheduled for retry → skip it
+            return True
+
+        if (
+            db_run.get("status", {}).get("state")
+            == mlrun.common.runtimes.constants.RunStates.aborted
+        ):
+            return True
+
+        return False
 
     def enrich_runtime(
         self,

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -173,9 +173,10 @@ class ServerSideLauncher(launcher.BaseLauncher):
         else:
             # single run
             try:
+                # Skip retried run if it was aborted or deleted
                 if self._should_skip_run(run):
                     mlrun.utils.logger.info(
-                        "Run was aborted or deleted, skipping launch",
+                        "The pending retry run was aborted or deleted, skipping launch",
                         uid=run.metadata.uid,
                         project=run.metadata.project,
                     )
@@ -433,7 +434,6 @@ class ServerSideLauncher(launcher.BaseLauncher):
         A run should be skipped if it is in 'pending_retry' state and was either aborted or deleted after being
         scheduled for retry.
         """
-        # if the retry was not scheduled for retry, then skip the checks
         if run.status.state != mlrun.common.runtimes.constants.RunStates.pending_retry:
             return False
 
@@ -446,9 +446,9 @@ class ServerSideLauncher(launcher.BaseLauncher):
                 project=run.metadata.project,
             )
         except mlrun.errors.MLRunNotFoundError:
-            # Run was deleted after being scheduled for retry → skip it
             return True
 
+        # check if it was aborted after the retry attempt
         if (
             db_run.get("status", {}).get("state")
             == mlrun.common.runtimes.constants.RunStates.aborted

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -386,8 +386,7 @@ def test_should_skip_run(initial_state, db_state, db_deleted, expected_should_sk
             "framework.db.session.run_function_with_new_db_session"
         ) as run_with_session_mock,
     ):
-        mock_db = unittest.mock.Mock()
-        get_db_mock.return_value = mock_db
+        get_db_mock.return_value = unittest.mock.Mock()
 
         if db_deleted:
             run_with_session_mock.side_effect = mlrun.errors.MLRunNotFoundError()

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -342,3 +342,108 @@ def test_run_status_retry_updates():
     assert run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] == str(
         enriched_run_2.status.retry_count
     )
+
+
+@pytest.mark.parametrize(
+    "initial_state, db_state, db_deleted, expected_should_skip",
+    [
+        # Not pending_retry, should not skip
+        (mlrun.common.runtimes.constants.RunStates.running, None, False, False),
+        # Deleted run in DB, should skip
+        (mlrun.common.runtimes.constants.RunStates.pending_retry, None, True, True),
+        # Aborted in DB, should skip
+        (
+            mlrun.common.runtimes.constants.RunStates.pending_retry,
+            mlrun.common.runtimes.constants.RunStates.aborted,
+            False,
+            True,
+        ),
+        # Not aborted in DB, should not skip
+        (
+            mlrun.common.runtimes.constants.RunStates.pending_retry,
+            mlrun.common.runtimes.constants.RunStates.running,
+            False,
+            False,
+        ),
+    ],
+)
+def test_should_skip_run(initial_state, db_state, db_deleted, expected_should_skip):
+    # Verify the `_should_skip_run` method correctly determines whether to skip retried runs based on their current
+    # state and the latest status in the database (including deleted or aborted runs).
+    run = mlrun.run.RunObject(
+        status=mlrun.model.RunStatus(state=initial_state),
+        spec=mlrun.model.RunSpec(
+            retry={
+                "count": 10,
+            },
+        ),
+    )
+    launcher = services.api.launcher.ServerSideLauncher()
+
+    with (
+        unittest.mock.patch("framework.utils.singletons.db.get_db") as get_db_mock,
+        unittest.mock.patch(
+            "framework.db.session.run_function_with_new_db_session"
+        ) as run_with_session_mock,
+    ):
+        mock_db = unittest.mock.Mock()
+        get_db_mock.return_value = mock_db
+
+        if db_deleted:
+            run_with_session_mock.side_effect = mlrun.errors.MLRunNotFoundError()
+        elif db_state:
+            run_with_session_mock.return_value = {"status": {"state": db_state}}
+
+        should_skip = launcher._should_skip_run(run)
+        assert should_skip is expected_should_skip
+
+
+def test_launcher_skips_aborted_or_deleted_run(monkeypatch):
+    """
+    Verify that the launcher skips running a function when `_should_skip_run` returns True,
+    meaning the run was aborted or deleted after being scheduled for retry.
+    """
+    runtime = mlrun.code_to_function(
+        name="test", kind="job", filename=str(func_path), handler=handler
+    )
+    run = mlrun.run.RunObject(
+        status=mlrun.model.RunStatus(
+            state=mlrun.common.runtimes.constants.RunStates.pending_retry
+        ),
+        spec=mlrun.model.RunSpec(
+            retry={
+                "count": 10,
+            },
+        ),
+    )
+    launcher = services.api.launcher.ServerSideLauncher()
+
+    # Force `_should_skip_run` to return True to simulate aborted/deleted run
+    monkeypatch.setattr(launcher, "_should_skip_run", lambda x: True)
+
+    # Mock runtime handler to validate that it is not called
+    runtime_handler_mock = unittest.mock.Mock()
+    monkeypatch.setattr(
+        services.api.runtime_handlers,
+        "get_runtime_handler",
+        lambda kind: unittest.mock.Mock(run=runtime_handler_mock),
+    )
+
+    # Mock execution object
+    mock_execution = unittest.mock.Mock()
+
+    try:
+        # Simulate the same logic that exists in the launcher
+        if launcher._should_skip_run(run):
+            run.status.state = mlrun.common.runtimes.constants.RunStates.aborted
+        else:
+            runtime_handler = services.api.runtime_handlers.get_runtime_handler(
+                runtime.kind
+            )
+            runtime_handler.run(runtime, run, mock_execution)
+    except mlrun.runtimes.utils.RunError:
+        pass
+
+    # Validate result
+    assert run.status.state == mlrun.common.runtimes.constants.RunStates.aborted
+    assert not runtime_handler_mock.called


### PR DESCRIPTION
When a run is submitted to the event loop for retry, it may be aborted (or aborted and deleted) by the user before the retry is actually triggered. In such cases, the retry logic still attempts to launch the run, since the task was already scheduled.
This fix adds a safeguard in the launcher to check if the run was aborted or deleted before launching it. If the run is no longer valid (e.g., aborted), the launcher skips it, ensuring that aborted runs are not retried.

Jira:
https://iguazio.atlassian.net/browse/ML-10355