### PR TITLE
[Tests] Fix `test_app_flow` system test with `with_training_set=False`

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -107,7 +107,6 @@ _DefaultDataDriftAppData = _AppData(
 class _V3IORecordsChecker:
     project_name: str
     _logger: Logger
-    apps_data: list[_AppData]
     app_interval: int
     mm_tsdb_profile: DatastoreProfile
 
@@ -120,7 +119,11 @@ class _V3IORecordsChecker:
 
     @classmethod
     def _test_tsdb_record(
-        cls, ep_id: str, last_request: datetime, error_count: float
+        cls,
+        ep_id: str,
+        last_request: datetime,
+        error_count: float,
+        apps_data: list[_AppData],
     ) -> None:
         df: pd.DataFrame = cls._tsdb_storage.get_results_metadata(endpoint_id=ep_id)
 
@@ -130,11 +133,11 @@ class _V3IORecordsChecker:
         ).all(), "The endpoint IDs are different than expected"
 
         assert set(df.application_name) == {
-            app_data.class_.NAME for app_data in cls.apps_data if app_data.results
+            app_data.class_.NAME for app_data in apps_data if app_data.results
         }, "The application names are different than expected"
 
         tsdb_metrics = df.groupby("application_name").result_name.unique()
-        for app_data in cls.apps_data:
+        for app_data in apps_data:
             if app_metrics := app_data.results:
                 app_name = app_data.class_.NAME
                 cls._logger.debug("Checking the TSDB record of app", app_name=app_name)
@@ -218,16 +221,23 @@ class _V3IORecordsChecker:
     def _test_v3io_records(
         cls,
         ep_id: str,
+        apps_data: list[_AppData],
         last_request: typing.Optional[datetime] = None,
         error_count: typing.Optional[float] = None,
     ) -> None:
-        cls._test_tsdb_record(ep_id, last_request=last_request, error_count=error_count)
+        cls._test_tsdb_record(
+            ep_id,
+            last_request=last_request,
+            error_count=error_count,
+            apps_data=apps_data,
+        )
 
     @classmethod
     def _test_api_get_metrics(
         cls,
         ep_id: str,
         run_db: mlrun.db.httpdb.HTTPRunDB,
+        apps_data: list[_AppData],
         type: typing.Literal["metrics", "results"] = "results",
     ) -> list[str]:
         cls._logger.debug("Checking the metrics", type=type)
@@ -249,7 +259,7 @@ class _V3IORecordsChecker:
             app_results_full_names.append(result.full_name)
 
         expected_results = set().union(
-            *[getattr(app_data, type) for app_data in cls.apps_data]
+            *[getattr(app_data, type) for app_data in apps_data]
         )
 
         if type == "metrics":
@@ -288,14 +298,14 @@ class _V3IORecordsChecker:
                 ], f"The values list is empty for result {result_values['full_name']}"
 
     @classmethod
-    def _test_api(cls, ep_id: str) -> None:
+    def _test_api(cls, ep_id: str, apps_data: list[_AppData]) -> None:
         cls._logger.debug("Checking model endpoint monitoring APIs")
         run_db = mlrun.db.httpdb.HTTPRunDB(mlrun.mlconf.dbpath)
         metrics_full_names = cls._test_api_get_metrics(
-            ep_id=ep_id, run_db=run_db, type="metrics"
+            ep_id=ep_id, run_db=run_db, apps_data=apps_data, type="metrics"
         )
         results_full_names = cls._test_api_get_metrics(
-            ep_id=ep_id, run_db=run_db, type="results"
+            ep_id=ep_id, run_db=run_db, apps_data=apps_data, type="results"
         )
 
         cls._test_api_get_values(
@@ -330,35 +340,6 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
 
         cls.app_interval: int = 1  # every 1 minute
         cls.app_interval_seconds = timedelta(minutes=cls.app_interval).total_seconds()
-
-        cls.evidently_workspace_path = (
-            f"/v3io/projects/{cls.project_name}/artifacts/evidently-workspace"
-        )
-        cls.evidently_project_id = str(uuid.uuid4())
-
-        cls.apps_data: list[_AppData] = [
-            _DefaultDataDriftAppData,
-            _AppData(
-                class_=DemoMonitoringApp,
-                rel_path="assets/application.py",
-                results={"data_drift_test", "model_perf"},
-            ),
-            _AppData(
-                class_=DemoEvidentlyMonitoringApp,
-                rel_path="assets/custom_evidently_app.py",
-                requirements=[f"evidently=={SUPPORTED_EVIDENTLY_VERSION}"],
-                kwargs={
-                    "evidently_workspace_path": cls.evidently_workspace_path,
-                    "evidently_project_id": cls.evidently_project_id,
-                },
-                results={"data_drift_test"},
-                artifacts={"evidently_report"},
-            ),
-            _AppData(
-                class_=ErrApp,
-                rel_path="assets/application.py",
-            ),
-        ]
 
         cls.run_db = mlrun.get_run_db()
 
@@ -684,6 +665,40 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         # Validate alert notification
         assert alert.count == 1
 
+    def _get_apps_data(self, with_training_set: bool) -> list[_AppData]:
+        apps_data = [
+            _AppData(
+                class_=DemoMonitoringApp,
+                rel_path="assets/application.py",
+                results={"data_drift_test", "model_perf"},
+            ),
+            _AppData(
+                class_=ErrApp,
+                rel_path="assets/application.py",
+            ),
+        ]
+        if with_training_set:
+            # Applications that need training set
+            apps_data.extend(
+                [
+                    _DefaultDataDriftAppData,
+                    _AppData(
+                        class_=DemoEvidentlyMonitoringApp,
+                        rel_path="assets/custom_evidently_app.py",
+                        requirements=[f"evidently=={SUPPORTED_EVIDENTLY_VERSION}"],
+                        kwargs={
+                            "evidently_workspace_path": (
+                                f"/v3io/projects/{self.project_name}/artifacts/evidently-workspace"
+                            ),
+                            "evidently_project_id": str(uuid.uuid4()),
+                        },
+                        results={"data_drift_test"},
+                        artifacts={"evidently_report"},
+                    ),
+                ]
+            )
+        return apps_data
+
     def _test_function_summaries(self):
         self._logger.debug("Checking function summaries")
         function_summaries = self.project.get_monitoring_function_summaries()
@@ -716,6 +731,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
     @pytest.mark.parametrize("with_training_set", [True, False])
     @pytest.mark.parametrize("with_model_runner", [True, False])
     def test_app_flow(self, with_training_set: bool, with_model_runner: bool) -> None:
+        self.apps_data = self._get_apps_data(with_training_set)
         self.project = typing.cast(mlrun.projects.MlrunProject, self.project)
         self._log_model(with_training_set)
 
@@ -730,8 +746,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         self._log_model(with_training_set=with_training_set)
 
         self._submit_controller_and_deploy_writer(
-            deploy_histogram_data_drift_app=_DefaultDataDriftAppData in self.apps_data,
-            # workaround for ML-5997
+            deploy_histogram_data_drift_app=_DefaultDataDriftAppData in self.apps_data
         )
         with concurrent.futures.ThreadPoolExecutor() as executor:
             executor.submit(self._set_and_deploy_monitoring_apps)
@@ -774,11 +789,12 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         self._test_v3io_records(
             ep_id=mep.metadata.uid,
             last_request=mep.status.last_request,
+            apps_data=self.apps_data,
             error_count=self.error_count,
         )
         self._test_predictions_table(mep.metadata.uid)
         self._test_artifacts(ep_id=mep.metadata.uid)
-        self._test_api(ep_id=mep.metadata.uid)
+        self._test_api(ep_id=mep.metadata.uid, apps_data=self.apps_data)
         if _DefaultDataDriftAppData in self.apps_data:
             self._test_model_endpoint_stats(mep=mep)
         self._test_error_alert()
@@ -910,7 +926,10 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
             feature_analysis=True,
             tsdb_metrics=True,
         )
-        self._test_v3io_records(mep.metadata.uid)
+        self._test_v3io_records(
+            mep.metadata.uid,
+            apps_data=self.apps_data,
+        )
         self._test_predictions_table(mep.metadata.uid, should_be_empty=True)
 
     @staticmethod

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -699,7 +699,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
             )
         return apps_data
 
-    def _test_function_summaries(self):
+    def _test_function_summaries(self) -> None:
         self._logger.debug("Checking function summaries")
         function_summaries = self.project.get_monitoring_function_summaries()
         assert len(function_summaries) == 3 + len(self.apps_data)
@@ -708,25 +708,41 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         )
         assert len(function_summaries) == len(self.apps_data)
 
-        evidently_func_summary_list = self.project.get_monitoring_function_summaries(
-            include_infra=False, names=[DemoEvidentlyMonitoringApp.NAME]
-        )
-        assert len(evidently_func_summary_list) == 1
-        evidently_func_summary = evidently_func_summary_list[0]
-        assert evidently_func_summary.name == DemoEvidentlyMonitoringApp.NAME
-        assert evidently_func_summary.status == mlrun.common.schemas.FunctionState.ready
-        assert evidently_func_summary.base_period == self.app_interval
-        assert not evidently_func_summary.stats
+        try:
+            # Check that Evidently app is in `self.apps_data`
+            self.project.get_function(
+                key=DemoEvidentlyMonitoringApp.NAME, ignore_cache=True
+            )
+            self._logger.debug("Checking Evidently function summary")
+            evidently_func_summary_list = (
+                self.project.get_monitoring_function_summaries(
+                    include_infra=False, names=[DemoEvidentlyMonitoringApp.NAME]
+                )
+            )
+            assert len(evidently_func_summary_list) == 1
+            evidently_func_summary = evidently_func_summary_list[0]
+            assert evidently_func_summary.name == DemoEvidentlyMonitoringApp.NAME
+            assert (
+                evidently_func_summary.status
+                == mlrun.common.schemas.FunctionState.ready
+            )
+            assert evidently_func_summary.base_period == self.app_interval
+            assert not evidently_func_summary.stats
 
-        # now get function summary with stats
-        evidently_func_summary_list = self.project.get_monitoring_function_summaries(
-            include_infra=False,
-            names=[DemoEvidentlyMonitoringApp.NAME],
-            include_stats=True,
-        )
-        evidently_func_summary = evidently_func_summary_list[0]
-        assert evidently_func_summary.stats["potential_detection"] == 1
-        assert evidently_func_summary.stats["detected"] == 0
+            # now get function summary with stats
+            evidently_func_summary_list = (
+                self.project.get_monitoring_function_summaries(
+                    include_infra=False,
+                    names=[DemoEvidentlyMonitoringApp.NAME],
+                    include_stats=True,
+                )
+            )
+            evidently_func_summary = evidently_func_summary_list[0]
+            assert evidently_func_summary.stats["potential_detection"] == 1
+            assert evidently_func_summary.stats["detected"] == 0
+        except mlrun.errors.MLRunNotFoundError:
+            # Evidently app was not deployed
+            pass
 
     @pytest.mark.parametrize("with_training_set", [True, False])
     @pytest.mark.parametrize("with_model_runner", [True, False])


### PR DESCRIPTION
Fixes [ML-10387](https://iguazio.atlassian.net/browse/ML-10387).

Port #8122 to dev and add the required change in `_test_function_summaries`.

I checked, and both

- `test_app_flow[True-False]`
- `test_app_flow[False-False]`

passed (`with_training_set=False` and `with_model_runner` either `True` or `False`).

[ML-10387]: https://iguazio.atlassian.net/browse/ML-10387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ