### PR TITLE
[Client spec] Add authentication mode [feature/ig4-authentication]

### DIFF
--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -67,3 +67,4 @@ class ClientSpec(pydantic.v1.BaseModel):
     alerts_mode: typing.Optional[str]
     system_id: typing.Optional[str]
     model_endpoint_monitoring_store_prefixes: typing.Optional[dict[str, str]]
+    httpdb_authentication_mode: typing.Optional[str]

--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -67,4 +67,4 @@ class ClientSpec(pydantic.v1.BaseModel):
     alerts_mode: typing.Optional[str]
     system_id: typing.Optional[str]
     model_endpoint_monitoring_store_prefixes: typing.Optional[dict[str, str]]
-    httpdb_authentication_mode: typing.Optional[str]
+    authentication_mode: typing.Optional[str]

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -624,7 +624,7 @@ class HTTPRunDB(RunDBInterface):
                         store_prefix_value,
                     )
             config.httpdb.authentication.mode = (
-                server_cfg.get("httpdb_authentication_mode")
+                server_cfg.get("authentication_mode")
                 or config.httpdb.authentication.mode
             )
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -623,6 +623,10 @@ class HTTPRunDB(RunDBInterface):
                         prefix,
                         store_prefix_value,
                     )
+            config.httpdb.authentication.mode = (
+                server_cfg.get("httpdb_authentication_mode")
+                or config.httpdb.authentication.mode
+            )
 
         except Exception as exc:
             logger.warning(

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -121,7 +121,7 @@ class ClientSpec(
             model_endpoint_monitoring_store_prefixes=self._get_config_value_if_not_default(
                 "model_endpoint_monitoring.store_prefixes"
             ),
-            httpdb_authentication_mode=self._get_config_value_if_not_default(
+            authentication_mode=self._get_config_value_if_not_default(
                 "httpdb.authentication.mode"
             ),
         )

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -121,6 +121,9 @@ class ClientSpec(
             model_endpoint_monitoring_store_prefixes=self._get_config_value_if_not_default(
                 "model_endpoint_monitoring.store_prefixes"
             ),
+            httpdb_authentication_mode=self._get_config_value_if_not_default(
+                "httpdb.authentication.mode"
+            ),
         )
 
     @staticmethod


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
The SDK needs to be aware when authentication is set to Iguazio v4 in order to enable certain SDK methods (e.g., storing secrets, listing secrets, revoking, and syncing).
To support this, we now pass the authentication mode value, configured on the server, to the client.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
Added `httpdb_authentication_mode` to the client spec schema.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Verified changes on an IG4 system

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10494
- Design docs links: https://iguazio.atlassian.net/wiki/spaces/MLRUN/pages/404521061/BE+Secret+Token+Support+HLD#2.1.9-Configurable-Authentication-Mode

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
