### PR TITLE
[User Secrets] Revoke token by sending the request header [feature/ig4-authentication]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ install-iguazio-sdk: ## Install iguazio package from Test PyPI only for Python 3
 		$(MLRUN_PYTHON_VENV_PIP_INSTALL) $(MLRUN_PIP_NO_CACHE_FLAG) \
 			--index-url https://test.pypi.org/simple/ \
 			--extra-index-url https://pypi.org/simple \
-			"iguazio~=0.0.1a11"; \
+			"iguazio~=0.0.1a12"; \
 	else \
 		echo "Skipping iguazio install (Python $(MLRUN_PYTHON_VERSION))"; \
 	fi

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -71,7 +71,7 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
 # TODO: remove this once iguazio package is released to PyPI and move to requirements.txt
 # Install iguazio package from Test PyPI
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
-    uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple iguazio~=0.0.1a11 --python-version ${MLRUN_PYTHON_VERSION}
+    uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple iguazio~=0.0.1a12 --python-version ${MLRUN_PYTHON_VERSION}
 
 # Remove server related files that are not needed in the base image
 # Remove ensurepip folders from both conda and system python

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -80,7 +80,7 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     if [ "${MLRUN_PYTHON_VERSION}" = "3.11" ]; then \
       uv pip install --index-url https://test.pypi.org/simple/ \
         --extra-index-url https://pypi.org/simple \
-        iguazio~=0.0.1a11 --python-version ${MLRUN_PYTHON_VERSION}; \
+        iguazio~=0.0.1a12 --python-version ${MLRUN_PYTHON_VERSION}; \
     else \
       echo "Skipping iguazio install for Python ${MLRUN_PYTHON_VERSION}"; \
     fi

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -108,7 +108,9 @@ class Client(BaseClient):
         # TODO: Implement this method once it is available in the Iguazio package
         pass
 
-    def revoke_offline_token(self, token: str) -> None:
+    def revoke_offline_token(
+        self, token: str, request_headers: typing.Optional[dict[str, str]] = None
+    ) -> None:
         """
         Revoke an offline token in Iguazio.
 
@@ -117,6 +119,7 @@ class Client(BaseClient):
         used to obtain access tokens.
 
         :param token: The offline token string to revoke.
+        :param request_headers: Optional request headers to use for authenticating with the Iguazio management service.
         :raises mlrun.errors.MLRunInvalidArgumentError: If the provided token is empty.
         :raises mlrun.errors.MLRunUnauthorizedError: If the revocation request fails.
         """
@@ -128,6 +131,7 @@ class Client(BaseClient):
         try:
             # Use Iguazio client to revoke the token
             options = RevokeOfflineTokenOptionsV1(token=token)
+            self._client.set_override_auth_headers(request_headers)
             self._client.revoke_offline_token(options=options)
             self._logger.info("Successfully revoked offline token via Iguazio")
         except httpx.HTTPStatusError as exc:

--- a/server/py/services/api/api/endpoints/user_secrets.py
+++ b/server/py/services/api/api/endpoints/user_secrets.py
@@ -76,4 +76,5 @@ async def revoke_secret_token(
         services.api.crud.Secrets().revoke_secret_token,
         name,
         auth_info.username,
+        auth_info.request_headers,
     )

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -535,12 +535,23 @@ class Secrets(
         self,
         token_name: str,
         authenticated_username: str,
+        request_headers: typing.Optional[dict[str, str]] = None,
     ):
         """
-        Revoke a user's offline token in Iguazio and delete its Kubernetes secret.
+        Revoke a stored offline token for a user and delete its corresponding Kubernetes secret.
 
-        :param token_name: Logical name of the token to revoke.
-        :param authenticated_username: The user who owns the token.
+        This method performs two actions:
+        1. Calls the Iguazio management service to revoke the offline token.
+        2. Removes the Kubernetes secret named `mlrun-auth-<username>-<token_name>`
+           associated with the token.
+
+        :param token_name:
+            Logical name of the token to revoke (used in the Kubernetes secret name).
+        :param authenticated_username:
+            The username of the authenticated user who owns the token.
+        :param request_headers:
+            Optional request headers (e.g., containing the user's access token)
+            to authenticate with the Iguazio management service.
         """
         logger.debug(
             "Revoking secret token for user",
@@ -564,7 +575,7 @@ class Secrets(
 
         # Revoke via Iguazio
         iguazio_client = framework.utils.clients.iguazio.v4.Client()
-        iguazio_client.revoke_offline_token(token)
+        iguazio_client.revoke_offline_token(token, request_headers)
 
         # Delete the Kubernetes secret
         try:

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -872,7 +872,7 @@ def test_revoke_secret_token_success(mock_iguazio_client):
     mock_secrets_provider.get_user_token_secret_value.assert_called_once_with(
         username=username, token_name=token_name
     )
-    mock_iguazio_client.revoke_offline_token.assert_called_once_with(fake_token)
+    mock_iguazio_client.revoke_offline_token.assert_called_once_with(fake_token, None)
     mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
         username=username, token_name=token_name
     )

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -858,6 +858,9 @@ def test_revoke_secret_token_success(mock_iguazio_client):
     username = "dummy-user"
     token_name = "my-token"
     fake_token = "jwt-token-123"
+    request_headers = {
+        mlrun.common.schemas.HeaderNames.authorization: f"{mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer}123",
+    }
 
     mock_secrets_provider = unittest.mock.Mock()
     services.api.crud.Secrets().secrets_provider = mock_secrets_provider
@@ -866,13 +869,17 @@ def test_revoke_secret_token_success(mock_iguazio_client):
     mock_secrets_provider.delete_user_token_secret = unittest.mock.Mock()
 
     services.api.crud.Secrets().revoke_secret_token(
-        token_name=token_name, authenticated_username=username
+        token_name=token_name,
+        authenticated_username=username,
+        request_headers=request_headers,
     )
 
     mock_secrets_provider.get_user_token_secret_value.assert_called_once_with(
         username=username, token_name=token_name
     )
-    mock_iguazio_client.revoke_offline_token.assert_called_once_with(fake_token, None)
+    mock_iguazio_client.revoke_offline_token.assert_called_once_with(
+        fake_token, request_headers
+    )
     mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
         username=username, token_name=token_name
     )

--- a/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
@@ -14,6 +14,7 @@
 #
 
 import http
+import unittest.mock
 
 import pytest
 from aioresponses import CallbackResult
@@ -27,6 +28,7 @@ from server.py.services.api.tests.unit.utils.clients.iguazio.conftest import (
 )
 from tests.common_fixtures import aioresponses_mock
 
+import framework.utils.clients.iguazio.v4
 from framework.utils.asyncio import maybe_coroutine
 
 
@@ -326,3 +328,22 @@ def sample_user_info(username="dummy-user", user_id="dummy-user-id", group_ids=N
         ],
         "status": {"ctx": "dummy-ctx", "statusCode": http.HTTPStatus.OK.value},
     }
+
+
+def test_revoke_offline_token_success():
+    token = "valid-token"
+    request_headers = {
+        mlrun.common.schemas.HeaderNames.authorization: f"{mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer}123",
+    }
+
+    # prevents from creating a real Iguazio client
+    with unittest.mock.patch("framework.utils.clients.iguazio.v4.iguazio.Client"):
+        client = framework.utils.clients.iguazio.v4.Client()
+        client._client = unittest.mock.MagicMock()
+
+        client.revoke_offline_token(token, request_headers)
+
+        client._client.set_override_auth_headers.assert_called_once_with(
+            request_headers
+        )
+        client._client.revoke_offline_token.assert_called_once()


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
When attempting to call `revoke_offline_token` in Iguazio, it fails with the error:
`No authentication is available, login required when trying to revoke token.`
This happens because the request requires passing the access token from the request headers to Iguazio.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

1. Call `set_override_auth_headers` before revoking the token in Iguazio using the request headers.
2. Bump the Iguazio package to 0.0.1a12.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Tested on my ig4 system 

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11075
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
