### PR TITLE
[Model Monitoring] Fix arguments handling in evaluate

### DIFF
--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -951,19 +951,6 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 )
                 params["end"] = end.isoformat() if isinstance(end, datetime) else end
                 params["base_period"] = base_period
-
-            params["write_output"] = write_output
-            params["existing_data_handling"] = existing_data_handling
-            if stream_profile:
-                if not run_local:
-                    raise mlrun.errors.MLRunValueError(
-                        "Passing a `stream_profile` is relevant only when running locally"
-                    )
-                if not write_output:
-                    raise mlrun.errors.MLRunValueError(
-                        "Passing a `stream_profile` is relevant only when writing the outputs"
-                    )
-            params["stream_profile"] = stream_profile
         elif start or end or base_period:
             raise mlrun.errors.MLRunValueError(
                 "Custom `start` and `end` times or base_period are supported only with endpoints data"
@@ -972,6 +959,19 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
             raise mlrun.errors.MLRunValueError(
                 "Writing the application output or passing `stream_profile` are supported only with endpoints data"
             )
+
+        params["write_output"] = write_output
+        params["existing_data_handling"] = existing_data_handling
+        if stream_profile:
+            if not run_local:
+                raise mlrun.errors.MLRunValueError(
+                    "Passing a `stream_profile` is relevant only when running locally"
+                )
+            if not write_output:
+                raise mlrun.errors.MLRunValueError(
+                    "Passing a `stream_profile` is relevant only when writing the outputs"
+                )
+        params["stream_profile"] = stream_profile
 
         inputs: dict[str, str] = {}
         for data, identifier in [

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -951,18 +951,19 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 )
                 params["end"] = end.isoformat() if isinstance(end, datetime) else end
                 params["base_period"] = base_period
-                params["write_output"] = write_output
-                params["existing_data_handling"] = existing_data_handling
-                if stream_profile:
-                    if not run_local:
-                        raise mlrun.errors.MLRunValueError(
-                            "Passing a `stream_profile` is relevant only when running locally"
-                        )
-                    if not write_output:
-                        raise mlrun.errors.MLRunValueError(
-                            "Passing a `stream_profile` is relevant only when writing the outputs"
-                        )
-                params["stream_profile"] = stream_profile
+
+            params["write_output"] = write_output
+            params["existing_data_handling"] = existing_data_handling
+            if stream_profile:
+                if not run_local:
+                    raise mlrun.errors.MLRunValueError(
+                        "Passing a `stream_profile` is relevant only when running locally"
+                    )
+                if not write_output:
+                    raise mlrun.errors.MLRunValueError(
+                        "Passing a `stream_profile` is relevant only when writing the outputs"
+                    )
+            params["stream_profile"] = stream_profile
         elif start or end or base_period:
             raise mlrun.errors.MLRunValueError(
                 "Custom `start` and `end` times or base_period are supported only with endpoints data"

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -268,6 +268,58 @@ class TestEvaluate:
             in captured.out
         ), "The error message is different than expected or was not captured"
 
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("pass_sample", "pass_reference"), [(True, False), (False, True), (True, True)]
+    )
+    def test_invalid_custom_dataframe_with_write_output(
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        pass_sample: bool,
+        pass_reference: bool,
+    ) -> None:
+        """write_output=True with sample_data/reference_data should be blocked"""
+        project = mlrun.get_or_create_project(
+            "local-test-sample-df", context=str(tmp_path)
+        )
+        project.artifact_path = str(tmp_path)
+
+        if pass_sample:
+            sample_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+            sample_artifact_path = project.log_dataset(
+                "sample-df", df=sample_df
+            ).target_path
+        else:
+            sample_artifact_path = None
+
+        if pass_reference:
+            reference_df = pd.DataFrame({"a": [1, 0, 1], "b": [5, 5, 6]})
+            reference_artifact_path = project.log_dataset(
+                "reference-df", df=reference_df
+            ).target_path
+        else:
+            reference_artifact_path = None
+
+        ModelEndpointAccessApp.evaluate(
+            func_path=__file__,
+            endpoints=[("ep-name", "ep-uid")],
+            sample_data=sample_artifact_path,
+            reference_data=reference_artifact_path,
+            start=datetime(2025, 5, 3),
+            end=datetime(2025, 5, 4),
+            run_local=True,
+            write_output=True,
+            stream_profile=DatastoreProfileKafkaSource(
+                name="kafka-stream", brokers=["broker-address:9092"], topics=[]
+            ),
+        )
+        captured = capsys.readouterr()
+        assert (
+            "Writing the results of an application to the TSDB is possible only when "
+            "working with endpoints, without any custom data-frame input"
+            in captured.out
+        ), "The error message is different than expected or was not captured"
+
 
 @pytest.mark.parametrize(
     ("start", "end", "base_period", "expectation"),


### PR DESCRIPTION
### 📝 Description

Previously, we prioritized the `sample_data` over `write_output`.
This created the following issue:
When passing endpoints, sample data, and `write_output=True`, the following condition discarded `write_output`
https://github.com/mlrun/mlrun/blob/c9b60bfe091d131f35395ed8112e7b5246e65173/mlrun/model_monitoring/applications/base.py#L943

Now, we pass the following args whenever, and the invalid combination described in the ticket will be caught here:
https://github.com/mlrun/mlrun/blob/c9b60bfe091d131f35395ed8112e7b5246e65173/mlrun/model_monitoring/applications/base.py#L311-L313

---

### 🛠️ Changes Made

Pass `write_output` and related parameters in evaluate to the application job.

---

### ✅ Checklist

- [x] I have tested the changes in this PR

---

### 🧪 Testing

Added a unit test.

---

### 🔗 References

- Ticket link: [ML-10820](https://iguazio.atlassian.net/browse/ML-10820)

---

### 🚨 Breaking Changes?

- [x] No


[ML-10820]: https://iguazio.atlassian.net/browse/ML-10820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ