### PR TITLE
[Runtimes] Inject deprecated MLRUN_DEFAULT_PROJECT for backward compatibility

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -443,9 +443,11 @@ class BaseRuntime(ModelObj):
         :param runobj: Run context object (RunObject) with run metadata and status
         :return: Dictionary with all the variables that could be parsed
         """
+        active_project = self.metadata.project or config.active_project
         runtime_env = {
-            mlrun_constants.MLRUN_ACTIVE_PROJECT: self.metadata.project
-            or config.active_project
+            mlrun_constants.MLRUN_ACTIVE_PROJECT: active_project,
+            # TODO: Remove this in 1.12.0 as MLRUN_DEFAULT_PROJECT is deprecated and should not be injected anymore
+            "MLRUN_DEFAULT_PROJECT": active_project,
         }
         if runobj:
             runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json(

--- a/server/py/services/api/tests/unit/runtimes/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtimes/test_kubejob.py
@@ -1444,6 +1444,27 @@ def my_func(context):
         )
         assert run["spec"]["state_thresholds"] == expected_state_thresholds
 
+    def test_generate_runtime_env_injects_deprecated_default_project(
+        self, db: Session, k8s_secrets_mock
+    ):
+        # TODO: Remove this test in 1.12.0
+        # This test ensures that even though MLRUN_DEFAULT_PROJECT is deprecated, it is still injected into the
+        # runtime environment for backward compatibility
+        runtime = self._generate_runtime()
+
+        runobj = mlrun.model.RunObject.from_dict(
+            {
+                "metadata": {"name": "job", "project": self.project},
+            }
+        )
+
+        env = runtime._generate_runtime_env(runobj)
+
+        assert env["MLRUN_ACTIVE_PROJECT"] == self.project
+
+        # validate that the default project env var is also set for backward compatibility
+        assert env["MLRUN_DEFAULT_PROJECT"] == self.project
+
     @staticmethod
     def _assert_build_commands(expected_commands, runtime):
         assert (


### PR DESCRIPTION

### 📝 Description
Inject the deprecated MLRUN_DEFAULT_PROJECT environment variable for backward compatibility with older clients.
This ensures older versions continue to function correctly while using the newer server version. 

Added a TODO to remove the injection in 1.12.0.

---

### 🛠️ Changes Made
- Inject `MLRUN_DEFAULT_PROJECT` alongside `MLRUN_ACTIVE_PROJECT` in `_generate_runtime_env`
- Added a TODO comment to remove this in 1.12.0

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added a dedicated unit test to validate MLRUN_DEFAULT_PROJECT injection.
- Manually tested on vmdev by patching the changes and running the failing notebook from the ticket using client version `1.9.2`.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10762

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
