### PR TITLE
[Authentication] Improve failure handling when token exchange fails [feature/ig4-authentication]

### DIFF
--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -87,25 +87,19 @@ class DynamicTokenProvider(TokenProvider):
         self._refresh_token_if_needed()
         return self._token
 
-    def fetch_token_with_retries(self, max_retries=None):
-        if not max_retries:
-            max_retries = self._max_retries
-        for attempt in range(max_retries):
-            try:
-                self.fetch_token()
-                # Successfully fetched the token, exit the method
-                return
-            except Exception as exc:
-                logger.warning(
-                    "Token fetch attempt failed",
-                    attempt=attempt + 1,
-                    max_retries=max_retries,
-                    error=str(exc),
-                )
-                if attempt == max_retries - 1:
-                    logger.warning("Max retries reached, failed to fetch token")
-
     def fetch_token(self):
+        try:
+            mlrun.utils.helpers.run_with_retry(
+                retry_count=self._max_retries,
+                func=self._fetch_token,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Max retries reached, failed to fetch token",
+                error=str(exc),
+            )
+
+    def _fetch_token(self):
         """
         Fetch a new access token from the token endpoint.
 
@@ -162,7 +156,7 @@ class DynamicTokenProvider(TokenProvider):
         if self._token and self._is_token_valid(cleanup_if_expired=True):
             return self._token
 
-        self.fetch_token_with_retries()
+        self.fetch_token()
         self._post_fetch_hook()
         return self._token
 
@@ -378,13 +372,15 @@ class IGTokenProvider(DynamicTokenProvider):
 
     def _post_fetch_hook(self):
         # After fetching a new token, sync the local token file with the backend to ensure the latest token is stored
-        mlrun.secrets.sync_secret_tokens()
-
-        # if we get there and have a token which is not valid, but not empty,
-        # it means that refresh threshold is reached and it will soon expire
+        mlrun.utils.helpers.run_with_retry(
+            retry_count=self._max_retries,
+            func=mlrun.secrets.sync_secret_tokens,
+        )
+        # if we reach this point and the token is non-empty but invalid,
+        # it means the refresh threshold has been reached and the token will expire soon.
         if self._token and self._is_token_valid(cleanup_if_expired=True):
             logger.warning(
-                "Fetching a new token failed and the existing token is still valid, but close to expiry. "
+                "Failed to fetch a new token. Using the existing token, which remains valid but is close to expiring."
             )
 
         if not self._token:

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -67,7 +67,7 @@ class DynamicTokenProvider(TokenProvider):
         self._token = None
         self._token_endpoint = token_endpoint
         self._timeout = timeout
-        self._max_retries = 1
+        self._max_retries = 0
 
         # Since we're only issuing POST requests, which are actually a disguised GET, then it's ok to allow retries
         # on them.
@@ -299,7 +299,7 @@ class IGTokenProvider(DynamicTokenProvider):
 
     def __init__(self, token_endpoint: str, timeout=5):
         super().__init__(token_endpoint=token_endpoint, timeout=timeout)
-        self._max_retries = 3
+        self._max_retries = 2
 
     def _cleanup(self):
         self._token = None

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -371,12 +371,6 @@ class IGTokenProvider(DynamicTokenProvider):
         )
 
     def _post_fetch_hook(self):
-        # After fetching a new token, sync the local token file with the backend to ensure the latest token is stored
-        # and all other tokens are up-to-date.
-        mlrun.utils.helpers.run_with_retry(
-            retry_count=self._max_retries,
-            func=mlrun.secrets.sync_secret_tokens,
-        )
         # if we reach this point and the token is non-empty but invalid,
         # it means the refresh threshold has been reached and the token will expire soon.
         if self._token and not self._is_token_valid(cleanup_if_expired=True):

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -67,6 +67,7 @@ class DynamicTokenProvider(TokenProvider):
         self._token = None
         self._token_endpoint = token_endpoint
         self._timeout = timeout
+        self._max_retries = 1
 
         # Since we're only issuing POST requests, which are actually a disguised GET, then it's ok to allow retries
         # on them.
@@ -86,7 +87,9 @@ class DynamicTokenProvider(TokenProvider):
         self._refresh_token_if_needed()
         return self._token
 
-    def fetch_token_with_retries(self, max_retries=3):
+    def fetch_token_with_retries(self, max_retries=None):
+        if not max_retries:
+            max_retries = self._max_retries
         for attempt in range(max_retries):
             try:
                 self.fetch_token()
@@ -286,10 +289,7 @@ class OAuthClientIDTokenProvider(DynamicTokenProvider):
         A hook that is called after fetching a new token.
         Can be used to perform additional actions, such as logging or updating state.
         """
-        if not self._token:
-            raise mlrun.errors.MLRunRuntimeError(
-                "Failed to fetch token, no token available after fetch"
-            )
+        pass
 
 
 class IGTokenProvider(DynamicTokenProvider):
@@ -305,6 +305,7 @@ class IGTokenProvider(DynamicTokenProvider):
 
     def __init__(self, token_endpoint: str, timeout=5):
         super().__init__(token_endpoint=token_endpoint, timeout=timeout)
+        self._max_retries = 3
 
     def _cleanup(self):
         self._token = None

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -75,7 +75,7 @@ class DynamicTokenProvider(TokenProvider):
             verbose=True,
         )
         self._cleanup()
-        self._refresh_token_if_needed(raise_on_error=True)
+        self._refresh_token_if_needed()
 
     def get_token(self):
         """
@@ -86,24 +86,32 @@ class DynamicTokenProvider(TokenProvider):
         self._refresh_token_if_needed()
         return self._token
 
-    def fetch_token(self, raise_on_error=False):
+    def fetch_token_with_retries(self, max_retries=3):
+        for attempt in range(max_retries):
+            try:
+                self.fetch_token()
+                # Successfully fetched the token, exit the method
+                return
+            except Exception as exc:
+                logger.warning(
+                    "Token fetch attempt failed",
+                    attempt=attempt + 1,
+                    max_retries=max_retries,
+                    error=str(exc),
+                )
+                if attempt == max_retries - 1:
+                    logger.warning("Max retries reached, failed to fetch token")
+
+    def fetch_token(self):
         """
         Fetch a new access token from the token endpoint.
 
         This method builds the token request, sends it to the token endpoint, and parses the response.
         If the request fails, it either raises an error or logs a warning based on the `raise_on_error` parameter.
-
-        :param raise_on_error: Whether to raise an error if token retrieval fails.
         """
-        try:
-            request_body, headers, body_type = self._build_token_request(
-                raise_on_error=True
-            )
-        except mlrun.errors.MLRunRuntimeError as err:
-            mlrun.utils.raise_or_log_error(
-                f"Failed to build token request. Error: {err}", raise_on_error
-            )
-            return
+        request_body, headers, body_type = self._build_token_request(
+            raise_on_error=True
+        )
 
         try:
             request_kwargs = {
@@ -121,11 +129,7 @@ class DynamicTokenProvider(TokenProvider):
             response = self._session.request(**request_kwargs)
         except requests.RequestException as exc:
             error = f"Retrieving token failed: {mlrun.errors.err_to_str(exc)}"
-            if raise_on_error:
-                raise mlrun.errors.MLRunRuntimeError(error) from exc
-            else:
-                logger.warning(error)
-                return
+            raise mlrun.errors.MLRunRuntimeError(error) from exc
 
         if not response.ok:
             error = "No error available"
@@ -138,28 +142,34 @@ class DynamicTokenProvider(TokenProvider):
             logger.warning(
                 "Retrieving token failed", status=response.status_code, error=error
             )
-            if raise_on_error:
-                mlrun.errors.raise_for_status(response)
-            return
+            mlrun.errors.raise_for_status(response)
 
         self._parse_response(response.json())
 
     def is_iguazio_session(self):
         return False
 
-    def _refresh_token_if_needed(self, raise_on_error=False):
+    def _refresh_token_if_needed(self):
         """
         Refresh the access token if it is expired or about to expire.
 
-        :param raise_on_error: Whether to raise an error if token refresh fails.
         :return: The refreshed access token.
         """
         # Check if there is an existing access token and if it is valid
         if self._token and self._is_token_valid(cleanup_if_expired=True):
             return self._token
 
-        self.fetch_token(raise_on_error=raise_on_error)
+        self.fetch_token_with_retries()
+        self._post_fetch_hook()
         return self._token
+
+    @abstractmethod
+    def _post_fetch_hook(self):
+        """
+        A hook that is called after fetching a new token.
+        Can be used to perform additional actions, such as logging or updating state.
+        """
+        pass
 
     @abstractmethod
     def _is_token_valid(self, cleanup_if_expired=True) -> bool:
@@ -271,6 +281,16 @@ class OAuthClientIDTokenProvider(DynamicTokenProvider):
             refresh=str(self.token_refresh_time),
         )
 
+    def _post_fetch_hook(self):
+        """
+        A hook that is called after fetching a new token.
+        Can be used to perform additional actions, such as logging or updating state.
+        """
+        if not self._token:
+            raise mlrun.errors.MLRunRuntimeError(
+                "Failed to fetch token, no token available after fetch"
+            )
+
 
 class IGTokenProvider(DynamicTokenProvider):
     """
@@ -334,7 +354,7 @@ class IGTokenProvider(DynamicTokenProvider):
         request_body = {"refreshToken": offline_token}
         return request_body, headers, "json"
 
-    def _parse_response(self, response_data: dict, raise_on_error=False):
+    def _parse_response(self, response_data):
         """
         Parse the response from the token endpoint.
 
@@ -345,16 +365,31 @@ class IGTokenProvider(DynamicTokenProvider):
         access_token = spec.get("accessToken")
 
         if not access_token:
-            mlrun.utils.helpers.raise_or_log_error(
-                "Access token is missing in the response from the token endpoint",
-                raise_on_error,
+            raise mlrun.errors.MLRunRuntimeError(
+                "Access token is missing in the response from the token endpoint"
             )
-            return
 
         self._token = access_token
+
         self._token_total_lifetime, self._token_expiry_time = (
             self._get_token_lifetime_and_expiry(access_token)
         )
+
+    def _post_fetch_hook(self):
+        # After fetching a new token, sync the local token file with the backend to ensure the latest token is stored
+        mlrun.secrets.sync_secret_tokens()
+
+        # if we get there and have a token which is not valid, but not empty,
+        # it means that refresh threshold is reached and it will soon expire
+        if self._token and self._is_token_valid(cleanup_if_expired=True):
+            logger.warning(
+                "Fetching a new token failed and the existing token is still valid, but close to expiry. "
+            )
+
+        if not self._token:
+            raise mlrun.errors.MLRunRuntimeError(
+                "Failed to fetch access token, no token available after fetch"
+            )
 
     @staticmethod
     def _get_token_lifetime_and_expiry(

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -378,7 +378,7 @@ class IGTokenProvider(DynamicTokenProvider):
         )
         # if we reach this point and the token is non-empty but invalid,
         # it means the refresh threshold has been reached and the token will expire soon.
-        if self._token and self._is_token_valid(cleanup_if_expired=True):
+        if self._token and not self._is_token_valid(cleanup_if_expired=True):
             logger.warning(
                 "Failed to fetch a new token. Using the existing token, which remains valid but is close to expiring."
             )

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -372,6 +372,7 @@ class IGTokenProvider(DynamicTokenProvider):
 
     def _post_fetch_hook(self):
         # After fetching a new token, sync the local token file with the backend to ensure the latest token is stored
+        # and all other tokens are up-to-date.
         mlrun.utils.helpers.run_with_retry(
             retry_count=self._max_retries,
             func=mlrun.secrets.sync_secret_tokens,

--- a/tests/auth/test_auth_providers.py
+++ b/tests/auth/test_auth_providers.py
@@ -21,23 +21,47 @@ import pytest
 
 import mlrun.auth.utils
 import mlrun.common.schemas
+import mlrun.common.types
+import mlrun.utils.logger
 from mlrun.auth.providers import IGTokenProvider
 from mlrun.config import config
 
 
-def test_ig_token_provider_successful_flow():
-    # Generate dynamic iat and exp
+@pytest.fixture
+def ig4_auth(monkeypatch):
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+    )
+    yield
+
+
+@pytest.fixture
+def patch_sync_secret_tokens_none(monkeypatch):
+    monkeypatch.setattr("mlrun.secrets.sync_secret_tokens", lambda: None)
+    yield
+
+
+@pytest.fixture
+def encoded_jwt_token():
     iat = int(time.time())
     exp = iat + 1000
-    token_payload = {
+    payload = {
         "iat": iat,
         "exp": exp,
-        "sub": "21c5db16-f0ca-4951-9702-3208a022bad6",
+        "sub": "test-user",
         "typ": "Bearer",
         "preferred_username": "admin",
     }
+    token = jwt.encode(payload, key=None, algorithm="none")
+    return token, iat, exp
 
-    encoded_jwt = jwt.encode(token_payload, key=None, algorithm="none")
+
+def test_ig_token_provider_successful_flow(
+    ig4_auth, patch_sync_secret_tokens_none, encoded_jwt_token
+):
+    encoded_jwt, iat, exp = encoded_jwt_token
 
     with patch.object(
         mlrun.auth.utils, "load_offline_token", return_value="offline-token"
@@ -132,3 +156,75 @@ def test_get_token_lifetime_and_expiry(token, expected_lifetime, expected_expira
         assert abs((expiry - expected_expiration).total_seconds()) < 2
     else:
         assert expiry is None
+
+
+def test_token_cleanup_when_expired(encoded_jwt_token, monkeypatch):
+    token, iat, exp = encoded_jwt_token
+    provider = IGTokenProvider.__new__(IGTokenProvider)
+    provider._token = token
+    provider._token_total_lifetime = 100
+    provider._token_expiry_time = datetime.now() - timedelta(seconds=5)
+
+    monkeypatch.setattr("mlrun.mlconf.auth_with_oauth_token.refresh_threshold", 0.5)
+
+    assert not provider._is_token_valid(cleanup_if_expired=True)
+    assert provider._token is None
+    assert provider._token_expiry_time is None
+
+
+def test_post_fetch_hook_warns_near_expiry(monkeypatch, encoded_jwt_token):
+    token, _, _ = encoded_jwt_token
+    provider = IGTokenProvider.__new__(IGTokenProvider)
+    provider._token = token
+    provider._token_total_lifetime = 100
+    provider._token_expiry_time = datetime.now() + timedelta(seconds=2)
+
+    monkeypatch.setattr("mlrun.secrets.sync_secret_tokens", MagicMock())
+    monkeypatch.setattr("mlrun.mlconf.auth_with_oauth_token.refresh_threshold", 0.9)
+    # simulate the case where after fetch almost expired token still in the provider (due to the fetching failure)
+    # post fetch hook in this case will make sure that token is not expired yet one more time
+    provider._post_fetch_hook()
+    assert provider._token == token
+
+
+def test_post_fetch_hook_raises_if_no_token(monkeypatch):
+    provider = IGTokenProvider.__new__(IGTokenProvider)
+    provider._token = None
+    monkeypatch.setattr("mlrun.secrets.sync_secret_tokens", MagicMock())
+    # should detect empty token and raise error
+    with pytest.raises(mlrun.errors.MLRunRuntimeError):
+        provider._post_fetch_hook()
+
+
+def test_refresh_token_fails_and_is_not_valid(
+    monkeypatch, ig4_auth, patch_sync_secret_tokens_none
+):
+    provider = IGTokenProvider.__new__(IGTokenProvider)
+
+    # expired token setup
+    provider._token = "expired"
+    provider._token_total_lifetime = 100
+    provider._token_expiry_time = datetime.now() - timedelta(seconds=5)
+
+    monkeypatch.setattr("mlrun.mlconf.auth_with_oauth_token.refresh_threshold", 0.5)
+
+    # should fail during building request, because file with token doesn't exist
+    # raises error because fetch failed, token expired, hence cleaned up
+    with pytest.raises(mlrun.errors.MLRunRuntimeError):
+        provider._refresh_token_if_needed()
+
+    # ensure expired token was cleaned
+    assert provider._token is None
+    assert provider._token_expiry_time is None
+
+    # set token lifetime to be almost expired
+    provider._token = "almost_expired_token"
+    provider._token_total_lifetime = 100
+    provider._token_expiry_time = datetime.now() + timedelta(seconds=2)
+
+    # refresh will fail, but should not raise an error in this case, because _token is not empty after post hook
+    provider._refresh_token_if_needed()
+
+    assert provider._token == "almost_expired_token"
+    assert provider._token is not None
+    assert provider._token_expiry_time is not None

--- a/tests/auth/test_auth_providers.py
+++ b/tests/auth/test_auth_providers.py
@@ -204,6 +204,8 @@ def test_refresh_token_fails_and_is_not_valid(
     # expired token setup
     provider._token = "expired"
     provider._token_total_lifetime = 100
+    provider._max_retries = 3
+
     provider._token_expiry_time = datetime.now() - timedelta(seconds=5)
 
     monkeypatch.setattr("mlrun.mlconf.auth_with_oauth_token.refresh_threshold", 0.5)

--- a/tests/auth/test_auth_providers.py
+++ b/tests/auth/test_auth_providers.py
@@ -177,6 +177,7 @@ def test_post_fetch_hook_warns_near_expiry(monkeypatch, encoded_jwt_token):
     provider = IGTokenProvider.__new__(IGTokenProvider)
     provider._token = token
     provider._token_total_lifetime = 100
+    provider._max_retries = 3
     provider._token_expiry_time = datetime.now() + timedelta(seconds=2)
 
     monkeypatch.setattr("mlrun.secrets.sync_secret_tokens", MagicMock())
@@ -190,6 +191,7 @@ def test_post_fetch_hook_warns_near_expiry(monkeypatch, encoded_jwt_token):
 def test_post_fetch_hook_raises_if_no_token(monkeypatch):
     provider = IGTokenProvider.__new__(IGTokenProvider)
     provider._token = None
+    provider._max_retries = 3
     monkeypatch.setattr("mlrun.secrets.sync_secret_tokens", MagicMock())
     # should detect empty token and raise error
     with pytest.raises(mlrun.errors.MLRunRuntimeError):
@@ -209,6 +211,9 @@ def test_refresh_token_fails_and_is_not_valid(
     provider._token_expiry_time = datetime.now() - timedelta(seconds=5)
 
     monkeypatch.setattr("mlrun.mlconf.auth_with_oauth_token.refresh_threshold", 0.5)
+    monkeypatch.setattr(
+        "mlrun.mlconf.auth_with_oauth_token.auth_token_file", "not-exists"
+    )
 
     # should fail during building request, because file with token doesn't exist
     # raises error because fetch failed, token expired, hence cleaned up

--- a/tests/auth/test_auth_providers.py
+++ b/tests/auth/test_auth_providers.py
@@ -28,22 +28,6 @@ from mlrun.config import config
 
 
 @pytest.fixture
-def ig4_auth(monkeypatch):
-    monkeypatch.setattr(
-        mlrun.mlconf.httpdb.authentication,
-        "mode",
-        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
-    )
-    yield
-
-
-@pytest.fixture
-def patch_sync_secret_tokens_none(monkeypatch):
-    monkeypatch.setattr("mlrun.secrets.sync_secret_tokens", lambda: None)
-    yield
-
-
-@pytest.fixture
 def encoded_jwt_token():
     iat = int(time.time())
     exp = iat + 1000
@@ -58,9 +42,7 @@ def encoded_jwt_token():
     return token, iat, exp
 
 
-def test_ig_token_provider_successful_flow(
-    ig4_auth, patch_sync_secret_tokens_none, encoded_jwt_token
-):
+def test_ig_token_provider_successful_flow(encoded_jwt_token):
     encoded_jwt, iat, exp = encoded_jwt_token
 
     with patch.object(
@@ -198,9 +180,7 @@ def test_post_fetch_hook_raises_if_no_token(monkeypatch):
         provider._post_fetch_hook()
 
 
-def test_refresh_token_fails_and_is_not_valid(
-    monkeypatch, ig4_auth, patch_sync_secret_tokens_none
-):
+def test_refresh_token_fails_and_is_not_valid(monkeypatch):
     provider = IGTokenProvider.__new__(IGTokenProvider)
 
     # expired token setup


### PR DESCRIPTION
### 📝 Description
Refresh Fallback Flow:

0. If the token refresh fails (i.e., `fetch_token()` raises an exception), retry the 1 and 2 steps up to 3 attempts:
1. Re-read the offline token from the configured file (to capture potential external updates such as rotation).
2. Retry exchanging the offline token at the token_endpoint.
3. If all refresh attempts fail, delegate handling to _post_fetch_hook:
        3.1 If a cached access token is still valid (not fully expired), it will continue to be used.
        3.2 If the token is expired, raise an error.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
UT

---

### 🔗 References
- Ticket link:  https://iguazio.atlassian.net/browse/ML-10780
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

