### PR TITLE
[Model Monitoring] Implement batch event handling in the controller

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -133,6 +133,7 @@ from .k8s import NodeSelectorOperator, Resources, ResourceSpec
 from .memory_reports import MostCommonObjectTypesReport, ObjectTypeReport
 from .model_monitoring import (
     DriftStatus,
+    EndpointMode,
     EndpointType,
     EndpointUID,
     EventFieldType,

--- a/mlrun/common/schemas/model_monitoring/__init__.py
+++ b/mlrun/common/schemas/model_monitoring/__init__.py
@@ -16,6 +16,7 @@ from .constants import (
     INTERSECT_DICT_KEYS,
     ApplicationEvent,
     DriftStatus,
+    EndpointMode,
     EndpointType,
     EndpointUID,
     EventFieldType,

--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -205,6 +205,11 @@ class ControllerEvent(MonitoringStrEnum):
     FIRST_REQUEST = "first_request"
     FEATURE_SET_URI = "feature_set_uri"
     ENDPOINT_TYPE = "endpoint_type"
+
+    # first_timestamp and last_timestamp are used to batch completed events
+    FIRST_TIMESTAMP = "first_timestamp"
+    LAST_TIMESTAMP = "last_timestamp"
+
     ENDPOINT_POLICY = "endpoint_policy"
     # Note: currently under endpoint policy we will have a dictionary including the keys: "application_names"
     # "base_period", and "updated_endpoint" stand for when the MEP was updated
@@ -219,6 +224,7 @@ class ControllerEventEndpointPolicy(MonitoringStrEnum):
 class ControllerEventKind(MonitoringStrEnum):
     NOP_EVENT = "nop_event"
     REGULAR_EVENT = "regular_event"
+    BATCH_COMPLETE = "batch_complete"
 
 
 class MetricData(MonitoringStrEnum):
@@ -319,6 +325,19 @@ class EndpointType(IntEnum):
     @classmethod
     def top_level_list(cls):
         return [cls.NODE_EP, cls.ROUTER, cls.BATCH_EP]
+
+    @classmethod
+    def real_time_list(cls):
+        return [cls.NODE_EP, cls.ROUTER, cls.LEAF_EP]
+
+    @classmethod
+    def batch_list(cls):
+        return [cls.BATCH_EP]
+
+
+class EndpointMode(StrEnum):
+    REAL_TIME = "real_time"
+    BATCH = "batch"
 
 
 class MonitoringFunctionNames(MonitoringStrEnum):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -741,6 +741,7 @@ class RunDBInterface(ABC):
         tsdb_metrics: bool = False,
         metric_list: Optional[list[str]] = None,
         top_level: bool = False,
+        mode: Optional[mlrun.common.schemas.EndpointMode] = None,
         uids: Optional[list[str]] = None,
         latest_only: bool = False,
     ) -> mlrun.common.schemas.ModelEndpointList:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3813,6 +3813,7 @@ class HTTPRunDB(RunDBInterface):
         tsdb_metrics: bool = False,
         metric_list: Optional[list[str]] = None,
         top_level: bool = False,
+        mode: mm_constants.EndpointMode = None,
         uids: Optional[list[str]] = None,
         latest_only: bool = False,
     ) -> mlrun.common.schemas.ModelEndpointList:
@@ -3833,6 +3834,8 @@ class HTTPRunDB(RunDBInterface):
                                 If tsdb_metrics=False, this parameter will be ignored and no tsdb metrics
                                 will be included.
         :param top_level:       Whether to return only top level model endpoints.
+        :param mode:            Specifies the mode of the model endpoint. Can be "real-time", "batch", or both if set
+                                to None.
         :param uids:            A list of unique ids to filter by.
         :param latest_only:     Whether to return only the latest model endpoint version.
         :return:                A list of model endpoints.
@@ -3856,6 +3859,7 @@ class HTTPRunDB(RunDBInterface):
                 "tsdb-metrics": tsdb_metrics,
                 "metric": metric_list,
                 "top-level": top_level,
+                "mode": mode,
                 "uid": uids,
                 "latest-only": latest_only,
             },

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -572,7 +572,9 @@ class MonitoringApplicationController:
 
                 endpoint_mode = mm_constants.EndpointMode.REAL_TIME
 
-            logger.info("Starting to analyze", timestamp=last_stream_timestamp)
+            logger.info(
+                "Starting to analyze", timestamp=last_stream_timestamp.isoformat()
+            )
 
             with _BatchWindowGenerator(
                 project=project_name,

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -883,7 +883,6 @@ class MonitoringApplicationController:
         :param endpoint_id: endpoint id string
         :param endpoint_name: the endpoint name string
         :param endpoint_type: Enum of the endpoint type
-
         """
         event = {
             ControllerEvent.KIND.value: kind,

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -145,16 +145,32 @@ class _BatchWindow:
                 last_analyzed=last_analyzed,
             )
 
-        if last_analyzed and self._endpoint_mode == mm_constants.EndpointMode.BATCH:
+        if self._endpoint_mode == mm_constants.EndpointMode.BATCH:
             # If the endpoint is a batch endpoint, we need to update the last analyzed time
             # to the end of the batch time.
-
-            yield _Interval(
-                datetime.datetime.fromtimestamp(
-                    last_analyzed, tz=datetime.timezone.utc
-                ),
-                datetime.datetime.fromtimestamp(self._stop, tz=datetime.timezone.utc),
-            )
+            if last_analyzed:
+                if last_analyzed < self._stop:
+                    # If the last analyzed time is earlier than the stop time,
+                    # yield the final partial interval from last_analyzed to stop
+                    yield _Interval(
+                        datetime.datetime.fromtimestamp(
+                            last_analyzed, tz=datetime.timezone.utc
+                        ),
+                        datetime.datetime.fromtimestamp(
+                            self._stop, tz=datetime.timezone.utc
+                        ),
+                    )
+            else:
+                # The time span between the start and end of the batch is shorter than the step,
+                # so we need to yield a partial interval covering that range.
+                yield _Interval(
+                    datetime.datetime.fromtimestamp(
+                        self._start, tz=datetime.timezone.utc
+                    ),
+                    datetime.datetime.fromtimestamp(
+                        self._stop, tz=datetime.timezone.utc
+                    ),
+                )
 
             self._update_last_analyzed(self._stop)
             logger.debug(
@@ -214,19 +230,23 @@ class _BatchWindowGenerator(AbstractContextManager):
     def _get_last_updated_time(
         cls,
         last_request: datetime.datetime,
+        endpoint_mode: mm_constants.EndpointMode,
     ) -> int:
         """
         Get the last updated time of a model endpoint.
         """
-        last_updated = int(
-            last_request.timestamp()
-            - cast(
-                float,
-                mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs,
-            )
-        )
 
-        return last_updated
+        if endpoint_mode == mm_constants.EndpointMode.REAL_TIME:
+            last_updated = int(
+                last_request.timestamp()
+                - cast(
+                    float,
+                    mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs,
+                )
+            )
+
+            return last_updated
+        return int(last_request.timestamp())
 
     def get_intervals(
         self,
@@ -246,7 +266,7 @@ class _BatchWindowGenerator(AbstractContextManager):
             schedules_file=self._schedules_file,
             application=application,
             timedelta_seconds=self._timedelta,
-            last_updated=self._get_last_updated_time(last_request),
+            last_updated=self._get_last_updated_time(last_request, endpoint_mode),
             first_request=int(first_request.timestamp()),
             endpoint_mode=endpoint_mode,
         )

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import concurrent.futures
 import datetime
 import json
 import os
 import traceback
-from collections import OrderedDict
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from types import TracebackType
@@ -29,20 +27,17 @@ import pandas as pd
 
 import mlrun
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
-import mlrun.feature_store as fstore
 import mlrun.model_monitoring
 import mlrun.model_monitoring.db._schedules as schedules
 import mlrun.model_monitoring.helpers
 import mlrun.platforms.iguazio
-from mlrun.common.schemas import EndpointType
 from mlrun.common.schemas.model_monitoring.constants import (
     ControllerEvent,
     ControllerEventEndpointPolicy,
-    ControllerEventKind,
 )
 from mlrun.errors import err_to_str
 from mlrun.model_monitoring.helpers import batch_dict2timedelta
-from mlrun.utils import datetime_now, logger
+from mlrun.utils import logger
 
 _SECONDS_IN_DAY = int(datetime.timedelta(days=1).total_seconds())
 _SECONDS_IN_MINUTE = 60
@@ -62,6 +57,7 @@ class _BatchWindow:
         timedelta_seconds: int,
         last_updated: int,
         first_request: int,
+        endpoint_mode: mm_constants.EndpointMode = mm_constants.EndpointMode.REAL_TIME,
     ) -> None:
         """
         Initialize a batch window object that handles the batch interval time range
@@ -74,6 +70,7 @@ class _BatchWindow:
         self._stop = last_updated
         self._step = timedelta_seconds
         self._db = schedules_file
+        self._endpoint_mode = endpoint_mode
         self._start = self._get_last_analyzed()
 
     def _get_saved_last_analyzed(self) -> Optional[int]:
@@ -85,10 +82,19 @@ class _BatchWindow:
         )
 
     def _get_initial_last_analyzed(self) -> int:
+        if self._endpoint_mode == mm_constants.EndpointMode.BATCH:
+            logger.info(
+                "No last analyzed time was found for this endpoint and application, as this is "
+                "probably the first time this application is running. Initializing last analyzed "
+                "to the start of the batch time",
+                application=self._application,
+                start_batch_time=self._first_request,
+            )
+            return self._first_request
         logger.info(
             "No last analyzed time was found for this endpoint and application, as this is "
             "probably the first time this application is running. Initializing last analyzed "
-            "to the latest between first request time or last update time minus one day",
+            "to the latest between first request the latest between first request time or last update time minus one day",
             application=self._application,
             first_request=self._first_request,
             last_updated=self._stop,
@@ -103,6 +109,9 @@ class _BatchWindow:
     def _get_last_analyzed(self) -> int:
         saved_last_analyzed = self._get_saved_last_analyzed()
         if saved_last_analyzed is not None:
+            if self._endpoint_mode == mm_constants.EndpointMode.BATCH:
+                # Use the maximum between the saved last analyzed and the start of the batch
+                return max(saved_last_analyzed, self._first_request)
             return saved_last_analyzed
         else:
             last_analyzed = self._get_initial_last_analyzed()
@@ -113,6 +122,7 @@ class _BatchWindow:
     def get_intervals(self) -> Iterator[_Interval]:
         """Generate the batch interval time ranges."""
         entered = False
+        last_analyzed = None
         # Iterate timestamp from start until timestamp <= stop - step
         # so that the last interval will end at (timestamp + step) <= stop.
         # Add 1 to stop - step to get <= and not <.
@@ -132,6 +142,24 @@ class _BatchWindow:
                 "Updated the last analyzed time for this endpoint and application",
                 application=self._application,
                 last_analyzed=last_analyzed,
+            )
+
+        if last_analyzed and self._endpoint_mode == mm_constants.EndpointMode.BATCH:
+            # If the endpoint is a batch endpoint, we need to update the last analyzed time
+            # to the end of the batch time.
+
+            yield _Interval(
+                datetime.datetime.fromtimestamp(
+                    last_analyzed, tz=datetime.timezone.utc
+                ),
+                datetime.datetime.fromtimestamp(self._stop, tz=datetime.timezone.utc),
+            )
+
+            self._update_last_analyzed(self._stop)
+            logger.debug(
+                "Updated the last analyzed time for this endpoint and application to the end of the batch time",
+                application=self._application,
+                last_analyzed=self._stop,
             )
 
         if not entered:
@@ -183,7 +211,8 @@ class _BatchWindowGenerator(AbstractContextManager):
 
     @classmethod
     def _get_last_updated_time(
-        cls, last_request: datetime.datetime, not_batch_endpoint: bool
+        cls,
+        last_request: datetime.datetime,
     ) -> int:
         """
         Get the last updated time of a model endpoint.
@@ -195,15 +224,7 @@ class _BatchWindowGenerator(AbstractContextManager):
                 mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs,
             )
         )
-        if not not_batch_endpoint:
-            # If the endpoint does not have a stream, `last_updated` should be
-            # the minimum between the current time and the last updated time.
-            # This compensates for the bumping mechanism - see
-            # `update_model_endpoint_last_request`.
-            last_updated = min(int(datetime_now().timestamp()), last_updated)
-            logger.debug(
-                "The endpoint does not have a stream", last_updated=last_updated
-            )
+
         return last_updated
 
     def get_intervals(
@@ -212,19 +233,21 @@ class _BatchWindowGenerator(AbstractContextManager):
         application: str,
         first_request: datetime.datetime,
         last_request: datetime.datetime,
-        not_batch_endpoint: bool,
+        endpoint_mode: mm_constants.EndpointMode,
     ) -> Iterator[_Interval]:
         """
         Get the batch window for a specific endpoint and application.
         `first_request` and `last_request` are the timestamps of the first request and last
         request to the endpoint, respectively. They are guaranteed to be nonempty at this point.
         """
+
         self.batch_window = _BatchWindow(
             schedules_file=self._schedules_file,
             application=application,
             timedelta_seconds=self._timedelta,
-            last_updated=self._get_last_updated_time(last_request, not_batch_endpoint),
+            last_updated=self._get_last_updated_time(last_request),
             first_request=int(first_request.timestamp()),
+            endpoint_mode=endpoint_mode,
         )
         yield from self.batch_window.get_intervals()
 
@@ -246,8 +269,6 @@ class MonitoringApplicationController:
     to manage the main monitoring drift detection process based on the current batch.
     Note that the MonitoringApplicationController object requires access keys along with valid project configurations.
     """
-
-    _MAX_FEATURE_SET_PER_WORKER = 1000
 
     def __init__(self) -> None:
         """Initialize Monitoring Application Controller"""
@@ -282,9 +303,6 @@ class MonitoringApplicationController:
                 mlrun.platforms.iguazio.KafkaOutputStream,
             ],
         ] = {}
-        self.feature_sets: OrderedDict[str, mlrun.feature_store.FeatureSet] = (
-            collections.OrderedDict()
-        )
         self.tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
             project=self.project
         )
@@ -421,7 +439,6 @@ class MonitoringApplicationController:
                 last_request=endpoint.status.last_request,
                 first_request=endpoint.status.first_request,
                 endpoint_type=endpoint.metadata.endpoint_type,
-                feature_set_uri=endpoint.spec.monitoring_feature_set_uri,
             )
         return False
 
@@ -477,24 +494,65 @@ class MonitoringApplicationController:
         try:
             project_name = event[ControllerEvent.PROJECT]
             endpoint_id = event[ControllerEvent.ENDPOINT_ID]
-            endpoint_name = event[ControllerEvent.ENDPOINT_NAME]
-            applications_names = event[ControllerEvent.ENDPOINT_POLICY][
-                ControllerEventEndpointPolicy.MONITORING_APPLICATIONS
-            ]
 
-            not_batch_endpoint = (
-                event[ControllerEvent.ENDPOINT_TYPE] != EndpointType.BATCH_EP
-            )
+            if (
+                event[ControllerEvent.KIND]
+                == mm_constants.ControllerEventKind.BATCH_COMPLETE
+            ):
+                monitoring_functions = (
+                    self.project_obj.list_model_monitoring_functions()
+                )
+                if monitoring_functions:
+                    applications_names = list(
+                        {app.metadata.name for app in monitoring_functions}
+                    )
+                    last_stream_timestamp = datetime.datetime.fromisoformat(
+                        event[ControllerEvent.LAST_TIMESTAMP]
+                    )
+                    first_request = datetime.datetime.fromisoformat(
+                        event[ControllerEvent.FIRST_TIMESTAMP]
+                    )
+                    endpoint_mode = mm_constants.EndpointMode.BATCH
+                    model_endpoint = self.project_obj.list_model_endpoints(
+                        uids=[endpoint_id],
+                        latest_only=True,
+                    ).endpoints
 
-            logger.info(
-                "Starting analyzing for", timestamp=event[ControllerEvent.TIMESTAMP]
-            )
-            last_stream_timestamp = datetime.datetime.fromisoformat(
-                event[ControllerEvent.TIMESTAMP]
-            )
-            first_request = datetime.datetime.fromisoformat(
-                event[ControllerEvent.FIRST_REQUEST]
-            )
+                    if not model_endpoint:
+                        logger.error(
+                            "Batch model endpoint not found",
+                            endpoint_id=endpoint_id,
+                            project=project_name,
+                        )
+                        return
+
+                    endpoint_name = model_endpoint[0].metadata.name
+                    endpoint_updated = model_endpoint[0].metadata.updated.isoformat()
+
+                else:
+                    logger.info("No monitoring functions found", project=self.project)
+                    return
+
+            else:
+                endpoint_name = event[ControllerEvent.ENDPOINT_NAME]
+                applications_names = event[ControllerEvent.ENDPOINT_POLICY][
+                    ControllerEventEndpointPolicy.MONITORING_APPLICATIONS
+                ]
+                last_stream_timestamp = datetime.datetime.fromisoformat(
+                    event[ControllerEvent.TIMESTAMP]
+                )
+                first_request = datetime.datetime.fromisoformat(
+                    event[ControllerEvent.FIRST_REQUEST]
+                )
+
+                endpoint_updated = event[ControllerEvent.ENDPOINT_POLICY][
+                    ControllerEventEndpointPolicy.ENDPOINT_UPDATED
+                ]
+
+                endpoint_mode = mm_constants.EndpointMode.REAL_TIME
+
+            logger.info("Starting analyzing for", timestamp=last_stream_timestamp)
+
             with _BatchWindowGenerator(
                 project=project_name,
                 endpoint_id=endpoint_id,
@@ -506,42 +564,20 @@ class MonitoringApplicationController:
                         end_infer_time,
                     ) in batch_window_generator.get_intervals(
                         application=application,
-                        not_batch_endpoint=not_batch_endpoint,
                         first_request=first_request,
                         last_request=last_stream_timestamp,
+                        endpoint_mode=endpoint_mode,
                     ):
                         data_in_window = False
-                        if not_batch_endpoint:
-                            # Serving endpoint - get the relevant window data from the TSDB
-                            prediction_metric = self.tsdb_connector.read_predictions(
-                                start=start_infer_time,
-                                end=end_infer_time,
-                                endpoint_id=endpoint_id,
-                            )
-                            if prediction_metric.data:
-                                data_in_window = True
-                        else:
-                            if endpoint_id not in self.feature_sets:
-                                self.feature_sets[endpoint_id] = fstore.get_feature_set(
-                                    event[ControllerEvent.FEATURE_SET_URI]
-                                )
-                            self.feature_sets.move_to_end(endpoint_id, last=False)
-                            if (
-                                len(self.feature_sets)
-                                > self._MAX_FEATURE_SET_PER_WORKER
-                            ):
-                                self.feature_sets.popitem(last=True)
-                            m_fs = self.feature_sets.get(endpoint_id)
+                        # Serving endpoint - get the relevant window data from the TSDB
+                        prediction_metric = self.tsdb_connector.read_predictions(
+                            start=start_infer_time,
+                            end=end_infer_time,
+                            endpoint_id=endpoint_id,
+                        )
+                        if prediction_metric.data:
+                            data_in_window = True
 
-                            # Batch endpoint - get the relevant window data from the parquet target
-                            df = m_fs.to_dataframe(
-                                start_time=start_infer_time,
-                                end_time=end_infer_time,
-                                time_column=mm_constants.EventFieldType.TIMESTAMP,
-                                storage_options=self.storage_options,
-                            )
-                            if len(df) > 0:
-                                data_in_window = True
                         if not data_in_window:
                             logger.info(
                                 "No data found for the given interval",
@@ -564,49 +600,47 @@ class MonitoringApplicationController:
                                 project=project_name,
                                 applications_names=[application],
                                 model_monitoring_access_key=self.model_monitoring_access_key,
-                                endpoint_updated=event[ControllerEvent.ENDPOINT_POLICY][
-                                    ControllerEventEndpointPolicy.ENDPOINT_UPDATED
-                                ],
+                                endpoint_updated=endpoint_updated,
                             )
-                base_period = event[ControllerEvent.ENDPOINT_POLICY][
-                    ControllerEventEndpointPolicy.BASE_PERIOD
-                ]
-                current_time = mlrun.utils.datetime_now()
+
                 if (
-                    self._should_send_nop_event(
+                    event[ControllerEvent.KIND]
+                    == mm_constants.ControllerEventKind.REGULAR_EVENT
+                ):
+                    base_period = event[ControllerEvent.ENDPOINT_POLICY][
+                        ControllerEventEndpointPolicy.BASE_PERIOD
+                    ]
+                    current_time = mlrun.utils.datetime_now()
+                    if self._should_send_nop_event(
                         base_period,
                         batch_window_generator.get_min_last_analyzed(),
                         current_time,
-                    )
-                    and event[ControllerEvent.KIND] != ControllerEventKind.NOP_EVENT
-                ):
-                    event = {
-                        ControllerEvent.KIND: mm_constants.ControllerEventKind.NOP_EVENT,
-                        ControllerEvent.PROJECT: project_name,
-                        ControllerEvent.ENDPOINT_ID: endpoint_id,
-                        ControllerEvent.ENDPOINT_NAME: endpoint_name,
-                        ControllerEvent.TIMESTAMP: current_time.isoformat(
-                            timespec="microseconds"
-                        ),
-                        ControllerEvent.ENDPOINT_POLICY: event[
-                            ControllerEvent.ENDPOINT_POLICY
-                        ],
-                        ControllerEvent.ENDPOINT_TYPE: event[
-                            ControllerEvent.ENDPOINT_TYPE
-                        ],
-                        ControllerEvent.FEATURE_SET_URI: event[
-                            ControllerEvent.FEATURE_SET_URI
-                        ],
-                        ControllerEvent.FIRST_REQUEST: event[
-                            ControllerEvent.FIRST_REQUEST
-                        ],
-                    }
-                    self._push_to_main_stream(
-                        event=event,
-                        endpoint_id=endpoint_id,
-                    )
+                    ):
+                        event = {
+                            ControllerEvent.KIND: mm_constants.ControllerEventKind.NOP_EVENT,
+                            ControllerEvent.PROJECT: project_name,
+                            ControllerEvent.ENDPOINT_ID: endpoint_id,
+                            ControllerEvent.ENDPOINT_NAME: endpoint_name,
+                            ControllerEvent.TIMESTAMP: current_time.isoformat(
+                                timespec="microseconds"
+                            ),
+                            ControllerEvent.ENDPOINT_POLICY: event[
+                                ControllerEvent.ENDPOINT_POLICY
+                            ],
+                            ControllerEvent.ENDPOINT_TYPE: event[
+                                ControllerEvent.ENDPOINT_TYPE
+                            ],
+                            ControllerEvent.FIRST_REQUEST: event[
+                                ControllerEvent.FIRST_REQUEST
+                            ],
+                        }
+                        self._push_to_main_stream(
+                            event=event,
+                            endpoint_id=endpoint_id,
+                        )
             logger.info(
-                "Finish analyze for", timestamp=event[ControllerEvent.TIMESTAMP]
+                "Finish analyze for",
+                timestamp=last_stream_timestamp,
             )
 
         except Exception:
@@ -674,7 +708,9 @@ class MonitoringApplicationController:
         """
         logger.info("Starting monitoring controller chief")
         applications_names = []
-        endpoints = self.project_obj.list_model_endpoints(tsdb_metrics=False).endpoints
+        endpoints = self.project_obj.list_model_endpoints(
+            tsdb_metrics=False, mode=mm_constants.EndpointMode.REAL_TIME
+        ).endpoints
         last_request_dict = self.tsdb_connector.get_last_request(
             endpoint_ids=[mep.metadata.uid for mep in endpoints]
         )
@@ -783,7 +819,6 @@ class MonitoringApplicationController:
                     sep=" ", timespec="microseconds"
                 ),
                 endpoint_type=endpoint.metadata.endpoint_type,
-                feature_set_uri=endpoint.spec.monitoring_feature_set_uri,
                 endpoint_policy=json.dumps(policy),
             )
             policy[ControllerEventEndpointPolicy.ENDPOINT_UPDATED] = (
@@ -801,7 +836,6 @@ class MonitoringApplicationController:
                     sep=" ", timespec="microseconds"
                 ),
                 endpoint_type=endpoint.metadata.endpoint_type.value,
-                feature_set_uri=endpoint.spec.monitoring_feature_set_uri,
                 endpoint_policy=policy,
             )
 
@@ -814,7 +848,6 @@ class MonitoringApplicationController:
         timestamp: str,
         first_request: str,
         endpoint_type: int,
-        feature_set_uri: str,
         endpoint_policy: dict[str, Any],
     ) -> None:
         """
@@ -827,7 +860,7 @@ class MonitoringApplicationController:
         :param endpoint_id: endpoint id string
         :param endpoint_name: the endpoint name string
         :param endpoint_type: Enum of the endpoint type
-        :param feature_set_uri: the feature set uri string
+
         """
         event = {
             ControllerEvent.KIND.value: kind,
@@ -837,7 +870,6 @@ class MonitoringApplicationController:
             ControllerEvent.TIMESTAMP.value: timestamp,
             ControllerEvent.FIRST_REQUEST.value: first_request,
             ControllerEvent.ENDPOINT_TYPE.value: endpoint_type,
-            ControllerEvent.FEATURE_SET_URI.value: feature_set_uri,
             ControllerEvent.ENDPOINT_POLICY.value: endpoint_policy,
         }
         logger.info(

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -94,7 +94,8 @@ class _BatchWindow:
         logger.info(
             "No last analyzed time was found for this endpoint and application, as this is "
             "probably the first time this application is running. Initializing last analyzed "
-            "to the latest between first request the latest between first request time or last update time minus one day",
+            "to the latest between first request the latest between first request time or last "
+            "update time minus one day",
             application=self._application,
             first_request=self._first_request,
             last_updated=self._stop,

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -172,7 +172,7 @@ class _BatchWindow:
                     ),
                 )
 
-            self._update_last_analyzed(self._stop)
+            self._update_last_analyzed(last_analyzed=self._stop)
             logger.debug(
                 "Updated the last analyzed time for this endpoint and application to the end of the batch time",
                 application=self._application,
@@ -572,7 +572,7 @@ class MonitoringApplicationController:
 
                 endpoint_mode = mm_constants.EndpointMode.REAL_TIME
 
-            logger.info("Starting analyzing for", timestamp=last_stream_timestamp)
+            logger.info("Starting to analyze", timestamp=last_stream_timestamp)
 
             with _BatchWindowGenerator(
                 project=project_name,

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -134,6 +134,9 @@ class EventStreamProcessor:
            the default parquet path is under mlrun.mlconf.model_endpoint_monitoring.user_space. Note that if you are
            using CE, the parquet target path is based on the defined MLRun artifact path.
 
+        In a separate branch, "batch complete" events are forwarded to the controller stream with an intentional delay,
+        to allow for data to first be written to parquet.
+
         :param fn: A serving function.
         :param tsdb_connector: Time series database connector.
         :param controller_stream_uri: The controller stream URI. Runs on server api pod so needed to be provided as
@@ -154,7 +157,7 @@ class EventStreamProcessor:
 
         graph.add_step(
             "Delay",
-            name="Delay",
+            name="BatchDelay",
             after="FilterBatchComplete",
             delay=self.parquet_batching_timeout_secs + 5,  # add margin
         )
@@ -275,7 +278,7 @@ class EventStreamProcessor:
                 "controller_stream",
                 path=stream_uri,
                 sharding_func=ControllerEvent.ENDPOINT_ID,
-                after=["ForwardNOP", "Delay"],
+                after=["ForwardNOP", "BatchDelay"],
                 # Force using the pipeline key instead of the one in the profile in case of v3io profile.
                 # In case of Kafka, this parameter will be ignored.
                 alternative_v3io_access_key="V3IO_ACCESS_KEY",

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import asyncio
 import datetime
 import typing
 
@@ -145,6 +145,20 @@ class EventStreamProcessor:
             fn.set_topology(mlrun.serving.states.StepKinds.flow, engine="async"),
         )
 
+        # forward back complete events to controller
+        graph.add_step(
+            "storey.Filter",
+            "FilterBatchComplete",
+            _fn="(event.get('kind') == 'batch_complete')",
+        )
+
+        graph.add_step(
+            "Delay",
+            name="Delay",
+            after="FilterBatchComplete",
+            delay=self.parquet_batching_timeout_secs + 5,  # add margin
+        )
+
         # split the graph between event with error vs valid event
         graph.add_step(
             "storey.Filter",
@@ -261,7 +275,7 @@ class EventStreamProcessor:
                 "controller_stream",
                 path=stream_uri,
                 sharding_func=ControllerEvent.ENDPOINT_ID,
-                after="ForwardNOP",
+                after=["ForwardNOP", "Delay"],
                 # Force using the pipeline key instead of the one in the profile in case of v3io profile.
                 # In case of Kafka, this parameter will be ignored.
                 alternative_v3io_access_key="V3IO_ACCESS_KEY",
@@ -306,6 +320,16 @@ class ProcessBeforeParquet(mlrun.feature_store.steps.MapClass):
             if not event.get(key):
                 event[key] = None
         logger.info("ProcessBeforeParquet2", event=event)
+        return event
+
+
+class Delay(mlrun.feature_store.steps.MapClass):
+    def __init__(self, delay: int, **kwargs):
+        super().__init__(**kwargs)
+        self._delay = delay
+
+    async def do(self, event):
+        await asyncio.sleep(self._delay)
         return event
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3901,6 +3901,7 @@ class MlrunProject(ModelObj):
         start: Optional[datetime.datetime] = None,
         end: Optional[datetime.datetime] = None,
         top_level: bool = False,
+        mode: Optional[mlrun.common.schemas.EndpointMode] = None,
         uids: Optional[list[str]] = None,
         latest_only: bool = False,
         tsdb_metrics: bool = False,
@@ -3916,8 +3917,9 @@ class MlrunProject(ModelObj):
         5) function_tag
         6) labels
         7) top level
-        8) uids
-        9) start and end time, corresponding to the `created` field.
+        8) mode
+        9) uids
+        10) start and end time, corresponding to the `created` field.
         By default, when no filters are applied, all available endpoints for the given project will be listed.
 
         In addition, this functions provides a facade for listing endpoint related metrics. This facade is time-based
@@ -3937,6 +3939,8 @@ class MlrunProject(ModelObj):
         :param start:           The start time to filter by.Corresponding to the `created` field.
         :param end:             The end time to filter by. Corresponding to the `created` field.
         :param top_level:       If true will return only routers and endpoint that are NOT children of any router.
+        :param mode:            Specifies the mode of the model endpoint. Can be "real-time", "batch", or both if set
+                                to None.
         :param uids:            If passed will return a list `ModelEndpoint` object with uid in uids.
         :param tsdb_metrics:    When True, the time series metrics will be added to the output
                                 of the resulting.
@@ -3958,6 +3962,7 @@ class MlrunProject(ModelObj):
             start=start,
             end=end,
             top_level=top_level,
+            mode=mode,
             uids=uids,
             latest_only=latest_only,
             tsdb_metrics=tsdb_metrics,

--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -1347,6 +1347,7 @@ class DBInterface(ABC):
         model_name: typing.Optional[str] = None,
         model_tag: typing.Optional[str] = None,
         top_level: typing.Optional[bool] = None,
+        mode: typing.Optional[mlrun.common.schemas.EndpointMode] = None,
         labels: typing.Optional[list[str]] = None,
         start: typing.Optional[datetime.datetime] = None,
         end: typing.Optional[datetime.datetime] = None,
@@ -1371,6 +1372,8 @@ class DBInterface(ABC):
         :param model_name:      The model name.
         :param model_tag:       The model tag.
         :param top_level:       Whether to return only top level model endpoints (1,2,4).
+        :param mode:            Specifies the mode of the model endpoint. Can be "real-time", "batch", or both if set
+                                to None.
         :param labels:          The labels to filter by.
         :param start:           The start time to filter by.
         :param end:             The end time to filter by.

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -67,6 +67,7 @@ from mlrun.common.schemas.feature_store import (
     FeatureSetDigestSpecV2,
 )
 from mlrun.common.schemas.model_monitoring import (
+    EndpointMode,
     EndpointType,
     ModelEndpointSchema,
     ModelMonitoringAppLabel,
@@ -5804,6 +5805,7 @@ class SQLDB(DBInterface):
         model_name: Optional[str] = None,
         model_tag: Optional[str] = None,
         top_level: Optional[bool] = None,
+        mode: Optional[EndpointMode] = None,
         labels: Optional[list[str]] = None,
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
@@ -5824,6 +5826,7 @@ class SQLDB(DBInterface):
         :param model_name: The model name of the model endpoint.
         :param model_tag: The model tag associated with the model endpoint.
         :param top_level: If True, filters for top-level model endpoints.
+        :param mode: Specifies the mode of the model endpoint. Can be "real-time", "batch", or both if set to None.
         :param labels: The labels to filter model endpoints.
         :param start: Start date-time filter.
         :param end: End date-time filter.
@@ -5873,6 +5876,17 @@ class SQLDB(DBInterface):
             query = query.filter(
                 ModelEndpoint.endpoint_type.in_(EndpointType.top_level_list())
             )
+        if mode:
+            if mode == EndpointMode.REAL_TIME:
+                # Real Time EP
+                query = query.filter(
+                    ModelEndpoint.endpoint_type.in_(EndpointType.real_time_list())
+                )
+            else:
+                # Batch EP
+                query = query.filter(
+                    ModelEndpoint.endpoint_type.in_(EndpointType.batch_list())
+                )
 
         # Apply function-related filters
         if function_name or function_tag:
@@ -8047,6 +8061,7 @@ class SQLDB(DBInterface):
         model_name: typing.Optional[str] = None,
         model_tag: typing.Optional[str] = None,
         top_level: typing.Optional[bool] = None,
+        mode: typing.Optional[mlrun.common.schemas.EndpointMode] = None,
         labels: typing.Optional[list[str]] = None,
         start: typing.Optional[datetime] = None,
         end: typing.Optional[datetime] = None,
@@ -8075,6 +8090,7 @@ class SQLDB(DBInterface):
             model_name=model_name,
             model_tag=model_tag,
             top_level=top_level,
+            mode=mode,
             start=start,
             end=end,
             uids=uids,

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -242,6 +242,7 @@ async def list_model_endpoints(
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
     top_level: bool = Query(False, alias="top-level"),
+    mode: mm_constants.EndpointMode = Query(None, alias="mode"),
     tsdb_metrics: bool = Query(True, alias="tsdb-metrics"),
     metric_list: Optional[list[str]] = Query(None, alias="metric"),
     uids: list[str] = Query(None, alias="uid"),
@@ -266,6 +267,8 @@ async def list_model_endpoints(
                             If tsdb_metrics=False, this parameter will be ignored and no tsdb metrics
                             will be included.
     :param top_level:       Whether to return only top level model endpoints.
+    :param mode:            Specifies the mode of the model endpoint. Can be "real-time", "batch", or both if set to
+                            None.
     :param uids:            A list of unique ids to filter by.
     :param latest_only:     Whether to return only the latest model endpoint for each name.
     :param auth_info:       The auth info of the request.
@@ -289,6 +292,7 @@ async def list_model_endpoints(
         start=start,
         end=end,
         top_level=top_level,
+        mode=mode,
         tsdb_metrics=tsdb_metrics,
         metric_list=metric_list,
         uids=uids,

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -242,7 +242,7 @@ async def list_model_endpoints(
     start: Optional[datetime] = None,
     end: Optional[datetime] = None,
     top_level: bool = Query(False, alias="top-level"),
-    mode: mm_constants.EndpointMode = Query(None, alias="mode"),
+    mode: mm_constants.EndpointMode = None,
     tsdb_metrics: bool = Query(True, alias="tsdb-metrics"),
     metric_list: Optional[list[str]] = Query(None, alias="metric"),
     uids: list[str] = Query(None, alias="uid"),

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -987,6 +987,7 @@ class ModelEndpoints:
         start: typing.Optional[datetime] = None,
         end: typing.Optional[datetime] = None,
         top_level: typing.Optional[bool] = None,
+        mode: typing.Optional[mlrun.common.schemas.EndpointMode] = None,
         tsdb_metrics: typing.Optional[bool] = None,
         metric_list: Optional[list[str]] = None,
         uids: typing.Optional[list[str]] = None,
@@ -1004,6 +1005,8 @@ class ModelEndpoints:
         :param start:               The start time of the model endpoint creation.
         :param end:                 The end time of the model endpoint creation.
         :param top_level:           When True, only top level model endpoints will be returned.
+        :param mode:                Specifies the mode of the model endpoint. Can be "real-time", "batch", or both
+                                    if set to None.
         :param tsdb_metrics:        When True, the time series metrics will be added to the output of the resulting
         :param metric_list:         List of metrics to include from the time series DB. Defaults to all metrics.
                                     If tsdb_metrics=False, this parameter will be ignored and no tsdb metrics
@@ -1029,6 +1032,7 @@ class ModelEndpoints:
             start=start,
             end=end,
             top_level=top_level,
+            mode=mode,
             tsdb_metrics=tsdb_metrics,
             metric_list=metric_list,
             uids=uids,
@@ -1049,6 +1053,7 @@ class ModelEndpoints:
             start=start,
             end=end,
             top_level=top_level,
+            mode=mode,
             uids=uids,
             latest_only=latest_only,
         )

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -741,6 +741,7 @@ class RunDBMock:
         labels: Optional[Union[str, dict[str, Optional[str]], list[str]]] = None,
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
+        mode: Optional[mlrun.common.schemas.EndpointMode] = None,
         tsdb_metrics: bool = False,
         metric_list: Optional[list[str]] = None,
         top_level: bool = False,

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -31,7 +31,7 @@ from mlrun.common.model_monitoring.helpers import (
     pad_features_hist,
     pad_hist,
 )
-from mlrun.common.schemas import EndpointType, ModelEndpoint
+from mlrun.common.schemas import EndpointMode, EndpointType, ModelEndpoint
 from mlrun.common.schemas.model_monitoring.constants import EventFieldType
 from mlrun.datastore import KafkaOutputStream, OutputStream
 from mlrun.datastore.datastore_profile import (
@@ -381,12 +381,21 @@ class TestBatchWindowGenerator:
     def test_last_updated_is_in_the_past() -> None:
         last_request = datetime.datetime(2023, 11, 16, 12, 0, 0)
         last_updated = _BatchWindowGenerator._get_last_updated_time(
-            last_request=last_request, not_batch_endpoint=True
+            last_request=last_request, endpoint_mode=EndpointMode.REAL_TIME
         )
         assert last_updated
         assert (
             last_updated < last_request.timestamp()
         ), "The last updated time should be before the last request"
+
+        last_updated = _BatchWindowGenerator._get_last_updated_time(
+            last_request=last_request, endpoint_mode=EndpointMode.BATCH
+        )
+
+        assert last_updated
+        assert (
+            last_updated == last_request.timestamp()
+        ), "The last updated time should similar to the last request time for batch endpoints"
 
 
 class TestBumpModelEndpointLastRequest:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1100,7 +1100,6 @@ class TestServingJobEndpoint(TestMLRunSystemModelMonitoring, _V3IORecordsChecker
 
         first_result = response_content[0]
         assert first_result["full_name"] in results_full_names
-        assert first_result["data"] == True
         assert len(first_result["values"]) == 2
 
     def test_serving_as_a_job(self) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -19,7 +19,7 @@ import time
 import typing
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import kafka
@@ -897,8 +897,13 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
 
 @TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
-    project_name = "test-mm-record-results"
+class TestServingJobEndpoint(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
+    """
+    Demonstrates running a serving job with model monitoring enabled.  In this test, we deploy a simple serving model
+    and then validate the newly created batch model endpoint along with its application results.
+    """
+
+    project_name = "test-mm-serving-job"
     name_prefix = "infer-monitoring"
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: typing.Optional[str] = None
@@ -932,7 +937,7 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
         # model monitoring infra
         cls.app_interval: int = 1  # every 1 minute
         cls.app_interval_seconds = timedelta(minutes=cls.app_interval).total_seconds()
-        cls.apps_data = [_DefaultDataDriftAppData, cls.app_data]
+        cls.apps_data = [cls.app_data]
 
     def custom_setup(self) -> None:
         self.set_mm_credentials()
@@ -952,6 +957,23 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
             cls.x_train,
             cls.y_train,  # pyright: ignore[reportGeneralTypeIssues]
         )
+
+    @staticmethod
+    def _generate_input_df() -> pd.DataFrame:
+        d = {
+            "column_0": {0: 0.1, 1: 1.3, 2: 0.7},
+            "column_1": {0: 0.3, 1: -2.2, 2: -2.0},
+            "column_2": {0: 0.01, 1: 2.3, 2: 1.59},
+            "column_3": {0: -0.38, 1: 1.83, 2: 1.86},
+            "column_4": {0: -0.7, 1: 0.8, 2: 1.27},
+        }
+
+        df = pd.DataFrame(d)
+        input_df = df.set_index(
+            pd.date_range("2025-07-24 05:00:10", freq="40s", periods=len(df))
+        )
+        input_df.reset_index(inplace=True)
+        return input_df
 
     def _log_model(self) -> None:
         self.project.log_model(  # pyright: ignore[reportOptionalMemberAccess]
@@ -976,27 +998,112 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
         self.project.deploy_function(fn)
         return fn
 
-    def _record_results(self) -> str:
-        model_endpoint = mlrun.model_monitoring.api.record_results(
-            project=self.project_name,
-            model_path=self.project.get_artifact_uri(  # pyright: ignore[reportOptionalMemberAccess]
-                key=self.model_name, category="model", tag="latest"
-            ),
-            model_endpoint_name=f"{self.name_prefix}-test",
-            function_name=self.function_name,
-            context=mlrun.get_or_create_ctx(name=f"{self.name_prefix}-context"),  # pyright: ignore[reportGeneralTypeIssues]
-            infer_results_df=self.infer_results_df,
-        )
-
-        return model_endpoint.metadata.uid
-
     def _deploy_monitoring_infra(self) -> None:
         self.project.enable_model_monitoring(  # pyright: ignore[reportOptionalMemberAccess]
             base_period=self.app_interval,
             **({} if self.image is None else {"image": self.image}),
+            deploy_histogram_data_drift_app=False,
+            wait_for_deployment=True,
         )
 
-    def test_inference_feature_set(self) -> None:
+    def _run_serving_job(self, input_df: pd.DataFrame) -> mlrun.runtimes.BaseRuntime:
+        function = self.project.set_function(
+            func=str(self.assets_path / "function_with_model.py"),
+            name="test",
+            kind="serving",
+            image=self.image,
+        )
+        graph = function.set_topology("flow", engine="async")
+
+        model_runner_step = mlrun.serving.ModelRunnerStep(name="my_model_runner")
+
+        model_runner_step.add_model(
+            endpoint_name="my_model",
+            model_class="DummyModel",
+            execution_mechanism="naive",
+            model_endpoint_creation_strategy=mm_constants.ModelEndpointCreationStrategy.OVERWRITE,
+        )
+
+        graph.to(model_runner_step)
+        function.set_tracking()
+        job = function.to_job()
+
+        input_dataset = self.project.log_dataset("input_dataset", input_df)
+        inputs = {"data": input_dataset.uri}
+        params = {"timestamp_column": "index"}
+        self.project.run_function(job, inputs=inputs, params=params)
+        return function
+
+    def _test_batch_ep_results(
+        self, function_name: str, input_df: pd.DataFrame
+    ) -> None:
+        model_endpoint = mlrun.get_run_db().get_model_endpoint(
+            name="my_model",
+            project=self.project_name,
+            function_name=function_name,
+            function_tag="latest",
+        )
+
+        assert model_endpoint is not None, "Model endpoint was not created"
+
+        self._test_predictions_table(model_endpoint.metadata.uid, should_be_empty=False)
+
+        assert model_endpoint.status.first_request == input_df[
+            "index"
+        ].min().to_pydatetime().replace(tzinfo=timezone.utc)
+        assert model_endpoint.status.last_request == input_df[
+            "index"
+        ].max().to_pydatetime().replace(tzinfo=timezone.utc)
+
+        run_db = mlrun.get_run_db()
+
+        monitoring_results = run_db.get_model_endpoint_monitoring_metrics(
+            project=self.project_name,
+            endpoint_id=model_endpoint.metadata.uid,
+            type="results",
+        )
+
+        assert len(monitoring_results) == 2
+        result_names = [result.full_name for result in monitoring_results]
+
+        self._test_result_values(
+            ep_id=model_endpoint.metadata.uid,
+            results_full_names=result_names,
+            run_db=run_db,
+            start=0,
+            end=datetime.now().timestamp() * 1000,
+        )
+
+    def _test_result_values(
+        self,
+        ep_id: str,
+        results_full_names: list[str],
+        run_db: mlrun.db.httpdb.HTTPRunDB,
+        start: typing.Optional[float],
+        end: typing.Optional[float],
+    ) -> None:
+        base_query = f"?name={'&name='.join(results_full_names)}"
+        query = f"{base_query}&start={start}&end={end}"
+
+        response = run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=f"projects/{self.project_name}/model-endpoints/{ep_id}/metrics-values{query}",
+        )
+        response_content = json.loads(response.content.decode())
+        for result_values in response_content:
+            assert result_values[
+                "data"
+            ], f"No data for result {result_values['full_name']}"
+            assert result_values[
+                "values"
+            ], f"The values list is empty for result {result_values['full_name']}"
+
+        first_result = response_content[0]
+        assert first_result["full_name"] in results_full_names
+        assert first_result["data"] == True
+        assert len(first_result["values"]) == 2
+
+    def test_serving_as_a_job(self) -> None:
         self._log_model()
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -1006,25 +1113,15 @@ class TestRecordResults(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
         fn = monitoring_app.result()
         self._assert_replicas(fn)
 
-        endpoint_id = self._record_results()
-
+        input_df = self._generate_input_df()
+        function = self._run_serving_job(input_df=input_df)
         time.sleep(
-            2 * self.app_interval_seconds
-            + mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
+            mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs + 20
         )
 
-        mep = mlrun.db.get_run_db().get_model_endpoint(
-            name=f"{self.name_prefix}-test",
-            project=self.project.name,
-            endpoint_id=endpoint_id,
-            feature_analysis=True,
-            tsdb_metrics=True,
+        self._test_batch_ep_results(
+            function_name=function.metadata.name, input_df=input_df
         )
-        self._test_v3io_records(
-            mep.metadata.uid,
-            apps_data=self.apps_data,
-        )
-        self._test_predictions_table(mep.metadata.uid, should_be_empty=True)
 
     @staticmethod
     def _assert_replicas(fn):

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -66,6 +66,7 @@ def mock_random_endpoint(
     function_tag: Optional[str] = "v1",
     model_path: Optional[str] = None,
     add_labels=True,
+    endpoint_type: EndpointType = EndpointType.NODE_EP,
 ) -> mlrun.common.schemas.model_monitoring.ModelEndpoint:
     def random_labels():
         return {f"{choice(string.ascii_letters)}": randint(0, 100) for _ in range(1, 5)}
@@ -75,6 +76,7 @@ def mock_random_endpoint(
             name=name,
             project=project_name,
             labels=random_labels() if add_labels else {},
+            endpoint_type=endpoint_type,
         ),
         spec=mlrun.common.schemas.model_monitoring.ModelEndpointSpec(
             function_name=function_name,
@@ -267,6 +269,39 @@ class TestModelEndpointsOperations(TestMLRunSystemModelMonitoring):
 
         endpoints_intersect = in_endpoint_names.intersection(out_endpoint_names)
         assert len(endpoints_intersect) == number_of_endpoints
+
+    def test_list_endpoints_mode(self):
+        db = mlrun.get_run_db()
+
+        number_of_real_time_eps = 2
+        number_of_batch_eps = 3
+        real_time_eps = [
+            mock_random_endpoint(self.project_name, f"real-time-{i}")
+            for i in range(number_of_real_time_eps)
+        ]
+
+        batch_eps = [
+            mock_random_endpoint(
+                self.project_name, f"batch-{i}", endpoint_type=EndpointType.BATCH_EP
+            )
+            for i in range(number_of_batch_eps)
+        ]
+
+        for endpoint in real_time_eps + batch_eps:
+            db.create_model_endpoint(endpoint)
+
+        eps = self.project.list_model_endpoints().endpoints
+        assert len(eps) == number_of_real_time_eps + number_of_batch_eps
+
+        real_time_eps = self.project.list_model_endpoints(
+            mode=mm_constants.EndpointMode.REAL_TIME
+        ).endpoints
+        assert len(real_time_eps) == number_of_real_time_eps
+
+        batch_eps = self.project.list_model_endpoints(
+            mode=mm_constants.EndpointMode.BATCH
+        ).endpoints
+        assert len(batch_eps) == number_of_batch_eps
 
     def test_labels(self):
         db = mlrun.get_run_db()


### PR DESCRIPTION
As part of supporting monitoring for batch model endpoints generated through serving jobs (#8355 ), this PR implements batch event handling in the controller.

In more detail:

- When a `batch_complete` event is pushed to the controller stream (#8363 ), it is identified as a new type of event that already includes both the start and end times of a potentially large time range, along with relevant `endpoint_id`.
- The controller generates analysis windows starting from the maximum of `last_analyzed` and the start batch time for the processed model endpoint.
- The final window is always analyzed and closed, even if it’s only a partial window (`base_period` - `delta`), and `last_analyzed` is updated accordingly.

Additionally, this PR introduces a new mode filter in the `list_model_endpoints` API, which can be either `real_time` or `batch`.


https://iguazio.atlassian.net/browse/ML-10558