### PR TITLE
[Monitoring app] Extra data fetched for future period

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -1512,21 +1512,32 @@ class V3IOTSDBConnector(TSDBConnector):
         return self._df_to_drift_data(df)
 
     @staticmethod
-    def _aggregate_raw_drift_data(df: pd.DataFrame, start, end, interval: str) -> pd.DataFrame:
+    def _aggregate_raw_drift_data(
+        df: pd.DataFrame, start, end, interval: str
+    ) -> pd.DataFrame:
         """
         Assumes df has a DatetimeIndex (time) and columns:
           - result_status
           - endpoint_id
         """
+        if df.empty:
+            return df
         if not isinstance(df.index, pd.DatetimeIndex):
             raise TypeError("Expected a DatetimeIndex on the DataFrame (time index).")
-        df["endpoint_id"] = df["endpoint_id"].astype(
-            "string").str.strip()  # remove extra data carried by the category dtype
-        window = df.loc[(df.index >= start) & (df.index < end), ["result_status", "endpoint_id"]]
+        df["endpoint_id"] = (
+            df["endpoint_id"].astype("string").str.strip()
+        )  # remove extra data carried by the category dtype
+        window = df.loc[
+            (df.index >= start) & (df.index < end), ["result_status", "endpoint_id"]
+        ]
         out = (
             window.groupby(
-                ["endpoint_id",
-                 pd.Grouper(freq=interval, origin=start, label="left", closed="left")]
+                [
+                    "endpoint_id",
+                    pd.Grouper(
+                        freq=interval, origin=start, label="left", closed="left"
+                    ),
+                ]
                 # align to start, [start, end) intervals
             )["result_status"]
             .max()
@@ -1534,4 +1545,5 @@ class V3IOTSDBConnector(TSDBConnector):
             .rename(columns={"result_status": "max(result_status)"})
         )
         return out.rename(
-            columns={"time": "_wstart"})  # rename datetime column to _wstart to align with the tdengine result
+            columns={"time": "_wstart"}
+        )  # rename datetime column to _wstart to align with the tdengine result

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -1513,36 +1513,36 @@ class V3IOTSDBConnector(TSDBConnector):
 
     @staticmethod
     def _aggregate_raw_drift_data(
-        df: pd.DataFrame, start, end, interval: str
+        df: pd.DataFrame, start: datetime, end: datetime, interval: str
     ) -> pd.DataFrame:
-        """
-        Assumes df has a DatetimeIndex (time) and columns:
-          - result_status
-          - endpoint_id
-        """
         if df.empty:
             return df
         if not isinstance(df.index, pd.DatetimeIndex):
             raise TypeError("Expected a DatetimeIndex on the DataFrame (time index).")
-        df["endpoint_id"] = (
-            df["endpoint_id"].astype("string").str.strip()
+        df[EventFieldType.ENDPOINT_ID] = (
+            df[EventFieldType.ENDPOINT_ID].astype("string").str.strip()
         )  # remove extra data carried by the category dtype
         window = df.loc[
-            (df.index >= start) & (df.index < end), ["result_status", "endpoint_id"]
+            (df.index >= start) & (df.index < end),
+            [mm_schemas.ResultData.RESULT_STATUS, EventFieldType.ENDPOINT_ID],
         ]
         out = (
             window.groupby(
                 [
-                    "endpoint_id",
+                    EventFieldType.ENDPOINT_ID,
                     pd.Grouper(
                         freq=interval, origin=start, label="left", closed="left"
                     ),
                 ]
                 # align to start, [start, end) intervals
-            )["result_status"]
+            )[mm_schemas.ResultData.RESULT_STATUS]
             .max()
             .reset_index()
-            .rename(columns={"result_status": "max(result_status)"})
+            .rename(
+                columns={
+                    mm_schemas.ResultData.RESULT_STATUS: f"max({mm_schemas.ResultData.RESULT_STATUS})"
+                }
+            )
         )
         return out.rename(
             columns={"time": "_wstart"}

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -1499,20 +1499,39 @@ class V3IOTSDBConnector(TSDBConnector):
     ) -> mm_schemas.ModelEndpointDriftValues:
         table = mm_schemas.V3IOTSDBTables.APP_RESULTS
         start, end, interval = self._prepare_aligned_start_end(start, end)
-
-        # get per time-interval x endpoint_id combination the max result status
         df = self._get_records(
             table=table,
             start=start,
             end=end,
-            interval=interval,
-            sliding_window_step=interval,
             columns=[mm_schemas.ResultData.RESULT_STATUS],
-            agg_funcs=["max"],
-            group_by=mm_schemas.WriterEvent.ENDPOINT_ID,
         )
+        df = self._aggregate_raw_drift_data(df, start, end, interval)
         if df.empty:
             return mm_schemas.ModelEndpointDriftValues(values=[])
         df = df[df[f"max({mm_schemas.ResultData.RESULT_STATUS})"] >= 1]
-        df = df.reset_index(names="_wstart")
         return self._df_to_drift_data(df)
+
+    @staticmethod
+    def _aggregate_raw_drift_data(df: pd.DataFrame, start, end, interval: str) -> pd.DataFrame:
+        """
+        Assumes df has a DatetimeIndex (time) and columns:
+          - result_status
+          - endpoint_id
+        """
+        if not isinstance(df.index, pd.DatetimeIndex):
+            raise TypeError("Expected a DatetimeIndex on the DataFrame (time index).")
+        df["endpoint_id"] = df["endpoint_id"].astype(
+            "string").str.strip()  # remove extra data carried by the category dtype
+        window = df.loc[(df.index >= start) & (df.index < end), ["result_status", "endpoint_id"]]
+        out = (
+            window.groupby(
+                ["endpoint_id",
+                 pd.Grouper(freq=interval, origin=start, label="left", closed="left")]
+                # align to start, [start, end) intervals
+            )["result_status"]
+            .max()
+            .reset_index()
+            .rename(columns={"result_status": "max(result_status)"})
+        )
+        return out.rename(
+            columns={"time": "_wstart"})  # rename datetime column to _wstart to align with the tdengine result

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -374,20 +374,16 @@ def predictions_df() -> pd.DataFrame:
 @pytest.fixture
 def drift_df() -> pd.DataFrame:
     now = datetime.now().astimezone()
-    return pd.DataFrame(
-        [
-            {
-                "_wstart": now - timedelta(hours=1),
-                "_wend": now - timedelta(hours=1),
-                "max(result_status)": 2,
-            },
-            {
-                "_wstart": now - timedelta(hours=2),
-                "_wend": now - timedelta(hours=2),
-                "max(result_status)": 1,
-            },
-        ]
-    ).set_index("_wstart")
+    data = {
+        "time": [
+            now - timedelta(hours=1),
+            now - timedelta(hours=1),
+            now - timedelta(hours=2),
+        ],
+        "result_status": [2, 1, 1],
+        "endpoint_id": ["ep-1", "ep-1", "ep-2"],
+    }
+    return pd.DataFrame(data).set_index("time")
 
 
 @pytest.fixture
@@ -574,7 +570,7 @@ def test_get_drift_data():
         start=start, end=end
     )
     assert drift_over_time is not None
-    assert len(drift_over_time.values) == 2, "Drift over time should have one value"
+    assert len(drift_over_time.values) == 2, "Drift over time should have two values"
     assert (
         drift_over_time.values[0].count_suspected == 1
     ), "Drift over time should have one detected drift"


### PR DESCRIPTION
### 📝 Description
There is a bug in the grouping to time intervals in the drift-over-time API when the TSDB is V3IO.
This PR implements a solution in which the data is pulled raw from the TSDB, then the grouping is done as part of the post-processing.
---

### 🛠️ Changes Made
- moved the grouping from the frames query to the post-processing step.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10960
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
