### PR TITLE
[RemoteModels] Load hf requirements from list, instead of file

### DIFF
--- a/tests/datastore/remote_model/remote_model_utils.py
+++ b/tests/datastore/remote_model/remote_model_utils.py
@@ -83,7 +83,6 @@ def setup_remote_model_test(
     execution_mechanism="naive",
     image=None,
     requirements=None,
-    requirements_file=None,
     model_class: str = "LLModel",
     default_config: Optional[dict] = None,
     include_llm_artifact=True,
@@ -116,7 +115,6 @@ def setup_remote_model_test(
         filename=__file__,
         image=image,
         requirements=requirements,
-        requirements_file=requirements_file,
     )
     graph = function.set_topology("flow", engine="async")
     model_runner_step = ModelRunnerStep(name="my_model_runner")

--- a/tests/system/datastore/model_providers/requirements_hf.txt
+++ b/tests/system/datastore/model_providers/requirements_hf.txt
@@ -1,4 +1,0 @@
---extra-index-url https://download.pytorch.org/whl/cpu
-transformers==4.53.2
-torch==2.7.1+cpu
-pillow~=11.3

--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -61,15 +61,18 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
     def test_basic_huggingface_model_runner(self, execution_mechanism):
         self.setup_datastore_profile()
         mlrun_model_name = "sync_invoke_model"
-        requirements_path = os.path.join(
-            os.path.dirname(__file__), "requirements_hf.txt"
-        )
         model_artifact, llm_prompt_artifact, function = setup_remote_model_test(
             self.project,
             self.model_url,
             mlrun_model_name=mlrun_model_name,
             image=self.image,
-            requirements_file=requirements_path,
+            requirements=[
+                "--extra-index-url",
+                "https://download.pytorch.org/whl/cpu",
+                "torch==2.7.1+cpu",
+                "transformers==4.53.2",
+                "pillow~=11.3",
+            ],
             default_config={"max_new_tokens": 50},
             execution_mechanism=execution_mechanism,
         )
@@ -125,15 +128,18 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
         v3io_path = artifact.get_target_path()
 
         mlrun_model_name = "custom_hf_model"
-        requirements_path = os.path.join(
-            os.path.dirname(__file__), "requirements_hf.txt"
-        )
         model_artifact, llm_prompt_artifact, function = setup_remote_model_test(
             self.project,
             self.model_url,
             mlrun_model_name=mlrun_model_name,
             image=self.image,
-            requirements_file=requirements_path,
+            requirements=[
+                "--extra-index-url",
+                "https://download.pytorch.org/whl/cpu",
+                "torch==2.7.1+cpu",
+                "transformers==4.53.2",
+                "pillow~=11.3",
+            ],
             default_config={"top_k": 2},
             execution_mechanism=execution_mechanism,
             model_class="MyHuggingFaceCustom",


### PR DESCRIPTION
### 📝 Description
Changed hf requirements usage.

---

### 🛠️ Changes Made
Load requirements from a list instead of a file to allow splitting --extra-index-url and its value. This avoids breaking the default behavior of requirements files, where pip expects `--extra-index-url `and the URL to appear on the same line when using pip -r.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: [ML-11058](https://iguazio.atlassian.net/browse/ML-11058)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-11058]: https://iguazio.atlassian.net/browse/ML-11058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ