### PR TITLE
[BackgroundTasks] Disable auto-cleanups

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -107,7 +107,11 @@ default_config = {
     "submit_timeout": "280",  # timeout when submitting a new k8s resource
     # runtimes cleanup interval in seconds
     "runtimes_cleanup_interval": "300",
-    "background_task_cleanup_interval": "86400",  # 24 hours in seconds
+    # disabled by default due to an internal bug in serving functions
+    # relying on a background task to hold the status for its model endpoints
+    # TODO: need to refine what/when we can delete the background tasks
+    # e.g: use labels or naming convention.
+    "background_task_cleanup_interval": "0",
     "background_task_max_age": "21600",  # 6 hours in seconds
     "monitoring": {
         "runs": {


### PR DESCRIPTION
### 📝 Description

Background tasks cleanup introduced on 1.10 to make sure we dont have needless background tasks. fact is a missed use-case where model serving relying on background task to understand the status of its model endpoints failed when its bg task was removed.

---

### 🛠️ Changes Made

Disable the cleanup interval as we cannot determine which background task to remove and which not, given backwards compatibility - we need not to delete old/existing background tasks.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

set interval to 0 and patched chief and ensured `Starting periodic background task cleanup` never logged.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10834
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
