### PR TITLE
[Auth] Support both .yml and .yaml extensions for secret tokens file [feature/ig4-authentication]

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -63,8 +63,10 @@ def read_secret_tokens_file(raise_on_error: bool = True) -> typing.Optional[dict
     If the file does not exist or cannot be parsed, it either raises an error or logs a warning based on the
     `raise_on_error` parameter.
 
-    Supports both ``.yaml`` and ``.yml`` extensions and will attempt to use the
-    alternate extension if the file with the configured extension does not exist.
+    - Supports both ``.yaml`` and ``.yml`` extensions and will attempt to use the
+      alternate extension if the file with the configured extension does not exist.
+    - The configured path may use ``~`` to represent the user’s home directory, which
+      will be expanded automatically.
 
     :param raise_on_error: Whether to raise an error or log a warning on failure.
     :return: The parsed content of the token file as a dictionary, or None if an error occurs.
@@ -81,15 +83,19 @@ def read_secret_tokens_file(raise_on_error: bool = True) -> typing.Optional[dict
                 token_file = alt_file
             else:
                 mlrun.utils.helpers.raise_or_log_error(
-                    f"Token file not found at {token_file} or {alt_file}",
+                    (
+                        f"Configured token file not found: {token_file}. "
+                        f"Tried alternative extension: {alt_file}, also not found."
+                    ),
                     raise_on_error,
                 )
                 return None
         else:
             mlrun.utils.helpers.raise_or_log_error(
-                f"Token file not found at {token_file}", raise_on_error
+                f"Configured token file not found: {token_file}", raise_on_error
             )
             return None
+
     try:
         with open(token_file) as token_file_io:
             data = yaml.safe_load(token_file_io)

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -63,25 +63,54 @@ def read_secret_tokens_file(raise_on_error: bool = True) -> typing.Optional[dict
     If the file does not exist or cannot be parsed, it either raises an error or logs a warning based on the
     `raise_on_error` parameter.
 
+    Supports both ``.yaml`` and ``.yml`` extensions and will attempt to use the
+    alternate extension if the file with the configured extension does not exist.
+
     :param raise_on_error: Whether to raise an error or log a warning on failure.
     :return: The parsed content of the token file as a dictionary, or None if an error occurs.
     """
-    token_file = config.auth_with_oauth_token.auth_token_file
+    token_file = os.path.expanduser(config.auth_with_oauth_token.auth_token_file)
+
+    # If the file doesn't exist, try the alternative extension
     if not os.path.exists(token_file):
-        mlrun.utils.helpers.raise_or_log_error(
-            f"Token file not found at {token_file}", raise_on_error
-        )
-        return None
-    data = None
+        base, ext = os.path.splitext(token_file)
+        if ext in [".yml", ".yaml"]:
+            alt_ext = ".yaml" if ext == ".yml" else ".yml"
+            alt_file = base + alt_ext
+            if os.path.exists(alt_file):
+                token_file = alt_file
+            else:
+                mlrun.utils.helpers.raise_or_log_error(
+                    f"Token file not found at {token_file} or {alt_file}",
+                    raise_on_error,
+                )
+                return None
+        else:
+            mlrun.utils.helpers.raise_or_log_error(
+                f"Token file not found at {token_file}", raise_on_error
+            )
+            return None
     try:
         with open(token_file) as token_file_io:
             data = yaml.safe_load(token_file_io)
+        if not data:
+            mlrun.utils.helpers.raise_or_log_error(
+                f"Token file {token_file} is empty or invalid",
+                raise_on_error,
+            )
+            return None
+        if not isinstance(data, dict):
+            mlrun.utils.helpers.raise_or_log_error(
+                f"Token file {token_file} must contain a YAML mapping (dictionary)",
+                raise_on_error,
+            )
+            return None
+        return data
     except yaml.YAMLError as exc:
         mlrun.utils.helpers.raise_or_log_error(
             f"Failed to parse token file {token_file}: {exc}", raise_on_error
         )
         return None
-    return data
 
 
 def parse_offline_token_data(

--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -252,6 +252,47 @@ def test_read_secret_tokens_file_alternative_extension(tmp_path, monkeypatch):
     assert result["secretTokens"][0]["name"] == "token2"
 
 
+@pytest.mark.parametrize(
+    "file_name, file_content, raise_on_error, expect_error, expected_result",
+    [
+        # 1. Empty file
+        ("tokens.yaml", "", True, True, None),
+        ("tokens.yaml", "", False, False, None),
+        # 2. Non-dict YAML (list at root)
+        ("tokens.yaml", "- just-a-list-item", True, True, None),
+        ("tokens.yaml", "- just-a-list-item", False, False, None),
+        # 3. Non-yaml extension (no fallback logic triggered)
+        (
+            "tokens.txt",
+            {"secretTokens": [{"name": "n1", "token": "t1"}]},
+            True,
+            False,
+            {"secretTokens": [{"name": "n1", "token": "t1"}]},
+        ),
+    ],
+)
+def test_read_secret_tokens_file_edge_cases(
+    tmp_path,
+    monkeypatch,
+    file_name,
+    file_content,
+    raise_on_error,
+    expect_error,
+    expected_result,
+):
+    # Use shared helper to write file
+    file_path = _write_file(tmp_path, file_name, file_content)
+
+    monkeypatch.setattr(config.auth_with_oauth_token, "auth_token_file", str(file_path))
+
+    if expect_error and raise_on_error:
+        with pytest.raises(mlrun.errors.MLRunRuntimeError):
+            mlrun.auth.utils.read_secret_tokens_file(raise_on_error=raise_on_error)
+    else:
+        result = mlrun.auth.utils.read_secret_tokens_file(raise_on_error=raise_on_error)
+        assert result == expected_result
+
+
 def _write_file(tmp_path, name: str, content) -> str:
     file_path = tmp_path / name
     if isinstance(content, dict):

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import textwrap
 from unittest.mock import patch
 
 import pytest
@@ -213,3 +215,47 @@ def test_get_offline_token_from_file(
             raise_on_error=raise_on_error
         )
         assert token == expected_token
+
+
+def test_read_secret_tokens_file_non_existent(tmp_path, monkeypatch):
+    file_path = tmp_path / "does_not_exist.yml"
+    monkeypatch.setattr(config.auth_with_oauth_token, "auth_token_file", str(file_path))
+
+    result = mlrun.auth.utils.read_secret_tokens_file(raise_on_error=False)
+    assert result is None
+
+    with pytest.raises(mlrun.errors.MLRunRuntimeError):
+        mlrun.auth.utils.read_secret_tokens_file(raise_on_error=True)
+
+
+def test_read_secret_tokens_file_alternative_extension(tmp_path, monkeypatch):
+    yml_content = textwrap.dedent("""\
+        secretTokens:
+          - name: token1
+            token: abc123
+    """)
+    yaml_content = textwrap.dedent("""\
+        secretTokens:
+          - name: token2
+            token: def456
+    """)
+
+    yml_path = _write_file(tmp_path, "tokens.yml", yml_content)
+    _write_file(tmp_path, "tokens.yaml", yaml_content)
+
+    monkeypatch.setattr(config.auth_with_oauth_token, "auth_token_file", yml_path)
+    result = mlrun.auth.utils.read_secret_tokens_file()
+    assert result["secretTokens"][0]["name"] == "token1"
+
+    os.remove(yml_path)
+    result = mlrun.auth.utils.read_secret_tokens_file()
+    assert result["secretTokens"][0]["name"] == "token2"
+
+
+def _write_file(tmp_path, name: str, content) -> str:
+    file_path = tmp_path / name
+    if isinstance(content, dict):
+        yaml.safe_dump(content, file_path.open("w"))
+    else:
+        file_path.write_text(content)
+    return str(file_path)


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Support both .yml and .yaml file extensions when loading secret tokens.
If the .yml file is not found, the code now attempts to load a .yaml file instead.

This issue occurred because the Iguazio SDK saved the file with a .yaml extension instead of .yml.
Additionally, `os.path.expanduser` is now used to resolve the file path correctly.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

1. Updated `read_secret_tokens_file` to support both .yml and .yaml file extensions.
2. Added `os.path.expanduse`r to expand ~ in file paths.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Added unit tests
Tested on the IG4 system. 

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10609
- Design docs links: https://iguazio.atlassian.net/wiki/spaces/MLRUN/pages/411960071/Support+sdk-side+IG4+authentication+-+token+usage+and+management+HLD
- External links: https://iguazio.atlassian.net/wiki/spaces/ARC/pages/361103361/MLRun+Secret+Tokens+in+IG4

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
