### PR TITLE
[Services] Fix `submit_run` call

### DIFF
--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -887,6 +887,15 @@ def submit_run_sync(
     return project, fn.kind, run_uid, {"data": response}
 
 
+def submit_run_from_body(
+    db_session: Session,
+    auth_info: mlrun.common.schemas.AuthInfo,
+    data,
+):
+    fn, task = _generate_function_and_task_from_submit_run_body(db_session, data)
+    return submit_run_sync(db_session, auth_info, fn, task, data)
+
+
 # uid is hexdigest of sha1 value, which is double the digest size due to hex encoding
 hash_len = sha1().digest_size * 2
 uid_regex = re.compile(f"^[0-9a-f]{{{hash_len}}}$", re.IGNORECASE)

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -893,6 +893,8 @@ def submit_run_from_body(
     data,
 ):
     fn, task = _generate_function_and_task_from_submit_run_body(db_session, data)
+    run_db = get_run_db_instance(db_session)
+    fn.set_db_connection(run_db)
     return submit_run_sync(db_session, auth_info, fn, task, data)
 
 

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -1105,7 +1105,7 @@ class Service(framework.service.Service):
                 "task": run.to_dict(),
             }
             framework.db.session.run_function_with_new_db_session(
-                framework.api.utils.submit_run_sync,
+                framework.api.utils.submit_run_from_body,
                 # auth is already masked on the function
                 mlrun.common.schemas.AuthInfo(),
                 # TODO: pass values for param_file_secrets ?

--- a/server/py/services/api/tests/unit/test_service.py
+++ b/server/py/services/api/tests/unit/test_service.py
@@ -38,12 +38,13 @@ class TestService(TestAPIBase):
         run = self._generate_retry_job(uid=run_uid)
         run_db = mlrun.db.get_run_db()
         with unittest.mock.patch(
-            "framework.api.utils.submit_run_sync", return_value=unittest.mock.Mock()
-        ) as mock_submit_run_sync:
+            "framework.api.utils.submit_run_from_body",
+            return_value=unittest.mock.Mock(),
+        ) as mock_submit_run_from_body:
             run_db.store_run(struct=run, uid=run_uid, project=self._project)
             await self._service._retry_jobs()
             await asyncio.sleep(1)
-            mock_submit_run_sync.assert_called_once()
+            mock_submit_run_from_body.assert_called_once()
 
     async def test_retry_job_retry_exhausted(self, db: Session):
         run_uid = "test-job-uid"
@@ -54,11 +55,12 @@ class TestService(TestAPIBase):
         )
         run_db = mlrun.db.get_run_db()
         with unittest.mock.patch(
-            "framework.api.utils.submit_run_sync", return_value=unittest.mock.Mock()
-        ) as mock_submit_run_sync:
+            "framework.api.utils.submit_run_from_body",
+            return_value=unittest.mock.Mock(),
+        ) as mock_submit_run_from_body:
             run_db.store_run(struct=run, uid=run_uid, project=self._project)
             await self._service._retry_jobs()
-            mock_submit_run_sync.assert_not_called()
+            mock_submit_run_from_body.assert_not_called()
 
         run = run_db.read_run(uid=run_uid, project=self._project)
         assert run["status"]["state"] == mlrun.common.runtimes.constants.RunStates.error
@@ -71,15 +73,16 @@ class TestService(TestAPIBase):
         run = self._generate_retry_job(uid=run_uid)
         run_db = mlrun.db.get_run_db()
         with unittest.mock.patch(
-            "framework.api.utils.submit_run_sync", return_value=unittest.mock.Mock()
-        ) as mock_submit_run_sync:
+            "framework.api.utils.submit_run_from_body",
+            return_value=unittest.mock.Mock(),
+        ) as mock_submit_run_from_body:
             run_db.store_run(struct=run, uid=run_uid, project=self._project)
             await self._service._retry_jobs()
             assert run_uid in self._service._retry_in_progress_run_uids
             # Next retry should not submit the job again
             await self._service._retry_jobs()
             await asyncio.sleep(1)
-            mock_submit_run_sync.assert_called_once()
+            mock_submit_run_from_body.assert_called_once()
             assert not self._service._retry_in_progress_run_uids
 
     async def test_retry_job_paginated_list_runs(self, db: Session):
@@ -105,10 +108,11 @@ class TestService(TestAPIBase):
         # Also, waiting less than a second does not work.
         await asyncio.sleep(1)
         with unittest.mock.patch(
-            "framework.api.utils.submit_run_sync", return_value=unittest.mock.Mock()
-        ) as mock_submit_run_sync:
+            "framework.api.utils.submit_run_from_body",
+            return_value=unittest.mock.Mock(),
+        ) as mock_submit_run_from_body:
             await self._service._retry_jobs()
-            assert mock_submit_run_sync.call_count == 10
+            assert mock_submit_run_from_body.call_count == 10
 
     async def test_retry_stale_job(self, db: Session):
         staleness_threshold = 60 * 24 * 1

--- a/server/py/services/api/utils/scheduler.py
+++ b/server/py/services/api/utils/scheduler.py
@@ -35,9 +35,6 @@ from mlrun.config import config
 from mlrun.errors import err_to_str
 from mlrun.model import RunObject
 from mlrun.utils import logger
-from server.py.framework.api.utils import (
-    _generate_function_and_task_from_submit_run_body,
-)
 
 import framework.api.utils
 import framework.utils.helpers
@@ -1114,11 +1111,8 @@ class Scheduler:
                     schedule_name,
                 )
 
-            fn, task = _generate_function_and_task_from_submit_run_body(
-                db_session, scheduled_object
-            )
-            _, _, _, response = framework.api.utils.submit_run_sync(
-                db_session, auth_info, fn, task, scheduled_object
+            _, _, _, response = framework.api.utils.submit_run_from_body(
+                db_session, auth_info, scheduled_object
             )
 
             run_metadata = response["data"]["metadata"]

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -736,6 +736,7 @@ def print_df(df):
             name="raise-func",
             kind="job",
             handler="handler",
+            image=self.image,
         )
 
         retry_count = 3


### PR DESCRIPTION
[ML-10641](https://iguazio.atlassian.net/browse/ML-10641)

Fixes `TestKubejobRuntime::test_retry_job_exhausted`

[ML-10641]: https://iguazio.atlassian.net/browse/ML-10641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ