### PR TITLE
[Framework] Ensure running _sync_system_metadata on both worker and chief

### DIFF
--- a/server/py/framework/db/session.py
+++ b/server/py/framework/db/session.py
@@ -47,8 +47,8 @@ def run_function_with_new_db_session(func, *args, **kwargs):
 async def run_async_function_with_new_db_session(func, *args, **kwargs):
     """
     Run an async function with a new db session.
-    If the func is async, use run_async_function_with_new_db_session below.
-    Otherwise, use the suggested logic.
+    If the func is a coroutine function (async def), use run_async_function_with_new_db_session below.
+    alternatively, given the async context, run the synchronous function in a thread pool.
 
     Any changes made by the new session will not be visible to old sessions until the old sessions commit
     due to isolation level.

--- a/server/py/framework/db/session.py
+++ b/server/py/framework/db/session.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
+import fastapi.concurrency
 from sqlalchemy.orm import Session
 
 import mlrun.utils.helpers
@@ -43,13 +46,28 @@ def run_function_with_new_db_session(func, *args, **kwargs):
 
 async def run_async_function_with_new_db_session(func, *args, **kwargs):
     """
-    Run an async function with a new db session, useful for concurrent requests where we can't share a single session.
-    However, any changes made by the new session will not be visible to old sessions until the old sessions commit
+    Run an async function with a new db session.
+    If the func is async, use run_async_function_with_new_db_session below.
+    Otherwise, use the suggested logic.
+
+    Any changes made by the new session will not be visible to old sessions until the old sessions commit
     due to isolation level.
     """
-    session = await mlrun.utils.helpers.run_in_threadpool(create_session)
-    try:
-        result = await func(session, *args, **kwargs)
-        return result
-    finally:
-        await mlrun.utils.helpers.run_in_threadpool(close_session, session)
+
+    # function is async. wrap its execution with a new db session
+    if inspect.iscoroutinefunction(func):
+        session = await mlrun.utils.helpers.run_in_threadpool(create_session)
+        try:
+            result = await func(session, *args, **kwargs)
+            return result
+        finally:
+            await mlrun.utils.helpers.run_in_threadpool(close_session, session)
+
+    # function is sync running in async context,
+    # move all together to a thread and execute it non-blocking
+    return await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
+        func,
+        *args,
+        **kwargs,
+    )

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-import concurrent.futures
 import contextlib
 import http
 import traceback
@@ -40,6 +39,7 @@ import framework.utils.clients.chief
 import framework.utils.clients.messaging
 import framework.utils.pagination
 import framework.utils.periodic
+from framework.db.session import run_async_function_with_new_db_session
 from framework.utils.singletons.db import initialize_db
 
 
@@ -71,10 +71,11 @@ class Service(ABC):
     # https://fastapi.tiangolo.com/advanced/events/
     @contextlib.asynccontextmanager
     async def lifespan(self, app_: fastapi.FastAPI):
-        setup_tasks = [self._setup_service()] + [
-            service._setup_service(mounted=True) for service in self._mounted_services
-        ]
-        await asyncio.gather(*setup_tasks)
+        # set up the top-level service only then the mounted services
+        await self._setup_service()
+        await asyncio.gather(
+            *[service._setup_mounted_service() for service in self._mounted_services]
+        )
 
         # Let the service run
         yield
@@ -157,45 +158,44 @@ class Service(ABC):
             mlrun_service=self,
         )
 
-    async def _setup_service(self, mounted: bool = False):
+    async def _setup_service(self):
         """
         This method is called when the service is starting up.
-        :param mounted: True if the service is mounted as a sub-service of another service, False otherwise
         """
-        if not mounted:
-            self._logger.info(
-                "On startup event handler called",
-                config=mlconf.dump_yaml(),
-                version=mlrun.utils.version.Version().get(),
-                service_name=self.service_name,
-            )
+        self._logger.info(
+            "Setting up service",
+            config=mlconf.dump_yaml(),
+            version=mlrun.utils.version.Version().get(),
+            service_name=self.service_name,
+        )
 
-            # Set the default thread limiter to the max workers config according to:
-            # https://github.com/fastapi/fastapi/issues/4221
-            anyio.lowlevel.RunVar("_default_thread_limiter").set(
-                anyio.CapacityLimiter(int(mlconf.httpdb.max_workers))
-            )
-            self._logger.info(
-                "Service default thread limiter set",
-                max_workers=anyio.to_thread.current_default_thread_limiter().total_tokens,
-            )
+        # Set the default thread limiter to the max workers config according to:
+        # https://github.com/fastapi/fastapi/issues/4221
+        anyio.lowlevel.RunVar("_default_thread_limiter").set(
+            anyio.CapacityLimiter(int(mlconf.httpdb.max_workers))
+        )
+        self._logger.info(
+            "Service default thread limiter set",
+            max_workers=anyio.to_thread.current_default_thread_limiter().total_tokens,
+        )
 
-            initialize_db()
+        await fastapi.concurrency.run_in_threadpool(initialize_db)
         await self._custom_setup_service()
 
-        self._initialize_data()
         if (
             mlconf.httpdb.clusterization.worker.sync_with_chief.mode
             == mlrun.common.schemas.WaitForChiefToReachOnlineStateFeatureFlag.enabled
             and mlconf.httpdb.clusterization.role
             == mlrun.common.schemas.ClusterizationRole.worker
-            and not mounted
         ):
             # in the background, wait for chief to reach online state
             self._start_chief_clusterization_spec_sync_loop()
 
-        if mlconf.httpdb.state == mlrun.common.schemas.APIStates.online and not mounted:
+        if mlconf.httpdb.state == mlrun.common.schemas.APIStates.online:
             await self.move_service_to_online()
+
+    async def _setup_mounted_service(self):
+        await self._custom_setup_service()
 
     async def _custom_setup_service(self):
         pass
@@ -281,9 +281,6 @@ class Service(ABC):
             reason="Handler not implemented for request",
             request_url=request.url,
         )
-
-    def _initialize_data(self):
-        pass
 
     async def _start_periodic_functions(self):
         pass

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -194,6 +194,8 @@ class Service(ABC):
         if mlconf.httpdb.state == mlrun.common.schemas.APIStates.online:
             await self.move_service_to_online()
 
+        await run_async_function_with_new_db_session(self._sync_system_metadata)
+
     async def _setup_mounted_service(self):
         await self._custom_setup_service()
 
@@ -403,6 +405,23 @@ class Service(ABC):
         for mounted_service in self._mounted_services:
             for cls, method in mounted_service._paginated_methods:
                 yield cls, method
+
+    def _sync_system_metadata(self, db_session):
+        """
+        Sync system metadata values from the database to the config.
+        Currently, it synchronizes only the system ID but can be extended for other new metadata values in the future.
+
+        :param db_session: The database session to use for the synchronization.
+        """
+
+        db = framework.db.sqldb.db.SQLDB()
+        system_id = db.get_system_id(db_session)
+        if system_id is not None:
+            self._logger.debug(
+                "Existing system ID found in the database",
+                system_id=system_id,
+            )
+            mlrun.mlconf.system_id = system_id
 
 
 class Daemon(ABC):

--- a/server/py/services/alerts/initial_data.py
+++ b/server/py/services/alerts/initial_data.py
@@ -22,11 +22,9 @@ from framework.db.session import close_session, create_session
 
 def update_default_configuration_data(logger):
     logger.debug("Updating default configuration data")
-    framework.db.session.run_function_with_new_db_session(
-        services.alerts.crud.Alerts().populate_caches
-    )
     db_session = create_session()
     try:
+        services.alerts.crud.Alerts().populate_caches(db_session)
         db = framework.db.sqldb.db.SQLDB()
         _add_default_alert_templates(db, db_session)
     finally:

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -547,7 +547,10 @@ class Service(framework.service.Service):
             get_project_member().start()
 
         if self._is_chief_or_standalone():
-            services.alerts.initial_data.update_default_configuration_data(self._logger)
+            await fastapi.concurrency.run_in_threadpool(
+                services.alerts.initial_data.update_default_configuration_data,
+                self._logger,
+            )
             await self._start_periodic_functions()
 
     @staticmethod
@@ -596,9 +599,6 @@ class Service(framework.service.Service):
         self.app.include_router(
             alerts_v1_router, prefix=self.base_versioned_service_prefix
         )
-
-    async def _custom_setup_service(self):
-        pass
 
     async def _start_periodic_functions(self):
         self._start_periodic_events_generation()

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -24,6 +24,7 @@ import alembic
 import alembic.command
 import alembic.config
 import pymysql.err
+import sqlalchemy.engine
 import sqlalchemy.exc
 import sqlalchemy.orm
 import sqlalchemy_utils
@@ -56,36 +57,56 @@ from framework.utils.db.utils import DBUtil
 def init_data(
     perform_migrations_if_needed: bool = False,
 ) -> None:
+    """
+    This function initializes the database with the necessary data.
+    It checks if the database exists and if it has any tables,
+    and if not, it creates the database and initializes it from scratch.
+    """
     mlrun.utils.logger.info("Initializing DB data")
 
     engine = framework.db.sqldb.sql_session.get_engine()
-    url = engine.url
-    from_scratch = False
-    if not sqlalchemy_utils.database_exists(url):
-        mlrun.utils.logger.info(
-            "Database does not exist, initializing from scratch",
-            database_url=url,
-        )
-        sqlalchemy_utils.create_database(url)
-        from_scratch = True
-    else:
-        has_tables = bool(sqlalchemy.inspect(engine).get_table_names())
-        if not has_tables:
-            mlrun.utils.logger.info(
-                "No tables found in the database, initializing from scratch",
-                database_url=url,
-            )
-            from_scratch = True
+    create_db_from_scratch = _ensure_db_instance_initialized(engine)
 
-    if from_scratch:
-        _initialize_db_from_scratch(engine, url)
+    if create_db_from_scratch:
+        mlrun.utils.logger.info("Creating database from scratch")
+        _initialize_db_from_scratch(engine)
     else:
+        mlrun.utils.logger.info("Migrating existing data")
         _migrate_existing_data(
             engine,
             perform_migrations_if_needed,
         )
 
     mlrun.utils.logger.info("Initial data created")
+
+
+def _ensure_db_instance_initialized(engine: sqlalchemy.engine.Engine) -> bool:
+    """
+    Checks if the database instance exists and is initialized.
+    Returns True if the database needs to be created or initialized from scratch (i.e.,
+    if the database does not exist or exists but has no tables).
+    Returns False if the database exists and has tables (i.e., is set up and ready).
+    """
+    url = engine.url
+    if not sqlalchemy_utils.database_exists(url):
+        mlrun.utils.logger.info(
+            "Database does not exist, creating",
+            database_url=url,
+        )
+        sqlalchemy_utils.create_database(url)
+        return True
+
+    # db exists, lets see if it has some tables
+    has_tables = bool(sqlalchemy.inspect(engine).get_table_names())
+    if not has_tables:
+        mlrun.utils.logger.info(
+            "No tables found in the database",
+            database_url=url,
+        )
+        return True
+
+    # db exists and have tables. nothing to ensure
+    return False
 
 
 def _create_schema(
@@ -98,9 +119,9 @@ def _create_schema(
 
 
 def _initialize_db_from_scratch(
-    engine: typing.Optional[sqlalchemy.engine.Engine],
-    url: sqlalchemy.engine.URL,
+    engine: sqlalchemy.engine.Engine,
 ):
+    url = engine.url
     _create_schema(
         engine=engine,
     )

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -65,9 +65,9 @@ def init_data(
     mlrun.utils.logger.info("Initializing DB data")
 
     engine = framework.db.sqldb.sql_session.get_engine()
-    create_db_from_scratch = _ensure_db_instance_initialized(engine)
+    db_initialized = _initialize_db_if_needed(engine)
 
-    if create_db_from_scratch:
+    if db_initialized:
         mlrun.utils.logger.info("Creating database from scratch")
         _initialize_db_from_scratch(engine)
     else:
@@ -80,7 +80,7 @@ def init_data(
     mlrun.utils.logger.info("Initial data created")
 
 
-def _ensure_db_instance_initialized(engine: sqlalchemy.engine.Engine) -> bool:
+def _initialize_db_if_needed(engine: sqlalchemy.engine.Engine) -> bool:
     """
     Checks if the database instance exists and is initialized.
     Returns True if the database needs to be created or initialized from scratch (i.e.,

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -113,30 +113,7 @@ class Service(framework.service.Service):
             services.api.initial_data.update_default_configuration_data()
             await self._start_periodic_functions()
 
-        # For the worker, fetch and sync the system metadata from the database to ensure that the config values are
-        # correctly set.
-        else:
-            self._sync_system_metadata()
         await self._move_mounted_services_to_online()
-
-    def _sync_system_metadata(self):
-        """
-        Sync system metadata values from the database to the config.
-        Currently, it synchronizes only the system ID but can be extended for other new metadata values in the future.
-        """
-
-        db_session = create_session()
-        try:
-            db = framework.db.sqldb.db.SQLDB()
-
-            system_id = db.get_system_id(db_session)
-            if system_id is not None:
-                self._logger.debug(
-                    "Existing system ID found in the database", system_id=system_id
-                )
-                mlrun.mlconf.system_id = system_id
-        finally:
-            close_session(db_session)
 
     async def _base_handler(
         self,

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -160,6 +160,7 @@ class Service(framework.service.Service):
 
     async def _custom_setup_service(self):
         initialize_logs_dir()
+        await fastapi.concurrency.run_in_threadpool(self._initialize_data)
 
     async def _custom_teardown_service(self):
         if get_project_member():


### PR DESCRIPTION
### 📝 Description

Issue was that chief starts with init_from_scrach generates the system id, then restarted and wont load the system id correctly. the worker has no concrete issue as the service initialize sets the system id once moved online.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

1. Ensure the system id is set on both chief and worker once moved online
2. Simplified the service setup flow. less conditions. easier to read
3. Added some docs and notes to init_data flow
4. Extended run_async_function_with_new_db_session functionality to allow running sync function within async context in a thread
5. Fixed couple of io-blocking calls within an async context [ 36130de40a778cc69e86c71655333e5138ff0317 / 26262a1f86d5815240bcddbd4656d733a7f4ffd3]

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

used `/patch_remote.py` before/after to ensure fix is applied.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10859
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
