### PR TITLE
[Application] Add warning if port and direct_port_access are set when creating api gw

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -568,6 +568,12 @@ class ApplicationRuntime(RemoteRuntime):
                 "Authentication credentials not provided"
             )
 
+        if direct_port_access and port:
+            logger.warning(
+                "Ignoring 'port' because 'direct_port_access' is enabled. "
+                "The 'port' setting is only applicable when 'direct_port_access' is disabled."
+            )
+
         ports = (
             port or self.spec.internal_application_port if direct_port_access else []
         )


### PR DESCRIPTION
### 📝 Description
Add warning that port is ignored if both `port` and `direct_port_access` are set when creating api gw for application runtime

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11235
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

