### PR TITLE
[Runtimes] Fix MPIJob scheduling constraints sanitization

### DIFF
--- a/server/py/services/api/runtime_handlers/mpijob/v1.py
+++ b/server/py/services/api/runtime_handlers/mpijob/v1.py
@@ -123,12 +123,8 @@ class MpiV1RuntimeHandler(AbstractMPIJobRuntimeHandler):
             "spec.nodeSelector": mlrun.utils.helpers.to_non_empty_values_dict(
                 run.spec.node_selector
             ),
-            "spec.affinity": mlrun.runtimes.pod.get_sanitized_attribute(
-                run.spec, "affinity"
-            ),
-            "spec.tolerations": mlrun.runtimes.pod.get_sanitized_attribute(
-                run.spec, "tolerations"
-            ),
+            "spec.affinity": run.spec.affinity,
+            "spec.tolerations": run.spec.tolerations,
             "spec.securityContext": mlrun.runtimes.pod.get_sanitized_attribute(
                 runtime.spec, "security_context"
             )

--- a/server/py/services/api/tests/unit/runtimes/test_mpijob.py
+++ b/server/py/services/api/tests/unit/runtimes/test_mpijob.py
@@ -53,6 +53,66 @@ class TestMpiV1Runtime(TestRuntimeBase):
 
             assert run.status.state == "running"
 
+    def test_run_with_affinity_and_tolerations(
+        self, db: Session, client: TestClient, k8s_secrets_mock
+    ):
+        """
+        Verify that affinity and tolerations are correctly applied to MPIJob pod templates.
+
+        This test ensures that when affinity and tolerations are set,
+        they are properly serialized and applied to the pod template without triggering type
+        validation errors during job submission.
+
+        """
+        self._mock_list_pods()
+        self._mock_create_namespaced_custom_object()
+        self._mock_get_namespaced_custom_object(workers=1)
+
+        mpijob_function = self._generate_runtime(self.runtime_kind)
+
+        # Create V1 affinity and tolerations objects
+        affinity = k8s_client.V1Affinity(
+            node_affinity=k8s_client.V1NodeAffinity(
+                required_during_scheduling_ignored_during_execution=k8s_client.V1NodeSelector(
+                    node_selector_terms=[
+                        k8s_client.V1NodeSelectorTerm(
+                            match_expressions=[
+                                k8s_client.V1NodeSelectorRequirement(
+                                    key="app.iguazio.com/lifecycle",
+                                    operator="NotIn",
+                                    values=["preemptible"],
+                                )
+                            ]
+                        )
+                    ]
+                )
+            )
+        )
+
+        tolerations = [
+            k8s_client.V1Toleration(
+                key="nvidia.com/gpu",
+                operator="Equal",
+                value="true",
+                effect="NoSchedule",
+            )
+        ]
+
+        mpijob_function.with_node_selection(
+            affinity=affinity,
+            tolerations=tolerations,
+        )
+
+        self.deploy(db, mpijob_function)
+
+        run = mpijob_function.run(
+            artifact_path="v3io:///mypath",
+            watch=False,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+        )
+
+        assert run.status.state == "running"
+
     def test_run_launcher_status_update(
         self, db: Session, client: TestClient, k8s_secrets_mock
     ):


### PR DESCRIPTION
### 📝 Description

Fixed a type validation error in MPIJob runtime that occurred after refactoring preemptible node configuration. The refactoring changed when affinity, tolerations, and node selector are enriched from preemptible configuration - moving from function-level configuration to run-level enrichment at launch time.

After this refactoring, the `get_sanitized_attribute` function was incorrectly rejecting valid dict types from `run.spec.affinity` and `run.spec.tolerations` with the error: `"expected to be of type <class 'dict'> but got dict"`. This PR removes the unnecessary sanitization calls for these attributes in the MPIJob pod template configuration, as they are now properly enriched and validated on the run spec at launch time, making the additional sanitization redundant.

---

### 🛠️ Changes Made

- Removed `get_sanitized_attribute` calls for `affinity` and `tolerations` in `_configure_pod_template` method
- Added unit test coverage to prevent regression of this type validation error

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Added unit test `test_run_with_affinity_and_tolerations` that verifies MPIJob runs complete successfully when affinity and tolerations are configured via `with_node_selection()`
- Tested manually against a system with preemptible configuration 


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11290
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

