### PR TITLE
[Tests] Fix load project remotely system test

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -20,6 +20,7 @@ import sys
 import time
 from sys import executable
 
+import git.exc
 import igz_mgmt
 import pandas as pd
 import pytest
@@ -1862,14 +1863,16 @@ class TestProject(TestMLRunSystem):
     def test_load_project_remotely_with_secrets_failed(self):
         name = "failed-to-load"
         self.custom_project_names_to_delete.append(name)
+        project_dir = f"{projects_dir}/{name}"
         db = self._run_db
-        state = db.load_project(
-            name=name,
-            url="git://github.com/some/wrong/uri.git",
-            secrets={"secret1": "1234"},
-            save_secrets=False,
-        )
-        assert state == "error"
+        with pytest.raises(git.exc.GitCommandError):
+            mlrun.load_project(
+                project_dir,
+                name=name,
+                url="git://github.com/some/wrong/uri.git",
+                secrets={"secret1": "1234"},
+                allow_cross_project=True,
+            )
         with pytest.raises(mlrun.errors.MLRunNotFoundError):
             db.get_project(name)
 


### PR DESCRIPTION
### 📝 Description
Fix the failing system test: `test_load_project_remotely_with_secrets_failed`
Similar to the changes done in this PR: https://github.com/mlrun/mlrun/pull/8673

---

### 🛠️ Changes Made
Replaced `db.load_project` with `mlrun.load_project` with `allow_cross_project=True`


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Verified by running the system tests successfully
  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11232
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
