### PR TITLE
[Datastore] Add `DatastoreProfileKafkaStream`

### DIFF
--- a/docs/feature-store/sources-targets.md
+++ b/docs/feature-store/sources-targets.md
@@ -66,13 +66,13 @@ Support for Confluent Kafka is currently in Tech Preview status.
 ```
 
 ```python
-profile = DatastoreProfileKafkaSource(
+profile = DatastoreProfileKafkaStream(
     name="profile-name", brokers="localhost", topic="topic_name"
 )
 target = KafkaSource(path="ds://profile-name")
 ```
 
-`DatastoreProfileKafkaSource` class parameters:
+`DatastoreProfileKafkaStream` class parameters:
 - `name` &mdash; Name of the profile
 - `brokers` &mdash; This parameter can either be a single string or a list of strings representing the Kafka brokers. Brokers serve as the contact points for clients to connect to the Kafka cluster.
 - `topics` &mdash; A string or list of strings that denote the Kafka topics from which data is sourced or read.

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -193,7 +193,7 @@ tsdb_profile = DatastoreProfileTDEngine(
 project.register_datastore_profile(tsdb_profile)
 
 # Create and register stream profile
-stream_profile = DatastoreProfileKafkaSource(
+stream_profile = DatastoreProfileKafkaStream(
     name="my-kafka",
     brokers=["<kafka-broker-ip-address>:9094"],
     topics=[],

--- a/docs/tutorials/src/model_monitoring_utils.py
+++ b/docs/tutorials/src/model_monitoring_utils.py
@@ -2,7 +2,7 @@ import os
 
 import mlrun
 from mlrun.datastore.datastore_profile import (
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileTDEngine,
     DatastoreProfileV3io,
 )
@@ -32,7 +32,7 @@ def enable_model_monitoring(
             port="6041",
         )
 
-        stream_profile = DatastoreProfileKafkaSource(
+        stream_profile = DatastoreProfileKafkaStream(
             name=stream_profile_name,
             brokers=f"kafka-stream.{mlrun_namespace}.svc.cluster.local:9092",
             topics=[],

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -43,7 +43,7 @@ import storey
 
 import mlrun.datastore.wasbfs
 from mlrun.datastore.datastore_profile import (
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileKafkaTarget,
     DatastoreProfileV3io,
 )
@@ -123,7 +123,7 @@ def get_stream_pusher(stream_path: str, **kwargs):
         )
         if isinstance(
             datastore_profile,
-            (DatastoreProfileKafkaSource, DatastoreProfileKafkaTarget),
+            (DatastoreProfileKafkaStream, DatastoreProfileKafkaTarget),
         ):
             attributes = datastore_profile.attributes()
             brokers = attributes.pop("brokers", None)

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -139,9 +139,14 @@ class ConfigProfile(DatastoreProfile):
         return res
 
 
+# TODO: Remove in 1.12.0
 @deprecated(
-    "This class is deprecated from mlrun 1.10.0, and will be removed in 1.12.0. "
-    "Use `DatastoreProfileKafkaStream` instead."
+    version="1.10.0",
+    reason=(
+        "This class is deprecated from mlrun 1.10.0, and will be removed in 1.12.0. "
+        "Use `DatastoreProfileKafkaStream` instead."
+    ),
+    category=FutureWarning,
 )
 class DatastoreProfileKafkaTarget(DatastoreProfile):
     type: str = pydantic.v1.Field("kafka_target")
@@ -203,9 +208,14 @@ class DatastoreProfileKafkaStream(DatastoreProfile):
         return attributes
 
 
+# TODO: Remove in 1.12.0
 @deprecated(
-    "This class is deprecated from mlrun 1.10.0, and will be removed in 1.12.0. "
-    "Use `DatastoreProfileKafkaStream` instead."
+    version="1.10.0",
+    reason=(
+        "This class is deprecated from mlrun 1.10.0, and will be removed in 1.12.0. "
+        "Use `DatastoreProfileKafkaStream` instead."
+    ),
+    category=FutureWarning,
 )
 class DatastoreProfileKafkaSource(DatastoreProfileKafkaStream):
     type: str = pydantic.v1.Field("kafka_source")

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -19,6 +19,7 @@ import typing
 from urllib.parse import ParseResult, urlparse
 
 import pydantic.v1
+from deprecated import deprecated
 from mergedeep import merge
 
 import mlrun
@@ -138,6 +139,10 @@ class ConfigProfile(DatastoreProfile):
         return res
 
 
+@deprecated(
+    "This class is deprecated from mlrun 1.10.0, and will be removed in 1.12.0. "
+    "Use `DatastoreProfileKafkaStream` instead."
+)
 class DatastoreProfileKafkaTarget(DatastoreProfile):
     type: str = pydantic.v1.Field("kafka_target")
     _private_attributes = "kwargs_private"
@@ -158,8 +163,8 @@ class DatastoreProfileKafkaTarget(DatastoreProfile):
         return attributes
 
 
-class DatastoreProfileKafkaSource(DatastoreProfile):
-    type: str = pydantic.v1.Field("kafka_source")
+class DatastoreProfileKafkaStream(DatastoreProfile):
+    type: str = pydantic.v1.Field("kafka_stream")
     _private_attributes = ("kwargs_private", "sasl_user", "sasl_pass")
     brokers: typing.Union[str, list[str]]
     topics: typing.Union[str, list[str]]
@@ -196,6 +201,14 @@ class DatastoreProfileKafkaSource(DatastoreProfile):
         ):
             attributes["sasl"] = sasl
         return attributes
+
+
+@deprecated(
+    "This class is deprecated from mlrun 1.10.0, and will be removed in 1.12.0. "
+    "Use `DatastoreProfileKafkaStream` instead."
+)
+class DatastoreProfileKafkaSource(DatastoreProfileKafkaStream):
+    type: str = pydantic.v1.Field("kafka_source")
 
 
 class DatastoreProfileV3io(DatastoreProfile):
@@ -524,6 +537,7 @@ _DATASTORE_TYPE_TO_PROFILE_CLASS: dict[str, type[DatastoreProfile]] = {
     "basic": DatastoreProfileBasic,
     "kafka_target": DatastoreProfileKafkaTarget,
     "kafka_source": DatastoreProfileKafkaSource,
+    "kafka_stream": DatastoreProfileKafkaStream,
     "dbfs": DatastoreProfileDBFS,
     "gcs": DatastoreProfileGCS,
     "az": DatastoreProfileAzureBlob,

--- a/mlrun/datastore/storeytargets.py
+++ b/mlrun/datastore/storeytargets.py
@@ -18,10 +18,9 @@ from mergedeep import merge
 from storey import V3ioDriver
 
 import mlrun
-import mlrun.model_monitoring.helpers
 from mlrun.datastore.base import DataStore
 from mlrun.datastore.datastore_profile import (
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileKafkaTarget,
     DatastoreProfileTDEngine,
     datastore_profile_read,
@@ -138,7 +137,7 @@ class KafkaStoreyTarget(storey.KafkaTarget):
             datastore_profile = datastore_profile_read(path)
             if not isinstance(
                 datastore_profile,
-                (DatastoreProfileKafkaSource, DatastoreProfileKafkaTarget),
+                (DatastoreProfileKafkaStream, DatastoreProfileKafkaTarget),
             ):
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"Unsupported datastore profile type: {type(datastore_profile)}"

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -143,7 +143,7 @@ def get_stream_path(
         return stream_uri.replace("v3io://", f"ds://{profile.name}")
 
     elif isinstance(
-        profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource
+        profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream
     ):
         topic = mlrun.common.model_monitoring.helpers.get_kafka_topic(
             project=project, function_name=function_name
@@ -152,7 +152,7 @@ def get_stream_path(
     else:
         raise mlrun.errors.MLRunValueError(
             f"Received an unexpected stream profile type: {type(profile)}\n"
-            "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaSource`."
+            "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaStream`."
         )
 
 
@@ -300,7 +300,7 @@ def _get_v3io_output_stream(
 
 def _get_kafka_output_stream(
     *,
-    kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource,
+    kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
     project: str,
     function_name: str,
     mock: bool = False,
@@ -356,7 +356,7 @@ def get_output_stream(
         )
 
     elif isinstance(
-        profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource
+        profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream
     ):
         return _get_kafka_output_stream(
             kafka_profile=profile,
@@ -368,7 +368,7 @@ def get_output_stream(
     else:
         raise mlrun.errors.MLRunValueError(
             f"Received an unexpected stream profile type: {type(profile)}\n"
-            "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaSource`."
+            "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaStream`."
         )
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3816,7 +3816,7 @@ class MlrunProject(ModelObj):
 
             import mlrun
             from mlrun.datastore.datastore_profile import (
-                DatastoreProfileKafkaSource,
+                DatastoreProfileKafkaStream,
                 DatastoreProfileTDEngine,
             )
 
@@ -3833,7 +3833,7 @@ class MlrunProject(ModelObj):
             project.register_datastore_profile(tsdb_profile)
 
             # Create and register stream profile
-            stream_profile = DatastoreProfileKafkaSource(
+            stream_profile = DatastoreProfileKafkaStream(
                 name="my-kafka",
                 brokers=["<kafka-broker-ip-address>:9094"],
                 topics=[],  # Keep the topics list empty
@@ -3875,9 +3875,9 @@ class MlrunProject(ModelObj):
 
         .. code-block:: python
 
-            from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
+            from mlrun.datastore.datastore_profile import DatastoreProfileKafkaStream
 
-            stream_profile = DatastoreProfileKafkaSource(
+            stream_profile = DatastoreProfileKafkaStream(
                 name="confluent-kafka",
                 brokers=["<server-domain-start>.confluent.cloud:9092"],
                 topics=[],
@@ -3906,7 +3906,7 @@ class MlrunProject(ModelObj):
                                           The supported profiles are:
 
                                           * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileV3io`
-                                          * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource`
+                                          * :py:class:`~mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream`
 
                                           You need to register one of them, and pass the profile's name.
         :param replace_creds:             If ``True`` - override the existing credentials.

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -3414,7 +3414,7 @@ def _init_async_objects(context, steps):
                         else:
                             raise mlrun.errors.MLRunValueError(
                                 f"Received an unexpected stream profile type: {type(datastore_profile)}\n"
-                                "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaSource`."
+                                "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaStream`."
                             )
                     elif stream_path.startswith("kafka://") or kafka_brokers:
                         topic, brokers = parse_kafka_url(stream_path, kafka_brokers)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -39,7 +39,7 @@ import mlrun.common.schemas as schemas
 from mlrun.artifacts.llm_prompt import LLMPromptArtifact, PlaceholderDefaultDict
 from mlrun.artifacts.model import ModelArtifact
 from mlrun.datastore.datastore_profile import (
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileKafkaTarget,
     DatastoreProfileV3io,
     datastore_profile_read,
@@ -3398,7 +3398,7 @@ def _init_async_objects(context, steps):
                         datastore_profile = datastore_profile_read(stream_path)
                         if isinstance(
                             datastore_profile,
-                            (DatastoreProfileKafkaTarget, DatastoreProfileKafkaSource),
+                            (DatastoreProfileKafkaTarget, DatastoreProfileKafkaStream),
                         ):
                             step._async_object = KafkaStoreyTarget(
                                 path=stream_path,

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -341,7 +341,7 @@ class MonitoringDeployment:
         profile = self._stream_profile
         # Note: explicit_ack_mode = "explicitOnly" while working with 'async' engine
         if isinstance(
-            profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource
+            profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream
         ):
             self._apply_and_create_kafka_source(
                 kafka_profile=profile,
@@ -379,7 +379,7 @@ class MonitoringDeployment:
     def _apply_and_create_kafka_source(
         self,
         *,
-        kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource,
+        kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
         function: mlrun.runtimes.ServingRuntime,
         function_name: str,
         stream_args: mlrun.config.Config,
@@ -1559,7 +1559,7 @@ class MonitoringDeployment:
                         f"Failed to delete v3io stream {stream_path}"
                     ) from exc
         elif isinstance(
-            profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource
+            profile, mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream
         ):
             # Delete Kafka topics
             topics = [
@@ -1673,7 +1673,7 @@ class MonitoringDeployment:
             )
         if isinstance(
             stream_profile,
-            mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource,
+            mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
         ):
             self._validate_kafka_stream(stream_profile)
         elif isinstance(
@@ -1683,12 +1683,12 @@ class MonitoringDeployment:
         else:
             raise mlrun.errors.MLRunInvalidMMStoreTypeError(
                 f"The model monitoring stream profile is of an unexpected type: '{type(stream_profile)}'\n"
-                "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaSource`."
+                "Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaStream`."
             )
 
     def _validate_kafka_stream(
         self,
-        kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource,
+        kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
     ) -> None:
         if kafka_profile.topics:
             raise mlrun.errors.MLRunInvalidMMStoreTypeError(
@@ -1698,7 +1698,7 @@ class MonitoringDeployment:
 
     @staticmethod
     def _verify_kafka_access(
-        kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaSource,
+        kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
     ) -> None:
         import kafka.errors
 

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -23,7 +23,7 @@ import taosws
 
 import mlrun.common.schemas
 import mlrun.runtimes
-from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
+from mlrun.datastore.datastore_profile import DatastoreProfileKafkaStream
 
 import services.api
 import services.api.crud.model_monitoring.deployment as mm_dep
@@ -185,7 +185,7 @@ def test_apply_and_create_kafka_source(
     """Test that the Kafka trigger is set correctly"""
     replication_factor = 3
 
-    kafka_profile = DatastoreProfileKafkaSource(
+    kafka_profile = DatastoreProfileKafkaStream(
         name="test-kafka-profile",
         brokers=["sub.confluent.cloud:9092"],
         topics=[],

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -24,13 +24,12 @@ import pytest
 import pytz
 
 import mlrun.datastore
-import mlrun.datastore.wasbfs
 from mlrun import MLRunInvalidArgumentError, new_function
 from mlrun.datastore import KafkaSource
 from mlrun.datastore.azure_blob import AzureBlobStore
 from mlrun.datastore.base import HttpStore
 from mlrun.datastore.datastore import schema_to_model_provider, schema_to_store
-from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
+from mlrun.datastore.datastore_profile import DatastoreProfileKafkaStream
 from mlrun.datastore.dbfs_store import DBFSStore
 from mlrun.datastore.filestore import FileStore
 from mlrun.datastore.google_cloud_storage import GoogleCloudStorageStore
@@ -97,7 +96,7 @@ def test_kafka_source_with_attributes():
 
 
 def test_kafka_source_with_attributes_as_ds_profile():
-    ds = DatastoreProfileKafkaSource(
+    ds = DatastoreProfileKafkaStream(
         name="dskafkasrc",
         brokers="broker_host:9092",
         topics="mytopic",
@@ -133,7 +132,7 @@ def test_kafka_source_with_attributes_as_ds_profile():
 
 
 def test_kafka_source_with_attributes_as_ds_profile_brokers_list():
-    ds = DatastoreProfileKafkaSource(
+    ds = DatastoreProfileKafkaStream(
         name="dskafkasrc",
         brokers=["broker_host:9092", "broker_host2:9093"],
         topics=["mytopic", "mytopic2"],

--- a/tests/datastore/test_datastore_profile.py
+++ b/tests/datastore/test_datastore_profile.py
@@ -15,16 +15,16 @@
 from collections.abc import Iterator
 from unittest.mock import patch
 
-import pydantic
+import pydantic.error_wrappers
 import pytest
 
 import mlrun
 import mlrun.common.schemas
-import mlrun.errors
 from mlrun.datastore.datastore_profile import (
     _DATASTORE_TYPE_TO_PROFILE_CLASS,
     DatastoreProfile,
     DatastoreProfile2Json,
+    DatastoreProfileKafkaStream,
     DatastoreProfileKafkaTarget,
     DatastoreProfileTDEngine,
     DatastoreProfileV3io,
@@ -43,18 +43,36 @@ def test_kafka_target_datastore():
     assert profile.brokers == "localhost:9092"
 
 
-def test_kafka_target_datastore_no_brokers():
-    with pytest.raises(
-        pydantic.error_wrappers.ValidationError,
-        match="none is not an allowed value",
-    ):
-        DatastoreProfileKafkaTarget(name="my_target", brokers=None, topic="my-topic")
+def test_kafka_stream_datastore() -> None:
+    profile = DatastoreProfileKafkaStream(
+        name="my_stream", topics=["my-topic"], brokers="localhost:9092"
+    )
+    assert profile.name == "my_stream"
+    assert profile.get_topic() == "my-topic"
+    assert profile.brokers == "localhost:9092"
 
+
+@pytest.mark.parametrize(
+    ("brokers_kwargs", "expected_err_msg"),
+    [
+        ({"brokers": None}, "none is not an allowed value"),
+        ({}, "field required"),
+    ],
+)
+@pytest.mark.parametrize(
+    "profile_class", [DatastoreProfileKafkaTarget, DatastoreProfileKafkaStream]
+)
+def test_kafka_target_datastore_no_brokers(
+    brokers_kwargs: dict, expected_err_msg: str, profile_class: type
+) -> None:
     with pytest.raises(
         pydantic.error_wrappers.ValidationError,
-        match="field required",
+        match=expected_err_msg,
     ):
-        DatastoreProfileKafkaTarget(name="my_target", topic="my-topic")
+        if isinstance(profile_class, DatastoreProfileKafkaStream):
+            profile_class(name="my_stream", topics=["my-topic"], **brokers_kwargs)
+        else:
+            profile_class(name="my_target", topic="my-topic", **brokers_kwargs)
 
 
 @pytest.fixture
@@ -124,9 +142,19 @@ class TestTDEngineProfile:
         assert profile_read.password == "1234", "Wrong password"
 
 
-def test_datastore_type_map() -> None:
-    assert set(_DATASTORE_TYPE_TO_PROFILE_CLASS.values()) == set(
-        DatastoreProfile.__subclasses__()
+@pytest.fixture
+def datastore_profile_classes() -> set[type[DatastoreProfile]]:
+    subclasses = DatastoreProfile.__subclasses__()
+    for subclass in subclasses:
+        subclasses.extend(subclass.__subclasses__())
+    return set(subclasses)
+
+
+def test_datastore_type_map(
+    datastore_profile_classes: set[type[DatastoreProfile]],
+) -> None:
+    assert (
+        set(_DATASTORE_TYPE_TO_PROFILE_CLASS.values()) == datastore_profile_classes
     ), "Missing profiles in the map"
     for type_, profile_class in _DATASTORE_TYPE_TO_PROFILE_CLASS.items():
         assert type_ == profile_class.schema().get("properties", {}).get("type").get(

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -26,7 +26,7 @@ import pytest
 import mlrun
 import mlrun.utils
 from mlrun.common.schemas.model_monitoring import ResultKindApp, ResultStatusApp
-from mlrun.datastore.datastore_profile import DatastoreProfileKafkaSource
+from mlrun.datastore.datastore_profile import DatastoreProfileKafkaStream
 from mlrun.model_monitoring.applications import (
     ExistingDataHandling,
     ModelMonitoringApplicationBase,
@@ -239,7 +239,7 @@ class TestEvaluate:
                 end=end,
                 run_local=run_local,
                 write_output=write_output,
-                stream_profile=DatastoreProfileKafkaSource(
+                stream_profile=DatastoreProfileKafkaStream(
                     name="should-not-be-passed-on-remote",
                     brokers=["broker-address:9092"],
                     topics=[],
@@ -255,7 +255,7 @@ class TestEvaluate:
             end=datetime(2025, 5, 4),
             run_local=True,
             write_output=True,
-            stream_profile=DatastoreProfileKafkaSource(
+            stream_profile=DatastoreProfileKafkaStream(
                 name="should-not-be-passed-on-remote",
                 brokers=["broker-address:9092"],
                 topics=[],
@@ -309,7 +309,7 @@ class TestEvaluate:
             end=datetime(2025, 5, 4),
             run_local=True,
             write_output=True,
-            stream_profile=DatastoreProfileKafkaSource(
+            stream_profile=DatastoreProfileKafkaStream(
                 name="kafka-stream", brokers=["broker-address:9092"], topics=[]
             ),
         )

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -36,8 +36,8 @@ from mlrun.common.schemas.model_monitoring.constants import EventFieldType
 from mlrun.datastore import KafkaOutputStream, OutputStream
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
-    DatastoreProfileKafkaSource,
-    DatastoreProfileKafkaTarget,
+    DatastoreProfileKafkaStream,
+    DatastoreProfileS3,
     DatastoreProfileV3io,
 )
 from mlrun.db.nopdb import NopDB
@@ -580,7 +580,7 @@ def test_get_kafka_topic(
     ("profile", "expected_output_stream_type"),
     [
         (
-            DatastoreProfileKafkaSource(
+            DatastoreProfileKafkaStream(
                 name="test-kafka-profile",
                 brokers=["localhost"],
                 topics=[],
@@ -620,16 +620,14 @@ def test_get_output_stream_unsupported() -> None:
         mlrun.errors.MLRunValueError,
         match=(
             r".*an unexpected stream profile type: "
-            r"<class 'mlrun\.datastore\.datastore_profile\.DatastoreProfileKafkaTarget'>"
+            r"<class 'mlrun\.datastore\.datastore_profile\.DatastoreProfileS3'>"
             r".*"
         ),
     ):
         get_output_stream(
             project="nmo",
             function_name="model-monitoring-controller",
-            profile=DatastoreProfileKafkaTarget(
-                name="k-tgt", brokers="localhost", topic="t1"
-            ),
+            profile=DatastoreProfileS3(name="k-tgt", bucket="b2"),
         )
 
 

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -36,6 +36,7 @@ from mlrun.common.schemas.model_monitoring.constants import EventFieldType
 from mlrun.datastore import KafkaOutputStream, OutputStream
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
+    DatastoreProfileKafkaSource,
     DatastoreProfileKafkaStream,
     DatastoreProfileS3,
     DatastoreProfileV3io,
@@ -581,6 +582,17 @@ def test_get_kafka_topic(
     [
         (
             DatastoreProfileKafkaStream(
+                name="test-kafka-profile",
+                brokers=["localhost"],
+                topics=[],
+                sasl_user="user1",
+                sasl_pass="1234",
+                kwargs_public={"api_version": (3, 9)},
+            ),
+            KafkaOutputStream,
+        ),
+        (
+            DatastoreProfileKafkaSource(
                 name="test-kafka-profile",
                 brokers=["localhost"],
                 topics=[],

--- a/tests/model_monitoring/test_stream_processing.py
+++ b/tests/model_monitoring/test_stream_processing.py
@@ -18,7 +18,7 @@ import mlrun
 import mlrun.model_monitoring
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileTDEngine,
     DatastoreProfileV3io,
 )
@@ -38,7 +38,7 @@ from mlrun.model_monitoring.stream_processing import EventStreamProcessor
     "stream_profile",
     [
         DatastoreProfileV3io(name="v3io-stream-test"),
-        DatastoreProfileKafkaSource(
+        DatastoreProfileKafkaStream(
             name="kafka-test", brokers=["localhost:9092"], topics=[]
         ),
     ],

--- a/tests/model_monitoring/test_target_path.py
+++ b/tests/model_monitoring/test_target_path.py
@@ -19,10 +19,9 @@ from unittest import mock
 import pytest
 
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
-import mlrun.config
 import mlrun.model_monitoring
 from mlrun.datastore.datastore_profile import (
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileV3io,
     register_temporary_client_datastore_profile,
     remove_temporary_client_datastore_profile,
@@ -88,7 +87,7 @@ def test_get_v3io_stream_path() -> None:
 @pytest.fixture
 def kafka_profile_name() -> Iterator[str]:
     profile_name = "kafka-prof"
-    profile = DatastoreProfileKafkaSource(
+    profile = DatastoreProfileKafkaStream(
         name=profile_name, brokers=["some_kafka_broker:8080"], topics=[]
     )
     register_temporary_client_datastore_profile(profile)

--- a/tests/serving/test_tracking.py
+++ b/tests/serving/test_tracking.py
@@ -28,7 +28,7 @@ import mlrun.common.schemas.model_monitoring.constants as mm_constants
 from mlrun.common.schemas import ModelEndpointCreationStrategy
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileRedis,
     DatastoreProfileV3io,
     register_temporary_client_datastore_profile,
@@ -264,7 +264,7 @@ def serving_output_stream(
         )
         expected_stream_type = OutputStream
     elif request.param == "kafka":
-        profile = DatastoreProfileKafkaSource(
+        profile = DatastoreProfileKafkaStream(
             name=stream_profile_name,
             brokers=["localhost"],
             topics=[],
@@ -1316,7 +1316,7 @@ def test_stream_is_set(serving_fn: ServingRuntime) -> None:
     ("stream_profile", "expectation"),
     [
         (
-            DatastoreProfileKafkaSource(
+            DatastoreProfileKafkaStream(
                 name="kafka-profile",
                 brokers=["localhost"],
                 topics=[],
@@ -1330,7 +1330,7 @@ def test_stream_is_set(serving_fn: ServingRuntime) -> None:
             ),
             pytest.raises(
                 mlrun.errors.MLRunValueError,
-                match="Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaSource`",
+                match="Expects `DatastoreProfileV3io` or `DatastoreProfileKafkaStream`",
             ),
         ),
     ],

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -97,7 +97,7 @@ mlrun_model_monitoring_stream_profile:
   # type: v3io
   # v3io_access_key: # can leave empty
   # # or:
-  # type: kafka_source
+  # type: kafka_stream
   # brokers: # <host>:<port>
   # topics: []
   # With SASL:

--- a/tests/system/model_monitoring/__init__.py
+++ b/tests/system/model_monitoring/__init__.py
@@ -24,6 +24,7 @@ from mlrun import MlrunProject
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
     DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileTDEngine,
     DatastoreProfileV3io,
 )
@@ -35,6 +36,7 @@ _DS_TYPE_TO_DS_PROFILE: _ProfilesMap = {
     "v3io": DatastoreProfileV3io,
     "taosws": DatastoreProfileTDEngine,
     "kafka_source": DatastoreProfileKafkaSource,
+    "kafka_stream": DatastoreProfileKafkaStream,
 }
 
 
@@ -68,7 +70,7 @@ class TestMLRunSystemModelMonitoring(TestMLRunSystem):
             profile_data,
             {
                 type_: _DS_TYPE_TO_DS_PROFILE[type_]
-                for type_ in ("v3io", "kafka_source")
+                for type_ in ("v3io", "kafka_source", "kafka_stream")
             },
         )
         if isinstance(profile, DatastoreProfileV3io):

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -51,7 +51,7 @@ from mlrun.common.schemas.model_monitoring.model_endpoints import (
 )
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
-    DatastoreProfileKafkaSource,
+    DatastoreProfileKafkaStream,
     DatastoreProfileV3io,
 )
 from mlrun.datastore.targets import ParquetTarget
@@ -351,7 +351,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         self.set_mm_credentials()
         self._external_stream_delay = 0
         if isinstance(
-            self.mm_stream_profile, DatastoreProfileKafkaSource
+            self.mm_stream_profile, DatastoreProfileKafkaStream
         ) and self.mm_stream_profile.attributes()["brokers"][0].endswith(
             ".confluent.cloud:9092"
         ):
@@ -391,7 +391,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
                     path=f"pipelines/{self.project_name}/model-endpoints/{mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER}/serving-state.json",
                 )
 
-        elif isinstance(stream_profile, DatastoreProfileKafkaSource):
+        elif isinstance(stream_profile, DatastoreProfileKafkaStream):
             kafka_profile_attributes = stream_profile.attributes()
             kafka_consumer_kwargs = mlrun.datastore.utils.KafkaParameters(
                 kafka_profile_attributes
@@ -1387,7 +1387,7 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
             with pytest.raises(v3io.dataplane.response.HttpResponseError):
                 v3io_client.stream.describe(container, stream_path)
 
-        elif isinstance(stream_profile, DatastoreProfileKafkaSource):
+        elif isinstance(stream_profile, DatastoreProfileKafkaStream):
             consumer = kafka.KafkaConsumer(bootstrap_servers=stream_profile.brokers)
             topics = consumer.topics()
 


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

This single Kafka profile replaces the two deprecated profiles.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

Add a new unified datastore profile for Kafka resources: `DatastoreProfileKafkaStream`.
Add a deprecation warning to the two existing Kafka profiles.

---

### ✅ Checklist

- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Modified and added unit tests.

---

### 🔗 References
- Ticket link: [ML-10170](https://iguazio.atlassian.net/browse/ML-10170)
- Additional link - 1.10 deprecation list: [ML-9706](https://iguazio.atlassian.net/browse/ML-9706)

---

### 🚨 Breaking Changes?

- [x] No

---



[ML-10170]: https://iguazio.atlassian.net/browse/ML-10170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ML-9706]: https://iguazio.atlassian.net/browse/ML-9706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ