### PR TITLE
[Auth] Fix token request handling in DynamicTokenProvider [feature/ig4-authentication]

### DIFF
--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -96,7 +96,9 @@ class DynamicTokenProvider(TokenProvider):
         :param raise_on_error: Whether to raise an error if token retrieval fails.
         """
         try:
-            request_body, headers = self._build_token_request(raise_on_error=True)
+            request_body, headers, request_type = self._build_token_request(
+                raise_on_error=True
+            )
         except mlrun.errors.MLRunRuntimeError as err:
             mlrun.utils.raise_or_log_error(
                 f"Failed to build token request. Error: {err}", raise_on_error
@@ -104,13 +106,19 @@ class DynamicTokenProvider(TokenProvider):
             return
 
         try:
-            response = self._session.request(
-                "POST",
-                self._token_endpoint,
-                timeout=self._timeout,
-                headers=headers,
-                data=request_body,
-            )
+            request_kwargs = {
+                "method": "POST",
+                "url": self._token_endpoint,
+                "timeout": self._timeout,
+                "headers": headers,
+                "verify": mlrun.mlconf.httpdb.http.verify,
+            }
+            if request_type == "json":
+                request_kwargs["json"] = request_body
+            else:
+                request_kwargs["data"] = request_body
+
+            response = self._session.request(**request_kwargs)
         except requests.RequestException as exc:
             error = f"Retrieving token failed: {mlrun.errors.err_to_str(exc)}"
             if raise_on_error:
@@ -239,7 +247,7 @@ class OAuthClientIDTokenProvider(DynamicTokenProvider):
             "client_id": self._client_id,
             "client_secret": self._client_secret,
         }
-        return request_body, headers
+        return request_body, headers, "data"
 
     def _parse_response(self, data: dict):
         # Response is described in https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3
@@ -324,7 +332,7 @@ class IGTokenProvider(DynamicTokenProvider):
 
         headers = {"Content-Type": "application/json"}
         request_body = {"refreshToken": offline_token}
-        return request_body, headers
+        return request_body, headers, "json"
 
     def _parse_response(self, response_data: dict, raise_on_error=False):
         """

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -96,7 +96,7 @@ class DynamicTokenProvider(TokenProvider):
         :param raise_on_error: Whether to raise an error if token retrieval fails.
         """
         try:
-            request_body, headers, request_type = self._build_token_request(
+            request_body, headers, body_type = self._build_token_request(
                 raise_on_error=True
             )
         except mlrun.errors.MLRunRuntimeError as err:
@@ -113,7 +113,7 @@ class DynamicTokenProvider(TokenProvider):
                 "headers": headers,
                 "verify": mlrun.mlconf.httpdb.http.verify,
             }
-            if request_type == "json":
+            if body_type == "json":
                 request_kwargs["json"] = request_body
             else:
                 request_kwargs["data"] = request_body


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Fix token request handling in DynamicTokenProvider.
Previously, all requests used `data=request_body`, which broke flows that require `application/json`.
Now, each subclass specifies the correct request format, and requests respect the configured SSL verification.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
Refactored `DynamicTokenProvider.fetch_token` to support both data and json payloads.
Added `mlrun.mlconf.httpdb.http.verify` to enforce SSL verification for all token requests.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Tested on IG4 system

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

