### PR TITLE
[Image] Explicitly accept conda TOS

### DIFF
--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR /mlrun
 RUN chmod 777 /mlrun
 
 # Install MiniConda:
-ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="-py312"
+ARG MLRUN_ANACONDA_PYTHON_DISTRIBUTION="-py311"
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_PYTHON_DISTRIBUTION}_25.1.1-2-Linux-x86_64.sh -O ~/installconda.sh && \
     /bin/bash ~/installconda.sh -b -p /opt/conda && \
     rm ~/installconda.sh && \
@@ -50,6 +50,11 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3${MLRUN_ANACONDA_
     echo "conda activate base" >> ~/.bashrc
 
 ENV PATH=/opt/conda/bin:$PATH
+
+# Accept terms of service for the conda channel
+RUN conda tos accept --override-channels \
+    --channel https://repo.anaconda.com/pkgs/main \
+    --channel https://repo.anaconda.com/pkgs/r
 
 # Install Open-MPI:
 ARG OMPI_VERSION=4.1.5


### PR DESCRIPTION
Add explicit non-interactive acceptance of the Anaconda Terms of Service for the pkgs/main and pkgs/r channels in our Dockerfile.

This change is needed because recent versions of Conda enforce explicit acceptance of the Anaconda Terms of Service for those channels, causing non-interactive conda update --all steps in CI/Docker builds to fail. By pre-approving the ToS immediately after installation, we restore reproducible, unattended build runs.