### PR TITLE
[HTTPDB] Create new SDK method to store or update tokens [feature/ig4-authentication]

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -213,6 +213,8 @@ from .secret import (
     SecretKeysData,
     SecretProviderName,
     SecretsData,
+    SecretToken,
+    StoreSecretTokensResponse,
 )
 from .tag import Tag, TagObjects
 from .workflow import (

--- a/mlrun/common/schemas/secret.py
+++ b/mlrun/common/schemas/secret.py
@@ -47,3 +47,14 @@ class AuthSecretData(BaseModel):
 class SecretKeysData(BaseModel):
     provider: SecretProviderName = Field(SecretProviderName.vault)
     secret_keys: Optional[list] = []
+
+
+class SecretToken(BaseModel):
+    name: str
+    token: str
+
+
+class StoreSecretTokensResponse(BaseModel):
+    created_tokens: list[str] = []
+    updated_tokens: list[str] = []
+    skipped_tokens: list[str] = []

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -1110,3 +1110,19 @@ class RunDBInterface(ABC):
     @abstractmethod
     def get_project_summary(self, project: str) -> mlrun.common.schemas.ProjectSummary:
         pass
+
+    @abstractmethod
+    def store_secret_token(
+        self,
+        secret_token: mlrun.common.schemas.SecretToken,
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        pass
+
+    @abstractmethod
+    def store_secret_tokens(
+        self,
+        secret_tokens: list[mlrun.common.schemas.SecretToken],
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        pass

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5027,6 +5027,13 @@ class HTTPRunDB(RunDBInterface):
         """
         Store or update a single secret token in the MLRun backend.
 
+        Example::
+
+            from mlrun.common.schemas import SecretToken
+
+            secret = SecretToken(name="my-token", token="dummy-token")
+            db.store_secret_token(secret)
+
         :param secret_token: A SecretToken object with name and token fields.
         :param log_warning: Whether to log a warning about local config sync. Defaults to True.
         :return: A structured response indicating which tokens were created, updated, or skipped.
@@ -5053,6 +5060,16 @@ class HTTPRunDB(RunDBInterface):
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         """
         Store or update multiple secret tokens in the MLRun backend.
+
+        Example::
+
+            from mlrun.common.schemas import SecretToken
+
+            tokens = [
+                SecretToken(name="token1", token="dummy-token-1"),
+                SecretToken(name="token2", token="dummy-token-2"),
+            ]
+            db.store_secret_tokens(tokens)
 
         :param secret_tokens: List of SecretToken objects with 'name' and 'token' fields.
         :param log_warning: Whether to log a warning about local config file sync. Defaults to True.

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5019,6 +5019,78 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", endpoint_path, error_message)
         return mlrun.common.schemas.ProjectSummary(**response.json())
 
+    def store_secret_token(
+        self,
+        secret_token: mlrun.common.schemas.SecretToken,
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        """
+        Store or update a single secret token in the MLRun backend.
+
+        :param secret_token: A SecretToken object with name and token fields.
+        :param log_warning: Whether to log a warning about local config sync. Defaults to True.
+        :return: A structured response indicating which tokens were created, updated, or skipped.
+        """
+        if not secret_token:
+            raise MLRunInvalidArgumentError("No secret token provided")
+
+        response = self._store_secret_tokens(
+            secret_tokens=[secret_token],
+            error=f"store user secret token {secret_token.name}",
+        )
+        if log_warning:
+            logger.warning(
+                f"Token '{secret_token.name}' was stored in the backend, "
+                "but the local configuration file (~/.igz.yaml) was not updated. "
+                "Update it manually or run `mlrun.sync_secret_tokens()` to sync your local environment."
+            )
+        return response
+
+    def store_secret_tokens(
+        self,
+        secret_tokens: list[mlrun.common.schemas.SecretToken],
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        """
+        Store or update multiple secret tokens in the MLRun backend.
+
+        :param secret_tokens: List of SecretToken objects with 'name' and 'token' fields.
+        :param log_warning: Whether to log a warning about local config file sync. Defaults to True.
+        :return: StoreSecretTokensResponse object indicating which tokens were created, updated, or skipped.
+        """
+        if not secret_tokens:
+            raise MLRunInvalidArgumentError("No secret tokens provided")
+
+        response = self._store_secret_tokens(
+            secret_tokens=secret_tokens,
+            error="store multiple user secret tokens",
+        )
+        if log_warning:
+            token_names = "', '".join(token.name for token in secret_tokens)
+            logger.warning(
+                f"Tokens '{token_names}' were stored in the backend, "
+                "but the local configuration file (~/.igz.yaml) was not updated. "
+                "Update it manually or run `mlrun.sync_secret_tokens()` to sync your local environment."
+            )
+        return response
+
+    def _store_secret_tokens(
+        self,
+        secret_tokens: list[mlrun.common.schemas.SecretToken],
+        error: str,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        body = [token.dict() for token in secret_tokens]
+        endpoint_path = "user-secrets/tokens"
+
+        response = self.api_call(
+            mlrun.common.types.HTTPMethod.PUT,
+            endpoint_path,
+            error,
+            body=dict_to_json(body),
+        )
+
+        return mlrun.common.schemas.StoreSecretTokensResponse(**response)
+
     @staticmethod
     def _parse_labels(
         labels: Optional[Union[str, dict[str, Optional[str]], list[str]]],

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -951,3 +951,17 @@ class NopDB(RunDBInterface):
 
     def get_project_summary(self, project: str):
         pass
+
+    def store_secret_token(
+        self,
+        secret_token: mlrun.common.schemas.SecretToken,
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        pass
+
+    def store_secret_tokens(
+        self,
+        secret_tokens: list[mlrun.common.schemas.SecretToken],
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        pass

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -1363,6 +1363,20 @@ class SQLRunDB(RunDBInterface):
     def get_project_summary(self, project: str):
         raise NotImplementedError
 
+    def store_secret_token(
+        self,
+        secret_token: mlrun.common.schemas.SecretToken,
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        raise NotImplementedError
+
+    def store_secret_tokens(
+        self,
+        secret_tokens: list[mlrun.common.schemas.SecretToken],
+        log_warning: bool = True,
+    ) -> mlrun.common.schemas.StoreSecretTokensResponse:
+        raise NotImplementedError
+
 
 # Once this file is imported it will override the default RunDB implementation (RunDBContainer)
 @containers.override(mlrun.db.factory.RunDBContainer)

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -1197,6 +1197,27 @@ def test_store_alert_config_missing_alert_name(
         )
 
 
+def test_store_secret_token_invalid_inputs(create_server):
+    server: Server = create_server()
+    db: HTTPRunDB = server.conn
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="No secret token provided"
+    ):
+        db.store_secret_token(None)
+
+
+@pytest.mark.parametrize("secret_tokens", [None, []])
+def test_store_secret_tokens_invalid_inputs(create_server, secret_tokens):
+    server: Server = create_server()
+    db: HTTPRunDB = server.conn
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="No secret tokens provided"
+    ):
+        db.store_secret_tokens(secret_tokens)
+
+
 def _assert_projects(expected_project, project):
     assert (
         deepdiff.DeepDiff(


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
This PR adds new HTTPDB SDK methods to store or update one or more token secrets in MLRun.
The new methods allow sending offline token JWTs to the MLRun API, which stores each token as a user secret and returns a structured response indicating whether each token was created, updated, or skipped.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

Added store_secret_token method to store or update a single token:
`db.store_secret_token(secret_token: mlrun.common.schemas.SecretToken, log_warning: bool = True)`

Added store_secret_tokens method to store or update multiple tokens:
`db.store_secret_tokens(secret_tokens: list[mlrun.common.schemas.SecretToken], log_warning: bool = True)`


---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10501
- Design docs links: https://iguazio.atlassian.net/wiki/spaces/MLRUN/pages/404521061/BE+Secret+Token+Support+HLD
- External links: https://iguazio.atlassian.net/wiki/spaces/ARC/pages/361103361/MLRun+Secret+Tokens+in+IG4

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->

API side PR - https://github.com/mlrun/mlrun/pull/8408