### PR TITLE
[Model Monitoring] Add support for `V3IO` in the Function Summary API

### DIFF
--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -336,8 +336,8 @@ class ModelEndpointMonitoringMetricNoData(_ModelEndpointMonitoringMetricValuesBa
 
 class ApplicationBaseRecord(BaseModel):
     type: Literal["metric", "result"]
-    time: datetime
     value: float
+    time: Optional[datetime] = None
 
 
 class ApplicationResultRecord(ApplicationBaseRecord):

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -804,25 +804,42 @@ class V3IOTSDBConnector(TSDBConnector):
     @staticmethod
     def _get_sql_query(
         *,
-        endpoint_id: str,
         table_path: str,
+        endpoint_id: Optional[str] = None,
+        application_names: Optional[list[str]] = None,
         name: str = mm_schemas.ResultData.RESULT_NAME,
         metric_and_app_names: Optional[list[tuple[str, str]]] = None,
         columns: Optional[list[str]] = None,
+        group_by_columns: Optional[list[str]] = None,
     ) -> str:
         """Get the SQL query for the results/metrics table"""
+
+        if metric_and_app_names and not endpoint_id:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "If metric_and_app_names is provided, endpoint_id must also be provided"
+            )
+
+        if metric_and_app_names and application_names:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Cannot provide both metric_and_app_names and application_names"
+            )
+
         if columns:
             selection = ",".join(columns)
         else:
             selection = "*"
 
         with StringIO() as query:
-            query.write(
-                f"SELECT {selection} FROM '{table_path}' "
-                f"WHERE {mm_schemas.WriterEvent.ENDPOINT_ID}='{endpoint_id}'"
-            )
+            query.write(f"SELECT {selection} FROM '{table_path}' ")
+            if endpoint_id:
+                query.write(
+                    f" WHERE {mm_schemas.WriterEvent.ENDPOINT_ID}='{endpoint_id}'"
+                )
             if metric_and_app_names:
-                query.write(" AND (")
+                if endpoint_id:
+                    query.write(" AND (")
+                else:
+                    query.write(" WHERE (")
 
                 for i, (app_name, result_name) in enumerate(metric_and_app_names):
                     sub_cond = (
@@ -834,6 +851,22 @@ class V3IOTSDBConnector(TSDBConnector):
                     query.write(sub_cond)
 
                 query.write(")")
+
+            if application_names:
+                if endpoint_id or metric_and_app_names:
+                    query.write(" AND (")
+                else:
+                    query.write(" WHERE (")
+                for i, app_name in enumerate(application_names):
+                    sub_cond = f"{mm_schemas.WriterEvent.APPLICATION_NAME}='{app_name}'"
+                    if i != 0:  # not first sub condition
+                        query.write(" OR ")
+                    query.write(sub_cond)
+                query.write(")")
+
+            if group_by_columns:
+                query.write(" GROUP BY ")
+                query.write(",".join(group_by_columns))
 
             query.write(";")
             return query.getvalue()
@@ -1272,7 +1305,49 @@ class V3IOTSDBConnector(TSDBConnector):
         end: Optional[Union[datetime, str]] = None,
         application_names: Optional[Union[str, list[str]]] = None,
     ) -> dict[str, int]:
-        raise NotImplementedError
+        start, end = get_start_end(start=start, end=end, delta=timedelta(hours=24))
+        group_by_columns = [
+            mm_schemas.ApplicationEvent.APPLICATION_NAME,
+            mm_schemas.ApplicationEvent.ENDPOINT_ID,
+        ]
+
+        def get_application_endpoints_records(
+            record_type: Literal["metrics", "results"],
+        ):
+            if record_type == "results":
+                table_path = self.tables[mm_schemas.V3IOTSDBTables.APP_RESULTS]
+            else:
+                table_path = self.tables[mm_schemas.V3IOTSDBTables.METRICS]
+            sql_query = self._get_sql_query(
+                table_path=table_path,
+                columns=[mm_schemas.WriterEvent.START_INFER_TIME],
+                group_by_columns=group_by_columns,
+                application_names=application_names,
+            )
+            return self.frames_client.read(
+                backend=_TSDB_BE,
+                start=start,
+                end=end,
+                query=sql_query,
+            )
+
+        df_results = get_application_endpoints_records("results")
+        df_metrics = get_application_endpoints_records("metrics")
+
+        if df_results.empty and df_metrics.empty:
+            return {}
+
+        # Combine the two dataframes and count unique endpoints per application
+        combined_df = pd.concat([df_results, df_metrics], ignore_index=True)
+        if combined_df.empty:
+            return {}
+        combined_df.drop_duplicates(subset=group_by_columns, inplace=True)
+
+        grouped_df = combined_df.groupby(
+            mm_schemas.WriterEvent.APPLICATION_NAME
+        ).count()
+
+        return grouped_df[mm_schemas.WriterEvent.ENDPOINT_ID].to_dict()
 
     def calculate_latest_metrics(
         self,
@@ -1282,4 +1357,93 @@ class V3IOTSDBConnector(TSDBConnector):
     ) -> list[
         Union[mm_schemas.ApplicationResultRecord, mm_schemas.ApplicationMetricRecord]
     ]:
-        raise NotImplementedError
+        metric_list = []
+        start, end = get_start_end(start=start, end=end, delta=timedelta(hours=24))
+
+        # Get the latest results
+        def get_latest_metrics_records(
+            record_type: Literal["metrics", "results"],
+        ) -> Union[pd.DataFrame]:
+            group_by_columns = [mm_schemas.ApplicationEvent.APPLICATION_NAME]
+            if record_type == "results":
+                table_path = self.tables[mm_schemas.V3IOTSDBTables.APP_RESULTS]
+                columns = [
+                    f"last({mm_schemas.ResultData.RESULT_STATUS})",
+                    f"last({mm_schemas.ResultData.RESULT_VALUE})",
+                    f"last({mm_schemas.ResultData.RESULT_KIND})",
+                ]
+                group_by_columns += [
+                    mm_schemas.ResultData.RESULT_NAME,
+                ]
+            else:
+                table_path = self.tables[mm_schemas.V3IOTSDBTables.METRICS]
+                columns = [f"last({mm_schemas.MetricData.METRIC_VALUE})"]
+                group_by_columns += [
+                    mm_schemas.MetricData.METRIC_NAME,
+                ]
+            sql_query = self._get_sql_query(
+                table_path=table_path,
+                columns=columns,
+                group_by_columns=group_by_columns,
+                application_names=application_names,
+            )
+
+            return self.frames_client.read(
+                backend=_TSDB_BE,
+                start=start,
+                end=end,
+                query=sql_query,
+            )
+
+        df_results = get_latest_metrics_records("results")
+        df_metrics = get_latest_metrics_records("metrics")
+
+        if df_results.empty and df_metrics.empty:
+            return metric_list
+
+        # Convert the results DataFrame to a list of ApplicationResultRecord
+        def build_metric_objects() -> (
+            list[
+                Union[
+                    mm_schemas.ApplicationResultRecord,
+                    mm_schemas.ApplicationMetricRecord,
+                ]
+            ]
+        ):
+            metric_objects = []
+            if not df_results.empty:
+                df_results.rename(
+                    columns={
+                        f"last({mm_schemas.ResultData.RESULT_VALUE})": mm_schemas.ResultData.RESULT_VALUE,
+                        f"last({mm_schemas.ResultData.RESULT_STATUS})": mm_schemas.ResultData.RESULT_STATUS,
+                        f"last({mm_schemas.ResultData.RESULT_KIND})": mm_schemas.ResultData.RESULT_KIND,
+                    },
+                    inplace=True,
+                )
+                for _, row in df_results.iterrows():
+                    metric_objects.append(
+                        mm_schemas.ApplicationResultRecord(
+                            result_name=row[mm_schemas.ResultData.RESULT_NAME],
+                            kind=row[mm_schemas.ResultData.RESULT_KIND],
+                            status=row[mm_schemas.ResultData.RESULT_STATUS],
+                            value=row[mm_schemas.ResultData.RESULT_VALUE],
+                        )
+                    )
+            if not df_metrics.empty:
+                df_metrics.rename(
+                    columns={
+                        f"last({mm_schemas.MetricData.METRIC_VALUE})": mm_schemas.MetricData.METRIC_VALUE,
+                    },
+                    inplace=True,
+                )
+
+                for _, row in df_metrics.iterrows():
+                    metric_objects.append(
+                        mm_schemas.ApplicationMetricRecord(
+                            metric_name=row[mm_schemas.MetricData.METRIC_NAME],
+                            value=row[mm_schemas.MetricData.METRIC_VALUE],
+                        )
+                    )
+            return metric_objects
+
+        return build_metric_objects()

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -830,16 +830,19 @@ class V3IOTSDBConnector(TSDBConnector):
             selection = "*"
 
         with StringIO() as query:
+            where_added = False
             query.write(f"SELECT {selection} FROM '{table_path}'")
             if endpoint_id:
                 query.write(
                     f" WHERE {mm_schemas.WriterEvent.ENDPOINT_ID}='{endpoint_id}'"
                 )
+                where_added = True
             if metric_and_app_names:
-                if endpoint_id:
+                if where_added:
                     query.write(" AND (")
                 else:
                     query.write(" WHERE (")
+                    where_added = True
 
                 for i, (app_name, result_name) in enumerate(metric_and_app_names):
                     sub_cond = (
@@ -853,7 +856,7 @@ class V3IOTSDBConnector(TSDBConnector):
                 query.write(")")
 
             if application_names:
-                if endpoint_id or metric_and_app_names:
+                if where_added:
                     query.write(" AND (")
                 else:
                     query.write(" WHERE (")

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -1366,7 +1366,7 @@ class V3IOTSDBConnector(TSDBConnector):
         # Get the latest results
         def get_latest_metrics_records(
             record_type: Literal["metrics", "results"],
-        ) -> Union[pd.DataFrame]:
+        ) -> pd.DataFrame:
             group_by_columns = [mm_schemas.ApplicationEvent.APPLICATION_NAME]
             if record_type == "results":
                 table_path = self.tables[mm_schemas.V3IOTSDBTables.APP_RESULTS]

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -830,7 +830,7 @@ class V3IOTSDBConnector(TSDBConnector):
             selection = "*"
 
         with StringIO() as query:
-            query.write(f"SELECT {selection} FROM '{table_path}' ")
+            query.write(f"SELECT {selection} FROM '{table_path}'")
             if endpoint_id:
                 query.write(
                     f" WHERE {mm_schemas.WriterEvent.ENDPOINT_ID}='{endpoint_id}'"

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -417,7 +417,7 @@ async def get_model_monitoring_function_summaries(
 
     :return: A list of FunctionSummary objects containing information about the monitoring functions.
     """
-    return MonitoringDeployment(
+    return await MonitoringDeployment(
         project=commons.project,
         auth_info=commons.auth_info,
         db_session=commons.db_session,
@@ -448,7 +448,7 @@ async def get_model_monitoring_function_summary(
     :return: A FunctionSummary object containing information about the monitoring function.
     """
 
-    res = MonitoringDeployment(
+    return await MonitoringDeployment(
         project=commons.project,
         auth_info=commons.auth_info,
         db_session=commons.db_session,
@@ -458,5 +458,3 @@ async def get_model_monitoring_function_summary(
         name=function_name,
         include_latest_metrics=include_latest_metrics,
     )
-
-    return res

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -794,7 +794,7 @@ class MonitoringDeployment:
             tag="*",
         )
 
-    def function_summaries(
+    async def function_summaries(
         self,
         start: typing.Optional[datetime] = None,
         end: typing.Optional[datetime] = None,
@@ -836,19 +836,21 @@ class MonitoringDeployment:
         )
 
         # Enrich response with monitoring applications
-        application_function_summaries_list = self._get_function_summary_applications(
-            base_period=base_period,
-            start=start,
-            end=end,
-            names=names,
-            labels=labels,
-            include_stats=include_stats,
-            include_processed_model_endpoints=include_processed_model_endpoints,
+        application_function_summaries_list = (
+            await self._get_function_summary_applications(
+                base_period=base_period,
+                start=start,
+                end=end,
+                names=names,
+                labels=labels,
+                include_stats=include_stats,
+                include_processed_model_endpoints=include_processed_model_endpoints,
+            )
         )
 
         return infra_function_summaries_list + application_function_summaries_list
 
-    def function_summary(
+    async def function_summary(
         self,
         name: str,
         start: typing.Optional[datetime] = None,
@@ -872,7 +874,7 @@ class MonitoringDeployment:
         start = start or (now - timedelta(hours=24))
         end = end or now
 
-        function_summary = self.function_summaries(
+        function_summary = await self.function_summaries(
             start=start,
             end=end,
             names=[name],
@@ -887,12 +889,11 @@ class MonitoringDeployment:
 
         if include_latest_metrics:
             # Enrich the function summary with latest metrics
-            function_summary[0].stats["metrics"] = (
-                self._tsdb_connector.calculate_latest_metrics(
-                    start=start,
-                    end=end,
-                    application_names=[name],
-                )
+            function_summary[0].stats["metrics"] = await run_in_threadpool(
+                self._tsdb_connector.calculate_latest_metrics,
+                start=start,
+                end=end,
+                application_names=[name],
             )
 
         return function_summary[0]
@@ -947,7 +948,7 @@ class MonitoringDeployment:
                 )
         return function_summaries_list, base_period
 
-    def _get_function_summary_applications(
+    async def _get_function_summary_applications(
         self,
         base_period: typing.Optional[float] = None,
         start: typing.Optional[datetime] = None,
@@ -983,7 +984,8 @@ class MonitoringDeployment:
 
         if include_stats:
             # enrich func stats with #detections and #possible_detections
-            detection_stats_dict = self._tsdb_connector.count_results_by_status(
+            detection_stats_dict = await run_in_threadpool(
+                self._tsdb_connector.count_results_by_status,
                 start=start,
                 end=end,
                 result_status_list=[
@@ -991,12 +993,14 @@ class MonitoringDeployment:
                     mm_constants.ResultStatusApp.potential_detection.value,
                 ],
             )
+
         if include_processed_model_endpoints:
             # enrich func stats with processed model endpoints
-            processed_model_endpoints_dict = (
-                self._tsdb_connector.count_processed_model_endpoints(
-                    start=start, end=end, application_names=names
-                )
+            processed_model_endpoints_dict = await run_in_threadpool(
+                self._tsdb_connector.count_processed_model_endpoints,
+                start=start,
+                end=end,
+                application_names=names,
             )
 
         for function in mm_functions_list:

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -253,6 +253,75 @@ def tsdb_df_extended() -> pd.DataFrame:
 
 
 @pytest.fixture
+def df_results() -> pd.DataFrame:
+    return pd.DataFrame.from_records(
+        [
+            (
+                pd.Timestamp("2024-04-02 18:00:28", tz="UTC"),
+                "some_app_v1",
+                "some_result_v1",
+                0,
+                0.123,
+                2,
+            ),
+            (
+                pd.Timestamp("2024-04-02 18:00:28", tz="UTC"),
+                "some_app_v1",
+                "some_result_v2",
+                1,
+                0.456,
+                2,
+            ),
+            (
+                pd.Timestamp("2024-04-02 18:00:28", tz="UTC"),
+                "some_app_v2",
+                "some_result_v3",
+                0,
+                0.789,
+                1,
+            ),
+        ],
+        index="time",
+        columns=[
+            "time",
+            "application_name",
+            "result_name",
+            "last(result_kind)",
+            "last(result_value)",
+            "last(result_status)",
+        ],
+    )
+
+
+@pytest.fixture
+def df_metrics() -> pd.DataFrame:
+    return pd.DataFrame.from_records(
+        [
+            (
+                pd.Timestamp("2024-04-02 18:00:28", tz="UTC"),
+                "some_app_v1",
+                "some_metric_v1",
+                0.123,
+            ),
+            (
+                pd.Timestamp("2024-04-02 18:00:28", tz="UTC"),
+                "some_app_v1",
+                "some_metric_v2",
+                0.456,
+            ),
+            (
+                pd.Timestamp("2024-04-02 18:00:28", tz="UTC"),
+                "some_app_v2",
+                "some_metric_v3",
+                0.789,
+            ),
+        ],
+        index="time",
+        columns=["time", "application_name", "metric_name", "last(metric_value)"],
+    )
+
+
+@pytest.fixture
 def predictions_df() -> pd.DataFrame:
     return pd.DataFrame.from_records(
         [
@@ -296,6 +365,29 @@ def _mock_frames_client_extended(tsdb_df_extended: pd.DataFrame) -> Iterator[Non
 def _mock_frames_client_predictions(predictions_df: pd.DataFrame) -> Iterator[None]:
     frames_client_mock = Mock()
     frames_client_mock.read = Mock(return_value=predictions_df)
+
+    with patch.object(
+        mlrun.utils.v3io_clients, "get_frames_client", return_value=frames_client_mock
+    ):
+        yield
+
+
+@pytest.fixture
+def _mock_frames_client_results(
+    df_results: pd.DataFrame, df_metrics: pd.DataFrame
+) -> Iterator[None]:
+    frames_client_mock = Mock()
+
+    def read_data(*args, **kwargs):
+        query = kwargs.get("query", "")
+        if "app-results" in query:
+            return df_results
+        elif "metrics" in query:
+            return df_metrics
+        else:
+            raise ValueError("Unknown query passed to frames_client.read")
+
+    frames_client_mock.read = Mock(side_effect=read_data)
 
     with patch.object(
         mlrun.utils.v3io_clients, "get_frames_client", return_value=frames_client_mock
@@ -391,7 +483,7 @@ def test_normalize_dict_for_v3io_frames(
 
 
 @pytest.mark.usefixtures("_mock_frames_client_extended")
-def count_read_results_by_status():
+def test_count_read_results_by_status():
     """Test reading results by status from V3IOTSDBConnector."""
     tsdb_connector = V3IOTSDBConnector(project="fictitious-one")
     data = tsdb_connector.count_results_by_status()
@@ -410,3 +502,35 @@ def count_read_results_by_status():
 
     data = tsdb_connector.count_results_by_status(result_status_list=[-1])
     assert len(data) == 0
+
+
+@pytest.mark.usefixtures("_mock_frames_client_extended")
+def test_processed_model_endpoints():
+    """Test reading processed model endpoints from V3IOTSDBConnector."""
+    tsdb_connector = V3IOTSDBConnector(project="fictitious-one")
+    data = tsdb_connector.count_processed_model_endpoints()
+
+    assert len(data) == 3
+    assert data["histogram-data-drift"] == 2
+    assert data["test-app"] == 1
+    assert data["test-app-v2"] == 1
+
+
+@pytest.mark.usefixtures("_mock_frames_client_results")
+def test_calculate_latest_metrics():
+    """Test calculating latest metrics from V3IOTSDBConnector."""
+    tsdb_connector = V3IOTSDBConnector(project="fictitious-one")
+    data = tsdb_connector.calculate_latest_metrics()
+
+    assert len(data) == 6
+
+    first_record = data[0]
+    assert first_record.type == mm_constants.ModelEndpointMonitoringMetricType.RESULT
+    assert first_record.result_name == "some_result_v1"
+    assert first_record.kind == mm_constants.ResultKindApp.data_drift
+    assert first_record.value == 0.123
+
+    last_record = data[-1]
+    assert last_record.type == mm_constants.ModelEndpointMonitoringMetricType.METRIC
+    assert last_record.metric_name == "some_metric_v3"
+    assert last_record.value == 0.789

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -71,7 +71,15 @@ def metric_event() -> dict[str, Any]:
 
 
 @pytest.mark.parametrize(
-    ("endpoint_id", "names", "table_path", "columns", "expected_query"),
+    (
+        "endpoint_id",
+        "names",
+        "table_path",
+        "columns",
+        "expected_query",
+        "application_names",
+        "group_by_columns",
+    ),
     [
         (
             "ddw2lke",
@@ -79,6 +87,8 @@ def metric_event() -> dict[str, Any]:
             "app-results",
             None,
             "SELECT * FROM 'app-results' WHERE endpoint_id='ddw2lke';",
+            None,
+            None,
         ),
         (
             "ep123",
@@ -90,6 +100,8 @@ def metric_event() -> dict[str, Any]:
                 "FROM 'path/to/app-results' WHERE endpoint_id='ep123' "
                 "AND ((application_name='app1' AND result_name='res1'));"
             ),
+            None,
+            None,
         ),
         (
             "ep123",
@@ -103,15 +115,32 @@ def metric_event() -> dict[str, Any]:
                 "(application_name='app1' AND result_name='res2') OR "
                 "(application_name='app2' AND result_name='res1'));"
             ),
+            None,
+            None,
+        ),
+        (
+            None,
+            None,
+            "app-results",
+            ["result_value", "result_status", "result_kind"],
+            (
+                "SELECT result_value,result_status,result_kind FROM 'app-results' "
+                "WHERE (application_name='some-app-v1' OR application_name='some-app-v2') "
+                "GROUP BY application_name,result_kind;"
+            ),
+            ["some-app-v1", "some-app-v2"],
+            ["application_name", "result_kind"],
         ),
     ],
 )
 def test_tsdb_query(
-    endpoint_id: str,
-    names: list[tuple[str, str]],
+    endpoint_id: Optional[str],
+    names: Optional[list[tuple[str, str]]],
     table_path: str,
     expected_query: str,
     columns: Optional[list[str]],
+    application_names: Optional[list[str]],
+    group_by_columns: Optional[list[str]],
 ) -> None:
     assert (
         V3IOTSDBConnector._get_sql_query(
@@ -119,6 +148,8 @@ def test_tsdb_query(
             metric_and_app_names=names,
             table_path=table_path,
             columns=columns,
+            application_names=application_names,
+            group_by_columns=group_by_columns,
         )
         == expected_query
     )

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -745,40 +745,38 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
             # Evidently app was not deployed
             pass
 
-        # TODO: Remove this check when the v3io function summary is supported (ML-10384)
-        if self._tsdb_storage.type == mm_constants.TSDBTarget.TDEngine:
-            if _DefaultDataDriftAppData in self.apps_data:
-                # test a specific function summary
-                hist_function_summary = self.project.get_monitoring_function_summary(
-                    name=HistogramDataDriftApplication.NAME, include_latest_metrics=True
-                )
-                assert hist_function_summary.stats
-                assert len(hist_function_summary.stats["metrics"]) == 4
+        if _DefaultDataDriftAppData in self.apps_data:
+            # test a specific function summary
+            hist_function_summary = self.project.get_monitoring_function_summary(
+                name=HistogramDataDriftApplication.NAME, include_latest_metrics=True
+            )
+            assert hist_function_summary.stats
+            assert len(hist_function_summary.stats["metrics"]) == 4
 
-                first_metric = hist_function_summary.stats["metrics"][0]
-                assert first_metric["type"] == "result"
-                # verify the expected keys of a result
-                assert first_metric.keys() == {
-                    "kind",
-                    "result_name",
-                    "status",
-                    "time",
-                    "type",
-                    "value",
-                }, "The result keys are not as expected"
+            first_metric = hist_function_summary.stats["metrics"][0]
+            assert first_metric["type"] == "result"
+            # verify the expected keys of a result
+            assert first_metric.keys() == {
+                "kind",
+                "result_name",
+                "status",
+                "time",
+                "type",
+                "value",
+            }, "The result keys are not as expected"
 
-                assert first_metric["result_name"] == "general_drift"
-                assert first_metric["value"] == 1
+            assert first_metric["result_name"] == "general_drift"
+            assert first_metric["value"] == 1
 
-                second_metric = hist_function_summary.stats["metrics"][1]
-                assert second_metric["type"] == "metric"
-                # verify the expected keys of a metric
-                assert second_metric.keys() == {
-                    "metric_name",
-                    "time",
-                    "type",
-                    "value",
-                }, "The metric keys are not as expected"
+            second_metric = hist_function_summary.stats["metrics"][1]
+            assert second_metric["type"] == "metric"
+            # verify the expected keys of a metric
+            assert second_metric.keys() == {
+                "metric_name",
+                "time",
+                "type",
+                "value",
+            }, "The metric keys are not as expected"
 
     @pytest.mark.parametrize("with_training_set", [True, False])
     @pytest.mark.parametrize("with_model_runner", [True, False])


### PR DESCRIPTION
Following the intro of the function summary api (#8241 ), in this PR we add support for `V3IO` tsdb.
Please note that due to a known limitation with aggregation operations on V3IO, time values for both the latest metric and latest result will not be available.

https://iguazio.atlassian.net/browse/ML-10384