### PR TITLE
[Retry] Warn ignore retry spec on local run

### DIFF
--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -276,6 +276,18 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
                     args = sp[1:]
         return command, args
 
+    def _validate_run(
+        self,
+        runtime: "mlrun.runtimes.BaseRuntime",
+        run: "mlrun.run.RunObject",
+    ):
+        super()._validate_run(runtime, run)
+        if self._is_run_local and run.spec.retry.count:
+            logger.warning(
+                "Retry is not supported for local runs, ignoring retry settings",
+                retry=run.spec.retry.to_dict(),
+            )
+
     def _push_notifications(
         self, runobj: "mlrun.run.RunObject", runtime: "mlrun.runtimes.BaseRuntime"
     ):

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -287,6 +287,7 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
                 "Retry is not supported for local runs, ignoring retry settings",
                 retry=run.spec.retry.to_dict(),
             )
+            run.spec.retry.count = 0
 
     def _push_notifications(
         self, runobj: "mlrun.run.RunObject", runtime: "mlrun.runtimes.BaseRuntime"

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import inspect
+import io
 import os
 import shutil
+import sys
 import unittest
 from datetime import datetime
 from http import HTTPStatus
@@ -911,3 +913,12 @@ def remote_builder_mock(monkeypatch):
         mlrun, "get_run_db", unittest.mock.Mock(return_value=builder_mock)
     )
     return builder_mock
+
+
+@pytest.fixture
+def logs_stream():
+    """Fixture to capture logs for verifying console output in tests."""
+    stream = io.StringIO()
+    mlrun.utils.logger.replace_handler_stream("default", stream)
+    yield stream
+    mlrun.utils.logger.replace_handler_stream("default", sys.stdout)

--- a/tests/launcher/test_local.py
+++ b/tests/launcher/test_local.py
@@ -282,3 +282,21 @@ def test_to_job_on_function_with_children():
         match="Cannot convert function 'test' to a job because it has child functions",
     ):
         function.to_job()
+
+
+def test_validate_run_retries_warning(logs_stream):
+    launcher = mlrun.launcher.local.ClientLocalLauncher(local=True)
+    runtime = mlrun.code_to_function(
+        name="test", kind="local", filename=str(func_path), handler=handler
+    )
+    run = mlrun.run.RunObject(
+        spec=mlrun.model.RunSpec(retry={"count": 5}, output_path="/tmp")
+    )
+
+    launcher._validate_run(runtime, run)
+
+    assert (
+        "Retry is not supported for local runs, ignoring retry settings"
+        in logs_stream.getvalue()
+    )
+    assert run.spec.retry.count == 0

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -400,7 +400,6 @@ def test_run_status_retry_updates(rundb_mock):
     with pytest.raises(mlrun.runtimes.RunError) as exc:
         function.run(
             runspec={"spec": {"retry": {"count": 10}}},
-            local=True,
             handler="func_with_default",
         )
         assert "Run is pending retry, error: kwargs is empty" in str(exc)
@@ -414,7 +413,6 @@ def test_run_status_retry_updates(rundb_mock):
     with pytest.raises(mlrun.runtimes.RunError) as exc:
         function.run(
             runspec=result,
-            local=True,
             handler="func_with_default",
         )
         assert "Run is pending retry, error: kwargs is empty" in str(exc)


### PR DESCRIPTION
When using local runs (i.e. `local=True`), retry is not supported but we don't want to explode as this is feature is for debugging purposes and the user should not have to change their code just to run the function locally.
This change, logs a warning that retry is not supported and it will be ignored.

https://iguazio.atlassian.net/browse/ML-10541