### PR TITLE
[CI] Fix hf requirement name

### DIFF
--- a/tests/system/datastore/model_providers/hf_requirements.txt
+++ b/tests/system/datastore/model_providers/hf_requirements.txt
@@ -1,5 +1,0 @@
---extra-index-url
-https://download.pytorch.org/whl/cpu
-transformers==4.53.2
-torch==2.7.1+cpu
-pillow~=11.3

--- a/tests/system/datastore/model_providers/requirements_hf.txt
+++ b/tests/system/datastore/model_providers/requirements_hf.txt
@@ -1,0 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+transformers==4.53.2
+torch==2.7.1+cpu
+pillow~=11.3

--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -62,7 +62,7 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
         self.setup_datastore_profile()
         mlrun_model_name = "sync_invoke_model"
         requirements_path = os.path.join(
-            os.path.dirname(__file__), "hf_requirements.txt"
+            os.path.dirname(__file__), "requirements_hf.txt"
         )
         model_artifact, llm_prompt_artifact, function = setup_remote_model_test(
             self.project,
@@ -126,7 +126,7 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
 
         mlrun_model_name = "custom_hf_model"
         requirements_path = os.path.join(
-            os.path.dirname(__file__), "hf_requirements.txt"
+            os.path.dirname(__file__), "requirements_hf.txt"
         )
         model_artifact, llm_prompt_artifact, function = setup_remote_model_test(
             self.project,


### PR DESCRIPTION
### 📝 Description

requirements file should start with `requirements` and may include a specific suffix to ensure CI covers its compatibility with other dependencies. in addition, fixed its content to have extra index url inline with the flag so should dependabot would run correctly.

dependabot action [ https://github.com/mlrun/mlrun/actions/runs/17667614569/job/50212126081 ] failed with 

```
| dependency_file_not_evaluatable | {                                                                                                                                                    |
|                                 |   "message": "RequirementsFileParseError('Invalid requirement: --extra-index-url\\nrun.py: error: --extra-index-url option requires 1 argument\\n')" |
|                                 | }      
```

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing

Run CI compatibility check, ran system test initialization to see requirement was taken correctly

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
