### PR TITLE
[Workflow] Fix scheduled workflows to use custom source in workflow request

### DIFF
--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -402,7 +402,6 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
             run_name=workflow_request.spec.name,
             uid=meta_uid,
             scrape_metrics=mlrun_config.config.scrape_metrics,
-            url=project.spec.source,
         )
 
         # Mask notification parameters
@@ -475,7 +474,6 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         run_name: Optional[str] = None,
         uid: Optional[str] = None,
         scrape_metrics: Optional[str] = None,
-        url: str = "",
         rerun_request: Optional[mlrun.common.schemas.RerunWorkflowRequest] = None,
     ) -> mlrun_model.RunObject:
         """
@@ -487,6 +485,7 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         :param run_name:         Name of the run.
         :param uid:              Unique identifier for the run.
         :param scrape_metrics:   Whether to scrape metrics.
+        :param rerun_request:    Workflow request containing the rerun spec.
         :return: RunObject ready for execution.
         """
         source, save, is_context = WorkflowRunners._validate_source(
@@ -519,7 +518,7 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
             engine=workflow_request.spec.engine,
             local=workflow_request.spec.run_local,
             subpath=project.spec.subpath,
-            url=url or source,
+            url=source,
         )
 
         run_object = self._create_run_object(
@@ -687,7 +686,6 @@ class RerunRunner(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         run_name: Optional[str] = None,
         uid: Optional[str] = None,
         scrape_metrics: Optional[str] = None,
-        url: str = "",
     ) -> mlrun_model.RunObject:
         """
         Prepare the RunObject for rerunning the workflow.

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -211,3 +211,55 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             )
         run = runner_class().run(**params)
         assert run.spec.parameters["save"] == expected_save
+
+    def test_schedule_workflow_with_custom_source(
+        self,
+        db: sqlalchemy.orm.Session,
+        k8s_secrets_mock,
+    ):
+        # This test verifies that if a custom source is provided in the workflow request,
+        # it is used for the scheduled workflow instead of the project's source.
+
+        project = mlrun.common.schemas.ProjectOut(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+            spec=mlrun.common.schemas.ProjectSpecOut(
+                source="git://github.com/mlrun/project-demo.git"
+            ),
+        )
+        services.api.crud.Projects().create_project(db, project)
+
+        run_name = "scheduled-run"
+        runner = services.api.crud.WorkflowRunners().create_runner(
+            run_name=run_name,
+            project=project.metadata.name,
+            db_session=db,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+            image="mlrun/mlrun",
+        )
+
+        custom_source = "v3io:///users/testuser/custom_project/project.zip"
+
+        with unittest.mock.patch(
+            "services.api.utils.singletons.scheduler.get_scheduler"
+        ) as scheduler_mock:
+            services.api.crud.WorkflowRunners().schedule(
+                runner=runner,
+                project=project,
+                workflow_request=mlrun.common.schemas.WorkflowRequest(
+                    spec=mlrun.common.schemas.WorkflowSpec(
+                        name=run_name,
+                        engine="remote",
+                        image="mlrun/mlrun",
+                    ),
+                    source=custom_source,
+                ),
+                auth_info=mlrun.common.schemas.AuthInfo(),
+            )
+
+            # Extract the stored scheduled task
+            scheduled_task = scheduler_mock.return_value.store_schedule.call_args[1][
+                "scheduled_object"
+            ]["task"]
+
+            # The run_object parameters should reflect the workflow_request.source
+            assert scheduled_task["spec"]["parameters"]["url"] == custom_source

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -256,10 +256,14 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
                 auth_info=mlrun.common.schemas.AuthInfo(),
             )
 
-            # Extract the stored scheduled task
-            scheduled_task = scheduler_mock.return_value.store_schedule.call_args[1][
-                "scheduled_object"
-            ]["task"]
+            scheduler_mock.return_value.store_schedule.assert_called_once()
+            scheduled_call_kwargs = (
+                scheduler_mock.return_value.store_schedule.call_args.kwargs
+            )
 
-            # The run_object parameters should reflect the workflow_request.source
-            assert scheduled_task["spec"]["parameters"]["url"] == custom_source
+            assert (
+                scheduled_call_kwargs["scheduled_object"]["task"]["spec"]["parameters"][
+                    "url"
+                ]
+                == custom_source
+            )


### PR DESCRIPTION
### 📝 Description
This PR fixes an issue where scheduled workflows always used `project.spec.source`, even when a custom source was provided in the workflow request.

---

### 🛠️ Changes Made

- Removed the explicit `url=project.spec.source` argument in the schedule method so now `_prepare_run_object` will consistently set the workflow URL based on `_validate_source`, ensuring that a custom source from the workflow request is used when provided, otherwise falling back to the project source.
- Removed the now unused url parameter from `_prepare_run_object` and related calls, as the source resolution is fully handled by `_validate_source` and no need for the url param now.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Added a new unit test `test_schedule_workflow_with_custom_source` that ensures:
When a custom source is provided in the workflow request, it is used in the scheduled workflow.
The scheduled workflow no longer defaults to `project.spec.source` when an override is given.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10293
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
