### PR TITLE
[Monitoring] Add debounce mechanism to prevent client-server status conflicts

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -556,7 +556,6 @@ class BaseRuntime(ModelObj):
         run_format: mlrun.common.formatters.RunFormat = mlrun.common.formatters.RunFormat.full,
     ) -> typing.Optional[dict]:
         """update the task state in the DB"""
-        logger.debug("yacouby: in update run state", err=err)
         was_none = False
         if resp is None and task:
             was_none = True
@@ -577,7 +576,6 @@ class BaseRuntime(ModelObj):
 
         updates = None
         last_state = get_in(resp, "status.state", "")
-        logger.debug("yacouby: in update run state 2", last_state=last_state)
         kind = get_in(resp, "metadata.labels.kind", "")
         if last_state in RunStates.error_states() or err:
             new_state = RunStates.error
@@ -619,7 +617,7 @@ class BaseRuntime(ModelObj):
 
         uid = get_in(resp, "metadata.uid")
         logger.debug(
-            "Run updates yacouby",
+            "Run updates",
             name=get_in(resp, "metadata.name"),
             uid=uid,
             kind=kind,

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -556,6 +556,7 @@ class BaseRuntime(ModelObj):
         run_format: mlrun.common.formatters.RunFormat = mlrun.common.formatters.RunFormat.full,
     ) -> typing.Optional[dict]:
         """update the task state in the DB"""
+        logger.debug("yacouby: in update run state", err=err)
         was_none = False
         if resp is None and task:
             was_none = True
@@ -576,6 +577,7 @@ class BaseRuntime(ModelObj):
 
         updates = None
         last_state = get_in(resp, "status.state", "")
+        logger.debug("yacouby: in update run state 2", last_state=last_state)
         kind = get_in(resp, "metadata.labels.kind", "")
         if last_state in RunStates.error_states() or err:
             new_state = RunStates.error
@@ -617,7 +619,7 @@ class BaseRuntime(ModelObj):
 
         uid = get_in(resp, "metadata.uid")
         logger.debug(
-            "Run updates",
+            "Run updates yacouby",
             name=get_in(resp, "metadata.name"),
             uid=uid,
             kind=kind,

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1745,13 +1745,7 @@ class BaseRuntimeHandler(ABC):
                     run, reason, message
                 )
 
-        logger.info(
-            "Updating run state",
-            run_uid=uid,
-            run_state=run_state,
-            reason=reason,
-            my_message=message,
-        )
+        logger.info("Updating run state", run_uid=uid, run_state=run_state)
         run_updates = {
             "status.state": run_state,
             "status.reason": reason or "",
@@ -1833,12 +1827,16 @@ class BaseRuntimeHandler(ABC):
             last_update = datetime.fromisoformat(last_update_str)
             debounce_period = config.monitoring.runs.interval
             debounce_cutoff = now - timedelta(seconds=float(debounce_period))
-            db_terminal = db_run_state in RunStates.terminal_states()
-            runtime_terminal = run_state in RunStates.terminal_states()
+            is_db_terminal = db_run_state in RunStates.terminal_states()
+            is_runtime_terminal = run_state in RunStates.terminal_states()
 
             # If the runtime has reached a terminal state but the DB still shows a recent non-terminal state,
             # debounce the update to avoid prematurely overriding the newer DB state.
-            if not db_terminal and runtime_terminal and last_update > debounce_cutoff:
+            if (
+                not is_db_terminal
+                and is_runtime_terminal
+                and last_update > debounce_cutoff
+            ):
                 logger.warning(
                     "Monitoring found terminal state on runtime resource but DB record was recently updated and is "
                     "still non-terminal. Debouncing.",
@@ -1851,11 +1849,11 @@ class BaseRuntimeHandler(ABC):
                 return True
 
             # if the current run state is terminal and different from the runtime state, handle accordingly
-            if db_terminal:
+            if is_db_terminal:
                 # This can happen when the SDK running in the user's Run updates the Run's state to terminal, but
                 # before it exits, when the runtime resource is still running, the API monitoring (here) is executed
                 # In this case, we debounce to avoid reverting the state prematurely.
-                if not runtime_terminal and last_update > debounce_cutoff:
+                if not is_runtime_terminal and last_update > debounce_cutoff:
                     logger.warning(
                         "Monitoring found non-terminal state on runtime resource but record has recently "
                         "updated to terminal state. Debouncing",

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1707,6 +1707,28 @@ class BaseRuntimeHandler(ABC):
         search_run: bool = True,
         runtime_resource: Optional[dict] = None,
     ) -> tuple[bool, str, dict]:
+        """
+        Retrieves the run from the database, compares its current state with the desired state,
+        and updates it only if needed.
+        Skips updates when the current state matches the desired one, when the run is in an aborting state, or
+        when the update should be debounced.
+
+        :param db:               Database interface
+        :param db_session:       Db session
+        :param project:          Project name
+        :param uid:              UID of the run
+        :param name:             Name of the function or job
+        :param run_state:        Desired run state
+        :param run:              Optional pre-fetched run object
+        :param search_run:       Whether to search for the run
+        :param runtime_resource: Optional runtime resource (used to resolve error reason)
+
+        :return: Tuple with:
+            was_updated (bool): True if the run state was updated
+            final_state (str): Final state after evaluation
+            run (dict): The updated (or unchanged) run object
+        """
+
         reason, message = "", ""
         run = self._ensure_run(
             db, db_session, name, project, run, search_run=search_run, uid=uid

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1746,7 +1746,7 @@ class BaseRuntimeHandler(ABC):
                 )
 
         logger.info(
-            "Updating run state yacouby",
+            "Updating run state",
             run_uid=uid,
             run_state=run_state,
             reason=reason,
@@ -1836,9 +1836,9 @@ class BaseRuntimeHandler(ABC):
             db_terminal = db_run_state in RunStates.terminal_states()
             runtime_terminal = run_state in RunStates.terminal_states()
 
-            # if the runtime has reached a terminal state but the DB hasn't, then debounce the status update
+            # If the runtime has reached a terminal state but the DB still shows a recent non-terminal state,
+            # debounce the update to avoid prematurely overriding the newer DB state.
             if not db_terminal and runtime_terminal and last_update > debounce_cutoff:
-                logger.info("yacouby: yes")
                 logger.warning(
                     "Monitoring found terminal state on runtime resource but DB record was recently updated and is "
                     "still non-terminal. Debouncing.",
@@ -1850,12 +1850,12 @@ class BaseRuntimeHandler(ABC):
                 )
                 return True
 
-            # if the current run state isu terminal and different from the desired - log
+            # if the current run state is terminal and different from the runtime state, handle accordingly
             if db_terminal:
                 # This can happen when the SDK running in the user's Run updates the Run's state to terminal, but
                 # before it exits, when the runtime resource is still running, the API monitoring (here) is executed
+                # In this case, we debounce to avoid reverting the state prematurely.
                 if not runtime_terminal and last_update > debounce_cutoff:
-                    logger.info("yacouby: yes 2")
                     logger.warning(
                         "Monitoring found non-terminal state on runtime resource but record has recently "
                         "updated to terminal state. Debouncing",
@@ -1870,7 +1870,6 @@ class BaseRuntimeHandler(ABC):
                     return True
 
                 elif run_state != db_run_state:
-                    logger.info("yacouby: yes 3")
                     logger.warning(
                         "Run record has terminal state but monitoring found different state on runtime resource. "
                         "Changing",

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1727,39 +1727,14 @@ class BaseRuntimeHandler(ABC):
                 )
                 return False, run_state, run
 
-            # if the current run state is terminal and different from the desired - log
-            if db_run_state in RunStates.terminal_states():
-                # This can happen when the SDK running in the user's Run updates the Run's state to terminal, but
-                # before it exits, when the runtime resource is still running, the API monitoring (here) is executed
-                if run_state not in RunStates.terminal_states():
-                    now = datetime.now(timezone.utc)
-                    last_update_str = run.get("status", {}).get("last_update")
-                    if last_update_str is not None:
-                        last_update = datetime.fromisoformat(last_update_str)
-                        debounce_period = config.monitoring.runs.interval
-                        if last_update > now - timedelta(
-                            seconds=float(debounce_period)
-                        ):
-                            logger.warning(
-                                "Monitoring found non-terminal state on runtime resource but record has recently "
-                                "updated to terminal state. Debouncing",
-                                project=project,
-                                uid=uid,
-                                db_run_state=db_run_state,
-                                run_state=run_state,
-                                last_update=last_update,
-                                now=now,
-                                debounce_period=debounce_period,
-                            )
-                            return False, run_state, run
-
-                logger.warning(
-                    "Run record has terminal state but monitoring found different state on runtime resource. Changing",
-                    project=project,
-                    uid=uid,
-                    db_run_state=db_run_state,
-                    run_state=run_state,
-                )
+            if self._should_debounce_run_update(
+                run=run,
+                db_run_state=db_run_state,
+                run_state=run_state,
+                project=project,
+                uid=uid,
+            ):
+                return False, run_state, run
 
             elif run_state == RunStates.error:
                 # Try resolving the error reason
@@ -1770,7 +1745,13 @@ class BaseRuntimeHandler(ABC):
                     run, reason, message
                 )
 
-        logger.info("Updating run state", run_uid=uid, run_state=run_state)
+        logger.info(
+            "Updating run state yacouby",
+            run_uid=uid,
+            run_state=run_state,
+            reason=reason,
+            my_message=message,
+        )
         run_updates = {
             "status.state": run_state,
             "status.reason": reason or "",
@@ -1829,6 +1810,76 @@ class BaseRuntimeHandler(ABC):
                     )
 
         return run
+
+    @staticmethod
+    def _should_debounce_run_update(
+        run: dict,
+        db_run_state: str,
+        run_state: str,
+        project: str,
+        uid: str,
+    ) -> bool:
+        """
+        Debounce run status updates to avoid premature or incorrect state overrides.
+        This handles cases where:
+        1. The runtime is terminal, but the DB still shows 'running' (e.g., final state not flushed yet)
+        2. The DB is terminal, but the runtime still appears active (e.g., SDK already finalized the run)
+        """
+
+        now = datetime.now(timezone.utc)
+        last_update_str = run.get("status", {}).get("last_update")
+
+        if last_update_str is not None:
+            last_update = datetime.fromisoformat(last_update_str)
+            debounce_period = config.monitoring.runs.interval
+            debounce_cutoff = now - timedelta(seconds=float(debounce_period))
+            db_terminal = db_run_state in RunStates.terminal_states()
+            runtime_terminal = run_state in RunStates.terminal_states()
+
+            # if the runtime has reached a terminal state but the DB hasn't, then debounce the status update
+            if not db_terminal and runtime_terminal and last_update > debounce_cutoff:
+                logger.info("yacouby: yes")
+                logger.warning(
+                    "Monitoring found terminal state on runtime resource but DB record was recently updated and is "
+                    "still non-terminal. Debouncing.",
+                    db_run_state=db_run_state,
+                    run_state=run_state,
+                    last_update=last_update,
+                    now=now,
+                    debounce_period=debounce_period,
+                )
+                return True
+
+            # if the current run state isu terminal and different from the desired - log
+            if db_terminal:
+                # This can happen when the SDK running in the user's Run updates the Run's state to terminal, but
+                # before it exits, when the runtime resource is still running, the API monitoring (here) is executed
+                if not runtime_terminal and last_update > debounce_cutoff:
+                    logger.info("yacouby: yes 2")
+                    logger.warning(
+                        "Monitoring found non-terminal state on runtime resource but record has recently "
+                        "updated to terminal state. Debouncing",
+                        project=project,
+                        uid=uid,
+                        db_run_state=db_run_state,
+                        run_state=run_state,
+                        last_update=last_update,
+                        now=now,
+                        debounce_period=debounce_period,
+                    )
+                    return True
+
+                elif run_state != db_run_state:
+                    logger.info("yacouby: yes 3")
+                    logger.warning(
+                        "Run record has terminal state but monitoring found different state on runtime resource. "
+                        "Changing",
+                        project=project,
+                        uid=uid,
+                        db_run_state=db_run_state,
+                        run_state=run_state,
+                    )
+        return False
 
     @staticmethod
     def _resolve_runtime_resource_run(runtime_resource: dict) -> tuple[str, str, str]:

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -453,6 +453,10 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
     async def test_monitor_run_debouncing_non_terminal_state(
         self, db: Session, client: TestClient
     ):
+        # This test verifies that a run in a non-terminal state is not updated if it was already updated recently
+        # (i.e., within the debounce interval).
+        # It ensures the debounce logic correctly skips redundant updates for active runs.
+
         # set monitoring interval so debouncing will be active
         config.monitoring.runs.interval = 100
 
@@ -508,6 +512,57 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             db, self.project, self.run_uid, RunStates.running
         )
 
+    @pytest.mark.asyncio
+    async def test_monitor_run_debouncing_terminal_state(
+        self, db: Session, client: TestClient
+    ):
+        # This test verifies the debounce logic when the runtime has reached a terminal state but the DB still shows a
+        # recent non-terminal update. Initially, the update should be debounced.
+
+        # Set monitoring interval so debouncing will be active
+        config.monitoring.runs.interval = 100
+
+        # Simulate record still in non-terminal state ("running")
+        self.run["status"]["state"] = RunStates.running
+        original_update_run_updated_time = (
+            framework.utils.singletons.db.get_db()._update_run_updated_time
+        )
+        framework.utils.singletons.db.get_db()._update_run_updated_time = (
+            tests.conftest.freeze(original_update_run_updated_time, now=now_date())
+        )
+        services.api.crud.Runs().store_run(
+            db, self.run, self.run_uid, project=self.project
+        )
+        framework.utils.singletons.db.get_db()._update_run_updated_time = (
+            original_update_run_updated_time
+        )
+
+        # Simulate runtime already in terminal state (extra one for the log collection)
+        self._mock_list_namespaced_pods([[self.running_job_pod]])
+
+        # Trigger monitoring - this should be debounced and not overwrite DB "running"
+        self.runtime_handler.monitor_runs(get_db(), db)
+
+        # Verify that debounce happened: state in DB should still be "running"
+        self._assert_run_reached_state(
+            db, self.project, self.run_uid, RunStates.running
+        )
+
+        # Now simulate that debounce window has passed (simulate old update)
+        debounce_period = config.monitoring.runs.interval
+        framework.utils.singletons.db.get_db()._update_run_updated_time = (
+            tests.conftest.freeze(
+                original_update_run_updated_time,
+                now=now_date() - timedelta(seconds=2 * debounce_period),
+            )
+        )
+        services.api.crud.Runs().store_run(
+            db, self.run, self.run_uid, project=self.project
+        )
+        framework.utils.singletons.db.get_db()._update_run_updated_time = (
+            original_update_run_updated_time
+        )
+
         # Mocking pod that is in terminal state (extra one for the log collection)
         self._mock_list_namespaced_pods(
             [[self.completed_job_pod], [self.completed_job_pod]]
@@ -516,10 +571,10 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         # Mocking read log calls
         log = self._mock_read_namespaced_pod_log()
 
-        # Triggering monitor cycle
+        # Re-run monitor (now update should go through)
         self.runtime_handler.monitor_runs(get_db(), db)
 
-        # verifying monitoring was not debounced
+        # DB should now reflect the terminal state
         self._assert_run_reached_state(
             db, self.project, self.run_uid, RunStates.completed
         )


### PR DESCRIPTION
This PR introduces a debouncing mechanism in the server-side monitoring logic to address a race condition between client-side status updates and server-side runtime monitoring.

**Background:**
In some scenarios - particularly when the runtime reaches a terminal state shortly after a client-side update (e.g., via user code or SDK) a race condition occurs:
The runtime has finished and returned a final (terminal) status.
The DB still holds a recent non-terminal update from the client.

The runs monitoring detects the mismatch and overwrites the newer DB state with the outdated runtime info, possibly losing important fields.
This issue is not limited to retries, but can happen in any flow where there's close timing between runtime termination and a client update.

**Fix:**
To mitigate this, a debounce check was added:
If the runtime is terminal, but the DB state is non-terminal, and the DB update is recent (within a configurable debounce interval), then monitoring will skip the status update to avoid overwriting a likely more up-to-date client-side update.

Jira:
https://iguazio.atlassian.net/browse/ML-10553