### PR TITLE
[Projects] Fix race condition during project logs deletion

### DIFF
--- a/server/py/services/api/crud/logs.py
+++ b/server/py/services/api/crud/logs.py
@@ -16,6 +16,7 @@ import os
 import pathlib
 import shutil
 import typing
+import errno
 from http import HTTPStatus
 
 from fastapi.concurrency import run_in_threadpool
@@ -77,12 +78,17 @@ class Logs(
         await self._delete_logs(project, run_uids)
 
     @staticmethod
-    def delete_project_logs_legacy(
-        project: str,
-    ):
+    def delete_project_logs_legacy(project: str):
+        def _ignore_missing_files(func, path, exc_info):
+            # covers a race condition where some of the files were deleted by log-collector
+            _, exc, _ = exc_info
+            if isinstance(exc, FileNotFoundError) or getattr(exc, "errno", None) == errno.ENOENT:
+                return
+            raise exc
+
         logs_path = framework.api.utils.project_logs_path(project)
         if logs_path.exists():
-            shutil.rmtree(str(logs_path))
+            shutil.rmtree(str(logs_path), onerror=_ignore_missing_files)
 
     @staticmethod
     def delete_run_logs_legacy(

--- a/server/py/services/api/crud/logs.py
+++ b/server/py/services/api/crud/logs.py
@@ -80,7 +80,7 @@ class Logs(
     @staticmethod
     def delete_project_logs_legacy(project: str):
         def _ignore_missing_files(func, path, exc_info):
-            # covers a race condition where some of the files were deleted by log-collector
+            # handles race conditions where files disappear during deletion (e.g., removed by log-collector or NFS cleanup)
             _, exc, _ = exc_info
             if (
                 isinstance(exc, FileNotFoundError)

--- a/server/py/services/api/crud/logs.py
+++ b/server/py/services/api/crud/logs.py
@@ -80,7 +80,8 @@ class Logs(
     @staticmethod
     def delete_project_logs_legacy(project: str):
         def _ignore_missing_files(func, path, exc_info):
-            # handles race conditions where files disappear during deletion (e.g., removed by log-collector or NFS cleanup)
+            # handles race conditions where files disappear during deletion
+            # (e.g., removed by log-collector or NFS cleanup)
             _, exc, _ = exc_info
             if (
                 isinstance(exc, FileNotFoundError)

--- a/server/py/services/api/crud/logs.py
+++ b/server/py/services/api/crud/logs.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import errno
 import os
 import pathlib
 import shutil
 import typing
-import errno
 from http import HTTPStatus
 
 from fastapi.concurrency import run_in_threadpool
@@ -82,7 +82,10 @@ class Logs(
         def _ignore_missing_files(func, path, exc_info):
             # covers a race condition where some of the files were deleted by log-collector
             _, exc, _ = exc_info
-            if isinstance(exc, FileNotFoundError) or getattr(exc, "errno", None) == errno.ENOENT:
+            if (
+                isinstance(exc, FileNotFoundError)
+                or getattr(exc, "errno", None) == errno.ENOENT
+            ):
                 return
             raise exc
 


### PR DESCRIPTION
### 📝 Description
When deleting project logs, the primary flow calls the log collector service.
If that fails (e.g. connectivity or gRPC errors), we fall back to `delete_project_logs_legacy`, which removes the logs directory with `shutil.rmtree`.

On NFS-backed storage, transient `.nfs*` files are created when a file is deleted but still open by some process. And. then they are automatically removed once the file handle is released. This creates a race condition:

1. `logs_path.exists()` (in https://github.com/mlrun/mlrun/blob/57ce59eea2f798176466d9ac1874ae77a62582e4/server/py/services/api/crud/logs.py#L415) succeeds.
2. `shutil.rmtree` starts walking the tree.
3. `.nfs*` file disappears mid-deletion.
4. `FileNotFoundError is raised`, breaking cleanup.

---

### 🛠️ Changes Made
Wrapped `shutil.rmtree` with an onerror handler that:

* Ignores only `FileNotFoundError` (`ENOENT`) 
* Surfaces all other errors (e.g. permissions and etc).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
Not tested, very hard to reproduce, bug was identified using logs and code reading
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10980
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No


