### PR TITLE
[Deprecations] Fix removal version 

### DIFF
--- a/mlrun/platforms/__init__.py
+++ b/mlrun/platforms/__init__.py
@@ -25,6 +25,7 @@ from .iguazio import (
 )
 
 
+# TODO: Remove in 1.11.0
 class _DeprecationHelper:
     """A helper class to deprecate old schemas"""
 
@@ -48,12 +49,12 @@ class _DeprecationHelper:
     def _warn(self):
         warnings.warn(
             f"mlrun.platforms.{self._new_target} is deprecated since version {self._version}, "
-            f"and will be removed in 1.10. Use mlrun.runtimes.mounts.{self._new_target} instead.",
+            f"and will be removed in 1.11.0. Use mlrun.runtimes.mounts.{self._new_target} instead.",
             FutureWarning,
         )
 
 
-# TODO: Remove in 1.10
+# TODO: Remove in 1.11.0
 # For backwards compatibility
 VolumeMount = _DeprecationHelper("VolumeMount")
 auto_mount = _DeprecationHelper("auto_mount")

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -291,6 +291,7 @@ def test_mount_v3io():
             )
 
 
+# TODO: Remove in 1.11.0
 @pytest.mark.parametrize(
     "mount, args, kwargs",
     [


### PR DESCRIPTION
 It was deprecated in 1.8.0, which means it will be removed in 1.11.0, not 1.10.0.
This has already been updated in the changelog - https://github.com/mlrun/mlrun/blob/4e73dbfebb123075e8a1cdf7beb925ca8c66f814/docs/change-log/index.md#deprecated-apis

related PR - https://github.com/mlrun/mlrun/pull/6754

https://iguazio.atlassian.net/browse/ML-9441

