### PR TITLE
[Chief] Optimize start logs concurrency

### DIFF
--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -478,9 +478,7 @@ class Service(framework.service.Service):
                 return run_uid
             try:
                 runtime_handler: services.api.runtime_handlers.BaseRuntimeHandler = (
-                    await fastapi.concurrency.run_in_threadpool(
-                        get_runtime_handler, run_kind
-                    )
+                    get_runtime_handler(run_kind)
                 )
                 object_id = runtime_handler.resolve_object_id(run)
                 label_selector = runtime_handler.resolve_label_selector(


### PR DESCRIPTION
### 📝 Description

On scale test, seems like the chief was choking on allocating a thread to handle api request, this can happen when start logs running for many runs, needlessly running the `get_runtime_handler` on a thread belongs to api pool.
mixing running N asyncio tasks where each allocating a thread drains the threadpol pretty quickly.

---

### 🛠️ Changes Made
function to be run on the asyncio thread rather on its own thread belongs to fastapi


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10970
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [n] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
