### PR TITLE
[Docs] Clarify retry default backoff delay

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -182,7 +182,7 @@ def run_function(
                             The `count` field in the `Retry` object specifies the number of retry attempts.
                             If `count=0`, the run will not be retried.
                             The `backoff` field specifies the retry backoff strategy between retry attempts.
-                            If not provided, no backoff is applied.
+                            If not provided, the default backoff delay is 30 seconds.
     :return: MLRun RunObject or PipelineNodeWrapper
     """
     if artifact_path:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4109,7 +4109,7 @@ class MlrunProject(ModelObj):
                                 The `count` field in the `Retry` object specifies the number of retry attempts.
                                 If `count=0`, the run will not be retried.
                                 The `backoff` field specifies the retry backoff strategy between retry attempts.
-                                If not provided, no backoff is applied.
+                                If not provided, the default backoff delay is 30 seconds.
         :return: MLRun RunObject or PipelineNodeWrapper
         """
         if artifact_path:

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -381,7 +381,7 @@ class BaseRuntime(ModelObj):
                                The `count` field in the `Retry` object specifies the number of retry attempts.
                                If `count=0`, the run will not be retried.
                                The `backoff` field specifies the retry backoff strategy between retry attempts.
-                               If not provided, no backoff is applied.
+                               If not provided, the default backoff delay is 30 seconds.
         :return: Run context object (RunObject) with run metadata, results and status
         """
         if artifact_path or out_path:


### PR DESCRIPTION
### 📝 Description
Updates the retry parameter documentation to clarify the default backoff behavior.
Previously, the docstring stated that no backoff is applied if not provided, which could be misleading.
It now specifies that the default backoff delay is 30 seconds.

---

### 🛠️ Changes Made
Clarified the retry parameter docstring to note the default backoff delay (30s).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10628
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
