### PR TITLE
[Dockefile] Set /mlrun workdir and ensure writable permissions 

### DIFF
--- a/dockerfiles/mlrun-kfp/Dockerfile
+++ b/dockerfiles/mlrun-kfp/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/pip \
   python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}
 
 WORKDIR /mlrun
+RUN chmod 777 /mlrun
 
 ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 
@@ -55,3 +56,4 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 # Remove server related files that are not needed
 # Remove ensurepip folders from both conda and system python
 RUN rm -rf /usr/local/lib/python${MLRUN_PYTHON_VERSION}/ensurepip /tmp/mlrun
+WORKDIR /mlrun

--- a/dockerfiles/mlrun-kfp/Dockerfile
+++ b/dockerfiles/mlrun-kfp/Dockerfile
@@ -27,7 +27,6 @@ RUN --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/pip \
   python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}
 
 WORKDIR /mlrun
-RUN chmod 777 /mlrun
 
 ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 
@@ -56,4 +55,6 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 # Remove server related files that are not needed
 # Remove ensurepip folders from both conda and system python
 RUN rm -rf /usr/local/lib/python${MLRUN_PYTHON_VERSION}/ensurepip /tmp/mlrun
+
+RUN chmod 777 /mlrun
 WORKDIR /mlrun

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -73,6 +73,7 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     uv pip install --no-deps --require-hashes -r locked-requirements.txt --python-version ${MLRUN_PYTHON_VERSION}
 
 WORKDIR /tmp/mlrun
+
 COPY *.txt *.md *.py *.toml ./
 COPY mlrun mlrun
 COPY dockerfiles/mlrun-api dockerfiles/mlrun-api
@@ -88,4 +89,4 @@ RUN rm -rf \
     /var/lib/apt/lists/* \
     /tmp/mlrun
 
-
+WORKDIR /mlrun


### PR DESCRIPTION
### 📝 Description
This change adds an explicit `WORKDIR /mlrun ` to both the mlrun and mlrun-kfp images, and applies chmod 777 /mlrun in the mlrun-kfp Dockerfile.

The goal is to guarantee that /mlrun is writable out of the box.
The working directory used to be /mlrun but recently changed to /tmp/mlrun after the Docker images improvements. This regression caused permission issues under restricted security contexts.

When using the override enrichment mode `override` on the security context (runAsGroup: 65534, runAsUser: 51), the container otherwise loses write permissions, leading to failures in both simple runs and remote workflows (e.g., git clone of a remote project inside the workflow runner fails on permissions as well).

- Fixes PermissionError: [Errno 13] Permission denied when writing files under /mlrun.
- Ensures cloning repositories and writing runtime files succeed under restricted security contexts.
- Keeps parity with the existing behavior in the standard MLRun image.

---

### 🛠️ Changes Made

Restored WORKDIR /mlrun in both images.
Added chmod 777 /mlrun in the mlrun-kfp Dockerfile to ensure write access.
Aligned permissions behavior between mlrun and mlrun-kfp images.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Manual test:
- Built new mlrun and mlrun-kfp images and deployed.
- Started pods with runAsUser=51 and runAsGroup=65534.
- Verified touch /mlrun/testfile and git clone inside pods succeeded.
- Ran jobs and workflows using the override mode and verified it works.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11016
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
---


