### PR TITLE
[Tests] Ensure correct project is used in kfp pipeline system test

### DIFF
--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -584,7 +584,7 @@ class TestProject(TestMLRunSystem):
 
         workflow_path = str(self.assets_path / "pipeline_with_resource_param.py")
         function_name = "func-1"
-        function = self._get_sleep_job(function_name=function_name)
+        self._get_sleep_job(project=project, function_name=function_name)
 
         # set and run a two-step workflow in the project
         project.set_workflow("paramflow", workflow_path)
@@ -2015,10 +2015,12 @@ class TestProject(TestMLRunSystem):
             project=self.project_name,
         )
 
-    def _get_sleep_job(self, function_name="sleep-job"):
+    def _get_sleep_job(self, project=None, function_name="sleep-job"):
+        if project is None:
+            project = self.project
         code_path = str(self.assets_path / "sleep.py")
 
-        function = self.project.set_function(
+        function = project.set_function(
             name=function_name,
             func=code_path,
             kind="job",


### PR DESCRIPTION
### 📝 Description
This PR fixes the failing system test: `test_kfp_pipeline_with_resource_param_passed`
where function was being created under the wrong project context.

---

### 🛠️ Changes Made
- Updated `_get_sleep_job` to accept a project parameter instead of always using `self.project`.
- Kept backward compatibility by defaulting to `self.project` when no project is provided for other tests that rely on the default project context

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
The system test now passes.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11252
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
