### PR TITLE
[CI] Add orjson to automation requirements

### DIFF
--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -8,3 +8,4 @@ packaging~=24.2
 coloredlogs~=15.0
 sqlalchemy~=2.0
 sqlalchemy-utils~=0.41.2
+orjson>=3.9.15, <4


### PR DESCRIPTION
### 📝 Description
system tests failing to run with:
```
Run python automation/system_test/prepare.py run \
Traceback (most recent call last):
  File "/__w/mlrun/mlrun/automation/system_test/prepare.py", line 30, in <module>
    import orjson
ModuleNotFoundError: No module named 'orjson'
```

---

### 🛠️ Changes Made
Add orjson to `automation/requirements.txt`
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->
