### PR TITLE
[Model Monitoring] Fix test_batch_drift

### DIFF
--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -658,6 +658,8 @@ class MonitoringApplicationController:
                                 self.feature_sets.popitem(last=True)
                             m_fs = self.feature_sets.get(endpoint_id)
                             print(f"m_fs: {m_fs}")
+                            print(f"start_infer_time: {start_infer_time}, end_infer_time:{end_infer_time}")
+                            print(f"self.storage_option: {self.storage_options}")
                             df = m_fs.to_dataframe(
                                 start_time=start_infer_time,
                                 end_time=end_infer_time,

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -642,25 +642,31 @@ class MonitoringApplicationController:
                                 # TODO: Remove this in 1.12.0
                                 FutureWarning,
                             )
-
+                            print(f"endpoint_id: {endpoint_id}")
                             if endpoint_id not in self.feature_sets:
+                                print("in endpoint_id not in self.feature_sets")
                                 self.feature_sets[endpoint_id] = fstore.get_feature_set(
                                     event[ControllerEvent.FEATURE_SET_URI]
                                 )
+                                print(f"self.feature_sets[endpoint_id]: {self.feature_sets[endpoint_id]}")
                             self.feature_sets.move_to_end(endpoint_id, last=False)
                             if (
                                 len(self.feature_sets)
                                 > self._MAX_FEATURE_SET_PER_WORKER
                             ):
+                                print("pop item")
                                 self.feature_sets.popitem(last=True)
                             m_fs = self.feature_sets.get(endpoint_id)
-
+                            print(f"m_fs: {m_fs}")
                             df = m_fs.to_dataframe(
                                 start_time=start_infer_time,
                                 end_time=end_infer_time,
                                 time_column=mm_constants.EventFieldType.TIMESTAMP,
                                 storage_options=self.storage_options,
                             )
+                            print(f"len(df): {len(df)}")
+                            print(f"df.empty: {df.empty}")
+                            print(f"df columns: {df.columns.to_list()}")
                             if len(df) > 0:
                                 data_in_window = True
 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -642,33 +642,23 @@ class MonitoringApplicationController:
                                 # TODO: Remove this in 1.12.0
                                 FutureWarning,
                             )
-                            print(f"endpoint_id: {endpoint_id}")
                             if endpoint_id not in self.feature_sets:
-                                print("in endpoint_id not in self.feature_sets")
                                 self.feature_sets[endpoint_id] = fstore.get_feature_set(
                                     event[ControllerEvent.FEATURE_SET_URI]
                                 )
-                                print(f"self.feature_sets[endpoint_id]: {self.feature_sets[endpoint_id]}")
                             self.feature_sets.move_to_end(endpoint_id, last=False)
                             if (
                                 len(self.feature_sets)
                                 > self._MAX_FEATURE_SET_PER_WORKER
                             ):
-                                print("pop item")
                                 self.feature_sets.popitem(last=True)
                             m_fs = self.feature_sets.get(endpoint_id)
-                            print(f"m_fs: {m_fs}")
-                            print(f"start_infer_time: {start_infer_time}, end_infer_time:{end_infer_time}")
-                            print(f"self.storage_option: {self.storage_options}")
                             df = m_fs.to_dataframe(
                                 start_time=start_infer_time,
                                 end_time=end_infer_time,
                                 time_column=mm_constants.EventFieldType.TIMESTAMP,
                                 storage_options=self.storage_options,
                             )
-                            print(f"len(df): {len(df)}")
-                            print(f"df.empty: {df.empty}")
-                            print(f"df columns: {df.columns.to_list()}")
                             if len(df) > 0:
                                 data_in_window = True
 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -642,6 +642,7 @@ class MonitoringApplicationController:
                                 # TODO: Remove this in 1.12.0
                                 FutureWarning,
                             )
+
                             if endpoint_id not in self.feature_sets:
                                 self.feature_sets[endpoint_id] = fstore.get_feature_set(
                                     event[ControllerEvent.FEATURE_SET_URI]
@@ -653,6 +654,7 @@ class MonitoringApplicationController:
                             ):
                                 self.feature_sets.popitem(last=True)
                             m_fs = self.feature_sets.get(endpoint_id)
+
                             df = m_fs.to_dataframe(
                                 start_time=start_infer_time,
                                 end_time=end_infer_time,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1551,10 +1551,11 @@ class TestBatchDrift(TestMLRunSystemModelMonitoring):
                 "p0": [0, 0],
             }
         )
+        # Add 20 seconds because the batch window is determined using datetime.now later in _generate_model_endpoint
+        # ML-11276
         infer_results_df[mlrun.common.schemas.EventFieldType.TIMESTAMP] = (
-            mlrun.utils.datetime_now()
+            mlrun.utils.datetime_now() + timedelta(seconds=20)
         )
-
         model_path = project.get_artifact_uri(
             key=model_name, category="model", tag="latest"
         )
@@ -1599,7 +1600,7 @@ class TestBatchDrift(TestMLRunSystemModelMonitoring):
         )
 
         # Wait for the controller, app and writer to complete
-        sleep(180)
+        sleep(240)
 
         model_endpoint_batch = mlrun.model_monitoring.api.get_or_create_model_endpoint(
             project=project.name,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1601,7 +1601,7 @@ class TestBatchDrift(TestMLRunSystemModelMonitoring):
         )
 
         # Wait for the controller, app and writer to complete
-        sleep(240)
+        sleep(300)
 
         model_endpoint_batch = mlrun.model_monitoring.api.get_or_create_model_endpoint(
             project=project.name,

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -1556,6 +1556,7 @@ class TestBatchDrift(TestMLRunSystemModelMonitoring):
         infer_results_df[mlrun.common.schemas.EventFieldType.TIMESTAMP] = (
             mlrun.utils.datetime_now() + timedelta(seconds=20)
         )
+
         model_path = project.get_artifact_uri(
             key=model_name, category="model", tag="latest"
         )


### PR DESCRIPTION
### 📝 Description

The `test_batch_drift` test was broken because the timestamp in `infer_df` was older than first_request.
 As a result, none of the events in the batch were processed since they didn’t pass the timestamp filters (they did not fit the timestamp window).
 
That's happen because the first_request time determined in this case in `_generate_model_endpoint`, which set it as default to datetime.now.

---

### 🛠️ Changes Made
Test updated to use additional 20 seconds to include these events in the controller window.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11276
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
