### PR TITLE
[Launcher] Raise error when retry is set for dask job

### DIFF
--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -159,7 +159,8 @@ class BaseLauncher(abc.ABC):
 
         # Raise an error if retry is configured for a runtime that doesn't support retries
         if (
-            run.spec.retry.count
+            not mlrun.runtimes.RuntimeKinds.is_local_runtime(runtime.kind)
+            and run.spec.retry.count
             and runtime.kind not in mlrun.runtimes.RuntimeKinds.retriable_runtimes()
         ):
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -157,6 +157,16 @@ class BaseLauncher(abc.ABC):
         ]:
             mlrun.utils.helpers.warn_on_deprecated_image(image)
 
+        # Raise an error if retry is configured for a runtime that doesn't support retries
+        if (
+            run.spec.retry.count
+            and runtime.kind not in mlrun.runtimes.RuntimeKinds.retriable_runtimes()
+        ):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Retry is not supported for {runtime.kind} runtime, supported runtimes are: "
+                f"{mlrun.runtimes.RuntimeKinds.retriable_runtimes()}"
+            )
+
     @staticmethod
     def _validate_output_path(
         runtime: "mlrun.runtimes.BaseRuntime",

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -157,11 +157,13 @@ class BaseLauncher(abc.ABC):
         ]:
             mlrun.utils.helpers.warn_on_deprecated_image(image)
 
+        logger.debug("yacouby: validating run",count = run.spec.retry.count,kind=runtime.kind)
         # Raise an error if retry is configured for a runtime that doesn't support retries
         if (
             run.spec.retry.count
             and runtime.kind not in mlrun.runtimes.RuntimeKinds.retriable_runtimes()
         ):
+            logger.debug("in if")
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Retry is not supported for {runtime.kind} runtime, supported runtimes are: "
                 f"{mlrun.runtimes.RuntimeKinds.retriable_runtimes()}"

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -157,7 +157,6 @@ class BaseLauncher(abc.ABC):
         ]:
             mlrun.utils.helpers.warn_on_deprecated_image(image)
 
-        logger.debug("yacouby: validating run",count = run.spec.retry.count,kind=runtime.kind)
         # Raise an error if retry is configured for a runtime that doesn't support retries
         if (
             run.spec.retry.count

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -162,7 +162,6 @@ class BaseLauncher(abc.ABC):
             run.spec.retry.count
             and runtime.kind not in mlrun.runtimes.RuntimeKinds.retriable_runtimes()
         ):
-            logger.debug("in if")
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Retry is not supported for {runtime.kind} runtime, supported runtimes are: "
                 f"{mlrun.runtimes.RuntimeKinds.retriable_runtimes()}"

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -157,7 +157,9 @@ class BaseLauncher(abc.ABC):
         ]:
             mlrun.utils.helpers.warn_on_deprecated_image(image)
 
-        # Raise an error if retry is configured for a runtime that doesn't support retries
+        # Raise an error if retry is configured for a runtime that doesn't support retries.
+        # For local runs, we intentionally skip this validation and allow the run to proceed, since they are typically
+        # used for debugging purposes, and in such cases we avoid blocking their execution.
         if (
             not mlrun.runtimes.RuntimeKinds.is_local_runtime(runtime.kind)
             and run.spec.retry.count

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -125,7 +125,6 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
             state_thresholds=state_thresholds,
             retry=retry,
         )
-        logger.info("yacouby: launching local run", kind=runtime.kind, count=run.spec.retry.count)
         self._validate_run(runtime, run)
         result = self._execute(
             runtime=runtime,

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -125,6 +125,7 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
             state_thresholds=state_thresholds,
             retry=retry,
         )
+        logger.info("yacouby: launching local run", kind=runtime.kind, count=run.spec.retry.count)
         self._validate_run(runtime, run)
         result = self._execute(
             runtime=runtime,

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -541,6 +541,7 @@ class DaskCluster(KubejobRuntime):
             notifications=notifications,
             returns=returns,
             state_thresholds=state_thresholds,
+            retry=retry,
             **launcher_kwargs,
         )
 

--- a/tests/launcher/test_local.py
+++ b/tests/launcher/test_local.py
@@ -300,3 +300,18 @@ def test_validate_run_retries_warning(logs_stream):
         in logs_stream.getvalue()
     )
     assert run.spec.retry.count == 0
+
+
+def test_validate_run_retries_invalid_runtime():
+    launcher = mlrun.launcher.local.ClientLocalLauncher(local=False)
+    runtime = mlrun.code_to_function(
+        name="test", kind="dask", filename=str(func_path), handler=handler
+    )
+    run = mlrun.run.RunObject(
+        spec=mlrun.model.RunSpec(retry={"count": 3}, output_path="/tmp")
+    )
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as excinfo:
+        launcher._validate_run(runtime, run)
+
+    assert "Retry is not supported for dask runtime" in str(excinfo.value)


### PR DESCRIPTION
This PR enhances validation in `_validate_run()` to prevent configuring retries for unsupported runtimes.
For the case of dask job, there was a missing param passing to the run function ( the retry param )

So added a check that raises `MLRunInvalidArgumentError` if retry is configured, and the runtime kind is not supported, and the runtime is not local (to preserve backward-compatible behavior in local runs).

Jira:
https://iguazio.atlassian.net/browse/ML-10625