### PR TITLE
[Jobs] Add retries attempts metadata to run status

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -94,6 +94,7 @@ class MLClientCtx:
         self._state_thresholds = {}
         self._retry_spec = {}
         self._retry_count = None
+        self._retries = []
 
         self._labels = {}
         self._annotations = {}
@@ -468,6 +469,7 @@ class MLClientCtx:
             for key, uri in status.get("artifact_uris", {}).items():
                 self._artifacts_manager.artifact_uris[key] = uri
             self._retry_count = status.get("retry_count", self._retry_count)
+            self._retries = status.get("retries", self._retries)
             # if run is a retry, the state needs to move to running
             if include_status:
                 self._state = status.get("state", self._state)
@@ -1267,6 +1269,7 @@ class MLClientCtx:
                 "start_time": to_date_str(self._start_time),
                 "last_update": to_date_str(self._last_update),
                 "retry_count": self._retry_count,
+                "retries": self._retries,
             },
         }
 

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1375,6 +1375,7 @@ class RunStatus(ModelObj):
         notifications: Optional[dict[str, Notification]] = None,
         artifact_uris: Optional[dict[str, str]] = None,
         retry_count: Optional[int] = None,
+        retries: Optional[list[dict]] = None,
     ):
         self.state = state or "created"
         self.status_text = status_text
@@ -1393,6 +1394,7 @@ class RunStatus(ModelObj):
         # Artifact key -> URI mapping, since the full artifacts are not stored in the runs DB table
         self._artifact_uris = artifact_uris or {}
         self._retry_count = retry_count or None
+        self._retries = retries or []
 
     @classmethod
     def from_dict(
@@ -1460,6 +1462,19 @@ class RunStatus(ModelObj):
         :param retry_count: The number of retries.
         """
         self._retry_count = retry_count
+
+    @property
+    def retries(self) -> list[dict]:
+        """List of metadata for each retry attempt."""
+        return self._retries
+
+    @retries.setter
+    def retries(self, retries: list[dict]):
+        """
+        Set the list of retry attempt metadata.
+        :param retries: A list of dictionaries, each representing a retry attempt.
+        """
+        self._retries = retries
 
     def is_failed(self) -> Optional[bool]:
         """

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
+import datetime
 import gzip
 from copy import deepcopy
 from typing import Optional, Union
@@ -321,7 +322,15 @@ class ServerSideLauncher(launcher.BaseLauncher):
         # retry_count may be None on first run attempt
         run.status.retry_count = run.status.retry_count or 0
         run.status.retry_count += 1
-        # TODO: Maintain start time of each retry ML-10169
+        # record retry metadata
+        run.status.retries = run.status.retries or []
+        run.status.retries.append(
+            {
+                "attempt": run.status.retry_count,
+                "start_time": datetime.datetime.now(tz=datetime.timezone.utc),
+                "error": run.status.error,
+            }
+        )
         run.status.start_time = None
         # The combination of retry attempt label and requested logs `False` is required for the log collector to
         # collect logs from the current run attempt.

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -328,7 +328,7 @@ class ServerSideLauncher(launcher.BaseLauncher):
             {
                 "attempt": retry_count,
                 "start_time": start_time,
-                "end_time": mlrun.utils.now_date().isoformat(),
+                "end_time": run.status.end_time,
                 "error": run.status.error,
             }
         )

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
-import datetime
 import gzip
 from copy import deepcopy
 from typing import Optional, Union
@@ -320,17 +319,21 @@ class ServerSideLauncher(launcher.BaseLauncher):
 
         run.status.state = mlrun.common.runtimes.constants.RunStates.running
         # retry_count may be None on first run attempt
-        run.status.retry_count = run.status.retry_count or 0
-        run.status.retry_count += 1
+        retry_count = run.status.retry_count or 0
+        start_time = run.status.start_time
+
         # record retry metadata
         run.status.retries = run.status.retries or []
         run.status.retries.append(
             {
-                "attempt": run.status.retry_count,
-                "start_time": datetime.datetime.now(tz=datetime.timezone.utc),
+                "attempt": retry_count,
+                "start_time": start_time,
+                "end_time": mlrun.utils.now_date().isoformat(),
                 "error": run.status.error,
             }
         )
+
+        run.status.retry_count = retry_count + 1
         run.status.start_time = None
         # The combination of retry attempt label and requested logs `False` is required for the log collector to
         # collect logs from the current run attempt.

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -331,6 +331,11 @@ def test_run_status_retry_updates():
     assert run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] == str(
         enriched_run.status.retry_count
     )
+    assert enriched_run.status.retries is not None
+    assert len(enriched_run.status.retries) == 1
+    assert enriched_run.status.retries[0]["attempt"] == 1
+    start_time_1 = enriched_run.status.retries[0]["start_time"]
+    assert start_time_1 is not None
 
     enriched_run.status.state = mlrun.common.runtimes.constants.RunStates.pending_retry
     enriched_run_2 = launcher._enrich_run(runtime=runtime, run=enriched_run)
@@ -342,6 +347,12 @@ def test_run_status_retry_updates():
     assert run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] == str(
         enriched_run_2.status.retry_count
     )
+    assert enriched_run_2.status.retries is not None
+    assert len(enriched_run_2.status.retries) == 2
+    assert enriched_run_2.status.retries[1]["attempt"] == 2
+    start_time_2 = enriched_run.status.retries[1]["start_time"]
+    assert start_time_2 is not None
+    assert start_time_1 < start_time_2
 
 
 @pytest.mark.parametrize(

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -334,8 +334,6 @@ def test_run_status_retry_updates():
     assert enriched_run.status.retries is not None
     assert len(enriched_run.status.retries) == 1
     assert enriched_run.status.retries[0]["attempt"] == 0
-    end_time_1 = enriched_run.status.retries[0]["end_time"]
-    assert end_time_1 is not None
 
     enriched_run.status.state = mlrun.common.runtimes.constants.RunStates.pending_retry
     enriched_run_2 = launcher._enrich_run(runtime=runtime, run=enriched_run)
@@ -350,9 +348,6 @@ def test_run_status_retry_updates():
     assert enriched_run_2.status.retries is not None
     assert len(enriched_run_2.status.retries) == 2
     assert enriched_run_2.status.retries[1]["attempt"] == 1
-    end_time_2 = enriched_run.status.retries[1]["end_time"]
-    assert end_time_2 is not None
-    assert end_time_1 < end_time_2
 
 
 @pytest.mark.parametrize(

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -333,9 +333,9 @@ def test_run_status_retry_updates():
     )
     assert enriched_run.status.retries is not None
     assert len(enriched_run.status.retries) == 1
-    assert enriched_run.status.retries[0]["attempt"] == 1
-    start_time_1 = enriched_run.status.retries[0]["start_time"]
-    assert start_time_1 is not None
+    assert enriched_run.status.retries[0]["attempt"] == 0
+    end_time_1 = enriched_run.status.retries[0]["end_time"]
+    assert end_time_1 is not None
 
     enriched_run.status.state = mlrun.common.runtimes.constants.RunStates.pending_retry
     enriched_run_2 = launcher._enrich_run(runtime=runtime, run=enriched_run)
@@ -349,10 +349,10 @@ def test_run_status_retry_updates():
     )
     assert enriched_run_2.status.retries is not None
     assert len(enriched_run_2.status.retries) == 2
-    assert enriched_run_2.status.retries[1]["attempt"] == 2
-    start_time_2 = enriched_run.status.retries[1]["start_time"]
-    assert start_time_2 is not None
-    assert start_time_1 < start_time_2
+    assert enriched_run_2.status.retries[1]["attempt"] == 1
+    end_time_2 = enriched_run.status.retries[1]["end_time"]
+    assert end_time_2 is not None
+    assert end_time_1 < end_time_2
 
 
 @pytest.mark.parametrize(

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -753,7 +753,7 @@ def print_df(df):
         max_attempts = retry_count + 1
         assert f"Run failed attempt 1 of {max_attempts}" in run.status.status_text
 
-        def _assert_retry_count():
+        def _assert_retry_info():
             runs = self._run_db.list_runs(project=self.project_name)
             assert len(runs) == 1
             run = mlrun.RunObject.from_dict(runs[0])
@@ -762,13 +762,14 @@ def print_df(df):
             ), f"Expected retry_count=3, got {run.status.retry_count}"
             assert run.status.state == mlrun.common.runtimes.constants.RunStates.error
             assert f"Run failed after {max_attempts} attempts" in run.status.status_text
+            self._assert_retry_attempts_metadata(run.status.retries)
 
         mlrun.utils.retry_until_successful(
             1,
             250,
             self._logger,
             True,
-            _assert_retry_count,
+            _assert_retry_info,
         )
 
         state, content = self._run_db.get_log(
@@ -778,3 +779,20 @@ def print_df(df):
         assert "Retrying run - attempt: 2" in str(
             content
         ), "Expected logs to contain retry attempt message"
+
+    @staticmethod
+    def _assert_retry_attempts_metadata(retry_attempts):
+        assert len(retry_attempts) == 3
+
+        previous_start_time = None
+        for i, retry in enumerate(retry_attempts):
+            assert "start_time" in retry
+            assert "error" in retry
+
+            current_start_time = retry["start_time"]
+            if previous_start_time is not None:
+                assert previous_start_time < current_start_time, (
+                    f"Retry {i + 1} start_time is not after retry {i}: "
+                    f"{previous_start_time} >= {current_start_time}"
+                )
+            previous_start_time = current_start_time

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -787,12 +787,19 @@ def print_df(df):
         previous_start_time = None
         for i, retry in enumerate(retry_attempts):
             assert "start_time" in retry
+            assert "end_time" in retry
             assert "error" in retry
 
             current_start_time = retry["start_time"]
+            current_end_time = retry["end_time"]
+
+            assert current_start_time < current_end_time, (
+                f"Retry {i} has end_time <= start_time: "
+                f"{current_end_time} <= {current_start_time}"
+            )
             if previous_start_time is not None:
                 assert previous_start_time < current_start_time, (
-                    f"Retry {i + 1} start_time is not after retry {i}: "
+                    f"Retry {i} start_time is not after retry {i-1}: "
                     f"{previous_start_time} >= {current_start_time}"
                 )
             previous_start_time = current_start_time


### PR DESCRIPTION
Added `retries` list to run status to track metadata about each retry attempt, including the attempt number, start time, end time and error message.

Jira:
https://iguazio.atlassian.net/browse/ML-10169