### PR TITLE
[Notifications] Use stable endpoint for webhook notification

### DIFF
--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -292,8 +292,8 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
         [
             (True, "error", "https://self-signed.badssl.com/"),
             (False, "sent", "https://self-signed.badssl.com/"),
-            (None, "sent", "http://httpstat.us/200"),
-            (False, "sent", "http://httpstat.us/200"),
+            (None, "sent", "http://httpbin.org/get"),
+            (False, "sent", "http://httpbin.org/get"),
         ],
     )
     def test_webhook_notification_ssl(self, verify_ssl, expected_run_status, url):


### PR DESCRIPTION
This PR fixes failing system test (`test_webhook_notification_ssl`) by replacing the URL `http://httpstat.us/200`, which now returns a 403 Forbidden with the message 'Site Disabled', instead of the expected 200 OK. 
The test now uses a consistently available endpoint to ensure stable and predictable behavior.