### PR TITLE
[Retry] Ignore outdated retry pods in monitor to prevent scheduler race

### DIFF
--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -2039,11 +2039,8 @@ class BaseRuntimeHandler(ABC):
         )
         run_retry_count = run.get("status", {}).get("retry_count") or 0
 
-        # If no retry label is present, treat pod as initial attempt (normalized to -1).
-        pod_retry_attempt = int(pod_retry_label) if pod_retry_label is not None else -1
+        if pod_retry_label is None:
+            # pods without a retry label are outdated once retries have started
+            return run_retry_count > 0
 
-        # first run with unlabeled pod is not outdated
-        if run_retry_count == 0 and pod_retry_attempt == -1:
-            return False
-
-        return pod_retry_attempt < run_retry_count
+        return int(pod_retry_label) < run_retry_count

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -636,7 +636,11 @@ class BaseRuntimeHandler(ABC):
 
                 # Check if the run should be retried, and update its status accordingly
                 run_state, message = self._evaluate_run_retry_state(run, reason)
-                logger.info("Updating run state", run_uid=run_uid, run_state=run_state)
+                logger.info(
+                    "Updating run state - non terminal recovery flow",
+                    run_uid=run_uid,
+                    run_state=run_state,
+                )
                 run_updates = {
                     "status.state": run_state,
                     "status.reason": reason,
@@ -1366,6 +1370,15 @@ class BaseRuntimeHandler(ABC):
         run = self._ensure_run(
             db, db_session, name, project, run, search_run=True, uid=uid
         )
+
+        # If retries are configured and this pod belongs to an earlier attempt, skip it to avoid collecting
+        # duplicate/outdated state
+        retry_spec = run.get("spec", {}).get("retry", {})
+        if retry_spec and self._is_pod_from_outdated_retry(
+            runtime_resource=runtime_resource, run=run
+        ):
+            return
+
         (
             run_state,
             threshold_exceeded,
@@ -1767,7 +1780,11 @@ class BaseRuntimeHandler(ABC):
                     run, reason, message
                 )
 
-        logger.info("Updating run state", run_uid=uid, run_state=run_state)
+        logger.info(
+            "Updating run state - ensure_run_state flow",
+            run_uid=uid,
+            run_state=run_state,
+        )
         run_updates = {
             "status.state": run_state,
             "status.reason": reason or "",
@@ -1998,3 +2015,35 @@ class BaseRuntimeHandler(ABC):
         else:
             new_state = RunStates.error
         return new_state, message
+
+    @staticmethod
+    def _is_pod_from_outdated_retry(runtime_resource: dict, run: dict) -> bool:
+        """
+        Determine whether a given pod belongs to an outdated retry attempt.
+
+        Each pod is labeled with its retry attempt number (`mlrun/retry-attempt`).
+        The run object tracks the current `retry_count`.
+        A pod is considered outdated if its retry attempt label is smaller than the
+        run's current retry_count. In such cases, the pod should be ignored by the
+        monitor flow.
+
+        :param runtime_resource: The Kubernetes pod resource.
+        :param run: The run object, including status and retry_count.
+
+        :returns: True if the pod is outdated and should be ignored, False otherwise.
+        """
+        pod_retry_label = (
+            runtime_resource.get("metadata", {})
+            .get("labels", {})
+            .get(mlrun.common.constants.MLRunInternalLabels.retry)
+        )
+        run_retry_count = run.get("status", {}).get("retry_count") or 0
+
+        # If no retry label is present, treat pod as initial attempt (normalized to -1).
+        pod_retry_attempt = int(pod_retry_label) if pod_retry_label is not None else -1
+
+        # first run with unlabeled pod is not outdated
+        if run_retry_count == 0 and pod_retry_attempt == -1:
+            return False
+
+        return pod_retry_attempt < run_retry_count

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -1781,7 +1781,7 @@ class BaseRuntimeHandler(ABC):
                 )
 
         logger.info(
-            "Updating run state - ensure_run_state flow",
+            "Ensuring run state",
             run_uid=uid,
             run_state=run_state,
         )

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -886,6 +886,11 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
 
     @pytest.mark.asyncio
     async def test_monitor_run_retry_exhausted(self, db: Session, client: TestClient):
+        # label the pods with the retry attempt (3). Without this, the pods would remain unlabeled and the monitor
+        # logic would treat them as outdated, causing them to be skipped.
+        for pod in [self.pending_job_pod, self.running_job_pod, self.failed_job_pod]:
+            pod.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] = "3"
+
         list_namespaced_pods_calls = [
             [self.pending_job_pod],
             [self.running_job_pod],

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -988,6 +988,10 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             ("1", 2, True),
             # pod attempt equals current run retry, pod is still valid
             ("2", 2, False),
+            # edge case: pod attempt label is ahead of the run's retry count.
+            # this situation shouldn't normally occur, but if it does (e.g. due to a transient state or race condition),
+            # we treat the pod as valid (not outdated) to avoid skipping an active attempt.
+            ("3", 2, False),
         ],
     )
     def test_is_pod_from_outdated_retry(

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -972,6 +972,33 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
             },
         )
 
+    @pytest.mark.parametrize(
+        "pod_retry_label, run_retry_count, expected_result",
+        [
+            # first run, no retry label means pod is valid and not outdated
+            (None, 0, False),
+            # retry count > 0 and no retry label is present, pod is outdated
+            (None, 1, True),
+            # pod attempt is older than current run retry, pod is outdated
+            ("1", 2, True),
+            # pod attempt equals current run retry, pod is still valid
+            ("2", 2, False),
+        ],
+    )
+    def test_is_pod_from_outdated_retry(
+        self, pod_retry_label, run_retry_count, expected_result
+    ):
+        pod = self._generate_pod("pod", self.job_labels, PodPhases.pending)
+        if pod_retry_label is not None:
+            pod.metadata.labels[mlrun.common.constants.MLRunInternalLabels.retry] = (
+                pod_retry_label
+            )
+        self.run["status"]["retry_count"] = run_retry_count
+        assert (
+            self.runtime_handler._is_pod_from_outdated_retry(pod.to_dict(), self.run)
+            is expected_result
+        )
+
     def _mock_list_resources_pods(self, pod=None):
         pod = pod or self.completed_job_pod
         mocked_responses = self._mock_list_namespaced_pods([[pod]])


### PR DESCRIPTION
### 📝 Description
This PR fixes a race condition in the runs monitor where pods from previous retry attempts were incorrectly considered when updating the run state.
The issue could cause the scheduler to start overlapping runs because the DB temporarily marked a retried run as error.

Now, the monitor ignores outdated pods and only tracks the latest retry attempt, ensuring correct run state and preventing duplicate runs.

---

### 🛠️ Changes Made

- Added `_is_pod_from_outdated_retry` to detect pods from outdated retry attempts.
- Updated monitor logic to skip outdated pods when determining run state.
- Improved debug logging for better visibility when updating a run's state.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

- Added a unit test to test the new functionality added.
- Manual validation on patched vm showed that the scheduler no longer triggers overlapping runs for jobs with retries.
- Modified an existing unit test (`test_monitor_run_retry_exhausted`) to label pods with their retry attempt, since unlabeled pods would otherwise be skipped by the monitor logic and fail that test.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10803

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

