### PR TITLE
[Dockerfiles] Add cmake to common image

### DIFF
--- a/dockerfiles/common/Dockerfile
+++ b/dockerfiles/common/Dockerfile
@@ -22,6 +22,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
+        cmake \
         curl \
         git \
         libffi-dev \


### PR DESCRIPTION
### 📝 Description
Add `cmake `apt package to mlrun_common image, which is used to compile some python packages.
This was added since some packages, like `horovod` require cmake to be built.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🧪 Testing
Make `mlrun` docker image

---

### 🔗 References
- Ticket link:https://iguazio.atlassian.net/browse/ML-10879


### 🚨 Breaking Changes?
- [X] No
