### PR TITLE
[Model Monitoring] Flatten nested dict outputs before saving to v3io TSDB

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/v3io/stream_graph_steps.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/stream_graph_steps.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import datetime
-from typing import Any
+from typing import Any, Dict
 
 import mlrun.feature_store.steps
 from mlrun.common.schemas.model_monitoring import (
@@ -23,12 +23,14 @@ from mlrun.common.schemas.model_monitoring import (
 from mlrun.utils import logger
 
 
-def _normalize_dict_for_v3io_frames(event: dict[str, Any]) -> dict[str, Any]:
+def _normalize_dict_for_v3io_frames(event: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Normalize user defined keys - input data to a model and its predictions,
-    to a form V3IO frames tolerates.
+    Normalize user-defined keys (e.g., model input data and predictions) to a format V3IO Frames tolerates.
 
-    The dictionary keys should conform to '^[a-zA-Z_:]([a-zA-Z0-9_:])*$'.
+    - Keys must match regex: '^[a-zA-Z_:]([a-zA-Z0-9_:])*$'
+    - Replace invalid characters (e.g., '-') with '_'.
+    - Prefix keys starting with digits with '_'.
+    - Flatten nested dictionaries using dot notation, while normalizing keys recursively.
     """
     prefix = "_"
 
@@ -38,7 +40,18 @@ def _normalize_dict_for_v3io_frames(event: dict[str, Any]) -> dict[str, Any]:
             return prefix + key
         return key
 
-    return {norm_key(k): v for k, v in event.items()}
+    def flatten_dict(d: Dict[str, Any], parent_key: str = "") -> Dict[str, Any]:
+        items = {}
+        for k, v in d.items():
+            new_key = norm_key(k)
+            full_key = f"{parent_key}.{new_key}" if parent_key else new_key
+            if isinstance(v, dict):
+                items.update(flatten_dict(v, full_key))
+            else:
+                items[full_key] = v
+        return items
+
+    return flatten_dict(event)
 
 
 class ProcessBeforeTSDB(mlrun.feature_store.steps.MapClass):

--- a/mlrun/model_monitoring/db/tsdb/v3io/stream_graph_steps.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/stream_graph_steps.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
 import mlrun.feature_store.steps
 from mlrun.common.schemas.model_monitoring import (
@@ -23,7 +23,7 @@ from mlrun.common.schemas.model_monitoring import (
 from mlrun.utils import logger
 
 
-def _normalize_dict_for_v3io_frames(event: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_dict_for_v3io_frames(event: dict[str, Any]) -> dict[str, Any]:
     """
     Normalize user-defined keys (e.g., model input data and predictions) to a format V3IO Frames tolerates.
 
@@ -40,7 +40,7 @@ def _normalize_dict_for_v3io_frames(event: Dict[str, Any]) -> Dict[str, Any]:
             return prefix + key
         return key
 
-    def flatten_dict(d: Dict[str, Any], parent_key: str = "") -> Dict[str, Any]:
+    def flatten_dict(d: dict[str, Any], parent_key: str = "") -> dict[str, Any]:
         items = {}
         for k, v in d.items():
             new_key = norm_key(k)

--- a/tests/model_monitoring/test_schemas.py
+++ b/tests/model_monitoring/test_schemas.py
@@ -31,7 +31,7 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
     _parse_metric_fqn_to_monitoring_metric,
 )
 from mlrun.model_monitoring.db.tsdb.v3io.stream_graph_steps import (
-    _normalize_dict_for_v3io_frames,  # update with actual path
+    _normalize_dict_for_v3io_frames,
 )
 
 

--- a/tests/model_monitoring/test_schemas.py
+++ b/tests/model_monitoring/test_schemas.py
@@ -30,6 +30,9 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointMonitoringMetric,
     _parse_metric_fqn_to_monitoring_metric,
 )
+from mlrun.model_monitoring.db.tsdb.v3io.stream_graph_steps import (
+    _normalize_dict_for_v3io_frames,  # update with actual path
+)
 
 
 @pytest.mark.parametrize(
@@ -125,3 +128,43 @@ def test_project_pattern() -> None:
         r"^.{0,63}$",
         r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
     ], f"The `project_name` regex changed, please update {PROJECT_PATTERN=} accordingly"
+
+
+@pytest.mark.parametrize(
+    "event,expected",
+    [
+        # basic case: valid key
+        ({"validKey": 1}, {"validKey": 1}),
+        # hyphens replaced with underscores
+        ({"key-name": 42}, {"key_name": 42}),
+        # keys starting with digit
+        ({"123abc": "value"}, {"_123abc": "value"}),
+        # nested dict flattening
+        (
+            {"outer": {"inner-key": 99}},
+            {"outer.inner_key": 99},
+        ),
+        # multiple nested levels
+        (
+            {"a": {"b": {"c-key": 5}}},
+            {"a.b.c_key": 5},
+        ),
+        # mixed dicts and values
+        (
+            {"root": {"sub1": 1, "sub-2": {"deep-key": "x"}}, "plain": 7},
+            {"root.sub1": 1, "root.sub_2.deep_key": "x", "plain": 7},
+        ),
+        # key with digit prefix deep inside
+        (
+            {"root": {"123abc": {"-bad-key": 1}}},
+            {"root._123abc._bad_key": 1},
+        ),
+    ],
+)
+def test_normalize_dict(event, expected):
+    result = _normalize_dict_for_v3io_frames(event)
+    assert result == expected
+
+
+def test_empty_dict():
+    assert _normalize_dict_for_v3io_frames({}) == {}


### PR DESCRIPTION
### 📝 Description

When using **v3io TSDB**, we store a snippet of the input and output in the events table. However, outputs cannot be stored as raw dictionaries since v3io TSDB does not support them.
To address this limitation, we now **flatten nested dictionaries** and normalize their keys before saving.

---

### 🛠️ Changes Made

* Improved the key normalization process in `ProcessBeforeTSDB(v3io)` to handle nested dictionaries.

---

### ✅ Checklist

* [ ] Documentation updated (if applicable)
* [x] Changes tested locally / with unit tests

---

### 🧪 Testing

* Added unit tests to validate dictionary flattening and key normalization.

---

### 🔗 References

* [ML-10917](https://iguazio.atlassian.net/browse/ML-10917)

---

### 🚨 Breaking Changes?

* [ ] Yes
* [x] No

---

[ML-10917]: https://iguazio.atlassian.net/browse/ML-10917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ