### PR TITLE
[Retry] Fix retry logic for early pod deletion

### DIFF
--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -642,7 +642,6 @@ class BaseRuntimeHandler(ABC):
                     "status.reason": reason,
                     "status.status_text": message,
                     "status.last_update": now.isoformat(),
-                    "status.end_time": now.isoformat(),
                 }
                 db.update_run(
                     db_session, updates=run_updates, uid=run_uid, project=project

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1769,6 +1769,8 @@ class BaseRuntimeHandler(ABC):
             elif run_state == RunStates.error:
                 # Try resolving the error reason
                 reason, message = self._resolve_container_error_status(runtime_resource)
+
+                # Check if the run should be retried, and update its status accordingly
                 run_state, message = self._evaluate_run_retry_state(
                     run, reason, message
                 )

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1929,9 +1929,7 @@ class BaseRuntimeHandler(ABC):
             message = f"Run failed attempt {attempt_number} of {max_retries + 1} with error: {message or reason}"
         elif 0 < max_retries <= retry_count:
             new_state = RunStates.error
-            message = (
-                f"Run failed after {attempt_number} attempts with error: {message or reason}"
-            )
+            message = f"Run failed after {attempt_number} attempts with error: {message or reason}"
         else:
             new_state = RunStates.error
         return new_state, message

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1919,14 +1919,14 @@ class BaseRuntimeHandler(ABC):
         max_retries = retry_spec.get("count", -1) if retry_spec else -1
         # Run status retry_count may be `None` if the run has never been retried
         retry_count = run.get("status", {}).get("retry_count") or 0
-        attempt_number = retry_count + 1
+        current_attempt = retry_count + 1
 
         if retry_count < max_retries:
             new_state = RunStates.pending_retry
-            message = f"Run failed attempt {attempt_number} of {max_retries + 1} with error: {message or reason}"
+            message = f"Run failed attempt {current_attempt} of {max_retries + 1} with error: {message or reason}"
         elif 0 < max_retries <= retry_count:
             new_state = RunStates.error
-            message = f"Run failed after {attempt_number} attempts with error: {message or reason}"
+            message = f"Run failed after {current_attempt} attempts with error: {message or reason}"
         else:
             new_state = RunStates.error
         return new_state, message

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -633,15 +633,23 @@ class BaseRuntimeHandler(ABC):
                         "possibly it was preempted or evicted. "
                         "Additional details may be available from Kubernetes events."
                     )
-                logger.info(
-                    "Updating run state", run_uid=run_uid, run_state=RunStates.error
-                )
-                run.setdefault("status", {})["state"] = RunStates.error
 
-                run.setdefault("status", {})["reason"] = reason
-                run.setdefault("status", {})["last_update"] = now.isoformat()
-                run.setdefault("status", {})["end_time"] = now.isoformat()
-                db.store_run(db_session, run, run_uid, project)
+                # Check if the run should be retried, and update its status accordingly
+                message = ""
+                run_state, message = self._evaluate_run_retry_state(
+                    run, reason, message
+                )
+                logger.info("Updating run state", run_uid=run_uid, run_state=run_state)
+                run_updates = {
+                    "status.state": run_state,
+                    "status.reason": reason,
+                    "status.status_text": message,
+                    "status.last_update": now.isoformat(),
+                    "status.end_time": now.isoformat(),
+                }
+                db.update_run(
+                    db_session, updates=run_updates, uid=run_uid, project=project
+                )
 
     def _get_runtime_resources(self, label_selector: str, namespace: str):
         """
@@ -1761,17 +1769,9 @@ class BaseRuntimeHandler(ABC):
             elif run_state == RunStates.error:
                 # Try resolving the error reason
                 reason, message = self._resolve_container_error_status(runtime_resource)
-                # Should run be retried
-                retry_spec = run.get("spec", {}).get("retry")
-                max_retries = retry_spec.get("count") if retry_spec else -1
-                # Run status retry_count may be `None` if the run has never been retried
-                retry_count = run.get("status", {}).get("retry_count", 0) or 0
-                attempts = retry_count + 1
-                if retry_count < max_retries:
-                    run_state = RunStates.pending_retry
-                    message = f"Run failed attempt {attempts} of {max_retries + 1} with error: {message or reason}"
-                elif 0 < max_retries <= retry_count:
-                    message = f"Run failed after {attempts} attempts with error: {message or reason}"
+                run_state, message = self._evaluate_run_retry_state(
+                    run, reason, message
+                )
 
         logger.info("Updating run state", run_uid=uid, run_state=run_state)
         run_updates = {
@@ -1908,3 +1908,28 @@ class BaseRuntimeHandler(ABC):
         else:
             new_meta.generate_name = norm_name
         return new_meta
+
+    @staticmethod
+    def _evaluate_run_retry_state(
+        run: dict, reason: str, message: str
+    ) -> tuple[str, str]:
+        """
+        Determine if the run should be retried or marked as failed, based on the retry policy and current attempt count.
+        """
+        retry_spec = run.get("spec", {}).get("retry")
+        max_retries = retry_spec.get("count") if retry_spec else -1
+        # Run status retry_count may be `None` if the run has never been retried
+        retry_count = run.get("status", {}).get("retry_count", 0) or 0
+        attempts = retry_count + 1
+
+        if retry_count < max_retries:
+            new_state = RunStates.pending_retry
+            message = f"Run failed attempt {attempts} of {max_retries + 1} with error: {message or reason}"
+        elif 0 < max_retries <= retry_count:
+            new_state = RunStates.error
+            message = (
+                f"Run failed after {attempts} attempts with error: {message or reason}"
+            )
+        else:
+            new_state = RunStates.error
+        return new_state, message

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1919,7 +1919,7 @@ class BaseRuntimeHandler(ABC):
         Determine if the run should be retried or marked as failed, based on the retry policy and current attempt count.
         """
         retry_spec = run.get("spec", {}).get("retry", {})
-        max_retries = retry_spec.get("count", -1)
+        max_retries = retry_spec.get("count") if retry_spec else -1
         # Run status retry_count may be `None` if the run has never been retried
         retry_count = run.get("status", {}).get("retry_count") or 0
         attempt_number = retry_count + 1

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -641,7 +641,6 @@ class BaseRuntimeHandler(ABC):
                     "status.state": run_state,
                     "status.reason": reason,
                     "status.status_text": message,
-                    "status.last_update": now.isoformat(),
                 }
                 db.update_run(
                     db_session, updates=run_updates, uid=run_uid, project=project

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -635,10 +635,7 @@ class BaseRuntimeHandler(ABC):
                     )
 
                 # Check if the run should be retried, and update its status accordingly
-                message = ""
-                run_state, message = self._evaluate_run_retry_state(
-                    run, reason, message
-                )
+                run_state, message = self._evaluate_run_retry_state(run, reason)
                 logger.info("Updating run state", run_uid=run_uid, run_state=run_state)
                 run_updates = {
                     "status.state": run_state,
@@ -1913,13 +1910,13 @@ class BaseRuntimeHandler(ABC):
 
     @staticmethod
     def _evaluate_run_retry_state(
-        run: dict, reason: str, message: str
+        run: dict, reason: str, message: str = ""
     ) -> tuple[str, str]:
         """
         Determine if the run should be retried or marked as failed, based on the retry policy and current attempt count.
         """
         retry_spec = run.get("spec", {}).get("retry", {})
-        max_retries = retry_spec.get("count") if retry_spec else -1
+        max_retries = retry_spec.get("count", -1) if retry_spec else -1
         # Run status retry_count may be `None` if the run has never been retried
         retry_count = run.get("status", {}).get("retry_count") or 0
         attempt_number = retry_count + 1

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1918,19 +1918,19 @@ class BaseRuntimeHandler(ABC):
         """
         Determine if the run should be retried or marked as failed, based on the retry policy and current attempt count.
         """
-        retry_spec = run.get("spec", {}).get("retry")
-        max_retries = retry_spec.get("count") if retry_spec else -1
+        retry_spec = run.get("spec", {}).get("retry", {})
+        max_retries = retry_spec.get("count", -1)
         # Run status retry_count may be `None` if the run has never been retried
-        retry_count = run.get("status", {}).get("retry_count", 0) or 0
-        attempts = retry_count + 1
+        retry_count = run.get("status", {}).get("retry_count") or 0
+        attempt_number = retry_count + 1
 
         if retry_count < max_retries:
             new_state = RunStates.pending_retry
-            message = f"Run failed attempt {attempts} of {max_retries + 1} with error: {message or reason}"
+            message = f"Run failed attempt {attempt_number} of {max_retries + 1} with error: {message or reason}"
         elif 0 < max_retries <= retry_count:
             new_state = RunStates.error
             message = (
-                f"Run failed after {attempts} attempts with error: {message or reason}"
+                f"Run failed after {attempt_number} attempts with error: {message or reason}"
             )
         else:
             new_state = RunStates.error

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -871,6 +871,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
     async def test_retry_pod_deleted_before_first_attempt(
         self, db: Session, client: TestClient
     ):
+        # Test that a run still retries if the pod is deleted before the first retry attempt starts.
         list_namespaced_pods_calls = [
             [self.pending_job_pod],
             [self.running_job_pod],
@@ -884,7 +885,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         self._mock_list_namespaced_pods(list_namespaced_pods_calls)
         self._mock_read_namespaced_pod_log()
 
-        # Simulate that no runtime resources are found, forcing retry logic
+        # Simulate that no runtime resources are found
         self.runtime_handler._get_runtime_resources = unittest.mock.Mock(
             return_value=[]
         )
@@ -892,6 +893,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             expected_number_of_list_pods_calls - 1
         )
 
+        # Store the run with retry spec
         self._store_run(
             db,
             retry_spec={"count": 3},

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -867,6 +867,54 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             },
         )
 
+    @pytest.mark.asyncio
+    async def test_retry_pod_deleted_before_first_attempt(
+        self, db: Session, client: TestClient
+    ):
+        list_namespaced_pods_calls = [
+            [self.pending_job_pod],
+            [self.running_job_pod],
+            # simulate deleted pod
+            [],
+            [self.failed_job_pod],
+            # additional time for the get_logger_pods
+            [self.failed_job_pod],
+        ]
+        expected_number_of_list_pods_calls = len(list_namespaced_pods_calls)
+        self._mock_list_namespaced_pods(list_namespaced_pods_calls)
+        self._mock_read_namespaced_pod_log()
+
+        # Simulate that no runtime resources are found, forcing retry logic
+        self.runtime_handler._get_runtime_resources = unittest.mock.Mock(
+            return_value=[]
+        )
+        expected_monitor_cycles_to_reach_expected_state = (
+            expected_number_of_list_pods_calls - 1
+        )
+
+        self._store_run(
+            db,
+            retry_spec={"count": 3},
+        )
+
+        for _ in range(expected_monitor_cycles_to_reach_expected_state):
+            self.runtime_handler.monitor_runs(get_db(), db)
+
+        self._assert_list_namespaced_pods_calls(
+            self.runtime_handler, expected_number_of_list_pods_calls
+        )
+
+        self._assert_run_reached_state(
+            db,
+            self.project,
+            self.run_uid,
+            RunStates.pending_retry,
+            expected_status_attrs={
+                "reason": "Some reason",
+                "status_text": "Run failed attempt 1 of 4 with error: Failed message",
+            },
+        )
+
     def _mock_list_resources_pods(self, pod=None):
         pod = pod or self.completed_job_pod
         mocked_responses = self._mock_list_namespaced_pods([[pod]])


### PR DESCRIPTION
This PR fixes a bug in the retry flow where retry attempts were not triggered if the initial pod was deleted before the first retry attempt began.
Previously, the system failed to detect this as a retryable failure, causing the run to be marked as failed without retrying.
With this change, the deletion of the first pod is now correctly handled, allowing the retry mechanism to proceed according to the defined retry policy.

Jira:
https://iguazio.atlassian.net/browse/ML-10684

Also should resolve this ticket as it has the same problem:
https://iguazio.atlassian.net/browse/ML-10560