### PR TITLE
[Test] Fix system test "test_kfp_terminate_pipeline"

### DIFF
--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import os
-import time
 
-import mlrun_pipelines.utils
 import pytest
 from kfp import dsl
 
@@ -181,7 +179,8 @@ class TestKFP(tests.system.base.TestMLRunSystem):
     # TODO - uncomment when system tests is bumped to kfp 2.0+ (IGZ 3.7+)
     # def test_kfp_terminate_pipeline(self):
     #     code_path = str(self.assets_path / "sleep.py")
-    #     self.project.set_function(func=code_path, name="sleep-func", kind="job", image="mlrun/mlrun",handler="handler")
+    #     self.project.set_function(func=code_path, name="sleep-func", kind="job",
+    #     image="mlrun/mlrun",handler="handler")
     #
     #     # 1. define a pipeline that sleeps for a few seconds
     #     @dsl.pipeline(name="terminate-test", description="pipeline to test termination")

--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -177,45 +177,46 @@ class TestKFP(tests.system.base.TestMLRunSystem):
         assert run["run"].get("error") == "Error (exit code 1)"
 
     # TODO - uncomment when system tests is bumped to kfp 2.0+ (IGZ 3.7+)
-    # def test_kfp_terminate_pipeline(self):
-    #     code_path = str(self.assets_path / "sleep.py")
-    #     self.project.set_function(func=code_path, name="sleep-func", kind="job",
-    #     image="mlrun/mlrun",handler="handler")
-    #
-    #     # 1. define a pipeline that sleeps for a few seconds
-    #     @dsl.pipeline(name="terminate-test", description="pipeline to test termination")
-    #     def terminate_pipeline(time_to_sleep: int = 10):
-    #         mlrun.run_function("sleep-func", params={"time_to_sleep": time_to_sleep})
-    #
-    #     # 2. Start the pipeline run
-    #     run_id = self.project.run(
-    #         workflow_handler=terminate_pipeline,
-    #         engine="kfp",
-    #         arguments={"time_to_sleep": 60},
-    #         name="terminate-exp",
-    #         watch=False)
-    #
-    #
-    #     # 3. Wait for it to start
-    #     while True:
-    #         db = mlrun.get_run_db()
-    #         record = db.get_pipeline(run_id, project=self.project_name)
-    #         if record["run"].get("status") == RunStatuses.running:
-    #             break
-    #         time.sleep(1)
-    #
-    #     # 4. issue a termination request
-    #     mlrun.terminate_pipeline(run_id, project=self.project_name)
-    #
-    #     # 5. wait for it to finish, expecting failed status
-    #     mlrun.wait_for_pipeline_completion(
-    #         run_id,
-    #         project=self.project_name,
-    #         expected_statuses=[RunStatuses.failed],
-    #     )
-    #
-    #     # 6. verify the run record shows a termination error
-    #     db = mlrun.get_run_db()
-    #     record = db.get_pipeline(run_id, project=self.project_name)
-    #     err = record["run"].get("status", "")
-    #     assert "failed" in err.lower(), f"expected failed error, got: {err}"
+    @pytest.mark.skip(reason="Not supported in kfp<2.0")
+    def test_kfp_terminate_pipeline(self):
+        code_path = str(self.assets_path / "sleep.py")
+        self.project.set_function(func=code_path, name="sleep-func", kind="job",
+        image="mlrun/mlrun",handler="handler")
+
+        # 1. define a pipeline that sleeps for a few seconds
+        @dsl.pipeline(name="terminate-test", description="pipeline to test termination")
+        def terminate_pipeline(time_to_sleep: int = 10):
+            mlrun.run_function("sleep-func", params={"time_to_sleep": time_to_sleep})
+
+        # 2. Start the pipeline run
+        run_id = self.project.run(
+            workflow_handler=terminate_pipeline,
+            engine="kfp",
+            arguments={"time_to_sleep": 60},
+            name="terminate-exp",
+            watch=False)
+
+
+        # 3. Wait for it to start
+        while True:
+            db = mlrun.get_run_db()
+            record = db.get_pipeline(run_id, project=self.project_name)
+            if record["run"].get("status") == RunStatuses.running:
+                break
+            time.sleep(1)
+
+        # 4. issue a termination request
+        mlrun.terminate_pipeline(run_id, project=self.project_name)
+
+        # 5. wait for it to finish, expecting failed status
+        mlrun.wait_for_pipeline_completion(
+            run_id,
+            project=self.project_name,
+            expected_statuses=[RunStatuses.failed],
+        )
+
+        # 6. verify the run record shows a termination error
+        db = mlrun.get_run_db()
+        record = db.get_pipeline(run_id, project=self.project_name)
+        err = record["run"].get("status", "")
+        assert "failed" in err.lower(), f"expected failed error, got: {err}"

--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import time
 
 import pytest
 from kfp import dsl
@@ -180,8 +181,13 @@ class TestKFP(tests.system.base.TestMLRunSystem):
     @pytest.mark.skip(reason="Not supported in kfp<2.0")
     def test_kfp_terminate_pipeline(self):
         code_path = str(self.assets_path / "sleep.py")
-        self.project.set_function(func=code_path, name="sleep-func", kind="job",
-        image="mlrun/mlrun",handler="handler")
+        self.project.set_function(
+            func=code_path,
+            name="sleep-func",
+            kind="job",
+            image="mlrun/mlrun",
+            handler="handler",
+        )
 
         # 1. define a pipeline that sleeps for a few seconds
         @dsl.pipeline(name="terminate-test", description="pipeline to test termination")
@@ -194,8 +200,8 @@ class TestKFP(tests.system.base.TestMLRunSystem):
             engine="kfp",
             arguments={"time_to_sleep": 60},
             name="terminate-exp",
-            watch=False)
-
+            watch=False,
+        )
 
         # 3. Wait for it to start
         while True:

--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -15,6 +15,7 @@
 import os
 import time
 
+import mlrun_pipelines.utils
 import pytest
 from kfp import dsl
 
@@ -177,61 +178,45 @@ class TestKFP(tests.system.base.TestMLRunSystem):
 
         assert run["run"].get("error") == "Error (exit code 1)"
 
-    def test_kfp_terminate_pipeline(self):
-        code_path = str(self.assets_path / "sleep.py")
-        sleep_fn = mlrun.code_to_function(
-            name="sleep-func",
-            kind="job",
-            filename=code_path,
-            project=self.project_name,
-            image="mlrun/mlrun",
-        )
-
-        # 1. define a pipeline that sleeps for a few seconds
-        @dsl.pipeline(name="terminate-test", description="pipeline to test termination")
-        def terminate_pipeline(time_to_sleep: int = 10):
-            sleep_fn.as_step(
-                handler="handler",
-                params={"time_to_sleep": time_to_sleep},
-            )
-
-        # 2. launch it (non-blocking)
-        run_id = mlrun._run_pipeline(
-            terminate_pipeline,
-            arguments={"time_to_sleep": 60},
-            experiment="terminate-exp",
-            project=self.project_name,
-        )
-
-        # 3. Wait for it to start
-        while True:
-            db = mlrun.get_run_db()
-            record = db.get_pipeline(run_id, project=self.project_name)
-            if record["run"].get("status") == RunStatuses.running:
-                break
-            time.sleep(1)
-
-        # 4. issue a termination request
-        terminate_task_id = mlrun.terminate_pipeline(run_id, project=self.project_name)
-
-        time.sleep(10)  # wait a bit to ensure the termination request is processed
-        duplicate_terminate_task_id = mlrun.terminate_pipeline(
-            run_id, project=self.project_name
-        )
-
-        assert (
-            terminate_task_id == duplicate_terminate_task_id
-        ), "Duplicate termination requests should return the same task ID"
-
-        # 5. wait for it to finish, expecting failed status
-        mlrun.wait_for_pipeline_completion(
-            run_id,
-            project=self.project_name,
-            expected_statuses=[RunStatuses.failed],
-        )
-
-        # 6. verify the run record shows a termination error
-        db = mlrun.get_run_db()
-        record = db.get_pipeline(run_id, project=self.project_name)
-        err = record["run"].get("error", "")
-        assert "failed" in err.lower(), f"expected failed error, got: {err}"
+    # TODO - uncomment when system tests is bumped to kfp 2.0+ (IGZ 3.7+)
+    # def test_kfp_terminate_pipeline(self):
+    #     code_path = str(self.assets_path / "sleep.py")
+    #     self.project.set_function(func=code_path, name="sleep-func", kind="job", image="mlrun/mlrun",handler="handler")
+    #
+    #     # 1. define a pipeline that sleeps for a few seconds
+    #     @dsl.pipeline(name="terminate-test", description="pipeline to test termination")
+    #     def terminate_pipeline(time_to_sleep: int = 10):
+    #         mlrun.run_function("sleep-func", params={"time_to_sleep": time_to_sleep})
+    #
+    #     # 2. Start the pipeline run
+    #     run_id = self.project.run(
+    #         workflow_handler=terminate_pipeline,
+    #         engine="kfp",
+    #         arguments={"time_to_sleep": 60},
+    #         name="terminate-exp",
+    #         watch=False)
+    #
+    #
+    #     # 3. Wait for it to start
+    #     while True:
+    #         db = mlrun.get_run_db()
+    #         record = db.get_pipeline(run_id, project=self.project_name)
+    #         if record["run"].get("status") == RunStatuses.running:
+    #             break
+    #         time.sleep(1)
+    #
+    #     # 4. issue a termination request
+    #     mlrun.terminate_pipeline(run_id, project=self.project_name)
+    #
+    #     # 5. wait for it to finish, expecting failed status
+    #     mlrun.wait_for_pipeline_completion(
+    #         run_id,
+    #         project=self.project_name,
+    #         expected_statuses=[RunStatuses.failed],
+    #     )
+    #
+    #     # 6. verify the run record shows a termination error
+    #     db = mlrun.get_run_db()
+    #     record = db.get_pipeline(run_id, project=self.project_name)
+    #     err = record["run"].get("status", "")
+    #     assert "failed" in err.lower(), f"expected failed error, got: {err}"


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

This PR fixes the `test_kfp_terminate_pipeline` system test. This test can only work with KFP 2+ (IGZ 3.7+) so the test is currently skipped (explanation on why in this jira https://iguazio.atlassian.net/browse/ML-10283) . Once system test env is bumped to IGZ 3.7, it should be re-enabled.

The test was refactored to only check that the pipeline terminates. The duplicate `terminate_pipeline` requests flow cannot be tested in a system test, and it is already checked in unit test as part of #8013 in `test_terminate_pipeline_success` test.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Refactor the `test_kfp_terminate_pipeline` system test so it works with KFP 2+ (IGZ 3.7+). Test is currently skipped


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

Test is working with IGZ 3.7 env

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11247
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
