### PR TITLE
[Pipeline] - crud.list_pipelines required filter by project name only when the project is not '*'

### DIFF
--- a/server/py/services/api/crud/pipelines.py
+++ b/server/py/services/api/crud/pipelines.py
@@ -86,7 +86,7 @@ class Pipelines(
             sort_by=sort_by,
             filter_json=filter_json,
         ):
-            if project:
+            if project and project != "*":
                 if isinstance(project, str):
                     page_runs = [
                         run

--- a/server/py/services/api/tests/unit/crud/test_pipelines.py
+++ b/server/py/services/api/tests/unit/crud/test_pipelines.py
@@ -13,16 +13,14 @@
 # limitations under the License.
 
 import json
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 import mlrun_pipelines
 import mlrun_pipelines.common.helpers
 
 import services.api.crud
-
-from unittest.mock import MagicMock, patch
-import pytest
-from services.api.crud.pipelines import Pipelines
-import mlrun.common.formatters
 
 
 def test_resolve_pipeline_project():
@@ -265,10 +263,13 @@ def test_resolve_pipeline_project():
         assert project == case["expected_project"]
 
 
-@pytest.mark.parametrize("project,expected_ids", [
-    ("project-a", ["run1"]),
-    ("*", ["run1", "run2"]),
-])
+@pytest.mark.parametrize(
+    "project,expected_ids",
+    [
+        ("project-a", ["run1"]),
+        ("*", ["run1", "run2"]),
+    ],
+)
 def test_list_pipelines_project_filtering(project, expected_ids):
     pipelines = services.api.crud.pipelines.Pipelines()
     db_session = MagicMock()
@@ -280,14 +281,24 @@ def test_list_pipelines_project_filtering(project, expected_ids):
     mock_kfp_client = MagicMock()
     mock_kfp_client.list_runs.return_value = [(all_runs, None)]
 
-    with patch.object(
-        services.api.crud.pipelines.Pipelines, "_initialize_kfp_client", return_value=mock_kfp_client
-    ), patch.object(
-        services.api.crud.pipelines.Pipelines, "_resolve_project_from_pipeline",
-        side_effect=lambda run: "project-a" if run.id == "run1" else "project-b"
-    ), patch.object(
-        services.api.crud.pipelines.Pipelines, "_format_runs",
-        side_effect=lambda kfp_client, runs, format_: [{"id": r.id, "name": r.name} for r in runs]
+    with (
+        patch.object(
+            services.api.crud.pipelines.Pipelines,
+            "_initialize_kfp_client",
+            return_value=mock_kfp_client,
+        ),
+        patch.object(
+            services.api.crud.pipelines.Pipelines,
+            "_resolve_project_from_pipeline",
+            side_effect=lambda run: "project-a" if run.id == "run1" else "project-b",
+        ),
+        patch.object(
+            services.api.crud.pipelines.Pipelines,
+            "_format_runs",
+            side_effect=lambda kfp_client, runs, format_: [
+                {"id": r.id, "name": r.name} for r in runs
+            ],
+        ),
     ):
         total_size, next_page_token, runs = pipelines.list_pipelines(
             db_session=db_session,

--- a/server/py/services/api/tests/unit/crud/test_pipelines.py
+++ b/server/py/services/api/tests/unit/crud/test_pipelines.py
@@ -19,6 +19,11 @@ import mlrun_pipelines.common.helpers
 
 import services.api.crud
 
+from unittest.mock import MagicMock, patch
+import pytest
+from services.api.crud.pipelines import Pipelines
+import mlrun.common.formatters
+
 
 def test_resolve_pipeline_project():
     cases = [
@@ -258,3 +263,37 @@ def test_resolve_pipeline_project():
             mlrun_pipelines.models.PipelineRun(pipeline)
         )
         assert project == case["expected_project"]
+
+
+@pytest.mark.parametrize("project,expected_ids", [
+    ("project-a", ["run1"]),
+    ("*", ["run1", "run2"]),
+])
+def test_list_pipelines_project_filtering(project, expected_ids):
+    pipelines = services.api.crud.pipelines.Pipelines()
+    db_session = MagicMock()
+
+    # Mock runs and KFP client
+    run1 = MagicMock(id="run1", name="pipeline1", status="Succeeded")
+    run2 = MagicMock(id="run2", name="pipeline2", status="Failed")
+    all_runs = [run1, run2]
+    mock_kfp_client = MagicMock()
+    mock_kfp_client.list_runs.return_value = [(all_runs, None)]
+
+    with patch.object(
+        services.api.crud.pipelines.Pipelines, "_initialize_kfp_client", return_value=mock_kfp_client
+    ), patch.object(
+        services.api.crud.pipelines.Pipelines, "_resolve_project_from_pipeline",
+        side_effect=lambda run: "project-a" if run.id == "run1" else "project-b"
+    ), patch.object(
+        services.api.crud.pipelines.Pipelines, "_format_runs",
+        side_effect=lambda kfp_client, runs, format_: [{"id": r.id, "name": r.name} for r in runs]
+    ):
+        total_size, next_page_token, runs = pipelines.list_pipelines(
+            db_session=db_session,
+            project=project,
+        )
+
+    assert total_size == len(expected_ids)
+    assert next_page_token is None
+    assert [r["id"] for r in runs] == expected_ids


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

When listing pipelines, each run was being filtered by project name. However, if `project="*"`, the filtering logic failed, causing the project summaries workflow counter to return empty results.
This PR fixes the filtering logic, ensuring the workflow counter works correctly when `project="*"`.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Fix crud `list_pipelines`
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

Manual testing that project summaries workflow counter displays the correct value

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11141
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
