### PR TITLE
[Test] Normalize artifacts datetime fields prior to deepdiff comparison

### DIFF
--- a/server/py/services/api/tests/unit/crud/test_runs.py
+++ b/server/py/services/api/tests/unit/crud/test_runs.py
@@ -14,6 +14,7 @@
 
 import unittest.mock
 import uuid
+from datetime import datetime
 
 import deepdiff
 import pytest
@@ -935,6 +936,20 @@ class TestRuns(services.api.tests.unit.conftest.MockedK8sHelper):
         iter=0,
         run_format: mlrun.common.formatters.RunFormat = None,
     ):
+        def _normalize_datetime_fields(artifact):
+            for field in ["created", "updated"]:
+                value = artifact.get("metadata", {}).get(field)
+                if value:
+                    # Parse and format to "YYYY-MM-DD HH:MM:SS+00:00"
+                    try:
+                        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+                        artifact["metadata"][field] = dt.strftime(
+                            "%Y-%m-%d %H:%M:%S%z"
+                        ).replace("+0000", "+00:00")
+
+                    except Exception:
+                        pass  # If parsing fails, leave as is
+
         run = services.api.crud.Runs().get_run(
             db,
             run_uid,
@@ -957,6 +972,8 @@ class TestRuns(services.api.tests.unit.conftest.MockedK8sHelper):
         enriched_artifacts.sort(key=sort_by_key)
         artifacts.sort(key=sort_by_key)
         for artifact, enriched_artifact in zip(artifacts, enriched_artifacts):
+            _normalize_datetime_fields(artifact)
+            _normalize_datetime_fields(enriched_artifact)
             assert (
                 deepdiff.DeepDiff(
                     artifact,

--- a/server/py/services/api/tests/unit/crud/test_runs.py
+++ b/server/py/services/api/tests/unit/crud/test_runs.py
@@ -936,7 +936,8 @@ class TestRuns(services.api.tests.unit.conftest.MockedK8sHelper):
         iter=0,
         run_format: mlrun.common.formatters.RunFormat = None,
     ):
-        def _normalize_datetime_fields(artifact):
+        def normalize_datetime_fields(artifact):
+            "Normalize 'created' and 'updated' datetime fields in artifact metadata to a standard format."
             for field in ["created", "updated"]:
                 value = artifact.get("metadata", {}).get(field)
                 if value:
@@ -972,8 +973,8 @@ class TestRuns(services.api.tests.unit.conftest.MockedK8sHelper):
         enriched_artifacts.sort(key=sort_by_key)
         artifacts.sort(key=sort_by_key)
         for artifact, enriched_artifact in zip(artifacts, enriched_artifacts):
-            _normalize_datetime_fields(artifact)
-            _normalize_datetime_fields(enriched_artifact)
+            normalize_datetime_fields(artifact)
+            normalize_datetime_fields(enriched_artifact)
             assert (
                 deepdiff.DeepDiff(
                     artifact,


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Test was failing transiently due to a difference in datetime object formatting. In `datetime.isoformat()` if the microsecond value is 0, Python omits it by default (documented [here](https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat). SQLAlchemy stores timestamps with microsecond precision, even if they are `.0000`. This can sometimes cause a formatting mismatch, resulting in the assertion error described in the ticket.
This PR normalize datetime fields prior to the deepdiff comparison



---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Added a function `_normalize_datetime_fields` inside `_validate_run_artifacts` to handle the formatting mismatch

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

To test this I have altered the `_update_artifact_record_from_dict` function which is responsible to update the `created` and `updated` fields when storing an artifact. I made this function save the artifact with hardcoded values for the datetime fields, making sure that the changes in the PR solve them.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11231
- Design docs links:
- External links: https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
