### PR TITLE
[Workflows] Add indication for rerun to notification body

### DIFF
--- a/server/py/services/api/crud/pipelines.py
+++ b/server/py/services/api/crud/pipelines.py
@@ -414,6 +414,7 @@ class Pipelines(
         :param original_runner:  The RunObject of the original workflow-runner function.
         :param auth_info:        Caller’s authentication info.
         :param client_version:   Optional SDK version header, to pin the runner image.
+        :param rerun_index:      The index of this retry (e.g. 1 for first retry, 2 for second, etc.).
         :return:                 A WorkflowResponse with:
                                    - project: same project name
                                    - name:    the MLRun function name for the rerun
@@ -451,13 +452,18 @@ class Pipelines(
         original_runner_notifications = (
             original_runner.spec.notifications.to_dict()
             if original_runner.spec.notifications
-            else None
+            else []
         )
+
+        rerun_notifications = [
+            self._augment_notification_for_retry(n, rerun_index)
+            for n in original_runner_notifications
+        ]
 
         rerun_request = mlrun.common.schemas.RerunWorkflowRequest(
             run_name=run_name,
             run_id=run_id,
-            notifications=original_runner_notifications,
+            notifications=rerun_notifications,
             workflow_runner_node_selector=original_runner.spec.node_selector,
             original_workflow_runner_uid=original_runner.metadata.uid,
             original_workflow_name=original_runner.spec.parameters["workflow_name"],
@@ -821,3 +827,15 @@ class Pipelines(
             return False
 
         return list(filter(filter_by, runs))
+
+    @staticmethod
+    def _augment_notification_for_retry(
+        notification: dict[str, typing.Any], rerun_index: int
+    ) -> dict[str, typing.Any]:
+        """
+        Return a new notification dict with its `name` suffixed by "– Retry #<idx>".
+        """
+        return {
+            **notification,
+            "name": f"{notification.get('name','')} – Retry #{rerun_index}",
+        }

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -943,6 +943,13 @@ class TestProject(TestMLRunSystem):
             == mlrun.common.runtimes.constants.RunStates.completed
         )
 
+        assert all(
+            [
+                "Retry #1" in notification[0]["spec"]["notifications"][0]["name"]
+                for notification in notifications
+            ]
+        )
+
         second_rerun_id = mlrun.retry_pipeline(
             run_id=run_id.run_id, project=project_name
         )


### PR DESCRIPTION
### Description
Adds a retry indicator and sequence number to pipeline notification titles, making it easy to distinguish and track individual retry attempts.
For example (see attachment) - the email notification header now include `– Retry #2` for the second retry.

### Testing
- Covered by system tests
- Manual validation of notification titles across multiple notification types

### References
 - Jira: [ML-10223](https://iguazio.atlassian.net/browse/ML-10223)

<img width="730" height="580" alt="image" src="https://github.com/user-attachments/assets/55f96103-e53b-47a0-b7f8-fb0fd71c4705" />


[ML-10223]: https://iguazio.atlassian.net/browse/ML-10223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ