### PR TITLE
[API] Moved system id sync to online phase

### DIFF
--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -66,6 +66,7 @@ class Service(ABC):
 
     async def move_service_to_online(self):
         self._logger.info("Moving service to online", service_name=self.service_name)
+        await run_async_function_with_new_db_session(self._sync_system_metadata)
         await self._move_service_to_online()
 
     # https://fastapi.tiangolo.com/advanced/events/
@@ -119,7 +120,7 @@ class Service(ABC):
 
     @abstractmethod
     async def _move_service_to_online(self):
-        await run_async_function_with_new_db_session(self._sync_system_metadata)
+        pass
 
     def _mount_services(self, mounts: typing.Optional[list] = None):
         if not mounts:

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -119,7 +119,7 @@ class Service(ABC):
 
     @abstractmethod
     async def _move_service_to_online(self):
-        pass
+        await run_async_function_with_new_db_session(self._sync_system_metadata)
 
     def _mount_services(self, mounts: typing.Optional[list] = None):
         if not mounts:
@@ -191,10 +191,14 @@ class Service(ABC):
             # in the background, wait for chief to reach online state
             self._start_chief_clusterization_spec_sync_loop()
 
+        # below logic must be relevant for chief only
+        # as at this point the worker is not yet online (the condition below is for chief only)
+        # and this means not all data / schemas are ready yet on worker level.
+
+        # relevant for chief only. workers will not reach this point as they
+        # are waiting for chief to reach online state.
         if mlconf.httpdb.state == mlrun.common.schemas.APIStates.online:
             await self.move_service_to_online()
-
-        await run_async_function_with_new_db_session(self._sync_system_metadata)
 
     async def _setup_mounted_service(self):
         await self._custom_setup_service()

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -542,6 +542,7 @@ class Service(framework.service.Service):
         return alert_activation
 
     async def _move_service_to_online(self):
+        await super()._move_service_to_online()
         if not get_project_member():
             await fastapi.concurrency.run_in_threadpool(initialize_project_member)
             get_project_member().start()

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -542,7 +542,6 @@ class Service(framework.service.Service):
         return alert_activation
 
     async def _move_service_to_online(self):
-        await super()._move_service_to_online()
         if not get_project_member():
             await fastapi.concurrency.run_in_threadpool(initialize_project_member)
             get_project_member().start()

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -110,7 +110,9 @@ class Service(framework.service.Service):
             mlconf.httpdb.clusterization.role
             == mlrun.common.schemas.ClusterizationRole.chief
         ):
-            services.api.initial_data.update_default_configuration_data()
+            await fastapi.concurrency.run_in_threadpool(
+                services.api.initial_data.update_default_configuration_data
+            )
             await self._start_periodic_functions()
 
         await self._move_mounted_services_to_online()

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -88,8 +88,6 @@ class Service(framework.service.Service):
         self._retry_in_progress_run_uids: dict[str, datetime.datetime] = {}
 
     async def _move_service_to_online(self):
-        await super()._move_service_to_online()
-
         # scheduler is needed on both workers and chief
         # on workers - it allows to us to list/get scheduler(s)
         # on chief - it allows to us to create/update/delete schedule(s)

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -88,6 +88,8 @@ class Service(framework.service.Service):
         self._retry_in_progress_run_uids: dict[str, datetime.datetime] = {}
 
     async def _move_service_to_online(self):
+        await super()._move_service_to_online()
+
         # scheduler is needed on both workers and chief
         # on workers - it allows to us to list/get scheduler(s)
         # on chief - it allows to us to create/update/delete schedule(s)


### PR DESCRIPTION
### 📝 Description

before the sync was on `_setup_service` which may be finished while chief/worker is yet to be online as they are pending migration and not all tables are ready yet.
now the sync is part of moving to online phase, where the data/schemas are mgirated and db is ready to be used.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

patched vm, verified migration, from scratch and simple scale up/down to see system id is returned on client-spec requests.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10929
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
