### PR TITLE
[Makefile] Include go services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ print-docker-images: ## Print all docker images
 	@for image in $(DEFAULT_IMAGES); do \
 		echo $$image ; \
 	done
-	@cd server/go && make print-docker-images
+	@make -C server/go print-docker-images
 
 
 MLRUN_IMAGE_NAME := $(MLRUN_DOCKER_IMAGE_PREFIX)/mlrun

--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,7 @@ print-docker-images: ## Print all docker images
 	@for image in $(DEFAULT_IMAGES); do \
 		echo $$image ; \
 	done
+	@cd server/go && make print-docker-images
 
 
 MLRUN_IMAGE_NAME := $(MLRUN_DOCKER_IMAGE_PREFIX)/mlrun

--- a/server/go/Makefile
+++ b/server/go/Makefile
@@ -24,6 +24,8 @@ KUBECONFIG := $(if $(KUBECONFIG),$(KUBECONFIG),$(HOME)/.kube/config)
 
 CI_BIN_DIR=$(shell pwd)/.bin
 DOCKER_IMAGES = log-collector
+LOG_COLLECTOR_IMAGE_NAME := $(MLRUN_DOCKER_IMAGE_PREFIX)/log-collector:$(MLRUN_DOCKER_TAG)
+DEFAULT_IMAGES += $(LOG_COLLECTOR_IMAGE_NAME)
 
 GOLANGCI_LINT_VERSION := 2.2.1
 GOLANGCI_LINT_BIN := $(CI_BIN_DIR)/golangci-lint
@@ -40,23 +42,29 @@ build: docker-images
 docker-images: compile-schemas $(DOCKER_IMAGES)
 	@echo Built $(DOCKER_IMAGES)
 
+.PHONY: print-docker-images
+print-docker-images:
+	@for image in $(DEFAULT_IMAGES); do \
+		echo $$image ; \
+	done
+
 .PHONY: log-collector
 log-collector: compile-schemas
 	@echo Building log-collector image
 	docker build \
 		--file services/logcollector/cmd/docker/Dockerfile \
 		--build-arg GO_VERSION=$(GO_VERSION) \
-		--tag $(MLRUN_DOCKER_IMAGE_PREFIX)/log-collector:$(MLRUN_DOCKER_TAG) \
+		--tag $(LOG_COLLECTOR_IMAGE_NAME) \
 		.
 
 .PHONY: push-log-collector
 push-log-collector:
 	@echo Pushing log-collector image
-	docker push $(MLRUN_DOCKER_IMAGE_PREFIX)/log-collector:$(MLRUN_DOCKER_TAG)
+	docker push $(LOG_COLLECTOR_IMAGE_NAME)
 
 .PHONY: pull-log-collector
 pull-log-collector:
-	docker pull $(MLRUN_DOCKER_IMAGE_PREFIX)/log-collector:$(MLRUN_DOCKER_TAG)
+	docker pull $(LOG_COLLECTOR_IMAGE_NAME)
 
 .PHONY: schemas-compiler
 schemas-compiler:


### PR DESCRIPTION
### 📝 Description
The `make print-docker-images` command did not include go services image names. This PR fixes it

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
run `make print-docker-images` to ensure log-collector is printed correctly.
same with explicit mlrun version, e.g `MLRUN_VERSION=1.10 make print-docker-images`.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
