### PR TITLE
[Deprecations] Remove /user-secrets endpoint and the corresponding SDK method [feature/ig4-authentication]

### DIFF
--- a/mlrun/api/schemas/__init__.py
+++ b/mlrun/api/schemas/__init__.py
@@ -253,8 +253,5 @@ AuthSecretData = DeprecationHelper(mlrun.common.schemas.AuthSecretData)
 SecretKeysData = DeprecationHelper(mlrun.common.schemas.SecretKeysData)
 SecretProviderName = DeprecationHelper(mlrun.common.schemas.SecretProviderName)
 SecretsData = DeprecationHelper(mlrun.common.schemas.SecretsData)
-UserSecretCreationRequest = DeprecationHelper(
-    mlrun.common.schemas.UserSecretCreationRequest
-)
 Tag = DeprecationHelper(mlrun.common.schemas.Tag)
 TagObjects = DeprecationHelper(mlrun.common.schemas.TagObjects)

--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -211,7 +211,6 @@ from .secret import (
     SecretKeysData,
     SecretProviderName,
     SecretsData,
-    UserSecretCreationRequest,
 )
 from .tag import Tag, TagObjects
 from .workflow import (

--- a/mlrun/common/schemas/secret.py
+++ b/mlrun/common/schemas/secret.py
@@ -47,7 +47,3 @@ class AuthSecretData(BaseModel):
 class SecretKeysData(BaseModel):
     provider: SecretProviderName = Field(SecretProviderName.vault)
     secret_keys: Optional[list] = []
-
-
-class UserSecretCreationRequest(SecretsData):
-    user: str

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -691,17 +691,6 @@ class RunDBInterface(ABC):
         pass
 
     @abstractmethod
-    def create_user_secrets(
-        self,
-        user: str,
-        provider: Union[
-            str, mlrun.common.schemas.SecretProviderName
-        ] = mlrun.common.schemas.SecretProviderName.vault,
-        secrets: Optional[dict] = None,
-    ):
-        pass
-
-    @abstractmethod
     def create_model_endpoint(
         self,
         model_endpoint: mlrun.common.schemas.ModelEndpoint,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3608,40 +3608,6 @@ class HTTPRunDB(RunDBInterface):
             )
         return parsed_metrics_by_endpoint
 
-    def create_user_secrets(
-        self,
-        user: str,
-        provider: Union[
-            str, mlrun.common.schemas.SecretProviderName
-        ] = mlrun.common.schemas.SecretProviderName.vault,
-        secrets: Optional[dict] = None,
-    ):
-        """Create user-context secret in Vault. Please refer to :py:func:`create_project_secrets` for more details
-        and status of this functionality.
-
-        Note:
-                This method is currently in technical preview, and requires a HashiCorp Vault infrastructure
-                properly set up and connected to the MLRun API server.
-
-        :param user: The user context for which to generate the infra and store secrets.
-        :param provider: The name of the secrets-provider to work with. Currently only ``vault`` is supported.
-        :param secrets: A set of secret values to store within the Vault.
-        """
-        path = "user-secrets"
-        secrets_creation_request = mlrun.common.schemas.UserSecretCreationRequest(
-            user=user,
-            provider=provider,
-            secrets=secrets,
-        )
-        body = secrets_creation_request.dict()
-        error_message = f"Failed creating user secrets - {user}"
-        self.api_call(
-            "POST",
-            path,
-            error_message,
-            body=dict_to_json(body),
-        )
-
     @staticmethod
     def _validate_version_compatibility(server_version, client_version) -> bool:
         try:

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -591,16 +591,6 @@ class NopDB(RunDBInterface):
     ):
         pass
 
-    def create_user_secrets(
-        self,
-        user: str,
-        provider: Union[
-            str, mlrun.common.schemas.SecretProviderName
-        ] = mlrun.common.schemas.SecretProviderName.vault,
-        secrets: Optional[dict] = None,
-    ):
-        pass
-
     def create_model_endpoint(
         self,
         model_endpoint: mlrun.common.schemas.ModelEndpoint,

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -1026,16 +1026,6 @@ class SQLRunDB(RunDBInterface):
     ):
         raise NotImplementedError()
 
-    def create_user_secrets(
-        self,
-        user: str,
-        provider: Union[
-            str, mlrun.common.schemas.SecretProviderName
-        ] = mlrun.common.schemas.SecretProviderName.vault,
-        secrets: Optional[dict] = None,
-    ):
-        raise NotImplementedError()
-
     def create_model_endpoint(
         self,
         model_endpoint: mlrun.common.schemas.ModelEndpoint,

--- a/server/py/services/api/api/endpoints/secrets.py
+++ b/server/py/services/api/api/endpoints/secrets.py
@@ -169,14 +169,3 @@ async def list_project_secrets(
         secrets,
         token,
     )
-
-
-@router.post("/user-secrets", status_code=HTTPStatus.CREATED.value)
-def add_user_secrets(
-    secrets: mlrun.common.schemas.UserSecretCreationRequest,
-):
-    # vault is not used
-    return fastapi.Response(
-        status_code=HTTPStatus.BAD_REQUEST.value,
-        content=f"Invalid secrets provider {secrets.provider}",
-    )


### PR DESCRIPTION
The previous `/user-secrets` POST endpoint was never implemented and always returns HTTP 400. It will be removed and replaced with a scoped API under `/api/v1/user-secrets/tokens`, which is purpose-built for token management.

removing also the related SDK method `db.create_user_secrets(...)`
https://iguazio.atlassian.net/browse/ML-10452