### PR TITLE
[CI] Prevent hangs in forked notification tests

### DIFF
--- a/mlrun/utils/notifications/notification/base.py
+++ b/mlrun/utils/notifications/notification/base.py
@@ -15,9 +15,27 @@
 import asyncio
 import typing
 from copy import deepcopy
+from typing import Optional
+
+import aiohttp
 
 import mlrun.common.schemas
 import mlrun.lists
+
+
+class TimedHTTPClient:
+    def __init__(self, timeout: Optional[float] = 30.0):
+        """
+        HTTP client wrapper with built-in timeout.
+
+        Args:
+            timeout: Request timeout in seconds (default: 30.0)
+        """
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+
+    def session(self, **kwargs) -> aiohttp.ClientSession:
+        """Create a new ClientSession with the configured timeout and additional parameters."""
+        return aiohttp.ClientSession(timeout=self.timeout, **kwargs)
 
 
 class NotificationBase:

--- a/mlrun/utils/notifications/notification/git.py
+++ b/mlrun/utils/notifications/notification/git.py
@@ -16,13 +16,11 @@ import json
 import os
 import typing
 
-import aiohttp
-
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.lists
 
-from .base import NotificationBase
+from .base import NotificationBase, TimedHTTPClient
 
 
 class GitNotification(NotificationBase):
@@ -148,7 +146,7 @@ class GitNotification(NotificationBase):
             }
             url = f"https://{server}/repos/{repo}/issues/{issue}/comments"
 
-        async with aiohttp.ClientSession() as session:
+        async with TimedHTTPClient().session() as session:
             resp = await session.post(url, headers=headers, json={"body": message})
             if not resp.ok:
                 resp_text = await resp.text()

--- a/mlrun/utils/notifications/notification/slack.py
+++ b/mlrun/utils/notifications/notification/slack.py
@@ -14,14 +14,12 @@
 
 import typing
 
-import aiohttp
-
 import mlrun.common.runtimes.constants as runtimes_constants
 import mlrun.common.schemas
 import mlrun.lists
 import mlrun.utils.helpers
 
-from .base import NotificationBase
+from .base import NotificationBase, TimedHTTPClient
 
 
 class SlackNotification(NotificationBase):
@@ -67,7 +65,7 @@ class SlackNotification(NotificationBase):
 
         data = self._generate_slack_data(message, severity, runs, alert, event_data)
 
-        async with aiohttp.ClientSession() as session:
+        async with TimedHTTPClient().session() as session:
             async with session.post(webhook, json=data) as response:
                 response.raise_for_status()
 

--- a/mlrun/utils/notifications/notification/webhook.py
+++ b/mlrun/utils/notifications/notification/webhook.py
@@ -15,14 +15,13 @@
 import re
 import typing
 
-import aiohttp
 import orjson
 
 import mlrun.common.schemas
 import mlrun.lists
 import mlrun.utils.helpers
 
-from .base import NotificationBase
+from .base import NotificationBase, TimedHTTPClient
 
 
 class WebhookNotification(NotificationBase):
@@ -87,9 +86,7 @@ class WebhookNotification(NotificationBase):
         # we automatically handle it as `ssl=None` for their convenience.
         verify_ssl = verify_ssl and None if url.startswith("https") else None
 
-        async with aiohttp.ClientSession(
-            json_serialize=self._encoder,
-        ) as session:
+        async with TimedHTTPClient().session(json_serialize=self._encoder) as session:
             response = await getattr(session, method)(
                 url,
                 headers=headers,

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1741,12 +1741,17 @@ class DummySessionContext:
 @pytest.fixture
 def client_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    Patch aiohttp.ClientSession only for the tests that need it.
+    Patch the session factory used by webhook notifications so tests
+    get a DummySessionContext instead of a real aiohttp session.
     """
+
+    def make_dummy_session(self, **kwargs):
+        return DummySessionContext(**kwargs)
+
     monkeypatch.setattr(
-        mlrun.utils.notifications.notification.webhook.aiohttp,
-        "ClientSession",
-        DummySessionContext,
+        mlrun.utils.notifications.notification.webhook.TimedHTTPClient,
+        "session",
+        make_dummy_session,
     )
 
 

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -18,6 +18,7 @@ import unittest.mock
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass, field
 from datetime import datetime
+from functools import partial
 from typing import Any, Callable, Optional
 
 import aiohttp
@@ -33,6 +34,16 @@ import mlrun.utils.helpers
 import mlrun.utils.notifications
 import mlrun.utils.notifications.notification.mail as mail
 import mlrun.utils.notifications.notification.webhook
+
+
+@pytest.fixture
+def inline_run_in_threadpool(monkeypatch):
+    async def _inline(func, *args, **kwargs):
+        if kwargs:
+            func = partial(func, **kwargs)
+        return func(*args)
+
+    monkeypatch.setattr(mlrun.utils.helpers, "run_in_threadpool", _inline)
 
 
 @pytest.mark.parametrize(
@@ -381,7 +392,7 @@ def test_notification_reason(notification_kind):
     )
 
 
-@pytest.mark.skip("Failing on CI - temporarily skipped pending fix")
+@pytest.mark.usefixtures("inline_run_in_threadpool")
 @pytest.mark.parametrize(
     "when, run_state, store_count",
     [
@@ -435,10 +446,10 @@ def test_notification_update_notification_status(when, run_state, store_count):
     ).get_notification()
     if asyncio.iscoroutinefunction(notification_kind_type.push):
         concrete_notification = notification_pusher._async_notifications[0][0]
+        concrete_notification.push = unittest.mock.AsyncMock()
     else:
         concrete_notification = notification_pusher._sync_notifications[0][0]
-
-    concrete_notification.push = unittest.mock.MagicMock()
+        concrete_notification.push = unittest.mock.MagicMock()
 
     # send notifications
     notification_pusher.push()
@@ -449,7 +460,7 @@ def test_notification_update_notification_status(when, run_state, store_count):
     assert db.store_run_notifications.call_count == store_count
 
 
-@pytest.mark.skip("Failing on CI - temporarily skipped pending fix")
+@pytest.mark.usefixtures("inline_run_in_threadpool")
 @pytest.mark.parametrize(
     "notification_kind",
     [
@@ -491,10 +502,10 @@ def test_update_notification_status(notification_kind, run_status):
     ).get_notification()
     if asyncio.iscoroutinefunction(notification_kind_type.push):
         concrete_notification = notification_pusher._async_notifications[0][0]
+        concrete_notification.push = unittest.mock.AsyncMock()
     else:
         concrete_notification = notification_pusher._sync_notifications[0][0]
-
-    concrete_notification.push = unittest.mock.MagicMock()
+        concrete_notification.push = unittest.mock.MagicMock()
 
     db = mlrun.get_run_db()
     db.store_run_notifications = unittest.mock.MagicMock()


### PR DESCRIPTION
### 📝 Description

This PR fixes a CI timeout that occurred only when running tests with `pytest --forked`.
Our test replaced an async push() method with a MagicMock (non-awaitable). In the async path this raised `TypeError: object MagicMock can't be used in 'await'` expression, and the task fell into the finally block which calls `run_in_threadpool(_update_notification_status, ...)`. Under --forked, work submitted to the loop’s default ThreadPoolExecutor occasionally stalled, causing `asyncio.gather(...)` to never complete and the forked test process to hit the global timeout.

This PR makes the tests awaitable-safe and avoids relying on the loop’s shared executor during these two tests. It also adds an explicit HTTP client timeout for notification HTTP calls to eliminate another potential hang vector.

---

### 🛠️ Changes Made

- Replace MagicMock with AsyncMock when stubbing async notification.push methods.
- Add a scoped inline fixture (inline_run_in_threadpool) used only by the two affected tests to monkeypatch mlrun.utils.helpers.run_in_threadpool so it executes the target inline (no background executor) and returns an Awaitable—removing the flakiness under --forked.
- Added TimedHTTPClient (aiohttp wrapper) with a default total timeout and use it in notification code, ensuring outbound HTTP operations cannot hang indefinitely.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Tested in the CI + manually

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: https://iguazio.slack.com/archives/C03LN00M1T4/p1756650241637449 

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---
