### PR TITLE
[Application] Ensure nuclio version when running multiple port sidecar

### DIFF
--- a/mlrun/runtimes/nuclio/__init__.py
+++ b/mlrun/runtimes/nuclio/__init__.py
@@ -16,6 +16,7 @@ from .serving import ServingRuntime, new_v2_model_server  # noqa
 from .nuclio import nuclio_init_hook  # noqa
 from .function import (
     min_nuclio_versions,
+    multiple_port_sidecar_is_supported,
     RemoteRuntime,
 )  # noqa
 from .api_gateway import APIGateway

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -22,7 +22,10 @@ import mlrun.errors
 import mlrun.run
 from mlrun.common.runtimes.constants import NuclioIngressAddTemplatedIngressModes
 from mlrun.runtimes import RemoteRuntime
-from mlrun.runtimes.nuclio import min_nuclio_versions
+from mlrun.runtimes.nuclio import (
+    min_nuclio_versions,
+    multiple_port_sidecar_is_supported,
+)
 from mlrun.runtimes.nuclio.api_gateway import (
     APIGateway,
     APIGatewayMetadata,
@@ -182,7 +185,13 @@ class ApplicationSpec(NuclioSpec):
             if port != self.internal_application_port:
                 cleaned_ports.append(port)
 
-        self._application_ports = [self.internal_application_port] + cleaned_ports
+        application_ports = [self.internal_application_port] + cleaned_ports
+
+        # ensure multiple ports are supported in Nuclio
+        if len(application_ports) > 1:
+            multiple_port_sidecar_is_supported()
+
+        self._application_ports = application_ports
 
     @property
     def internal_application_port(self):

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1045,6 +1045,9 @@ class RemoteRuntime(KubeResource):
             sidecar["image"] = image
 
         ports = mlrun.utils.helpers.as_list(ports)
+        if len(ports) > 1:
+            mlrun.runtimes.nuclio.multiple_port_sidecar_is_supported()
+
         # according to RFC-6335, port name should be less than 15 characters,
         # so we truncate it if needed and leave room for the index
         port_name = name[:13].rstrip("-_") if len(name) > 13 else name
@@ -1458,3 +1461,10 @@ def enrich_nuclio_function_from_headers(
         else []
     )
     func.status.container_image = headers.get("x-mlrun-container-image", "")
+
+
+@min_nuclio_versions("1.14.14")
+def multiple_port_sidecar_is_supported():
+    # multiple ports are supported from nuclio version 1.14.14
+    # this method exists only for running the min_nuclio_versions decorator
+    return True

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -93,6 +93,30 @@ def test_create_application_runtime_many_ports(rundb_mock, igz_version_mock):
     assert fn.spec.internal_application_port == 22
 
 
+def test_create_application_runtime_multiple_ports_different_nuclio_versions(
+    rundb_mock,
+):
+    # Test multiple ports with different nuclio versions
+    for nuclio_version in ["1.14.13", "1.14.14", "1.14.15"]:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(mlrun.mlconf, "nuclio_version", nuclio_version)
+            fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+                "application-test",
+                kind="application",
+                image="mlrun/mlrun",
+                command="echo",
+            )
+            if nuclio_version >= "1.14.14":
+                fn.with_sidecar("echo", command="echo", ports=[80, 22])
+                fn.deploy()
+                assert fn.spec.application_ports == [80, 22]
+            else:
+                with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
+                    fn.with_sidecar("echo", command="echo", ports=[80, 22])
+                with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
+                    fn.spec.application_ports = [22, 80]
+
+
 def test_application_runtime_update_port(rundb_mock, igz_version_mock):
     # deploy with default value
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(


### PR DESCRIPTION
### 📝 Description
Nuclio had a bug before 1.14.14 which didn't allow setting more than 1 port for a sidecar, so we need to make sure that multiple ports are used only when nuclio is higher than that.


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Unit tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-583 , https://iguazio.atlassian.net/browse/ML-9752
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
>
