### PR TITLE
[Nuclio] Prevent conflict between functions code and source archive

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -296,7 +296,8 @@ class RemoteRuntime(KubeResource):
         code = (
             self.spec.build.functionSourceCode if hasattr(self.spec, "build") else None
         )
-        if code and self.spec.build.source:
+        load_archive = self.spec.build.load_source_on_run and self.spec.build.source
+        if code and load_archive:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "cannot specify both code and source archive"
             )

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -292,6 +292,14 @@ class RemoteRuntime(KubeResource):
     def pre_deploy_validation(self):
         if self.metadata.tag:
             mlrun.utils.validate_tag_name(self.metadata.tag, "function.metadata.tag")
+        # prevent using both code and source archive together
+        code = (
+            self.spec.build.functionSourceCode if hasattr(self.spec, "build") else None
+        )
+        if code and self.spec.build.source:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "cannot specify both code and source archive"
+            )
 
     def mask_sensitive_data_in_config(self):
         if not self.spec.config:

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -266,3 +266,29 @@ def test_with_sidecar(command: str, args: list, expected_sidecars: list):
     )
 
     assert function.spec.config["spec.sidecars"] == expected_sidecars
+
+
+@pytest.mark.parametrize(
+    "with_repo, should_raise",
+    [
+        # conflict between code and archive should raise an error
+        (False, True),
+        # correct config: should not raise
+        (True, False),
+    ],
+)
+def test_pre_deploy_validation_source_repo_alignment(with_repo, should_raise):
+    function = mlrun.new_function("test", kind="nuclio")
+    function.spec.build.source = "v3io:///some/path/src.zip"
+    function.spec.build.load_source_on_run = True
+    function.spec.build.with_repo = with_repo
+    if not with_repo:
+        function.spec.build.functionSourceCode = "some-code"
+
+    if should_raise:
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+            function.pre_deploy_validation()
+        assert "cannot specify both code and source archive" in str(exc_info.value)
+    else:
+        # should not raise
+        function.pre_deploy_validation()

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -280,7 +280,6 @@ def test_with_sidecar(command: str, args: list, expected_sidecars: list):
 def test_pre_deploy_validation_source_repo_alignment(with_repo, should_raise):
     function = mlrun.new_function("test", kind="nuclio")
     function.spec.build.source = "v3io:///some/path/src.zip"
-    function.spec.build.load_source_on_run = True
     function.spec.build.with_repo = with_repo
     if not with_repo:
         function.spec.build.functionSourceCode = "some-code"

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -269,18 +269,23 @@ def test_with_sidecar(command: str, args: list, expected_sidecars: list):
 
 
 @pytest.mark.parametrize(
-    "with_repo, should_raise",
+    "with_repo,load_source_on_run, should_raise",
     [
         # conflict between code and archive should raise an error
-        (False, True),
+        (False, True, True),
         # correct config: should not raise
-        (True, False),
+        (True, True, False),
     ],
 )
-def test_pre_deploy_validation_source_repo_alignment(with_repo, should_raise):
+def test_pre_deploy_validation_source_repo_alignment(
+    with_repo, load_source_on_run, should_raise
+):
     function = mlrun.new_function("test", kind="nuclio")
     function.spec.build.source = "v3io:///some/path/src.zip"
     function.spec.build.with_repo = with_repo
+    function.spec.build.load_source_on_run = load_source_on_run
+
+    # only add code if not using repo
     if not with_repo:
         function.spec.build.functionSourceCode = "some-code"
 


### PR DESCRIPTION
This PR adds a validation step in `pre_deploy_validation` for Nuclio functions to prevent a misconfiguration where both the function source code and a source archive are provided. 

Jira:
https://iguazio.atlassian.net/browse/ML-7678