### PR TITLE
[Model Monitoring] Fix uses of context in system steps

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -395,7 +395,6 @@ def add_monitoring_general_steps(
     monitor_flow_step = graph.add_step(
         "mlrun.serving.system_steps.BackgroundTaskStatus",
         "background_task_status_step",
-        context=context,
         model_endpoint_creation_strategy=mlrun.common.schemas.ModelEndpointCreationStrategy.SKIP,
     )
     graph.add_step(
@@ -410,7 +409,6 @@ def add_monitoring_general_steps(
         "monitoring_pre_processor_step",
         after="filter_none",
         full_event=True,
-        context=context,
         model_endpoint_creation_strategy=mlrun.common.schemas.ModelEndpointCreationStrategy.SKIP,
     )
     # flatten the events

--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -378,11 +378,7 @@ class MockStreamPusher(storey.MapClass):
     def __init__(self, output_stream=None, **kwargs):
         super().__init__(**kwargs)
         stream = self.context.stream if self.context else None
-        self.output_stream = output_stream or getattr(stream, "output_stream", None)
-        if self.output_stream is None:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "output_stream is None meaning not provided and " "not part of contex"
-            )
+        self.output_stream = output_stream or getattr(stream, "output_stream")
 
     def do(self, event):
         self.output_stream.push(

--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -35,7 +35,9 @@ class MonitoringPreProcessor(storey.MapClass):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.server: mlrun.serving.GraphServer = getattr(self.context, "server", None)
+        self.server: mlrun.serving.GraphServer = (
+            getattr(self.context, "server", None) if self.context else None
+        )
 
     def reconstruct_request_resp_fields(
         self, event, model: str, model_monitoring_data: dict
@@ -253,7 +255,9 @@ class BackgroundTaskStatus(storey.MapClass):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.server: mlrun.serving.GraphServer = getattr(self.context, "server", None)
+        self.server: mlrun.serving.GraphServer = (
+            getattr(self.context, "server", None) if self.context else None
+        )
         self._background_task_check_timestamp = None
         self._background_task_state = mlrun.common.schemas.BackgroundTaskState.running
 
@@ -375,6 +379,10 @@ class MockStreamPusher(storey.MapClass):
         super().__init__(**kwargs)
         stream = self.context.stream if self.context else None
         self.output_stream = output_stream or getattr(stream, "output_stream", None)
+        if self.output_stream is None:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "output_stream is None meaning not provided and " "not part of contex"
+            )
 
     def do(self, event):
         self.output_stream.push(

--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -378,7 +378,7 @@ class MockStreamPusher(storey.MapClass):
     def __init__(self, output_stream=None, **kwargs):
         super().__init__(**kwargs)
         stream = self.context.stream if self.context else None
-        self.output_stream = output_stream or getattr(stream, "output_stream")
+        self.output_stream = output_stream or stream.output_stream
 
     def do(self, event):
         self.output_stream.push(

--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import random
-from copy import copy, deepcopy
+from copy import deepcopy
 from datetime import timedelta
 from typing import Any, Optional, Union
 
@@ -32,11 +32,11 @@ class MonitoringPreProcessor(storey.MapClass):
 
     def __init__(
         self,
-        context,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.context = copy(context)
+        context = kwargs.get("context")
+        self.server: mlrun.serving.GraphServer = getattr(context, "server", None)
 
     def reconstruct_request_resp_fields(
         self, event, model: str, model_monitoring_data: dict
@@ -148,9 +148,8 @@ class MonitoringPreProcessor(storey.MapClass):
 
     def do(self, event):
         monitoring_event_list = []
-        server: mlrun.serving.GraphServer = getattr(self.context, "server", None)
         model_runner_name = event._metadata.get("model_runner_name", "")
-        step = server.graph.steps[model_runner_name] if server else {}
+        step = self.server.graph.steps[model_runner_name] if self.server else {}
         monitoring_data = step.monitoring_data
         logger.debug(
             "monitoring preprocessor started",
@@ -184,8 +183,8 @@ class MonitoringPreProcessor(storey.MapClass):
                             mm_schemas.StreamProcessingEvent.LABELS: monitoring_data[
                                 model
                             ].get(mlrun.common.schemas.MonitoringData.OUTPUTS),
-                            mm_schemas.StreamProcessingEvent.FUNCTION_URI: server.function_uri
-                            if server
+                            mm_schemas.StreamProcessingEvent.FUNCTION_URI: self.server.function_uri
+                            if self.server
                             else None,
                             mm_schemas.StreamProcessingEvent.REQUEST: request,
                             mm_schemas.StreamProcessingEvent.RESPONSE: resp,
@@ -226,8 +225,8 @@ class MonitoringPreProcessor(storey.MapClass):
                     mm_schemas.StreamProcessingEvent.LABELS: monitoring_data[model].get(
                         mlrun.common.schemas.MonitoringData.OUTPUTS
                     ),
-                    mm_schemas.StreamProcessingEvent.FUNCTION_URI: server.function_uri
-                    if server
+                    mm_schemas.StreamProcessingEvent.FUNCTION_URI: self.server.function_uri
+                    if self.server
                     else None,
                     mm_schemas.StreamProcessingEvent.REQUEST: request,
                     mm_schemas.StreamProcessingEvent.RESPONSE: resp,
@@ -253,9 +252,9 @@ class BackgroundTaskStatus(storey.MapClass):
     creation failed or in progress
     """
 
-    def __init__(self, context, **kwargs):
-        self.context = copy(context)
-        self.server: mlrun.serving.GraphServer = getattr(self.context, "server", None)
+    def __init__(self, **kwargs):
+        context = kwargs.get("context")
+        self.server: mlrun.serving.GraphServer = getattr(context, "server", None)
         self._background_task_check_timestamp = None
         self._background_task_state = mlrun.common.schemas.BackgroundTaskState.running
         super().__init__(**kwargs)
@@ -382,8 +381,9 @@ class SamplingStep(storey.MapClass):
 
 
 class MockStreamPusher(storey.MapClass):
-    def __init__(self, context, output_stream=None, **kwargs):
+    def __init__(self, output_stream=None, **kwargs):
         super().__init__(**kwargs)
+        context = kwargs.get("context")
         self.output_stream = output_stream or context.stream.output_stream
 
     def do(self, event):

--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -279,14 +279,8 @@ class BackgroundTaskStatus(storey.MapClass):
             self._background_task_check_timestamp = mlrun.utils.now_date()
             self._log_background_task_state(background_task.status.state)
             self._background_task_state = background_task.status.state
-            if (
-                background_task.status.state
-                == mlrun.common.schemas.BackgroundTaskState.succeeded
-            ):
-                return event
-            else:
-                return None
-        elif (
+
+        if (
             self._background_task_state
             == mlrun.common.schemas.BackgroundTaskState.succeeded
         ):
@@ -382,7 +376,8 @@ class MockStreamPusher(storey.MapClass):
     def __init__(self, output_stream=None, **kwargs):
         super().__init__(**kwargs)
         context = kwargs.get("context")
-        self.output_stream = output_stream or context.stream.output_stream
+        stream = context.stream if context else None
+        self.output_stream = output_stream or getattr(stream, "output_stream", None)
 
     def do(self, event):
         self.output_stream.push(

--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -35,8 +35,7 @@ class MonitoringPreProcessor(storey.MapClass):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        context = kwargs.get("context")
-        self.server: mlrun.serving.GraphServer = getattr(context, "server", None)
+        self.server: mlrun.serving.GraphServer = getattr(self.context, "server", None)
 
     def reconstruct_request_resp_fields(
         self, event, model: str, model_monitoring_data: dict
@@ -253,11 +252,10 @@ class BackgroundTaskStatus(storey.MapClass):
     """
 
     def __init__(self, **kwargs):
-        context = kwargs.get("context")
-        self.server: mlrun.serving.GraphServer = getattr(context, "server", None)
+        super().__init__(**kwargs)
+        self.server: mlrun.serving.GraphServer = getattr(self.context, "server", None)
         self._background_task_check_timestamp = None
         self._background_task_state = mlrun.common.schemas.BackgroundTaskState.running
-        super().__init__(**kwargs)
 
     def do(self, event):
         if self.server is None:
@@ -375,8 +373,7 @@ class SamplingStep(storey.MapClass):
 class MockStreamPusher(storey.MapClass):
     def __init__(self, output_stream=None, **kwargs):
         super().__init__(**kwargs)
-        context = kwargs.get("context")
-        stream = context.stream if context else None
+        stream = self.context.stream if self.context else None
         self.output_stream = output_stream or getattr(stream, "output_stream", None)
 
     def do(self, event):


### PR DESCRIPTION
Fix providing remove context param from steps,  allowing storey to provide it to `storey.Flow::__init__`
`test_app_flow` fails on` _test_function_summaries` for v3io as spoke in data-flow meeting