### PR TITLE
[Images] Fix ml-base deprecation check to respect image tag

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -907,8 +907,13 @@ def enrich_image_url(
 
     # it's an mlrun image if the repository is mlrun
     is_mlrun_image = image_url.startswith("mlrun/") or "/mlrun/" in image_url
-
+    if ":" in image_url:
+        _, image_tag = image_url.rsplit(":", 1)
+    else:
+        image_tag = None
     if is_mlrun_image and "mlrun/ml-base" in image_url:
+        # use the tag from image URL if available, else fallback to the given tag
+        tag = image_tag or tag
         if tag:
             if mlrun.utils.helpers.validate_component_version_compatibility(
                 "mlrun-client", "1.10.0-rc0", mlrun_client_version=tag

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -812,6 +812,30 @@ def test_validate_v3io_consumer_group(value, expected):
             "images_registry": "",
             "expected_output": "mlrun/ml-base:1.9.0",
         },
+        {
+            # explicit older tag in image should keep ml-base without replacement despite newer client version
+            "image": "mlrun/ml-base:1.7.2",
+            "client_version": "1.10.0",
+            "images_tag": None,
+            "images_registry": "",
+            "expected_output": "mlrun/ml-base:1.7.2",
+        },
+        {
+            # image tag > 1.10.0, the image should be switched to mlrun/mlrun
+            "image": "mlrun/ml-base",
+            "client_version": None,
+            "images_tag": "1.10.0",
+            "images_registry": "",
+            "expected_output": "mlrun/mlrun:1.10.0",
+        },
+        {
+            # images_tag takes precedence over client_version and triggers replacement even if client_version is older
+            "image": "mlrun/ml-base",
+            "client_version": "1.9.0",
+            "images_tag": "1.10.0",
+            "images_registry": "",
+            "expected_output": "mlrun/mlrun:1.10.0",
+        },
     ],
 )
 def test_enrich_image(case):


### PR DESCRIPTION
This PR fixes an issue in the `enrich_image_url` logic where the client version was used for the `mlrun/ml-base` deprecation check, even when the user explicitly provided a tag in the image URL.

Jira:
https://iguazio.atlassian.net/browse/ML-10336