### PR TITLE
[Tests] Pin `pipdeptree` to <2.29.0 untill mlflow is updated (conflicts on required version of `packaging` package) 

### DIFF
--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -242,9 +242,9 @@ class PackageTester:
             extra=extra,
         )
         self._run_command(
-            # pin pipdeptree below 2.29 until mlflow upgrade:
+            # pin pipdeptree below 2.29.0 until mlflow upgrade:
             # pipdeptree ver 2.29 requires packaging >= 25.0 while mlflow-skinny (mlflow dep) requires packaging < 25.0
-            "pip install pipdeptree<'2.29.0'",
+            "pip install 'pipdeptree<2.29.0'",
             run_in_venv=True,
         )
         self._run_command(

--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -242,7 +242,9 @@ class PackageTester:
             extra=extra,
         )
         self._run_command(
-            "pip install pipdeptree",
+            # pin pipdeptree below 2.29 until mlflow upgrade:
+            # pipdeptree ver 2.29 requires packaging >= 25.0 while mlflow-skinny (mlflow dep) requires packaging < 25.0
+            "pip install pipdeptree<'2.29.0'",
             run_in_venv=True,
         )
         self._run_command(


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

CI started to fail on make test-package.
Reason: pipdeptree version 2.29 (new version) requires packaging >= 25.0 while mlflow-skinny (mlflow dep) requires packaging < 25.0


### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

Pinned pipdeptree to version < 2.29.0

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

By running make test-package

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
