### PR TITLE
[Serving] Fix serialization of filename spec attribute

### DIFF
--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -109,6 +109,7 @@ class KubeResourceSpec(FunctionSpec):
         "track_models",
         "parameters",
         "graph",
+        "filename",
     ]
     _default_fields_to_strip = FunctionSpec._default_fields_to_strip + [
         "volumes",

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -735,8 +735,9 @@ def print_df(df):
             "return": [{"x": "a", "y": 1, "extra": 123}],
         }
 
-    @pytest.mark.parametrize("local", [False])
-    def test_job_from_serving_runtime(self, local):
+    @pytest.mark.parametrize("local", [True, False])
+    @pytest.mark.parametrize("deploy_original", [True, False])
+    def test_job_from_serving_runtime(self, local, deploy_original):
         function = self.project.set_function(
             func=str(self.assets_path / "function_with_simple_transformation.py"),
             name="test",
@@ -750,6 +751,10 @@ def print_df(df):
             class_name="storey.ParquetTarget",
             path=f"v3io:///projects/{self.project_name}/out.parquet",
         )
+
+        if deploy_original:
+            # Make sure it works even after the function has been deployed (ML-10940)
+            function.deploy()
 
         job = function.to_job()
 


### PR DESCRIPTION
This caused a failure when running a job with `local=True`, if the job was derived from a function that had already been deployed.

Also expands a system test to cover this case.

[ML-10940](https://iguazio.atlassian.net/browse/ML-10940)

[ML-10940]: https://iguazio.atlassian.net/browse/ML-10940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ