### PR TITLE
[Secret Tokens] Enable Conditional Support Based on authentication.mode [feature/ig4-authentication]

### DIFF
--- a/mlrun/common/types.py
+++ b/mlrun/common/types.py
@@ -37,3 +37,11 @@ class HTTPMethod(StrEnum):
 class Operation(StrEnum):
     ADD = "add"
     REMOVE = "remove"
+
+
+class AuthenticationMode(StrEnum):
+    NONE = "none"
+    BASIC = "basic"
+    BEARER = "bearer"
+    IGUAZIO = "iguazio"
+    IGUAZIO_V4 = "iguazio-v4"

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -80,14 +80,13 @@ def bool2str(val):
     return "yes" if val else "no"
 
 
-def require_iguazio_v4(function):
+def iguazio_v4_only(function):
     @functools.wraps(function)
     def wrapper(*args, **kwargs):
         authentication_mode = mlrun.mlconf.httpdb.authentication.mode
         if authentication_mode != AuthenticationMode.IGUAZIO_V4:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"This method is only supported when mlrun.authentication.mode='iguazio-v4', "
-                f"but current mode is '{authentication_mode}'."
+            raise mlrun.errors.MLRunRuntimeError(
+                "This method is only supported in an Iguazio V4 system."
             )
         return function(*args, **kwargs)
 
@@ -5035,7 +5034,7 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", endpoint_path, error_message)
         return mlrun.common.schemas.ProjectSummary(**response.json())
 
-    @require_iguazio_v4
+    @iguazio_v4_only
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
@@ -5070,7 +5069,7 @@ class HTTPRunDB(RunDBInterface):
             )
         return response
 
-    @require_iguazio_v4
+    @iguazio_v4_only
     def store_secret_tokens(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import enum
+import functools
 import http
 import re
 import time
@@ -44,6 +45,7 @@ import mlrun.runtimes.nuclio.api_gateway
 import mlrun.runtimes.nuclio.function
 import mlrun.utils
 from mlrun.alerts.alert import AlertConfig
+from mlrun.common.types import AuthenticationMode
 from mlrun.db.auth_utils import OAuthClientIDTokenProvider, StaticTokenProvider
 from mlrun.errors import MLRunInvalidArgumentError, err_to_str
 from mlrun_pipelines.utils import compile_pipeline
@@ -76,6 +78,20 @@ _artifact_keys = [
 
 def bool2str(val):
     return "yes" if val else "no"
+
+
+def require_iguazio_v4(function):
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        authentication_mode = mlrun.mlconf.httpdb.authentication.mode
+        if authentication_mode != AuthenticationMode.IGUAZIO_V4:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"This method is only supported when mlrun.authentication.mode='iguazio-v4', "
+                f"but current mode is '{authentication_mode}'."
+            )
+        return function(*args, **kwargs)
+
+    return wrapper
 
 
 class HTTPRunDB(RunDBInterface):
@@ -5019,6 +5035,7 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", endpoint_path, error_message)
         return mlrun.common.schemas.ProjectSummary(**response.json())
 
+    @require_iguazio_v4
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
@@ -5053,6 +5070,7 @@ class HTTPRunDB(RunDBInterface):
             )
         return response
 
+    @require_iguazio_v4
     def store_secret_tokens(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],

--- a/server/py/framework/api/deps.py
+++ b/server/py/framework/api/deps.py
@@ -96,9 +96,8 @@ def expose_internal_endpoints(request: Request):
             )
 
 
-def require_iguazio_v4(request: Request):
+def iguazio_v4_only(request: Request):
     if mlrun.mlconf.httpdb.authentication.mode != AuthenticationMode.IGUAZIO_V4:
         raise mlrun.errors.MLRunBadRequestError(
-            f"This endpoint is only supported when mlrun.mlconf.httpdb.authentication.mode='iguazio-v4', "
-            f"but current mode is '{mlrun.mlconf.httpdb.authentication.mode}'."
+            "This endpoint is only supported in an Iguazio V4 system."
         )

--- a/server/py/framework/api/deps.py
+++ b/server/py/framework/api/deps.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 
 import mlrun
 import mlrun.common.schemas
+from mlrun.common.types import AuthenticationMode
 
 import framework.db.session
 import framework.utils.auth.verifier
@@ -93,3 +94,11 @@ def expose_internal_endpoints(request: Request):
             raise mlrun.errors.MLRunPreconditionFailedError(
                 "Internal endpoints are not exposed"
             )
+
+
+def require_iguazio_v4(request: Request):
+    if mlrun.mlconf.httpdb.authentication.mode != AuthenticationMode.IGUAZIO_V4:
+        raise mlrun.errors.MLRunBadRequestError(
+            f"This endpoint is only supported when mlrun.mlconf.httpdb.authentication.mode='iguazio-v4', "
+            f"but current mode is '{mlrun.mlconf.httpdb.authentication.mode}'."
+        )

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -21,20 +21,12 @@ import fastapi
 import mlrun
 import mlrun.common.schemas
 import mlrun.utils.singleton
-from mlrun.common.types import StrEnum
+from mlrun.common.types import AuthenticationMode
 
 import framework.utils.auth.providers.nop
 import framework.utils.auth.providers.opa
 import framework.utils.clients.iguazio.v3
 import framework.utils.clients.iguazio.v4
-
-
-class AuthenticationMode(StrEnum):
-    NONE = "none"
-    BASIC = "basic"
-    BEARER = "bearer"
-    IGUAZIO = "iguazio"
-    IGUAZIO_V4 = "iguazio-v4"
 
 
 class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):

--- a/server/py/services/api/api/api.py
+++ b/server/py/services/api/api/api.py
@@ -146,7 +146,7 @@ api_router.include_router(
 api_router.include_router(
     user_secrets.router,
     tags=["user-secrets"],
-    dependencies=[Depends(deps.authenticate_request), Depends(deps.require_iguazio_v4)],
+    dependencies=[Depends(deps.authenticate_request), Depends(deps.iguazio_v4_only)],
 )
 api_router.include_router(grafana_proxy.router, tags=["grafana", "model-endpoints"])
 api_router.include_router(model_endpoints.router, tags=["model-endpoints"])

--- a/server/py/services/api/api/api.py
+++ b/server/py/services/api/api/api.py
@@ -146,7 +146,7 @@ api_router.include_router(
 api_router.include_router(
     user_secrets.router,
     tags=["user-secrets"],
-    dependencies=[Depends(deps.authenticate_request)],
+    dependencies=[Depends(deps.authenticate_request), Depends(deps.require_iguazio_v4)],
 )
 api_router.include_router(grafana_proxy.router, tags=["grafana", "model-endpoints"])
 api_router.include_router(model_endpoints.router, tags=["model-endpoints"])

--- a/server/py/services/api/tests/unit/api/test_auth.py
+++ b/server/py/services/api/tests/unit/api/test_auth.py
@@ -21,10 +21,10 @@ import starlette.datastructures
 
 import mlrun.common.schemas
 import mlrun.common.types
+from mlrun.common.types import AuthenticationMode
 from tests.common_fixtures import aioresponses_mock
 
 import framework.utils.auth.verifier
-from framework.utils.auth.verifier import AuthenticationMode
 
 
 def test_verify_authorization(

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -32,6 +32,7 @@ import mlrun.common.model_monitoring.helpers
 import mlrun.common.schemas
 import mlrun.errors
 import tests.conftest
+from mlrun.common.types import AuthenticationMode
 
 import framework.api.utils
 import framework.utils.clients.async_nuclio
@@ -45,7 +46,6 @@ import services.api.crud
 import services.api.tests.unit.api.utils
 import services.api.utils.builder
 import services.api.utils.functions
-from framework.utils.auth.verifier import AuthenticationMode
 from services.api.daemon import daemon
 
 PROJECT = "project-name"

--- a/server/py/services/api/tests/unit/api/test_grafana_proxy.py
+++ b/server/py/services/api/tests/unit/api/test_grafana_proxy.py
@@ -26,11 +26,11 @@ import mlrun
 import mlrun.common.schemas.model_monitoring
 import mlrun.utils
 from mlrun.common.model_monitoring.helpers import parse_model_endpoint_store_prefix
+from mlrun.common.types import AuthenticationMode
 from mlrun.errors import MLRunBadRequestError
 from mlrun.utils.v3io_clients import get_frames_client
 
 import framework.utils.clients.iguazio.v3
-from framework.utils.auth.verifier import AuthenticationMode
 from services.api.crud.model_monitoring.grafana import (
     parse_query_parameters,
     validate_query_parameters,

--- a/server/py/services/api/tests/unit/api/test_nuclio.py
+++ b/server/py/services/api/tests/unit/api/test_nuclio.py
@@ -23,12 +23,12 @@ import mlrun
 import mlrun.common.schemas
 import mlrun.runtimes.nuclio
 from mlrun.common.constants import MLRUN_FUNCTIONS_ANNOTATION
+from mlrun.common.types import AuthenticationMode
 
 import framework.utils.clients.async_nuclio
 import framework.utils.clients.iguazio.v3
 import services.api.crud
 import services.api.tests.unit.api.utils
-from framework.utils.auth.verifier import AuthenticationMode
 
 PROJECT = "project-name"
 

--- a/server/py/services/api/tests/unit/api/test_submit.py
+++ b/server/py/services/api/tests/unit/api/test_submit.py
@@ -27,13 +27,13 @@ from sqlalchemy.orm import Session
 import mlrun
 import mlrun.common.constants as mlrun_constants
 from mlrun.common.schemas import AuthInfo
+from mlrun.common.types import AuthenticationMode
 from mlrun.config import config as mlconf
 
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
 import framework.utils.singletons.k8s
 import services.api.tests.unit.api.utils
-from framework.utils.auth.verifier import AuthenticationMode
 from services.api.daemon import daemon
 from services.api.tests.unit.conftest import K8sSecretsMock
 

--- a/server/py/services/api/tests/unit/api/test_user_secrets.py
+++ b/server/py/services/api/tests/unit/api/test_user_secrets.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+import mlrun
+from mlrun.common.types import AuthenticationMode
+
+API_USER_SECRETS_PATH = "user-secrets"
+
+
+def test_require_iguazio_v4_dependency(db: Session, client: TestClient):
+    # Force unsupported auth mode
+    mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.BASIC
+
+    # Pick an endpoint that includes the require_iguazio_v4 dependency
+    response = client.put("/user-secrets/tokens", json=[])
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST.value
+    assert "only supported when mlrun.authentication.mode='iguazio-v4'" in response.text

--- a/server/py/services/api/tests/unit/api/test_user_secrets.py
+++ b/server/py/services/api/tests/unit/api/test_user_secrets.py
@@ -23,11 +23,11 @@ from mlrun.common.types import AuthenticationMode
 API_USER_SECRETS_PATH = "user-secrets"
 
 
-def test_require_iguazio_v4_dependency(db: Session, client: TestClient):
+def test_iguazio_v4_only_dependency(db: Session, client: TestClient):
     # Force unsupported auth mode
     mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.BASIC
 
-    # Pick an endpoint that includes the require_iguazio_v4 dependency
+    # Pick an endpoint that includes the iguazio_v4_only dependency
     response = client.put("/user-secrets/tokens", json=[])
 
     assert response.status_code == HTTPStatus.BAD_REQUEST.value

--- a/server/py/services/api/tests/unit/api/test_user_secrets.py
+++ b/server/py/services/api/tests/unit/api/test_user_secrets.py
@@ -31,4 +31,3 @@ def test_require_iguazio_v4_dependency(db: Session, client: TestClient):
     response = client.put("/user-secrets/tokens", json=[])
 
     assert response.status_code == HTTPStatus.BAD_REQUEST.value
-    assert "only supported when mlrun.authentication.mode='iguazio-v4'" in response.text

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -23,12 +23,12 @@ import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.launcher.base
 import mlrun.launcher.factory
+from mlrun.common.types import AuthenticationMode
 from mlrun.config import Config
 
 import framework.utils.clients.iguazio.v3
 import services.api.launcher
 import services.api.tests.unit.api.utils
-from framework.utils.auth.verifier import AuthenticationMode
 
 
 @pytest.mark.parametrize(

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -37,6 +37,7 @@ import mlrun.artifacts
 import mlrun.artifacts.base
 import mlrun.common.formatters
 import mlrun.common.schemas
+import mlrun.common.types
 import mlrun.errors
 import mlrun.projects.project
 from mlrun import RunObject
@@ -1200,6 +1201,9 @@ def test_store_alert_config_missing_alert_name(
 def test_store_secret_token_invalid_inputs(create_server):
     server: Server = create_server()
     db: HTTPRunDB = server.conn
+    mlrun.mlconf.httpdb.authentication.mode = (
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4
+    )
 
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError, match="No secret token provided"
@@ -1211,6 +1215,9 @@ def test_store_secret_token_invalid_inputs(create_server):
 def test_store_secret_tokens_invalid_inputs(create_server, secret_tokens):
     server: Server = create_server()
     db: HTTPRunDB = server.conn
+    mlrun.mlconf.httpdb.authentication.mode = (
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4
+    )
 
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError, match="No secret tokens provided"

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -26,6 +26,7 @@ import urllib3.exceptions
 import mlrun.artifacts.base
 import mlrun.config
 import mlrun.db.httpdb
+from mlrun.common.types import AuthenticationMode
 
 
 class SomeEnumClass(str, enum.Enum):
@@ -340,3 +341,21 @@ def test_resolve_page_params(params, expected_page_params):
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
     resolved_page_params = db._resolve_page_params(params)
     assert expected_page_params == resolved_page_params
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "store_secret_token",
+        "store_secret_tokens",
+    ],
+)
+def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
+    mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.BASIC
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+    method = getattr(db, method_name)
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+        method(None)
+    assert "only supported when mlrun.authentication.mode='iguazio-v4'" in str(
+        exc_info.value
+    )

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -354,8 +354,8 @@ def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
     mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.BASIC
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
     method = getattr(db, method_name)
-    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+    with pytest.raises(mlrun.errors.MLRunRuntimeError) as exc_info:
         method(None)
-    assert "only supported when mlrun.authentication.mode='iguazio-v4'" in str(
+    assert "This method is only supported in an Iguazio V4 system" in str(
         exc_info.value
     )


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Enable conditional support for secret tokens based on `mlrun.httpdb.authentication.mode`.
This PR restricts certain SDK methods and API endpoints so they can only be used when authentication.mode is set to `iguazio-v4`.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

1. Moved AuthenticationMode enum to a shared location.
2. Created a `iguazio_v4_only ` wrapper for SDK methods to control execution based on the authentication mode.
3. Added a FastAPI dependency for `user-secrets` endpoints to enforce mode-based access control.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

1. Verified SDK methods fail when called outside iguazio-v4 mode.
2. Verified API user-secrets endpoints return 400 when the mode is not iguazio-v4.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10494
- Design docs links: https://iguazio.atlassian.net/wiki/spaces/MLRUN/pages/404521061/BE+Secret+Token+Support+HLD#2.1.9-Configurable-Authentication-Mode

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
