### PR TITLE
[Serving] Fix ModelSelector serialization

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1463,16 +1463,17 @@ class ModelRunnerStep(MonitoredStep):
                 "`model_selector_parameters`."
             )
         if model_selector:
-            model_selector = (
-                model_selector
-                if isinstance(model_selector, str)
-                else model_selector.__class__.__name__
-            )
             model_selector_parameters = model_selector_parameters or (
                 model_selector.to_dict()
                 if isinstance(model_selector, ModelSelector)
                 else {}
             )
+            model_selector = (
+                model_selector
+                if isinstance(model_selector, str)
+                else model_selector.__class__.__name__
+            )
+
         super().__init__(
             *args,
             name=name,

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1332,6 +1332,9 @@ class LLModel(Model):
 class ModelSelector(ModelObj):
     """Used to select which models to run on each event."""
 
+    def __init__(self, **kwargs):
+        super().__init__()
+
     def __init_subclass__(cls):
         super().__init_subclass__()
         cls._dict_fields = list(
@@ -1459,16 +1462,17 @@ class ModelRunnerStep(MonitoredStep):
                 "Cannot provide a model_selector object as argument to `model_selector` and also provide "
                 "`model_selector_parameters`."
             )
-        model_selector_parameters = model_selector_parameters or (
-            model_selector.to_dict()
-            if isinstance(model_selector, ModelSelector)
-            else {}
-        )
-        model_selector = (
-            model_selector
-            if isinstance(model_selector, str)
-            else model_selector.__class__.__name__
-        )
+        if model_selector:
+            model_selector = (
+                model_selector
+                if isinstance(model_selector, str)
+                else model_selector.__class__.__name__
+            )
+            model_selector_parameters = model_selector_parameters or (
+                model_selector.to_dict()
+                if isinstance(model_selector, ModelSelector)
+                else {}
+            )
         super().__init__(
             *args,
             name=name,

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1329,7 +1329,14 @@ class LLModel(Model):
         return prompt_template, llm_prompt_artifact.spec.model_configuration
 
 
-class ModelSelector:
+class JsonSerializable(dict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class ModelSelector(JsonSerializable):
     """Used to select which models to run on each event."""
 
     def select(

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1332,6 +1332,14 @@ class LLModel(Model):
 class ModelSelector(ModelObj):
     """Used to select which models to run on each event."""
 
+    def __init_subclass__(cls):
+        super().__init_subclass__()
+        cls._dict_fields = list(
+            set(cls._dict_fields)
+            | set(inspect.signature(cls.__init__).parameters.keys())
+        )
+        cls._dict_fields.remove("self")
+
     def select(
         self, event, available_models: list[Model]
     ) -> Union[list[str], list[Model]]:
@@ -1843,14 +1851,17 @@ class ModelRunnerStep(MonitoredStep):
         if not self._is_local_function(context):
             # skip init of non local functions
             return
-        model_selector, model_selector_params = self.class_args.get("model_selector")
+        model_selector, model_selector_params = self.class_args.get(
+            "model_selector", (None, None)
+        )
         execution_mechanism_by_model_name = self.class_args.get(
             schemas.ModelRunnerStepData.MODEL_TO_EXECUTION_MECHANISM
         )
         models = self.class_args.get(schemas.ModelRunnerStepData.MODELS, {})
-        model_selector = get_class(model_selector, namespace).from_dict(
-            model_selector_params, init_with_params=True
-        )
+        if model_selector:
+            model_selector = get_class(model_selector, namespace).from_dict(
+                model_selector_params, init_with_params=True
+            )
         model_objects = []
         for model, model_params in models.values():
             model_params[schemas.MonitoringData.INPUT_PATH] = (

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1329,14 +1329,7 @@ class LLModel(Model):
         return prompt_template, llm_prompt_artifact.spec.model_configuration
 
 
-class JsonSerializable(dict):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-
-
-class ModelSelector(JsonSerializable):
+class ModelSelector(ModelObj):
     """Used to select which models to run on each event."""
 
     def select(
@@ -1449,15 +1442,31 @@ class ModelRunnerStep(MonitoredStep):
         *args,
         name: Optional[str] = None,
         model_selector: Optional[Union[str, ModelSelector]] = None,
+        model_selector_parameters: Optional[dict] = None,
         raise_exception: bool = True,
         **kwargs,
     ):
+        if isinstance(model_selector, ModelSelector) and model_selector_parameters:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Cannot provide a model_selector object as argument to `model_selector` and also provide "
+                "`model_selector_parameters`."
+            )
+        model_selector_parameters = model_selector_parameters or (
+            model_selector.to_dict()
+            if isinstance(model_selector, ModelSelector)
+            else {}
+        )
+        model_selector = (
+            model_selector
+            if isinstance(model_selector, str)
+            else model_selector.__class__.__name__
+        )
         super().__init__(
             *args,
             name=name,
             raise_exception=raise_exception,
             class_name="mlrun.serving.ModelRunner",
-            class_args=dict(model_selector=model_selector),
+            class_args=dict(model_selector=(model_selector, model_selector_parameters)),
             **kwargs,
         )
         self.raise_exception = raise_exception
@@ -1834,13 +1843,14 @@ class ModelRunnerStep(MonitoredStep):
         if not self._is_local_function(context):
             # skip init of non local functions
             return
-        model_selector = self.class_args.get("model_selector")
+        model_selector, model_selector_params = self.class_args.get("model_selector")
         execution_mechanism_by_model_name = self.class_args.get(
             schemas.ModelRunnerStepData.MODEL_TO_EXECUTION_MECHANISM
         )
         models = self.class_args.get(schemas.ModelRunnerStepData.MODELS, {})
-        if isinstance(model_selector, str):
-            model_selector = get_class(model_selector, namespace)()
+        model_selector = get_class(model_selector, namespace).from_dict(
+            model_selector_params, init_with_params=True
+        )
         model_objects = []
         for model, model_params in models.values():
             model_params[schemas.MonitoringData.INPUT_PATH] = (

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import pathlib
 import unittest.mock
+from copy import deepcopy
 from types import SimpleNamespace
 from typing import Optional, Union
 
@@ -539,7 +540,7 @@ def _test_model_runner_raise_error_output(
 class MyModelSelector(ModelSelector):
     def __init__(self, models: Union[list[str], list[Model]]):
         super().__init__()
-        self.models = copy(models)
+        self.models = deepcopy(models)
 
     def select(
         self, event, available_models: list[Model]

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -537,8 +537,17 @@ def _test_model_runner_raise_error_output(
 
 
 class MyModelSelector(ModelSelector):
-    def select(self, event, available_models: list[Model]) -> Optional[list[str]]:
-        return event.body.get("models")
+    def __init__(self, models: Union[list[str], list[Model]]):
+        super().__init__()
+        self.models = copy(models)
+
+    def select(
+        self, event, available_models: list[Model]
+    ) -> Union[list[str], list[Model]]:
+        current_models = event.body.get("models")
+        if current_models and set(current_models).issubset(set(self.models)):
+            return current_models
+        return []
 
 
 @pytest.mark.parametrize(
@@ -557,7 +566,7 @@ def test_model_runner_with_selector(execution_mechanism: str):
     graph = function.set_topology("flow", engine="async")
     model_runner_step = ModelRunnerStep(
         name="my_model_runner",
-        model_selector="MyModelSelector",
+        model_selector=MyModelSelector(models=["m1", "m2"]),
     )
     model_runner_step.add_model(
         endpoint_name=m1.name,
@@ -574,7 +583,7 @@ def test_model_runner_with_selector(execution_mechanism: str):
     server = function.to_mock_server()
     try:
         # both models
-        resp = server.test(body={"n": 1})
+        resp = server.test(body={"n": 1, "models": ["m1", "m2"]})
         expected = {
             "m1": {"n": 2},
             "m2": {"n": 3},

--- a/tests/system/runtimes/assets/function_with_model.py
+++ b/tests/system/runtimes/assets/function_with_model.py
@@ -11,11 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from copy import copy
+from typing import Union
 
-from mlrun.serving import Model
+from mlrun.serving import Model, ModelSelector
 
 
 class DummyModel(Model):
     def predict(self, body, **kwargs):
         body["extra"] = 123
+        body.pop("models", None)
         return body
+
+
+class MyModelSelector(ModelSelector):
+    def __init__(self, models: Union[list[str], list[Model]]):
+        super().__init__()
+        self.models = copy(models)
+
+    def select(
+        self, event, available_models: list[Model]
+    ) -> Union[list[str], list[Model]]:
+        current_models = event.body.get("models")
+        if set(current_models).issubset(set(self.models)):
+            return current_models
+        return []

--- a/tests/system/runtimes/assets/function_with_model.py
+++ b/tests/system/runtimes/assets/function_with_model.py
@@ -20,7 +20,6 @@ from mlrun.serving import Model, ModelSelector
 class DummyModel(Model):
     def predict(self, body, **kwargs):
         body["extra"] = 123
-        body.pop("models", None)
         return body
 
 
@@ -32,7 +31,7 @@ class MyModelSelector(ModelSelector):
     def select(
         self, event, available_models: list[Model]
     ) -> Union[list[str], list[Model]]:
-        current_models = event.body.get("models")
-        if set(current_models).issubset(set(self.models)):
+        current_models = event.body.pop("models", [])
+        if current_models and set(current_models).issubset(set(self.models)):
             return current_models
         return []

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -165,7 +165,7 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         assert deployment == function.get_url()  # check function url
 
         resp = function.invoke("/", {"x": "y", "models": ["my-model"]})
-        assert resp == {'my-model': {'extra': 123, 'x': 'y'}}
+        assert resp == {"my-model": {"extra": 123, "x": "y"}}
 
     def test_model_runner_with_llm_and_shared_models(self):
         code_path = str(self.assets_path / "function_with_llm.py")

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -34,7 +34,7 @@ from mlrun.datastore.targets import ParquetTarget
 from mlrun.serving import ModelRunnerStep
 from tests.system.model_monitoring import TestMLRunSystemModelMonitoring
 from tests.system.runtimes.assets.function_with_llm import MyLLM
-from tests.system.runtimes.assets.function_with_model import DummyModel
+from tests.system.runtimes.assets.function_with_model import DummyModel, MyModelSelector
 
 
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
@@ -115,6 +115,57 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
 
         resp = function.invoke("/", {"x": "y"})
         assert resp == {"x": "y", "extra": 123}
+
+    @pytest.mark.parametrize("with_object", [True, False])
+    def test_deploy_function_with_model_runner_with_selector(self, with_object):
+        code_path = str(self.assets_path / "function_with_model.py")
+
+        self._logger.debug("Creating nuclio function")
+        function = mlrun.code_to_function(
+            name="function_with_model",
+            kind="serving",
+            project=self.project_name,
+            filename=code_path,
+            image=self.image,
+        )
+        graph = function.set_topology("flow", engine="async")
+
+        if with_object:
+            dummy_model = DummyModel(name="my-model")
+            dummy_model_2 = DummyModel(name="another-model")
+            model_selector = MyModelSelector(models=["my-model", "another-model"])
+        else:
+            dummy_model = "DummyModel"
+            dummy_model_2 = "DummyModel"
+            model_selector = "MyModelSelector"
+        model_runner_step = ModelRunnerStep(
+            name="model-runner",
+            model_selector=model_selector,
+            model_selector_parameters={"models": ["my-model", "another-model"]}
+            if not with_object
+            else None,
+        )
+
+        model_runner_step.add_model(
+            model_class=dummy_model,
+            execution_mechanism="naive",
+            endpoint_name="my-model",
+        )
+        model_runner_step.add_model(
+            model_class=dummy_model_2,
+            execution_mechanism="naive",
+            endpoint_name="another-model",
+        )
+
+        graph.to(model_runner_step).respond()
+
+        self._logger.debug("Deploying nuclio function with model selector")
+        deployment = function.deploy()
+
+        assert deployment == function.get_url()  # check function url
+
+        resp = function.invoke("/", {"x": "y", "models": ["my-model"]})
+        assert resp == {'my-model': {'extra': 123, 'x': 'y'}}
 
     def test_model_runner_with_llm_and_shared_models(self):
         code_path = str(self.assets_path / "function_with_llm.py")


### PR DESCRIPTION
### 📝 Description
Fix allows to initialize a `ModelRunnerStep` with a model selector object

---

### 🛠️ Changes Made
1.  `ModelSelector` inherits ModelObj.
2.  `ModelRunnerStep:init_object` use from_dict as we handle Model serialization.
3.  `ModelRunnerStep:__init__` allow the user to add model selector parameters for initialization 

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Adding a system_test allowing to add model selector as object

---

### 🔗 References
- Ticket link:  https://iguazio.atlassian.net/browse/ML-10832
---