### PR TITLE
[Deprecations] Remove the warning when using underscores

### DIFF
--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -281,12 +281,6 @@ class BaseLauncher(abc.ABC):
 
         run.metadata.name = mlrun.utils.normalize_name(
             name=name or run.metadata.name or def_name,
-            # if name or runspec.metadata.name are set then it means that is user defined name and we want to warn the
-            # user that the passed name needs to be set without underscore, if its not user defined but rather enriched
-            # from the handler(function) name then we replace the underscore without warning the user.
-            # most of the time handlers will have `_` in the handler name (python convention is to separate function
-            # words with `_`), therefore we don't want to be noisy when normalizing the run name
-            verbose=bool(name or run.metadata.name),
         )
         mlrun.utils.verify_field_regex(
             "run.metadata.name", run.metadata.name, mlrun.utils.regex.run_name

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -647,7 +647,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             else:
                 class_name = handler_to_class.split(".")[-1].split("::")[0]
 
-            job_name = mlrun.utils.normalize_name(class_name, verbose=False)
+            job_name = mlrun.utils.normalize_name(class_name)
 
         if not mm_constants.APP_NAME_REGEX.fullmatch(job_name):
             raise mlrun.errors.MLRunValueError(

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -464,17 +464,11 @@ def to_date_str(d):
     return ""
 
 
-def normalize_name(name: str, verbose: bool = True):
+def normalize_name(name: str):
     # TODO: Must match
     # [a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?
     name = re.sub(r"\s+", "-", name)
     if "_" in name:
-        if verbose:
-            warnings.warn(
-                "Names with underscore '_' are about to be deprecated, use dashes '-' instead. "
-                f"Replacing '{name}' underscores with dashes.",
-                FutureWarning,
-            )
         name = name.replace("_", "-")
     return name.lower()
 
@@ -835,7 +829,7 @@ def extend_hub_uri_if_needed(uri) -> tuple[str, bool]:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Invalid character '/' in function name or source name"
             ) from exc
-    name = normalize_name(name=name, verbose=False)
+    name = normalize_name(name=name)
     if not source_name:
         # Searching item in all sources
         sources = db.list_hub_sources(item_name=name, tag=tag)

--- a/server/py/services/api/crud/hub.py
+++ b/server/py/services/api/crud/hub.py
@@ -338,11 +338,7 @@ class Hub(metaclass=mlrun.utils.singleton.Singleton):
                 # This is necessary since the item names are originally collected from the yaml files
                 # which may can contain underscores.
                 object_details_dict.update(
-                    {
-                        "name": mlrun.utils.helpers.normalize_name(
-                            object_name, verbose=False
-                        )
-                    }
+                    {"name": mlrun.utils.helpers.normalize_name(object_name)}
                 )
                 metadata = mlrun.common.schemas.hub.HubItemMetadata(
                     tag=version_tag, **object_details_dict
@@ -373,5 +369,5 @@ class Hub(metaclass=mlrun.utils.singleton.Singleton):
 
         :return:   list of item objects from catalog
         """
-        normalized_name = mlrun.utils.helpers.normalize_name(item_name, verbose=False)
+        normalized_name = mlrun.utils.helpers.normalize_name(item_name)
         return [item for item in catalog if item.metadata.name == normalized_name]


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
When using underscores, the code replaces them with dashes and logs a warning for the user. This behavior was added in version 1.3.0 in this pr - https://github.com/mlrun/mlrun/pull/3018 and hasn’t been removed since. So, in a way, the use of underscores is deprecated, as we automatically replace them for the user.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
Removed the log warning triggered by underscores in names.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---
### 🧪 Testing
Testing it on client side 
Before the change, it raised a warning:
<img width="1465" height="88" alt="image" src="https://github.com/user-attachments/assets/837416fd-3c9b-4e1f-ba03-b34467cdea0c" />

After the change:
<img width="799" height="76" alt="image" src="https://github.com/user-attachments/assets/4bd27d17-5fed-4052-a1d5-a2d547b34001" />

---
### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-9441

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---
