### PR TITLE
[Logs] Get logs from last attempt by default [feature/retry-job]

### DIFF
--- a/server/py/services/api/api/endpoints/logs.py
+++ b/server/py/services/api/api/endpoints/logs.py
@@ -104,6 +104,9 @@ async def get_log_size(
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         framework.api.deps.authenticate_request
     ),
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
 ):
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
@@ -115,9 +118,9 @@ async def get_log_size(
         )
     )
 
-    if attempt and attempt > 1:
-        uid = f"{uid}-attempt-{attempt}"
-    log_file_size = await services.api.crud.Logs().get_log_size(project, uid)
+    log_file_size = await services.api.crud.Logs().get_log_size(
+        db_session, project, uid, attempt=attempt
+    )
     return {
         "size": log_file_size,
     }

--- a/server/py/services/api/crud/logs.py
+++ b/server/py/services/api/crud/logs.py
@@ -95,10 +95,19 @@ class Logs(
 
     async def get_log_size(
         self,
+        db_session: Session,
         project: str,
         run_uid: str,
+        attempt: int = 0,
     ):
-        logger.debug("Getting log size for run", project=project, run_uid=run_uid)
+        logger.debug(
+            "Getting log size for run",
+            project=project,
+            run_uid=run_uid,
+            attempt=attempt,
+        )
+        run = await self._get_run_for_log(db_session, project, run_uid)
+        run_uid = self._resolve_run_uid(run_uid, run, attempt)
         if (
             mlrun.mlconf.log_collector.mode
             == mlrun.common.schemas.LogsCollectorMode.sidecar
@@ -156,9 +165,7 @@ class Logs(
         run = await self._get_run_for_log(db_session, project, uid)
         run_state = run.get("status", {}).get("state", "")
         log_stream = None
-        if attempt and attempt > 1:
-            # if attempt is specified, we need to get the logs for the specific attempt
-            uid = f"{uid}-attempt-{attempt}"
+        uid = self._resolve_run_uid(uid, run, attempt)
 
         if (
             mlrun.mlconf.log_collector.mode
@@ -436,3 +443,22 @@ class Logs(
         logger.debug(
             f"Successfully deleted {resource} logs", project=project, runs=run_uids
         )
+
+    @staticmethod
+    def _resolve_run_uid(uid: str, run: dict, attempt: int) -> str:
+        """
+        Resolve the run uid based on the attempt number.
+        If the attempt is not specified or 0, we will get the logs for the last attempt.
+        If the attempt is specified and greater than 1, we add the attempt suffix to the run uid in order
+        to get the correct logs from the log collector.
+        """
+        retry_count = run.get("status", {}).get("retry_count", 0)
+        if not attempt and retry_count:
+            # if attempt is not specified, we will get the logs for the last attempt
+            # which is the retry_count + 1 (the first run is considered attempt 1)
+            attempt = retry_count + 1
+
+        if attempt and attempt > 1:
+            # if attempt is specified, we need to get the logs for the specific attempt
+            uid = f"{uid}-attempt-{attempt}"
+        return uid

--- a/server/py/services/api/tests/unit/crud/test_logs.py
+++ b/server/py/services/api/tests/unit/crud/test_logs.py
@@ -72,9 +72,57 @@ class TestLogs:
 
         project = "project-name"
         uid = "m33"
+
+        services.api.crud.Runs().store_run(
+            db,
+            {"metadata": {"name": "run-name", "project": project, "uid": uid}},
+            uid,
+            project=project,
+        )
+
         if expected_error:
             with pytest.raises(mlrun.errors.MLRunNotFoundError):
-                await services.api.crud.Logs().get_log_size(project, uid)
+                await services.api.crud.Logs().get_log_size(db, project, uid)
         else:
-            log_size = await services.api.crud.Logs().get_log_size(project, uid)
+            log_size = await services.api.crud.Logs().get_log_size(db, project, uid)
             assert return_value == log_size
+
+    @pytest.mark.parametrize(
+        "attempt, expected_run_uid",
+        [
+            (None, "m33-attempt-2"),
+            (0, "m33-attempt-2"),
+            (1, "m33"),
+            (2, "m33-attempt-2"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_get_log_size_with_attempt(
+        self, db: sqlalchemy.orm.Session, attempt, expected_run_uid
+    ):
+        mlrun.mlconf.log_collector.mode = mlrun.common.schemas.LogsCollectorMode.sidecar
+        log_collector_client = (
+            framework.utils.clients.log_collector.LogCollectorClient()
+        )
+        log_collector_client.get_log_size = unittest.mock.AsyncMock(return_value=5)
+
+        project = "project-name"
+        uid = "m33"
+
+        services.api.crud.Runs().store_run(
+            db,
+            {
+                "metadata": {"name": "run-name", "project": project, "uid": uid},
+                "status": {"retry_count": 1},
+            },
+            uid,
+            project=project,
+        )
+
+        log_size = await services.api.crud.Logs().get_log_size(
+            db, project, uid, attempt=attempt
+        )
+        assert log_size == log_size
+        log_collector_client.get_log_size.assert_called_once_with(
+            project=project, run_uid=expected_run_uid
+        )


### PR DESCRIPTION
By default, get the logs of the last attempt (when attempt is `None/0`)

https://iguazio.atlassian.net/browse/ML-10423