### PR TITLE
[HTTPDB] Disable retries for storing secret tokens [feature/ig4-authentication]

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -123,7 +123,8 @@ class HTTPRunDB(RunDBInterface):
     ]
 
     NON_RETRIABLE_PATHS = [
-        r"user-secrets/tokens",
+        # Storing user secret tokens is not idempotent — retrying the request may result inconsistent secret storage.
+        r"\/?user-secrets/tokens",
     ]
 
     def __init__(self, url):
@@ -287,10 +288,9 @@ class HTTPRunDB(RunDBInterface):
 
         retry_on_post = self._is_retry_on_post_allowed(method, path)
 
-        # PUT retries are allowed unless the path is in NON_RETRIABLE_PATHS
         retry_on_put = self._is_retry_put_allowed(method, path)
 
-        # if the method is POST or PUST, we need to update the session with the appropriate retry policy
+        # if the method is POST or PUT, we need to update the session with the appropriate retry policy
         if not self.session or method in ("POST", "PUT"):
             self.session = self._init_session(retry_on_post, retry_on_put)
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -122,6 +122,10 @@ class HTTPRunDB(RunDBInterface):
         r"\/?run\/.+\/.+",
     ]
 
+    NON_RETRIABLE_PATHS = [
+        r"user-secrets/tokens",
+    ]
+
     def __init__(self, url):
         self.server_version = ""
         self.session = None
@@ -281,10 +285,14 @@ class HTTPRunDB(RunDBInterface):
                     if isinstance(dict_[key], enum.Enum):
                         dict_[key] = dict_[key].value
 
-        # if the method is POST, we need to update the session with the appropriate retry policy
-        if not self.session or method == "POST":
-            retry_on_post = self._is_retry_on_post_allowed(method, path)
-            self.session = self._init_session(retry_on_post)
+        retry_on_post = self._is_retry_on_post_allowed(method, path)
+
+        # PUT retries are allowed unless the path is in NON_RETRIABLE_PATHS
+        retry_on_put = self._is_retry_put_allowed(method, path)
+
+        # if the method is POST or PUST, we need to update the session with the appropriate retry policy
+        if not self.session or method in ("POST", "PUT"):
+            self.session = self._init_session(retry_on_post, retry_on_put)
 
         try:
             response = self.session.request(
@@ -400,11 +408,12 @@ class HTTPRunDB(RunDBInterface):
             data.extend(response.json().get(key, []))
         return data, page_token
 
-    def _init_session(self, retry_on_post: bool = False):
+    def _init_session(self, retry_on_post: bool = False, retry_on_put: bool = True):
         return mlrun.utils.HTTPSessionWithRetry(
             retry_on_exception=config.httpdb.retry_api_call_on_exception
             == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value,
             retry_on_post=retry_on_post,
+            retry_on_put=retry_on_put,
         )
 
     def _path_of(self, resource, project, uid=None):
@@ -425,6 +434,26 @@ class HTTPRunDB(RunDBInterface):
         return method == "POST" and any(
             re.match(regex, path) for regex in self.RETRIABLE_POST_PATHS
         )
+
+    def _is_retry_put_allowed(self, method: str, path: str) -> bool:
+        """
+        Determine if PUT request to the given path should be retried.
+        :param method: HTTP method
+        :param path: API path to check
+        :return: True if retry is allowed, False otherwise
+        """
+        if method != "PUT":
+            return True
+
+        # Strip query parameters and fragment if present
+        parsed_path = urlparse(path).path.lstrip("/")
+
+        # If the path matches a non-retriable path, do not allow retry
+        for regex in self.NON_RETRIABLE_PATHS:
+            if re.fullmatch(regex, parsed_path):
+                return False
+
+        return True
 
     def connect(self, secrets=None):
         """Connect to the MLRun API server. Must be called prior to executing any other method.

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -438,6 +438,7 @@ class HTTPRunDB(RunDBInterface):
     def _is_retry_put_allowed(self, method: str, path: str) -> bool:
         """
         Determine if PUT request to the given path should be retried.
+
         :param method: HTTP method
         :param path: API path to check
         :return: True if retry is allowed, False otherwise

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -79,6 +79,8 @@ class HTTPSessionWithRetry(requests.Session):
         :param retry_on_exception:      Retry on the HTTP_RETRYABLE_EXCEPTIONS. defaults to True.
         :param retry_on_status:         Retry on error status codes. defaults to True.
         :param retry_on_post:           Retry on POST requests. defaults to False.
+        :param retry_on_put:            Whether to allow retries on PUT requests. Actual behavior may exclude specific
+                                        paths from retrying. defaults to True.
         :param verbose:                 Print debug messages.
         """
         super().__init__()

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -69,6 +69,7 @@ class HTTPSessionWithRetry(requests.Session):
         retry_on_exception=True,
         retry_on_status=True,
         retry_on_post=False,
+        retry_on_put=True,
         verbose=False,
     ):
         """
@@ -87,7 +88,7 @@ class HTTPSessionWithRetry(requests.Session):
         self.retry_on_exception = retry_on_exception
         self.verbose = verbose
         self._logger = logger.get_child("http-client")
-        self._retry_methods = self._resolve_retry_methods(retry_on_post)
+        self._retry_methods = self._resolve_retry_methods(retry_on_post, retry_on_put)
 
         if retry_on_status:
             self._http_adapter = requests.adapters.HTTPAdapter(
@@ -201,9 +202,13 @@ class HTTPSessionWithRetry(requests.Session):
     def _method_retryable(self, method: str):
         return method in self._retry_methods
 
-    def _resolve_retry_methods(self, retry_on_post: bool = False) -> frozenset[str]:
+    def _resolve_retry_methods(
+        self, retry_on_post: bool = False, retry_on_put: bool = True
+    ) -> frozenset[str]:
         methods = urllib3.util.retry.Retry.DEFAULT_ALLOWED_METHODS
         methods = methods.union({"PATCH"})
+        if not retry_on_put:
+            methods = methods.difference({"PUT"})
         if retry_on_post:
             methods = methods.union({"POST"})
         return frozenset(methods)

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -234,7 +234,6 @@ def test_resolve_artifacts_to_tag_objects():
             1 + mlrun.mlconf.http_retry_defaults.max_retries,
         ),
         ("POST", "/run/default/uid", 1 + mlrun.mlconf.http_retry_defaults.max_retries),
-
         # non-retriable
         ("POST", "/not/retriable", 1),
         ("PUT", "user-secrets/tokens", 1),
@@ -243,8 +242,6 @@ def test_resolve_artifacts_to_tag_objects():
 def test_retriable_requests(method, path, call_amount):
     mlrun.mlconf.httpdb.retry_api_call_on_exception = "enabled"
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
-    # init the session to make sure it will be reinitialized when needed
-    # db.session = db._init_session(False)
     original_request = requests.Session.request
     requests.Session.request = unittest.mock.Mock()
     requests.Session.request.side_effect = ConnectionRefusedError(

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -210,34 +210,41 @@ def test_resolve_artifacts_to_tag_objects():
 
 
 @pytest.mark.parametrize(
-    "path, call_amount",
+    "method, path, call_amount",
     [
         (
+            "POST",
             "projects/default/artifacts/uid/tag",
             1 + mlrun.mlconf.http_retry_defaults.max_retries,
         ),
         (
+            "POST",
             "projects/default/artifacts/8bbaaa9f-919e-4438-8e6c-edbf6d37f3bf/v1",
             1 + mlrun.mlconf.http_retry_defaults.max_retries,
         ),
         (
+            "POST",
             "/projects/default/artifacts/uid/tag",
             1 + mlrun.mlconf.http_retry_defaults.max_retries,
         ),
-        ("run/default/uid", 1 + mlrun.mlconf.http_retry_defaults.max_retries),
+        ("POST", "run/default/uid", 1 + mlrun.mlconf.http_retry_defaults.max_retries),
         (
+            "POST",
             "run/default/8bbaaa9f-919e-4438-8e6c-edbf6d37f3bf",
             1 + mlrun.mlconf.http_retry_defaults.max_retries,
         ),
-        ("/run/default/uid", 1 + mlrun.mlconf.http_retry_defaults.max_retries),
-        ("/not/retriable", 1),
+        ("POST", "/run/default/uid", 1 + mlrun.mlconf.http_retry_defaults.max_retries),
+
+        # non-retriable
+        ("POST", "/not/retriable", 1),
+        ("PUT", "user-secrets/tokens", 1),
     ],
 )
-def test_retriable_post_requests(path, call_amount):
+def test_retriable_requests(method, path, call_amount):
     mlrun.mlconf.httpdb.retry_api_call_on_exception = "enabled"
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
     # init the session to make sure it will be reinitialized when needed
-    db.session = db._init_session(False)
+    # db.session = db._init_session(False)
     original_request = requests.Session.request
     requests.Session.request = unittest.mock.Mock()
     requests.Session.request.side_effect = ConnectionRefusedError(
@@ -249,7 +256,7 @@ def test_retriable_post_requests(path, call_amount):
         # Catching also MLRunRuntimeError as if the exception inherits from requests.RequestException, it will be
         # wrapped with MLRunRuntimeError
         with pytest.raises(ConnectionRefusedError):
-            db.api_call("POST", path)
+            db.api_call(method, path)
 
     assert requests.Session.request.call_count == call_amount
     requests.Session.request = original_request

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -237,6 +237,7 @@ def test_resolve_artifacts_to_tag_objects():
         # non-retriable
         ("POST", "/not/retriable", 1),
         ("PUT", "user-secrets/tokens", 1),
+        ("PUT", "/user-secrets/tokens", 1),
     ],
 )
 def test_retriable_requests(method, path, call_amount):


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
This PR updates the HTTP session retry logic to prevent retries for PUT requests to `/user-secrets/tokens`.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
1. Added `_is_retry_put_allowed` method to determine whether retries are allowed for PUT requests.
2. Defined `NON_RETRIABLE_PATHS` to include `/user-secrets/tokens`
3. Updated HTTP session initialization to respect `retry_on_put` based on the requested path.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Ran unit tests to verify retry logic.
Tested on an IG4 system by sending a request to `/user-secrets/tokens` and confirmed that it was sent only once (no retries).

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10847
---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
