### PR TITLE
[DB] Ensure consistent system ID initialization

### DIFF
--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -85,6 +85,8 @@ def init_data(
             engine,
             perform_migrations_if_needed,
         )
+    # initialize system id
+    framework.db.session.run_function_with_new_db_session(func=_init_system_id)
 
     mlrun.utils.logger.info("Initial data created")
 
@@ -179,9 +181,6 @@ def _migrate_existing_data(
                 )
                 mlrun.mlconf.httpdb.state = state
                 raise
-
-        # initialize system id
-        _init_system_id(db_session)
     finally:
         framework.db.session.close_session(db_session)
 

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -528,6 +528,24 @@ def test_init_system_id(
     assert system_id_after_second_init == system_id
 
 
+def test_system_id_initialized(monkeypatch: pytest.MonkeyPatch):
+    # This test ensures that calling init_data correctly initializes the system ID
+    monkeypatch.setattr(mlrun.mlconf, "system_id", None)
+
+    db, db_session = _initialize_db_without_migrations()
+
+    # Run the init_data flow
+    services.api.initial_data.init_data()
+
+    # After init, system ID must be defined in config
+    config_system_id = mlrun.mlconf.system_id
+    assert config_system_id is not None
+
+    # Ensure it's persisted in the DB too
+    db_system_id = db.get_system_id(db_session)
+    assert db_system_id == config_system_id
+
+
 def test_ensure_latest_tag_for_artifacts():
     # This test verifies that the migration to ensure the "latest" tag is assigned correctly to artifacts works as
     # expected. The test creates a set of artifacts with different iteration numbers and tags:


### PR DESCRIPTION
Following a previous db logic refactoring (https://github.com/mlrun/mlrun/pull/8205) , the system ID initialization was unintentionally skipped when the database was newly created and the call to initialize the system ID was placed only in the migration path, resulting in it being bypassed when the database was set up from scratch.

This fix ensures `_init_system_id` is called unconditionally after both the database creation and migration flows, guaranteeing consistent system ID initialization.

Jira:
https://iguazio.atlassian.net/browse/ML-10545