### PR TITLE
[Tests] Remove v3io user label from test_run_pipeline

### DIFF
--- a/tests/system/examples/dask/test_dask.py
+++ b/tests/system/examples/dask/test_dask.py
@@ -112,9 +112,6 @@ class TestDask(TestMLRunSystem):
             name=f"{dask_function.metadata.name}-main",
             project=self.project_name,
             labels={
-                mlrun_constants.MLRunInternalLabels.v3io_user: self._test_env[
-                    "V3IO_USERNAME"
-                ],
                 mlrun_constants.MLRunInternalLabels.owner: self._test_env[
                     "V3IO_USERNAME"
                 ],


### PR DESCRIPTION
### 📝 Description

Removed the redundant `v3io_user` label from the `test_run_pipeline` system test.
This label no longer serves any purpose, as the test already includes the owner label, which correctly represents the user who triggered the workflow.
And the `v3io_user` label was also deprecated in a previous PR ( https://github.com/mlrun/mlrun/pull/8343) , so it can be removed from the test as well.

---

### 🛠️ Changes Made
Removed the `v3io_user` label from `test_run_pipeline`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
The system test passes now.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11236
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
