### PR TITLE
[Tests] Fix project secret handling in load project system test

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -1845,13 +1845,15 @@ class TestProject(TestMLRunSystem):
         self.custom_project_names_to_delete.append(name)
         project_dir = f"{projects_dir}/{name}"
         db = self._run_db
-        mlrun.load_project(
+        project = mlrun.load_project(
             project_dir,
             name=name,
             url="git://github.com/mlrun/project-demo.git",
-            secrets={"secret1": "1234"},
             allow_cross_project=True,
         )
+
+        if save_secrets:
+            project.set_secrets({"secret1": "1234"})
 
         secrets = db.list_project_secret_keys(name)
 


### PR DESCRIPTION
### 📝 Description
Project secrets are now handled correctly when loading a project remotely. 
The test now uses `project.set_secrets()` to persist secrets.

---

### 🛠️ Changes Made
added `project.set_secrets` to save the secrets, replacing the previous approach which attempted to store secrets via `db.load_project` call after the changes done in this PR: ( https://github.com/mlrun/mlrun/pull/8673 )

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
system test now passes.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11232
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
