### PR TITLE
[Docker] Explicitly set Docker build --platform in Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,7 @@ mlrun: common-image update-version-file ## Build mlrun docker image
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
 		--build-arg MLRUN_UV_IMAGE=$(MLRUN_UV_IMAGE) \
 		--build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		$(MLRUN_IMAGE_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_IMAGE_NAME_TAGGED) .
@@ -344,6 +345,7 @@ mlrun-kfp: common-image-3.9 update-version-file ## Build mlrun docker image with
 		--build-arg MLRUN_VERSION=$(MLRUN_VERSION) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
 		--build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		$(MLRUN_KFP_IMAGE_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_KFP_IMAGE_NAME):$(MLRUN_DOCKER_TAG)$(MLRUN_PYTHON_VERSION_SUFFIX) .
@@ -386,6 +388,7 @@ mlrun-gpu: update-version-file ## Build mlrun gpu docker image
 		--build-arg MLRUN_GPU_BASE_IMAGE=$(MLRUN_GPU_BASE_IMAGE) \
 		--build-arg MLRUN_UV_IMAGE=$(MLRUN_UV_IMAGE) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		$(MLRUN_GPU_IMAGE_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_GPU_IMAGE_NAME_TAGGED) \
@@ -407,6 +410,7 @@ prebake-mlrun-gpu: ## Build prebake mlrun GPU based docker image
 		--build-arg CUDA_VER=$(MLRUN_GPU_CUDA_VERSION) \
 		--build-arg MLRUN_ANACONDA_PYTHON_DISTRIBUTION=$(MLRUN_ANACONDA_PYTHON_DISTRIBUTION) \
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		--tag $(MLRUN_GPU_PREBAKED_IMAGE_NAME_TAGGED) \
 		.
 
@@ -432,6 +436,7 @@ jupyter: update-version-file ## Build mlrun jupyter docker image
 		--build-arg MLRUN_CACHE_DATE=$(MLRUN_CACHE_DATE) \
 		--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 		--build-arg MLRUN_UV_IMAGE=$(MLRUN_UV_IMAGE) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		$(MLRUN_JUPYTER_IMAGE_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_JUPYTER_IMAGE_NAME_TAGGED) \
@@ -505,6 +510,7 @@ $(COMMON_STAMP): $(COMMON_DOCKERFILE)
 	docker build \
 	--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 	--build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+	--platform $(DOCKER_DEFAULT_PLATFORM) \
 	-f $(COMMON_DOCKERFILE) \
 	-t $(COMMON_IMAGE_NAME) . \
 	 && mkdir -p $(dir $@) && touch $@
@@ -515,6 +521,7 @@ common-image:
 	  --no-cache $(COMMON_DOCKER_ARGS) \
  	  --build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
  	  --build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+	  --platform $(DOCKER_DEFAULT_PLATFORM) \
  	  -f $(COMMON_DOCKERFILE) \
 	  -t $(COMMON_IMAGE_NAME) .
 endif
@@ -546,6 +553,7 @@ api: common-image-3.11	 compile-schemas update-version-file ## Build mlrun-api d
 		--build-arg MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 		--build-arg MLRUN_UV_IMAGE=$(MLRUN_UV_IMAGE) \
 		--build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		$(MLRUN_API_IMAGE_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_API_IMAGE_NAME_TAGGED) .
@@ -578,6 +586,7 @@ build-test: common-image compile-schemas update-version-file ## Build test docke
 		--build-arg MLRUN_PIPELINES_KFP_VERSION=$(MLRUN_PIPELINES_KFP_VERSION) \
 		--build-arg MLRUN_UV_VERSION=$(MLRUN_UV_VERSION) \
 		--build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		$(MLRUN_TEST_IMAGE_DOCKER_CACHE_FROM_FLAG) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_TEST_IMAGE_NAME_TAGGED) .
@@ -597,6 +606,7 @@ build-test-system: common-image compile-schemas update-version-file ## Build sys
 		--build-arg MLRUN_PIP_VERSION=$(MLRUN_PIP_VERSION) \
 		--build-arg MLRUN_UV_VERSION=$(MLRUN_UV_VERSION) \
 		--build-arg DOCKER_DEFAULT_PLATFORM=$(DOCKER_DEFAULT_PLATFORM) \
+		--platform $(DOCKER_DEFAULT_PLATFORM) \
 		$(MLRUN_DOCKER_NO_CACHE_FLAG) \
 		--tag $(MLRUN_SYSTEM_TEST_IMAGE_NAME) .
 


### PR DESCRIPTION
### 📝 Description
This change adds an explicit `--platform $(DOCKER_DEFAULT_PLATFORM)` flag to all relevant Docker build commands in the Makefile, including:

- mlrun
- mlrun-kfp
- mlrun-gpu
- jupyter
- common-image
- api
- build-test
- build-test-system

Previously, we passed `DOCKER_DEFAULT_PLATFORM` as a build argument but did not explicitly set the Docker build `--platform` flag. When building on architectures different from the target (e.g., building on ARM hosts targeting amd64), this could cause Docker to default to the host platform instead of the intended target platform, leading to platform mismatch warnings or incorrect image builds.

By explicitly specifying the platform in all Makefile targets, we:
- Ensure consistent image builds across all environments
- Prevent cross-platform build failures or incorrect architectures in output images
- Align the build command with the intended `DOCKER_DEFAULT_PLATFORM` value
### 🛠️ Changes Made
- Updated `mlrun`, `mlrun-kfp`, `mlrun-gpu`, `jupyter`, `common-image`, `api`, `build-test`, and `build-test-system` Makefile targets to include `--platform $(DOCKER_DEFAULT_PLATFORM)`.

---

### ✅ Checklist
- [x] Verified builds complete successfully with explicit `--platform`.
- [x] Confirmed no changes to image content apart from platform metadata.

---

### 🧪 Testing
- Local build on `linux/arm64` targeting `linux/amd64` completed successfully, both with DOCKER_DEFAULT_PLATFORM set and unset.

---

### 🔗 References
- Ticket: [ML-10852](https://iguazio.atlassian.net/browse/ML-10852)

---

### 💥 Breaking Changes?
- [ ] Yes
- [x] No

---

### 📝 Additional Notes
This change is mainly to prevent cross-platform build issues and to unify build parameters across all targets.

[ML-10852]: https://iguazio.atlassian.net/browse/ML-10852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ