### PR TITLE
[Config] Add configuration methods for authentication mode [feature/ig4-authentication]

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -40,6 +40,7 @@ import yaml
 
 import mlrun.common.constants
 import mlrun.common.schemas
+import mlrun.common.types
 import mlrun.errors
 
 env_prefix = "MLRUN_"
@@ -1377,6 +1378,18 @@ class Config:
         # True if the setup is in CE environment
         return isinstance(mlrun.mlconf.ce, mlrun.config.Config) and any(
             ver in mlrun.mlconf.ce.mode for ver in ["lite", "full"]
+        )
+
+    def is_iguazio_mode(self):
+        return (
+            mlrun.mlconf.httpdb.authentication.mode
+            == mlrun.common.types.AuthenticationMode.IGUAZIO
+        )
+
+    def is_iguazio_v4_mode(self):
+        return (
+            mlrun.mlconf.httpdb.authentication.mode
+            == mlrun.common.types.AuthenticationMode.IGUAZIO_V4
         )
 
     def is_explicit_ack_enabled(self) -> bool:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import enum
-import functools
 import http
 import re
 import time
@@ -45,7 +44,6 @@ import mlrun.runtimes.nuclio.api_gateway
 import mlrun.runtimes.nuclio.function
 import mlrun.utils
 from mlrun.alerts.alert import AlertConfig
-from mlrun.common.types import AuthenticationMode
 from mlrun.db.auth_utils import OAuthClientIDTokenProvider, StaticTokenProvider
 from mlrun.errors import MLRunInvalidArgumentError, err_to_str
 from mlrun_pipelines.utils import compile_pipeline
@@ -78,19 +76,6 @@ _artifact_keys = [
 
 def bool2str(val):
     return "yes" if val else "no"
-
-
-def iguazio_v4_only(function):
-    @functools.wraps(function)
-    def wrapper(*args, **kwargs):
-        authentication_mode = mlrun.mlconf.httpdb.authentication.mode
-        if authentication_mode != AuthenticationMode.IGUAZIO_V4:
-            raise mlrun.errors.MLRunRuntimeError(
-                "This method is only supported in an Iguazio V4 system."
-            )
-        return function(*args, **kwargs)
-
-    return wrapper
 
 
 class HTTPRunDB(RunDBInterface):
@@ -5064,7 +5049,7 @@ class HTTPRunDB(RunDBInterface):
         response = self.api_call("GET", endpoint_path, error_message)
         return mlrun.common.schemas.ProjectSummary(**response.json())
 
-    @iguazio_v4_only
+    @mlrun.utils.iguazio_v4_only
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
@@ -5105,7 +5090,7 @@ class HTTPRunDB(RunDBInterface):
         # maybe the response should not be a list?
         return response
 
-    @iguazio_v4_only
+    @mlrun.utils.iguazio_v4_only
     def store_secret_tokens(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
@@ -5148,7 +5133,7 @@ class HTTPRunDB(RunDBInterface):
 
         return response
 
-    @iguazio_v4_only
+    @mlrun.utils.iguazio_v4_only
     def list_secret_tokens(
         self,
     ) -> mlrun.common.schemas.ListSecretTokensResponse:
@@ -5164,6 +5149,7 @@ class HTTPRunDB(RunDBInterface):
 
         return mlrun.common.schemas.ListSecretTokensResponse(**response.json())
 
+    @mlrun.utils.iguazio_v4_only
     def _store_secret_tokens(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2297,3 +2297,15 @@ def encode_user_code(
             "Consider using `with_source_archive` to add user code as a remote source to the function."
         )
     return encoded
+
+
+def iguazio_v4_only(function):
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        if not mlrun.mlconf.is_iguazio_v4_mode():
+            raise mlrun.errors.MLRunRuntimeError(
+                "This method is only supported in an Iguazio V4 system."
+            )
+        return function(*args, **kwargs)
+
+    return wrapper

--- a/server/py/framework/api/deps.py
+++ b/server/py/framework/api/deps.py
@@ -20,7 +20,6 @@ from sqlalchemy.orm import Session
 
 import mlrun
 import mlrun.common.schemas
-from mlrun.common.types import AuthenticationMode
 
 import framework.db.session
 import framework.utils.auth.verifier
@@ -97,7 +96,7 @@ def expose_internal_endpoints(request: Request):
 
 
 def iguazio_v4_only(request: Request):
-    if mlrun.mlconf.httpdb.authentication.mode != AuthenticationMode.IGUAZIO_V4:
+    if not mlrun.mlconf.is_iguazio_v4_mode():
         raise mlrun.errors.MLRunBadRequestError(
             "This endpoint is only supported in an Iguazio V4 system."
         )

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -309,11 +309,11 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
 
     @staticmethod
     def _iguazio_auth_configured():
-        return mlrun.mlconf.httpdb.authentication.mode == AuthenticationMode.IGUAZIO
+        return mlrun.mlconf.is_iguazio_mode()
 
     @staticmethod
     def _iguaziov4_auth_configured():
-        return mlrun.mlconf.httpdb.authentication.mode == AuthenticationMode.IGUAZIO_V4
+        return mlrun.mlconf.is_iguazio_v4_mode()
 
     @staticmethod
     def _parse_basic_auth(header):


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
This PR introduces new configuration methods to better define the authentication mode in MLRun.  
It also relocates the `iguazio_v4_only` function wrapper to a shared location for reuse.  

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
Create new configuration methods to define the authentication mode
- `mlrun.mlconf.is_iguazio_mode()`
- `mlrun.mlconf.is_iguazio_v4_mode()`

Move the iguazio_v4_only function wrapper to a common location

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Existing unit tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10983

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---