### PR TITLE
[HTTPDB] Move sync secret tokens [feature/ig4-authentication]

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1396,7 +1396,7 @@ class Config:
 
     def is_iguazio_v4_mode(self):
         return (
-            mlrun.mlconf.httpdb.authentication.mode
+            config.httpdb.authentication.mode
             == mlrun.common.types.AuthenticationMode.IGUAZIO_V4
         )
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -635,7 +635,11 @@ class HTTPRunDB(RunDBInterface):
                 traceback=traceback.format_exc(),
             )
 
-        if config.is_iguazio_v4_mode() and config.auth_with_oauth_token.enabled:
+        # we are not using mlconf in that point to avoid circular import
+        if (
+            config.httpdb.authentication.mode
+            == mlrun.common.types.AuthenticationMode.IGUAZIO_V4
+        ) and config.auth_with_oauth_token.enabled:
             mlrun.secrets.sync_secret_tokens()
         return self
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -169,7 +169,6 @@ class HTTPRunDB(RunDBInterface):
             self.token_provider = mlrun.auth.IGTokenProvider(
                 token_endpoint=config.auth_token_endpoint,
             )
-            mlrun.secrets.sync_secret_tokens()
         else:
             username, password, token = mlrun.platforms.add_or_refresh_credentials(
                 parsed_url.hostname, username, password, config.httpdb.token
@@ -635,6 +634,9 @@ class HTTPRunDB(RunDBInterface):
                 exc=err_to_str(exc),
                 traceback=traceback.format_exc(),
             )
+
+        if config.is_iguazio_v4_mode() and config.auth_with_oauth_token.enabled:
+            mlrun.secrets.sync_secret_tokens()
         return self
 
     def store_log(self, uid, project="", body=None, append=False):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -635,11 +635,7 @@ class HTTPRunDB(RunDBInterface):
                 traceback=traceback.format_exc(),
             )
 
-        # we are not using mlconf in that point to avoid circular import
-        if (
-            config.httpdb.authentication.mode
-            == mlrun.common.types.AuthenticationMode.IGUAZIO_V4
-        ) and config.auth_with_oauth_token.enabled:
+        if config.is_iguazio_v4_mode() and config.auth_with_oauth_token.enabled:
             mlrun.secrets.sync_secret_tokens()
         return self
 


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Sync tokens must be called only after retrieving the client spec, since the sync method is available only in IG4 mode

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
move  `mlrun.secrets.sync_secret_tokens()` after we get the client spec

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
