### PR TITLE
[Model Monitoring] Fix wrong timestamp for last request while using `pd.to_datetime`

### DIFF
--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -858,8 +858,13 @@ class MonitoringApplicationController:
             ) as schedule_file:
                 for endpoint in endpoints:
                     last_request = last_request_dict.get(endpoint.metadata.uid, None)
-                    if isinstance(last_request, float):
-                        last_request = pd.to_datetime(last_request, unit="s", utc=True)
+                    last_request = (
+                        datetime.datetime.fromtimestamp(
+                            last_request, tz=datetime.timezone.utc
+                        )
+                        if last_request
+                        else None
+                    )
                     endpoint.status.last_request = (
                         last_request or endpoint.status.last_request
                     )

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -858,13 +858,8 @@ class MonitoringApplicationController:
             ) as schedule_file:
                 for endpoint in endpoints:
                     last_request = last_request_dict.get(endpoint.metadata.uid, None)
-                    last_request = (
-                        datetime.datetime.fromtimestamp(
-                            last_request, tz=datetime.timezone.utc
-                        )
-                        if last_request
-                        else None
-                    )
+                    if isinstance(last_request, float):
+                        last_request = pd.to_datetime(last_request, unit="ms", utc=True)
                     endpoint.status.last_request = (
                         last_request or endpoint.status.last_request
                     )


### PR DESCRIPTION
### 📝 Description
Change usage of `pd.to_datetime` fixing units to "ms"
---
### ✅ Checklist
- [x] I have tested the changes in this PR
---
### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10926
---
### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No
