### PR TITLE
[Log Collector] Create file before finding pod

### DIFF
--- a/server/go/services/logcollector/logcollector_test.go
+++ b/server/go/services/logcollector/logcollector_test.go
@@ -261,6 +261,12 @@ func (suite *LogCollectorTestSuite) TestStartLogBestEffort() {
 	response, err := suite.logCollectorServer.StartLog(suite.ctx, request)
 	suite.Require().NoError(err, "Failed to start log")
 	suite.Require().True(response.Success, "Failed to start log")
+
+	// validate a file was created
+	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(request.ProjectName, request.RunUID)
+	exists, err := common.FileExists(logFilePath)
+	suite.Require().NoError(err, "Failed to check if log file exists")
+	suite.Require().True(exists, "Log file doesn't exist")
 }
 
 func (suite *LogCollectorTestSuite) TestStartLogOnPodStates() {

--- a/server/go/services/logcollector/server.go
+++ b/server/go/services/logcollector/server.go
@@ -228,6 +228,21 @@ func (s *Server) StartLog(ctx context.Context,
 		return s.successfulBaseResponse(), nil
 	}
 
+	// create a log file for the run so the legacy log collector will not try collect logs for it on deletion
+	logFilePath := s.resolveRunLogFilePath(request.ProjectName, request.RunUID)
+	if err := common.EnsureFileExists(logFilePath); err != nil {
+		s.Logger.ErrorWithCtx(ctx,
+			"Failed to ensure log file for run",
+			"runUID", request.RunUID,
+			"projectName", request.ProjectName,
+			"logFilePath", logFilePath)
+		return &protologcollector.BaseResponse{
+			Success:      false,
+			ErrorCode:    common.ErrCodeNotFound,
+			ErrorMessage: err.Error(),
+		}, err
+	}
+
 	var pod v1.Pod
 
 	s.Logger.DebugWithCtx(ctx, "Getting run pod using label selector", "selector", request.Selector)

--- a/server/go/services/logcollector/server.go
+++ b/server/go/services/logcollector/server.go
@@ -238,7 +238,7 @@ func (s *Server) StartLog(ctx context.Context,
 			"logFilePath", logFilePath)
 		return &protologcollector.BaseResponse{
 			Success:      false,
-			ErrorCode:    common.ErrCodeNotFound,
+			ErrorCode:    common.ErrCodeInternal,
 			ErrorMessage: err.Error(),
 		}, err
 	}


### PR DESCRIPTION
### 📝 Description

When the log collector can't find the pod to stream logs from, it fails and doesn't create a file.
If the run is deleted before the api calls `start_logs` on it again, it falls back to the legacy log collection, [which does a k8s api call to get the logs](https://github.com/mlrun/mlrun/blob/3398b8ade56e6474cf195be28686fdc9804b7115/server/py/services/api/runtime_handlers/base.py#L1669-L1696).
In case we have many pods in this state, we are doing many k8s api call which can choke the API.

To alleviate this a bit, we now first create an empty file for the run in the log collector, before trying to find the pod.
The legacy log collection will not run, as it first checks if the file exists.

---

### 🛠️ Changes Made
- Ensure the run has a log file before starting log collection.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- All tests pass

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10765
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
