### PR TITLE
[Model Monitoring] Fixes and additions to graph job monitoring

### DIFF
--- a/mlrun/common/schemas/serving.py
+++ b/mlrun/common/schemas/serving.py
@@ -47,3 +47,6 @@ class MonitoringData(StrEnum):
 class ModelsData(enum.Enum):
     MODEL_CLASS = 0
     MODEL_PARAMETERS = 1
+
+
+MAX_BATCH_JOB_DURATION = "1w"

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -42,6 +42,7 @@ from mlrun.secrets import SecretsStore
 
 from ..common.helpers import parse_versioned_object_uri
 from ..common.schemas.model_monitoring.constants import FileTargetKind
+from ..common.schemas.serving import MAX_BATCH_JOB_DURATION
 from ..datastore import DataItem, get_stream_pusher
 from ..datastore.store_resources import ResourceCache
 from ..errors import MLRunInvalidArgumentError
@@ -629,7 +630,7 @@ async def async_execute_graph(
             start_time = start_time.isoformat()
             end_time = end_time.isoformat()
             # TODO: tie this to the controller's base period
-            if time_range > pd.Timedelta("1w"):
+            if time_range > pd.Timedelta(MAX_BATCH_JOB_DURATION):
                 raise mlrun.errors.MLRunRuntimeError(
                     f"Dataframe time range is too long: {time_range}. "
                     "Please disable tracking or reduce the input dataset's time range to under one week."

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -608,14 +608,15 @@ async def async_execute_graph(
                 f"(status='{task_state}')"
             )
 
-    mm_enabled = True
     df = data.as_df()
 
     if df.empty:
         context.logger.warn("Job terminated due to empty inputs (0 rows)")
         return []
 
-    if timestamp_column:
+    track_models = spec.get("track_models")
+
+    if track_models and timestamp_column:
         context.logger.info(f"Sorting dataframe by {timestamp_column}")
         df[timestamp_column] = pd.to_datetime(  # in case it's a string
             df[timestamp_column]
@@ -628,25 +629,24 @@ async def async_execute_graph(
             start_time = start_time.isoformat()
             end_time = end_time.isoformat()
             # TODO: tie this to the controller's base period
-            if time_range > pd.Timedelta("10000h"):
-                context.logger.warn(
-                    f"Dataframe time range is too long: {time_range}. Job will not be tracked!"
+            if time_range > pd.Timedelta("1w"):
+                raise mlrun.errors.MLRunRuntimeError(
+                    f"Dataframe time range is too long: {time_range}. "
+                    "Please disable tracking or reduce the input dataset's time range to under one week."
                 )
-                mm_enabled = False
         else:
             start_time = end_time = df["timestamp"].iloc[0].isoformat()
     else:
         start_time = datetime.now(tz=timezone.utc).isoformat()
 
-    if mm_enabled:
-        server.graph = add_system_steps_to_graph(
-            server.project,
-            copy.deepcopy(server.graph),
-            spec.get("track_models"),
-            context,
-            spec,
-            pause_until_background_task_completion=False,  # we've already awaited it
-        )
+    server.graph = add_system_steps_to_graph(
+        server.project,
+        copy.deepcopy(server.graph),
+        track_models,
+        context,
+        spec,
+        pause_until_background_task_completion=False,  # we've already awaited it
+    )
 
     if config.log_level.lower() == "debug":
         server.verbose = True
@@ -667,8 +667,6 @@ async def async_execute_graph(
     if server.verbose:
         context.logger.info(server.to_yaml())
 
-    responses = []
-
     async def run(body):
         event = storey.Event(id=index, body=body)
         if timestamp_column:
@@ -682,13 +680,13 @@ async def async_execute_graph(
                     f"Event body '{body}' did not contain timestamp column '{timestamp_column}'"
                 )
             event._original_timestamp = body[timestamp_column]
-        response = await server.run(event, context)
-        responses.append(response)
+        return await server.run(event, context)
 
     if batching and not batch_size:
         batch_size = len(df)
 
     batch = []
+    tasks = []
     for index, row in df.iterrows():
         data = row.to_list() if read_as_lists else row.to_dict()
         if nest_under_inputs:
@@ -696,13 +694,15 @@ async def async_execute_graph(
         if batching:
             batch.append(data)
             if len(batch) == batch_size:
-                await run(batch)
+                tasks.append(asyncio.create_task(run(batch)))
                 batch = []
         else:
-            await run(data)
+            tasks.append(asyncio.create_task(run(data)))
 
     if batch:
-        await run(batch)
+        tasks.append(asyncio.create_task(run(batch)))
+
+    responses = await asyncio.gather(*tasks)
 
     termination_result = server.wait_for_completion()
     if asyncio.iscoroutine(termination_result):

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -670,7 +670,9 @@ async def async_execute_graph(
     async def run(body):
         event = storey.Event(id=index, body=body)
         if timestamp_column:
-            body = event.body
+            if batching:
+                # we use the first row in the batch to determine the timestamp for the whole batch
+                body = body[0]
             if not isinstance(body, dict):
                 raise mlrun.errors.MLRunRuntimeError(
                     f"When timestamp_column=True, event body must be a dict – got {type(body).__name__} instead"

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -22,8 +22,10 @@ import os
 import socket
 import traceback
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Optional, Union
 
+import pandas as pd
 import storey
 from nuclio import Context as NuclioContext
 from nuclio.request import Logger as NuclioLogger
@@ -561,6 +563,7 @@ def v2_serving_init(context, namespace=None):
 async def async_execute_graph(
     context: MLClientCtx,
     data: DataItem,
+    timestamp_column: Optional[str],
     batching: bool,
     batch_size: Optional[int],
     read_as_lists: bool,
@@ -605,14 +608,45 @@ async def async_execute_graph(
                 f"(status='{task_state}')"
             )
 
-    server.graph = add_system_steps_to_graph(
-        server.project,
-        copy.deepcopy(server.graph),
-        spec.get("track_models"),
-        context,
-        spec,
-        pause_until_background_task_completion=False,  # we've already awaited it
-    )
+    mm_enabled = True
+    df = data.as_df()
+
+    if df.empty:
+        context.logger.warn("Job terminated due to empty inputs (0 rows)")
+        return []
+
+    if timestamp_column:
+        context.logger.info(f"Sorting dataframe by {timestamp_column}")
+        df[timestamp_column] = pd.to_datetime(  # in case it's a string
+            df[timestamp_column]
+        )
+        df.sort_values(by=timestamp_column, inplace=True)
+        if len(df) >= 2:
+            start_time = df[timestamp_column].iloc[0]
+            end_time = df[timestamp_column].iloc[-1]
+            time_range = end_time - start_time
+            start_time = start_time.isoformat()
+            end_time = end_time.isoformat()
+            # TODO: tie this to the controller's base period
+            if time_range > pd.Timedelta("10000h"):
+                context.logger.warn(
+                    f"Dataframe time range is too long: {time_range}. Job will not be tracked!"
+                )
+                mm_enabled = False
+        else:
+            start_time = end_time = df["timestamp"].iloc[0].isoformat()
+    else:
+        start_time = datetime.now(tz=timezone.utc).isoformat()
+
+    if mm_enabled:
+        server.graph = add_system_steps_to_graph(
+            server.project,
+            copy.deepcopy(server.graph),
+            spec.get("track_models"),
+            context,
+            spec,
+            pause_until_background_task_completion=False,  # we've already awaited it
+        )
 
     if config.log_level.lower() == "debug":
         server.verbose = True
@@ -633,12 +667,21 @@ async def async_execute_graph(
     if server.verbose:
         context.logger.info(server.to_yaml())
 
-    df = data.as_df()
-
     responses = []
 
     async def run(body):
         event = storey.Event(id=index, body=body)
+        if timestamp_column:
+            body = event.body
+            if not isinstance(body, dict):
+                raise mlrun.errors.MLRunRuntimeError(
+                    f"When timestamp_column=True, event body must be a dict – got {type(body).__name__} instead"
+                )
+            if timestamp_column not in body:
+                raise mlrun.errors.MLRunRuntimeError(
+                    f"Event body '{body}' did not contain timestamp column '{timestamp_column}'"
+                )
+            event._original_timestamp = body[timestamp_column]
         response = await server.run(event, context)
         responses.append(response)
 
@@ -665,12 +708,42 @@ async def async_execute_graph(
     if asyncio.iscoroutine(termination_result):
         await termination_result
 
+    model_endpoint_uids = spec.get("model_endpoint_uids", [])
+
+    # needed for output_stream to be created
+    server = GraphServer.from_dict(spec)
+    server.init_states(None, namespace)
+
+    batch_completion_time = datetime.now(tz=timezone.utc).isoformat()
+
+    if not timestamp_column:
+        end_time = batch_completion_time
+
+    mm_stream_record = dict(
+        kind="batch_complete",
+        project=context.project,
+        first_timestamp=start_time,
+        last_timestamp=end_time,
+        batch_completion_time=batch_completion_time,
+    )
+    output_stream = server.context.stream.output_stream
+    for mep_uid in spec.get("model_endpoint_uids", []):
+        mm_stream_record["endpoint_id"] = mep_uid
+        output_stream.push(mm_stream_record, partition_key=mep_uid)
+
+    context.logger.info(
+        f"Job completed processing {len(df)} rows",
+        timestamp_column=timestamp_column,
+        model_endpoint_uids=model_endpoint_uids,
+    )
+
     return responses
 
 
 def execute_graph(
     context: MLClientCtx,
     data: DataItem,
+    timestamp_column: Optional[str] = None,
     batching: bool = False,
     batch_size: Optional[int] = None,
     read_as_lists: bool = False,
@@ -681,6 +754,7 @@ def execute_graph(
 
     :param context: The job's execution client context.
     :param data: The input data to the job, to be pushed into the graph row by row, or in batches.
+    :param timestamp_column: The name of the column that will be used as the timestamp for model monitoring purposes.
     :param batching: Whether to push one or more batches into the graph rather than row by row.
     :param batch_size: The number of rows to push per batch. If not set, and batching=True, the entire dataset will
         be pushed into the graph in one batch.
@@ -691,7 +765,13 @@ def execute_graph(
     """
     return asyncio.run(
         async_execute_graph(
-            context, data, batching, batch_size, read_as_lists, nest_under_inputs
+            context,
+            data,
+            timestamp_column,
+            batching,
+            batch_size,
+            read_as_lists,
+            nest_under_inputs,
         )
     )
 

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -623,7 +623,7 @@ async def async_execute_graph(
             df[timestamp_column]
         )
         df.sort_values(by=timestamp_column, inplace=True)
-        if len(df) >= 2:
+        if len(df) > 1:
             start_time = df[timestamp_column].iloc[0]
             end_time = df[timestamp_column].iloc[-1]
             time_range = end_time - start_time
@@ -633,11 +633,13 @@ async def async_execute_graph(
             if time_range > pd.Timedelta(MAX_BATCH_JOB_DURATION):
                 raise mlrun.errors.MLRunRuntimeError(
                     f"Dataframe time range is too long: {time_range}. "
-                    "Please disable tracking or reduce the input dataset's time range to under one week."
+                    "Please disable tracking or reduce the input dataset's time range below the defined limit "
+                    f"of {MAX_BATCH_JOB_DURATION}."
                 )
         else:
             start_time = end_time = df["timestamp"].iloc[0].isoformat()
     else:
+        # end time will be set from clock time when the batch completes
         start_time = datetime.now(tz=timezone.utc).isoformat()
 
     server.graph = add_system_steps_to_graph(

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -760,6 +760,8 @@ def execute_graph(
     :param context: The job's execution client context.
     :param data: The input data to the job, to be pushed into the graph row by row, or in batches.
     :param timestamp_column: The name of the column that will be used as the timestamp for model monitoring purposes.
+        when timestamp_column is used in conjunction with batching, the first timestamp will be used for the entire
+        batch.
     :param batching: Whether to push one or more batches into the graph rather than row by row.
     :param batch_size: The number of rows to push per batch. If not set, and batching=True, the entire dataset will
         be pushed into the graph in one batch.

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1695,9 +1695,10 @@ class ModelRunnerStep(MonitoredStep):
         except (
             mlrun.errors.MLRunNotFoundError,
             mlrun.errors.MLRunInvalidArgumentError,
-        ):
+        ) as ex:
             logger.warning(
-                f"Model endpoint not found, using default output schema for model {name}"
+                f"Model endpoint not found, using default output schema for model {name}",
+                error=f"{type(ex).__name__}: {ex}",
             )
         return output_schema
 

--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -168,6 +168,12 @@ class MonitoringPreProcessor(storey.MapClass):
                     request, resp = self.reconstruct_request_resp_fields(
                         event, model, monitoring_data[model]
                     )
+                    if hasattr(event, "_original_timestamp"):
+                        when = event._original_timestamp
+                    else:
+                        when = event._metadata.get(model, {}).get(
+                            mm_schemas.StreamProcessingEvent.WHEN
+                        )
                     monitoring_event_list.append(
                         {
                             mm_schemas.StreamProcessingEvent.MODEL: model,
@@ -177,9 +183,7 @@ class MonitoringPreProcessor(storey.MapClass):
                             mm_schemas.StreamProcessingEvent.MICROSEC: event._metadata.get(
                                 model, {}
                             ).get(mm_schemas.StreamProcessingEvent.MICROSEC),
-                            mm_schemas.StreamProcessingEvent.WHEN: event._metadata.get(
-                                model, {}
-                            ).get(mm_schemas.StreamProcessingEvent.WHEN),
+                            mm_schemas.StreamProcessingEvent.WHEN: when,
                             mm_schemas.StreamProcessingEvent.ENDPOINT_ID: monitoring_data[
                                 model
                             ].get(
@@ -212,6 +216,10 @@ class MonitoringPreProcessor(storey.MapClass):
             request, resp = self.reconstruct_request_resp_fields(
                 event, model, monitoring_data[model]
             )
+            if hasattr(event, "_original_timestamp"):
+                when = event._original_timestamp
+            else:
+                when = event._metadata.get(mm_schemas.StreamProcessingEvent.WHEN)
             monitoring_event_list.append(
                 {
                     mm_schemas.StreamProcessingEvent.MODEL: model,
@@ -221,9 +229,7 @@ class MonitoringPreProcessor(storey.MapClass):
                     mm_schemas.StreamProcessingEvent.MICROSEC: event._metadata.get(
                         mm_schemas.StreamProcessingEvent.MICROSEC
                     ),
-                    mm_schemas.StreamProcessingEvent.WHEN: event._metadata.get(
-                        mm_schemas.StreamProcessingEvent.WHEN
-                    ),
+                    mm_schemas.StreamProcessingEvent.WHEN: when,
                     mm_schemas.StreamProcessingEvent.ENDPOINT_ID: monitoring_data[
                         model
                     ].get(mlrun.common.schemas.MonitoringData.MODEL_ENDPOINT_UID),

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -230,6 +230,7 @@ async def submit_run(
                 fn,
                 model_endpoint_creation_task_name,
                 _,
+                model_endpoint_uids,
             ) = await start_model_endpoint_creation_background_task(
                 project=project,
                 name=function_name,
@@ -249,16 +250,21 @@ async def submit_run(
 
             # TODO: there should be a better way to do this
             serving_spec = getattr(fn.spec, "serving_spec")
+            # update the graph from the function, because MEP IDs were added
             if serving_spec:
                 serving_spec = json.loads(serving_spec)
+                new_graph = fn.spec.graph.to_dict(strip=True) if fn.spec.graph else {}
+                serving_spec["graph"] = new_graph
                 serving_spec["model_endpoint_creation_task_name"] = (
                     model_endpoint_creation_task_name
                 )
+                serving_spec["model_endpoint_uids"] = model_endpoint_uids
                 fn.spec.serving_spec = json.dumps(serving_spec)
 
             logger.info(
                 "Started model endpoint creation task",
                 model_endpoint_creation_task_name=model_endpoint_creation_task_name,
+                serving_spec=json.dumps(serving_spec),
             )
 
         _, _, _, response = await run_in_threadpool(

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -264,7 +264,6 @@ async def submit_run(
             logger.info(
                 "Started model endpoint creation task",
                 model_endpoint_creation_task_name=model_endpoint_creation_task_name,
-                serving_spec=json.dumps(serving_spec),
             )
 
         _, _, _, response = await run_in_threadpool(

--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -271,6 +271,7 @@ async def deploy_function(
         function,
         model_endpoint_creation_task_name,
         returned_background_tasks,
+        _,
     ) = await start_model_endpoint_creation_background_task(
         project=project,
         name=name,

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1521,6 +1521,11 @@ class MonitoringDeployment:
                         access_key=mlrun.mlconf.get_v3io_access_key()
                         if container.startswith("users")
                         else profile.v3io_access_key,
+                        raise_for_status=[
+                            200,
+                            204,
+                            404,
+                        ],  # if the stream doesn't exist then there's nothing to delete
                     )
                     logger.debug(
                         "Deleted v3io stream",

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1094,8 +1094,6 @@ class ModelEndpoints:
             "Deleting model monitoring endpoints resources",
             project_name=project_name,
             stream_path=stream_path,
-            igz_version=mlrun.mlconf.igz_version,
-            v3io_api=mlrun.mlconf.v3io_api,
         )
 
         # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1087,11 +1087,15 @@ class ModelEndpoints:
         :param model_monitoring_access_key:   The access key for the model monitoring resources. Relevant only for
                                               V3IO resources.
         """
-        logger.debug(
-            "Deleting model monitoring endpoints resources", project_name=project_name
-        )
         stream_path = mlrun.model_monitoring.get_stream_path(
             project=project_name, profile=stream_profile
+        )
+        logger.debug(
+            "Deleting model monitoring endpoints resources",
+            project_name=project_name,
+            stream_path=stream_path,
+            igz_version=mlrun.mlconf.igz_version,
+            v3io_api=mlrun.mlconf.v3io_api,
         )
 
         # We would ideally base on config.v3io_api but can't for backwards compatibility reasons,

--- a/server/py/services/api/utils/endpoints.py
+++ b/server/py/services/api/utils/endpoints.py
@@ -34,6 +34,7 @@ async def start_model_endpoint_creation_background_task(
     returned_background_tasks = mlrun.common.schemas.BackgroundTaskList(
         background_tasks=[]
     )
+    model_endpoints_instructions = []
     kind = function.get("kind")
     if (
         kind == RuntimeKinds.serving
@@ -74,4 +75,13 @@ async def start_model_endpoint_creation_background_task(
         else None
     )
 
-    return function, model_endpoint_creation_task_name, returned_background_tasks
+    model_endpoint_uids = [
+        model_endpoint.metadata.uid
+        for (model_endpoint, _) in model_endpoints_instructions
+    ]
+    return (
+        function,
+        model_endpoint_creation_task_name,
+        returned_background_tasks,
+        model_endpoint_uids,
+    )

--- a/tests/system/model_monitoring/__init__.py
+++ b/tests/system/model_monitoring/__init__.py
@@ -18,6 +18,8 @@ import pytest
 from typing_extensions import TypeAlias
 
 import mlrun
+import mlrun.common.model_monitoring.helpers
+import mlrun.model_monitoring.helpers
 from mlrun import MlrunProject
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
@@ -93,3 +95,22 @@ class TestMLRunSystemModelMonitoring(TestMLRunSystem):
             tsdb_profile_name=self.mm_tsdb_profile.name,
             stream_profile_name=self.mm_stream_profile.name,
         )
+
+    def get_stream_path(self, function_name) -> (str, str):
+        """
+        :returns: tuple of container and stream_path
+        """
+        stream_profile = TestMLRunSystemModelMonitoring.get_stream_profile(
+            self.mm_stream_profile_data
+        )
+        stream_uri = mlrun.model_monitoring.helpers.get_stream_path(
+            project=self.project.name,
+            function_name=function_name,
+            profile=stream_profile,
+        )
+        _, container, stream_path = (
+            mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
+                stream_uri,
+            )
+        )
+        return container, stream_path

--- a/tests/system/model_monitoring/assets/test_data.csv
+++ b/tests/system/model_monitoring/assets/test_data.csv
@@ -1,5 +1,5 @@
-Product,Price,Stock
-Keyboard,30.0,100
-Mouse,15.0,200
-Monitor,150.0,50
-Headphones,50.0,75
+Product,Price,Stock,time
+Keyboard,30.0,100,2020-01-01T01:00:00Z
+Mouse,15.0,200,2020-01-01T02:00:00Z
+Monitor,150.0,50,2020-01-01T03:00:00Z
+Headphones,50.0,75,2020-01-01T04:00:00Z

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1114,16 +1114,7 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
 
             # controller and writer(with has stream) should be deleted
             for name in mm_constants.MonitoringFunctionNames.list():
-                stream_path = mlrun.model_monitoring.helpers.get_stream_path(
-                    project=self.project.name,
-                    function_name=name,
-                    profile=stream_profile,
-                )
-                _, container, stream_path = (
-                    mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
-                        stream_path
-                    )
-                )
+                container, stream_path = self.get_stream_path(name)
                 if name != mm_constants.MonitoringFunctionNames.STREAM:
                     with pytest.raises(mlrun.errors.MLRunNotFoundError):
                         self.project.get_function(
@@ -1142,15 +1133,8 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
             self._disable_stream_function()
 
             # check that the stream of the stream resource is not deleted
-            stream_path = mlrun.model_monitoring.helpers.get_stream_path(
-                project=self.project.name,
-                function_name=mm_constants.HistogramDataDriftApplicationConstants.NAME,
-                profile=stream_profile,
-            )
-            _, container, stream_path = (
-                mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
-                    stream_path
-                )
+            container, stream_path = self.get_stream_path(
+                mm_constants.HistogramDataDriftApplicationConstants.NAME
             )
             v3io_client.stream.describe(container, stream_path)
 
@@ -1158,16 +1142,6 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
             self._delete_histogram_app()
 
             with pytest.raises(v3io.dataplane.response.HttpResponseError):
-                stream_path = mlrun.model_monitoring.helpers.get_stream_path(
-                    project=self.project.name,
-                    function_name=mm_constants.HistogramDataDriftApplicationConstants.NAME,
-                    profile=stream_profile,
-                )
-                _, container, stream_path = (
-                    mlrun.common.model_monitoring.helpers.parse_model_endpoint_store_prefix(
-                        stream_path
-                    )
-                )
                 v3io_client.stream.describe(container, stream_path)
 
         elif isinstance(stream_profile, DatastoreProfileKafkaSource):

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -2016,7 +2016,7 @@ class TestModelMonitoringOverJob(TestMLRunSystemModelMonitoring):
         with open(str(self.assets_path / "test_data.csv")) as f:
             csv_content = f.read()
 
-        v3io_client = v3io.Client()
+        v3io_client = v3io.Client(endpoint=mlrun.mlconf.v3io_api)
         try:
             v3io_client.object.put(
                 "projects", f"{self.project_name}/in.csv", body=csv_content
@@ -2043,17 +2043,19 @@ class TestModelMonitoringOverJob(TestMLRunSystemModelMonitoring):
             assert model_endpoints[0].metadata.name == "my_model"
             assert model_endpoints[0].metadata.endpoint_type == EndpointType.BATCH_EP
 
-            stream_uri = f"{self.project_name}/model-endpoints/stream-v1"
+            container, stream_path = self.get_stream_path(
+                mm_constants.MonitoringFunctionNames.STREAM
+            )
             describe_output = v3io_client.stream.describe(
-                "projects",
-                stream_uri,
+                container,
+                stream_path,
             ).output
             shard_count = describe_output.shard_count
             read_back_records = []
             for shard in range(shard_count):
                 try:
                     location = v3io_client.stream.seek(
-                        "projects", stream_uri, shard, "EARLIEST"
+                        container, stream_path, shard, "EARLIEST"
                     ).output.location
                 except V3ioHttpResponseError as response_error:
                     if response_error.status_code == 404:
@@ -2061,7 +2063,7 @@ class TestModelMonitoringOverJob(TestMLRunSystemModelMonitoring):
                     raise response_error
                 while True:
                     get_records_result = v3io_client.stream.get_records(
-                        "projects", stream_uri, shard, location
+                        container, stream_path, shard, location
                     ).output
                     location = get_records_result.next_location
                     for record in get_records_result.records:

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -32,6 +32,7 @@ from sklearn.datasets import load_diabetes, load_iris, make_classification
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
+from v3io.dataplane.response import HttpResponseError as V3ioHttpResponseError
 
 import mlrun.artifacts.model
 import mlrun.common.schemas.alert as alert_objects
@@ -1978,7 +1979,8 @@ class TestModelMonitoringOverJob(TestMLRunSystemModelMonitoring):
     project_name = "model-monitoring-over-job"
     image = "mlrun/mlrun"
 
-    def test_job_from_serving_runtime_with_model_tracking(self):
+    @pytest.mark.parametrize("with_timestamp_column", [False, True])
+    def test_job_from_serving_runtime_with_model_tracking(self, with_timestamp_column):
         function = self.project.set_function(
             func=str(self.assets_path / "function_with_model.py"),
             name="test",
@@ -1992,6 +1994,7 @@ class TestModelMonitoringOverJob(TestMLRunSystemModelMonitoring):
             endpoint_name="my_model",
             model_class="DummyModel",
             execution_mechanism="naive",
+            model_endpoint_creation_strategy=mm_constants.ModelEndpointCreationStrategy.OVERWRITE,
         )
 
         graph.to(model_runner_step).to(
@@ -2019,23 +2022,99 @@ class TestModelMonitoringOverJob(TestMLRunSystemModelMonitoring):
                 "projects", f"{self.project_name}/in.csv", body=csv_content
             )
             inputs = {"data": f"v3io:///projects/{self.project_name}/in.csv"}
-            self.project.run_function(job, inputs=inputs, local=False)
+            params = {}
+            if with_timestamp_column:
+                params["timestamp_column"] = "time"
+            start_time = datetime.now(timezone.utc)  # any time zone will do
+            self.project.run_function(job, inputs=inputs, params=params, local=False)
+            end_time = datetime.now(timezone.utc)
             read_back_df = pd.read_parquet(
                 f"v3io:///projects/{self.project_name}/out.parquet"
             )
             assert (
                 "extra" in read_back_df.columns
             ), "Extra column was not added by model"
+
+            model_endpoints = (
+                mlrun.get_run_db().list_model_endpoints(self.project_name).endpoints
+            )
+
+            assert len(model_endpoints) == 1
+            assert model_endpoints[0].metadata.name == "my_model"
+            assert model_endpoints[0].metadata.endpoint_type == EndpointType.BATCH_EP
+
+            stream_uri = f"{self.project_name}/model-endpoints/stream-v1"
+            describe_output = v3io_client.stream.describe(
+                "projects",
+                stream_uri,
+            ).output
+            shard_count = describe_output.shard_count
+            read_back_records = []
+            for shard in range(shard_count):
+                try:
+                    location = v3io_client.stream.seek(
+                        "projects", stream_uri, shard, "EARLIEST"
+                    ).output.location
+                except V3ioHttpResponseError as response_error:
+                    if response_error.status_code == 404:
+                        continue
+                    raise response_error
+                while True:
+                    get_records_result = v3io_client.stream.get_records(
+                        "projects", stream_uri, shard, location
+                    ).output
+                    location = get_records_result.next_location
+                    for record in get_records_result.records:
+                        read_back_records.append(json.loads(record.data))
+                    if get_records_result.records_behind_latest == 0:
+                        break
+            assert len(read_back_records) == 5
+            earliest_time_in_dataset = datetime(2020, 1, 1, 1, tzinfo=timezone.utc)
+            latest_time_in_dataset = datetime(2020, 1, 1, 4, tzinfo=timezone.utc)
+            for record in read_back_records:
+                if record.get("kind") == "batch_complete":
+                    assert "endpoint_id" in record
+                    assert record["kind"] == "batch_complete"
+                    assert record["project"] == self.project_name
+                    if with_timestamp_column:
+                        assert record["first_timestamp"] == "2020-01-01T01:00:00+00:00"
+                        assert record["last_timestamp"] == "2020-01-01T04:00:00+00:00"
+                    else:
+                        first_timestamp = datetime.fromisoformat(
+                            record["first_timestamp"]
+                        )
+                        last_timestamp = datetime.fromisoformat(
+                            record["last_timestamp"]
+                        )
+                        assert end_time > last_timestamp > first_timestamp > start_time
+                    assert (
+                        end_time
+                        > datetime.fromisoformat(record["batch_completion_time"])
+                        > start_time
+                    )
+                else:
+                    assert {
+                        "model",
+                        "model_class",
+                        "when",
+                        "request",
+                        "resp",
+                        "endpoint_id",
+                    }.issubset(record)
+                    assert record.get("error") is None
+                    assert (
+                        record["request"]["inputs"][0] + [123]
+                        == record["resp"]["outputs"][0]
+                    )
+                    when = datetime.fromisoformat(record["when"])
+                    if with_timestamp_column:
+                        assert (
+                            latest_time_in_dataset >= when >= earliest_time_in_dataset
+                        )
+                    else:
+                        assert end_time > when > start_time
         finally:
             v3io_client.close()
-
-        model_endpoints = (
-            mlrun.get_run_db().list_model_endpoints(self.project_name).endpoints
-        )
-
-        assert len(model_endpoints) == 1
-        assert model_endpoints[0].metadata.name == "my_model"
-        assert model_endpoints[0].metadata.endpoint_type == EndpointType.BATCH_EP
 
 
 def _validate_model_uri(model_obj, model_endpoint):


### PR DESCRIPTION
[ML-10613](https://iguazio.atlassian.net/browse/ML-10613)

* Add MEP list to serving spec and extract it at runtime
* Push batch completion event per MEP
* Allow the user to set timestamp column to set event time for monitoring purposes
* Disable monitoring when batch it too long (as measured from start time to end time)

Also:
* Fixes writes to MM stream
* Fixes failure to delete model monitoring resources when only some resources exist
* Improves warning to avoid completely silencing errors
* Improves debug log
* Expands relevant system test

Passed:
* `TestMonitoringAppFlow::test_app_flow[with_training_set=False, with_model_runner=*]`
* `TestModelMonitoringInitialize::test_model_monitoring_crud`
* `TestModelMonitoringOverJob::test_job_from_serving_runtime_with_model_tracking[*]`
* `TestKubejobRuntime::test_job_from_serving_runtime[*]`
* `TestNuclioRuntime::test_deploy_function_with_model_runner[raise_exception=*, with_object=True]`

[ML-10613]: https://iguazio.atlassian.net/browse/ML-10613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ