### PR TITLE
[Model Monitoring] Add a warning in evaluate when no data was found

### DIFF
--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -390,6 +390,16 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                         context.log_result(
                             result_key, self._flatten_data_result(result)
                         )
+                # Check if no result was produced for any endpoint (e.g., due to no data in all windows)
+                if not any(endpoints_output.values()):
+                    context.logger.warning(
+                        "No data was found for any of the specified endpoints. "
+                        "No results were produced.",
+                        application_name=application_name,
+                        endpoints=endpoints,
+                        start=start,
+                        end=end,
+                    )
             else:
                 result = call_do_tracking(
                     mm_context.MonitoringApplicationContext._from_ml_ctx(

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -233,7 +233,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
         try:
             yield endpoints_output, application_schedules.__enter__()
         finally:
-            if write_output:
+            if write_output and any(endpoints_output.values()):
                 logger.debug(
                     "Pushing model monitoring application job data to the writer stream",
                     passed_stream_profile=str(stream_profile),
@@ -394,7 +394,7 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 if not any(endpoints_output.values()):
                     context.logger.warning(
                         "No data was found for any of the specified endpoints. "
-                        "No results were produced.",
+                        "No results were produced",
                         application_name=application_name,
                         endpoints=endpoints,
                         start=start,


### PR DESCRIPTION
### 📝 Description

Add a warning log when using MM app evaluate with endpoints, and no data was found in any of the windows or `sample_data` is empty.
In addition, skip the "pushing to stream" logs and stream object instantiation when there is no data.

---

### ✅ Checklist

- [x] I have tested the changes in this PR

---

### 🧪 Testing

Manual testing.

---

### 🔗 References

- Ticket link: [ML-11188](https://iguazio.atlassian.net/browse/ML-11188)

---

### 🚨 Breaking Changes?

- [x] No

[ML-11188]: https://iguazio.atlassian.net/browse/ML-11188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ