### PR TITLE
[Datastore] Fix WASBS path conversion to use container

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -234,7 +234,18 @@ class AzureBlobStore(DataStore):
         #  if called without passing dataitem - like in fset.purge_targets,
         #  key will include schema.
         if not schema:
-            key = Path(self.endpoint, key).as_posix()
+            # For wasbs/wasb, the filesystem is scoped to the container, so we need to use
+            # the container name as the base path, not the hostname endpoint.
+            # For az://, endpoint already contains the container name.
+            if self.kind in ["wasbs", "wasb"]:
+                container = self.storage_options.get("container")
+                if container:
+                    key = Path(container, key).as_posix()
+                else:
+                    # If no container found, use endpoint (might be hostname, but better than nothing)
+                    key = Path(self.endpoint, key).as_posix()
+            else:
+                key = Path(self.endpoint, key).as_posix()
         return key
 
     def upload(self, key, src_path):

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -614,3 +614,81 @@ class TestAzureBlobStore:
             assert (
                 parsed_url.netloc == case["expected_netloc"]
             ), f"Netloc mismatch for {case['url']}"
+
+    def test_convert_key_to_remote_path_wasbs(self):
+        """Test _convert_key_to_remote_path for WASBS URLs uses container, not hostname"""
+        # For WASBS URLs, the endpoint after constructor is the hostname
+        # but _convert_key_to_remote_path should use the container from storage_options
+        connection_string = (
+            "DefaultEndpointsProtocol=https;AccountName=testdata;"
+            "AccountKey=xxx;EndpointSuffix=core.windows.net"
+        )
+        store = self._create_store(
+            schema="wasbs",
+            endpoint="testdata.blob.core.windows.net",  # hostname after container extraction
+            secrets={"connection_string": connection_string},
+        )
+        store._container_from_endpoint = "testcbs"
+
+        # Mock storage_options to include the container
+        mock_storage_options = {
+            "container": "testcbs",
+            "account_name": "testdata",
+        }
+        with patch.object(store, "_storage_options", mock_storage_options):
+            # Test path conversion - should NOT include hostname
+            result = store._convert_key_to_remote_path(
+                "vmdev213.lab.iguazeng.com/cmtayiymak/1759222142345_752"
+            )
+            expected = "testcbs/vmdev213.lab.iguazeng.com/cmtayiymak/1759222142345_752"
+            assert result == expected, f"Expected {expected}, got {result}"
+
+            # Verify it does NOT include hostname
+            assert "testdata.blob.core.windows.net" not in result
+
+    def test_convert_key_to_remote_path_az(self):
+        """Test _convert_key_to_remote_path for az:// URLs uses endpoint as container"""
+        # For az:// URLs, endpoint IS the container name
+        store = self._create_store(
+            schema="az", endpoint="mycontainer", secrets={"account_name": "teststorage"}
+        )
+
+        result = store._convert_key_to_remote_path("path/to/file.txt")
+        expected = "mycontainer/path/to/file.txt"
+        assert result == expected
+
+    def test_convert_key_to_remote_path_with_schema(self):
+        """Test _convert_key_to_remote_path when key already has schema"""
+        store = self._create_store(
+            schema="wasbs",
+            endpoint="testdata.blob.core.windows.net",
+        )
+
+        # When key has a schema, it should be returned as-is (stripped of leading /)
+        result = store._convert_key_to_remote_path(
+            "wasbs://container@host/path/to/file"
+        )
+        expected = "wasbs://container@host/path/to/file"
+        assert result == expected
+
+    def test_convert_key_to_remote_path_wasbs_no_container_fallback(self):
+        """Test _convert_key_to_remote_path falls back to endpoint when container is missing for wasbs"""
+        # Edge case: wasbs without container (invalid config, but should not crash)
+        store = self._create_store(
+            schema="wasbs",
+            endpoint="testdata.blob.core.windows.net",
+            secrets={"account_name": "testdata", "account_key": "xxx"},
+        )
+
+        # Mock storage_options WITHOUT container
+        mock_storage_options = {
+            "account_name": "testdata",
+            "account_key": "xxx",
+            # No container!
+        }
+        with patch.object(store, "_storage_options", mock_storage_options):
+            # Should fall back to using endpoint (even though it's hostname)
+            result = store._convert_key_to_remote_path("path/to/file.txt")
+            # Falls back to endpoint (hostname) - not ideal but maintains backward compatibility
+            expected = "testdata.blob.core.windows.net/path/to/file.txt"
+            assert result == expected


### PR DESCRIPTION
 Fixed `InvalidResourceName` error when using Azure WASBS datastore with filesystem operations like `fs.rm()`, `fs.get()`, `fs.put()`, etc.

  **Problem:**
  When using WASBS URLs (`wasbs://container@host/path`), the `_convert_key_to_remote_path()` method was incorrectly using the storage account hostname instead of the container name when constructing filesystem paths. This caused Azure to reject operations with
   `InvalidResourceName` error because paths included the hostname (e.g., `account.blob.core.windows.net/path`).

  **Root Cause:**
  For WASBS URLs, after the constructor extracts the container from the URL format `container@host`, `self.endpoint` contains the hostname. The old code used `self.endpoint` for all schemas, which worked for `az://` (where endpoint IS the container) but failed
   for `wasbs://` (where endpoint is the hostname).

  **Solution:**
  Updated `_convert_key_to_remote_path()` to use the container name from `storage_options` for wasbs/wasb schemas, with a fallback to endpoint for backward compatibility if container is missing.

  ---

  ### 🛠️ Changes Made

  - **mlrun/datastore/azure_blob.py**:
    - Modified `_convert_key_to_remote_path()` to use container instead of hostname for wasbs/wasb schemas
    - Added fallback logic to use endpoint if container is missing (backward compatibility)
    - Added inline comments explaining the logic for different schemas

  - **tests/datastore/test_azure_blob_store.py**:
    - Added `test_convert_key_to_remote_path_wasbs` - Verifies WASBS uses container, not hostname
    - Added `test_convert_key_to_remote_path_az` - Ensures az:// continues working correctly
    - Added `test_convert_key_to_remote_path_with_schema` - Tests full URL pass-through
    - Added `test_convert_key_to_remote_path_wasbs_no_container_fallback` - Tests edge case handling

  ---

  ### ✅ Checklist
  - [x] I updated the documentation (if applicable) - Code comments added
  - [x] I have tested the changes in this PR

  ---

  ### 🧪 Testing

  **Unit Tests:**
  4 new tests added
  - Tests cover:
    - WASBS path conversion with container (main fix)
    - az:// path conversion (regression prevention)
    - Full URL pass-through behavior
    - Missing container fallback (edge case)

  **Test Coverage:**
  - Main fix: Verified paths use container name instead of hostname
  - Backward compatibility: Ensured az:// schema still works
  - Edge cases: Tested fallback when container is missing


  ---

  ### 🔗 References
  - Ticket link: ML-10748
  - Related issue: Azure WASBS datastore `fs.rm()` operations failing with InvalidResourceName

  ---

  ### 🚨 Breaking Changes?

  - [x] No

  This change maintains backward compatibility:
  - Existing az:// URLs work unchanged
  - WASBS URLs now work correctly (previously broken)
  - Edge case fallback preserves old behavior for incomplete configs

  ---

  ### 🔍️ Additional Notes

  **Container Resolution Priority** (unchanged):
  1. Container extracted from WASBS URL (`wasbs://container@host`)
  2. Container from az:// endpoint (endpoint IS the container)
  3. Container from connection string BlobEndpoint path

  **Impact:**
  - Fixes filesystem operations (rm, get, put, listdir) for WASBS URLs
  - No impact on Spark operations (spark_url, get_spark_options)
  - No breaking changes to existing functionality