### PR TITLE
[Model Monitoring] Fix project deletion

### DIFF
--- a/mlrun/model_monitoring/__init__.py
+++ b/mlrun/model_monitoring/__init__.py
@@ -15,4 +15,5 @@
 from mlrun.common.schemas import ModelEndpoint, ModelEndpointList
 
 from .db import get_tsdb_connector
+from .db._schedules import delete_model_monitoring_schedules_user_folder
 from .helpers import get_stream_path

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -39,7 +39,6 @@ from mlrun.model_monitoring.db._schedules import (
     ModelMonitoringSchedulesFileChief,
     ModelMonitoringSchedulesFileEndpoint,
     delete_model_monitoring_schedules_folder,
-    delete_model_monitoring_schedules_user_folder,
 )
 from mlrun.model_monitoring.db._stats import (
     ModelMonitoringCurrentStatsFile,
@@ -1153,9 +1152,6 @@ class ModelEndpoints:
 
         # Delete model monitoring schedules folder
         delete_model_monitoring_schedules_folder(project_name)
-
-        # Delete batch runs schedules folder
-        delete_model_monitoring_schedules_user_folder(project_name)
 
         logger.debug(
             "Successfully deleted model monitoring endpoints resources",

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1708,6 +1708,12 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
             executor.submit(self._set_infra)
             executor.submit(self._deploy_model_serving)
 
+    def custom_teardown(self) -> None:
+        mlrun.model_monitoring.delete_model_monitoring_schedules_user_folder(
+            self.project_name
+        )
+        return super().custom_teardown()
+
     @pytest.mark.parametrize("run_local", [False, True])
     @pytest.mark.parametrize("write_output", [True])
     def test_count_app(self, run_local: bool, write_output: bool) -> None:


### PR DESCRIPTION
Previously, we attempted to delete the user-space schedules folder from MLRun service, which doesn't have the
permissions to do it.
Instead, delete it with the SDK in user code.

This fixed the following error:
https://github.com/mlrun/mlrun/actions/runs/16383691421/job/46299860984#step:9:4254
```
FAILED tests/system/model_monitoring/test_app.py::TestAppJobModelEndpointData::test_count_app[True-True] - OSError: error: cannot get deploy status, details: MLRunNotFoundError('Failed to get function mm-job-mep-data-model-server deploy status'), caused by: 404 Client Error: Not Found for url: https://mlrun-api.default-tenant.app.mlrun-ci-test-3-6-0.iguazio-cd1.com/api/v1/projects/mm-job-mep-data/nuclio/model-server/deploy?name=model-server&project=mm-job-mep-data&tag=latest&last_log_timestamp=0&verbose=no
```
This error is caused by an improper deletion of the project.

To be included in the documentation.