### PR TITLE
[Bugfix] Add schemas/proto to PYTHONPATH for generated gRPC imports

### DIFF
--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -67,7 +67,7 @@ RUN python -m pip uninstall pip -y \
 
 
 VOLUME /mlrun/db
-ENV PYTHONPATH=/mlrun/server/py
+ENV PYTHONPATH=/mlrun/server/py:/mlrun/server/py/schemas/proto
 ENV MLRUN_HTTPDB__DSN='sqlite:////mlrun/db/mlrun.db?check_same_thread=false'
 ENV MLRUN_HTTPDB__LOGS_PATH=/mlrun/db/logs
 ENV MLRUN_HTTPDB__DIRPATH=/mlrun/db


### PR DESCRIPTION
### 📝 Description

  Following the changes in https://github.com/mlrun/mlrun/pull/8337, Python gRPC stubs are now compiled into `server/py/schemas/proto` without modifying their absolute imports (e.g., `import log_collector_pb2`). As a result, these imports fail at runtime unless the `schemas/proto` directory is also on the Python path.

This change adds `/mlrun/server/py/schemas/proto` to PYTHONPATH in the Docker image, ensuring generated gRPC modules resolve correctly without altering their generated code or build output.


### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🧪 Testing
Built API image and imported log collector class, patched lab system

---

### 🔗 References
- Ticket link:  https://iguazio.atlassian.net/browse/ML-10829

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No
---