### PR TITLE
[Application] Add missing params to ApplicationSpec

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -79,6 +79,10 @@ class ApplicationSpec(NuclioSpec):
         add_templated_ingress_host_mode=None,
         state_thresholds=None,
         disable_default_http_trigger=None,
+        serving_spec=None,
+        graph=None,
+        parameters=None,
+        track_models=None,
         internal_application_port=None,
         application_ports=None,
     ):
@@ -120,6 +124,10 @@ class ApplicationSpec(NuclioSpec):
             security_context=security_context,
             service_type=service_type,
             add_templated_ingress_host_mode=add_templated_ingress_host_mode,
+            serving_spec=serving_spec,
+            graph=graph,
+            parameters=parameters,
+            track_models=track_models,
             state_thresholds=state_thresholds,
             disable_default_http_trigger=disable_default_http_trigger,
         )

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -22,6 +22,7 @@ import mlrun
 import mlrun.runtimes.databricks_job.databricks_runtime
 import mlrun.runtimes.mpijob.abstract
 import mlrun.runtimes.mpijob.v1
+import mlrun.runtimes.nuclio.application
 import mlrun.runtimes.pod
 
 
@@ -54,6 +55,7 @@ def test_runtimes_inheritance(method, base_classes):
         ],
         mlrun.runtimes.nuclio.function.NuclioSpec: [
             mlrun.runtimes.nuclio.serving.ServingSpec,
+            mlrun.runtimes.nuclio.application.application.ApplicationSpec,
         ],
         mlrun.runtimes.base.FunctionStatus: [
             mlrun.runtimes.daskjob.DaskStatus,


### PR DESCRIPTION

### 📝 Description
While working on the mlrun coding exercise #8486 I noticed that ApplicationSpec is missing from one of the tests. I added it and had to fix the parameters it is getting in its constructor to pass the test. 

---

### 🛠️ Changes Made
Added ApplicationSpec to the 'test_runtimes_inheritance' test
Added missing KubeResourceSpec parameters into ApplicationSpec constructor
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
test_runtimes_inheritance
---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
