### PR TITLE
[Model-Monitoring] Exempt MM-stream pod from "double" enable-MM reject

### DIFF
--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -153,11 +153,19 @@ class MonitoringDeployment:
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
             self.set_credentials()
-        if deployed_functions := self.get_deployed_model_monitoring_functions():
+        # reject the request if controller and/or writer pods are already deployed.
+        # stream-pod is not checked since by default it is not deleted by disable_model_monitoring.
+        if deployed_functions := [
+            function_name
+            for function_name in self.get_deployed_model_monitoring_functions()
+            if function_name != mm_constants.MonitoringFunctionNames.STREAM
+        ]:
             raise mlrun.errors.MLRunConflictError(
                 "The following model-montioring infrastructure functions are already deployed, aborting: "
                 f"{deployed_functions}\n"
-                "If you want to redeploy the model-monitoring infrastructure, call disable_model_monitoring"
+                "If you want to redeploy the model-monitoring controller (maybe with different base-period), "
+                "use update_model_monitoring_controller."
+                "If you want to redeploy all of model-monitoring infrastructure, call disable_model_monitoring"
                 "before calling enable_model_monitoring again."
             )
         self.check_if_credentials_are_set()

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1832,6 +1832,7 @@ class TestMonitoredServings(TestMLRunSystemModelMonitoring):
     def test_enable_model_monitoring_after_failure(self) -> None:
         self.function_name = "test-function"
 
+        # non-exstent-image, should fail
         with pytest.raises(
             mlrun.runtimes.utils.RunError,
             match="Function .* deployment failed",
@@ -1840,10 +1841,13 @@ class TestMonitoredServings(TestMLRunSystemModelMonitoring):
                 image="nonexistent-image:1.0.0",
                 wait_for_deployment=True,
             )
+
         self.project.enable_model_monitoring(
             image=self.image or "mlrun/mlrun",
             wait_for_deployment=True,
         )
+
+        # double enable should fail
         with pytest.raises(
             mlrun.errors.MLRunConflictError,
             match="The following model-montioring infrastructure functions are already deployed, aborting: ",
@@ -1852,6 +1856,14 @@ class TestMonitoredServings(TestMLRunSystemModelMonitoring):
                 image=self.image or "mlrun/mlrun",
                 wait_for_deployment=True,
             )
+
+        # disable + enable should succeed
+        self.project.disable_model_monitoring()
+        self.project.enable_model_monitoring(
+            image=self.image or "mlrun/mlrun",
+            wait_for_deployment=True,
+        )
+
         # check that all the function are still deployed
         all_functions = mm_constants.MonitoringFunctionNames.list() + [
             mm_constants.HistogramDataDriftApplicationConstants.NAME


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
See [RCA + discussion on fix](https://iguazio.atlassian.net/browse/ML-11268?focusedCommentId=190019) in the jira.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
1. Ignore stream-pod when checking existing mm-infra functions on enable_model_monitoring
2. On double enable reject, suggest the user to use update_model_monitoring_controller as well (as alternative to disable+enable)
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR
- [X] I confirmed whether my changes are covered by system tests
  - [X] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [X] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Tested by updated test_enable_model_monitoring_after_failure
---

### 🔗 References
- Ticket link: ML-11268
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
