### PR TITLE
[Model Monitoring] Check model monitoring status before enable MM

### DIFF
--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -153,11 +153,11 @@ class MonitoringDeployment:
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
             self.set_credentials()
-        if deployed_functions := self.check_model_monitoring_status():
+        if deployed_functions := self.get_deployed_model_monitoring_functions():
             raise mlrun.errors.MLRunConflictError(
                 f"Model monitoring functions are already deployed: {deployed_functions}"
                 f". If you want to redeploy them, please use disable_model_monitoring first "
-                f"and when you will be able to enable it again."
+                f"and enable it again."
             )
         self.check_if_credentials_are_set()
 
@@ -2543,7 +2543,7 @@ class MonitoringDeployment:
             endpoint_ids=endpoint_ids,
         )
 
-    def check_model_monitoring_status(self) -> list[str]:
+    def get_deployed_model_monitoring_functions(self) -> list[str]:
         """
         Check which model monitoring functions are already deployed in the project.
         :return: list of deployed model monitoring functions.

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -153,6 +153,12 @@ class MonitoringDeployment:
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
             self.set_credentials()
+        if deployed_functions := self.check_model_monitoring_status():
+            raise mlrun.errors.MLRunConflictError(
+                f"Model monitoring functions are already deployed: {deployed_functions}"
+                f". If you want to redeploy them, please use disable_model_monitoring first "
+                f"and when you will be able to enable it again."
+            )
         self.check_if_credentials_are_set()
 
         self.deploy_model_monitoring_controller(
@@ -2536,6 +2542,17 @@ class MonitoringDeployment:
             application_name=application_name,
             endpoint_ids=endpoint_ids,
         )
+
+    def check_model_monitoring_status(self) -> list[str]:
+        """
+        Check which model monitoring functions are already deployed in the project.
+        :return: list of deployed model monitoring functions.
+        """
+        deployed_functions = []
+        for function_name in mm_constants.MonitoringFunctionNames.list():
+            if not self._should_deploy_function(function_name=function_name):
+                deployed_functions.append(function_name)
+        return deployed_functions
 
 
 def get_endpoint_features(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1275,7 +1275,7 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
 
     project_name = "test-mm-initialize"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = None
+    image: typing.Optional[str] = "artifactory.iguazeng.com:10557/davids/mlrun:1.10.0"
 
     def test_model_monitoring_crud(self) -> None:
         # Main validations:
@@ -1299,6 +1299,11 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
             wait_for_deployment=True,
         )
 
+        with pytest.raises(mlrun.errors.MLRunConflictError):
+            self.project.enable_model_monitoring(
+                image=self.image or "mlrun/mlrun",
+            )
+
         controller = self.project.get_function(
             key=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
             ignore_cache=True,
@@ -1308,10 +1313,6 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
                 "interval"
             ]
             == "3m"
-        )
-        self.project.enable_model_monitoring(
-            image=self.image or "mlrun/mlrun",
-            wait_for_deployment=False,
         )
         # check that all the function are still deployed
         for name in all_functions:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1275,7 +1275,7 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
 
     project_name = "test-mm-initialize"
     # Set image to "<repo>/mlrun:<tag>" for local testing
-    image: typing.Optional[str] = "artifactory.iguazeng.com:10557/davids/mlrun:1.10.0"
+    image: typing.Optional[str] = None
 
     def test_model_monitoring_crud(self) -> None:
         # Main validations:


### PR DESCRIPTION
### 📝 Description

Check the model monitoring status before enabling MM. The status is determined by the deployment state of the MM infrastructure functions. If any of them are deployed, MM is considered **enabled**; otherwise, it is **disabled**.

---

### 🛠️ Changes Made

When attempting to enable MM, if any of the infrastructure functions are already deployed, a conflict error is raised. To re-enable MM, the user must first disable it.



### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR

---

### 🧪 Testing
Update `test_model_monitoring_crud` accordingly.
---

### 🔗 References
[ML-10815](https://iguazio.atlassian.net/browse/ML-10815)

---

### 🚨 Breaking Changes?

- [X] No




[ML-10815]: https://iguazio.atlassian.net/browse/ML-10815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ