### PR TITLE
[Jobs] Abort stale pending retry jobs

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -125,6 +125,7 @@ default_config = {
                 "interval": "30",
                 # runs limit to fetch for retrying
                 "fetch_runs_limit": 1000,
+                "staleness_threshold": 3,  # days until a run is considered stale and will be aborted
             },
         },
         "projects": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -125,7 +125,9 @@ default_config = {
                 "interval": "30",
                 # runs limit to fetch for retrying
                 "fetch_runs_limit": 1000,
-                "staleness_threshold": 3,  # days until a run is considered stale and will be aborted
+                "staleness_threshold": 60
+                * 24
+                * 3,  # minutes until a run is considered stale and will be aborted
             },
         },
         "projects": {

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -125,9 +125,8 @@ default_config = {
                 "interval": "30",
                 # runs limit to fetch for retrying
                 "fetch_runs_limit": 1000,
-                "staleness_threshold": 60
-                * 24
-                * 3,  # minutes until a run is considered stale and will be aborted
+                # minutes until a run is considered stale and will be aborted
+                "staleness_threshold": 60 * 24 * 3,
             },
         },
         "projects": {

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -1002,7 +1002,8 @@ class Service(framework.service.Service):
                                     project=run.metadata.project,
                                     uid=run.metadata.uid,
                                     run_updates={
-                                        "status.status_text": f"Run retry timed out after {staleness_threshold} days",
+                                        "status.status_text": "Retry aborted: run was pending retry for more than "
+                                        f"{staleness_threshold} days",
                                     },
                                     run=run_dict,
                                 )
@@ -1067,7 +1068,9 @@ class Service(framework.service.Service):
             await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
     def _submit_run_for_retry(self, run: mlrun.RunObject):
-        self._retry_in_progress_run_uids[run.metadata.uid] = datetime.datetime.now()
+        self._retry_in_progress_run_uids[run.metadata.uid] = datetime.datetime.now(
+            datetime.timezone.utc
+        )
         loop = asyncio.get_running_loop()
 
         # Calculate the delay based on the retry policy

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -964,7 +964,7 @@ class Service(framework.service.Service):
         db_session = await fastapi.concurrency.run_in_threadpool(create_session)
         fetch_runs_limit = int(mlconf.monitoring.runs.retry.fetch_runs_limit)
         staleness_threshold = int(mlconf.monitoring.runs.retry.staleness_threshold)
-        stale_after = datetime.timedelta(days=staleness_threshold)
+        stale_after = datetime.timedelta(minutes=staleness_threshold)
         now = datetime.datetime.now(datetime.timezone.utc)
         try:
             offset = 0
@@ -1003,7 +1003,7 @@ class Service(framework.service.Service):
                                     uid=run.metadata.uid,
                                     run_updates={
                                         "status.status_text": "Retry aborted: run was pending retry for more than "
-                                        f"{staleness_threshold} days",
+                                        f"{staleness_threshold} minutes",
                                     },
                                     run=run_dict,
                                 )

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -84,7 +84,7 @@ class Service(framework.service.Service):
             (services.api.crud.Functions, "list_functions"),
             (services.api.crud.Artifacts, "list_artifacts"),
         ]
-        self._retry_in_progress_run_uids = set()
+        self._retry_in_progress_run_uids: dict[str, datetime.datetime] = {}
 
     async def _move_service_to_online(self):
         # scheduler is needed on both workers and chief
@@ -963,6 +963,9 @@ class Service(framework.service.Service):
         self._logger.debug("Retrying jobs with retry policy configured")
         db_session = await fastapi.concurrency.run_in_threadpool(create_session)
         fetch_runs_limit = int(mlconf.monitoring.runs.retry.fetch_runs_limit)
+        staleness_threshold = int(mlconf.monitoring.runs.retry.staleness_threshold)
+        stale_after = datetime.timedelta(days=staleness_threshold)
+        now = datetime.datetime.now(datetime.timezone.utc)
         try:
             offset = 0
             while runs := await fastapi.concurrency.run_in_threadpool(
@@ -982,10 +985,33 @@ class Service(framework.service.Service):
                 for run_dict in runs:
                     run = mlrun.RunObject.from_dict(run_dict)
                     if run.metadata.uid in self._retry_in_progress_run_uids:
-                        self._logger.debug(
-                            "Run is already being retried, skipping",
-                            run_uid=run.metadata.uid,
-                        )
+                        first_retry_time = self._retry_in_progress_run_uids[
+                            run.metadata.uid
+                        ]
+                        if now - first_retry_time > stale_after:
+                            self._logger.warning(
+                                "Run is stale, aborting retry",
+                                run_uid=run.metadata.uid,
+                                first_retry_time=first_retry_time,
+                                now=now,
+                            )
+                            futures.append(
+                                fastapi.concurrency.run_in_threadpool(
+                                    framework.db.session.run_function_with_new_db_session,
+                                    services.api.crud.Runs().abort_run,
+                                    project=run.metadata.project,
+                                    uid=run.metadata.uid,
+                                    run_updates={
+                                        "status.status_text": f"Run retry timed out after {staleness_threshold} days",
+                                    },
+                                    run=run_dict,
+                                )
+                            )
+                        else:
+                            self._logger.debug(
+                                "Run is already being retried, skipping",
+                                run_uid=run.metadata.uid,
+                            )
                         continue
 
                     # retry_count may be None on the first attempt
@@ -1041,7 +1067,7 @@ class Service(framework.service.Service):
             await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
     def _submit_run_for_retry(self, run: mlrun.RunObject):
-        self._retry_in_progress_run_uids.add(run.metadata.uid)
+        self._retry_in_progress_run_uids[run.metadata.uid] = datetime.datetime.now()
         loop = asyncio.get_running_loop()
 
         # Calculate the delay based on the retry policy
@@ -1084,7 +1110,7 @@ class Service(framework.service.Service):
             )
 
         finally:
-            self._retry_in_progress_run_uids.discard(run.metadata.uid)
+            self._retry_in_progress_run_uids.pop(run.metadata.uid)
 
 
 if __name__ == "__main__":

--- a/server/py/services/api/tests/unit/test_service.py
+++ b/server/py/services/api/tests/unit/test_service.py
@@ -111,7 +111,8 @@ class TestService(TestAPIBase):
             assert mock_submit_run_sync.call_count == 10
 
     async def test_retry_stale_job(self, db: Session):
-        mlrun.mlconf.monitoring.runs.retry.staleness_threshold = 1
+        staleness_threshold = 1
+        mlrun.mlconf.monitoring.runs.retry.staleness_threshold = staleness_threshold
         run_uid = "test-stale-job-uid"
         run = self._generate_retry_job(uid=run_uid)
 
@@ -129,7 +130,10 @@ class TestService(TestAPIBase):
         assert (
             run["status"]["state"] == mlrun.common.runtimes.constants.RunStates.aborted
         )
-        assert "Run retry timed out" in run["status"]["status_text"]
+        assert (
+            f"Retry aborted: run was pending retry for more than {staleness_threshold} days"
+            in run["status"]["status_text"]
+        )
 
     def _generate_retry_job(
         self,

--- a/server/py/services/api/tests/unit/test_service.py
+++ b/server/py/services/api/tests/unit/test_service.py
@@ -110,6 +110,27 @@ class TestService(TestAPIBase):
             await self._service._retry_jobs()
             assert mock_submit_run_sync.call_count == 10
 
+    async def test_retry_stale_job(self, db: Session):
+        mlrun.mlconf.monitoring.runs.retry.staleness_threshold = 1
+        run_uid = "test-stale-job-uid"
+        run = self._generate_retry_job(uid=run_uid)
+
+        run_db = mlrun.db.get_run_db()
+        run_db.store_run(struct=run, uid=run_uid, project=self._project)
+
+        # manually add the run to the retry in progress dictionary to simulate a stale run
+        self._service._retry_in_progress_run_uids[run_uid] = datetime.datetime.now(
+            datetime.timezone.utc
+        ) - datetime.timedelta(days=2)
+
+        await self._service._retry_jobs()
+
+        run = run_db.read_run(uid=run_uid, project=self._project)
+        assert (
+            run["status"]["state"] == mlrun.common.runtimes.constants.RunStates.aborted
+        )
+        assert "Run retry timed out" in run["status"]["status_text"]
+
     def _generate_retry_job(
         self,
         uid: str = "test-job-uid",
@@ -117,19 +138,23 @@ class TestService(TestAPIBase):
         state: typing.Optional[str] = None,
         count: int = 3,
         retry_count: int = 0,
+        base_delay: str = "1s",
     ):
         return {
             "metadata": {
                 "name": "test-job",
                 "project": project or self._project,
                 "uid": uid or str(uuid.uuid4()),
+                "labels": {
+                    "kind": "job",
+                },
             },
             "spec": {
                 "function": f"{self._project}/test@c37401e5c6bf55b826bafa336a2c6e796280292a",
                 "retry": {
                     "count": count,
                     "backoff": {
-                        "base_delay": "1s",
+                        "base_delay": base_delay,
                     },
                 },
             },

--- a/server/py/services/api/tests/unit/test_service.py
+++ b/server/py/services/api/tests/unit/test_service.py
@@ -111,7 +111,7 @@ class TestService(TestAPIBase):
             assert mock_submit_run_sync.call_count == 10
 
     async def test_retry_stale_job(self, db: Session):
-        staleness_threshold = 1
+        staleness_threshold = 60 * 24 * 1
         mlrun.mlconf.monitoring.runs.retry.staleness_threshold = staleness_threshold
         run_uid = "test-stale-job-uid"
         run = self._generate_retry_job(uid=run_uid)
@@ -131,7 +131,7 @@ class TestService(TestAPIBase):
             run["status"]["state"] == mlrun.common.runtimes.constants.RunStates.aborted
         )
         assert (
-            f"Retry aborted: run was pending retry for more than {staleness_threshold} days"
+            f"Retry aborted: run was pending retry for more than {staleness_threshold} minutes"
             in run["status"]["status_text"]
         )
 


### PR DESCRIPTION
This pull request introduces functionality to handle stale job retries. It adds a staleness threshold configuration, updates the retry mechanism to abort stale jobs, and includes unit tests to validate the new behavior.

Jira - https://iguazio.atlassian.net/browse/ML-10252

### Enhancements to job retry logic:

* **Added staleness threshold configuration**: Introduced a new parameter, `staleness_threshold`, in `mlrun/config.py` to define the number of days after which a run is considered stale and aborted.
* **Updated retry mechanism**: Modified `async def _retry_jobs(self)` in `server/py/services/api/main.py` to check the staleness of jobs and abort retries for stale runs. This includes logging warnings and updating the run's status to indicate timeout. [[1]](diffhunk://#diff-7430a66849887136c5802c51c164ed481387f22bd56d24fa2e242f585de76d89R966-R968) [[2]](diffhunk://#diff-7430a66849887136c5802c51c164ed481387f22bd56d24fa2e242f585de76d89R988-R1010)
* **Changed retry tracking structure**: Replaced the `set` used for tracking retrying runs with a `dict` that maps run UIDs to their first retry timestamps, enabling staleness checks. [[1]](diffhunk://#diff-7430a66849887136c5802c51c164ed481387f22bd56d24fa2e242f585de76d89L87-R87) [[2]](diffhunk://#diff-7430a66849887136c5802c51c164ed481387f22bd56d24fa2e242f585de76d89L1044-R1070) [[3]](diffhunk://#diff-7430a66849887136c5802c51c164ed481387f22bd56d24fa2e242f585de76d89L1087-R1113)

### Unit tests for stale job retries:

* **Added test for stale job handling**: Created a new test, `test_retry_stale_job`, in `server/py/services/api/tests/unit/test_service.py` to verify that stale runs are correctly aborted based on the staleness threshold.
* **Enhanced job generation for tests**: Updated the `_generate_retry_job` helper method to allow dynamic configuration of `base_delay` and added labels to the generated job metadata.