### PR TITLE
[Project] Enable get_current_project in nuclio and job runtimes

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -168,8 +168,23 @@ def set_environment(
 
 
 def get_current_project(silent: bool = False) -> Optional[MlrunProject]:
-    project_from_env = environ.get(MLRUN_ACTIVE_PROJECT, None)
-    project = pipeline_context.project or project_from_env
+    if pipeline_context.project:
+        return pipeline_context.project
+
+    project_name = environ.get(MLRUN_ACTIVE_PROJECT, None)
+    if not project_name:
+        if not silent:
+            raise MLRunInvalidArgumentError(
+                "No current project is initialized. Use new, get or load project functions first."
+            )
+        return None
+
+    project = load_project(
+        name=project_name,
+        url=project_name,
+        save=False,
+        sync_functions=False)
+
     if not project and not silent:
         raise MLRunInvalidArgumentError(
             "No current project is initialized. Use new, get or load project functions first."

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -183,7 +183,8 @@ def get_current_project(silent: bool = False) -> Optional[MlrunProject]:
         name=project_name,
         url=project_name,
         save=False,
-        sync_functions=False)
+        sync_functions=False,
+    )
 
     if not project and not silent:
         raise MLRunInvalidArgumentError(

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -31,6 +31,7 @@ from typing import Optional
 
 import dotenv
 
+from .common.constants import MLRUN_ACTIVE_PROJECT
 from .config import config as mlconf
 from .datastore import DataItem, ModelProvider, store_manager
 from .db import get_run_db
@@ -167,11 +168,13 @@ def set_environment(
 
 
 def get_current_project(silent: bool = False) -> Optional[MlrunProject]:
-    if not pipeline_context.project and not silent:
+    project_from_env = environ.get(MLRUN_ACTIVE_PROJECT, None)
+    project = pipeline_context.project or project_from_env
+    if not project and not silent:
         raise MLRunInvalidArgumentError(
             "No current project is initialized. Use new, get or load project functions first."
         )
-    return pipeline_context.project
+    return project
 
 
 def get_sample_path(subpath=""):

--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -30,6 +30,7 @@ RESERVED_TAG_NAME_LATEST = "latest"
 JOB_TYPE_WORKFLOW_RUNNER = "workflow-runner"
 JOB_TYPE_PROJECT_LOADER = "project-loader"
 JOB_TYPE_RERUN_WORKFLOW_RUNNER = "rerun-workflow-runner"
+MLRUN_ACTIVE_PROJECT = "MLRUN_ACTIVE_PROJECT"
 
 
 class MLRunInternalLabels:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -447,14 +447,17 @@ class BaseRuntime(ModelObj):
         :return: Dictionary with all the variables that could be parsed
         """
         runtime_env = {
-            "MLRUN_ACTIVE_PROJECT": self.metadata.project or config.active_project
+            mlrun_constants.MLRUN_ACTIVE_PROJECT: self.metadata.project
+            or config.active_project
         }
         if runobj:
             runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json(
                 exclude_notifications_params=True
             )
             if runobj.metadata.project:
-                runtime_env["MLRUN_ACTIVE_PROJECT"] = runobj.metadata.project
+                runtime_env[mlrun_constants.MLRUN_ACTIVE_PROJECT] = (
+                    runobj.metadata.project
+                )
             if runobj.spec.verbose:
                 runtime_env["MLRUN_LOG_LEVEL"] = "DEBUG"
         if config.httpdb.api_url:

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -29,6 +29,7 @@ from kubernetes import client
 from nuclio.deploy import find_dashboard_url, get_deploy_status
 from nuclio.triggers import V3IOStreamTrigger
 
+import mlrun.common.constants
 import mlrun.db
 import mlrun.errors
 import mlrun.k8s_utils
@@ -830,7 +831,8 @@ class RemoteRuntime(KubeResource):
     def _get_runtime_env(self):
         # for runtime specific env var enrichment (before deploy)
         runtime_env = {
-            "MLRUN_ACTIVE_PROJECT": self.metadata.project or mlconf.active_project,
+            mlrun.common.constants.MLRUN_ACTIVE_PROJECT: self.metadata.project
+            or mlconf.active_project,
         }
         if mlconf.httpdb.api_url:
             runtime_env["MLRUN_DBPATH"] = mlconf.httpdb.api_url

--- a/tests/system/runtimes/assets/nuclio_mlrun_function.py
+++ b/tests/system/runtimes/assets/nuclio_mlrun_function.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 import mlrun
 
+
 def my_func(context, event):
     return mlrun.get_current_project().to_json()

--- a/tests/system/runtimes/assets/nuclio_mlrun_function.py
+++ b/tests/system/runtimes/assets/nuclio_mlrun_function.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mlrun
+
+def my_func(context, event):
+    return mlrun.get_current_project().to_json()

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -63,6 +63,20 @@ class TestNuclioRuntime(tests.system.base.TestMLRunSystem):
 
         assert deployment == function.get_url()  # check function url
 
+    def test_mlrun_project_accessibility(self):
+        fn = mlrun.code_to_function(
+            filename=str(self.assets_path / "nuclio_mlrun_function.py"),
+            name="nuclio-mlrun",
+            kind="nuclio",
+            image=self.image,
+            handler="my_func",
+            project=self.project_name,
+        )
+        fn.deploy()
+        response = fn.invoke(path="/")
+        response_body = json.loads(response.decode("utf-8"))
+        assert response_body.get("metadata", {}).get("name") == self.project_name
+
     @pytest.mark.parametrize("raise_exception", [True, False])
     @pytest.mark.parametrize("with_object", [True, False])
     def test_deploy_function_with_model_runner(self, raise_exception, with_object):


### PR DESCRIPTION
Enables get_current_project in nuclio and job runtimes, and basically in any runtime that doesn't have pipeline_context. 

tested by eval function:
<img width="1827" height="126" alt="image" src="https://github.com/user-attachments/assets/1c7a2944-b2bb-4d15-b30d-d9ff0d96f2a2" />


Jira - https://iguazio.atlassian.net/browse/ML-10612

Added system test, run with custom mlrun image built with the latest changes:
<img width="1405" height="422" alt="image" src="https://github.com/user-attachments/assets/600fd01f-7ddf-4c94-ad71-9790fdf5bbca" />
