### PR TITLE
[Application] Fix code entry type enrichment

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -39,6 +39,7 @@ import framework.utils.singletons.k8s
 import services.api.crud.runtimes.nuclio.helpers
 import services.api.runtime_handlers
 import services.api.utils.builder
+from services.api.crud.runtimes.nuclio.helpers import pure_nuclio_deployed_restricted
 
 
 def deploy_nuclio_function(
@@ -227,28 +228,6 @@ async def delete_nuclio_functions_in_batches(
                     failed_requests.append(error_message)
 
     return failed_requests
-
-
-def pure_nuclio_deployed_restricted():
-    """
-    Decorator to restrict the usage of the decorated function to pure nuclio deployed runtimes only.
-    Pure nuclio deployed runtimes are runtimes that their images are not built by MLRun, but are built and deployed
-    completely by nuclio.
-    """
-
-    def decorator(callback):
-        def wrapper(function, *args, **kwargs):
-            if (
-                function.kind
-                not in mlrun.runtimes.RuntimeKinds.pure_nuclio_deployed_runtimes()
-            ):
-                return
-
-            return callback(function, *args, **kwargs)
-
-        return wrapper
-
-    return decorator
 
 
 def _compile_function_config(
@@ -502,7 +481,7 @@ def _set_build_params(function, nuclio_spec, builder_env, project, auth_info=Non
     # handle archive build params
     if function.spec.build.source:
         services.api.crud.runtimes.nuclio.helpers.compile_nuclio_archive_config(
-            nuclio_spec, function, builder_env, project, auth_info=auth_info
+            function, nuclio_spec, builder_env, project, auth_info=auth_info
         )
 
     if function.spec.no_cache:

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -26,6 +26,28 @@ import framework.utils.runtimes.nuclio
 import framework.utils.singletons.k8s
 
 
+def pure_nuclio_deployed_restricted():
+    """
+    Decorator to restrict the usage of the decorated function to pure nuclio deployed runtimes only.
+    Pure nuclio deployed runtimes are runtimes that their images are not built by MLRun, but are built and deployed
+    completely by nuclio.
+    """
+
+    def decorator(callback):
+        def wrapper(function, *args, **kwargs):
+            if (
+                function.kind
+                not in mlrun.runtimes.RuntimeKinds.pure_nuclio_deployed_runtimes()
+            ):
+                return
+
+            return callback(function, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 def resolve_function_http_trigger(function_spec):
     for trigger_name, trigger_config in function_spec.get("triggers", {}).items():
         if trigger_config.get("kind") != "http":
@@ -218,9 +240,10 @@ def is_nuclio_version_in_range(min_version: str, max_version: str) -> bool:
     return parsed_min_version <= parsed_current_version < parsed_max_version
 
 
+@pure_nuclio_deployed_restricted()
 def compile_nuclio_archive_config(
-    nuclio_spec,
     function: mlrun.runtimes.nuclio.function.RemoteRuntime,
+    nuclio_spec,
     builder_env,
     project=None,
     auth_info=None,

--- a/server/py/services/api/tests/unit/runtimes/test_application.py
+++ b/server/py/services/api/tests/unit/runtimes/test_application.py
@@ -49,12 +49,13 @@ class TestApplicationRuntime(TestRuntimeBase):
         requirements = ["requests", "numpy"]
         function.with_requirements(requirements=requirements)
         function.spec.build.base_image = "my-base-image"
+        function.spec.build.source = "v3io://my-source.tar.gz"
         (
             _,
             _,
             config,
         ) = services.api.crud.runtimes.nuclio.function._compile_function_config(
-            function
+            function, builder_env={}
         )
         assert not mlrun.utils.get_in(
             config,
@@ -63,6 +64,10 @@ class TestApplicationRuntime(TestRuntimeBase):
         assert not mlrun.utils.get_in(
             config,
             "spec.build.baseImage",
+        )
+        assert not mlrun.utils.get_in(
+            config,
+            "spec.build.codeEntryType",
         )
 
     def test_create_function_validate_min_nuclio_version(

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1870,7 +1870,9 @@ def get_archive_spec(function, secrets):
     spec = nuclio.ConfigSpec()
     config = {}
     services.api.crud.runtimes.nuclio.helpers.compile_nuclio_archive_config(
-        spec, function, secrets
+        function,
+        spec,
+        secrets,
     )
     spec.merge(config)
     return config


### PR DESCRIPTION
Regression from - https://github.com/mlrun/mlrun/pull/7631
The code entry type was enriched to `archive` because of the function source which is ment for the application sidecar.
This fixes `system.runtimes.test_application.TestApplicationRuntime.test_deploy_application`