### PR TITLE
[User secrets] Implement store user token secrets in k8s [feature/ig4-authentication]

### DIFF
--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -82,6 +82,8 @@ class MLRunInternalLabels:
     workflow = "workflow"
     feature_vector = "feature-vector"
 
+    user_token_secret_label_key = "mlrun/user"
+
     @classmethod
     def all(cls):
         return [

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -65,6 +65,34 @@ class SecretProviderInterface(ABC):
     ) -> mlrun.common.schemas.SecretEventActions:
         pass
 
+        # secret_name = f"mlrun-auth-{username}-{token_name}"
+        #
+        # encoded_token_yaml = base64.b64encode(
+        #     yaml.safe_dump(
+        #         {"secretTokens": [{"name": token_name, "token": token}]}
+        #     ).encode()
+        # ).decode()
+        #
+        # secret_data = {
+        #     "tokensFile": encoded_token_yaml,
+        #     "tokenExpiration": str(expiration),
+        #     "labels": {"mlrun/user": username},
+        # }
+        #
+        # # TODO get existing by the label mlrun/user
+        # existing_secret = self.get_secret_data(secret_name)
+        #
+        # if not existing_secret:
+        #     self.store_secret(secret_name, secret_data)
+        #     return mlrun.common.schemas.SecretEventActions.created
+        #
+        # existing_exp = int(existing_secret.get("tokenExpiration", 0))
+        # if expiration > existing_exp:
+        #     self.store_secret(secret_name, secret_data)
+        #     return mlrun.common.schemas.SecretEventActions.updated
+        #
+        # return mlrun.common.schemas.SecretEventActions.skipped
+
 
 class InMemorySecretProvider(SecretProviderInterface):
     def __init__(self):
@@ -148,7 +176,6 @@ class InMemorySecretProvider(SecretProviderInterface):
         token: str,
         expiration: int,
     ) -> mlrun.common.schemas.SecretEventActions:
-        # TODO: Implement storing user token secrets in the in-memory provider.
         raise NotImplementedError()
 
     @staticmethod

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -56,42 +56,15 @@ class SecretProviderInterface(ABC):
         pass
 
     @abstractmethod
-    def create_or_update_user_token_secret(
+    def store_user_token_secret(
         self,
         username: str,
         token_name: str,
         token: str,
         expiration: int,
+        namespace: str = "",
     ) -> mlrun.common.schemas.SecretEventActions:
         pass
-
-        # secret_name = f"mlrun-auth-{username}-{token_name}"
-        #
-        # encoded_token_yaml = base64.b64encode(
-        #     yaml.safe_dump(
-        #         {"secretTokens": [{"name": token_name, "token": token}]}
-        #     ).encode()
-        # ).decode()
-        #
-        # secret_data = {
-        #     "tokensFile": encoded_token_yaml,
-        #     "tokenExpiration": str(expiration),
-        #     "labels": {"mlrun/user": username},
-        # }
-        #
-        # # TODO get existing by the label mlrun/user
-        # existing_secret = self.get_secret_data(secret_name)
-        #
-        # if not existing_secret:
-        #     self.store_secret(secret_name, secret_data)
-        #     return mlrun.common.schemas.SecretEventActions.created
-        #
-        # existing_exp = int(existing_secret.get("tokenExpiration", 0))
-        # if expiration > existing_exp:
-        #     self.store_secret(secret_name, secret_data)
-        #     return mlrun.common.schemas.SecretEventActions.updated
-        #
-        # return mlrun.common.schemas.SecretEventActions.skipped
 
 
 class InMemorySecretProvider(SecretProviderInterface):
@@ -169,12 +142,13 @@ class InMemorySecretProvider(SecretProviderInterface):
     def get_secret_data(self, secret_name, namespace=""):
         return self.secrets_map[secret_name]
 
-    def create_or_update_user_token_secret(
+    def store_user_token_secret(
         self,
         username: str,
         token_name: str,
         token: str,
         expiration: int,
+        namespace: str = "",
     ) -> mlrun.common.schemas.SecretEventActions:
         raise NotImplementedError()
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -662,6 +662,7 @@ default_config = {
             "auto_add_project_secrets": True,
             "project_secret_name": "mlrun-project-secrets-{project}",
             "auth_secret_name": "mlrun-auth-secrets.{hashed_access_key}",
+            "user_token_secret_name": "mlrun-auth-{username}-{token_name}",
             "env_variable_prefix": "",
             "global_function_env_secret_name": None,
         },

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5091,12 +5091,18 @@ class HTTPRunDB(RunDBInterface):
             secret_tokens=[secret_token],
             error=f"store user secret token {secret_token.name}",
         )
-        if log_warning:
+
+        # Only log if the token was created or updated
+        if log_warning and (
+            secret_token.name in response.created_tokens
+            or secret_token.name in response.updated_tokens
+        ):
             logger.warning(
                 f"Token '{secret_token.name}' was stored in the backend, "
                 "but the local configuration file (~/.igz.yaml) was not updated. "
                 "Update it manually or run `mlrun.sync_secret_tokens()` to sync your local environment."
             )
+        # maybe the response should not be a list?
         return response
 
     @iguazio_v4_only
@@ -5153,7 +5159,7 @@ class HTTPRunDB(RunDBInterface):
             body=dict_to_json(body),
         )
 
-        return mlrun.common.schemas.StoreSecretTokensResponse(**response)
+        return mlrun.common.schemas.StoreSecretTokensResponse(**response.json())
 
     @staticmethod
     def _parse_labels(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5136,6 +5136,7 @@ class HTTPRunDB(RunDBInterface):
             error="store multiple user secret tokens",
         )
 
+        # Only log a warning if at least one token was actually created or updated
         if log_warning and (response.created_tokens or response.updated_tokens):
             affected_tokens = response.created_tokens + response.updated_tokens
             token_names = "', '".join(affected_tokens)

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5135,13 +5135,16 @@ class HTTPRunDB(RunDBInterface):
             secret_tokens=secret_tokens,
             error="store multiple user secret tokens",
         )
-        if log_warning:
-            token_names = "', '".join(token.name for token in secret_tokens)
+
+        if log_warning and (response.created_tokens or response.updated_tokens):
+            affected_tokens = response.created_tokens + response.updated_tokens
+            token_names = "', '".join(affected_tokens)
             logger.warning(
                 f"Tokens '{token_names}' were stored in the backend, "
                 "but the local configuration file (~/.igz.yaml) was not updated. "
                 "Update it manually or run `mlrun.sync_secret_tokens()` to sync your local environment."
             )
+
         return response
 
     def _store_secret_tokens(

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -601,18 +601,26 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 name=secret_name,
                 namespace=namespace,
             )
+
             if labels:
                 secret_labels = k8s_secret.metadata.labels or {}
-                for key, value in labels.items():
-                    if secret_labels.get(key) != value:
-                        if not silent:
-                            logger.debug(
-                                "Secret found but labels did not match",
-                                secret_name=secret_name,
-                                expected_labels=labels,
-                                actual_labels=secret_labels,
-                            )
-                        return None
+
+                # Find any label that does not match
+                mismatched = {
+                    k: (v, secret_labels.get(k))
+                    for k, v in labels.items()
+                    if secret_labels.get(k) != v
+                }
+                if mismatched:
+                    if not silent:
+                        logger.debug(
+                            "Secret found but labels did not match",
+                            secret_name=secret_name,
+                            expected_labels=labels,
+                            actual_labels=secret_labels,
+                            mismatched_labels=mismatched,
+                        )
+                    return None
         except k8s_client_rest.ApiException as exc:
             if silent:
                 return
@@ -1052,12 +1060,15 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :return: SecretEventActions.{created, updated, skipped}
         """
         namespace = self.resolve_namespace(namespace)
-        secret_name = f"mlrun-auth-{username}-{token_name}"
-        labels = {"mlrun/user": username}
+        secret_name = self._resolve_user_token_secret_name(username, token_name)
+        labels = {
+            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: username
+        }
 
         logger.debug(
             "Preparing to store user token secret",
             secret_name=secret_name,
+            namespace=namespace,
         )
 
         secret_data = self._encode_user_token(token_name, token, expiration)
@@ -1096,6 +1107,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             expiration=expiration,
         )
         return mlrun.common.schemas.SecretEventActions.skipped
+
+    def _resolve_user_token_secret_name(self, username: str, token: str) -> str:
+        return mlrun.mlconf.secret_stores.kubernetes.user_token_secret_name.format(
+            username=username, token_name=token
+        )
 
     def _encode_user_token(
         self, token_name: str, token: str, expiration: int

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1053,6 +1053,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         secret_name = f"mlrun-auth-{username}-{token_name}"
         labels = {"mlrun/user": username}
 
+        logger.debug(
+            "Preparing to store user token secret",
+            secret_name=secret_name,
+        )
+
         secret_data = self._encode_user_token(token_name, token, expiration)
 
         # Try to read existing secret (may return None if not found or labels mismatch)
@@ -1083,6 +1088,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             )
             return mlrun.common.schemas.SecretEventActions.updated
 
+        logger.debug(
+            "Secret exists and is up-to-date, skipping update",
+            secret_name=secret_name,
+            expiration=expiration,
+        )
         return mlrun.common.schemas.SecretEventActions.skipped
 
     def _encode_user_token(

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -629,7 +629,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
     def read_secret_data(
         self, secret_name: str, namespace: str = "", load_as_json=False, silent=False
     ) -> typing.Optional[dict[str, str]]:
-        k8s_secret = self.read_secret(secret_name, namespace, silent)
+        k8s_secret = self.read_secret(
+            secret_name=secret_name, namespace=namespace, silent=silent
+        )
         if k8s_secret is None:
             return
         return self._decode_secret_data(k8s_secret.data, load_as_json=load_as_json)

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -21,6 +21,7 @@ import typing
 
 import kubernetes.client.rest as k8s_client_rest
 import kubernetes.dynamic.exceptions as k8s_dynamic_exceptions
+import yaml
 from kubernetes import client, config
 
 import mlrun
@@ -1013,9 +1014,81 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         token: str,
         expiration: int,
     ) -> mlrun.common.schemas.SecretEventActions:
-        # TODO: Implement this method to create or update a user token secret in k8s
-        raise NotImplementedError()
+        """
+        Creates or updates a Kubernetes secret for a user's offline token.
 
+        :param username: The user who owns the token.
+        :param token_name: The logical name for the token.
+        :param token: The offline token string (JWT).
+        :param exp: The token's expiration timestamp (int UNIX epoch).
+        :return: SecretEventActions.{created, updated, skipped}
+        """
+        secret_name = f"mlrun-auth-{username}-{token_name}"
+
+        secret_data, labels = self._prepare_token_secret_data_and_labels(
+            username, token_name, token, exp
+        )
+
+        try:
+            existing_secret = self._k8s.get_secret(secret_name)
+        except Exception:
+            existing_secret = None
+
+        if existing_secret:
+            existing_data = existing_secret.get("data", {})
+            existing_exp_b64 = existing_data.get("tokenExpiration")
+
+            try:
+                existing_exp = int(base64.b64decode(existing_exp_b64).decode("utf-8"))
+            except Exception:
+                existing_exp = 0  # fallback: force update if invalid
+
+            if exp <= existing_exp:
+                # New token is older or equal — skip update
+                return mlrun.common.schemas.SecretEventActions.skipped
+
+            try:
+                self._k8s.update_secret(secret_name, secret_data, labels)
+                return mlrun.common.schemas.SecretEventActions.updated
+            except Exception as exc:
+                raise mlrun.errors.MLRunInternalServerError(
+                    f"Failed to update secret '{secret_name}': {exc}"
+                ) from exc
+
+        # Secret does not exist — create it
+        try:
+            self._k8s.create_secret(secret_name, secret_data, labels)
+            return mlrun.common.schemas.SecretEventActions.created
+        except Exception as exc:
+            raise MLRunInternalServerError(
+                f"Failed to create secret '{secret_name}': {exc}"
+            ) from exc
+
+    def _prepare_token_secret_data_and_labels(
+        self,
+        username: str,
+        token_name: str,
+        token: str,
+        token_expiration: int,
+    ) -> tuple[dict, dict]:
+        encoded_tokens_file = base64.b64encode(
+            yaml.safe_dump(
+                {"secretTokens": [{"name": token_name, "token": token}]}
+            ).encode()
+        ).decode()
+
+        secret_data = {
+            "tokensFile": encoded_tokens_file,
+            "tokenExpiration": base64.b64encode(
+                str(token_expiration).encode()
+            ).decode(),
+        }
+
+        labels = {
+            "mlrun/user": username,
+        }
+
+        return secret_data, labels
 
 class BasePod:
     def __init__(

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -558,6 +558,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.read_secret(
                 secret_name=secret_name,
                 namespace=namespace,
+                labels=labels,
             )
         except (
             k8s_dynamic_exceptions.NotFoundError
@@ -581,22 +582,45 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return mlrun.common.schemas.SecretEventActions.updated
 
     def read_secret(
-        self, secret_name: str, namespace: str = "", silent=False
+        self,
+        secret_name: str,
+        namespace: str = "",
+        labels: typing.Optional[dict[str, str]] = None,
+        silent=False,
     ) -> typing.Optional[client.V1Secret]:
         namespace = self.resolve_namespace(namespace)
         if not silent:
-            logger.debug("Reading secret", secret_name=secret_name, namespace=namespace)
+            logger.debug(
+                "Reading secret",
+                secret_name=secret_name,
+                namespace=namespace,
+                labels=labels,
+            )
         try:
             k8s_secret = self.v1api.read_namespaced_secret(
                 name=secret_name,
                 namespace=namespace,
             )
+            if labels:
+                secret_labels = k8s_secret.metadata.labels or {}
+                for key, value in labels.items():
+                    if secret_labels.get(key) != value:
+                        if not silent:
+                            logger.debug(
+                                "Secret found but labels did not match",
+                                secret_name=secret_name,
+                                expected_labels=labels,
+                                actual_labels=secret_labels,
+                            )
+                        return None
         except k8s_client_rest.ApiException as exc:
             if silent:
                 return
             logger.error(
                 "Failed to retrieve k8s secret",
                 secret_name=secret_name,
+                labels=labels,
+                namespace=namespace,
                 exc=mlrun.errors.err_to_str(exc),
             )
             raise k8s_dynamic_exceptions.api_exception(exc)
@@ -1007,12 +1031,13 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
     def _hash_access_key(access_key: str):
         return hashlib.sha224(access_key.encode()).hexdigest()
 
-    def create_or_update_user_token_secret(
+    def store_user_token_secret(
         self,
         username: str,
         token_name: str,
         token: str,
         expiration: int,
+        namespace: str = "",
     ) -> mlrun.common.schemas.SecretEventActions:
         """
         Creates or updates a Kubernetes secret for a user's offline token.
@@ -1020,75 +1045,79 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :param username: The user who owns the token.
         :param token_name: The logical name for the token.
         :param token: The offline token string (JWT).
-        :param exp: The token's expiration timestamp (int UNIX epoch).
+        :param expiration: The token's expiration timestamp (int UNIX epoch).
+        :param namespace: Kubernetes namespace for the secret.
         :return: SecretEventActions.{created, updated, skipped}
         """
+        namespace = self.resolve_namespace(namespace)
         secret_name = f"mlrun-auth-{username}-{token_name}"
+        labels = {"mlrun/user": username}
 
-        secret_data, labels = self._prepare_token_secret_data_and_labels(
-            username, token_name, token, exp
+        secret_data = self._encode_user_token(token_name, token, expiration)
+
+        # Try to read existing secret (may return None if not found or labels mismatch)
+        k8s_secret = self.read_secret(
+            secret_name=secret_name,
+            namespace=namespace,
+            labels=labels,
+            silent=True,
         )
 
-        try:
-            existing_secret = self._k8s.get_secret(secret_name)
-        except Exception:
-            existing_secret = None
-
-        if existing_secret:
-            existing_data = existing_secret.get("data", {})
-            existing_exp_b64 = existing_data.get("tokenExpiration")
-
-            try:
-                existing_exp = int(base64.b64decode(existing_exp_b64).decode("utf-8"))
-            except Exception:
-                existing_exp = 0  # fallback: force update if invalid
-
-            if exp <= existing_exp:
-                # New token is older or equal — skip update
-                return mlrun.common.schemas.SecretEventActions.skipped
-
-            try:
-                self._k8s.update_secret(secret_name, secret_data, labels)
-                return mlrun.common.schemas.SecretEventActions.updated
-            except Exception as exc:
-                raise mlrun.errors.MLRunInternalServerError(
-                    f"Failed to update secret '{secret_name}': {exc}"
-                ) from exc
-
-        # Secret does not exist — create it
-        try:
-            self._k8s.create_secret(secret_name, secret_data, labels)
+        if not k8s_secret:
+            # Secret does not exist (or labels mismatch) → create it
+            self._create_secret(
+                labels=labels,
+                namespace=namespace,
+                secret_name=secret_name,
+                secrets=secret_data,
+            )
             return mlrun.common.schemas.SecretEventActions.created
-        except Exception as exc:
-            raise MLRunInternalServerError(
-                f"Failed to create secret '{secret_name}': {exc}"
-            ) from exc
 
-    def _prepare_token_secret_data_and_labels(
-        self,
-        username: str,
-        token_name: str,
-        token: str,
-        token_expiration: int,
-    ) -> tuple[dict, dict]:
-        encoded_tokens_file = base64.b64encode(
-            yaml.safe_dump(
-                {"secretTokens": [{"name": token_name, "token": token}]}
-            ).encode()
-        ).decode()
+        # Update only if expiration is newer
+        if self._should_update_token_secret(k8s_secret, expiration):
+            self._update_secret(
+                k8s_secret=k8s_secret,
+                namespace=namespace,
+                secret_name=secret_name,
+                secrets=secret_data,
+            )
+            return mlrun.common.schemas.SecretEventActions.updated
 
-        secret_data = {
-            "tokensFile": encoded_tokens_file,
-            "tokenExpiration": base64.b64encode(
-                str(token_expiration).encode()
-            ).decode(),
+        return mlrun.common.schemas.SecretEventActions.skipped
+
+    def _encode_user_token(
+        self, token_name: str, token: str, expiration: int
+    ) -> dict[str, str]:
+        """
+        Encode token and expiration into a dict suitable for Kubernetes Secret.data
+        """
+        token_yaml = yaml.safe_dump(
+            {"secretTokens": [{"name": token_name, "token": token}]}
+        )
+        encoded_token_yaml = base64.b64encode(token_yaml.encode()).decode()
+        return {
+            "tokensFile": encoded_token_yaml,
+            "tokenExpiration": str(expiration),
         }
 
-        labels = {
-            "mlrun/user": username,
-        }
+    def _should_update_token_secret(
+        self, k8s_secret: client.V1Secret, new_expiration: int
+    ) -> bool:
+        """
+        Determine if the secret should be updated based on tokenExpiration
+        """
+        if not k8s_secret.data or "tokenExpiration" not in k8s_secret.data:
+            return True
 
-        return secret_data, labels
+        try:
+            existing_exp = int(
+                base64.b64decode(k8s_secret.data["tokenExpiration"]).decode()
+            )
+        except Exception:
+            existing_exp = 0
+
+        return new_expiration > existing_exp
+
 
 class BasePod:
     def __init__(

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -440,6 +440,12 @@ class Secrets(
                 "Failed to store secret tokens – no tokens provided"
             )
 
+        logger.debug(
+            "Starting to store secret tokens",
+            username=authenticated_username,
+            token_count=len(secret_tokens),
+        )
+
         # First validate all token names
         seen_names = set()
         for secret_token in secret_tokens:
@@ -469,6 +475,19 @@ class Secrets(
                 expiration=expiration,
             )
             token_actions[action].append(token_name)
+
+        logger.debug(
+            "Finished storing tokens",
+            created_tokens=token_actions[
+                mlrun.common.schemas.SecretEventActions.created
+            ],
+            updated_tokens=token_actions[
+                mlrun.common.schemas.SecretEventActions.updated
+            ],
+            skipped_tokens=token_actions[
+                mlrun.common.schemas.SecretEventActions.skipped
+            ],
+        )
 
         return mlrun.common.schemas.StoreSecretTokensResponse(
             created_tokens=token_actions[

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -462,7 +462,7 @@ class Secrets(
 
             expiration = self._extract_and_validate_expiration(token_name, token)
 
-            action = self.secrets_provider.create_or_update_user_token_secret(
+            action = self.secrets_provider.store_user_token_secret(
                 username=authenticated_username,
                 token_name=token_name,
                 token=token,

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -773,7 +773,7 @@ def test_store_secret_tokens_return_values():
 
     mock_secrets_provider = unittest.mock.Mock()
     services.api.crud.Secrets().secrets_provider = mock_secrets_provider
-    mock_secrets_provider.create_or_update_user_token_secret.side_effect = [
+    mock_secrets_provider.store_user_token_secret.side_effect = [
         mlrun.common.schemas.SecretEventActions.created,
         mlrun.common.schemas.SecretEventActions.updated,
         mlrun.common.schemas.SecretEventActions.skipped,
@@ -789,7 +789,7 @@ def test_store_secret_tokens_return_values():
         "skipped_tokens": ["token3"],
     }
 
-    assert mock_secrets_provider.create_or_update_user_token_secret.call_count == 3
+    assert mock_secrets_provider.store_user_token_secret.call_count == 3
 
 
 def _generate_token(payload: dict) -> str:

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import datetime
 import unittest.mock
 from contextlib import nullcontext as does_not_raise
@@ -54,11 +55,11 @@ def k8s_helper():
         )
         k8s_helper._create_secret = mock.MagicMock()
         k8s_helper._update_secret = mock.MagicMock()
-        k8s_helper.read_secret = mock.MagicMock()
         return k8s_helper
 
 
 def test_create_new_secret(k8s_helper):
+    k8s_helper.read_secret = mock.MagicMock()
     k8s_helper.read_secret.side_effect = k8s_dynamic_exceptions.NotFoundError(
         k8s_client_rest.ApiException(status=404)
     )
@@ -73,6 +74,7 @@ def test_create_new_secret(k8s_helper):
 
 
 def test_conflict_during_create_secret(k8s_helper):
+    k8s_helper.read_secret = mock.MagicMock()
     k8s_helper.read_secret.side_effect = k8s_dynamic_exceptions.NotFoundError(
         k8s_client_rest.ApiException(status=404)
     )
@@ -91,6 +93,7 @@ def test_conflict_during_create_secret(k8s_helper):
 
 
 def test_update_existing_secret(k8s_helper):
+    k8s_helper.read_secret = mock.MagicMock()
     k8s_helper.read_secret.return_value = k8s_client.V1Secret()
     k8s_helper._create_secret.side_effect = k8s_dynamic_exceptions.api_exception(
         k8s_client_rest.ApiException(status=409)
@@ -107,6 +110,7 @@ def test_update_existing_secret(k8s_helper):
 
 
 def test_update_failure(k8s_helper):
+    k8s_helper.read_secret = mock.MagicMock()
     k8s_helper.read_secret.return_value = k8s_client.V1Secret()
     k8s_helper._update_secret.side_effect = k8s_dynamic_exceptions.api_exception(
         k8s_client_rest.ApiException(status=500)
@@ -123,6 +127,7 @@ def test_update_failure(k8s_helper):
 
 
 def test_read_secret_failure(k8s_helper):
+    k8s_helper.read_secret = mock.MagicMock()
     k8s_helper.read_secret.side_effect = k8s_dynamic_exceptions.api_exception(
         k8s_client_rest.ApiException(status=403)
     )
@@ -135,6 +140,49 @@ def test_read_secret_failure(k8s_helper):
         )
 
     k8s_helper.read_secret.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "labels_in_secret, labels_to_match, expected",
+    [
+        # Matching labels
+        ({"key1": "value1", "key2": "value2"}, {"key1": "value1"}, True),
+        # Non-matching labels
+        ({"key1": "value1", "key2": "value2"}, {"key1": "wrong"}, False),
+        # No labels provided (always accept)
+        ({"key1": "value1"}, None, True),
+        # Secret has no labels but caller requires them
+        ({}, {"key1": "value1"}, False),
+    ],
+)
+def test_read_secret_label_validation(
+    k8s_helper, labels_in_secret, labels_to_match, expected
+):
+    """
+    Verify that read_secret correctly validates labels on top of name-based lookup.
+    """
+    secret_name = "my-secret"
+    secret_data = {"secret-key1": "secret-value1"}
+
+    secret_obj = k8s_client.V1Secret(
+        metadata=k8s_client.V1ObjectMeta(
+            name=secret_name,
+            labels=labels_in_secret,
+        )
+    )
+    secret_obj.string_data = secret_data
+
+    # Mock the Kubernetes API return
+    k8s_helper.v1api.read_namespaced_secret.return_value = secret_obj
+
+    secret = k8s_helper.read_secret(secret_name=secret_name, labels=labels_to_match)
+
+    assert k8s_helper.v1api.read_namespaced_secret.call_count == 1
+
+    if expected:
+        assert secret is secret_obj
+    else:
+        assert secret is None
 
 
 @pytest.mark.parametrize(
@@ -208,6 +256,7 @@ def test_store_secret(
     expected_data: dict,
     expected_result: SecretEventActions,
 ):
+    k8s_helper.read_secret = mock.MagicMock()
     if existing_secret_data:
         k8s_helper.read_secret.return_value = k8s_client.V1Secret(
             data=existing_secret_data,
@@ -402,3 +451,71 @@ def test_list_pod_events(k8s_helper):
         assert events[0].reason == event.reason
         assert events[0].message == event.message
         assert events[0].first_timestamp == event.first_timestamp
+
+
+def test_store_user_token_secret_created(k8s_helper):
+    k8s_helper.read_secret = mock.MagicMock()
+    k8s_helper.read_secret.return_value = None
+
+    result = k8s_helper.store_user_token_secret(
+        username="test-user",
+        token_name="my-token",
+        token="abc123",
+        expiration=9999,
+        namespace="default",
+    )
+
+    assert result == mlrun.common.schemas.SecretEventActions.created
+    k8s_helper._create_secret.assert_called_once()
+    k8s_helper._update_secret.assert_not_called()
+
+
+def test_store_user_token_secret_updated(k8s_helper):
+    secret_name = "mlrun-auth-test-user-mytoken"
+    existing_secret = _make_secret(secret_name, expiration=1000)
+
+    k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
+
+    result = k8s_helper.store_user_token_secret(
+        username="test-user",
+        token_name="mytoken",
+        token="abc123",
+        expiration=2000,
+        namespace="default",
+    )
+
+    assert result == mlrun.common.schemas.SecretEventActions.updated
+    k8s_helper._update_secret.assert_called_once()
+    k8s_helper._create_secret.assert_not_called()
+
+
+def test_store_user_token_secret_skipped(k8s_helper):
+    secret_name = "mlrun-auth-test-user-mytoken"
+    existing_secret = _make_secret(secret_name, expiration=5000)
+
+    k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
+
+    result = k8s_helper.store_user_token_secret(
+        username="test-user",
+        token_name="mytoken",
+        token="abc123",
+        expiration=4000,  # older expiration -> should skip
+        namespace="default",
+    )
+
+    assert result == mlrun.common.schemas.SecretEventActions.skipped
+    k8s_helper._update_secret.assert_not_called()
+    k8s_helper._create_secret.assert_not_called()
+
+
+def _make_secret(secret_name, expiration=None, labels=None):
+    labels = labels or {"mlrun/user": "test-user"}
+    secret = k8s_client.V1Secret(
+        metadata=k8s_client.V1ObjectMeta(name=secret_name, labels=labels),
+        data={},
+    )
+    if expiration is not None:
+        secret.data["tokenExpiration"] = base64.b64encode(
+            str(expiration).encode()
+        ).decode()
+    return secret

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -471,14 +471,16 @@ def test_store_user_token_secret_created(k8s_helper):
 
 
 def test_store_user_token_secret_updated(k8s_helper):
-    secret_name = "mlrun-auth-test-user-mytoken"
+    username = "test-user"
+    token_name = "mytoken"
+    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
     existing_secret = _make_secret(secret_name, expiration=1000)
 
     k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
 
     result = k8s_helper.store_user_token_secret(
-        username="test-user",
-        token_name="mytoken",
+        username=username,
+        token_name=token_name,
         token="abc123",
         expiration=2000,
         namespace="default",
@@ -490,14 +492,16 @@ def test_store_user_token_secret_updated(k8s_helper):
 
 
 def test_store_user_token_secret_skipped(k8s_helper):
-    secret_name = "mlrun-auth-test-user-mytoken"
+    username = "test-user"
+    token_name = "mytoken"
+    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
     existing_secret = _make_secret(secret_name, expiration=5000)
 
     k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
 
     result = k8s_helper.store_user_token_secret(
-        username="test-user",
-        token_name="mytoken",
+        username=username,
+        token_name=token_name,
         token="abc123",
         expiration=4000,  # older expiration -> should skip
         namespace="default",
@@ -509,7 +513,9 @@ def test_store_user_token_secret_skipped(k8s_helper):
 
 
 def _make_secret(secret_name, expiration=None, labels=None):
-    labels = labels or {"mlrun/user": "test-user"}
+    labels = labels or {
+        mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: "test-user"
+    }
     secret = k8s_client.V1Secret(
         metadata=k8s_client.V1ObjectMeta(name=secret_name, labels=labels),
         data={},


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
This PR implements storing user tokens in Kubernetes secrets by first attempting to read the secret (by name and labels).

- If the secret does not exist, it is created.
- If the secret exists, the token’s expiration is checked, and the secret is updated only if the new token has a later expiration.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

- Implemented store_user_token_secret to handle secret creation and conditional update based on expiration.
- Updated k8s.read_secret to find secrets by name and verify labels.
- Fixed SDK response methods to correctly report created, updated, and skipped tokens.
- Adjusted SDK warnings to only log when tokens are actually stored or updated.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Unit tests for secret creation, update, and skip scenarios.
Verified manually on IG4 system.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10492
- Design docs links: https://iguazio.atlassian.net/wiki/spaces/MLRUN/pages/404521061/BE+Secret+Token+Support+HLD#2.2.3-Token-Store-or-Update-Flow
- External links: https://iguazio.atlassian.net/wiki/spaces/ARC/pages/361103361/MLRun+Secret+Tokens+in+IG4

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
