### PR TITLE
[Tests] Mock Iguazio v4 client in tests to prevent real initialization [feature/ig4-authentication]

### DIFF
--- a/server/py/services/api/tests/unit/conftest.py
+++ b/server/py/services/api/tests/unit/conftest.py
@@ -193,20 +193,24 @@ def iguazio_client(
 
     if version == "v3":
         module = framework.utils.clients.iguazio.v3
+        client_cls = module.Client if mode == "sync" else module.AsyncClient
+        client = client_cls()
     elif version == "v4":
         module = framework.utils.clients.iguazio.v4
+        client_cls = module.Client if mode == "sync" else module.AsyncClient
+
+        # PATCH iguazio.Client before instantiation
+        with unittest.mock.patch(
+            "framework.utils.clients.iguazio.v4.iguazio.Client"
+        ) as mock_iguazio_cls:
+            mock_instance = unittest.mock.MagicMock()
+            mock_iguazio_cls.return_value = mock_instance
+
+            # Now when Client.__init__ runs, self._client is assigned to mock_instance
+            client = client_cls()
     else:
         raise ValueError(f"Unsupported client version: {version}")
 
-    if mode == "async":
-        client = module.AsyncClient()
-    elif mode == "sync":
-        client = module.Client()
-    else:
-        raise ValueError(f"Unsupported client mode: {mode}")
-
-    # force running init again so the configured api url will be used
-    client.__init__()
     client._wait_for_job_completion_retry_interval = 0
 
     # inject the request param into client, so we can use it in tests


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Fix an issue when running tests for the v4 Iguazio client.
Previously, instantiating the v4 client would initialize the real iguazio.Client, which reads the local igz.yaml file and attempts to refresh tokens. If this file exists on the machine, it could trigger real network requests during tests.

This PR mocks the iguazio.Client using unittest.mock.MagicMock to prevent actual initialization and external calls, allowing tests to run safely in isolation.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

- Mocked `self._client` in the v4 client to avoid real Iguazio client initialization.
- Updated the `iguazio_client` pytest fixture to apply the mock for v4 clients.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
