### PR TITLE
[Go] Bump to 1.23.10 [1.9.x]

### DIFF
--- a/server/go/.golangci.yml
+++ b/server/go/.golangci.yml
@@ -13,67 +13,60 @@
 # limitations under the License.
 #
 
-linters:
-  disable-all: true
-  enable:
-    - goconst
-    - gofmt
-    - revive
-    - gosimple
-    - ineffassign
-    - misspell
-    - staticcheck
-    - unconvert
-    - errcheck
-    - govet
-    - typecheck
-    - unused
-    - gocritic
-    - gci
-    - govet
+version: "2"
+
+# timeout for analysis
+timeout: 5m
 
 run:
-
-  # timeout for analysis
-  timeout: 15m
   build-tags:
     - test_unit
     - test_integration
+linters:
+    default: none
+    enable:
+      - errcheck
+      - goconst
+      - gocritic
+      - govet
+      - ineffassign
+      - misspell
+      - revive
+      - staticcheck
+      - unconvert
+      - unused
+    settings:
+      gocritic:
+        disabled-checks:
+          - commentFormatting
+      revive:
+        rules:
+          - name: errorf
+            disabled: true
+    exclusions:
+      generated: lax
+      presets:
+        - comments
+        - common-false-positives
+        - legacy
+        - std-error-handling
+      rules:
 
-linters-settings:
-  revive:
-    rules:
-
-      # avoid  errorf: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)  messages
-      - name: errorf
-        disabled: true
-
-  gocritic:
-    disabled-checks:
-      - commentFormatting # we dont want to enforce space before the comment text
-
-  gci:
-    sections:
-      - standard
-      - prefix(github.com/mlrun/framework)
-      - prefix(github.com/mlrun/proto)
-      - prefix(github.com/mlrun/services)
-      - default
-      - blank
-      - dot
-
-    custom-order: true
-
-issues:
-
-  # List of regexps of issue texts to exclude
-  exclude:
-    - "comment on"
-    - "error should be the last"
-
-  exclude-rules:
-
-    # list of excluded linters applied on test files
-    - path: _test\.go
-      linters:
-        - goconst
+        - linters:
+            - goconst
+          path: _test\.go
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - prefix(github.com/mlrun/framework)
+        - prefix(github.com/mlrun/proto)
+        - prefix(github.com/mlrun/services)
+        - default
+        - blank
+        - dot
+      custom-order: true

--- a/server/go/Makefile
+++ b/server/go/Makefile
@@ -25,6 +25,10 @@ KUBECONFIG := $(if $(KUBECONFIG),$(KUBECONFIG),$(HOME)/.kube/config)
 CI_BIN_DIR=$(shell pwd)/.bin
 DOCKER_IMAGES = log-collector
 
+GOLANGCI_LINT_VERSION := 2.2.1
+GOLANGCI_LINT_BIN := $(CI_BIN_DIR)/golangci-lint
+GOLANGCI_LINT_INSTALL_COMMAND := GOBIN=$(CI_BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
+
 #
 # Build
 #
@@ -113,13 +117,13 @@ test-integration-dockerized: schemas-compiler
 fmt: ensure-golangci compile-schemas-go
 	@echo Formatting...
 	gofmt -s -w .
-	$(CI_BIN_DIR)/golangci-lint run --fix ./...
+	$(GOLANGCI_LINT_BIN) run --fix ./...
 	@echo Done.
 
 .PHONY: lint
 lint: ensure-golangci compile-schemas-go ensure-test-files-annotated
 	@echo Linting...
-	$(CI_BIN_DIR)/golangci-lint run --verbose ./...
+	$(GOLANGCI_LINT_BIN) run --verbose ./...
 	@echo Done.
 
 .PHONY: security
@@ -142,5 +146,13 @@ ensure-test-files-annotated:
 
 .PHONY: ensure-golangci
 ensure-golangci:
-	@test -e $(CI_BIN_DIR)/golangci-lint || \
-		(curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(CI_BIN_DIR) v1.63.4)
+	@if ! command -v $(GOLANGCI_LINT_BIN) >/dev/null 2>&1; then \
+		echo "golangci-lint not found. Installing..."; \
+		$(GOLANGCI_LINT_INSTALL_COMMAND); \
+	else \
+		installed_version=$$($(GOLANGCI_LINT_BIN) version | awk '/version/ {print $$4}' | sed 's/^v//'); \
+		if [ "$$installed_version" != "$(GOLANGCI_LINT_VERSION)" ]; then \
+			echo "golangci-lint version mismatch ($$installed_version != $(GOLANGCI_LINT_VERSION)). Reinstalling..."; \
+			$(GOLANGCI_LINT_INSTALL_COMMAND); \
+		fi \
+	fi

--- a/server/go/framework/common/utils.go
+++ b/server/go/framework/common/utils.go
@@ -35,9 +35,10 @@ var ErrRetryUntilSuccessfulTimeout = errors.New(TimedOutErrorMessage)
 // value if the environment variable is not set
 func GetEnvOrDefaultString(key string, defaultValue string) string {
 	value := os.Getenv(key)
-	if value == "" {
+	switch value {
+	case "":
 		return defaultValue
-	} else if value == "nil" || value == "none" {
+	case "nil", "none":
 		return ""
 	}
 	return value

--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/mlrun
 
-go 1.23.8
+go 1.23.10
 
 require (
 	github.com/google/uuid v1.6.0

--- a/server/go/services/logcollector/logcollector_test.go
+++ b/server/go/services/logcollector/logcollector_test.go
@@ -227,10 +227,7 @@ func (suite *LogCollectorTestSuite) TestStreamPodLogs() {
 	timeout := time.After(30 * time.Second)
 	var logFileContent []byte
 	foundLogs := false
-	for {
-		if foundLogs {
-			break
-		}
+	for !foundLogs {
 		select {
 		case <-timeout:
 			suite.Require().Fail("Timed out waiting for log file to have content")

--- a/server/go/services/logcollector/statestore/file/client.go
+++ b/server/go/services/logcollector/statestore/file/client.go
@@ -78,7 +78,7 @@ func (s *Store) Initialize(ctx context.Context) error {
 }
 
 func (s *Store) AddLogItem(ctx context.Context, runUID, selector, project string) error {
-	if s.Store.AdvancedLogLevel >= 1 {
+	if s.AdvancedLogLevel >= 1 {
 		s.Logger.DebugWithCtx(ctx,
 			"Adding item to state file",
 			"runUID", runUID,
@@ -89,7 +89,7 @@ func (s *Store) AddLogItem(ctx context.Context, runUID, selector, project string
 }
 
 func (s *Store) RemoveLogItem(ctx context.Context, runUID, project string) error {
-	if s.Store.AdvancedLogLevel >= 1 {
+	if s.AdvancedLogLevel >= 1 {
 		s.Logger.DebugWithCtx(ctx,
 			"Removing item from state file",
 			"runUID", runUID,

--- a/server/go/services/logcollector/statestore/inmemory/client.go
+++ b/server/go/services/logcollector/statestore/inmemory/client.go
@@ -38,7 +38,7 @@ func (s *Store) Initialize(ctx context.Context) error {
 }
 
 func (s *Store) AddLogItem(ctx context.Context, runUID, selector, project string) error {
-	if s.Store.AdvancedLogLevel >= 1 {
+	if s.AdvancedLogLevel >= 1 {
 		s.Logger.DebugWithCtx(ctx,
 			"Adding item to in memory state",
 			"runUID", runUID,
@@ -49,7 +49,7 @@ func (s *Store) AddLogItem(ctx context.Context, runUID, selector, project string
 }
 
 func (s *Store) RemoveLogItem(ctx context.Context, runUID, project string) error {
-	if s.Store.AdvancedLogLevel >= 1 {
+	if s.AdvancedLogLevel >= 1 {
 		s.Logger.DebugWithCtx(ctx,
 			"Removing item from in memory state",
 			"runUID", runUID,


### PR DESCRIPTION
Remedy vulnerabilities
Updates golangci-lint to version 2.2.1 and refactors the configuration to improve linting.
https://iguazio.atlassian.net/browse/IG-23742