### PR TITLE
[Application] Use custom http trigger instead of default one

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -304,6 +304,7 @@ default_config = {
         "application": {
             "default_sidecar_internal_port": 8050,
             "default_authentication_mode": mlrun.common.schemas.APIGatewayAuthenticationMode.none,
+            "default_worker_number": 10000,
         },
     },
     # TODO: function defaults should be moved to the function spec config above

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -802,6 +802,7 @@ class ApplicationRuntime(RemoteRuntime):
                 if isinstance(value, dict):
                     if value.get("kind") == "http":
                         skip_http_trigger_creation = True
+                        break
         if not skip_http_trigger_creation:
             self.with_http(
                 workers=mlrun.mlconf.function.application.default_worker_number,

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -413,8 +413,7 @@ class ApplicationRuntime(RemoteRuntime):
                 show_on_failure=show_on_failure,
             )
 
-        # This is a class method that accepts a function instance, so we pass self as the function instance
-        self._ensure_reverse_proxy_configurations(self)
+        self._ensure_reverse_proxy_configurations()
         self._configure_application_sidecar()
 
         # We only allow accessing the application via the API Gateway
@@ -793,27 +792,41 @@ class ApplicationRuntime(RemoteRuntime):
             with_mlrun=with_mlrun,
         )
 
-    @staticmethod
-    def _ensure_reverse_proxy_configurations(function: RemoteRuntime):
-        if function.spec.build.functionSourceCode or function.status.container_image:
+    def _ensure_reverse_proxy_configurations(self):
+        # If an HTTP trigger already exists in the spec,
+        # it means the user explicitly defined a custom configuration,
+        # so, skip automatic creation.
+        skip_http_trigger_creation = False
+        for key, value in self.spec.config.items():
+            if key.startswith("spec.triggers"):
+                if isinstance(value, dict):
+                    if value.get("kind") == "http":
+                        skip_http_trigger_creation = True
+        if not skip_http_trigger_creation:
+            self.with_http(
+                workers=mlrun.mlconf.function.application.default_worker_number,
+                trigger_name="application-http",
+            )
+
+        if self.spec.build.functionSourceCode or self.status.container_image:
             return
 
         filename, handler = ApplicationRuntime.get_filename_and_handler()
         name, spec, code = nuclio.build_file(
             filename,
-            name=function.metadata.name,
+            name=self.metadata.name,
             handler=handler,
         )
-        function.spec.function_handler = mlrun.utils.get_in(spec, "spec.handler")
-        function.spec.build.functionSourceCode = mlrun.utils.get_in(
+        self.spec.function_handler = mlrun.utils.get_in(spec, "spec.handler")
+        self.spec.build.functionSourceCode = mlrun.utils.get_in(
             spec, "spec.build.functionSourceCode"
         )
-        function.spec.nuclio_runtime = mlrun.utils.get_in(spec, "spec.runtime")
+        self.spec.nuclio_runtime = mlrun.utils.get_in(spec, "spec.runtime")
 
         # default the reverse proxy logger level to info
         logger_sinks_key = "spec.loggerSinks"
-        if not function.spec.config.get(logger_sinks_key):
-            function.set_config(
+        if not self.spec.config.get(logger_sinks_key):
+            self.set_config(
                 logger_sinks_key, [{"level": "info", "sink": "myStdoutLoggerSink"}]
             )
 

--- a/server/py/services/api/tests/unit/runtimes/test_application.py
+++ b/server/py/services/api/tests/unit/runtimes/test_application.py
@@ -82,6 +82,22 @@ class TestApplicationRuntime(TestRuntimeBase):
             == "'Application Runtime' function requires Nuclio v1.13.1 or higher"
         )
 
+    def test_http_trigger_configuration(self):
+        runtime = self._generate_runtime(self.runtime_kind)
+        assert (
+            runtime.spec.config.get("spec.triggers.application-http", {}).get(
+                "maxWorkers"
+            )
+            == mlrun.mlconf.function.application.default_worker_number
+        )
+        # replace an http trigger name to simulate custom http trigger
+        runtime.spec.config["spec.triggers.application-http-copy"] = (
+            runtime.spec.config.get("spec.triggers.application-http")
+        )
+        runtime.spec.config.pop("spec.triggers.application-http")
+        runtime._ensure_reverse_proxy_configurations()
+        assert runtime.spec.config.get("spec.triggers.application-http") is None
+
     def _execute_run(self, runtime, **kwargs):
         # deploy_nuclio_function doesn't accept watch, so we need to remove it
         kwargs.pop("watch", None)
@@ -97,6 +113,6 @@ class TestApplicationRuntime(TestRuntimeBase):
             project=self.project,
             kind=kind or self.runtime_kind,
         )
-        runtime._ensure_reverse_proxy_configurations(runtime)
+        runtime._ensure_reverse_proxy_configurations()
         runtime._configure_application_sidecar()
         return runtime

--- a/server/py/services/api/tests/unit/runtimes/test_application.py
+++ b/server/py/services/api/tests/unit/runtimes/test_application.py
@@ -96,6 +96,7 @@ class TestApplicationRuntime(TestRuntimeBase):
         )
         runtime.spec.config.pop("spec.triggers.application-http")
         runtime._ensure_reverse_proxy_configurations()
+        # ensure default application-http is not added as part of enrichment
         assert runtime.spec.config.get("spec.triggers.application-http") is None
 
     def _execute_run(self, runtime, **kwargs):


### PR DESCRIPTION
### 📝 Description
The application runtime's HTTP trigger was always created with NumWorkers = 1.
This happened because no HTTP trigger was explicitly defined within the application runtime, causing Nuclio to automatically generate a default trigger with a single worker.

As a result, the runtime could not take full advantage of Go’s lightweight concurrency model, where multiple workers can efficiently handle concurrent requests.

---

### 🛠️ Changes Made

Defined an HTTP trigger (with_http) in the application runtime’s spec, explicitly setting the desired number of workers.
This ensures the runtime uses multiple workers by default, leveraging Go’s concurrency capabilities for improved performance.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
unit, vmdev

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11295
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
