### PR TITLE
[Artifacts] return the desired parent tag, according to the provided parent uri

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6128,26 +6128,26 @@ class SQLDB(DBInterface):
         return model_endpoint_full_dict
 
     @staticmethod
-    def _get_obj_tag_prioritizing_user_tag(function_tag_list, desired_tag=None) -> str:
+    def _get_obj_tag_prioritizing_user_tag(obj_tag_list, desired_tag=None) -> str:
         """
         Determine which tag to use from a list of function/model tags.
 
         Args:
-            function_tag_list (list): List of tag objects (with `.name`).
+            obj_tag_list (list): List of tag objects (with `.name`).
             desired_tag (str, optional): Specific tag name to prioritize.
 
         Returns:
             str: The selected tag name, or an empty string if no match is found.
         """
-        function_tag_list_names = [tag.name for tag in function_tag_list]
+        obj_tag_list_names = [tag.name for tag in obj_tag_list]
 
         # Case 1: desired tag is explicitly in the list
-        if desired_tag and desired_tag in function_tag_list_names:
+        if desired_tag and desired_tag in obj_tag_list_names:
             return desired_tag
 
         latest = False
         first_tag = None
-        for tag_name in function_tag_list_names:
+        for tag_name in obj_tag_list_names:
             if tag_name == mlrun.common.constants.RESERVED_TAG_NAME_LATEST:
                 latest = True
             elif not first_tag:

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1691,7 +1691,6 @@ class SQLDB(DBInterface):
     def _set_parent_uri(
         self, artifact: dict, parent: ArtifactV2, parent_uri: Optional[str] = None
     ):
-        _, uri = mlrun.datastore.parse_store_uri(parent_uri)
         (
             _,
             _,
@@ -1699,7 +1698,7 @@ class SQLDB(DBInterface):
             parent_tag,
             _,
             _,
-        ) = parse_artifact_uri(uri)
+        ) = self._get_parent_artifact_params_from_uri(parent_uri)
         artifact_spec = artifact.setdefault("spec", {})
         if parent:
             artifact_spec["parent_uri"] = mlrun.datastore.get_store_uri(
@@ -1710,8 +1709,9 @@ class SQLDB(DBInterface):
                     iter=parent.iteration,
                     tree=parent.producer_id,
                     uid=parent.uid,
-                    tag=parent_tag
-                    or self._get_obj_tag_prioritizing_user_tag(parent.tags or [])
+                    tag=self._get_obj_tag_prioritizing_user_tag(
+                        parent.tags or [], parent_tag
+                    )
                     or None,
                 ),
             )
@@ -2157,22 +2157,7 @@ class SQLDB(DBInterface):
             parent_tag,
             parent_tree,
             parent_uid,
-        ) = [None] * 6
-        if mlrun.datastore.is_store_uri(parent_uri):
-            # Parse the parent URI to extract project, key, iteration, tag, tree, and uid
-            _, uri = mlrun.datastore.parse_store_uri(parent_uri)
-            (
-                parent_project,
-                parent_key,
-                parent_iteration,
-                parent_tag,
-                parent_tree,
-                parent_uid,
-            ) = parse_artifact_uri(uri)
-        elif ":" in parent_uri:
-            parent_key, parent_tag = parent_uri.split(":", maxsplit=1)
-        else:
-            parent_key = parent_uri
+        ) = self._get_parent_artifact_params_from_uri(parent_uri)
 
         ref_alias = aliased(ArtifactV2)
 
@@ -2208,6 +2193,50 @@ class SQLDB(DBInterface):
                 column=ref_tag.name,
             )
         return query
+
+    @staticmethod
+    def _get_parent_artifact_params_from_uri(
+        parent_uri: str,
+    ) -> tuple[
+        Optional[str],
+        Optional[str],
+        Optional[int],
+        Optional[str],
+        Optional[str],
+        Optional[str],
+    ]:
+        (
+            parent_project,
+            parent_key,
+            parent_iteration,
+            parent_tag,
+            parent_tree,
+            parent_uid,
+        ) = [None] * 6
+        if mlrun.datastore.is_store_uri(parent_uri):
+            # Parse the parent URI to extract project, key, iteration, tag, tree, and uid
+            _, uri = mlrun.datastore.parse_store_uri(parent_uri)
+            (
+                parent_project,
+                parent_key,
+                parent_iteration,
+                parent_tag,
+                parent_tree,
+                parent_uid,
+            ) = parse_artifact_uri(uri)
+        elif parent_uri and ":" in parent_uri:
+            parent_key, parent_tag = parent_uri.split(":", maxsplit=1)
+        else:
+            parent_key = parent_uri
+
+        return (
+            parent_project,
+            parent_key,
+            parent_iteration,
+            parent_tag,
+            parent_tree,
+            parent_uid,
+        )
 
     @staticmethod
     def _add_artifact_category_query(category, query):
@@ -6099,18 +6128,35 @@ class SQLDB(DBInterface):
         return model_endpoint_full_dict
 
     @staticmethod
-    def _get_obj_tag_prioritizing_user_tag(function_tag_list):
+    def _get_obj_tag_prioritizing_user_tag(function_tag_list, desired_tag=None) -> str:
         """
-        Used by model endpoints, this extracts the function/model tag from the list,
-        prioritizing the user tag over the system's latest tag if available.
-        If neither exists, it returns an empty string.
+        Determine which tag to use from a list of function/model tags.
+
+        Args:
+            function_tag_list (list): List of tag objects (with `.name`).
+            desired_tag (str, optional): Specific tag name to prioritize.
+
+        Returns:
+            str: The selected tag name, or an empty string if no match is found.
         """
+        function_tag_list_names = [tag.name for tag in function_tag_list]
+
+        # Case 1: desired tag is explicitly in the list
+        if desired_tag and desired_tag in function_tag_list_names:
+            return desired_tag
+
         latest = False
-        for tag in function_tag_list:
-            if tag.name == mlrun.common.constants.RESERVED_TAG_NAME_LATEST:
+        first_tag = None
+        for tag_name in function_tag_list_names:
+            if tag_name == mlrun.common.constants.RESERVED_TAG_NAME_LATEST:
                 latest = True
-            else:
-                return tag.name
+            elif not first_tag:
+                first_tag = tag_name
+            if desired_tag and desired_tag in tag_name:
+                return tag_name
+
+        if first_tag:
+            return first_tag
         if latest:
             return mlrun.common.constants.RESERVED_TAG_NAME_LATEST
         return ""

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -2693,12 +2693,21 @@ class TestArtifacts(TestDatabaseBase):
         assert len(artifacts) == 1
         assert artifacts[0]["metadata"]["key"] == child_artifact_name
 
+        # Filter using parent_tag
+        artifacts = self._db.list_artifacts(
+            self._db_session, parent_uri=":lat", project=project
+        )
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["key"] == child_artifact_name
+        assert "latest" in artifacts[0]["spec"]["parent_uri"]
+
         # Filter using partial parent_tag
         artifacts = self._db.list_artifacts(
             self._db_session, parent_uri=":ref", project=project
         )
         assert len(artifacts) == 1
         assert artifacts[0]["metadata"]["key"] == child_artifact_name
+        assert "ref-tag" in artifacts[0]["spec"]["parent_uri"]
 
         # Filter using both name and tag
         artifacts = self._db.list_artifacts(


### PR DESCRIPTION
### 📝 Description

This PR addresses an issue where the `parent_uri` for filtered artifacts could show an incorrect tag. The filtering logic was sound, but if a parent had multiple tags, the returned artifact's `parent_uri` would default to the first tag rather than the one the user explicitly filtered for. This change ensures the returned `parent_uri` accurately reflects the user's requested tag.

---
### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Add unit test to this specific scenario 

---

### 🔗 References
[ML-10973](https://iguazio.atlassian.net/browse/ML-10973)

---

### 🚨 Breaking Changes?
- [x] No



[ML-10973]: https://iguazio.atlassian.net/browse/ML-10973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ