### PR TITLE
[DB] Fix iteration over None in DB configuration utility

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -406,11 +406,7 @@ default_config = {
                 #
                 # if set to "nil" or "none", nothing would be set
                 "modes": (
-                    "STRICT_TRANS_TABLES"
-                    ",NO_ZERO_IN_DATE"
-                    ",NO_ZERO_DATE"
-                    ",ERROR_FOR_DIVISION_BY_ZERO"
-                    ",NO_ENGINE_SUBSTITUTION",
+                    "STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
                 )
             },
         },

--- a/server/py/framework/utils/db/utils.py
+++ b/server/py/framework/utils/db/utils.py
@@ -102,7 +102,7 @@ class ParsedDsn:
             return False
         if not self.host or not self._HOST_REGEX.fullmatch(self.host):
             return False
-        if self.port is not None or not 1 <= self.port <= 65535:
+        if self.port is not None and not 1 <= self.port <= 65535:
             return False
 
         return True
@@ -175,7 +175,7 @@ class DBUtil:
         items = config_items or self._DEFAULT_DB_CONFIGURATIONS
         keys = _to_keyset(items)
 
-        if not keys or keys.issubset(self._EMPTY_DB_CONFIGURATIONS):
+        if not keys or keys.intersection(self._EMPTY_DB_CONFIGURATIONS):
             mlrun.utils.logger.debug(
                 "No configurations specified – skipping",
                 configs=config_items,
@@ -437,7 +437,7 @@ def _to_keyset(
     items: Optional[Union[list[str], dict[str, Any]]],
 ) -> Optional[set[str]]:
     if items is None:
-        return None
+        return set()
     if isinstance(items, dict):
         return set(items.keys())
     else:

--- a/server/py/framework/utils/db/utils.py
+++ b/server/py/framework/utils/db/utils.py
@@ -142,8 +142,8 @@ class DBUtil:
     _DIALECT = None
     _DSN_ENV = "MLRUN_HTTPDB__DSN"
     _DRIVER_CACHE: dict[str, Any] = {}
+    _EMPTY_DB_CONFIGURATIONS = {"nil", "none"}
     _DEFAULT_DB_CONFIGURATIONS = None
-    _EMPTY_DB_CONFIGURATIONS: set[str] = {"nil", "none"}
 
     def wait_for_db_liveness(
         self,
@@ -172,10 +172,10 @@ class DBUtil:
         self,
         config_items: Optional[Union[list[str], dict[str, Any]]] = None,
     ) -> None:
-        items = config_items or self._EMPTY_DB_CONFIGURATIONS
+        items = config_items or self._DEFAULT_DB_CONFIGURATIONS
         keys = _to_keyset(items)
 
-        if not keys or keys.intersection(self._EMPTY_DB_CONFIGURATIONS):
+        if not keys or keys.issubset(self._EMPTY_DB_CONFIGURATIONS):
             mlrun.utils.logger.debug(
                 "No configurations specified – skipping",
                 configs=config_items,
@@ -254,7 +254,7 @@ class DBUtil:
         connection: Any,
         config_items: Union[list[str], dict[str, str]],
     ) -> None:
-        raise NotImplementedError()
+        mlrun.utils.logger.debug("Applying configurations", configs=config_items)
 
 
 class UtilMySQL(DBUtil):
@@ -267,16 +267,19 @@ class UtilMySQL(DBUtil):
             with connection.cursor() as cursor:
                 cursor.execute("SELECT @@GLOBAL.sql_mode;")
                 raw = cursor.fetchone()[0] or ""
-                modes = [m.strip() for m in raw.split(",") if m.strip()]
-                return {mode: True for mode in modes}
         except Exception as exc:
             mlrun.utils.logger.exception(
                 "Failed to fetch current MySQL configurations",
                 error=mlrun.errors.err_to_str(exc),
             )
             raise
+        else:
+            modes = {
+                mode: True for mode in [m.strip() for m in raw.split(",") if m.strip()]
+            }
         finally:
             connection.close()
+        return modes
 
     def _apply_configurations(
         self,
@@ -308,13 +311,15 @@ class UtilPostgres(DBUtil):
                     FROM pg_settings
                         """
                 )
-                return {name: value for name, value in cursor.fetchall()}
+                modes = {name: value for name, value in cursor.fetchall()}
         except Exception as exc:
             mlrun.utils.logger.exception(
                 "Failed to fetch current PostgreSQL configurations",
                 error=mlrun.errors.err_to_str(exc),
             )
             raise exc
+        else:
+            return modes
         finally:
             connection.close()
 

--- a/server/py/framework/utils/db/utils.py
+++ b/server/py/framework/utils/db/utils.py
@@ -172,7 +172,7 @@ class DBUtil:
         self,
         config_items: Optional[Union[list[str], dict[str, Any]]] = None,
     ) -> None:
-        items = config_items or self._DEFAULT_DB_CONFIGURATIONS
+        items = config_items or self._EMPTY_DB_CONFIGURATIONS
         keys = _to_keyset(items)
 
         if not keys or keys.intersection(self._EMPTY_DB_CONFIGURATIONS):
@@ -184,7 +184,7 @@ class DBUtil:
 
         connection = self._get_connection()
         try:
-            self._apply_configurations(connection, config_items)
+            self._apply_configurations(connection, items)
         finally:
             connection.close()
 

--- a/server/py/framework/utils/db/utils.py
+++ b/server/py/framework/utils/db/utils.py
@@ -259,7 +259,7 @@ class DBUtil:
 
 class UtilMySQL(DBUtil):
     _DIALECT = mlrun.common.db.dialects.Dialects.MYSQL
-    _DEFAULT_DB_CONFIGURATIONS = mlrun.mlconf.httpdb.db.mysql.modes
+    _DEFAULT_DB_CONFIGURATIONS = mlrun.mlconf.httpdb.db.mysql.modes.split(",")
 
     def get_current_configurations(self) -> dict[str, bool]:
         connection = self._get_connection()

--- a/server/py/services/api/migrations/tests/base/migrations_tests.py
+++ b/server/py/services/api/migrations/tests/base/migrations_tests.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import logging
 import pathlib
 
 import alembic.config
@@ -26,9 +25,7 @@ from pytest_alembic.tests import (  # noqa
     test_upgrade,
 )
 
-from framework.db.sqldb.models import Run
-
-log = logging.getLogger(__name__)
+import framework.db.sqldb.models
 
 
 class Constants:
@@ -103,9 +100,12 @@ def test_notification_params_to_secret_params(
     )
 
     for index, item in enumerate(
-        alembic_session.query(Run.Notification.params, Run.Notification.secret_params)
+        alembic_session.query(
+            framework.db.sqldb.models.Run.Notification.params,
+            framework.db.sqldb.models.Run.Notification.secret_params,
+        )
         .filter_by(project=Constants.notifications_params_to_secret_params_project)
-        .order_by(Run.Notification.id)
+        .order_by(framework.db.sqldb.models.Run.Notification.id)
     ):
         assert not item.params
         assert (

--- a/server/py/services/api/migrations/tests/mysql/conftest.py
+++ b/server/py/services/api/migrations/tests/mysql/conftest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import collections.abc
 import os
 
 import pytest
@@ -22,10 +23,10 @@ import mlrun
 import framework.utils.db.utils
 import framework.utils.singletons.db
 
-mysql_engine = pytest_mock_resources.create_mysql_fixture()
+mysql_engine = pytest_mock_resources.create_mysql_fixture(scope="session")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def alembic_engine(
     mysql_engine: sqlalchemy.engine.Engine,
 ) -> sqlalchemy.engine.Engine:
@@ -37,7 +38,7 @@ def alembic_engine(
     return mysql_engine.execution_options(isolation_level="AUTOCOMMIT")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def pmr_mysql_container(pytestconfig, pmr_mysql_config):
     yield from pytest_mock_resources.get_container(
         pytestconfig=pytestconfig,
@@ -47,7 +48,7 @@ def pmr_mysql_container(pytestconfig, pmr_mysql_config):
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def pmr_mysql_config():
     return pytest_mock_resources.MysqlConfig(
         image="mysql:8.0",
@@ -58,10 +59,21 @@ def pmr_mysql_config():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def db_util(
-    alembic_engine: sqlalchemy.engine.Engine,
-) -> framework.utils.db.utils.DBUtil:
+    alembic_engine: sqlalchemy.Engine,
+) -> collections.abc.Generator[framework.utils.db.utils.DBUtil, None, None]:
     util = framework.utils.db.utils.DBUtil()
     util.wait_for_db_liveness()
-    return util
+    yield util
+
+    db_url = alembic_engine.url
+    db_name = db_url.database
+    admin_url = db_url.set(database=None)
+
+    admin_engine = sqlalchemy.create_engine(admin_url)
+
+    with admin_engine.connect() as conn:
+        conn.execute(sqlalchemy.text(f"DROP DATABASE IF EXISTS `{db_name}`"))
+        conn.execute(sqlalchemy.text(f"CREATE DATABASE `{db_name}`"))
+    admin_engine.dispose()

--- a/server/py/services/api/migrations/tests/mysql/conftest.py
+++ b/server/py/services/api/migrations/tests/mysql/conftest.py
@@ -11,12 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections.abc
+
 import os
+from collections.abc import Generator, Iterator
 
 import pytest
 import pytest_mock_resources
 import sqlalchemy
+from _pytest.config import Config
 
 import mlrun
 
@@ -27,29 +29,7 @@ mysql_engine = pytest_mock_resources.create_mysql_fixture(scope="session")
 
 
 @pytest.fixture(scope="session")
-def alembic_engine(
-    mysql_engine: sqlalchemy.engine.Engine,
-) -> sqlalchemy.engine.Engine:
-    os.environ["MLRUN_HTTPDB__DSN"] = mysql_engine.url.render_as_string(
-        hide_password=False,
-    )
-    mlrun.mlconf.reload()
-    framework.utils.singletons.db.initialize_db()
-    return mysql_engine.execution_options(isolation_level="AUTOCOMMIT")
-
-
-@pytest.fixture(scope="session")
-def pmr_mysql_container(pytestconfig, pmr_mysql_config):
-    yield from pytest_mock_resources.get_container(
-        pytestconfig=pytestconfig,
-        config=pmr_mysql_config,
-        interval=1,
-        retries=60,
-    )
-
-
-@pytest.fixture(scope="session")
-def pmr_mysql_config():
+def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
     return pytest_mock_resources.MysqlConfig(
         image="mysql:8.0",
         port=3306,
@@ -60,20 +40,43 @@ def pmr_mysql_config():
 
 
 @pytest.fixture(scope="session")
-def db_util(
-    alembic_engine: sqlalchemy.Engine,
-) -> collections.abc.Generator[framework.utils.db.utils.DBUtil, None, None]:
-    util = framework.utils.db.utils.DBUtil()
-    util.wait_for_db_liveness()
-    yield util
-
-    db_url = alembic_engine.url
+def alembic_engine(
+    mysql_engine: sqlalchemy.engine.Engine,
+) -> sqlalchemy.engine.Engine:
+    db_url = mysql_engine.url
     db_name = db_url.database
     admin_url = db_url.set(database=None)
-
     admin_engine = sqlalchemy.create_engine(admin_url)
 
     with admin_engine.connect() as conn:
         conn.execute(sqlalchemy.text(f"DROP DATABASE IF EXISTS `{db_name}`"))
         conn.execute(sqlalchemy.text(f"CREATE DATABASE `{db_name}`"))
     admin_engine.dispose()
+
+    os.environ["MLRUN_HTTPDB__DSN"] = db_url.render_as_string(hide_password=False)
+    mlrun.mlconf.reload()
+    framework.utils.singletons.db.initialize_db()
+
+    return mysql_engine.execution_options(isolation_level="AUTOCOMMIT")
+
+
+@pytest.fixture(scope="session")
+def pmr_mysql_container(
+    pytestconfig: Config,
+    pmr_mysql_config: pytest_mock_resources.MysqlConfig,
+) -> Iterator[None]:
+    yield from pytest_mock_resources.get_container(
+        pytestconfig=pytestconfig,
+        config=pmr_mysql_config,
+        interval=1,
+        retries=60,
+    )
+
+
+@pytest.fixture(scope="session")
+def db_util(
+    alembic_engine: sqlalchemy.engine.Engine,
+) -> Generator[framework.utils.db.utils.DBUtil, None, None]:
+    util = framework.utils.db.utils.DBUtil()
+    util.wait_for_db_liveness()
+    yield util

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_partitions.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_partitions.py
@@ -14,8 +14,8 @@
 from datetime import datetime
 
 import pytest
-from sqlalchemy import text
-from sqlalchemy.orm import sessionmaker
+import sqlalchemy
+import sqlalchemy.orm
 
 import mlrun.common.schemas as schemas
 
@@ -28,11 +28,11 @@ import services.api.utils.db.partitioner
 @pytest.mark.usefixtures("pmr_mysql_container")
 @services.api.migrations.tests.base.conftest.freeze_datetime(datetime(2025, 1, 1))
 def test_create_partitions_mysql(alembic_engine):
-    session = sessionmaker(bind=alembic_engine)()
+    session = sqlalchemy.orm.sessionmaker(bind=alembic_engine)()
     table = "dyn_table"
 
     session.execute(
-        text(
+        sqlalchemy.text(
             f"""
             CREATE TABLE `{table}` (
                 id   INT NOT NULL,
@@ -71,11 +71,11 @@ def test_create_partitions_mysql(alembic_engine):
 @pytest.mark.usefixtures("pmr_mysql_container")
 @services.api.migrations.tests.base.conftest.freeze_datetime(datetime(2025, 1, 6))
 def test_drop_partitions_mysql(alembic_engine):
-    session = sessionmaker(bind=alembic_engine)()
+    session = sqlalchemy.orm.sessionmaker(bind=alembic_engine)()
     table = "dyn_table_drop"
 
     session.execute(
-        text(
+        sqlalchemy.text(
             f"""
             CREATE TABLE `{table}` (
                 id   INT NOT NULL,

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_partitions.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_partitions.py
@@ -25,7 +25,6 @@ import services.api.utils.db.partitioner
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("pmr_mysql_container")
 @services.api.migrations.tests.base.conftest.freeze_datetime(datetime(2025, 1, 1))
 def test_create_partitions_mysql(alembic_engine):
     session = sqlalchemy.orm.sessionmaker(bind=alembic_engine)()
@@ -38,7 +37,7 @@ def test_create_partitions_mysql(alembic_engine):
                 id   INT NOT NULL,
                 data TEXT
             ) PARTITION BY RANGE (id) (
-                PARTITION p0 VALUES LESS THAN (1)
+                PARTITION {table}_p0 VALUES LESS THAN (1)
             );
             """
         )
@@ -59,7 +58,7 @@ def test_create_partitions_mysql(alembic_engine):
             partition_number=2,
         )
     }
-    expected_names.add("p0")
+    expected_names.add(f"{table}_p0")
 
     actual_names = set(
         framework.db.sqldb.db.MySQLDB._get_partition_metadata(session, table).keys()
@@ -68,7 +67,6 @@ def test_create_partitions_mysql(alembic_engine):
     session.close()
 
 
-@pytest.mark.usefixtures("pmr_mysql_container")
 @services.api.migrations.tests.base.conftest.freeze_datetime(datetime(2025, 1, 6))
 def test_drop_partitions_mysql(alembic_engine):
     session = sqlalchemy.orm.sessionmaker(bind=alembic_engine)()
@@ -81,7 +79,7 @@ def test_drop_partitions_mysql(alembic_engine):
                 id   INT NOT NULL,
                 data TEXT
             ) PARTITION BY RANGE (id) (
-                PARTITION p0 VALUES LESS THAN (1)
+                PARTITION {table}_p0 VALUES LESS THAN (1)
             );
             """
         )

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
@@ -18,7 +18,7 @@ import framework.utils.db.utils
 
 
 @pytest.mark.integration
-def test_mysql_apply_strict_all_tables_live(
+def test_mysql_apply_pipes_as_concat_live(
     db_util: framework.utils.db.utils.DBUtil,
 ):
     original = list(db_util.get_current_configurations())
@@ -32,3 +32,19 @@ def test_mysql_apply_strict_all_tables_live(
 
     db_util.set_configurations(original)
     assert list(db_util.get_current_configurations()) == original
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("noop_key", ["nil", "none"])
+def test_set_configurations_noop_values_are_ignored(
+    db_util: framework.utils.db.utils.DBUtil,
+    noop_key: str,
+):
+    original = list(db_util.get_current_configurations())
+
+    db_util.set_configurations([noop_key])
+    after = list(db_util.get_current_configurations())
+
+    assert (
+        after == original
+    ), f"Configuration changed after setting noop value '{noop_key}'"

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
@@ -29,7 +29,7 @@ def test_set_mysql_modes(
         )
     raw_configs = mlrun.mlconf.httpdb.db.mysql.modes.split(",") + [
         "PIPES_AS_CONCAT",
-        "ONLY_FULL_GROUP_BY", # This is a default setting.
+        "ONLY_FULL_GROUP_BY",  # This is a default setting.
     ]
     try:
         db_util.set_configurations(raw_configs)

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
@@ -11,14 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import pytest
+
+import mlrun
 
 import framework.utils.db.utils
 
 
 @pytest.mark.integration
-def test_mysql_apply_pipes_as_concat_live(
+def test_set_mysql_modes(
     db_util: framework.utils.db.utils.DBUtil,
 ):
     original = db_util.get_current_configurations()
@@ -26,11 +27,15 @@ def test_mysql_apply_pipes_as_concat_live(
         raise AssertionError(
             "The test is not applicable, 'PIPES_AS_CONCAT' is already set."
         )
-
+    raw_configs = mlrun.mlconf.httpdb.db.mysql.modes.split(",") + [
+        "PIPES_AS_CONCAT",
+        "ONLY_FULL_GROUP_BY",
+    ]
     try:
-        db_util.set_configurations(["PIPES_AS_CONCAT"])
-        updated = db_util.get_current_configurations()
-        assert "PIPES_AS_CONCAT" in updated
+        db_util.set_configurations(raw_configs)
+        updated = set(db_util.get_current_configurations())
+        original["PIPES_AS_CONCAT"] = True
+        assert set(original) == set(updated)
     finally:
         db_util.set_configurations(original)
 

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
@@ -21,17 +21,21 @@ import framework.utils.db.utils
 def test_mysql_apply_pipes_as_concat_live(
     db_util: framework.utils.db.utils.DBUtil,
 ):
-    original = list(db_util.get_current_configurations())
+    original = db_util.get_current_configurations()
     if "PIPES_AS_CONCAT" in original:
         raise AssertionError(
             "The test is not applicable, 'PIPES_AS_CONCAT' is already set."
         )
 
-    db_util.set_configurations(["PIPES_AS_CONCAT"])
-    assert db_util.get_current_configurations()
+    try:
+        db_util.set_configurations(["PIPES_AS_CONCAT"])
+        updated = db_util.get_current_configurations()
+        assert "PIPES_AS_CONCAT" in updated
+    finally:
+        db_util.set_configurations(original)
 
-    db_util.set_configurations(original)
-    assert list(db_util.get_current_configurations()) == original
+    restored = db_util.get_current_configurations()
+    assert restored == original
 
 
 @pytest.mark.integration

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_utils.py
@@ -29,7 +29,7 @@ def test_set_mysql_modes(
         )
     raw_configs = mlrun.mlconf.httpdb.db.mysql.modes.split(",") + [
         "PIPES_AS_CONCAT",
-        "ONLY_FULL_GROUP_BY",
+        "ONLY_FULL_GROUP_BY", # This is a default setting.
     ]
     try:
         db_util.set_configurations(raw_configs)

--- a/server/py/services/api/migrations/tests/postgres/conftest.py
+++ b/server/py/services/api/migrations/tests/postgres/conftest.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections.abc
 import os
+from collections.abc import Generator, Iterator
 
 import pytest
 import pytest_mock_resources
 import sqlalchemy
 import sqlalchemy.engine
+from _pytest.config import Config
 
 import mlrun
 
@@ -28,23 +29,12 @@ pytest.importorskip(
     "psycopg2",
     reason="psycopg2 not installed",
 )
+
 postgres_engine = pytest_mock_resources.create_postgres_fixture(scope="session")
 
 
 @pytest.fixture(scope="session")
-def alembic_engine(
-    postgres_engine: sqlalchemy.engine.Engine,
-) -> sqlalchemy.engine.Engine:
-    os.environ["MLRUN_HTTPDB__DSN"] = postgres_engine.url.render_as_string(
-        hide_password=False,
-    )
-    mlrun.mlconf.reload()
-    framework.utils.singletons.db.initialize_db()
-    return postgres_engine.execution_options(isolation_level="AUTOCOMMIT")
-
-
-@pytest.fixture(scope="session")
-def pmr_postgres_config():
+def pmr_postgres_config() -> pytest_mock_resources.PostgresConfig:
     return pytest_mock_resources.PostgresConfig(
         image="postgres:17",
         port=5432,
@@ -56,7 +46,39 @@ def pmr_postgres_config():
 
 
 @pytest.fixture(scope="session")
-def pmr_postgres_container(pytestconfig, pmr_postgres_config):
+def alembic_engine(
+    postgres_engine: sqlalchemy.engine.Engine,
+) -> sqlalchemy.engine.Engine:
+    db_url = postgres_engine.url
+    db_name = db_url.database
+
+    postgres_engine.dispose()
+
+    admin_url = db_url.set(database="postgres")
+    admin_engine = sqlalchemy.create_engine(admin_url)
+    raw_conn = admin_engine.raw_connection()
+    try:
+        raw_conn.connection.set_session(autocommit=True)
+        with raw_conn.cursor() as cur:
+            cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+            cur.execute(f'CREATE DATABASE "{db_name}"')
+    finally:
+        raw_conn.close()
+        admin_engine.dispose()
+
+    os.environ["MLRUN_HTTPDB__DSN"] = postgres_engine.url.render_as_string(
+        hide_password=False
+    )
+    mlrun.mlconf.reload()
+    framework.utils.singletons.db.initialize_db()
+    return postgres_engine.execution_options(isolation_level="AUTOCOMMIT")
+
+
+@pytest.fixture(scope="session")
+def pmr_postgres_container(
+    pytestconfig: Config,
+    pmr_postgres_config: pytest_mock_resources.PostgresConfig,
+) -> Iterator[None]:
     yield from pytest_mock_resources.get_container(
         pytestconfig=pytestconfig,
         config=pmr_postgres_config,
@@ -68,30 +90,7 @@ def pmr_postgres_container(pytestconfig, pmr_postgres_config):
 @pytest.fixture(scope="session")
 def db_util(
     alembic_engine: sqlalchemy.engine.Engine,
-) -> collections.abc.Generator[framework.utils.db.utils.DBUtil]:
+) -> Generator[framework.utils.db.utils.DBUtil, None, None]:
     util = framework.utils.db.utils.DBUtil()
     util.wait_for_db_liveness()
     yield util
-
-    db_url = alembic_engine.url
-    db_name = db_url.database
-    admin_url = db_url.set(database="postgres")
-    admin_engine = sqlalchemy.create_engine(admin_url)
-
-    raw_conn = admin_engine.raw_connection()
-    try:
-        raw_conn.connection.set_session(autocommit=True)
-        with raw_conn.cursor() as cur:
-            cur.execute(
-                """
-                        SELECT pg_terminate_backend(pid)
-                        FROM pg_stat_activity
-                        WHERE datname = %s
-                          AND pid <> pg_backend_pid()
-                        """,
-                (db_name,),
-            )
-            cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
-            cur.execute(f'CREATE DATABASE "{db_name}"')
-    finally:
-        raw_conn.close()

--- a/server/py/services/api/migrations/tests/postgres/conftest.py
+++ b/server/py/services/api/migrations/tests/postgres/conftest.py
@@ -17,6 +17,7 @@ import os
 import pytest
 import pytest_mock_resources
 import sqlalchemy
+import sqlalchemy.engine
 
 import mlrun
 
@@ -64,13 +65,9 @@ def pmr_postgres_container(pytestconfig, pmr_postgres_config):
     )
 
 
-import sqlalchemy
-from sqlalchemy.engine import Engine
-
-
 @pytest.fixture(scope="session")
 def db_util(
-    alembic_engine: Engine,
+    alembic_engine: sqlalchemy.engine.Engine,
 ) -> collections.abc.Generator[framework.utils.db.utils.DBUtil]:
     util = framework.utils.db.utils.DBUtil()
     util.wait_for_db_liveness()

--- a/server/py/services/api/migrations/tests/postgres/conftest.py
+++ b/server/py/services/api/migrations/tests/postgres/conftest.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import collections.abc
 import os
 
 import pytest
@@ -26,10 +27,10 @@ pytest.importorskip(
     "psycopg2",
     reason="psycopg2 not installed",
 )
-postgres_engine = pytest_mock_resources.create_postgres_fixture()
+postgres_engine = pytest_mock_resources.create_postgres_fixture(scope="session")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def alembic_engine(
     postgres_engine: sqlalchemy.engine.Engine,
 ) -> sqlalchemy.engine.Engine:
@@ -41,7 +42,7 @@ def alembic_engine(
     return postgres_engine.execution_options(isolation_level="AUTOCOMMIT")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def pmr_postgres_config():
     return pytest_mock_resources.PostgresConfig(
         image="postgres:17",
@@ -53,7 +54,7 @@ def pmr_postgres_config():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def pmr_postgres_container(pytestconfig, pmr_postgres_config):
     yield from pytest_mock_resources.get_container(
         pytestconfig=pytestconfig,
@@ -63,10 +64,37 @@ def pmr_postgres_container(pytestconfig, pmr_postgres_config):
     )
 
 
-@pytest.fixture
+import sqlalchemy
+from sqlalchemy.engine import Engine
+
+
+@pytest.fixture(scope="session")
 def db_util(
-    alembic_engine: sqlalchemy.engine.Engine,
-) -> framework.utils.db.utils.DBUtil:
+    alembic_engine: Engine,
+) -> collections.abc.Generator[framework.utils.db.utils.DBUtil]:
     util = framework.utils.db.utils.DBUtil()
     util.wait_for_db_liveness()
-    return util
+    yield util
+
+    db_url = alembic_engine.url
+    db_name = db_url.database
+    admin_url = db_url.set(database="postgres")
+    admin_engine = sqlalchemy.create_engine(admin_url)
+
+    raw_conn = admin_engine.raw_connection()
+    try:
+        raw_conn.connection.set_session(autocommit=True)
+        with raw_conn.cursor() as cur:
+            cur.execute(
+                """
+                        SELECT pg_terminate_backend(pid)
+                        FROM pg_stat_activity
+                        WHERE datname = %s
+                          AND pid <> pg_backend_pid()
+                        """,
+                (db_name,),
+            )
+            cur.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+            cur.execute(f'CREATE DATABASE "{db_name}"')
+    finally:
+        raw_conn.close()

--- a/server/py/services/api/migrations/tests/postgres/test_postgres_partitions.py
+++ b/server/py/services/api/migrations/tests/postgres/test_postgres_partitions.py
@@ -28,7 +28,6 @@ pytest.importorskip(
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("pmr_postgres_container")
 def test_create_partitions_postgres(alembic_engine):
     session = sessionmaker(bind=alembic_engine)()
     table = "dyn_table"
@@ -40,7 +39,7 @@ def test_create_partitions_postgres(alembic_engine):
             data TEXT
         ) PARTITION BY RANGE (id);
 
-        CREATE TABLE p0 PARTITION OF {table}
+        CREATE TABLE {table}_p0 PARTITION OF {table}
         FOR VALUES FROM (MINVALUE) TO (1);
         """)
     )
@@ -56,13 +55,12 @@ def test_create_partitions_postgres(alembic_engine):
             session, table
         ).keys()
     )
-    expected = {name for name, _ in parts}.union({"p0"})
+    expected = {name for name, _ in parts}.union({f"{table}_p0"})
     assert attached == expected
     session.close()
 
 
 @pytest.mark.integration
-@pytest.mark.usefixtures("pmr_postgres_container")
 def test_drop_partitions_postgres(alembic_engine):
     session = sessionmaker(bind=alembic_engine)()
     table = "dyn_table_drop"
@@ -75,7 +73,7 @@ def test_drop_partitions_postgres(alembic_engine):
             data TEXT
         ) PARTITION BY RANGE (id);
 
-        CREATE TABLE p0 PARTITION OF {table}
+        CREATE TABLE {table}_p0 PARTITION OF {table}
         FOR VALUES FROM (MINVALUE) TO (1);
         """)
     )

--- a/server/py/services/api/migrations/tests/postgres/test_postgres_utils.py
+++ b/server/py/services/api/migrations/tests/postgres/test_postgres_utils.py
@@ -37,7 +37,6 @@ def test_postgres_apply_work_mem_live(
         assert updated.get("work_mem") == "65536", "'work_mem' was not updated"
     finally:
         db_util.set_configurations({"work_mem": old_value})
-
     restored = db_util.get_current_configurations()
     assert restored.get("work_mem") == old_value, "'work_mem' was not restored"
 

--- a/server/py/services/api/migrations/tests/postgres/test_postgres_utils.py
+++ b/server/py/services/api/migrations/tests/postgres/test_postgres_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pytest
 
 import framework.utils.db.utils
@@ -19,22 +20,6 @@ pytest.importorskip(
     "psycopg2",
     reason="psycopg2 not installed",
 )
-
-# Copyright 2025 Iguazio
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-import pytest
 
 
 @pytest.mark.integration

--- a/server/py/services/api/migrations/tests/postgres/test_postgres_utils.py
+++ b/server/py/services/api/migrations/tests/postgres/test_postgres_utils.py
@@ -20,29 +20,52 @@ pytest.importorskip(
     reason="psycopg2 not installed",
 )
 
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
 
 @pytest.mark.integration
-def test_postgres_apply_modes_live(
+def test_postgres_apply_work_mem_live(
     db_util: framework.utils.db.utils.DBUtil,
 ):
-    configs = db_util.get_current_configurations()
-    old_value = configs.get("work_mem")
+    original = db_util.get_current_configurations()
+    old_value = original.get("work_mem")
 
-    assert (
-        old_value != "65536"
-    ), "The test is not applicable, 'work_mem' is already set to '65536'."
+    assert old_value != "65536", "Test requires 'work_mem' to not be '65536' initially"
 
-    # apply new setting
-    db_util.set_configurations({"work_mem": 65536})
+    try:
+        db_util.set_configurations({"work_mem": 65536})
+        updated = db_util.get_current_configurations()
+        assert updated.get("work_mem") == "65536", "'work_mem' was not updated"
+    finally:
+        db_util.set_configurations({"work_mem": old_value})
 
-    assert db_util.get_current_configurations()["work_mem"] == "65536"
+    restored = db_util.get_current_configurations()
+    assert restored.get("work_mem") == old_value, "'work_mem' was not restored"
 
-    # restore original
-    db_util.set_configurations({"work_mem": old_value})
 
-    assert db_util.get_current_configurations()["work_mem"] == old_value
+@pytest.mark.integration
+@pytest.mark.parametrize("noop_key", ["nil", "none"])
+def test_postgres_set_configurations_noop_values_ignored(
+    db_util: framework.utils.db.utils.DBUtil,
+    noop_key: str,
+):
+    original = dict(db_util.get_current_configurations())
 
-    # sanity: ensure only work_mem changed back
-    final = db_util.get_current_configurations()
+    db_util.set_configurations({noop_key: "some_val"})
+    after = dict(db_util.get_current_configurations())
 
-    assert final.get("work_mem") == old_value
+    assert after == original, f"Config changed after noop key '{noop_key}'"

--- a/server/py/services/api/tests/unit/db/test_db_util.py
+++ b/server/py/services/api/tests/unit/db/test_db_util.py
@@ -30,3 +30,31 @@ def test_set_configurations_skips_when_nil_or_none(
     db_util.set_configurations([empty_key])
 
     mocked_apply.assert_not_called()
+
+
+def test_set_configurations_skips_when_none(
+    db_util: framework.utils.db.utils.DBUtil,
+    monkeypatch,
+):
+    mocked_apply = unittest.mock.MagicMock()
+    monkeypatch.setattr(db_util, "_apply_configurations", mocked_apply)
+
+    db_util.set_configurations(None)
+
+    mocked_apply.assert_not_called()
+
+
+@pytest.mark.parametrize("item", ["STRICT_TRANS_TABLES", "NO_ZERO_IN_DATE"])
+def test_set_configurations_called_with_modes(
+    db_util: framework.utils.db.utils.DBUtil,
+    monkeypatch,
+    item: str,
+):
+    mocked_apply = unittest.mock.MagicMock()
+    connection_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(db_util, "_apply_configurations", mocked_apply)
+    monkeypatch.setattr(db_util, "_get_connection", connection_mock)
+
+    db_util.set_configurations([item])
+
+    mocked_apply.assert_called_with(unittest.mock.ANY, [item])

--- a/server/py/services/api/tests/unit/db/test_db_util.py
+++ b/server/py/services/api/tests/unit/db/test_db_util.py
@@ -40,7 +40,6 @@ def test_set_configurations_skips_when_none(
     monkeypatch.setattr(db_util, "_apply_configurations", mocked_apply)
 
     db_util.set_configurations(None)
-
     mocked_apply.assert_not_called()
 
 
@@ -56,5 +55,4 @@ def test_set_configurations_called_with_modes(
     monkeypatch.setattr(db_util, "_get_connection", connection_mock)
 
     db_util.set_configurations([item])
-
     mocked_apply.assert_called_with(unittest.mock.ANY, [item])


### PR DESCRIPTION
### [DBUtil] Fix crash on startup, improve config logic and tests

- Fixed crash when `config_items` was `None` (e.g. no custom DB config)
  - Previously caused `TypeError` on `",".join(None)`
  - Now uses `_EMPTY_DB_CONFIGURATIONS` as fallback
  - Ensures resolved items are passed to `_apply_configurations()`
- Fixed `is_valid()` port check (`or` → `and`)
- `_to_keyset(None)` now returns `set()` instead of `None`

**Tests:**
- Added integration tests for noop values (`"nil"`, `"none"`)
- Added live config apply/restore tests (`work_mem`, `PIPES_AS_CONCAT`)
- Added unit tests for skipped noop input and apply call args


https://iguazio.atlassian.net/browse/ML-10647