### PR TITLE
[Tutorial] removed the double import from tutorial 5

### DIFF
--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -52,9 +52,6 @@
     "import mlrun\n",
     "import os\n",
     "\n",
-    "# Install and use a version of evidently that was tested to be working with mlrun\n",
-    "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION\n",
-    "\n",
     "# run this only once (restart the notebook after the install !!!)\n",
     "!pip install \"evidently=={SUPPORTED_EVIDENTLY_VERSION}\""
    ]
@@ -309,6 +306,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Install and use a version of evidently that was tested to be working with mlrun\n",
     "from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION"
    ]
   },
@@ -571,9 +569,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mlrun",
+   "display_name": "mlrun-base",
    "language": "python",
-   "name": "mlrun"
+   "name": "conda-env-mlrun-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -585,7 +583,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.9.22"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
removed the double import from tutorial 5

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
removed the double import from tutorial 5
from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION
was written twice, first at the beginning the second before the evidently part, left only the second one
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
i rerun it and it works

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10209
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
