### PR TITLE
[Model Monitoring] Run app code only if `sample_df` is non-empty

### DIFF
--- a/docs/model-monitoring/running-applications.md
+++ b/docs/model-monitoring/running-applications.md
@@ -101,6 +101,9 @@ You can divide the run into small time windows with the `base_period` parameter.
 difference between the `start` and `end` times is divided into smaller non-overlapping intervals,
 each `base_period` minutes length.
 
+When the model endpoint does not have data in the requested time window, the application will not
+run.
+
 ### Running locally
 
 When running locally and writing outputs (with `run_local=True` and `write_output=True`),

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -347,6 +347,21 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                         feature_stats=feature_stats,
                     )
                 )
+
+                if (
+                    monitoring_context.endpoint_id
+                    and monitoring_context.sample_df.empty
+                ):
+                    # The current sample is empty
+                    context.logger.warning(
+                        "No sample data available for tracking",
+                        application_name=application_name,
+                        endpoint_id=monitoring_context.endpoint_id,
+                        start_time=monitoring_context.start_infer_time,
+                        end_time=monitoring_context.end_infer_time,
+                    )
+                    return
+
                 result = self.do_tracking(monitoring_context)
                 endpoints_output[monitoring_context.endpoint_id].append(
                     (monitoring_context, result)


### PR DESCRIPTION
### 📝 Description

Skip windows that do not include data for the MEP.

---

### 🛠️ Changes Made

First, check that an endpoint is configured and that the sample data frame is empty.
When it is the case, return `None` from the app call and do not include this in the results to be written in the DBs.

---

### ✅ Checklist

- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Manual testing.

---

### 🔗 References
- Ticket link: [ML-10681](https://iguazio.atlassian.net/browse/ML-10681)

---

### 🚨 Breaking Changes?

- [x] No


[ML-10681]: https://iguazio.atlassian.net/browse/ML-10681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ