### PR TITLE
[Integration] Append mlrun's docker registry value to mlrun-api image in TestMLRunIntegration's fixture

### DIFF
--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -155,8 +155,9 @@ class TestMLRunIntegration:
         if real_path := os.getenv("MLRUN_HTTPDB__REAL_PATH"):
             env_vars["MLRUN_HTTPDB__REAL_PATH"] = real_path
 
-        image = image or os.getenv("MLRUN_DOCKER_REGISTRY", "docker.io/") + os.getenv(
-            "MLRUN_API_IMAGE_NAME_TAGGED", "mlrun/mlrun-api:unstable"
+        image = image or (
+            os.getenv("MLRUN_DOCKER_REGISTRY", "docker.io/")
+            + os.getenv("MLRUN_API_IMAGE_NAME_TAGGED", "mlrun/mlrun-api:unstable")
         )
 
         client = docker.from_env()

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -155,7 +155,7 @@ class TestMLRunIntegration:
         if real_path := os.getenv("MLRUN_HTTPDB__REAL_PATH"):
             env_vars["MLRUN_HTTPDB__REAL_PATH"] = real_path
 
-        image = image or os.getenv(
+        image = image or os.getenv("MLRUN_DOCKER_REGISTRY", "docker.io/") + os.getenv(
             "MLRUN_API_IMAGE_NAME_TAGGED", "mlrun/mlrun-api:unstable"
         )
 

--- a/tests/integration/sdk_api/hub/test_hub.py
+++ b/tests/integration/sdk_api/hub/test_hub.py
@@ -28,7 +28,6 @@ class TestHub(tests.integration.sdk_api.base.TestMLRunIntegration):
         for i in range(len(expected_response)):
             assert expected_response[i].source.diff(response[i].source) == {}
 
-    # @pytest.mark.skip(reason="Mismatch between test image and CI image, see ML-11002")
     def test_hub(self):
         db = mlrun.get_run_db()
 

--- a/tests/integration/sdk_api/hub/test_hub.py
+++ b/tests/integration/sdk_api/hub/test_hub.py
@@ -28,7 +28,7 @@ class TestHub(tests.integration.sdk_api.base.TestMLRunIntegration):
         for i in range(len(expected_response)):
             assert expected_response[i].source.diff(response[i].source) == {}
 
-    @pytest.mark.skip(reason="Mismatch between test image and CI image, see ML-11002")
+    # @pytest.mark.skip(reason="Mismatch between test image and CI image, see ML-11002")
     def test_hub(self):
         db = mlrun.get_run_db()
 


### PR DESCRIPTION
### 📝 Description
During CI, the mlrun-api image is built with ghcr.io prefix but then the fixture of TestMLRunIntegration looks for mlrun/mlrun-api without the prefix. This PR appends the mlrun's docker registry prefix in the image name to fix that.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Add the value of MLRUN_DOCKER_REGISTRY in the image name used by the TestMLRunIntegration.
- Unskip the test that was failing
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11002 
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
