### PR TITLE
[Model Monitoring] batch inference fails with  'StatementError('(builtins.ValueError) badly formed hexadecimal UUID string')'

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta
 from os import environ, path, remove
 from typing import Literal, Optional, Union
 from urllib.parse import urlparse
+from uuid import UUID
 
 import pydantic.v1
 import requests
@@ -3968,6 +3969,13 @@ class HTTPRunDB(RunDBInterface):
             raise MLRunInvalidArgumentError(
                 "Either endpoint_uid or function_name and function_tag must be provided"
             )
+        if uid:
+            try:
+                UUID(uid)
+            except (ValueError, TypeError):
+                raise MLRunInvalidArgumentError(
+                    "endpoint_id must be a valid UUID string"
+                )
 
     def update_model_monitoring_controller(
         self,

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -91,25 +91,26 @@ def get_or_create_model_endpoint(
         function_name = FunctionURI.from_string(
             context.to_dict()["spec"]["function"]
         ).function
-    try:
-        model_endpoint = db_session.get_model_endpoint(
-            project=project,
-            name=model_endpoint_name,
-            endpoint_id=endpoint_id,
-            function_name=function_name,
-            function_tag=function_tag or "latest",
-            feature_analysis=feature_analysis,
-        )
-        # If other fields provided, validate that they are correspond to the existing model endpoint data
-        _model_endpoint_validations(
-            model_endpoint=model_endpoint,
-            model_path=model_path,
-            sample_set_statistics=sample_set_statistics,
-        )
+    if endpoint_id or function_name:
+        try:
+            model_endpoint = db_session.get_model_endpoint(
+                project=project,
+                name=model_endpoint_name,
+                endpoint_id=endpoint_id,
+                function_name=function_name,
+                function_tag=function_tag or "latest",
+                feature_analysis=feature_analysis,
+            )
+            # If other fields provided, validate that they are correspond to the existing model endpoint data
+            _model_endpoint_validations(
+                model_endpoint=model_endpoint,
+                model_path=model_path,
+                sample_set_statistics=sample_set_statistics,
+            )
 
-    except mlrun.errors.MLRunNotFoundError:
-        # Create a new model endpoint with the provided details
-        pass
+        except mlrun.errors.MLRunNotFoundError:
+            # Create a new model endpoint with the provided details
+            pass
     if not model_endpoint:
         model_endpoint = _generate_model_endpoint(
             project=project,

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -67,8 +67,8 @@ def get_or_create_model_endpoint(
     :param model_endpoint_name:      If a new model endpoint is created, the model endpoint name will be presented
                                      under this endpoint (applicable only to new endpoint_id).
     :param model_path:               The model store path (applicable only to new endpoint_id).
-    :param endpoint_id:              Model endpoint unique ID. If not exist in DB, will generate a new record based
-                                     on the provided `endpoint_id`.
+    :param endpoint_id:              Model endpoint unique ID. If not exist in DB, will generate a new record with a
+                                     newly generated ID.
     :param function_name:            If a new model endpoint is created, use this function name.
     :param function_tag:             If a new model endpoint is created, use this function tag.
     :param context:                  MLRun context. If `function_name` not provided, use the context to generate the
@@ -144,8 +144,8 @@ def record_results(
     :param model_path:               The model Store path.
     :param model_endpoint_name:      If a new model endpoint is generated, the model endpoint name will be presented
                                      under this endpoint.
-    :param endpoint_id:              Model endpoint unique ID. If not exist in DB, will generate a new record based
-                                     on the provided `endpoint_id`.
+    :param endpoint_id:              Model endpoint unique ID. If not exist in DB, will generate a new record with a
+                                     newly generated ID.
     :param function_name:            If a new model endpoint is created, use this function name for generating the
                                      function URI.
     :param context:                  MLRun context. Note that the context is required generating the model endpoint.

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -236,7 +236,7 @@ def _model_endpoint_validations(
             key=model_obj.key,
             iter=model_obj.iter,
             tree=model_obj.tree,
-            uid= model_obj.uid,
+            uid=model_obj.uid,
         )
 
         # Enrich the uri schema with the store prefix

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -236,6 +236,7 @@ def _model_endpoint_validations(
             key=model_obj.key,
             iter=model_obj.iter,
             tree=model_obj.tree,
+            uid= model_obj.uid,
         )
 
         # Enrich the uri schema with the store prefix

--- a/mlrun/model_monitoring/api.py
+++ b/mlrun/model_monitoring/api.py
@@ -107,7 +107,7 @@ def get_or_create_model_endpoint(
             sample_set_statistics=sample_set_statistics,
         )
 
-    except (mlrun.errors.MLRunNotFoundError, mlrun.errors.MLRunInvalidArgumentError):
+    except mlrun.errors.MLRunNotFoundError:
         # Create a new model endpoint with the provided details
         pass
     if not model_endpoint:

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -190,7 +190,7 @@ class TestAlerts(TestMLRunSystem):
             project=self.project.metadata.name,
             model_endpoint_name="test-endpoint",
             context=mlrun.get_or_create_ctx("demo"),
-            endpoint_id=uuid.uuid4().hex # either endpoint-id or function_name and function_tag must be provided
+            endpoint_id=uuid.uuid4().hex,  # either endpoint-id or function_name and function_tag must be provided
         )
 
         # waits for the writer function to be deployed

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -15,6 +15,7 @@
 import json
 import time
 import typing
+import uuid
 
 import deepdiff
 import pytest
@@ -184,10 +185,12 @@ class TestAlerts(TestMLRunSystem):
         nuclio_function_url = notification_helpers.deploy_notification_nuclio(
             self.project, self.image
         )
+        # generate a new model-endpoint
         model_endpoint = mlrun.model_monitoring.api.get_or_create_model_endpoint(
             project=self.project.metadata.name,
             model_endpoint_name="test-endpoint",
             context=mlrun.get_or_create_ctx("demo"),
+            endpoint_id=uuid.uuid4().hex # either endpoint-id or function_name and function_tag must be provided
         )
 
         # waits for the writer function to be deployed

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -15,7 +15,6 @@
 import json
 import time
 import typing
-import uuid
 
 import deepdiff
 import pytest
@@ -190,7 +189,6 @@ class TestAlerts(TestMLRunSystem):
             project=self.project.metadata.name,
             model_endpoint_name="test-endpoint",
             context=mlrun.get_or_create_ctx("demo"),
-            endpoint_id=uuid.uuid4().hex,  # either endpoint-id or function_name and function_tag must be provided
         )
 
         # waits for the writer function to be deployed

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1878,7 +1878,6 @@ class TestModelEndpointWithManyFeatures(TestMLRunSystemModelMonitoring):
         out_model_endpoint = mlrun.model_monitoring.api.get_or_create_model_endpoint(
             project=project.name,
             model_path=model_obj.uri,
-            endpoint_id=model_obj.metadata.uid,
             function_name="dummy_func",
             model_endpoint_name="dummy_ep",
             feature_analysis=True,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1667,6 +1667,7 @@ class TestInferenceWithSpecialChars(TestMLRunSystemModelMonitoring):
     def custom_setup_class(cls) -> None:
         cls.classif = SVC()
         cls.model_name = "classif_model"
+        cls.function_name = "classif-function"
         cls.columns = ["feat 1", "b (C)", "Last   for df "]
         cls.y_name = "class (0-4) "
         cls.num_rows = 20
@@ -1743,7 +1744,7 @@ class TestInferenceWithSpecialChars(TestMLRunSystemModelMonitoring):
             model_path=self.project.get_artifact_uri(
                 key=self.model_name, category="model", tag="latest"
             ),
-            function_name=self.model_name,
+            function_name=self.function_name,
             model_endpoint_name=self.model_endpoint_name,
             context=mlrun.get_or_create_ctx(name=f"{self.name_prefix}-context"),  # pyright: ignore[reportGeneralTypeIssues]
             infer_results_df=self.infer_results_df,
@@ -1779,6 +1780,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystemModelMonitoring):
             ],
         )
         cls.model_name = "clf_model"
+        cls.function_name = "clf_function"
 
         cls.infer_results_df = cls.train_set.copy()
 
@@ -1834,7 +1836,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystemModelMonitoring):
             project=self.project_name,
             infer_results_df=self.infer_results_df,
             model_path=model_uri,
-            function_name=self.model_name,
+            function_name=self.function_name,
             model_endpoint_name=f"{self.name_prefix}-test",
             context=mlrun.get_or_create_ctx(name=f"{self.name_prefix}-context"),  # pyright: ignore[reportGeneralTypeIssues]
             # TODO: activate ad-hoc mode when ML-5792 is done

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1743,6 +1743,7 @@ class TestInferenceWithSpecialChars(TestMLRunSystemModelMonitoring):
             model_path=self.project.get_artifact_uri(
                 key=self.model_name, category="model", tag="latest"
             ),
+            function_name=self.model_name,
             model_endpoint_name=self.model_endpoint_name,
             context=mlrun.get_or_create_ctx(name=f"{self.name_prefix}-context"),  # pyright: ignore[reportGeneralTypeIssues]
             infer_results_df=self.infer_results_df,
@@ -1833,6 +1834,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystemModelMonitoring):
             project=self.project_name,
             infer_results_df=self.infer_results_df,
             model_path=model_uri,
+            function_name=self.model_name,
             model_endpoint_name=f"{self.name_prefix}-test",
             context=mlrun.get_or_create_ctx(name=f"{self.name_prefix}-context"),  # pyright: ignore[reportGeneralTypeIssues]
             # TODO: activate ad-hoc mode when ML-5792 is done


### PR DESCRIPTION
https://iguazio.atlassian.net/browse/ML-10551

1. Update the documentation of `get_or_create_model_endpoint` end `record_results` to clarify that the `endpoint_id` passed must belong to an existing model endpoint—otherwise, a new UID will be generated anyway.

2. Add a validation on the client side to return a clearer, more indicative error earlier in case the provided `endpoint_id` is not a valid UUID (also in case the user hasn't provided sufficient arguments) and fix the tests that's been affected by this change.

3. Fix `test_model_endpoint_with_many_features` so it doesn’t pass the endpoint_id argument unnecessarily.
