### PR TITLE
[Model Monitoring] Change `model_configuration` to be named `invocation_config`

### DIFF
--- a/mlrun/artifacts/llm_prompt.py
+++ b/mlrun/artifacts/llm_prompt.py
@@ -41,7 +41,7 @@ class LLMPromptArtifactSpec(ArtifactSpec):
         prompt_template: Optional[list[dict]] = None,
         prompt_path: Optional[str] = None,
         prompt_legend: Optional[dict] = None,
-        model_configuration: Optional[dict] = None,
+        invocation_config: Optional[dict] = None,
         description: Optional[str] = None,
         target_path: Optional[str] = None,
         **kwargs,
@@ -68,13 +68,11 @@ class LLMPromptArtifactSpec(ArtifactSpec):
 
         self.prompt_template = prompt_template
         self.prompt_legend = prompt_legend
-        if model_configuration is not None and not isinstance(
-            model_configuration, dict
-        ):
+        if invocation_config is not None and not isinstance(invocation_config, dict):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "LLMPromptArtifact model_configuration must be a dictionary or None"
             )
-        self.model_configuration = model_configuration or {}
+        self.model_configuration = invocation_config or {}
         self.description = description
         self._model_artifact = (
             model_artifact
@@ -177,7 +175,7 @@ class LLMPromptArtifact(Artifact):
         prompt_template: Optional[list[dict]] = None,
         prompt_path: Optional[str] = None,
         prompt_legend: Optional[dict] = None,
-        model_configuration: Optional[dict] = None,
+        invocation_config: Optional[dict] = None,
         description: Optional[str] = None,
         target_path=None,
         **kwargs,
@@ -187,7 +185,7 @@ class LLMPromptArtifact(Artifact):
             prompt_path=prompt_path,
             prompt_legend=prompt_legend,
             model_artifact=model_artifact,
-            model_configuration=model_configuration,
+            invocation_config=invocation_config,
             target_path=target_path,
             description=description,
         )

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -917,7 +917,7 @@ class MLClientCtx:
         prompt_path: Optional[str] = None,
         prompt_legend: Optional[dict] = None,
         model_artifact: Union[ModelArtifact, str] = None,
-        model_configuration: Optional[dict] = None,
+        invocation_config: Optional[dict] = None,
         description: Optional[str] = None,
         target_path: Optional[str] = None,
         artifact_path: Optional[str] = None,
@@ -997,7 +997,7 @@ class MLClientCtx:
                with the place-holder name. "description" will point to explanation of what that placeholder represents.
                Useful for documenting and clarifying dynamic parts of the prompt.
         :param model_artifact: Reference to the parent model (either `ModelArtifact` or model URI string).
-        :param model_configuration: Dictionary of generation parameters (e.g., temperature, max_tokens).
+        :param invocation_config: Dictionary of generation parameters (e.g., temperature, max_tokens).
         :param description:   Optional description of the prompt.
         :param target_path:   Absolute target path (instead of using artifact_path + local_path)
         :param artifact_path: Target artifact path (when not using the default)
@@ -1023,7 +1023,7 @@ class MLClientCtx:
             prompt_path=prompt_path,
             prompt_legend=prompt_legend,
             model_artifact=model_artifact,
-            model_configuration=model_configuration,
+            invocation_config=invocation_config,
             target_path=target_path,
             description=description,
             **kwargs,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1888,7 +1888,7 @@ class MlrunProject(ModelObj):
         prompt_path: Optional[str] = None,
         prompt_legend: Optional[dict] = None,
         model_artifact: Union[ModelArtifact, str] = None,
-        model_configuration: Optional[dict] = None,
+        invocation_config: Optional[dict] = None,
         description: Optional[str] = None,
         target_path: Optional[str] = None,
         artifact_path: Optional[str] = None,
@@ -1971,7 +1971,7 @@ class MlrunProject(ModelObj):
                with the place-holder name. "description" will point to explanation of what that placeholder represents.
                Useful for documenting and clarifying dynamic parts of the prompt.
         :param model_artifact: Reference to the parent model (either `ModelArtifact` or model URI string).
-        :param model_configuration: Configuration dictionary for model generation parameters
+        :param invocation_config: Configuration dictionary for model generation parameters
                (e.g., temperature, max tokens).
         :param description:   Optional description of the prompt.
         :param target_path:   Absolute target path (instead of using artifact_path + local_path)
@@ -1998,7 +1998,7 @@ class MlrunProject(ModelObj):
             prompt_path=prompt_path,
             prompt_legend=prompt_legend,
             model_artifact=model_artifact,
-            model_configuration=model_configuration,
+            invocation_config=invocation_config,
             target_path=target_path,
             description=description,
             **kwargs,

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1338,7 +1338,7 @@ class LLModel(Model):
         self,
         body: Any,
         messages: Optional[list[dict]] = None,
-        model_configuration: Optional[dict] = None,
+        invocation_config: Optional[dict] = None,
         **kwargs,
     ) -> Any:
         llm_prompt_artifact = kwargs.get("llm_prompt_artifact")
@@ -1349,12 +1349,12 @@ class LLModel(Model):
                 "Invoking model provider",
                 model_name=self.name,
                 messages=messages,
-                model_configuration=model_configuration,
+                model_configuration=invocation_config,
             )
             response_with_stats = self.model_provider.invoke(
                 messages=messages,
                 invoke_response_format=InvokeResponseFormat.USAGE,
-                **(model_configuration or {}),
+                **(invocation_config or {}),
             )
             set_data_by_path(
                 path=self._result_path, data=body, value=response_with_stats
@@ -1428,7 +1428,7 @@ class LLModel(Model):
         return self.predict(
             body,
             messages=messages,
-            model_configuration=model_configuration,
+            invocation_config=model_configuration,
             llm_prompt_artifact=llm_prompt_artifact,
         )
 

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -138,10 +138,10 @@ def test_llm_prompt_artifact_validator():
         match="LLMPromptArtifact model_configuration must be a dictionary or None",
     ):
         mlrun.artifacts.LLMPromptArtifact(
-            model_artifact=model_artifact, model_configuration=50
+            model_artifact=model_artifact, invocation_config=50
         )
     llm_prompt_artifact = mlrun.artifacts.LLMPromptArtifact(
-        model_artifact=model_artifact, model_configuration=None
+        model_artifact=model_artifact, invocation_config=None
     )
     assert llm_prompt_artifact.spec.model_configuration == {}
 

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -205,7 +205,7 @@ class MyLLM(LLModel):
     def predict(self, body, **kwargs):
         body["url"] = self.model_artifact.model_url
         body["default_config"] = self.model_artifact.default_config
-        body["model_configuration"] = kwargs.get("model_configuration")
+        body["model_configuration"] = kwargs.get("invocation_config")
         body["prompt"] = kwargs.get("messages")
         return body
 

--- a/tests/system/runtimes/assets/function_with_llm.py
+++ b/tests/system/runtimes/assets/function_with_llm.py
@@ -19,6 +19,6 @@ class MyLLM(LLModel):
     def predict(self, body, **kwargs):
         body["url"] = self.model_artifact.model_url
         body["default_config"] = self.model_artifact.default_config
-        body["model_configuration"] = kwargs.get("model_configuration")
+        body["model_configuration"] = kwargs.get("invocation_config")
         body["prompt"] = kwargs.get("messages")
         return body


### PR DESCRIPTION
### 📝 Description
The name model_configuration in the LLM prompt artifact as well as the LLModel predict param is misleading - it is not really the configuration for the model (which is passed in the Model class itself), but rather the configuration to be used when invoking the model under the given prompt.

Therefore, we are changing the name of this parameters to invocation_config.

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🔗 References
[ML-11158](https://iguazio.atlassian.net/browse/ML-11158)

---


[ML-11158]: https://iguazio.atlassian.net/browse/ML-11158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ