### PR TITLE
[Frameworks] pre_compile Horovod to TensorFlow adjustments bug fixes [1.9.x]

### DIFF
--- a/mlrun/frameworks/tf_keras/mlrun_interface.py
+++ b/mlrun/frameworks/tf_keras/mlrun_interface.py
@@ -280,7 +280,10 @@ class TFKerasMLRunInterface(MLRunInterface, ABC):
             print(f"Horovod worker #{self._hvd.rank()} is using CPU")
 
         # Adjust learning rate based on the number of GPUs:
-        optimizer.lr = optimizer.lr * self._hvd.size()
+        if hasattr(optimizer, "lr"):
+            optimizer.lr = optimizer.lr * self._hvd.size()
+        else:
+            optimizer.learning_rate = optimizer.learning_rate * self._hvd.size()
 
         # Wrap the optimizer in horovod's distributed optimizer: 'hvd.DistributedOptimizer'.
         optimizer = self._hvd.DistributedOptimizer(optimizer)

--- a/mlrun/frameworks/tf_keras/mlrun_interface.py
+++ b/mlrun/frameworks/tf_keras/mlrun_interface.py
@@ -107,14 +107,10 @@ class TFKerasMLRunInterface(MLRunInterface, ABC):
             )
 
         # Call the pre compile method:
-        (optimizer, experimental_run_tf_function) = self._pre_compile(
-            optimizer=kwargs["optimizer"]
-        )
+        optimizer = self._pre_compile(optimizer=kwargs["optimizer"])
 
         # Assign parameters:
         kwargs["optimizer"] = optimizer
-        if experimental_run_tf_function is not None:
-            kwargs["experimental_run_tf_function"] = experimental_run_tf_function
 
         # Call the original compile method:
         return self.original_compile(*args, **kwargs)
@@ -235,23 +231,20 @@ class TFKerasMLRunInterface(MLRunInterface, ABC):
         """
         self._RANK_0_ONLY_CALLBACKS.add(callback_name)
 
-    def _pre_compile(self, optimizer: Optimizer) -> tuple[Optimizer, Union[bool, None]]:
+    def _pre_compile(self, optimizer: Optimizer) -> Optimizer:
         """
         Method to call before calling 'compile' to setup the run and inputs for using horovod.
 
         :param optimizer: The optimzier to compile. It will be wrapped in horovod's distributed optimizer:
                           'hvd.DistributedOptimizer'.
 
-        :return: The updated parameters:
-                 [0] = Wrapped optimizer.
-                 [1] = The 'experimental_run_tf_function' parameter for 'compile' kwargs or 'None' if horovod should not
-                       be used.
+        :return: The updated Wrapped optimizer.
 
         :raise MLRunInvalidArgumentError: In case the optimizer was passed as a string.
         """
         # Check if needed to run with horovod:
         if self._hvd is None:
-            return optimizer, None
+            return optimizer
 
         # Validate the optimizer input:
         if isinstance(optimizer, str):
@@ -288,11 +281,7 @@ class TFKerasMLRunInterface(MLRunInterface, ABC):
         # Wrap the optimizer in horovod's distributed optimizer: 'hvd.DistributedOptimizer'.
         optimizer = self._hvd.DistributedOptimizer(optimizer)
 
-        # Compile the model with `experimental_run_tf_function=False` to ensure Tensorflow uses the distributed
-        # optimizer to compute the gradients:
-        experimental_run_tf_function = False
-
-        return optimizer, experimental_run_tf_function
+        return optimizer
 
     def _pre_fit(
         self,

--- a/mlrun/frameworks/tf_keras/model_handler.py
+++ b/mlrun/frameworks/tf_keras/model_handler.py
@@ -518,7 +518,6 @@ class TFKerasModelHandler(DLModelHandler):
         )
 
         # Read additional files according to the model format used:
-        # # ModelFormats.SAVED_MODEL - Unzip the SavedModel archive:
         if self._model_format == TFKerasModelHandler.ModelFormats.SAVED_MODEL:
             # Unzip the SavedModel directory:
             with zipfile.ZipFile(self._model_file, "r") as zip_file:
@@ -528,21 +527,17 @@ class TFKerasModelHandler(DLModelHandler):
                 os.path.dirname(self._model_file), self._model_name
             )
         elif self._model_format == TFKerasModelHandler.ModelFormats.KERAS:
-            # When keras tried to load it, it validates the suffix. The `artifacts.model.get_model` function is
-            # downloading the keras file to a temp file with a `pkl` suffix, so it needs to be replaced:
-            self._model_file = self._model_file.rsplit(".pkl", 1)[0] + ".keras"
+            # Rename the model file suffix:
+            self._rename_model_file_suffix(suffix="keras")
         elif self._model_format == TFKerasModelHandler.ModelFormats.H5:
-            # When keras tried to load it, it validates the suffix. The `artifacts.model.get_model` function is
-            # downloading the keras file to a temp file with a `pkl` suffix, so it needs to be replaced:
-            self._model_file = self._model_file.rsplit(".pkl", 1)[0] + ".h5"
-        # # ModelFormats.JSON_ARCHITECTURE_H5_WEIGHTS - Get the weights file:
-        elif (
+            # Rename the model file suffix:
+            self._rename_model_file_suffix(suffix="h5")
+        elif (  # ModelFormats.JSON_ARCHITECTURE_H5_WEIGHTS
             self._model_format
             == TFKerasModelHandler.ModelFormats.JSON_ARCHITECTURE_H5_WEIGHTS
         ):
-            # When keras tried to load it, it validates the suffix. The `artifacts.model.get_model` function is
-            # downloading the keras file to a temp file with a `pkl` suffix, so it needs to be replaced:
-            self._model_file = self._model_file.rsplit(".pkl", 1)[0] + ".json"
+            # Rename the model file suffix:
+            self._rename_model_file_suffix(suffix="json")
             # Get the weights file:
             self._weights_file = self._extra_data[
                 self._get_weights_file_artifact_name()
@@ -550,6 +545,20 @@ class TFKerasModelHandler(DLModelHandler):
 
         # Continue collecting from abstract class:
         super()._collect_files_from_store_object()
+
+    def _rename_model_file_suffix(self, suffix: str):
+        """
+        Rename the model file suffix to the given one.
+
+        This is used for the case of loading a model from a store object that was saved with a different suffix as when
+        keras tries to load it, it validates the suffix. The `artifacts.model.get_model` function is downloading the
+        file to a temp file with a `pkl` suffix, so it needs to be replaced:than the one keras expects.
+
+        :param suffix: The suffix to rename the model file to (without the trailing dot).
+        """
+        new_name = self._model_file.rsplit(".", 1)[0] + f".{suffix}"
+        os.rename(self._model_file, new_name)
+        self._model_file = new_name
 
     def _collect_files_from_local_path(self):
         """

--- a/mlrun/frameworks/tf_keras/model_handler.py
+++ b/mlrun/frameworks/tf_keras/model_handler.py
@@ -527,11 +527,22 @@ class TFKerasModelHandler(DLModelHandler):
             self._model_file = os.path.join(
                 os.path.dirname(self._model_file), self._model_name
             )
+        elif self._model_format == TFKerasModelHandler.ModelFormats.KERAS:
+            # When keras tried to load it, it validates the suffix. The `artifacts.model.get_model` function is
+            # downloading the keras file to a temp file with a `pkl` suffix, so it needs to be replaced:
+            self._model_file = self._model_file.rsplit(".pkl", 1)[0] + ".keras"
+        elif self._model_format == TFKerasModelHandler.ModelFormats.H5:
+            # When keras tried to load it, it validates the suffix. The `artifacts.model.get_model` function is
+            # downloading the keras file to a temp file with a `pkl` suffix, so it needs to be replaced:
+            self._model_file = self._model_file.rsplit(".pkl", 1)[0] + ".h5"
         # # ModelFormats.JSON_ARCHITECTURE_H5_WEIGHTS - Get the weights file:
         elif (
             self._model_format
             == TFKerasModelHandler.ModelFormats.JSON_ARCHITECTURE_H5_WEIGHTS
         ):
+            # When keras tried to load it, it validates the suffix. The `artifacts.model.get_model` function is
+            # downloading the keras file to a temp file with a `pkl` suffix, so it needs to be replaced:
+            self._model_file = self._model_file.rsplit(".pkl", 1)[0] + ".json"
             # Get the weights file:
             self._weights_file = self._extra_data[
                 self._get_weights_file_artifact_name()


### PR DESCRIPTION
Fixing the two bugs:

https://iguazio.atlassian.net/browse/ML-10383 - tf.Variable do not implement the *= operator.
https://iguazio.atlassian.net/browse/ML-10359 - experimental_run_tf_funcion  was removed from TensorFlow v2.16, but according to https://github.com/tensorflow/tensorflow/issues/35138#issuecomment-789962430, it is not needed since TensorFlow v2.2. We support TensorFlow >= 2.4.