### PR TITLE
[DB] Remove all cross-thread SQLAlchemy Sessions

### DIFF
--- a/server/py/services/api/api/endpoints/pipelines.py
+++ b/server/py/services/api/api/endpoints/pipelines.py
@@ -41,6 +41,7 @@ import mlrun_pipelines.utils
 import framework.api
 import framework.api.deps
 import framework.api.utils
+import framework.db.session
 import framework.utils.auth.verifier
 import framework.utils.background_tasks
 import framework.utils.notifications
@@ -90,16 +91,16 @@ async def list_pipelines(
             else format_
         )
         total_size, next_page_token, runs = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             services.api.crud.Pipelines().list_pipelines,
-            db_session,
-            allowed_project_names,
-            namespace,
-            sort_by,
-            page_token,
-            filter_,
-            name_contains,
-            computed_format,
-            page_size,
+            project=allowed_project_names,
+            namespace=namespace,
+            sort_by=sort_by,
+            page_token=page_token,
+            filter_=filter_,
+            name_contains=name_contains,
+            format_=computed_format,
+            page_size=page_size,
         )
     allowed_runs = await framework.utils.auth.verifier.AuthVerifier().filter_project_resources_by_permissions(
         mlrun.common.schemas.AuthorizationResourceTypes.pipeline,
@@ -160,8 +161,8 @@ async def retry_pipeline(
 ):
     project: mlrun.common.schemas.ProjectOut = (
         await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             framework.utils.singletons.project_member.get_project_member().get_project,
-            db_session=db_session,
             name=project,
             leader_session=auth_info.session,
         )
@@ -183,8 +184,8 @@ async def retry_pipeline(
             original_runner,
             original_workflow_id,
         ) = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             services.api.crud.Pipelines().get_original_workflow_run,
-            db_session=db_session,
             run_id=run_id,
             project=project.metadata.name,
         )
@@ -215,16 +216,16 @@ async def retry_pipeline(
         # we lock the original-runner row, mark it retrying, and block any
         # parallel retry requests until it’s cleared.
         rerun_index = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             services.api.crud.Pipelines().lock_run_and_mark_retrying,
-            db_session=db_session,
             project=project.metadata.name,
             run_id=original_runner.metadata.uid,
         )
     except mlrun.errors.MLRunConflictError as exc:
         try:
             return await fastapi.concurrency.run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
                 services.api.crud.Pipelines().get_running_rerun_runner,
-                db_session=db_session,
                 project=project.metadata.name,
                 original_workflow_id=original_workflow_id,
             )
@@ -236,8 +237,8 @@ async def retry_pipeline(
     try:
         workflow_response: mlrun.common.schemas.WorkflowResponse = (
             await fastapi.concurrency.run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
                 services.api.crud.Pipelines().rerun_pipeline_via_runner,
-                db_session=db_session,
                 run_id=original_workflow_id,
                 project=project,
                 original_runner=original_runner,
@@ -340,8 +341,8 @@ async def push_notifications(
     )
 
     background_task = await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         framework.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task,
-        db_session,
         project,
         background_tasks,
         _push_notifications,
@@ -547,8 +548,8 @@ async def _terminate_pipeline(
         framework.utils.background_tasks.ProjectBackgroundTasksHandler()
     )
     existing_terminate_pipeline_task = await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         background_task_handler.get_background_task_by_state_and_labels,
-        db_session=db_session,
         status=mlrun.common.schemas.BackgroundTaskState.running,
         labels={
             mlrun.common.schemas.background_task.BackGroundTaskLabel.pipeline: run_id,
@@ -564,8 +565,8 @@ async def _terminate_pipeline(
         return existing_terminate_pipeline_task
     else:
         terminate_pipeline_task = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             framework.utils.background_tasks.ProjectBackgroundTasksHandler().create_background_task,
-            db_session,
             project,
             background_tasks,
             services.api.crud.pipelines.Pipelines().terminate_pipeline,

--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -26,6 +26,7 @@ from mlrun.utils import logger
 
 import framework.api.deps
 import framework.api.utils
+import framework.db.session
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
 import framework.utils.helpers
@@ -465,8 +466,8 @@ async def load_project(
 
     # Ensure the project exists before calling the remote load_project function
     project, _ = await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         get_project_member().create_project,
-        db_session=db_session,
         project=project,
         projects_role=auth_info.projects_role,
         leader_session=auth_info.session,
@@ -490,10 +491,10 @@ async def load_project(
 
     # Creating the auxiliary function for loading the project:
     load_project_runner = await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         services.api.crud.LoadRunner().create_runner,
         run_name=f"load-{name}",
         project=name,
-        db_session=db_session,
         auth_info=auth_info,
         image=mlrun.mlconf.default_base_image,
     )

--- a/server/py/services/api/api/endpoints/schedules.py
+++ b/server/py/services/api/api/endpoints/schedules.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 import mlrun.common.schemas
 from mlrun.utils import logger
 
+import framework.db.session
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
 import framework.utils.singletons.project_member
@@ -302,9 +303,9 @@ async def set_schedule_notifications(
     db_session: Session = fastapi.Depends(deps.get_db_session),
 ):
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         framework.utils.singletons.project_member.get_project_member().ensure_project,
-        db_session,
-        project,
+        name=project,
         auth_info=auth_info,
     )
 
@@ -337,11 +338,11 @@ async def set_schedule_notifications(
         )
 
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         services.api.crud.Notifications().set_object_notifications,
-        db_session,
-        auth_info,
-        project,
-        set_notifications_request.notifications,
-        mlrun.common.schemas.ScheduleIdentifier(name=name),
+        auth_info=auth_info,
+        project=project,
+        notifications=set_notifications_request.notifications,
+        notification_parent=mlrun.common.schemas.ScheduleIdentifier(name=name),
     )
     return fastapi.Response(status_code=HTTPStatus.OK.value)

--- a/server/py/services/api/api/endpoints/submit.py
+++ b/server/py/services/api/api/endpoints/submit.py
@@ -26,6 +26,7 @@ import mlrun.utils.helpers
 from mlrun.utils import logger
 
 import framework.api.utils
+import framework.db.session
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
 import framework.utils.singletons.project_member
@@ -60,9 +61,9 @@ async def submit_job(
         )
 
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         framework.utils.singletons.project_member.get_project_member().ensure_project,
-        db_session,
-        data["task"]["metadata"]["project"],
+        name=data["task"]["metadata"]["project"],
         auth_info=auth_info,
     )
     function_dict, function_url, task = framework.api.utils.parse_submit_run_body(data)

--- a/server/py/services/api/api/endpoints/tags.py
+++ b/server/py/services/api/api/endpoints/tags.py
@@ -23,6 +23,7 @@ import mlrun.common.schemas
 from mlrun.utils.helpers import tag_name_regex_as_string
 
 import framework.api.deps
+import framework.db.session
 import framework.utils.auth.verifier
 import framework.utils.singletons.project_member
 import services.api.crud.tags
@@ -43,9 +44,9 @@ async def overwrite_object_tags_with_tag(
     ),
 ):
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         framework.utils.singletons.project_member.get_project_member().ensure_project,
-        db_session,
-        project,
+        name=project,
         auth_info=auth_info,
     )
 
@@ -64,11 +65,11 @@ async def overwrite_object_tags_with_tag(
     _check_reserved_tag(tag)
 
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         services.api.crud.Tags().overwrite_object_tags_with_tag,
-        db_session,
-        project,
-        tag,
-        tag_objects,
+        project=project,
+        tag=tag,
+        tag_objects=tag_objects,
     )
     return mlrun.common.schemas.Tag(name=tag, project=project)
 
@@ -86,9 +87,9 @@ async def append_tag_to_objects(
     ),
 ):
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         framework.utils.singletons.project_member.get_project_member().ensure_project,
-        db_session,
-        project,
+        name=project,
         auth_info=auth_info,
     )
 
@@ -105,11 +106,11 @@ async def append_tag_to_objects(
     _check_reserved_tag(tag)
 
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         services.api.crud.Tags().append_tag_to_objects,
-        db_session,
-        project,
-        tag,
-        tag_objects,
+        project=project,
+        tag=tag,
+        tag_objects=tag_objects,
     )
     return mlrun.common.schemas.Tag(name=tag, project=project)
 
@@ -127,9 +128,9 @@ async def delete_tag_from_objects(
     ),
 ):
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         framework.utils.singletons.project_member.get_project_member().ensure_project,
-        db_session,
-        project,
+        name=project,
         auth_info=auth_info,
     )
 
@@ -147,11 +148,11 @@ async def delete_tag_from_objects(
     _check_reserved_tag(tag)
 
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         services.api.crud.Tags().delete_tag_from_objects,
-        db_session,
-        project,
-        tag,
-        tag_objects,
+        project=project,
+        tag=tag,
+        tag_objects=tag_objects,
     )
     return fastapi.Response(status_code=http.HTTPStatus.NO_CONTENT.value)
 

--- a/server/py/services/api/api/endpoints/workflows.py
+++ b/server/py/services/api/api/endpoints/workflows.py
@@ -32,6 +32,7 @@ from mlrun.k8s_utils import sanitize_label_value
 from mlrun.utils.helpers import logger
 
 import framework.api.deps
+import framework.db.session
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
 import framework.utils.singletons.project_member
@@ -476,10 +477,10 @@ async def set_run_retrying_status(
 
     # call into your CRUD
     await fastapi.concurrency.run_in_threadpool(
+        framework.db.session.run_function_with_new_db_session,
         services.api.crud.RerunRunner().set_run_retrying_status,
-        db_session,
-        project,
-        uid,
-        retrying,
+        project=project,
+        run_id=uid,
+        retrying=retrying,
     )
     return {}

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -357,12 +357,12 @@ class Projects(
         names: typing.Optional[list[str]] = None,
     ) -> mlrun.common.schemas.ProjectSummariesOutput:
         project_summaries = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             framework.utils.singletons.db.get_db().list_project_summaries,
-            session,
-            owner,
-            labels,
-            state,
-            names,
+            owner=owner,
+            labels=labels,
+            state=state,
+            names=names,
         )
 
         return mlrun.common.schemas.ProjectSummariesOutput(
@@ -375,8 +375,8 @@ class Projects(
         # Call get project so we'll explode if project doesn't exists
         await fastapi.concurrency.run_in_threadpool(self.get_project, session, name)
         return await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             framework.utils.singletons.db.get_db().get_project_summary,
-            session,
             project=name,
         )
 
@@ -420,8 +420,8 @@ class Projects(
         self, session: sqlalchemy.orm.Session
     ):
         projects_output = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             self.list_projects,
-            session,
             format_=mlrun.common.formatters.ProjectFormat.name_and_creation_time,
         )
 
@@ -523,9 +523,9 @@ class Projects(
                 )
             )
         await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             framework.utils.singletons.db.get_db().refresh_project_summaries,
-            session,
-            project_summaries,
+            project_summaries=project_summaries,
         )
 
     @staticmethod

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -20,7 +20,6 @@ import typing
 
 import fastapi
 import fastapi.concurrency
-import sqlalchemy.orm
 
 import mlrun
 import mlrun.common.runtimes.constants
@@ -249,8 +248,8 @@ class Service(framework.service.Service):
             "Getting all runs which are in non terminal state and require logs collection"
         )
         runs_uids = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             get_db().list_distinct_runs_uids,
-            db_session,
             requested_logs_modes=[None, False],
             only_uids=True,
             states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
@@ -261,8 +260,8 @@ class Service(framework.service.Service):
         )
         runs_uids.extend(
             await fastapi.concurrency.run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
                 get_db().list_distinct_runs_uids,
-                db_session,
                 requested_logs_modes=[None, False],
                 # get only uids as there might be many runs which reached terminal state while the API was down, the
                 # run objects will be fetched in the next step
@@ -299,15 +298,14 @@ class Service(framework.service.Service):
             # terminal state while the API was down)
             await self._start_log_and_update_runs(
                 start_logs_limit=start_logs_limit,
-                db_session=db_session,
                 runs_uids=runs_uids,
                 best_effort=True,
             )
 
             if skipped_run_uids:
                 await fastapi.concurrency.run_in_threadpool(
+                    framework.db.session.run_function_with_new_db_session,
                     get_db().update_runs_requested_logs,
-                    db_session,
                     uids=skipped_run_uids,
                     requested_logs=True,
                 )
@@ -318,55 +316,48 @@ class Service(framework.service.Service):
         are in a state which requires logs collection and will initiate the logs collection process for each of them.
         :param start_logs_limit: a semaphore which limits the number of concurrent logs collection processes
         """
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-        try:
-            # list all the runs currently still running in the system which we didn't request logs collection for yet
-            runs_uids = await fastapi.concurrency.run_in_threadpool(
+        # list all the runs currently still running in the system which we didn't request logs collection for yet
+        runs_uids = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
+            get_db().list_distinct_runs_uids,
+            requested_logs_modes=[False],
+            only_uids=True,
+            states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
+        )
+
+        last_update_time = datetime.datetime.now(
+            datetime.timezone.utc
+        ) - datetime.timedelta(
+            seconds=int(mlconf.runtime_resources_deletion_grace_period)
+        )
+
+        # Add all the completed/failed runs in the system which we didn't request logs collection for yet.
+        # Aborted means the pods were deleted and logs were already fetched.
+        run_states = mlrun.common.runtimes.constants.RunStates.terminal_states()
+        run_states.remove(mlrun.common.runtimes.constants.RunStates.aborted)
+        runs_uids.extend(
+            await fastapi.concurrency.run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
                 get_db().list_distinct_runs_uids,
-                db_session,
                 requested_logs_modes=[False],
                 only_uids=True,
-                states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
+                last_update_time_from=last_update_time,
+                states=run_states,
             )
-
-            last_update_time = datetime.datetime.now(
-                datetime.timezone.utc
-            ) - datetime.timedelta(
-                seconds=int(mlconf.runtime_resources_deletion_grace_period)
+        )
+        if runs_uids:
+            self._logger.debug(
+                "Found runs which require logs collection",
+                runs_uids=len(runs_uids),
             )
-
-            # Add all the completed/failed runs in the system which we didn't request logs collection for yet.
-            # Aborted means the pods were deleted and logs were already fetched.
-            run_states = mlrun.common.runtimes.constants.RunStates.terminal_states()
-            run_states.remove(mlrun.common.runtimes.constants.RunStates.aborted)
-            runs_uids.extend(
-                await fastapi.concurrency.run_in_threadpool(
-                    get_db().list_distinct_runs_uids,
-                    db_session,
-                    requested_logs_modes=[False],
-                    only_uids=True,
-                    last_update_time_from=last_update_time,
-                    states=run_states,
-                )
+            await self._start_log_and_update_runs(
+                start_logs_limit=start_logs_limit,
+                runs_uids=runs_uids,
             )
-            if runs_uids:
-                self._logger.debug(
-                    "Found runs which require logs collection",
-                    runs_uids=len(runs_uids),
-                )
-                await self._start_log_and_update_runs(
-                    start_logs_limit=start_logs_limit,
-                    db_session=db_session,
-                    runs_uids=runs_uids,
-                )
-
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
     async def _start_log_and_update_runs(
         self,
         start_logs_limit: asyncio.Semaphore,
-        db_session: sqlalchemy.orm.Session,
         runs_uids: list[str],
         best_effort: bool = False,
     ):
@@ -375,8 +366,8 @@ class Service(framework.service.Service):
 
         # get the runs from the DB
         runs = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             get_db().list_runs,
-            db_session,
             uid=runs_uids,
             project="*",
         )
@@ -437,8 +428,8 @@ class Service(framework.service.Service):
             )
             # update the runs to indicate that we have requested log collection for them
             await fastapi.concurrency.run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
                 get_db().update_runs_requested_logs,
-                db_session,
                 uids=runs_to_mark_as_requested_logs,
             )
 
@@ -703,30 +694,26 @@ class Service(framework.service.Service):
             "Getting current log collected runs which have reached terminal state and already have logs requested",
             run_uids_in_progress_count=len(run_uids_in_progress),
         )
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-        try:
-            runs = await fastapi.concurrency.run_in_threadpool(
-                get_db().list_distinct_runs_uids,
-                db_session,
-                requested_logs_modes=[True],
-                only_uids=False,
-                states=mlrun.common.runtimes.constants.RunStates.terminal_states()
-                + [
-                    # add unknown state as well, as it's possible that the run reached such state
-                    # usually it happens when run pods get preempted
-                    mlrun.common.runtimes.constants.RunStates.unknown,
-                ],
-                specific_uids=run_uids_in_progress,
-            )
+        runs = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
+            get_db().list_distinct_runs_uids,
+            requested_logs_modes=[True],
+            only_uids=False,
+            states=mlrun.common.runtimes.constants.RunStates.terminal_states()
+            + [
+                # add unknown state as well, as it's possible that the run reached such state
+                # usually it happens when run pods get preempted
+                mlrun.common.runtimes.constants.RunStates.unknown,
+            ],
+            specific_uids=run_uids_in_progress,
+        )
 
-            if len(runs) > 0:
-                self._logger.debug(
-                    "Stopping logs for runs which reached terminal state before startup",
-                    runs_count=len(runs),
-                )
-                await self._stop_logs_for_runs(runs)
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
+        if len(runs) > 0:
+            self._logger.debug(
+                "Stopping logs for runs which reached terminal state before startup",
+                runs_count=len(runs),
+            )
+            await self._stop_logs_for_runs(runs)
 
     async def _monitor_runs(self):
         stale_runs = await framework.db.session.run_async_function_with_new_db_session(
@@ -888,28 +875,22 @@ class Service(framework.service.Service):
             "Getting all runs which reached terminal state in the previous interval and have logs requested",
             interval_seconds=int(mlconf.log_collector.stop_logs_interval),
         )
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-        try:
-            runs = await fastapi.concurrency.run_in_threadpool(
-                get_db().list_distinct_runs_uids,
-                db_session,
-                requested_logs_modes=[True],
-                only_uids=False,
-                states=mlrun.common.runtimes.constants.RunStates.terminal_states(),
-                last_update_time_from=datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(
-                    seconds=1.5 * mlconf.log_collector.stop_logs_interval
-                ),
-            )
+        runs = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
+            get_db().list_distinct_runs_uids,
+            requested_logs_modes=[True],
+            only_uids=False,
+            states=mlrun.common.runtimes.constants.RunStates.terminal_states(),
+            last_update_time_from=datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=1.5 * mlconf.log_collector.stop_logs_interval),
+        )
 
-            if len(runs) > 0:
-                self._logger.debug(
-                    "Stopping logs for runs which reached terminal state in the previous interval",
-                    runs_count=len(runs),
-                )
-                await self._stop_logs_for_runs(runs)
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
+        if len(runs) > 0:
+            self._logger.debug(
+                "Stopping logs for runs which reached terminal state in the previous interval",
+                runs_count=len(runs),
+            )
+            await self._stop_logs_for_runs(runs)
 
     async def _stop_logs_for_runs(self, runs: list, chunk_size: int = 10):
         project_to_run_uids = collections.defaultdict(list)
@@ -946,15 +927,14 @@ class Service(framework.service.Service):
         This function is called periodically to retry jobs that have failed and can be retried.
         """
         self._logger.debug("Retrying jobs with retry policy configured")
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
         fetch_runs_limit = int(mlconf.monitoring.runs.retry.fetch_runs_limit)
         stale_after = mlconf.get_run_retry_staleness_threshold_timedelta()
         now = datetime.datetime.now(datetime.timezone.utc)
         try:
             offset = 0
             while runs := await fastapi.concurrency.run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
                 get_db().list_runs,
-                db_session,
                 project="*",
                 states=[mlrun.common.runtimes.constants.RunStates.pending_retry],
                 limit=fetch_runs_limit,
@@ -1048,8 +1028,6 @@ class Service(framework.service.Service):
                 exc=err_to_str(exc),
                 traceback=traceback.format_exc(),
             )
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
     def _submit_run_for_retry(self, run: mlrun.RunObject):
         self._retry_in_progress_run_uids[run.metadata.uid] = datetime.datetime.now(

--- a/server/py/services/api/tests/unit/api/test_pipelines.py
+++ b/server/py/services/api/tests/unit/api/test_pipelines.py
@@ -859,7 +859,7 @@ def test_terminate_pipeline_success(
         namespace=unittest.mock.ANY,
     )
     mock_get_bg.assert_called_with(
-        db_session=unittest.mock.ANY,
+        unittest.mock.ANY,
         status=BackgroundTaskState.running,
         labels={BackGroundTaskLabel.pipeline: RUN_ID},
     )

--- a/server/py/services/api/utils/scheduler.py
+++ b/server/py/services/api/utils/scheduler.py
@@ -76,7 +76,8 @@ class Scheduler:
         # don't fail the start on re-scheduling failure
         try:
             await fastapi.concurrency.run_in_threadpool(
-                self._reload_schedules, db_session
+                framework.db.session.run_function_with_new_db_session,
+                self._reload_schedules,
             )
         except Exception as exc:
             logger.warning("Failed reloading schedules", exc=err_to_str(exc))
@@ -447,10 +448,10 @@ class Scheduler:
     ):
         logger.debug("Invoking schedule", project=project, name=name)
         db_schedule = await fastapi.concurrency.run_in_threadpool(
+            framework.db.session.run_function_with_new_db_session,
             get_db().get_schedule,
-            db_session,
-            project,
-            name,
+            project=project,
+            name=name,
         )
         await fastapi.concurrency.run_in_threadpool(
             self._ensure_auth_info_has_access_key, auth_info, db_schedule.kind


### PR DESCRIPTION
### 📝 Description

This PR removes all places that pass an SQLAlchemy Session across threads, Instead, every DB operation executed in a threadpool opens and closes its own session via `run_function_with_new_db_session`.
Rationale: SQLAlchemy Session objects are not thread-safe, sharing them leads to subtle concurrency bugs and intermittent errors. This refactor makes DB access consistent and safe under concurrency.

---

### 🛠️ Changes Made

Replaced `run_in_threadpool()` + passing db_session with:
`run_in_threadpool(run_function_with_new_db_session, <db_fn>, **kwargs)` across the codebase.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10665

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Isolation note: uncommitted changes from other sessions won’t be visible until they commit. Call sites where we need atomic “read-then-write” behavior should wrap the entire sequence inside a single function and execute it via `run_function_with_new_db_session`.
