### PR TITLE
[Datastore] Change S3_ENDPOINT_URL  to AWS_ENDPOINT_URL_S3

### DIFF
--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -413,10 +413,11 @@ Set up the following project-secrets (refer to [**Data stores**](../store/datast
 for any project used:
 
 * `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` &mdash; S3 credentials
-* `S3_ENDPOINT_URL` &mdash; the AWS S3 endpoint to use, depending on the region. For example: 
+* `AWS_ENDPOINT_URL_S3` &mdash; the AWS S3 endpoint to use, depending on the region. For example: 
     ``` console
-    S3_ENDPOINT_URL = https://s3.us-east-2.amazonaws.com/
+    AWS_ENDPOINT_URL_S3 = https://s3.us-east-2.amazonaws.com/
     ```
+    **Note**: `S3_ENDPOINT_URL` is deprecated as of v1.10.0 and will be removed in v1.12.0. Use `AWS_ENDPOINT_URL_S3` instead.
 
 ### Disabling auto-mount
 

--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -332,8 +332,9 @@ feature_set.ingest(..., run_config=run_config)
 
 * `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` &mdash; [access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
   parameters
-* `S3_ENDPOINT_URL` &mdash; The S3 endpoint to use. If not specified, it defaults to AWS. For example, to access 
-  a storage bucket in Wasabi storage, use `S3_ENDPOINT_URL = "https://s3.wasabisys.com"`
+* `AWS_ENDPOINT_URL_S3` &mdash; The S3 endpoint to use. If not specified, it defaults to AWS. For example, to access 
+  a storage bucket in Wasabi storage, use `AWS_ENDPOINT_URL_S3 = "https://s3.wasabisys.com"`
+  **Note**: `S3_ENDPOINT_URL` is deprecated as of v1.10.0 and will be removed in v1.12.0.
 * `MLRUN_AWS_ROLE_ARN` &mdash; [IAM role to assume](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html). 
   Connect to AWS using the secret key and access key, and assume the role whose ARN is provided. The 
   ARN must be of the format `arn:aws:iam::<account-of-role-to-assume>:role/<name-of-role>`
@@ -351,7 +352,7 @@ ParquetTarget(path="ds://profile-name/aws_bucket/path/to/parquet.pq")
 
 `DatastoreProfileS3` init parameters:
 - `name` &mdash; Name of the profile
-- `endpoint_url` &mdash; A string representing the endpoint URL of the S3 service. It's typically required for non-AWS S3-compatible services. If not provided, the default is `None`. The equivalent to this parameter in environment authentication is env["S3_ENDPOINT_URL"].
+- `endpoint_url` &mdash; A string representing the endpoint URL of the S3 service. It's typically required for non-AWS S3-compatible services. If not provided, the default is `None`. The equivalent to this parameter in environment authentication is env["AWS_ENDPOINT_URL_S3"]. **Note**: The deprecated env["S3_ENDPOINT_URL"] is also supported for backward compatibility.
 - `force_non_anonymous` &mdash; A string that determines whether to force non-anonymous access to the S3 bucket. The default value is `None`, meaning the behavior is not explicitly set. The equivalent to this parameter in environment authentication is env["S3_NON_ANONYMOUS"].
 - `profile_name` &mdash; A string representing the name of the profile. This might be used to refer to specific named configurations for connecting to S3. The default value is `None`. The equivalent to this parameter in environment authentication is env["AWS_PROFILE"].
 - `assume_role_arn` &mdash; A string representing the Amazon Resource Name (ARN) of the role to assume when interacting with the S3 service. This can be useful for granting temporary permissions. By default, it is set to `None`. The equivalent to this parameter in environment authentication is env["MLRUN_AWS_ROLE_ARN"]

--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -39,7 +39,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Please make sure to run the following once and restart the notebook after the install !!! After that, you can comment out</br> ```!pip install \"evidently=={SUPPORTED_EVIDENTLY_VERSION}\"```"
+   "source": [
+    "### Please make sure to run the following once and restart the notebook after the install !!! After that, you can comment out</br> ```!pip install \"evidently=={SUPPORTED_EVIDENTLY_VERSION}\"```"
+   ]
   },
   {
    "cell_type": "code",
@@ -80,8 +82,9 @@
    "source": [
     "project = mlrun.get_or_create_project(\"tutorial\", context=\"./\", user_project=True)\n",
     "\n",
-    "# Needed when using S3/minio until AWS_ENDPOINT_URL_S3 env-var is adopted in mlrun\n",
-    "aws_url = os.environ.get(\"S3_ENDPOINT_URL\")\n",
+    "# Backward compatibility: Support both S3_ENDPOINT_URL (deprecated) and AWS_ENDPOINT_URL_S3\n",
+    "# TODO: Remove this in 1.12.0\n",
+    "aws_url = os.environ.get(\"AWS_ENDPOINT_URL_S3\") or os.environ.get(\"S3_ENDPOINT_URL\")\n",
     "if aws_url:\n",
     "    os.environ[\"AWS_ENDPOINT_URL_S3\"] = aws_url\n",
     "    project.set_secrets({\"AWS_ENDPOINT_URL_S3\": aws_url})"

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -232,7 +232,7 @@ class DatastoreProfileS3(DatastoreProfile):
         if self.secret_key:
             res["AWS_SECRET_ACCESS_KEY"] = self.secret_key
         if self.endpoint_url:
-            res["S3_ENDPOINT_URL"] = self.endpoint_url
+            res["AWS_ENDPOINT_URL_S3"] = self.endpoint_url
         if self.force_non_anonymous:
             res["S3_NON_ANONYMOUS"] = self.force_non_anonymous
         if self.profile_name:

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import warnings
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -28,6 +29,27 @@ from .base import DataStore, FileStats, make_datastore_schema_sanitizer
 class S3Store(DataStore):
     using_bucket = True
 
+    # TODO: Remove this in 1.12.0
+    def _get_endpoint_url_with_deprecation_warning(self):
+        """Get S3 endpoint URL with backward compatibility for deprecated S3_ENDPOINT_URL"""
+        # First try the new environment variable
+        endpoint_url = self._get_secret_or_env("AWS_ENDPOINT_URL_S3")
+        if endpoint_url:
+            return endpoint_url
+
+        # Check for deprecated environment variable
+        deprecated_endpoint_url = self._get_secret_or_env("S3_ENDPOINT_URL")
+        if deprecated_endpoint_url:
+            warnings.warn(
+                "S3_ENDPOINT_URL is deprecated in 1.10.0 and will be removed in 1.12.0, "
+                "use AWS_ENDPOINT_URL_S3 instead.",
+                # TODO: Remove this in 1.12.0
+                FutureWarning,
+            )
+            return deprecated_endpoint_url
+
+        return None
+
     def __init__(
         self, parent, schema, name, endpoint="", secrets: Optional[dict] = None
     ):
@@ -41,7 +63,7 @@ class S3Store(DataStore):
         access_key_id = self._get_secret_or_env("AWS_ACCESS_KEY_ID")
         secret_key = self._get_secret_or_env("AWS_SECRET_ACCESS_KEY")
         token_file = self._get_secret_or_env("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
-        endpoint_url = self._get_secret_or_env("S3_ENDPOINT_URL")
+        endpoint_url = self._get_endpoint_url_with_deprecation_warning()
         force_non_anonymous = self._get_secret_or_env("S3_NON_ANONYMOUS")
         profile_name = self._get_secret_or_env("AWS_PROFILE")
         assume_role_arn = self._get_secret_or_env("MLRUN_AWS_ROLE_ARN")
@@ -159,7 +181,7 @@ class S3Store(DataStore):
     def get_storage_options(self):
         force_non_anonymous = self._get_secret_or_env("S3_NON_ANONYMOUS")
         profile = self._get_secret_or_env("AWS_PROFILE")
-        endpoint_url = self._get_secret_or_env("S3_ENDPOINT_URL")
+        endpoint_url = self._get_endpoint_url_with_deprecation_warning()
         access_key_id = self._get_secret_or_env("AWS_ACCESS_KEY_ID")
         secret = self._get_secret_or_env("AWS_SECRET_ACCESS_KEY")
         token_file = self._get_secret_or_env("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")

--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -14,6 +14,7 @@
 
 import os
 import typing
+import warnings
 from collections import namedtuple
 
 from mlrun.config import config
@@ -247,10 +248,22 @@ def mount_s3(
     def _use_s3_cred(runtime: "KubeResource"):
         _access_key = aws_access_key or os.environ.get(prefix + "AWS_ACCESS_KEY_ID")
         _secret_key = aws_secret_key or os.environ.get(prefix + "AWS_SECRET_ACCESS_KEY")
-        _endpoint_url = endpoint_url or os.environ.get(prefix + "S3_ENDPOINT_URL")
+
+        # Check for endpoint URL with backward compatibility
+        _endpoint_url = endpoint_url or os.environ.get(prefix + "AWS_ENDPOINT_URL_S3")
+        if not _endpoint_url:
+            # Check for deprecated environment variable
+            _endpoint_url = os.environ.get(prefix + "S3_ENDPOINT_URL")
+            if _endpoint_url:
+                warnings.warn(
+                    "S3_ENDPOINT_URL is deprecated in 1.10.0 and will be removed in 1.12.0, "
+                    "use AWS_ENDPOINT_URL_S3 instead.",
+                    # TODO: Remove this in 1.12.0
+                    FutureWarning,
+                )
 
         if _endpoint_url:
-            runtime.set_env(prefix + "S3_ENDPOINT_URL", _endpoint_url)
+            runtime.set_env(prefix + "AWS_ENDPOINT_URL_S3", _endpoint_url)
         if aws_region:
             runtime.set_env(prefix + "AWS_REGION", aws_region)
         if non_anonymous:

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -96,7 +96,7 @@ def test_mount_s3():
     )
     env_dict = {var["name"]: var["value"] for var in function.spec.env}
     assert env_dict == {
-        "S3_ENDPOINT_URL": "a.b",
+        "AWS_ENDPOINT_URL_S3": "a.b",
         "AWS_ACCESS_KEY_ID": "xx",
         "AWS_SECRET_ACCESS_KEY": "yy",
     }
@@ -109,7 +109,7 @@ def test_mount_s3():
         var["name"]: var.get("value", var.get("valueFrom")) for var in function.spec.env
     }
     assert env_dict == {
-        "S3_ENDPOINT_URL": "a.b",
+        "AWS_ENDPOINT_URL_S3": "a.b",
         "AWS_ACCESS_KEY_ID": {
             "secretKeyRef": {"key": "AWS_ACCESS_KEY_ID", "name": "s"}
         },
@@ -117,6 +117,48 @@ def test_mount_s3():
             "secretKeyRef": {"key": "AWS_SECRET_ACCESS_KEY", "name": "s"}
         },
     }
+
+
+# TODO: Remove this in 1.12.0
+def test_mount_s3_backward_compatibility():
+    """Test backward compatibility for S3_ENDPOINT_URL environment variable"""
+    import os
+    import warnings
+
+    # Set up deprecated environment variable
+    os.environ["S3_ENDPOINT_URL"] = "s3.deprecated.com"
+
+    # Ensure AWS_ENDPOINT_URL_S3 is not set so we test the fallback
+    os.environ.pop("AWS_ENDPOINT_URL_S3", None)
+
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+
+    # Capture deprecation warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        # Use credentials so that the mount function actually sets environment variables
+        function.apply(
+            mlrun.runtimes.mounts.mount_s3(
+                aws_access_key="test-key", aws_secret_key="test-secret"
+            )
+        )
+
+        # Check that deprecation warning was issued
+        assert len(w) == 1
+        assert issubclass(w[0].category, FutureWarning)
+        assert "S3_ENDPOINT_URL is deprecated" in str(w[0].message)
+
+    env_dict = {var["name"]: var["value"] for var in function.spec.env}
+    assert env_dict == {
+        "AWS_ENDPOINT_URL_S3": "s3.deprecated.com",
+        "AWS_ACCESS_KEY_ID": "test-key",
+        "AWS_SECRET_ACCESS_KEY": "test-secret",
+    }
+
+    # Clean up
+    os.environ.pop("S3_ENDPOINT_URL", None)
 
 
 def test_set_env_variables():


### PR DESCRIPTION
 📝 Description

Replace S3_ENDPOINT_URL with AWS_ENDPOINT_URL_S3 throughout the codebase while maintaining backward compatibility. This change standardizes the environment variable naming to align with AWS conventions while ensuring existing deployments continue to work with appropriate deprecation warnings.

The PR updates all references from the deprecated S3_ENDPOINT_URL to the new AWS_ENDPOINT_URL_S3, while implementing backward compatibility logic to prevent breaking changes for users still using the old variable name.

  ---
  🛠️ Changes Made

  - Replaced S3_ENDPOINT_URL with AWS_ENDPOINT_URL_S3 in:
    - mlrun/datastore/s3.py - S3Store class implementation
    - mlrun/runtimes/mounts.py - mount_s3() function
    - mlrun/datastore/datastore_profile.py - DatastoreProfileS3 class
    - tests/runtimes/test_mounts.py - Updated test assertions
  - Added backward compatibility with deprecation warnings when S3_ENDPOINT_URL is still used
  - Updated documentation to use AWS_ENDPOINT_URL_S3 with deprecation notes
  - Enhanced tutorial notebook to support both variables for backward compatibility
  - Added test coverage for the backward compatibility scenario

  ---
  ✅ Checklist

  - I updated the documentation 
  - I have tested the changes in this PR

  ---
  🧪 Testing

  - Added test_mount_s3_backward_compatibility() to verify deprecated S3_ENDPOINT_URL still works with warnings
  - Updated existing test_mount_s3() assertions to expect AWS_ENDPOINT_URL_S3
  - Verified deprecation warnings are properly issued with correct message and type
  - All existing functionality preserved while using the new environment variable name

  ---
  🔗 References

  - Ticket link: ML-10157
  - Design docs links: N/A
  - External links: N/A

  ---
  🚨 Breaking Changes?
 No breaking changes: While we replaced S3_ENDPOINT_URL with AWS_ENDPOINT_URL_S3 throughout the codebase, backward compatibility ensures existing deployments using S3_ENDPOINT_URL continue to work with deprecation warnings.
