### PR TITLE
[Artifacts] add has_children to minimal list format

### DIFF
--- a/mlrun/common/formatters/artifact.py
+++ b/mlrun/common/formatters/artifact.py
@@ -41,6 +41,7 @@ class ArtifactFormat(ObjectFormat, mlrun.common.types.StrEnum):
                     "spec.metrics",
                     "spec.target_path",
                     "spec.parent_uri",
+                    "spec.has_children",
                 ]
             ),
         }[_format]


### PR DESCRIPTION
Add `has_children` to minimal artifact format.
This flag is needed for the UI in order to disable model deletion from the table view.