### PR TITLE
[Function] Do not allow running of functions that use secrets from the wrong project

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -502,9 +502,14 @@ def get_in(obj, keys, default=None):
     if isinstance(keys, str):
         keys = keys.split(".")
     for key in keys:
-        if not obj or key not in obj:
+        if obj is None:
             return default
-        obj = obj[key]
+        if isinstance(obj, dict):
+            if key not in obj:
+                return default
+            obj = obj[key]
+        else:
+            obj = getattr(obj, key, default)
     return obj
 
 

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -313,12 +313,6 @@ def validate_function_secret_sources(function):
     secrets = mlrun.secrets.SecretsStore.from_list(secrets_list)
 
     project_name = get_in(function, ["metadata", "project"])
-    if k8s_secrets := secrets.get_k8s_secrets():
-        for secret_name in k8s_secrets.keys():
-            validate_secret_allowed(
-                project_name=project_name,
-                secret_name=secret_name,
-            )
 
     if azure_k8s_secrets := secrets.get_azure_vault_k8s_secret():
         validate_secret_allowed(

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -336,6 +336,7 @@ def apply_enrichment_and_validation_on_function(
     validate_service_account: bool = True,
     mask_sensitive_data: bool = True,
     ensure_security_context: bool = True,
+        allow_empty_access_key: bool = False,
 ):
     """
     This function should be used only on server side.
@@ -350,7 +351,11 @@ def apply_enrichment_and_validation_on_function(
     # if auth given in request ensure the function pod will have these auth env vars set, otherwise the job won't
     # be able to communicate with the api
     if ensure_auth:
-        ensure_function_has_auth_set(function, auth_info)
+        ensure_function_has_auth_set(
+            function,
+            auth_info,
+            allow_empty_access_key=allow_empty_access_key,
+        )
 
     # if this was triggered by the UI, we will need to attempt auto-mount based on auto-mount config and params passed
     # in the auth_info. If this was triggered by the SDK, then auto-mount was already attempted and will be skipped.
@@ -456,15 +461,6 @@ def validate_secret_allowed(
             f"Failed to validate secret '{secret_name}': it belongs to a different project than the"
             f" function's project '{project_name}'"
         )
-
-
-def ensure_function_auth_and_sensitive_data_is_masked(
-    function,
-    auth_info: mlrun.common.schemas.AuthInfo,
-    allow_empty_access_key: bool = False,
-):
-    ensure_function_has_auth_set(function, auth_info, allow_empty_access_key)
-    mask_function_sensitive_data(function, auth_info)
 
 
 def mask_function_sensitive_data(function, auth_info: mlrun.common.schemas.AuthInfo):

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -294,22 +294,25 @@ async def submit_run(
     return response
 
 
-def apply_enrichment_and_validation_on_task(task: dict):
+def apply_enrichment_and_validation_on_task(
+    task: dict, mask_notification_params_on_task: bool = True
+):
     # Conceal notification config params from the task object with secrets
-    framework.utils.notifications.mask_notification_params_on_task(
-        task, framework.constants.MaskOperations.CONCEAL
-    )
+    if mask_notification_params_on_task:
+        framework.utils.notifications.mask_notification_params_on_task(
+            task, framework.constants.MaskOperations.CONCEAL
+        )
     # validates that secrets used in the task are allowed
     # currently, this only ensures that if k8s mlrun project secrets are used,
     # they belong to the correct project (not another project’s secret)
-    validate_task_secrets(task)
+    validate_function_secret_sources(task)
 
 
-def validate_task_secrets(task: dict):
-    spec = task.get("spec", {})
-    secrets = mlrun.secrets.SecretsStore.from_list(spec.get(RunKeys.secrets))
-    project_name = task.get("metadata", {}).get("project")
+def validate_function_secret_sources(function):
+    secrets_list = get_in(function, ["spec", RunKeys.secrets], default=[])
+    secrets = mlrun.secrets.SecretsStore.from_list(secrets_list)
 
+    project_name = get_in(function, ["metadata", "project"])
     if k8s_secrets := secrets.get_k8s_secrets():
         for secret_name in k8s_secrets.keys():
             validate_secret_allowed(
@@ -364,29 +367,43 @@ def apply_enrichment_and_validation_on_function(
     if ensure_security_context:
         ensure_function_security_context(function, auth_info)
 
-    validate_volume_mounts(function)
-    validate_env_vars(function)
+    validate_function_volume_mounts(function)
+    validate_function_env_vars(function)
+    validate_function_secret_sources(function)
 
 
-def validate_volume_mounts(function):
+def validate_function_volume_mounts(
+    function: typing.Union[dict, mlrun.runtimes.KubeResource],
+):
     """
     Ensure that if a project secret is mounted to the function,
     it matches the function's project.
     """
-    if function.spec.volumes:
-        for volume in function.spec.volumes:
-            secret_name = volume.get("secret", {}).get("secretName", "")
-            if not secret_name:
-                continue
-            validate_secret_allowed(function.metadata.project, secret_name)
+    project = get_in(function, "metadata.project")
+    volumes = get_in(function, "spec.volumes")
+
+    if not project or not volumes:
+        return
+
+    for volume in volumes:
+        secret_name = volume.get("secret", {}).get("secretName", "")
+        if not secret_name:
+            continue
+        validate_secret_allowed(project, secret_name)
 
 
-def validate_env_vars(function):
+def validate_function_env_vars(function):
     """
     Ensure that if a project secret is referenced through environment variables,
     the secret belongs to the same project as the function.
     """
-    for env_var in function.spec.env or []:
+    project = get_in(function, "metadata.project")
+    env_vars = get_in(function, "spec.env")
+
+    if not env_vars or not project:
+        return
+
+    for env_var in env_vars:
         # Handle both dict and V1EnvVar
         if isinstance(env_var, dict):
             value_from = env_var.get("valueFrom")
@@ -414,7 +431,7 @@ def validate_env_vars(function):
             continue
 
         validate_secret_allowed(
-            project_name=function.metadata.project,
+            project_name=project,
             secret_name=secret_name,
         )
 
@@ -436,13 +453,9 @@ def validate_secret_allowed(
         and secret_name != project_secret_name
     ):
         raise mlrun.errors.MLRunInvalidArgumentError(
-            f"Function project {project_name} does not match "
-            f"project secret mounted {secret_name}"
+            f"Failed to validate secret '{secret_name}': it belongs to a different project than the"
+            f" function's project '{project_name}'"
         )
-
-
-def validate_secrets():
-    pass
 
 
 def ensure_function_auth_and_sensitive_data_is_masked(

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -31,6 +31,7 @@ import semver
 import sqlalchemy.orm
 from fastapi import BackgroundTasks, HTTPException
 from fastapi.concurrency import run_in_threadpool
+from kubernetes.client import V1EnvVar, V1EnvVarSource
 from sqlalchemy.orm import Session
 
 import mlrun.common.schemas
@@ -43,7 +44,7 @@ from mlrun.config import config
 from mlrun.errors import err_to_str
 from mlrun.run import import_function, new_function
 from mlrun.runtimes.utils import enrich_function_from_dict
-from mlrun.utils import get_in, logger
+from mlrun.utils import RunKeys, get_in, logger
 
 import framework.constants
 import framework.db.session
@@ -172,7 +173,9 @@ def parse_submit_run_body(data):
     return function_dict, function_url, task
 
 
-def _generate_function_and_task_from_submit_run_body(db_session: Session, data):
+def _generate_function_and_task_from_submit_run_body(
+    db_session: Session, auth_info: mlrun.common.schemas.AuthInfo, data
+):
     function_dict, function_url, task = parse_submit_run_body(data)
 
     if function_dict and not function_url:
@@ -200,6 +203,7 @@ def _generate_function_and_task_from_submit_run_body(db_session: Session, data):
             # assign values from it to the main function object
             function = enrich_function_from_dict(function, function_dict)
 
+    apply_enrichment_and_validation_on_function(function=function, auth_info=auth_info)
     apply_enrichment_and_validation_on_task(task)
 
     return function, task
@@ -218,7 +222,9 @@ async def submit_run(
     response = None
 
     try:
-        fn, task = _generate_function_and_task_from_submit_run_body(db_session, data)
+        fn, task = _generate_function_and_task_from_submit_run_body(
+            db_session, auth_info, data
+        )
         run_db = get_run_db_instance(db_session)
         fn.set_db_connection(run_db)
 
@@ -288,11 +294,34 @@ async def submit_run(
     return response
 
 
-def apply_enrichment_and_validation_on_task(task):
+def apply_enrichment_and_validation_on_task(task: dict):
     # Conceal notification config params from the task object with secrets
     framework.utils.notifications.mask_notification_params_on_task(
         task, framework.constants.MaskOperations.CONCEAL
     )
+    # validates that secrets used in the task are allowed
+    # currently, this only ensures that if k8s mlrun project secrets are used,
+    # they belong to the correct project (not another project’s secret)
+    validate_task_secrets(task)
+
+
+def validate_task_secrets(task: dict):
+    spec = task.get("spec", {})
+    secrets = mlrun.secrets.SecretsStore.from_list(spec.get(RunKeys.secrets))
+    project_name = task.get("metadata", {}).get("project")
+
+    if k8s_secrets := secrets.get_k8s_secrets():
+        for secret_name in k8s_secrets.keys():
+            validate_secret_allowed(
+                project_name=project_name,
+                secret_name=secret_name,
+            )
+
+    if azure_k8s_secrets := secrets.get_azure_vault_k8s_secret():
+        validate_secret_allowed(
+            project_name=project_name,
+            secret_name=azure_k8s_secrets,
+        )
 
 
 # TODO: split enrichment and validation to separate functions should be in the launcher
@@ -334,6 +363,86 @@ def apply_enrichment_and_validation_on_function(
 
     if ensure_security_context:
         ensure_function_security_context(function, auth_info)
+
+    validate_volume_mounts(function)
+    validate_env_vars(function)
+
+
+def validate_volume_mounts(function):
+    """
+    Ensure that if a project secret is mounted to the function,
+    it matches the function's project.
+    """
+    if function.spec.volumes:
+        for volume in function.spec.volumes:
+            secret_name = volume.get("secret", {}).get("secretName", "")
+            if not secret_name:
+                continue
+            validate_secret_allowed(function.metadata.project, secret_name)
+
+
+def validate_env_vars(function):
+    """
+    Ensure that if a project secret is referenced through environment variables,
+    the secret belongs to the same project as the function.
+    """
+    for env_var in function.spec.env or []:
+        # Handle both dict and V1EnvVar
+        if isinstance(env_var, dict):
+            value_from = env_var.get("valueFrom")
+        elif isinstance(env_var, V1EnvVar):
+            value_from = env_var.value_from
+        else:
+            continue
+
+        if not value_from:
+            continue
+
+        # Handle both dict and V1EnvVarSource
+        if isinstance(value_from, dict):
+            secret_ref = value_from.get("secretKeyRef")
+            if secret_ref and "name" in secret_ref:
+                secret_name = secret_ref["name"]
+            else:
+                continue
+        elif isinstance(value_from, V1EnvVarSource) and value_from.secret_key_ref:
+            secret_name = value_from.secret_key_ref.name
+        else:
+            continue
+
+        if not secret_name:
+            continue
+
+        validate_secret_allowed(
+            project_name=function.metadata.project,
+            secret_name=secret_name,
+        )
+
+
+def validate_secret_allowed(
+    project_name: str,
+    secret_name: str,
+):
+    project_secret_name = (
+        framework.utils.singletons.k8s.get_k8s_helper().get_project_secret_name(
+            project_name
+        )
+    )
+    project_secret_prefix = (
+        framework.utils.singletons.k8s.get_k8s_helper().get_project_secret_name("")
+    )
+    if (
+        secret_name.startswith(project_secret_prefix)
+        and secret_name != project_secret_name
+    ):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Function project {project_name} does not match "
+            f"project secret mounted {secret_name}"
+        )
+
+
+def validate_secrets():
+    pass
 
 
 def ensure_function_auth_and_sensitive_data_is_masked(
@@ -897,7 +1006,9 @@ def submit_run_from_body(
     auth_info: mlrun.common.schemas.AuthInfo,
     data,
 ):
-    fn, task = _generate_function_and_task_from_submit_run_body(db_session, data)
+    fn, task = _generate_function_and_task_from_submit_run_body(
+        db_session, auth_info, data
+    )
     run_db = get_run_db_instance(db_session)
     fn.set_db_connection(run_db)
     return submit_run_sync(db_session, auth_info, fn, task, data)

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -336,7 +336,7 @@ def apply_enrichment_and_validation_on_function(
     validate_service_account: bool = True,
     mask_sensitive_data: bool = True,
     ensure_security_context: bool = True,
-        allow_empty_access_key: bool = False,
+    allow_empty_access_key: bool = False,
 ):
     """
     This function should be used only on server side.

--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -461,6 +461,17 @@ def _deploy_function(
         launcher.enrich_runtime(runtime=fn, full=True, client_version=client_version)
 
         fn.pre_deploy_validation()
+
+        # only validate
+        framework.api.utils.apply_enrichment_and_validation_on_function(
+            function=fn,
+            auth_info=auth_info,
+            ensure_auth=False,
+            perform_auto_mount=False,
+            mask_sensitive_data=False,
+            ensure_security_context=False,
+        )
+
         # before saving function to DB, we need to mask some nuclio-specific fields
         # which later in Nuclio will be masked and saved to secrets
         raw_config = fn.mask_sensitive_data_in_config()

--- a/server/py/services/api/crud/functions.py
+++ b/server/py/services/api/crud/functions.py
@@ -51,8 +51,12 @@ class Functions(
             # intermediate steps or temporary objects which might not be executed at any phase and therefore we don't
             # want to enrich if user didn't requested.
             # (The way user will request to generate is by passing $generate in the metadata.credentials.access_key)
-            framework.api.utils.ensure_function_auth_and_sensitive_data_is_masked(
-                function_obj, auth_info, allow_empty_access_key=True
+            framework.api.utils.apply_enrichment_and_validation_on_function(
+                function=function_obj,
+                auth_info=auth_info,
+                allow_empty_access_key=True,
+                perform_auto_mount=False,
+                ensure_security_context=False,
             )
             function = function_obj.to_dict()
 

--- a/server/py/services/api/tests/unit/api/assets/handler.py
+++ b/server/py/services/api/tests/unit/api/assets/handler.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def handler():
+    return ""

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -14,6 +14,7 @@
 
 import base64
 import json
+import pathlib
 import unittest.mock
 from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -30,6 +31,7 @@ import mlrun
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.k8s_utils
+import mlrun.runtimes.mounts
 import mlrun.runtimes.pod
 import mlrun.utils
 from server.py.framework.api.utils import (
@@ -51,6 +53,10 @@ pytestmark = pytest.mark.usefixtures("k8s_secrets_mock")
 PROJECT = "some-project"
 
 
+def assets_path():
+    return pathlib.Path(__file__).absolute().parent / "assets"
+
+
 def test_submit_run_sync(db: Session, client: TestClient):
     auth_info = mlrun.common.schemas.AuthInfo()
     services.api.tests.unit.api.utils.create_project(client, PROJECT)
@@ -69,7 +75,9 @@ def test_submit_run_sync(db: Session, client: TestClient):
             "metadata": {"credentials": {"access_key": "some-access-key-override"}},
         },
     }
-    fn, task = _generate_function_and_task_from_submit_run_body(db, submit_job_body)
+    fn, task = _generate_function_and_task_from_submit_run_body(
+        db, auth_info, submit_job_body
+    )
     _, _, _, response_data = framework.api.utils.submit_run_sync(
         db,
         auth_info,
@@ -81,7 +89,9 @@ def test_submit_run_sync(db: Session, client: TestClient):
 
     # submit again, make sure it was modified
     submit_job_body["schedule"] = "0 1 * * *"  # change schedule
-    fn, task = _generate_function_and_task_from_submit_run_body(db, submit_job_body)
+    fn, task = _generate_function_and_task_from_submit_run_body(
+        db, auth_info, submit_job_body
+    )
     _, _, _, response_data = framework.api.utils.submit_run_sync(
         db,
         auth_info,
@@ -133,7 +143,9 @@ def test_submit_run_sync_schedule_with_function_overrides(
             },
         },
     }
-    fn, task = _generate_function_and_task_from_submit_run_body(db, submit_job_body)
+    fn, task = _generate_function_and_task_from_submit_run_body(
+        db, auth_info, submit_job_body
+    )
     _, _, _, response_data = framework.api.utils.submit_run_sync(
         db, auth_info, fn, task, submit_job_body
     )
@@ -301,7 +313,7 @@ def test_generate_function_and_task_from_submit_run_body_body_override_values(
     }
     parsed_function_object, task = (
         framework.api.utils._generate_function_and_task_from_submit_run_body(
-            db, submit_job_body
+            db, mlrun.common.schemas.AuthInfo(), submit_job_body
         )
     )
     assert parsed_function_object.metadata.name == function_name
@@ -405,7 +417,7 @@ def test_function_object_only_persists_preemption_mode_no_scheduling_fields_on_s
 
     parsed_function_object, task = (
         framework.api.utils._generate_function_and_task_from_submit_run_body(
-            db, submit_job_body
+            db, mlrun.common.schemas.AuthInfo(), submit_job_body
         )
     )
     assert (
@@ -435,7 +447,7 @@ def test_function_object_only_persists_preemption_mode_no_scheduling_fields_on_s
     }
     parsed_function_object, task = (
         framework.api.utils._generate_function_and_task_from_submit_run_body(
-            db, submit_job_body
+            db, mlrun.common.schemas.AuthInfo(), submit_job_body
         )
     )
 
@@ -464,7 +476,7 @@ def test_generate_function_and_task_from_submit_run_body_keep_resources(
     }
     parsed_function_object, task = (
         framework.api.utils._generate_function_and_task_from_submit_run_body(
-            db, submit_job_body
+            db, mlrun.common.schemas.AuthInfo(), submit_job_body
         )
     )
     assert parsed_function_object.metadata.name == function_name
@@ -507,7 +519,7 @@ def test_generate_function_and_task_from_submit_run_body_keep_credentials(
     }
     parsed_function_object, task = (
         framework.api.utils._generate_function_and_task_from_submit_run_body(
-            db, submit_job_body
+            db, mlrun.common.schemas.AuthInfo(), submit_job_body
         )
     )
     assert parsed_function_object.metadata.name == function_name
@@ -1321,7 +1333,7 @@ def test_generate_function_and_task_from_submit_run_body_imported_function_proje
     }
     parsed_function_object, task = (
         framework.api.utils._generate_function_and_task_from_submit_run_body(
-            db, submit_job_body
+            db, mlrun.common.schemas.AuthInfo(), submit_job_body
         )
     )
     assert parsed_function_object.metadata.project == PROJECT
@@ -1898,3 +1910,150 @@ def test_resolve_client_default_kfp_image(
         project, workflow_spec, client_version
     )
     assert image == expected_image
+
+
+@pytest.mark.parametrize(
+    "secret_sources, expected_exception",
+    [
+        # Inline secrets only (should pass)
+        ([{"kind": "inline", "source": {}}], None),
+        # Azure Vault with empty secrets but correct k8s_secret (should raise)
+        (
+            [
+                {"kind": "inline", "source": {}},
+                {
+                    "kind": "azure_vault",
+                    "source": {
+                        "k8s_secret": "mlrun-project-secrets-default",
+                        "name": "my-vault-name",
+                        "secrets": [],
+                    },
+                },
+            ],
+            mlrun.errors.MLRunInvalidArgumentError,
+        ),
+        # Kubernetes secret with incorrect project secret (should raise)
+        (
+            [
+                {
+                    "kind": "kubernetes",
+                    "source": ["mlrun-project-secrets-wrong"],
+                }
+            ],
+            mlrun.errors.MLRunInvalidArgumentError,
+        ),
+        # Kubernetes secret with allowed project secret (should pass)
+        (
+            [
+                {
+                    "kind": "kubernetes",
+                    "source": ["mlrun-project-secrets-project-1"],
+                }
+            ],
+            None,
+        ),
+    ],
+)
+def test_apply_enrichment_and_validation_on_task_param(
+    secret_sources, expected_exception
+):
+    task = {
+        "metadata": {
+            "iteration": 0,
+            "name": "mytask",
+            "project": "project-1",
+        },
+        "spec": {
+            "secret_sources": secret_sources,
+        },
+    }
+
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            framework.api.utils.apply_enrichment_and_validation_on_task(task)
+    else:
+        framework.api.utils.apply_enrichment_and_validation_on_task(task)
+
+
+@pytest.mark.parametrize(
+    "secret_name, expect_exception",
+    [
+        # Valid project secret
+        ("mlrun-project-secrets-test-project", False),
+        # Invalid secret (should raise)
+        ("mlrun-project-secrets-other-project", True),
+    ],
+)
+def test_validate_volume_mounts_param(secret_name, expect_exception):
+    func_name = "name_with_underscores"
+
+    # create a function with a name that includes underscores
+    func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
+    func = mlrun.code_to_function(
+        name=func_name,
+        kind="job",
+        image="mlrun/mlrun",
+        handler="myhandler",
+        filename=func_path,
+    )
+    func.metadata.project = "test-project"
+    func.apply(mlrun.runtimes.mounts.mount_secret(secret_name, "./secrets/"))
+
+    if expect_exception:
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="does not match project secret mounted",
+        ):
+            framework.api.utils.validate_volume_mounts(func)
+    else:
+        # Should not raise
+        framework.api.utils.validate_volume_mounts(func)
+
+
+@pytest.mark.parametrize(
+    "secret_name, expect_exception",
+    [
+        # Valid project secret
+        ("mlrun-project-secrets-test-project", False),
+        # Invalid secret (should raise)
+        ("mlrun-project-secrets-other-project", True),
+    ],
+)
+def test_setenv_from_the_project_secret(secret_name, expect_exception):
+    func_name = "name_with_underscores"
+
+    # create a function with a name that includes underscores
+    func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
+    func = mlrun.code_to_function(
+        name=func_name,
+        kind="job",
+        image="mlrun/mlrun",
+        handler="myhandler",
+        filename=func_path,
+    )
+    func.metadata.project = "test-project"
+    func.set_env_from_secret(name="MY_ENV", secret=secret_name)
+
+    if expect_exception:
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="does not match project secret mounted",
+        ):
+            framework.api.utils.validate_env_vars(func)
+    else:
+        # Should not raise
+        framework.api.utils.validate_env_vars(func)
+
+    # now validate the server side object, which is formed via sending dict and then enriching from dict
+    function = mlrun.new_function(runtime=func.to_dict())
+    mlrun.runtimes.utils.enrich_function_from_dict(function, func.to_dict())
+
+    if expect_exception:
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="does not match project secret mounted",
+        ):
+            framework.api.utils.validate_env_vars(func)
+    else:
+        # Should not raise
+        framework.api.utils.validate_env_vars(func)

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -1932,26 +1932,21 @@ def test_resolve_client_default_kfp_image(
             ],
             mlrun.errors.MLRunInvalidArgumentError,
         ),
-        # Kubernetes secret with incorrect project secret (should raise)
         (
-            [
-                {
-                    "kind": "kubernetes",
-                    "source": ["mlrun-project-secrets-wrong"],
-                }
-            ],
-            mlrun.errors.MLRunInvalidArgumentError,
+                [
+                    {"kind": "inline", "source": {}},
+                    {
+                        "kind": "azure_vault",
+                        "source": {
+                            "k8s_secret": "mlrun-project-secrets-project-1",
+                            "name": "my-vault-name",
+                            "secrets": [],
+                        },
+                    },
+                ],
+                None,
         ),
-        # Kubernetes secret with allowed project secret (should pass)
-        (
-            [
-                {
-                    "kind": "kubernetes",
-                    "source": ["mlrun-project-secrets-project-1"],
-                }
-            ],
-            None,
-        ),
+
     ],
 )
 def test_validate_function_secret_sources(secret_sources, expected_exception):

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -1954,10 +1954,8 @@ def test_resolve_client_default_kfp_image(
         ),
     ],
 )
-def test_apply_enrichment_and_validation_on_task_param(
-    secret_sources, expected_exception
-):
-    task = {
+def test_validate_function_secret_sources(secret_sources, expected_exception):
+    function = {
         "metadata": {
             "iteration": 0,
             "name": "mytask",
@@ -1970,9 +1968,9 @@ def test_apply_enrichment_and_validation_on_task_param(
 
     if expected_exception:
         with pytest.raises(expected_exception):
-            framework.api.utils.apply_enrichment_and_validation_on_task(task)
+            framework.api.utils.validate_function_secret_sources(function)
     else:
-        framework.api.utils.apply_enrichment_and_validation_on_task(task)
+        framework.api.utils.validate_function_secret_sources(function)
 
 
 @pytest.mark.parametrize(
@@ -1998,35 +1996,36 @@ def test_validate_volume_mounts_param(secret_name, expect_exception):
     )
     func.metadata.project = "test-project"
     func.apply(mlrun.runtimes.mounts.mount_secret(secret_name, "./secrets/"))
-
-    if expect_exception:
-        with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError,
-            match="does not match project secret mounted",
-        ):
-            framework.api.utils.validate_volume_mounts(func)
-    else:
-        # Should not raise
-        framework.api.utils.validate_volume_mounts(func)
+    for function in [func, func.to_dict()]:
+        if expect_exception:
+            with pytest.raises(
+                mlrun.errors.MLRunInvalidArgumentError,
+            ):
+                framework.api.utils.validate_function_volume_mounts(function)
+        else:
+            # Should not raise
+            framework.api.utils.validate_function_volume_mounts(function)
 
 
 @pytest.mark.parametrize(
-    "secret_name, expect_exception",
+    "secret_name, expect_exception, kind",
     [
         # Valid project secret
-        ("mlrun-project-secrets-test-project", False),
+        ("mlrun-project-secrets-test-project", False, "job"),
         # Invalid secret (should raise)
-        ("mlrun-project-secrets-other-project", True),
+        ("mlrun-project-secrets-other-project", True, "job"),
+        # Invalid secret (should raise)
+        ("mlrun-project-secrets-other-project", True, "serving"),
     ],
 )
-def test_setenv_from_the_project_secret(secret_name, expect_exception):
+def test_setenv_from_the_project_secret(secret_name, expect_exception, kind):
     func_name = "name_with_underscores"
 
     # create a function with a name that includes underscores
     func_path = str(pathlib.Path(__file__).parent / "assets" / "handler.py")
     func = mlrun.code_to_function(
         name=func_name,
-        kind="job",
+        kind=kind,
         image="mlrun/mlrun",
         handler="myhandler",
         filename=func_path,
@@ -2034,26 +2033,17 @@ def test_setenv_from_the_project_secret(secret_name, expect_exception):
     func.metadata.project = "test-project"
     func.set_env_from_secret(name="MY_ENV", secret=secret_name)
 
-    if expect_exception:
-        with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError,
-            match="does not match project secret mounted",
-        ):
-            framework.api.utils.validate_env_vars(func)
-    else:
-        # Should not raise
-        framework.api.utils.validate_env_vars(func)
-
-    # now validate the server side object, which is formed via sending dict and then enriching from dict
-    function = mlrun.new_function(runtime=func.to_dict())
-    mlrun.runtimes.utils.enrich_function_from_dict(function, func.to_dict())
-
-    if expect_exception:
-        with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError,
-            match="does not match project secret mounted",
-        ):
-            framework.api.utils.validate_env_vars(func)
-    else:
-        # Should not raise
-        framework.api.utils.validate_env_vars(func)
+    # simulate the server side object, which is formed via sending dict and then enriching from dict
+    function_retranslated = mlrun.new_function(runtime=func.to_dict())
+    mlrun.runtimes.utils.enrich_function_from_dict(
+        function_retranslated, func.to_dict()
+    )
+    for function in [func, func.to_dict(), function_retranslated]:
+        if expect_exception:
+            with pytest.raises(
+                mlrun.errors.MLRunInvalidArgumentError,
+            ):
+                framework.api.utils.validate_function_env_vars(function)
+        else:
+            # Should not raise
+            framework.api.utils.validate_function_env_vars(function)

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -1933,20 +1933,19 @@ def test_resolve_client_default_kfp_image(
             mlrun.errors.MLRunInvalidArgumentError,
         ),
         (
-                [
-                    {"kind": "inline", "source": {}},
-                    {
-                        "kind": "azure_vault",
-                        "source": {
-                            "k8s_secret": "mlrun-project-secrets-project-1",
-                            "name": "my-vault-name",
-                            "secrets": [],
-                        },
+            [
+                {"kind": "inline", "source": {}},
+                {
+                    "kind": "azure_vault",
+                    "source": {
+                        "k8s_secret": "mlrun-project-secrets-project-1",
+                        "name": "my-vault-name",
+                        "secrets": [],
                     },
-                ],
-                None,
+                },
+            ],
+            None,
         ),
-
     ],
 )
 def test_validate_function_secret_sources(secret_sources, expected_exception):

--- a/server/py/services/api/utils/functions.py
+++ b/server/py/services/api/utils/functions.py
@@ -66,6 +66,16 @@ def build_function(
             runtime=fn, full=is_nuclio_deploy, client_version=client_version
         )
 
+        # only validate
+        framework.api.utils.apply_enrichment_and_validation_on_function(
+            function=fn,
+            auth_info=auth_info,
+            ensure_auth=False,
+            perform_auto_mount=False,
+            mask_sensitive_data=False,
+            ensure_security_context=False,
+        )
+
         if is_nuclio_deploy:
             fn: mlrun.runtimes.RemoteRuntime
             # before saving function to DB, we need to mask some nuclio-specific fields

--- a/tests/system/projects/assets/nuclio_handler.py
+++ b/tests/system/projects/assets/nuclio_handler.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def handler(context, event):
+    return "hello"

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -29,6 +29,7 @@ import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
+import mlrun.runtimes.mounts
 import mlrun.utils
 import mlrun.utils.logger
 import mlrun_pipelines.common.models
@@ -70,6 +71,7 @@ def pipe_test():
 @pytest.mark.enterprise
 class TestProject(TestMLRunSystem):
     project_name = "project-system-test-project"
+    image: str = "mlrun/mlrun"
     _logger_redirected = False
 
     def custom_setup(self):
@@ -579,16 +581,10 @@ class TestProject(TestMLRunSystem):
         self.custom_project_names_to_delete.append(project_name)
         project = mlrun.new_project(project_name, context=str(self.assets_path))
 
-        code_path = str(self.assets_path / "sleep.py")
         workflow_path = str(self.assets_path / "pipeline_with_resource_param.py")
+        function_name = "func-1"
+        function = self._get_sleep_job(function_name=function_name)
 
-        project.set_function(
-            name="func-1",
-            func=code_path,
-            kind="job",
-            image="mlrun/mlrun",
-            handler="handler",
-        )
         # set and run a two-step workflow in the project
         project.set_workflow("paramflow", workflow_path)
 
@@ -599,7 +595,7 @@ class TestProject(TestMLRunSystem):
         assert pipeline_status.workflow.args == arguments
 
         # get the function from the db
-        function = project.get_function("func-1", ignore_cache=True)
+        function = project.get_function(function_name, ignore_cache=True)
         assert function.spec.resources["requests"]["memory"] == arguments["memory"]
 
     def test_remote_pipeline_with_workflow_runner_node_selector(self):
@@ -1966,6 +1962,78 @@ class TestProject(TestMLRunSystem):
         assert (
             len(notifications) == 2
         ), f"Expected 2 notifications, got {len(notifications)}"
+
+    @pytest.mark.parametrize("kind", ["nuclio", "job", "mpijob"])
+    def test_deploy_function_with_mounted_project_secret(self, kind):
+        # create a secret in another project
+        project_with_secret_name = "project-with-secret"
+        self.custom_project_names_to_delete.append(project_with_secret_name)
+
+        project_with_secret = mlrun.get_or_create_project(
+            project_with_secret_name, context="./project-with-secret"
+        )
+        # define a secret in this project
+        project_with_secret.set_secrets({"key": "secret-1"})
+        secret_name = f"mlrun-project-secrets-{project_with_secret_name}"
+        # mount the secret of the other project
+        fn = self._get_simple_function(kind=kind)
+        fn.apply(mlrun.runtimes.mounts.mount_secret(secret_name, "./secrets/"))
+        with pytest.raises(OSError, match="it belongs to a different project"):
+            if kind == "nuclio":
+                fn.deploy()
+            else:
+                fn.run()
+
+        # set env from the secret of the other project
+        fn = self._get_simple_function(kind=kind)
+        fn.set_env_from_secret(name="key", secret=secret_name)
+        with pytest.raises(OSError, match="it belongs to a different project"):
+            if kind == "nuclio":
+                fn.deploy()
+            else:
+                fn.run()
+
+    def _get_simple_function(self, kind="job"):
+        if kind == "job":
+            return self._get_sleep_job()
+        if kind == "nuclio":
+            return self._get_new_nuclio_function_object()
+        if kind == "mpijob":
+            return self._get_new_mpijob_function()
+        else:
+            raise ValueError(f"Unsupported function kind: {kind}")
+
+    def _get_new_nuclio_function_object(self, function_name="nuclio-func"):
+        return mlrun.code_to_function(
+            filename=str(self.assets_path / "nuclio_handler.py"),
+            name=function_name,
+            kind="nuclio",
+            image=self.image,
+            project=self.project_name,
+        )
+
+    def _get_sleep_job(self, function_name="sleep-job"):
+        code_path = str(self.assets_path / "sleep.py")
+
+        function = self.project.set_function(
+            name=function_name,
+            func=code_path,
+            kind="job",
+            image="mlrun/mlrun",
+            handler="handler",
+        )
+        return function
+
+    def _get_new_mpijob_function(self, function_name="mpijob-func"):
+        code_path = str(self.assets_path / "mpijob_function.py")
+        return mlrun.code_to_function(
+            name=function_name,
+            kind="mpijob",
+            handler="handler",
+            project=self.project_name,
+            filename=code_path,
+            image="mlrun/mlrun",
+        )
 
     @staticmethod
     def _generate_pipeline_notifications(


### PR DESCRIPTION
### 📝 Description
Do not allow running of functions that use secrets from the wrong project, 
Prevent functions from using secrets that belong to a different project.
This applies to the following cases:

* Volumes mounting secrets from another project
* Environment variables referencing secrets from another project
* Tasks including secrets from another project in their secrets list

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
UT + vmdev + system test

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11219, https://iguazio.atlassian.net/browse/ML-11214, https://iguazio.atlassian.net/browse/ML-11220, https://iguazio.atlassian.net/browse/ML-11222
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (if users were relying on this bug)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<img width="1940" height="353" alt="image" src="https://github.com/user-attachments/assets/af9d6233-dfd0-4eaa-ab4a-f61cedcaa119" />
