### PR TITLE
[Retry] Ensure retry message use only ascii characters

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -308,7 +308,7 @@ class NotificationPusher(_NotificationPusherBase):
                 and retry_count >= max_retries
             ):
                 message += (
-                    "\nRetry limit reached — run has failed after all retry attempts."
+                    "\nRetry limit reached - run has failed after all retry attempts."
                 )
 
         severity = (


### PR DESCRIPTION
### 📝 Description
This PR replaces the em dash character `—` with a standard ASCII dash `-` in a retry failure message to ensure compatibility with ASCII characters. 
Previously, when a job was run with both mail notification and retry enabled, the failure message included a non-ASCII character (the em dash), which caused the resulting `mail.subject` to be encoded in UTF-8. 
This led to inconsistencies in automation tests where ASCII format was expected.

---

### 🛠️ Changes Made
Replaced em dash (—) with ASCII dash (-) in retry failure message formatting

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Manually tested job runs with mail notifications in both scenarios: with retries enabled and without retries.
Verified that the sent emails (subject and body) are consistently encoded in ASCII format across both cases.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10711

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

