### PR TITLE
[CI] Ensure vendor images are pulled from gcr registry

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -367,6 +367,7 @@ class SystemTestPreparer:
             else "mlrun[complete]"
         )
         data = {
+            "MLRUN_VENDOR_IMAGES_REGISTRY": "gcr.io/iguazio",
             "MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER": version_specifier,
             # Disable the scheduler minimum allowed interval to allow fast tests (default minimum is 10 minutes, which
             # will make our tests really long)


### PR DESCRIPTION
### 📝 Description

Let mlrun system test ci pull images from gcr.io/iguazio rather than docker itself. This came due to many limit rates we have encountered

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
