### PR TITLE
[User Secret] Refresh multiple access tokens at once when storing tokens [feature/ig4-authentication]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ install-iguazio-sdk: ## Install iguazio package from Test PyPI only for Python 3
 		$(MLRUN_PYTHON_VENV_PIP_INSTALL) $(MLRUN_PIP_NO_CACHE_FLAG) \
 			--index-url https://test.pypi.org/simple/ \
 			--extra-index-url https://pypi.org/simple \
-			"iguazio~=0.0.1a12"; \
+			"iguazio~=0.0.1a14"; \
 	else \
 		echo "Skipping iguazio install (Python $(MLRUN_PYTHON_VERSION))"; \
 	fi

--- a/dockerfiles/mlrun-api/Dockerfile
+++ b/dockerfiles/mlrun-api/Dockerfile
@@ -61,7 +61,7 @@ RUN chmod -R a+rX /mlrun/server/py/schemas/proto
 # TODO: remove this once iguazio package is released to PyPI and move to requirements.txt
 # Install iguazio package from Test PyPI
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
-    uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple iguazio~=0.0.1a12 --python-version ${MLRUN_PYTHON_VERSION}
+    uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple iguazio~=0.0.1a14 --python-version ${MLRUN_PYTHON_VERSION}
 
 # Remove server related files that are not needed in the base image
 # Remove ensurepip folders from both conda and system python

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -89,7 +89,7 @@ RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     if [ "${MLRUN_PYTHON_VERSION}" = "3.11" ]; then \
       uv pip install --index-url https://test.pypi.org/simple/ \
         --extra-index-url https://pypi.org/simple \
-        iguazio~=0.0.1a12 --python-version ${MLRUN_PYTHON_VERSION}; \
+        iguazio~=0.0.1a14 --python-version ${MLRUN_PYTHON_VERSION}; \
     else \
       echo "Skipping iguazio install for Python ${MLRUN_PYTHON_VERSION}"; \
     fi

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -21,6 +21,7 @@ if sys.version_info >= (3, 11):
     import iguazio
     from iguazio.schemas import (
         RefreshAccessTokenOptionsV1,
+        RefreshAccessTokensOptionsV1,
         RevokeOfflineTokenOptionsV1,
     )
 
@@ -51,10 +52,13 @@ class Client(BaseClient):
         Refreshes the access token by validating the provided token via the Iguazio client.
 
         :param secret_token: SecretToken object containing the token name and offline token string.
-        :raises mlrun.errors.MLRunInvalidArgumentError: If the offline token is empty.
+        :raises mlrun.errors.MLRunInvalidArgumentError: If the secret_token is None or the offline token is empty.
         :raises mlrun.errors.MLRunUnauthorizedError: If the offline token is invalid, expired, or an error
         occurs while refreshing.
         """
+        if not secret_token:
+            raise mlrun.errors.MLRunInvalidArgumentError("SecretToken is None")
+
         if not secret_token.token:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Offline token for '{secret_token.name}' is empty"
@@ -102,11 +106,59 @@ class Client(BaseClient):
         """
         Refresh all offline tokens using the Iguazio client to validate them.
 
-        :param secret_tokens: List of SecretToken objects
+        :param secret_tokens: List of SecretToken
+        :raises mlrun.errors.MLRunInvalidArgumentError: If the list is empty or any token is empty
         :raises mlrun.errors.MLRunUnauthorizedError: If any token is invalid or expired
         """
-        # TODO: Implement this method once it is available in the Iguazio package
-        pass
+        if not secret_tokens:
+            raise mlrun.errors.MLRunInvalidArgumentError("No offline tokens provided")
+
+        token_names = [t.name for t in secret_tokens]
+        token_values = [t.token for t in secret_tokens]
+
+        if not all(token_values):
+            empty_tokens = [t.name for t in secret_tokens if not t.token]
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Offline tokens are empty for: {', '.join(empty_tokens)}"
+            )
+
+        self._logger.info(
+            "Refreshing multiple access tokens via Iguazio", token_names=token_names
+        )
+
+        try:
+            options = RefreshAccessTokensOptionsV1(refresh_tokens=token_values)
+            # Call Iguazio batch refresh
+            self._client.refresh_access_tokens(options=options)
+
+            self._logger.info(
+                "Successfully refreshed multiple access tokens via Iguazio",
+                token_names=token_names,
+            )
+
+        except httpx.HTTPStatusError as exc:
+            error_message, ctx = self._extract_response_error(exc.response)
+            self._logger.warning(
+                "Failed to refresh multiple access tokens from Iguazio",
+                token_names=token_names,
+                status_code=exc.response.status_code,
+                error_message=error_message,
+                ctx=ctx,
+                exc=mlrun.errors.err_to_str(exc),
+            )
+            raise mlrun.errors.MLRunUnauthorizedError(
+                f"Failed to refresh tokens '{', '.join(token_names)}' from Iguazio: {error_message}, ctx={ctx}"
+            ) from exc
+        except Exception as exc:
+            exc_str = mlrun.errors.err_to_str(exc)
+            self._logger.warning(
+                "Failed to refresh multiple access tokens from Iguazio (unexpected error)",
+                token_names=token_names,
+                exc=exc_str,
+            )
+            raise mlrun.errors.MLRunUnauthorizedError(
+                f"Failed to refresh tokens '{', '.join(token_names)}' from Iguazio: {exc_str}"
+            ) from exc
 
     def revoke_offline_token(
         self, token: str, request_headers: typing.Optional[dict[str, str]] = None

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -454,18 +454,14 @@ class Secrets(
         # TODO: move init iguazio_client (ML-11077)
         iguazio_client = framework.utils.clients.iguazio.v4.Client()
 
-        # TODO: Enable this once it is implemented in the Iguazio client (ML-10776)
-        # iguazio_client.refresh_access_tokens(secret_tokens)
+        # We validate the offline tokens by sending it to Iguazio for verification.
+        iguazio_client.refresh_access_tokens(secret_tokens)
 
         token_actions = defaultdict(list)
 
         for secret_token in secret_tokens:
             token_name = secret_token.name
             token = secret_token.token
-
-            # TODO remove this and use refresh_access_tokens once it is implemented in Iguazio client (ML-10776)
-            # We validate the offline token by sending it to Iguazio for verification.
-            iguazio_client.refresh_access_token(secret_token)
 
             expiration = self._extract_and_validate_expiration(token_name, token)
 

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -701,7 +701,7 @@ def mock_iguazio_client():
         "framework.utils.clients.iguazio.v4.Client"
     ) as mock_client_cls:
         mock_client_instance = unittest.mock.MagicMock()
-        mock_client_instance.refresh_access_token.return_value = None
+        mock_client_instance.refresh_access_tokens.return_value = None
         mock_client_instance.revoke_offline_token.return_value = None
         mock_client_cls.return_value = mock_client_instance
         yield mock_client_instance
@@ -803,11 +803,11 @@ def test_store_secret_tokens_return_values(mock_iguazio_client):
     }
 
     assert mock_secrets_provider.store_user_token_secret.call_count == 3
-    assert mock_iguazio_client.refresh_access_token.call_count == 3
+    assert mock_iguazio_client.refresh_access_tokens.call_count == 1
 
 
 def test_store_secret_tokens_refresh_access_tokens_failure(mock_iguazio_client):
-    mock_iguazio_client.refresh_access_token.side_effect = (
+    mock_iguazio_client.refresh_access_tokens.side_effect = (
         mlrun.errors.MLRunUnauthorizedError("Refresh failed")
     )
 
@@ -821,7 +821,7 @@ def test_store_secret_tokens_refresh_access_tokens_failure(mock_iguazio_client):
     with pytest.raises(mlrun.errors.MLRunUnauthorizedError, match="Refresh failed"):
         services.api.crud.Secrets().store_secret_tokens(secret_tokens, "dummy-username")
 
-    mock_iguazio_client.refresh_access_token.assert_called_once_with(secret_tokens[0])
+    mock_iguazio_client.refresh_access_tokens.assert_called_once_with(secret_tokens)
 
 
 def test_list_secret_tokens_returns_tokens():

--- a/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
@@ -17,6 +17,7 @@ import http
 import sys
 import unittest.mock
 
+import httpx
 import pytest
 from aioresponses import CallbackResult
 
@@ -33,7 +34,6 @@ from server.py.services.api.tests.unit.utils.clients.iguazio.conftest import (
 )
 from tests.common_fixtures import aioresponses_mock
 
-import framework.utils.clients.iguazio.v4
 from framework.utils.asyncio import maybe_coroutine
 
 
@@ -335,20 +335,103 @@ def sample_user_info(username="dummy-user", user_id="dummy-user-id", group_ids=N
     }
 
 
-def test_revoke_offline_token_success():
+@pytest.mark.parametrize(
+    "secret_token, expected_exception",
+    [
+        (None, mlrun.errors.MLRunInvalidArgumentError),  # None token
+        (
+            mlrun.common.schemas.SecretToken(name="t1", token=""),
+            mlrun.errors.MLRunInvalidArgumentError,
+        ),  # empty token
+        (
+            mlrun.common.schemas.SecretToken(name="t1", token="valid-token"),
+            None,
+        ),  # valid token
+    ],
+)
+@pytest.mark.parametrize("iguazio_client", [("v4", "sync")], indirect=True)
+def test_refresh_access_token_cases(iguazio_client, secret_token, expected_exception):
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            iguazio_client.refresh_access_token(secret_token)
+    else:
+        # simulate HTTP error
+        iguazio_client._client.refresh_access_token.side_effect = httpx.HTTPStatusError(
+            "Error",
+            request=None,
+            response=unittest.mock.MagicMock(
+                status_code=401,
+                json=lambda: {"status": {"errorMessage": "invalid", "ctx": "dummy"}},
+            ),
+        )
+        with pytest.raises(mlrun.errors.MLRunUnauthorizedError):
+            iguazio_client.refresh_access_token(secret_token)
+
+
+@pytest.mark.parametrize("iguazio_client", [("v4", "sync")], indirect=True)
+def test_refresh_access_token_success(iguazio_client):
+    secret_token = mlrun.common.schemas.SecretToken(
+        name="test-token", token="valid-token"
+    )
+
+    # Should not raise
+    iguazio_client.refresh_access_token(secret_token)
+
+    iguazio_client._client.refresh_access_token.assert_called_once()
+    called_options = iguazio_client._client.refresh_access_token.call_args[1]["options"]
+    assert called_options.refresh_token == "valid-token"
+
+
+@pytest.mark.parametrize(
+    "secret_tokens, expected_exception",
+    [
+        ([], mlrun.errors.MLRunInvalidArgumentError),  # empty list
+        (
+            [mlrun.common.schemas.SecretToken(name="t1", token="")],
+            mlrun.errors.MLRunInvalidArgumentError,
+        ),  # empty token in list
+        (
+            [
+                mlrun.common.schemas.SecretToken(name="t1", token="token1"),
+                mlrun.common.schemas.SecretToken(name="t2", token="token2"),
+            ],
+            None,
+        ),  # valid tokens
+    ],
+)
+@pytest.mark.parametrize("iguazio_client", [("v4", "sync")], indirect=True)
+def test_refresh_access_tokens_cases(iguazio_client, secret_tokens, expected_exception):
+    if expected_exception:
+        with pytest.raises(expected_exception):
+            iguazio_client.refresh_access_tokens(secret_tokens)
+    else:
+        # simulate HTTP error
+        iguazio_client._client.refresh_access_tokens.side_effect = (
+            httpx.HTTPStatusError(
+                "Error",
+                request=None,
+                response=unittest.mock.MagicMock(
+                    status_code=401,
+                    json=lambda: {
+                        "status": {"errorMessage": "invalid", "ctx": "dummy"}
+                    },
+                ),
+            )
+        )
+        with pytest.raises(mlrun.errors.MLRunUnauthorizedError):
+            iguazio_client.refresh_access_tokens(secret_tokens)
+
+
+@pytest.mark.parametrize("iguazio_client", [("v4", "sync")], indirect=True)
+def test_revoke_offline_token_success(iguazio_client):
     token = "valid-token"
     request_headers = {
         mlrun.common.schemas.HeaderNames.authorization: f"{mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer}123",
     }
 
-    # prevents from creating a real Iguazio client
-    with unittest.mock.patch("framework.utils.clients.iguazio.v4.iguazio.Client"):
-        client = framework.utils.clients.iguazio.v4.Client()
-        client._client = unittest.mock.MagicMock()
+    iguazio_client.revoke_offline_token(token, request_headers)
 
-        client.revoke_offline_token(token, request_headers)
-
-        client._client.set_override_auth_headers.assert_called_once_with(
-            request_headers
-        )
-        client._client.revoke_offline_token.assert_called_once()
+    iguazio_client._client.set_override_auth_headers.assert_called_once_with(
+        request_headers
+    )
+    iguazio_client._client.revoke_offline_token.assert_called_once()


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Implement `refresh_access_tokens` in the Iguazio v4 client, which delegates to the iguazio package to refresh multiple access tokens at once.
rebase this pr - https://github.com/mlrun/mlrun/pull/8677

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Bumped iguazio to 0.0.1a14.
- Implemented refresh_access_tokens in Iguazio v4 client.
- Added tests for refresh_access_token and refresh_access_tokens.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [x] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Verified functionality with unit tests.
Tested on IG4 system

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10776
- Design docs links: https://iguazio.atlassian.net/wiki/spaces/MLRUN/pages/404521061/BE+Secret+Token+Support+HLD#2.2.3-Token-Store-or-Update-Flow
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
