### PR TITLE
[ModelProvider] support Openai system test in GitHub workflows.

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -258,6 +258,8 @@ jobs:
           --slack-webhook-url "${{ secrets.LATEST_SYSTEM_TEST_SLACK_WEBHOOK_URL }}" \
           --branch "${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}" \
           --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}" \
+          --openai-base-url "${{ secrets.OPENAI_BASE_URL }}" \
+          --openai-api-key "${{ secrets.OPENAI_API_KEY }}" \
           --save-to-path "$GITHUB_WORKSPACE/env.yml" \
           --kubeconfig-content "${{ secrets.LATEST_SYSTEM_TEST_KUBECONFIG }}"
 

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -278,7 +278,9 @@ jobs:
         source venv/bin/activate
         python automation/system_test/prepare.py env \
           --mlrun-dbpath "http://localhost:${MLRUN_API_NODE_PORT}" \
-          --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}"
+          --github-access-token "${{ secrets.SYSTEM_TEST_GITHUB_ACCESS_TOKEN }}" \
+          --openai-base-url "${{ secrets.OPENAI_BASE_URL }}" \
+          --openai-api-key "${{ secrets.OPENAI_API_KEY }}"
 
     - name: Run system tests
       run: |

--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -93,6 +93,8 @@ class SystemTestPreparer:
         branch: typing.Optional[str] = None,
         mlrun_dbpath: typing.Optional[str] = None,
         kubeconfig_content: typing.Optional[str] = None,
+        openai_base_url: typing.Optional[str] = None,
+        openai_api_key: typing.Optional[str] = None,
     ):
         self._logger = logger
         self._debug = debug
@@ -124,6 +126,8 @@ class SystemTestPreparer:
             # (e.g. tests which use public repos, therefor doesn't need that access token)
             "MLRUN_SYSTEM_TESTS_GIT_TOKEN": github_access_token,
             "MLRUN_SYSTEM_TEST_KUBECONFIG": kubeconfig_content,
+            "OPENAI_BASE_URL": openai_base_url,
+            "OPENAI_API_KEY": openai_api_key,
         }
 
     def prepare_local_env(self, save_to_path: str = ""):
@@ -873,6 +877,14 @@ def run(
     "--kubeconfig-content",
     help="Kubeconfig file content encoded in base64",
 )
+@click.option(
+    "--openai-base-url",
+    help="Base URL for the OpenAI API endpoint",
+)
+@click.option(
+    "--openai-api-key",
+    help="API key for accessing the OpenAI service",
+)
 def env(
     data_cluster_ip: str,
     data_cluster_ssh_username: str,
@@ -886,6 +898,8 @@ def env(
     save_to_path: str,
     mlrun_dbpath: str,
     kubeconfig_content: str,
+    openai_base_url: str,
+    openai_api_key: str,
 ):
     system_test_preparer = SystemTestPreparer(
         data_cluster_ip=data_cluster_ip,
@@ -899,6 +913,8 @@ def env(
         github_access_token=github_access_token,
         mlrun_dbpath=mlrun_dbpath,
         kubeconfig_content=kubeconfig_content,
+        openai_base_url=openai_base_url,
+        openai_api_key=openai_api_key,
     )
     try:
         system_test_preparer.connect_to_remote()

--- a/tests/datastore/remote_model/remote_model_utils.py
+++ b/tests/datastore/remote_model/remote_model_utils.py
@@ -163,7 +163,9 @@ class MyOpenAIAsyncEvents(mlrun.serving.states.LLModel):
         model_configuration = {}
         all_messages = []
         for event in body["input"]:
-            messages, model_configuration = self.enrich_prompt(event, origin_name)
+            messages, model_configuration = self.enrich_prompt(
+                event, origin_name, llm_prompt_artifact=self.invocation_artifact
+            )
             all_messages.extend(messages)
         return await self.predict_async(
             body, messages=all_messages, model_configuration=model_configuration

--- a/tests/system/datastore/model_providers/test_openai.py
+++ b/tests/system/datastore/model_providers/test_openai.py
@@ -30,6 +30,8 @@ from tests.datastore.remote_model.remote_model_utils import (
 )
 from tests.system.base import TestMLRunSystem
 
+MAX_ATTEMPTS = 3
+
 
 def get_missing_openai_env_variables():
     return [
@@ -89,16 +91,35 @@ class TestOpenAIModelRunner(TestMLRunSystem):
             default_config={"max_tokens": 100},
         )
         function.deploy()
-        response = function.invoke(
-            f"v2/models/{mlrun_model_name}/infer",
-            json.dumps(INPUT_DATA[0]),
-        )["output"]
-        assert len(response) == 2
-        answer = response[UsageResponseKeys.ANSWER]
-        assert EXPECTED_RESULTS[0] in answer.lower()
+
+        response = None
+        answer = None
+
+        # retry loop only for fragile assertions
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            try:
+                response = function.invoke(
+                    f"v2/models/{mlrun_model_name}/infer",
+                    json.dumps(INPUT_DATA[0]),
+                )["output"]
+
+                assert len(response) == 2
+                answer = response[UsageResponseKeys.ANSWER]
+                assert EXPECTED_RESULTS[0] in answer.lower()
+
+                # success, exit loop
+                break
+            except AssertionError as e:
+                if attempt < MAX_ATTEMPTS:
+                    print(f"[Attempt {attempt}] Assertion failed, retrying...")
+                    continue
+                else:
+                    print(f"[Attempt {attempt}] Giving up after {MAX_ATTEMPTS} tries.")
+                    raise e
+
+        # only run these once, after a valid answer was obtained
         encoding = tiktoken.encoding_for_model(self.basic_llm_model)
         assert len(encoding.encode(answer)) == 100
-
         stats = response[UsageResponseKeys.USAGE]
         assert stats["completion_tokens"] == 100
         assert stats["prompt_tokens"] > 0
@@ -120,17 +141,29 @@ class TestOpenAIModelRunner(TestMLRunSystem):
         )
         function.deploy()
 
-        start = time.perf_counter()
-        results_with_times = function.invoke(
-            f"v2/models/{mlrun_model_name}/infer",
-            json.dumps({"input": INPUT_DATA}),
-        )
-        total_duration = time.perf_counter() - start
-        assert_async_invocations(
-            results_with_times=results_with_times,
-            model_name=self.basic_llm_model,
-            total_duration=total_duration,
-        )
+        for attempt in range(1, MAX_ATTEMPTS + 1):
+            start = time.perf_counter()
+            results_with_times = function.invoke(
+                f"v2/models/{mlrun_model_name}/infer",
+                json.dumps({"input": INPUT_DATA}),
+            )
+            total_duration = time.perf_counter() - start
+
+            try:
+                assert_async_invocations(
+                    results_with_times=results_with_times,
+                    model_name=self.basic_llm_model,
+                    total_duration=total_duration,
+                )
+                # success, break out of the retry loop
+                break
+            except AssertionError as e:
+                if attempt < MAX_ATTEMPTS:
+                    print(f"[Attempt {attempt}] Assertion failed, retrying...")
+                    continue
+                else:
+                    print(f"[Attempt {attempt}] Giving up after {MAX_ATTEMPTS} tries.")
+                    raise e
 
     @pytest.mark.parametrize(
         "execution_mechanism",


### PR DESCRIPTION
### 📝 Description
Edit tests and secret handling to support openai system tests in GitHub workflows.
---

### 🛠️ Changes Made
1) Add retry mechanism for system tests (LLMs may respond incorrectly, and we want to avoid raising false errors).
2) Handle OpenAI secrets in GitHub system tests:

```
system-tests-enterprise.yml
system-tests-opensource.yml
```
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Add 2 retries attempts in order to avoid rising a false error.

---

### 🔗 References
- Ticket link: [ML-10365](https://iguazio.atlassian.net/browse/ML-10365)
---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-10365]: https://iguazio.atlassian.net/browse/ML-10365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ