### PR TITLE
[Retry] Add retry parameter docstring and usage example

### DIFF
--- a/docs/runtimes/job-function.md
+++ b/docs/runtimes/job-function.md
@@ -49,6 +49,21 @@ To run the job:
 project.run_function("train")
 ```
 
+You can configure automatic retries for failed job runs by passing a `retry` dictionary
+when running a function. This enables MLRun to handle transient errors such as runtime failures,
+OOM, or pod evictions automatically.
+
+Example:
+```python
+project.run_function(
+    "train",
+    retry={
+        "count": 3,  # total retries allowed
+        "backoff": {"base_delay": 30},  # delay in seconds between retries
+    },
+)
+```
+
 **See also**
 - [Create and register functions](../runtimes/create-and-use-functions.ipynb)
 - [How to annotate notebooks (to be used as functions)](../runtimes/mlrun_code_annotations.ipynb)

--- a/docs/runtimes/job-function.md
+++ b/docs/runtimes/job-function.md
@@ -50,8 +50,8 @@ project.run_function("train")
 ```
 
 You can configure automatic retries for failed job runs by passing a `retry` dictionary
-when running a function. This enables MLRun to handle transient errors such as runtime failures,
-OOM, or pod evictions automatically.
+when running a function. This enables MLRun to automatically handle transient errors such as runtime failures,
+OOM, or pod evictions.
 
 Example:
 ```python

--- a/docs/runtimes/job-function.md
+++ b/docs/runtimes/job-function.md
@@ -66,7 +66,7 @@ project.run_function(
 )
 ```
 
-In th UI, You can view:
+In the UI, you can view:
 - Retries status in **Jobs and Workflows > Monitor Jobs** under the Retries column.
 - Pending retries in **Jobs and Workflows > Monitor Jobs**.
 - Logs per attempt in the Logs tab by selecting an attempt from the drop-down list.

--- a/docs/runtimes/job-function.md
+++ b/docs/runtimes/job-function.md
@@ -66,6 +66,13 @@ project.run_function(
 )
 ```
 
+In th UI, You can view:
+- Retries status in **Jobs and Workflows > Monitor Jobs** under the Retries column.
+- Pending retries in **Jobs and Workflows > Monitor Jobs**.
+- Logs per attempt in the Logs tab by selecting an attempt from the drop-down list.
+
+If notifications are configured for the run, the final notification (success or failure) is sent after the last attempt and includes the total number of retries.
+
 **See also**
 - [Create and register functions](../runtimes/create-and-use-functions.ipynb)
 - [How to annotate notebooks (to be used as functions)](../runtimes/mlrun_code_annotations.ipynb)

--- a/docs/runtimes/job-function.md
+++ b/docs/runtimes/job-function.md
@@ -49,7 +49,7 @@ To run the job:
 project.run_function("train")
 ```
 
-You can configure automatic retries for failed job runs by passing a `retry` dictionary
+You can configure automatic retries for failed job runs by passing a `retry` parameter
 when running a function. This enables MLRun to automatically handle transient errors such as runtime failures,
 OOM, or pod evictions.
 
@@ -58,8 +58,10 @@ Example:
 project.run_function(
     "train",
     retry={
-        "count": 3,  # total retries allowed
-        "backoff": {"base_delay": 30},  # delay in seconds between retries
+        "count": 3,  # total retries allowed (0 to disable retries)
+        "backoff": {
+            "base_delay": 30,  # delay in seconds between retries
+        },
     },
 )
 ```

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -177,7 +177,11 @@ def run_function(
                             This ensures latest code changes are executed. This argument must be used in
                             conjunction with the local=True argument.
     :param output_path:     path to store artifacts, when running in a workflow this will be set automatically
-    :param retry:           Retry configuration for the run, can be a dict or an instance of mlrun.model.Retry.
+    :param retry:           Retry configuration for the run, can be a dict or an instance of `mlrun.model.Retry`.
+                            The `count` field in the `Retry` object specifies the number of retry attempts.
+                            If `count=0`, the run will not be retried.
+                            The `backoff` field specifies the retry backoff strategy between retry attempts.
+                            If not provided, no backoff is applied.
     :return: MLRun RunObject or PipelineNodeWrapper
     """
     if artifact_path:

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -177,7 +177,8 @@ def run_function(
                             This ensures latest code changes are executed. This argument must be used in
                             conjunction with the local=True argument.
     :param output_path:     path to store artifacts, when running in a workflow this will be set automatically
-    :param retry:           Retry configuration for the run, can be a dict or an instance of `mlrun.model.Retry`.
+    :param retry:           Retry configuration for the run, can be a dict or an instance of
+                            :py:class:`~mlrun.model.Retry`.
                             The `count` field in the `Retry` object specifies the number of retry attempts.
                             If `count=0`, the run will not be retried.
                             The `backoff` field specifies the retry backoff strategy between retry attempts.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4104,7 +4104,8 @@ class MlrunProject(ModelObj):
                                 This ensures latest code changes are executed. This argument must be used in
                                 conjunction with the local=True argument.
         :param output_path:     path to store artifacts, when running in a workflow this will be set automatically
-        :param retry:           Retry configuration for the run, can be a dict or an instance of `mlrun.model.Retry`.
+        :param retry:           Retry configuration for the run, can be a dict or an instance of
+                                :py:class:`~mlrun.model.Retry`.
                                 The `count` field in the `Retry` object specifies the number of retry attempts.
                                 If `count=0`, the run will not be retried.
                                 The `backoff` field specifies the retry backoff strategy between retry attempts.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4104,7 +4104,11 @@ class MlrunProject(ModelObj):
                                 This ensures latest code changes are executed. This argument must be used in
                                 conjunction with the local=True argument.
         :param output_path:     path to store artifacts, when running in a workflow this will be set automatically
-        :param retry:           Retry configuration for the run, can be a dict or an instance of mlrun.model.Retry.
+        :param retry:           Retry configuration for the run, can be a dict or an instance of `mlrun.model.Retry`.
+                                The `count` field in the `Retry` object specifies the number of retry attempts.
+                                If `count=0`, the run will not be retried.
+                                The `backoff` field specifies the retry backoff strategy between retry attempts.
+                                If not provided, no backoff is applied.
         :return: MLRun RunObject or PipelineNodeWrapper
         """
         if artifact_path:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -376,7 +376,11 @@ class BaseRuntime(ModelObj):
                              This ensures latest code changes are executed. This argument must be used in
                              conjunction with the local=True argument.
         :param output_path:    Default artifact output path.
-        :param retry:          Retry configuration for the run, can be a dict or an instance of mlrun.model.Retry.
+        :param retry:          Retry configuration for the run, can be a dict or an instance of `mlrun.model.Retry`.
+                               The `count` field in the `Retry` object specifies the number of retry attempts.
+                               If `count=0`, the run will not be retried.
+                               The `backoff` field specifies the retry backoff strategy between retry attempts.
+                               If not provided, no backoff is applied.
         :return: Run context object (RunObject) with run metadata, results and status
         """
         if artifact_path or out_path:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -376,7 +376,8 @@ class BaseRuntime(ModelObj):
                              This ensures latest code changes are executed. This argument must be used in
                              conjunction with the local=True argument.
         :param output_path:    Default artifact output path.
-        :param retry:          Retry configuration for the run, can be a dict or an instance of `mlrun.model.Retry`.
+        :param retry:          Retry configuration for the run, can be a dict or an instance of
+                               :py:class:`~mlrun.model.Retry`.
                                The `count` field in the `Retry` object specifies the number of retry attempts.
                                If `count=0`, the run will not be retried.
                                The `backoff` field specifies the retry backoff strategy between retry attempts.


### PR DESCRIPTION
### 📝 Description
Added documentation and example for the retry feature when running a function. 
Clarified the behavior of `retry.count`, including that `count=0 ` disables retries.

---

### 🛠️ Changes Made
- Updated `run_function` docstring to explain the retry parameter.
- Added a notebook example demonstrating usage of retry with count and backoff.base_delay.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10628

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
