### PR TITLE
[Test] Remove software-properties-common [1.9.x]

### DIFF
--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         gnupg2 \
         graphviz \
         make \
-        software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
 # set initial git config


### PR DESCRIPTION
Which has been removed from the debian repository, breaking our CI.