### PR TITLE
[CI] Fix building mlrun image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,6 @@ MLRUN_KFP_CACHE_IMAGE_PUSH_COMMAND := $(if $(and $(MLRUN_DOCKER_CACHE_FROM_TAG),
 DEFAULT_IMAGES += $(MLRUN_KFP_IMAGE_NAME_TAGGED)
 
 .PHONY: mlrun-kfp
-mlrun-kfp: export MLRUN_PYTHON_VERSION = 3.9
 mlrun-kfp: common-image-3.9 update-version-file ## Build mlrun docker image with KFP
 	$(MLRUN_KFP_CACHE_IMAGE_PULL_COMMAND)
 	docker build \
@@ -503,17 +502,20 @@ ifeq ($(strip $(MLRUN_NO_CACHE)),)
 common-image: $(COMMON_STAMP)
 
 $(COMMON_STAMP): $(COMMON_DOCKERFILE)
-	docker build  \
+	docker build \
 	--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 	--build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
-	-f $(COMMON_DOCKERFILE) -t $(COMMON_IMAGE_NAME) .  && mkdir -p $(dir $@) && touch $@
+	-f $(COMMON_DOCKERFILE) \
+	-t $(COMMON_IMAGE_NAME) . \
+	 && mkdir -p $(dir $@) && touch $@
 else  # when MLRUN_NO_CACHE is set
 .PHONY: common-image
 common-image:
-	docker build --no-cache $(COMMON_DOCKER_ARGS) \
- 	  -f $(COMMON_DOCKERFILE) \
+	docker build \
+	  --no-cache $(COMMON_DOCKER_ARGS) \
  	  --build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
  	  --build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+ 	  -f $(COMMON_DOCKERFILE) \
 	  -t $(COMMON_IMAGE_NAME) .
 endif
 

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -19,7 +19,7 @@ ARG OMPI_VERSION=4.1.5
 ARG MICROMAMBA_VERSION=2.3.0
 ARG DOCKER_DEFAULT_PLATFORM=linux/amd64
 
-FROM mambaorg/micromamba:${MICROMAMBA_VERSION} AS conda-build
+FROM --platform=${DOCKER_DEFAULT_PLATFORM} mambaorg/micromamba:${MICROMAMBA_VERSION} AS conda-build
 ARG MLRUN_PYTHON_VERSION
 ARG MLRUN_PIP_VERSION
 ARG OMPI_VERSION
@@ -50,8 +50,7 @@ ARG MLRUN_PIP_VERSION
 
 COPY --from=conda-build /opt/conda /opt/conda
 ENV PATH="/opt/conda/bin:${PATH}"
-# Install Python
-# use /usr/local/bin/python to ensure system pip is also upgraded
+
 RUN --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/pip \
     /opt/conda/bin/python -m pip install --upgrade setuptools pip~=${MLRUN_PIP_VERSION}
 
@@ -59,15 +58,14 @@ WORKDIR /mlrun
 # non-recursive chmod for the run to be able to create the handler file with any security context
 RUN chmod 777 /mlrun
 
+ARG MLRUN_PYTHON_VERSION
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
+
 # Install MLRun:
 # no-deps to ignore existing dependencies, just add the locked requirements
 # mainly because of how the image is built with conda.
 # see https://iguazio.atlassian.net/browse/ML-8712 for example
 # where 'tqdm' is given by conda env but will get remove if we omit the `--no-deps`.
-
-ARG MLRUN_PYTHON_VERSION
-
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \
     --mount=type=bind,source=dockerfiles/mlrun/locked-requirements.txt,target=locked-requirements.txt \


### PR DESCRIPTION
### 📝 Description
Fixed building mlrun image on non-amd64 platform. beforehand the build were failing on

```
0.078 /bin/sh: 1: /opt/conda/bin/python: not found
------
Dockerfile:54
--------------------
  53 |     
  54 | >>> RUN --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/pip \
  55 | >>>     /opt/conda/bin/python -m pip install --upgrade setuptools pip~=${MLRUN_PIP_VERSION}
  56 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c /opt/conda/bin/python -m pip install --upgrade setuptools pip~=${MLRUN_PIP_VERSION}" did not complete successfully: exit code: 127
```

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
ran `patch_remote.py` to build mlrun / mlrun-kfp and api targets

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No


---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
