### PR TITLE
[Bugfix] Include version.json in mlrun package to fix server version reporting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,12 @@ setup(
             "server",
         ]
     ),
-    package_data={"mlrun": ["runtimes/nuclio/application/*.go"]},
+    package_data={
+        "mlrun": [
+            "utils/version/version.json",
+            "runtimes/nuclio/application/*.go",
+        ]
+    },
     keywords=[
         "mlrun",
         "mlops",


### PR DESCRIPTION
### 📝 Description
Fix server version being reported as `0.0.0+unstable` by including `utils/version/version.json` in the package build.  
Previously, the file was missing from the built wheel, causing the server to fall back to default unstable values.  

---

### 🛠️ Changes Made
- Updated `setup.py` to include `utils/version/version.json` in `package_data`.  
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🧪 Testing
- Built wheel/image locally and verified `mlrun/utils/version/version.json` is included.  
- ---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10830 

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No