### PR TITLE
[Runs] Allow running remote jobs while kfp is not set

### DIFF
--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -228,11 +228,11 @@ class _PipelineContext:
         force_run_local = mlrun.mlconf.force_run_local
         if force_run_local is None or force_run_local == "auto":
             force_run_local = not mlrun.mlconf.is_api_running_on_k8s()
+
+        if self.workflow:
             if not mlrun.mlconf.kfp_url:
                 logger.debug("Kubeflow pipeline URL is not set, running locally")
                 force_run_local = True
-
-        if self.workflow:
             force_run_local = force_run_local or self.workflow.run_local
 
         return force_run_local

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,9 +76,9 @@ def has_secrets():
     return Path("secrets.txt").is_file()
 
 
-def verify_state(result: RunObject):
+def verify_state(result: RunObject, expected="completed"):
     state = result.status.state
-    assert state == "completed", f"wrong state ({state}) {result.status.error}"
+    assert state == expected, f"wrong state ({state}) {result.status.error}"
 
 
 def wait_for_server(url, timeout_sec):

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -23,7 +23,7 @@ import mlrun
 import mlrun.common.runtimes.constants
 import mlrun.errors
 import mlrun.launcher.factory
-from mlrun import new_function, new_task
+from mlrun import code_to_function, new_function, new_task
 from tests.conftest import (
     examples_path,
     has_secrets,
@@ -75,7 +75,29 @@ def test_noparams(rundb_mock):
 
     # verify the DF artifact was created and stored
     df = result.artifact("mydf").as_df()
-    df.shape
+
+
+def test_ensure_remote_run(tmp_path, monkeypatch):
+    """This test ensures that function is not running locally when the API is running on k8s
+    and context is not a workflow.
+    """
+    spec = tag_test(base_spec, "test_force_run_local")
+    spec.spec.handler = "training"
+    nb_path = f"{examples_path}/mlrun_jobs.ipynb"
+    fn = code_to_function(name="mlrun-job", filename=nb_path, kind="job")
+
+    # monkeypatch is_api_running_on_k8s to return True
+    monkeypatch.setattr(mlrun.config.Config, "is_api_running_on_k8s", lambda self: True)
+
+    result = mlrun.run_function(fn, base_task=spec, workdir=str(tmp_path))
+    print(result.to_yaml())
+
+    # kind is job and not local
+    assert result.metadata.labels["kind"] == "job"
+
+    # running remotely, thus created and not completed (as it is not running locally but waiting
+    # to be scheduled)
+    verify_state(result, expected="created")
 
 
 def test_failed_schedule_not_creating_run():

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -74,7 +74,7 @@ def test_noparams(rundb_mock):
     assert result.status.artifacts[0]["metadata"].get("key") == "chart", "failed to run"
 
     # verify the DF artifact was created and stored
-    df = result.artifact("mydf").as_df()
+    result.artifact("mydf").as_df()
 
 
 def test_ensure_remote_run(tmp_path, monkeypatch):


### PR DESCRIPTION
### 📝 Description

(taken from jira)
When the config mlrun.mlconf.force_run_local == "auto" (which is the default), MLRun’s run_function determines if the job should run locally or not by checking if the  the value of mlrun.mlconf.kfp_urlis empty or not.
Since KFP is disabled - the value is empty, and it is automatically run locally.

---

### 🛠️ Changes Made

Moved the check to happen *only* when running a workflow.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

tested by adding unit-test coverage and debugging

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11036
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
