### PR TITLE
[Tests] Add missing `execution_mechanism` parameter

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -522,6 +522,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
             model_runner_step.add_model(
                 endpoint_name=f"{cls.model_name}_{with_training_set}",
                 model_class="MyModel",
+                execution_mechanism="naive",
                 model_artifact=f"store://models/{cls.project_name}/{cls.model_name}_{with_training_set}:latest",
                 input_path="inputs",
                 result_path="outputs",
@@ -1848,6 +1849,7 @@ class TestBatchServingWithSampling(TestMLRunSystemModelMonitoring):
             model_runner_step.add_model(
                 endpoint_name=self._model_name,
                 model_class="MyModel",
+                execution_mechanism="naive",
                 model_artifact=model_uri,
                 input_path="inputs",
                 result_path="outputs",

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -587,10 +587,16 @@ class TestModelEndpointsOperations(TestMLRunSystemModelMonitoring):
         graph = function.set_topology("flow", engine="async")
         model_runner_step = mlrun.serving.states.ModelRunnerStep(name="model-runner")
         model_runner_step.add_model(
-            model_class="IncModel", endpoint_name="my-model-1", inc=1
+            model_class="IncModel",
+            endpoint_name="my-model-1",
+            execution_mechanism="naive",
+            inc=1,
         )
         model_runner_step.add_model(
-            model_class="IncModel", endpoint_name="my-model-2", inc=2
+            model_class="IncModel",
+            endpoint_name="my-model-2",
+            execution_mechanism="naive",
+            inc=2,
         )
         graph.to(name="echo", class_name="Echo").to(
             model_runner_step, "runner"

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -113,7 +113,11 @@ class TestNuclioRuntime(tests.system.base.TestMLRunSystem):
 
         graph = function.set_topology("flow", engine="async")
         model_runner_step = ModelRunnerStep(name="model-runner", raise_exception=True)
-        model_runner_step.add_model(model_class="DummyModel", endpoint_name="my-model")
+        model_runner_step.add_model(
+            model_class="DummyModel",
+            execution_mechanism="naive",
+            endpoint_name="my-model",
+        )
         step = graph.to(model_runner_step).respond()
         step.to(name="inc", handler="inc", function="child")
         function.add_child_function(


### PR DESCRIPTION
Following #8172.

`TestMonitoringAppFlow::test_app_flow` passed all permutations.
`TestNuclioRuntime:test_deploy_function_with_model_runner_with_child_function` passed.