### PR TITLE
[Model Monitoring] Improve the error message in `evaluate` when there's no data

### DIFF
--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -26,6 +26,7 @@ import pandas as pd
 import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.helpers
+import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.types
 import mlrun.datastore.datastore_profile as ds_profile
@@ -369,7 +370,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 return result
 
             if endpoints is not None:
-                resolved_endpoints = self._handle_endpoints_type_evaluate(
+                resolved_endpoints = self._validate_endpoints(
                     project=project, endpoints=endpoints
                 )
                 if (
@@ -421,7 +422,25 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 return self._flatten_data_result(call_do_tracking())
 
     @staticmethod
-    def _handle_endpoints_type_evaluate(
+    def _check_endpoints_first_request(
+        endpoints: list[mlrun.common.schemas.ModelEndpoint],
+    ) -> None:
+        """Make sure that all the endpoints have had at least one request"""
+        endpoints_no_requests = [
+            (endpoint.metadata.name, endpoint.metadata.uid)
+            for endpoint in endpoints
+            if not endpoint.status.first_request
+        ]
+        if endpoints_no_requests:
+            raise mlrun.errors.MLRunValueError(
+                "The following model endpoints have not had any requests yet and "
+                "have no data, cannot run the model monitoring application on them: "
+                f"{endpoints_no_requests}"
+            )
+
+    @classmethod
+    def _validate_endpoints(
+        cls,
         project: "mlrun.MlrunProject",
         endpoints: Union[
             list[tuple[str, str]], list[list[str]], list[str], Literal["all"]
@@ -457,6 +476,9 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         endpoints_list = project.list_model_endpoints(
             names=endpoint_names, latest_only=True
         ).endpoints
+
+        cls._check_endpoints_first_request(endpoints_list)
+
         if endpoints_list:
             list_endpoints_result = [
                 (endpoint.metadata.name, endpoint.metadata.uid)

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -762,7 +762,11 @@ class RunDBMock:
                         name=name, project=project, uid=f"{name}-uid"
                     ),
                     spec=mlrun.common.schemas.ModelEndpointSpec(),
-                    status=mlrun.common.schemas.ModelEndpointStatus(),
+                    status=mlrun.common.schemas.ModelEndpointStatus(
+                        first_request=datetime(2024, 1, 1)
+                        if name != "model-ep-no-first-request"
+                        else None,
+                    ),
                 )
             )
 

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -588,30 +588,33 @@ def project(tmpdir: Path) -> mlrun.MlrunProject:
     "endpoints", ["all", ["model-ep-1"], [("model-ep-1", "model-ep-1-uid")]]
 )
 @pytest.mark.usefixtures("rundb_mock")
-def test_handle_endpoints_type_evaluate(
+def test_validate_endpoints(
     project: mlrun.MlrunProject, endpoints: Union[str, list[str], list[tuple[str, str]]]
 ) -> None:
-    endpoints_output = ModelMonitoringApplicationBase._handle_endpoints_type_evaluate(
+    endpoints_output = ModelMonitoringApplicationBase._validate_endpoints(
         project, endpoints
     )
     assert endpoints_output == [("model-ep-1", "model-ep-1-uid")]
 
 
+@pytest.mark.usefixtures("rundb_mock")
 @pytest.mark.parametrize(
     ("endpoints", "err_msg"),
     [
         ("*", 'A string input for `endpoints` can only be "all"'),
         ([], "The endpoints list cannot be empty"),
         ([1], r"Could not resolve endpoints as list of \[\(name, uid\)\]"),
+        (
+            ["model-ep-no-first-request"],
+            "have no data, cannot run the model monitoring application on them",
+        ),
     ],
 )
-def test_handle_endpoints_type_evaluate_error(
+def test_validate_endpoints_error(
     project: mlrun.MlrunProject, endpoints: Union[str, list[str]], err_msg: str
 ) -> None:
     with pytest.raises(mlrun.errors.MLRunValueError, match=err_msg):
-        ModelMonitoringApplicationBase._handle_endpoints_type_evaluate(
-            project, endpoints
-        )
+        ModelMonitoringApplicationBase._validate_endpoints(project, endpoints)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description

Previously, when one ran a MM app with evaluate on a model endpoint that had no requests, the final error message was "file not found" error because of missing parquet files.
Now, we check that for all the model endpoints before running the application on them.
Please note - in the edge case when the `first_request` was updated but the first parquet file has not yet been written, the previous error message is shown. 

---

### ✅ Checklist

- [x] I have tested the changes in this PR

---

### 🧪 Testing
 Unit tests, manual testing.

---

### 🔗 References
- Ticket link: [ML-11190](https://iguazio.atlassian.net/browse/ML-11190)

---

### 🚨 Breaking Changes?

- [x] No


[ML-11190]: https://iguazio.atlassian.net/browse/ML-11190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ