### PR TITLE
[DB] Harden DSN parser, add exhaustive tests

### DIFF
--- a/server/py/framework/utils/db/dsn.py
+++ b/server/py/framework/utils/db/dsn.py
@@ -1,0 +1,150 @@
+import re
+from typing import Any, Optional, Union
+from urllib.parse import parse_qs, quote, unquote, urlparse
+
+import sqlalchemy
+
+import mlrun
+import mlrun.common.db.dialects
+
+
+class Dsn:
+    _IDENTIFIER_REGEX = re.compile(r"[A-Za-z][A-Za-z0-9_.-]*")  # driver
+    _HOST_REGEX = re.compile(r"(?:[A-Za-z0-9.\-]+|\[[0-9A-Fa-f:]+\])")  # host / IPv6
+    # SQLite path may not start with “/” and must not contain “..”
+    _PATH_REGEX = re.compile(r"(?!/)(?!.*\.\.)[A-Za-z0-9_\-./]+")
+    _DBNAME_REGEX = re.compile(r"[A-Za-z0-9_\-\.$]+")  # db‑name
+    _SAFE_USERINFO_CHARS = "~/"  # characters we do NOT percent‑encode in user‑info
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        escaped_dsn = self._encode_credentials(dsn)
+        self._parsed = urlparse(escaped_dsn)
+        self.dialect, self.driver = self._split_scheme(self._parsed.scheme)
+
+        # Connection components
+        if self.dialect == mlrun.common.db.dialects.Dialects.SQLITE:
+            # For SQLite the path is part of the file name, not the DB name
+            self.username = self.password = self.host = self.port = self.database = None
+        else:
+            self.username = (
+                unquote(self._parsed.username) if self._parsed.username else None
+            )
+            if self._parsed.password:
+                # first pass undoes our own %25 escaping, second pass undoes user‑supplied escapes
+                pwd_once_unquoted = unquote(self._parsed.password)
+                self.password = unquote(pwd_once_unquoted)
+            else:
+                self.password = None
+            self.host = self._parsed.hostname
+            try:
+                # urlparse.port raises ValueError for non‑numeric ports
+                self.port = self._parsed.port
+            except ValueError:
+                self.port = None
+            self.database = self._parsed.path.lstrip("/") or None
+
+        # Query configurations
+        if self._parsed.query:
+            raw_qs = parse_qs(self._parsed.query)
+            self.configurations: dict[str, Union[str, list[str]]] = {
+                key: (value[0] if len(value) == 1 else value)
+                for key, value in raw_qs.items()
+            }
+        else:
+            self.configurations = {}
+
+    def _encode_credentials(self, dsn: str) -> str:
+        """
+        Percent‑encode the user‑info (everything up to, but not including, the
+        final “@” in the authority component) so that urlparse() will not split
+        on reserved characters such as '#', '?', '|', '<', etc.
+        """
+        if "://" not in dsn or "@" not in dsn:
+            return dsn
+        scheme, url_after_scheme = dsn.split("://", 1)
+        # split on the *last* “@” to tolerate raw “@” inside the password
+        userinfo, _, host_port = url_after_scheme.rpartition("@")
+        if not userinfo:  # no credentials section
+            return dsn
+        if ":" in userinfo:
+            user, pwd = userinfo.split(":", 1)
+            encoded_userinfo = (
+                f"{quote(user, safe=self._SAFE_USERINFO_CHARS)}:"
+                f"{quote(pwd, safe=self._SAFE_USERINFO_CHARS)}"
+            )
+        else:
+            encoded_userinfo = quote(userinfo, safe=self._SAFE_USERINFO_CHARS)
+        return f"{scheme}://{encoded_userinfo}@{host_port}"
+
+    def is_valid(self) -> bool:
+        """
+        DSN validator
+
+        1. Dialect must be known.
+        2. Driver (if present) must be a valid identifier.
+        3. SQLite DSNs: validate the optional path and return early.
+        4. Other DBs: validate database name, user/host/port.
+        """
+        if self.dialect not in mlrun.common.db.dialects.Dialects.all():
+            return False
+
+        if self.driver and not self._IDENTIFIER_REGEX.fullmatch(self.driver):
+            return False
+
+        # The authority part must contain exactly *one* raw “@”
+        url_after_scheme = self._dsn.split("://", 1)[-1]
+        if url_after_scheme.count("@") != 1:
+            return False
+
+        if self.dialect == mlrun.common.db.dialects.Dialects.SQLITE:
+            raw_path = self._parsed.path.lstrip("/")
+            return (
+                not raw_path
+                or raw_path == ":memory:"
+                or self._PATH_REGEX.fullmatch(raw_path)
+            )
+
+        if self.database is None or not self._DBNAME_REGEX.fullmatch(self.database):
+            return False
+        if not self.username:  # username required
+            return False
+        if not self.host or not self._HOST_REGEX.fullmatch(self.host):
+            return False
+        if self.port is None or not 1 <= self.port <= 65535:
+            return False
+        return True
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "dialect": self.dialect,
+            "driver": self.driver,
+            "username": self.username,
+            "password": self.password,
+            "host": self.host,
+            "port": self.port,
+            "database": self.database,
+            "configurations": self.configurations,
+        }
+
+    def as_sqlalchemy_dsn(self):
+        drivername = (
+            self.dialect if self.driver is None else f"{self.dialect}+{self.driver}"
+        )
+        return sqlalchemy.URL(
+            drivername=drivername,
+            username=self.username,
+            password=self.password,
+            host=self.host,
+            port=self.port,
+            database=self.database,
+            query=self.configurations or None,  # keep query params
+        )
+
+    def __str__(self) -> str:
+        return self.as_sqlalchemy_dsn().render_as_string()
+
+    @staticmethod
+    def _split_scheme(scheme: str) -> tuple[str, Optional[str]]:
+        parts = scheme.split("+", 1)
+        return parts[0], parts[1] if len(parts) == 2 else None

--- a/server/py/framework/utils/db/dsn.py
+++ b/server/py/framework/utils/db/dsn.py
@@ -1,3 +1,16 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import re
 from typing import Any, Optional, Union
 from urllib.parse import parse_qs, quote, unquote, urlparse

--- a/server/py/framework/utils/db/utils.py
+++ b/server/py/framework/utils/db/utils.py
@@ -16,7 +16,7 @@ import importlib
 import os
 import re
 from typing import Any, Optional, Union
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse, urlsplit
 
 import sqlalchemy
 
@@ -37,6 +37,7 @@ class ParsedDsn:
     _HOST_REGEX = re.compile(r"[A-Za-z0-9.\-]+")  # host
     _PATH_REGEX = re.compile(r"[A-Za-z0-9_\-./]+")  # sqlite path
     _DBNAME_REGEX = re.compile(r"[A-Za-z0-9_\-$]+")  # db-name
+    _SAFE_CHARS = "~"
 
     def __init__(self, dsn: str) -> None:
         self._dsn = dsn
@@ -72,6 +73,25 @@ class ParsedDsn:
             }
         else:
             self.configurations = {}
+
+    def _encode_credentials(self, dsn: str) -> str:
+        """
+        Percent‑encode the username / password part (everything left of the
+        last '@') so urlsplit() won’t treat reserved chars (#, ?, |, < …) as
+        delimiters.
+        """
+        if "://" not in dsn or "@" not in dsn:
+            return dsn
+        scheme, rest = dsn.split("://", 1)
+        creds, hostport = rest.rsplit("@", 1)
+        if ":" in creds:
+            user, pwd = creds.split(":", 1)
+            user_enc = quote(user, safe=self._SAFE_CHARS)
+            pwd_enc = quote(pwd, safe=self._SAFE_CHARS)
+            creds_enc = f"{user_enc}:{pwd_enc}"
+        else:
+            creds_enc = quote(creds, safe=self._SAFE_CHARS)
+        return f"{scheme}://{creds_enc}@{hostport}"
 
     def is_valid(self) -> bool:
         """
@@ -193,7 +213,20 @@ class DBUtil:
 
     @classmethod
     def get_parsed_dsn(cls) -> ParsedDsn:
-        return ParsedDsn(cls.get_dsn())
+        raw_dsn = cls.get_dsn()
+        if not raw_dsn:
+            raise ValueError("No DSN provided.")
+
+        clean = cls._encode_credentials(raw_dsn)
+        parsed = urlsplit(clean)
+
+        return ParsedDsn(
+            username=unquote(parsed.username) if parsed.username else None,
+            password=unquote(parsed.password) if parsed.password else None,
+            host=parsed.hostname,
+            port=parsed.port,
+            database=parsed.path.lstrip("/") or None,
+        )
 
     def _get_connection(self):
         return self._get_driver().connect(**self._connection_kwargs())

--- a/server/py/framework/utils/db/utils.py
+++ b/server/py/framework/utils/db/utils.py
@@ -14,15 +14,13 @@
 
 import importlib
 import os
-import re
 from typing import Any, Optional, Union
-from urllib.parse import parse_qs, quote, unquote, urlparse, urlsplit
-
-import sqlalchemy
 
 import mlrun.common.db.dialects
 import mlrun.errors
 import mlrun.utils
+
+import framework.utils.db.dsn
 
 _DEFAULT_DRIVER_FOR_DIALECT: dict[str, str] = {
     mlrun.common.db.dialects.Dialects.MYSQL: "pymysql",
@@ -30,132 +28,6 @@ _DEFAULT_DRIVER_FOR_DIALECT: dict[str, str] = {
     mlrun.common.db.dialects.Dialects.SQLITE: "sqlite3",
 }
 _ALLOWED_DRIVERS: set[str] = set(_DEFAULT_DRIVER_FOR_DIALECT.values())
-
-
-class ParsedDsn:
-    _IDENTIFIER_REGEX = re.compile(r"[A-Za-z][A-Za-z0-9_]*")  # driver
-    _HOST_REGEX = re.compile(r"[A-Za-z0-9.\-]+")  # host
-    _PATH_REGEX = re.compile(r"[A-Za-z0-9_\-./]+")  # sqlite path
-    _DBNAME_REGEX = re.compile(r"[A-Za-z0-9_\-$]+")  # db-name
-    _SAFE_CHARS = "~"
-
-    def __init__(self, dsn: str) -> None:
-        self._dsn = dsn
-        self._parsed = urlparse(dsn)
-        self.dialect, self.driver = self._split_scheme(
-            scheme=self._parsed.scheme,
-        )
-
-        # Connection components
-        if self.dialect == mlrun.common.db.dialects.Dialects.SQLITE:
-            self.username = None
-            self.password = None
-            self.host = None
-            self.port = None
-            # SQLite DSNs ignore database path
-            self.database = None
-        else:
-            self.username = self._parsed.username
-            self.password = self._parsed.password
-            self.host = self._parsed.hostname
-            try:
-                self.port = self._parsed.port
-            except ValueError:
-                self.port = 0
-            self.database = self._parsed.path.lstrip("/") or None
-
-        # Query configurations
-        if self._parsed.query:
-            raw_qs = parse_qs(self._parsed.query)
-            self.configurations: dict[str, Union[str, list[str]]] = {
-                key: (value[0] if len(value) == 1 else value)
-                for key, value in raw_qs.items()
-            }
-        else:
-            self.configurations = {}
-
-    def _encode_credentials(self, dsn: str) -> str:
-        """
-        Percent‑encode the username / password part (everything left of the
-        last '@') so urlsplit() won’t treat reserved chars (#, ?, |, < …) as
-        delimiters.
-        """
-        if "://" not in dsn or "@" not in dsn:
-            return dsn
-        scheme, rest = dsn.split("://", 1)
-        creds, hostport = rest.rsplit("@", 1)
-        if ":" in creds:
-            user, pwd = creds.split(":", 1)
-            user_enc = quote(user, safe=self._SAFE_CHARS)
-            pwd_enc = quote(pwd, safe=self._SAFE_CHARS)
-            creds_enc = f"{user_enc}:{pwd_enc}"
-        else:
-            creds_enc = quote(creds, safe=self._SAFE_CHARS)
-        return f"{scheme}://{creds_enc}@{hostport}"
-
-    def is_valid(self) -> bool:
-        """
-        DSN validator
-
-        1. Dialect must be known.
-        2. Driver (if present) must be a valid identifier.
-        3. SQLite DSNs: validate the optional path and return early.
-        4. Other DBs: validate database name, user/host/port.
-        """
-        if self.dialect not in mlrun.common.db.dialects.Dialects.all():
-            return False
-
-        if self.driver and not self._IDENTIFIER_REGEX.fullmatch(self.driver):
-            return False
-
-        if self.dialect == mlrun.common.db.dialects.Dialects.SQLITE:
-            raw_path = self._parsed.path.lstrip("/")
-            return (
-                not raw_path
-                or raw_path == ":memory:"
-                or self._PATH_REGEX.fullmatch(raw_path)
-            )
-
-        if self.database is None or not self._DBNAME_REGEX.fullmatch(self.database):
-            return False
-        if not self.username:
-            return False
-        if not self.host or not self._HOST_REGEX.fullmatch(self.host):
-            return False
-        if self.port is not None and not 1 <= self.port <= 65535:
-            return False
-
-        return True
-
-    def as_dict(self) -> dict[str, Any]:
-        return {
-            "dialect": self.dialect,
-            "driver": self.driver,
-            "username": self.username,
-            "password": self.password,
-            "host": self.host,
-            "port": self.port,
-            "database": self.database,
-            "configurations": self.configurations,
-        }
-
-    def as_sqlalchemy_dsn(self):
-        return sqlalchemy.URL(
-            drivername=f"{self.dialect}+{self.driver}",
-            username=self.username,
-            password=self.password,
-            host=self.host,
-            port=self.port,
-            database=self.database,
-        )
-
-    def __str__(self) -> str:
-        return self.as_sqlalchemy_dsn().render_as_string()
-
-    @staticmethod
-    def _split_scheme(scheme: str) -> tuple[str, Optional[str]]:
-        parts = scheme.split("+", 1)
-        return parts[0], parts[1] if len(parts) == 2 else None
 
 
 class DBUtil:
@@ -212,21 +84,12 @@ class DBUtil:
         raise NotImplementedError()
 
     @classmethod
-    def get_parsed_dsn(cls) -> ParsedDsn:
+    def get_parsed_dsn(cls) -> framework.utils.db.dsn.Dsn:
         raw_dsn = cls.get_dsn()
         if not raw_dsn:
             raise ValueError("No DSN provided.")
 
-        clean = cls._encode_credentials(raw_dsn)
-        parsed = urlsplit(clean)
-
-        return ParsedDsn(
-            username=unquote(parsed.username) if parsed.username else None,
-            password=unquote(parsed.password) if parsed.password else None,
-            host=parsed.hostname,
-            port=parsed.port,
-            database=parsed.path.lstrip("/") or None,
-        )
+        return framework.utils.db.dsn.Dsn(raw_dsn)
 
     def _get_connection(self):
         return self._get_driver().connect(**self._connection_kwargs())
@@ -262,12 +125,6 @@ class DBUtil:
                 ) from exc
 
         return self._DRIVER_CACHE[driver_name]
-
-    @classmethod
-    def _split_scheme(cls, dsn: str) -> tuple[str, Optional[str]]:
-        scheme = urlparse(dsn).scheme
-        parts = scheme.split("+", 1)
-        return parts[0], parts[1] if len(parts) == 2 else None
 
     def __new__(cls, *_, **__) -> "DBUtil":
         if cls is DBUtil:

--- a/server/py/services/api/tests/unit/utils/db/test_dsn.py
+++ b/server/py/services/api/tests/unit/utils/db/test_dsn.py
@@ -11,16 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+import typing
 
 import pytest
 
-import framework.utils.db.utils
+import framework.utils.db.dsn
 
 
 @pytest.mark.parametrize(
-    "http_dsn, expected_output",
+    "dsn, expected_output",
     [
+        (
+            "mysql+pymysql://test_user1:p~Xfi70|-ZM#U~Rf_5Ht2N<:ha9?@mlrun-test-db-instance.cucgqhjk51rp.us-east-2.rds.amazonaws.com:3306/mlrundb_vmdev214.lab.iguazeng.com",
+            {
+                "username": "test_user1",
+                "password": "p~Xfi70|-ZM#U~Rf_5Ht2N<:ha9?",
+                "host": "mlrun-test-db-instance.cucgqhjk51rp.us-east-2.rds.amazonaws.com",
+                "port": 3306,
+                "database": "mlrundb_vmdev214.lab.iguazeng.com",
+            },
+        ),
         (
             "mysql+pymysql://root:pass@localhost:3307/mlrun",
             {
@@ -116,15 +126,70 @@ import framework.utils.db.utils
         ("mysql+pymysql://root:pw@localhost:70000/mlrun", None),
         ("oracle://root:pw@localhost:1521/xe", None),
         ("mysql+pymysql://root:pw@:3306/mlrun", None),
+        # Encoded '@' in password
+        (
+            "mysql+pymysql://user:p%40ssw%40rd@db-host:3306/mlrun",
+            {
+                "username": "user",
+                "password": "p@ssw@rd",
+                "host": "db-host",
+                "port": 3306,
+                "database": "mlrun",
+            },
+        ),
+        # Password present, username missing → invalid
+        ("mysql+pymysql://:pw@localhost:3306/mlrun", None),
+        # No credentials & no '@' → invalid
+        ("mysql+pymysql://localhost:3306/mlrun", None),
+        # Non‑numeric port text → invalid
+        ("mysql+pymysql://root:pw@localhost:abC/mlrun", None),
+        # Missing port entirely → invalid
+        ("mysql+pymysql://root:pw@localhost/mlrun", None),
+        # MySQL with query params (valid, configs stored separately)
+        (
+            "mysql+pymysql://root:pw@db:3306/mlrun?charset=utf8mb4&ssl=true",
+            {
+                "username": "root",
+                "password": "pw",
+                "host": "db",
+                "port": 3306,
+                "database": "mlrun",
+            },
+        ),
+        # Postgres dialect
+        (
+            "postgresql://alice:pw@pg-host:5432/analytics",
+            {
+                "username": "alice",
+                "password": "pw",
+                "host": "pg-host",
+                "port": 5432,
+                "database": "analytics",
+            },
+        ),
+        # SQLite path traversal attempt is invalid
+        ("sqlite:///../etc/passwd", None),
+        # SQLite file with query string (valid)
+        (
+            "sqlite:///var/data/app.db?mode=ro&cache=shared",
+            {
+                "username": None,
+                "password": None,
+                "host": None,
+                "port": None,
+                "database": None,
+            },
+        ),
+        # password contains both %40 (encoded) and raw '@'
+        ("mysql+pymysql://u:foo%40ba@r@host:3306/db", None),  # should be invalid
     ],
 )
-def test_get_dsn_data(
-    http_dsn: str,
-    expected_output: Optional[dict],
+def test_parse_dsn(
+    dsn: str,
+    expected_output: typing.Optional[dict],
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setenv("MLRUN_HTTPDB__DSN", http_dsn)
-    parsed = framework.utils.db.utils.DBUtil.get_parsed_dsn()
+    parsed = framework.utils.db.dsn.Dsn(dsn)
 
     if expected_output is None:
         assert not parsed.is_valid()


### PR DESCRIPTION
**Refactored and relocated DSN parser logic**

- Moved `ParsedDsn` class from `framework/utils/db/utils.py` to `framework/utils/db/dsn.py`, renamed to `Dsn`.
- Refactored parser internals:
  - Improved percent-encoding for user-info components.
  - Stricter validation of dialect, driver, host, port, and database.
  - SQLite-specific path validation.
  - Uses `_encode_credentials()` and `urlsplit()` to avoid breaking on reserved characters.
- Enhanced unit tests:
  - Added coverage for encoded passwords, invalid port values, missing components, SQLite edge cases, and query strings.
https://iguazio.atlassian.net/browse/ML-10704