### PR TITLE
[KFP] Fix image suffix enrichment for python 3.9

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -87,7 +87,7 @@ def extra_requirements() -> dict[str, list[str]]:
     extras_require.update(
         {
             "dev-postgres": ["pytest-mock-resources[postgres]~=2.12"],
-            "kfp18": ["mlrun_pipelines_kfp_v1_8[kfp]>=0.5.7"],
+            "kfp18": ["mlrun_pipelines_kfp_v1_8[kfp]~=0.5.8"],
             # TODO uncomment when KFP 1.8 support is removed
             # "kfp2": ["mlrun_pipelines_kfp_v2[kfp]>=0.5.0 ; python_version >= '3.11'"],
             "api": api_deps,

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -924,10 +924,21 @@ def enrich_image_url(
     )
     mlrun_version = config.images_tag or client_version or server_version
     tag = mlrun_version or ""
-    tag += resolve_image_tag_suffix(
-        mlrun_version=mlrun_version,
-        python_version=client_python_version,
+
+    # starting mlrun 1.10.0-rc0 we want to enrich the kfp image with the python version
+    # e.g for 1.9 we have a single mlrun-kfp image that supports only python 3.9
+    enrich_kfp_python_version = (
+        "mlrun-kfp" in image_url
+        and mlrun_version
+        and semver.VersionInfo.parse(mlrun_version)
+        >= semver.VersionInfo.parse("1.10.0-rc0")
     )
+
+    if "mlrun-kfp" not in image_url or enrich_kfp_python_version:
+        tag += resolve_image_tag_suffix(
+            mlrun_version=mlrun_version,
+            python_version=client_python_version,
+        )
 
     # it's an mlrun image if the repository is mlrun
     is_mlrun_image = image_url.startswith("mlrun/") or "/mlrun/" in image_url

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -930,6 +930,7 @@ def enrich_image_url(
     enrich_kfp_python_version = (
         "mlrun-kfp" in image_url
         and mlrun_version
+        and semver.VersionInfo.is_valid(mlrun_version)
         and semver.VersionInfo.parse(mlrun_version)
         >= semver.VersionInfo.parse("1.10.0-rc0")
     )

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -140,9 +140,6 @@ def test_requirement_specifiers_convention():
         "scikit-learn": {"~=1.5.2"},
         # ensure minimal version to gain vulnerability fixes
         "setuptools": {">=75.2"},
-        "mlrun_pipelines_kfp_v1_8[kfp]": {
-            ">=0.5.7",
-        },
         "snowballstemmer": {"!=3.0.0"},
         "kafka-python": {"~=2.1.0"},
         "urllib3": {
@@ -184,7 +181,7 @@ def test_requirement_specifiers_convention():
 
     assert (
         missing_requirements == []
-    ), f"The following requirements are missing from the ignored_invalid_map: {missing_requirements}"
+    ), f"The following requirements are needlessly ignored: {missing_requirements}"
 
     assert invalid_requirement_specifiers_map == {}
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -860,6 +860,23 @@ def test_validate_v3io_consumer_group(value, expected):
             "expected_output": "mlrun/mlrun-kfp:1.10.0",
             "images_to_enrich_registry": "",
         },
+        {
+            "image": "mlrun/mlrun-kfp",
+            "client_version": "1.10.0-rc1",
+            "client_python_version": "3.11.13",
+            "images_tag": None,
+            "expected_output": "mlrun/mlrun-kfp:1.10.0-rc1",
+            "images_to_enrich_registry": "",
+        },
+        {
+            "image": "mlrun/mlrun-kfp",
+            "client_version": "1.9.0",
+            "client_python_version": "3.9.10",
+            "images_tag": None,
+            # no -py suffix as 1.9 has no dual python support
+            "expected_output": "mlrun/mlrun-kfp:1.9.0",
+            "images_to_enrich_registry": "",
+        },
     ],
 )
 def test_enrich_image(case):


### PR DESCRIPTION
### 📝 Description

Image enrichment did not take into consideration old mlrun clients (< 1.10) where mlrun-kfp image did not have dual python support (py 39 / py311) and set the mlrun kfp image suffix to wronfully include python 3.9

---

### 🛠️ Changes Made

Conditioned the enrichment on mlrun client

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Added UT coverage

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11270
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
