### PR TITLE
[User secrets] Add force flag when storing secret token [feature/ig4-authentication]

### DIFF
--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -62,6 +62,7 @@ class SecretProviderInterface(ABC):
         token_name: str,
         token: str,
         expiration: int,
+        force: bool = False,
         namespace: typing.Optional[str] = None,
     ) -> typing.Optional[mlrun.common.schemas.SecretEventActions]:
         pass
@@ -174,6 +175,7 @@ class InMemorySecretProvider(SecretProviderInterface):
         token_name: str,
         token: str,
         expiration: int,
+        force: bool = False,
         namespace: typing.Optional[str] = None,
     ) -> typing.Optional[mlrun.common.schemas.SecretEventActions]:
         raise NotImplementedError()

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -1165,6 +1165,7 @@ class RunDBInterface(ABC):
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
+        force: bool = False,
         log_warning: bool = True,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         pass
@@ -1174,6 +1175,7 @@ class RunDBInterface(ABC):
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         pass
 

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -1165,8 +1165,8 @@ class RunDBInterface(ABC):
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
-        force: bool = False,
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         pass
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5236,6 +5236,7 @@ class HTTPRunDB(RunDBInterface):
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
+        force: bool = False,
         log_warning: bool = True,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         """
@@ -5249,6 +5250,7 @@ class HTTPRunDB(RunDBInterface):
             db.store_secret_token(secret)
 
         :param secret_token: A SecretToken object with name and token fields.
+        :param force: Whether to force update the token if it already exists. Defaults to False.
         :param log_warning: Whether to log a warning about local config sync. Defaults to True.
         :return: A structured response indicating which tokens were created, updated, or skipped.
         """
@@ -5257,6 +5259,7 @@ class HTTPRunDB(RunDBInterface):
 
         response = self._store_secret_tokens(
             secret_tokens=[secret_token],
+            force=force,
             error=f"store user secret token {secret_token.name}",
         )
 
@@ -5278,6 +5281,7 @@ class HTTPRunDB(RunDBInterface):
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         """
         Store or update multiple secret tokens in the MLRun backend.
@@ -5293,6 +5297,7 @@ class HTTPRunDB(RunDBInterface):
             db.store_secret_tokens(tokens)
 
         :param secret_tokens: List of SecretToken objects with 'name' and 'token' fields.
+        :param force: Whether to force update tokens if they already exist. Defaults to False.
         :param log_warning: Whether to log a warning about local config file sync. Defaults to True.
         :return: StoreSecretTokensResponse object indicating which tokens were created, updated, or skipped.
         """
@@ -5301,6 +5306,7 @@ class HTTPRunDB(RunDBInterface):
 
         response = self._store_secret_tokens(
             secret_tokens=secret_tokens,
+            force=force,
             error="store multiple user secret tokens",
         )
 
@@ -5345,15 +5351,18 @@ class HTTPRunDB(RunDBInterface):
     def _store_secret_tokens(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
+        force: bool,
         error: str,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         body = [token.dict() for token in secret_tokens]
+        params = {"force": str(force).lower()}  # send as query param
         endpoint_path = "user-secrets/tokens"
 
         response = self.api_call(
             mlrun.common.types.HTTPMethod.PUT,
             endpoint_path,
             error,
+            params=params,
             body=dict_to_json(body),
         )
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5236,8 +5236,8 @@ class HTTPRunDB(RunDBInterface):
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
-        force: bool = False,
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         """
         Store or update a single secret token in the MLRun backend.

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -5351,11 +5351,11 @@ class HTTPRunDB(RunDBInterface):
     def _store_secret_tokens(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
-        force: bool,
         error: str,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         body = [token.dict() for token in secret_tokens]
-        params = {"force": str(force).lower()}  # send as query param
+        params = {"force": force}  # send as query param
         endpoint_path = "user-secrets/tokens"
 
         response = self.api_call(

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -1000,6 +1000,7 @@ class NopDB(RunDBInterface):
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
+        force: bool = False,
         log_warning: bool = True,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         pass
@@ -1008,6 +1009,7 @@ class NopDB(RunDBInterface):
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         pass
 

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -1000,8 +1000,8 @@ class NopDB(RunDBInterface):
     def store_secret_token(
         self,
         secret_token: mlrun.common.schemas.SecretToken,
-        force: bool = False,
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         pass
 

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -1411,6 +1411,7 @@ class SQLRunDB(RunDBInterface):
         self,
         secret_token: mlrun.common.schemas.SecretToken,
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         raise NotImplementedError
 
@@ -1418,6 +1419,7 @@ class SQLRunDB(RunDBInterface):
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
         log_warning: bool = True,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         raise NotImplementedError
 

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1177,6 +1177,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         token_name: str,
         token: str,
         expiration: int,
+        force: bool = False,
         namespace: typing.Optional[str] = None,
     ) -> typing.Optional[mlrun.common.schemas.SecretEventActions]:
         """
@@ -1194,6 +1195,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :param token_name: The logical name for the token.
         :param token: The offline token string (JWT).
         :param expiration: The token's expiration timestamp (int UNIX epoch).
+        :param force: If True, forces an update of the secret even if the expiration
+                      is not later than the existing one.
         :param namespace: Kubernetes namespace for the secret.
         :return: SecretEventActions.{created, updated, skipped}
         """
@@ -1230,8 +1233,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             )
             return mlrun.common.schemas.SecretEventActions.created
 
-        # Update only if expiration is newer
-        if self._should_update_token_secret(k8s_secret, expiration):
+        # Update if force or if expiration is newer
+        if force or self._should_update_token_secret(k8s_secret, expiration):
             self._update_secret(
                 k8s_secret=k8s_secret,
                 namespace=namespace,

--- a/server/py/services/api/api/endpoints/user_secrets.py
+++ b/server/py/services/api/api/endpoints/user_secrets.py
@@ -35,7 +35,7 @@ router = fastapi.APIRouter(prefix="/user-secrets")
 )
 async def store_secret_tokens(
     secret_tokens: list[mlrun.common.schemas.SecretToken],
-    force: bool,
+    force: bool = False,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         framework.api.deps.authenticate_request
     ),

--- a/server/py/services/api/api/endpoints/user_secrets.py
+++ b/server/py/services/api/api/endpoints/user_secrets.py
@@ -35,6 +35,7 @@ router = fastapi.APIRouter(prefix="/user-secrets")
 )
 async def store_secret_tokens(
     secret_tokens: list[mlrun.common.schemas.SecretToken],
+    force:bool,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         framework.api.deps.authenticate_request
     ),
@@ -44,6 +45,7 @@ async def store_secret_tokens(
         services.api.crud.Secrets().store_secret_tokens,
         secret_tokens,
         auth_info.username,
+        force,
     )
 
 

--- a/server/py/services/api/api/endpoints/user_secrets.py
+++ b/server/py/services/api/api/endpoints/user_secrets.py
@@ -35,7 +35,7 @@ router = fastapi.APIRouter(prefix="/user-secrets")
 )
 async def store_secret_tokens(
     secret_tokens: list[mlrun.common.schemas.SecretToken],
-    force:bool,
+    force: bool,
     auth_info: mlrun.common.schemas.AuthInfo = fastapi.Depends(
         framework.api.deps.authenticate_request
     ),

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -427,7 +427,7 @@ class Secrets(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
         authenticated_username: str,
-        force: bool,
+        force: bool = False,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         """
         Validate and store offline tokens as Kubernetes secrets.

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -427,11 +427,13 @@ class Secrets(
         self,
         secret_tokens: list[mlrun.common.schemas.SecretToken],
         authenticated_username: str,
+        force: bool,
     ) -> mlrun.common.schemas.StoreSecretTokensResponse:
         """
         Validate and store offline tokens as Kubernetes secrets.
 
         :param secret_tokens: List of SecretToken objects to store.
+        :param force: Whether to force update existing tokens.
         :param authenticated_username: Username used to name Kubernetes secrets.
         :return: StoreSecretTokensResponse object with created, updated, and skipped tokens.
         """
@@ -474,6 +476,7 @@ class Secrets(
                 token_name=token_name,
                 token=token,
                 expiration=expiration,
+                force=force,
             )
             if action is not None:
                 token_actions[action].append(token_name)

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -564,6 +564,36 @@ def test_store_user_token_secret_skipped(k8s_helper):
     k8s_helper._create_secret.assert_not_called()
 
 
+def test_store_user_token_secret_force_update(k8s_helper):
+    username = "test-user"
+    token_name = "my-token"
+    token_value = "abc123"
+    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+
+    # Existing secret with newer expiration
+    existing_secret = _make_user_token_secret(
+        secret_name,
+        token_name=token_name,
+        token_value=token_value,
+        expiration=5000,
+    )
+    k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
+
+    # Call with force=True and older expiration
+    result = k8s_helper.store_user_token_secret(
+        username=username,
+        token_name=token_name,
+        token=token_value,
+        expiration=4000,
+        namespace="default",
+        force=True,
+    )
+
+    assert result == mlrun.common.schemas.SecretEventActions.updated
+    k8s_helper._update_secret.assert_called_once()
+    k8s_helper._create_secret.assert_not_called()
+
+
 def test_list_secrets_with_labels(k8s_helper):
     secret1 = _make_k8s_secret(
         "secret1",

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -535,42 +535,27 @@ def test_store_user_token_secret_updated(k8s_helper):
     assert decoded_expiration == new_expiration
 
 
-def test_store_user_token_secret_skipped(k8s_helper):
+@pytest.mark.parametrize(
+    "expiration, force, expected_result, update_called, create_called",
+    [
+        (4000, False, None, False, False),  # skip update, expiration older
+        (
+            4000,
+            True,
+            mlrun.common.schemas.SecretEventActions.updated,
+            True,
+            False,
+        ),  # force update
+    ],
+)
+def test_store_user_token_secret_skipped_and_force_update(
+    k8s_helper, expiration, force, expected_result, update_called, create_called
+):
     username = "test-user"
     token_name = "my-token"
     token_value = "abc123"
     secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
 
-    # Existing secret with newer expiration than what we pass -> should skip update
-    existing_secret = _make_user_token_secret(
-        secret_name,
-        token_name=token_name,
-        token_value=token_value,
-        expiration=5000,  # current expiration is newer
-    )
-
-    k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
-
-    result = k8s_helper.store_user_token_secret(
-        username=username,
-        token_name=token_name,
-        token=token_value,
-        expiration=4000,  # older expiration -> should skip
-        namespace="default",
-    )
-
-    assert result is None
-    k8s_helper._update_secret.assert_not_called()
-    k8s_helper._create_secret.assert_not_called()
-
-
-def test_store_user_token_secret_force_update(k8s_helper):
-    username = "test-user"
-    token_name = "my-token"
-    token_value = "abc123"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
-
-    # Existing secret with newer expiration
     existing_secret = _make_user_token_secret(
         secret_name,
         token_name=token_name,
@@ -579,19 +564,26 @@ def test_store_user_token_secret_force_update(k8s_helper):
     )
     k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
 
-    # Call with force=True and older expiration
     result = k8s_helper.store_user_token_secret(
         username=username,
         token_name=token_name,
         token=token_value,
-        expiration=4000,
+        expiration=expiration,
         namespace="default",
-        force=True,
+        force=force,
     )
 
-    assert result == mlrun.common.schemas.SecretEventActions.updated
-    k8s_helper._update_secret.assert_called_once()
-    k8s_helper._create_secret.assert_not_called()
+    assert result == expected_result
+
+    if update_called:
+        k8s_helper._update_secret.assert_called_once()
+    else:
+        k8s_helper._update_secret.assert_not_called()
+
+    if create_called:
+        k8s_helper._create_secret.assert_called_once()
+    else:
+        k8s_helper._create_secret.assert_not_called()
 
 
 def test_list_secrets_with_labels(k8s_helper):

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -1224,6 +1224,9 @@ def test_store_secret_token_invalid_inputs(create_server):
         db.store_secret_token(None)
 
 
+# TODO add test for force parameter when IG4 mode is enabled for integration test (ML-11332)
+
+
 @pytest.mark.parametrize("secret_tokens", [None, []])
 def test_store_secret_tokens_invalid_inputs(create_server, secret_tokens):
     server: Server = create_server()


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

This PR adds a `force` flag to `httpdb.store_secret_token()` that forces the token to be stored even if expiration date of the new token is newer.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Add `force` parameter to `httpdb.store_secret_token()` and also to nopdb and sqldb
- Add `force` parameter to `store_secret_token` `store_secret_tokens` endpoint
- Add `force` parameter to `store_secret_tokens` CRUD
- Add `force` parameter to `store_user_token_secret` function in k8s_utils

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

- Manual testing on an IG4 system
- Added a unit test on the server side for `store_user_token_secret` function
- Added a comment for missing integration test on client side (requires [ML-11332](https://iguazio.atlassian.net/browse/ML-11332) to be completed)

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10955
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-11332]: https://iguazio.atlassian.net/browse/ML-11332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ