### PR TITLE
[Model Monitoring] Fix parquet labels column wrong type

### DIFF
--- a/mlrun/serving/system_steps.py
+++ b/mlrun/serving/system_steps.py
@@ -257,9 +257,10 @@ class MonitoringPreProcessor(storey.MapClass):
                             ].get(
                                 mlrun.common.schemas.MonitoringData.MODEL_ENDPOINT_UID
                             ),
-                            mm_schemas.StreamProcessingEvent.LABELS: monitoring_data[
+                            mm_schemas.StreamProcessingEvent.LABELS: event.body[
                                 model
-                            ].get(mlrun.common.schemas.MonitoringData.OUTPUTS),
+                            ].get("labels")
+                            or {},
                             mm_schemas.StreamProcessingEvent.FUNCTION_URI: self.server.function_uri
                             if self.server
                             else None,
@@ -301,19 +302,16 @@ class MonitoringPreProcessor(storey.MapClass):
                     mm_schemas.StreamProcessingEvent.ENDPOINT_ID: monitoring_data[
                         model
                     ].get(mlrun.common.schemas.MonitoringData.MODEL_ENDPOINT_UID),
-                    mm_schemas.StreamProcessingEvent.LABELS: monitoring_data[model].get(
-                        mlrun.common.schemas.MonitoringData.OUTPUTS
-                    ),
+                    mm_schemas.StreamProcessingEvent.LABELS: event.body.get("labels")
+                    or {},
                     mm_schemas.StreamProcessingEvent.FUNCTION_URI: self.server.function_uri
                     if self.server
                     else None,
                     mm_schemas.StreamProcessingEvent.REQUEST: request,
                     mm_schemas.StreamProcessingEvent.RESPONSE: resp,
-                    mm_schemas.StreamProcessingEvent.ERROR: event.body[
+                    mm_schemas.StreamProcessingEvent.ERROR: event.body.get(
                         mm_schemas.StreamProcessingEvent.ERROR
-                    ]
-                    if mm_schemas.StreamProcessingEvent.ERROR in event.body
-                    else None,
+                    ),
                     mm_schemas.StreamProcessingEvent.METRICS: event.body[
                         mm_schemas.StreamProcessingEvent.METRICS
                     ]

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1592,6 +1592,27 @@ class TestMonitoredServings(TestMLRunSystemModelMonitoring):
             label_column=label_column,
         )
 
+    def _log_iris_model(self) -> tuple[set[str], set[str]]:
+        dataset = load_iris()
+        train_set = pd.DataFrame(
+            dataset.data,
+            columns=dataset.feature_names,
+        )
+        inputs = {
+            mlrun.feature_store.api.norm_column_name(feature)
+            for feature in dataset.feature_names
+        }
+
+        self.project.log_model(
+            "classification",
+            model_dir=str((Path(__file__).parent / "assets").absolute()),
+            model_file="model.pkl",
+            training_set=train_set,
+        )
+        outputs = {"p0"}
+
+        return inputs, outputs
+
     def _deploy_model_router(
         self,
         name: str,
@@ -1842,6 +1863,60 @@ class TestMonitoredServings(TestMLRunSystemModelMonitoring):
             )
             func._get_db().get_nuclio_deploy_status(func, verbose=False)
             assert func.status.state == "ready"
+
+    def test_monitored_model_runner_with_labels(self):
+        self.function_name = "model-runner-function"
+        self.project.enable_model_monitoring(
+            image=self.image or "mlrun/mlrun",
+            base_period=1,
+            deploy_histogram_data_drift_app=True,
+        )
+        self._log_iris_model()
+
+        function = self.project.set_function(
+            func=str(self.assets_path / "models.py"),
+            name=self.function_name,
+            kind="serving",
+            image=self.image,
+        )
+        graph = function.set_topology("flow", engine="async")
+
+        model_runner_step = mlrun.serving.ModelRunnerStep(name="my_model_runner")
+
+        model_runner_step.add_model(
+            endpoint_name="my_model",
+            model_class="MyModel",
+            execution_mechanism="naive",
+            model_artifact=f"store://models/{self.project_name}/classification:latest",
+            input_path="inputs",
+            result_path="outputs",
+        )
+        graph.to(model_runner_step)
+        function.set_tracking()
+        function.deploy()
+        serving_fn = self.project.get_function(self.function_name)
+        serving_fn.invoke("/", body=json.dumps({"inputs": [[0, 0, 0, 0]]}))
+        time.sleep(1)
+        serving_fn.invoke(
+            "/", body=json.dumps({"inputs": [[1, 1, 1, 1]], "labels": {"user": "test"}})
+        )
+        time.sleep(
+            mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs + 60
+        )
+        endpoints_list = (
+            mlrun.db.get_run_db()
+            .list_model_endpoints(project=self.project_name, tsdb_metrics=True)
+            .endpoints
+        )
+        feature_set_uri = endpoints_list[0].spec.monitoring_feature_set_uri
+        offline_response_df = ParquetTarget(
+            name="temp",
+            path=fstore.get_feature_set(feature_set_uri).spec.targets[0].path,
+        ).as_df()
+        assert len(offline_response_df) == 2, "Not all the events were saved"
+        assert offline_response_df["labels"].iloc[1] == {
+            "user": "test"
+        }, "Labels were not saved correctly"
 
 
 class TestAppJob(TestMLRunSystem):


### PR DESCRIPTION
### 📝 Description
Bug fix, labels column wrong type was given by adding None value as labels, more over adding under this field the model output schema instead of model labels.
Fixed by changing the default behavior so the labels field will hold an empty dict, second preventing the writing of the model output schema under this event field in `system_steps.py`

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
added `test_monitored_model_runner_with_labels` system test for the sequence of writing first event with empty labels and later on adding labels to the events, checking the parquet writing was successful.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10943

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
