### PR TITLE
[Artifacts] Add json as default format for LLMPromptArtifact

### DIFF
--- a/mlrun/artifacts/llm_prompt.py
+++ b/mlrun/artifacts/llm_prompt.py
@@ -62,6 +62,7 @@ class LLMPromptArtifactSpec(ArtifactSpec):
             parent_uri=model_artifact.uri
             if isinstance(model_artifact, model_art.ModelArtifact)
             else model_artifact,
+            format=kwargs.pop("format", "") or "json",
             **kwargs,
         )
 

--- a/tests/artifacts/test_llm_prompts.py
+++ b/tests/artifacts/test_llm_prompts.py
@@ -86,6 +86,7 @@ def test_prompt_limitation():
 
     prompt_template = llm_prompt.read_prompt()
     assert prompt_template == [{"role": "user", "content": "A" * 2000}]
+    assert llm_prompt.target_path.endswith(f"{llm_key}.json")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description
Add json as default format for LLMPromptArtifact - relevant especially when we uploading the prompt for the user. 

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🔗 References
[ML-10989](https://iguazio.atlassian.net/browse/ML-10989)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->


[ML-10989]: https://iguazio.atlassian.net/browse/ML-10989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ