### PR TITLE
[Model Monitoring] Fix datetime formatting in error messages

### DIFF
--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -544,15 +544,17 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                         else:
                             raise mlrun.errors.MLRunValueError(
                                 "The start time for the application and endpoint precedes the last analyzed time: "
-                                f"{start_dt=}, {last_analyzed=}, {application_name=}, {endpoint_id=}. "
+                                f"start_dt='{start_dt}', last_analyzed='{last_analyzed}', {application_name=}, "
+                                f"{endpoint_id=}. "
                                 "Writing data out of order is not supported, and the start time could not be "
                                 "dynamically reset, as last_analyzed is later than the given end time or that "
-                                f"base_period was specified ({end_dt=}, {base_period=})."
+                                f"base_period was specified (end_dt='{end_dt}', {base_period=})."
                             )
                     else:
                         raise mlrun.errors.MLRunValueError(
                             "The start time for the application and endpoint precedes the last analyzed time: "
-                            f"{start_dt=}, {last_analyzed=}, {application_name=}, {endpoint_id=}. "
+                            f"start_dt='{start_dt}', last_analyzed='{last_analyzed}', {application_name=}, "
+                            f"{endpoint_id=}. "
                             "Writing data out of order is not supported. You should change the start time to "
                             f"'{last_analyzed}' or later."
                         )


### PR DESCRIPTION
### 📝 Description

Fixes the remaining part of [ML-10819](https://iguazio.atlassian.net/browse/ML-10819).
Turns out that in an f-string, `f"{x=}"` print the representation of x `repr(x)` instead of the string formatting `str(x)`, which is used in `f"{x}"`.

---

### 🛠️ Changes Made

Change the formatting in `evaluate` error messages with datetimes.

---

### ✅ Checklist

- [x] I have tested the changes in this PR

---

### 🧪 Testing

Manual.  

---

### 🔗 References
- Ticket link: [ML-10819](https://iguazio.atlassian.net/browse/ML-10819)

---

### 🚨 Breaking Changes?

- [x] No


[ML-10819]: https://iguazio.atlassian.net/browse/ML-10819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-10819]: https://iguazio.atlassian.net/browse/ML-10819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ