### PR TITLE
[Artifacts] Add validation in ModelArtifact init for conflicting attributes

### DIFF
--- a/mlrun/artifacts/model.py
+++ b/mlrun/artifacts/model.py
@@ -190,10 +190,10 @@ class ModelArtifact(Artifact):
         """
         super().__init__(key, body, format=format, target_path=target_path, **kwargs)
         model_file = str(model_file or "")
-        if model_file and model_url:
+        if (model_file or model_dir or body) and model_url:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "Arguments 'model_file' and 'model_dir' cannot be"
-                " used together with 'model_url'."
+                "Arguments 'model_file' and 'model_url' cannot be"
+                " used together with 'model_file', 'model_dir' or 'body'."
             )
         if model_file and "/" in model_file:
             if model_dir:

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -91,12 +91,21 @@ def test_extend_artifact_path():
 def test_model_artifact_validators():
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match="Arguments 'model_file' and 'model_dir' cannot be"
-        " used together with 'model_url'.",
+        match="Arguments 'model_file' and 'model_url' cannot be"
+        " used together with 'model_file', 'model_dir' or 'body'.",
     ):
         mlrun.artifacts.ModelArtifact(
             model_dir="y",
             model_file="model.pkl",
+            model_url="http://localhost:8080/v2/models/mymodel/infer",
+        )
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="Arguments 'model_file' and 'model_url' cannot be"
+        " used together with 'model_file', 'model_dir' or 'body'.",
+    ):
+        mlrun.artifacts.ModelArtifact(
+            body=b"dummy_model_content",
             model_url="http://localhost:8080/v2/models/mymodel/infer",
         )
     project = mlrun.new_project("test-project", save=False)


### PR DESCRIPTION
### 📝 Description
[Artifacts] Add validation in ModelArtifact init for conflicting attributes

- Raise MLRunInvalidArgumentError when using `model_url` together with 
  `model_file`, `model_dir`, or `body`.
- Added corresponding pytest checks for:
  * model_file + model_dir + model_url
  * model_file + body + model_url
---

### 🛠️ Changes Made
Added validation in ModelArtifact.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Add unit tests - in `test_model_artifact_validators`. 

---

### 🔗 References
- Ticket link: [ML-10826](https://iguazio.atlassian.net/browse/ML-10826)
- Design docs links: [ML-9764](https://iguazio.atlassian.net/browse/ML-9764)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes




[ML-10826]: https://iguazio.atlassian.net/browse/ML-10826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9764]: https://iguazio.atlassian.net/browse/ML-9764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ