### PR TITLE
[Application] Improve ports enrichment logic to preserve BC

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -186,6 +186,13 @@ class ApplicationSpec(NuclioSpec):
         is_valid_port(port, raise_on_error=True)
         self._internal_application_port = port
 
+        # If when internal application port is being set, length of self._application_ports is 1,
+        # it means that it consist of [old_port] only
+        # so in this case, we rewrite the list completely, by setting value to [new_value]
+        if len(self.application_ports) == 1:
+            self._application_ports = [port]
+            return
+
         # when setting new internal application port, ensure that it is included in the application ports
         # it just triggers setter logic, so setting to the same value is a no-op
         self.application_ports = self._application_ports

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -93,6 +93,23 @@ def test_create_application_runtime_many_ports(rundb_mock, igz_version_mock):
     assert fn.spec.internal_application_port == 22
 
 
+def test_application_runtime_update_port(rundb_mock, igz_version_mock):
+    # deploy with default value
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun", command="echo"
+    )
+    # both should be the same
+    assert fn.spec.internal_application_port == 8050
+    assert fn.spec.application_ports == [8050]
+
+    # simulate the case where the user updates the application port (without setting application ports)
+
+    fn.set_internal_application_port(5000)
+
+    assert fn.spec.internal_application_port == 5000
+    assert fn.spec.application_ports == [5000]
+
+
 def test_deploy_application_runtime(rundb_mock, igz_version_mock):
     image = "my/web-app:latest"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(


### PR DESCRIPTION
### 📝 Description

This pr fixes the bug created by this [pr](https://github.com/mlrun/mlrun/pull/8392). The reason of the bug is the new parameter spec.application_ports in application ports, that is enriched on the __init__ and on setting the internal_application_port. This parameter is responsible for setting all active ports of the sidecar. So, on init:

```
internal_application_port = 8050
application_ports = [8050]
```
after setting internal application port to 5000:
```
internal_application_port = 5000
application_ports = [5000, 8050]
```
this can be workaround-ed by setting `spec.application_ports = [5000]`. In order to preserve BC, If the application_ports list contains only one port (the old internal application port), the list is rewritten to include only the new internal application port. This ensures consistency when the internal application port is updated. This ensures proper BC with previous versions.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
tested on vmdev using the notebook from the ticket

---

### 🔗 References
- Ticket link:https://iguazio.atlassian.net/browse/ML-10806

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No