### PR TITLE
[Model Monitoring] Fix deletion of model monitoring functions

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4081,7 +4081,7 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call(
             method=mlrun.common.types.HTTPMethod.DELETE,
             path=f"projects/{project}/model-monitoring/functions",
-            params={"functions": functions},
+            params={"function": functions},
         )
         deletion_failed = False
         if response.status_code == http.HTTPStatus.ACCEPTED:

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -278,7 +278,7 @@ async def delete_model_monitoring_function(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     background_tasks: fastapi.BackgroundTasks,
     response: fastapi.Response,
-    functions: list[str] = Query([], alias="functions"),
+    functions: list[str] = Query([], alias="function"),
 ):
     """
     Delete model monitoring functions.

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -278,7 +278,7 @@ async def delete_model_monitoring_function(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     background_tasks: fastapi.BackgroundTasks,
     response: fastapi.Response,
-    functions: list[str] = Query([], alias="function"),
+    functions: list[str] = Query([], alias="functions"),
 ):
     """
     Delete model monitoring functions.

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1367,20 +1367,7 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
                 mm_constants.HistogramDataDriftApplicationConstants.NAME
             )
             v3io_client.stream.describe(container, stream_path)
-            demo_app = _AppData(
-                class_=DemoMonitoringApp,
-                rel_path="assets/application.py",
-                results={"data_drift_test", "model_perf"},
-            )
-            fn = self.project.set_model_monitoring_function(
-                func=demo_app.abs_path,
-                application_class=demo_app.class_.__name__,
-                name=demo_app.class_.NAME,
-                image="mlrun/mlrun" if self.image is None else self.image,
-                requirements=demo_app.requirements,
-                **demo_app.kwargs,
-            )
-            fn.deploy()
+            self._deploy_demo_app()
 
             # check that the stream of the histogram data drift app is deleted
             self._delete_histogram_app()
@@ -1394,7 +1381,7 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
                 "app"
             )
             assert [fn.metadata.name for fn in monitoring_functions] == [
-                demo_app.class_.NAME
+                DemoMonitoringApp.NAME
             ], "the remaining function should be the demo app"
 
             with pytest.raises(v3io.dataplane.response.HttpResponseError):
@@ -1456,6 +1443,22 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
                 f"monitoring_stream_{mlrun.mlconf.system_id}_{self.project_name}_{mm_constants.HistogramDataDriftApplicationConstants.NAME}_v1"
                 not in topics
             )
+
+    def _deploy_demo_app(self):
+        demo_app = _AppData(
+            class_=DemoMonitoringApp,
+            rel_path="assets/application.py",
+            results={"data_drift_test", "model_perf"},
+        )
+        fn = self.project.set_model_monitoring_function(
+            func=demo_app.abs_path,
+            application_class=demo_app.class_.__name__,
+            name=demo_app.class_.NAME,
+            image="mlrun/mlrun" if self.image is None else self.image,
+            requirements=demo_app.requirements,
+            **demo_app.kwargs,
+        )
+        fn.deploy()
 
     def _disable_stream_function(self):
         self.project.disable_model_monitoring(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1367,9 +1367,35 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
                 mm_constants.HistogramDataDriftApplicationConstants.NAME
             )
             v3io_client.stream.describe(container, stream_path)
+            demo_app = _AppData(
+                class_=DemoMonitoringApp,
+                rel_path="assets/application.py",
+                results={"data_drift_test", "model_perf"},
+            )
+            fn = self.project.set_model_monitoring_function(
+                func=demo_app.abs_path,
+                application_class=demo_app.class_.__name__,
+                name=demo_app.class_.NAME,
+                image="mlrun/mlrun" if self.image is None else self.image,
+                requirements=demo_app.requirements,
+                **demo_app.kwargs,
+            )
+            fn.deploy()
 
             # check that the stream of the histogram data drift app is deleted
             self._delete_histogram_app()
+
+            # check that only the demo app is remaining
+            monitoring_functions = self.project.list_model_monitoring_functions(
+                tag="latest"
+            )
+            assert len(monitoring_functions) == 1, (
+                "expected a single monitoring function after deletion of histogram "
+                "app"
+            )
+            assert [fn.metadata.name for fn in monitoring_functions] == [
+                demo_app.class_.NAME
+            ], "the remaining function should be the demo app"
 
             with pytest.raises(v3io.dataplane.response.HttpResponseError):
                 v3io_client.stream.describe(container, stream_path)


### PR DESCRIPTION
### 📝 Description

avoid deleting all functions when deleting a single function by name
---

### 🛠️ Changes Made

small change in the alias for functions

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing

`test_model_monitoring_crud` added a check on the application deletion while adding another demo app

---

### 🔗 References

- Ticket link: https://iguazio.atlassian.net/browse/ML-10905


---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

