### PR TITLE
[Model Monitoring] Fixed last_request wrong conversion

### DIFF
--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -859,7 +859,9 @@ class MonitoringApplicationController:
                 for endpoint in endpoints:
                     last_request = last_request_dict.get(endpoint.metadata.uid, None)
                     if isinstance(last_request, float):
-                        last_request = datetime.datetime.fromtimestamp(last_request, tz=datetime.timezone.utc)
+                        last_request = datetime.datetime.fromtimestamp(
+                            last_request, tz=datetime.timezone.utc
+                        )
                     elif isinstance(last_request, pd.Timestamp):
                         last_request = last_request.to_pydatetime()
                     endpoint.status.last_request = (

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -859,7 +859,9 @@ class MonitoringApplicationController:
                 for endpoint in endpoints:
                     last_request = last_request_dict.get(endpoint.metadata.uid, None)
                     if isinstance(last_request, float):
-                        last_request = pd.to_datetime(last_request, unit="ms", utc=True)
+                        last_request = datetime.datetime.fromtimestamp(last_request, tz=datetime.timezone.utc)
+                    elif isinstance(last_request, pd.Timestamp):
+                        last_request = last_request.to_pydatetime()
                     endpoint.status.last_request = (
                         last_request or endpoint.status.last_request
                     )


### PR DESCRIPTION
### 📝 Description
Wrong conversion of pd.to_datetime with ms resolution caused wrong year value for timestamp

---

### 🛠️ Changes Made
fixed by using datetime.fromtimestamp

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Passed `test_app_flow[True, True]` and manual scripting with multiple timestamps

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10926

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

