### PR TITLE
[Invoke] Fetch function state if function was run with watch=false

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1227,7 +1227,11 @@ class RemoteRuntime(KubeResource):
         # if none of urls is set, function was deployed with watch=False
         # and status wasn't fetched with Nuclio
         # _get_state fetches the state and updates url
-        if not self.status.address and not self.status.internal_invocation_urls and not self.status.external_invocation_urls:
+        if (
+            not self.status.address
+            and not self.status.internal_invocation_urls
+            and not self.status.external_invocation_urls
+        ):
             state, _, _ = self._get_state()
             if state not in ["ready", "scaledToZero"]:
                 logger.warning(f"Function is in the {state} state")

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1224,6 +1224,14 @@ class RemoteRuntime(KubeResource):
         # try to infer the invocation url from the internal and if not exists, use external.
         # $$$$ we do not want to use the external invocation url (e.g.: ingress, nodePort, etc.)
 
+        # if none of urls is set, function was deployed with watch=False
+        # and status wasn't fetched with Nuclio
+        # _get_state fetches the state and updates url
+        if not self.status.address and not self.status.internal_invocation_urls and not self.status.external_invocation_urls:
+            state, _, _ = self._get_state()
+            if state not in ["ready", "scaledToZero"]:
+                logger.warning(f"Function is in the {state} state")
+
         # prefer internal invocation url if running inside k8s cluster
         if (
             not force_external_address


### PR DESCRIPTION
### 📝 Description

Fixes a bug where for the function that was deployed without waiting for finish of deployment, invocation url wasn't resolved. 
Fixed by checking that if all urls in status are empty, function status is populated by sending request to server which then checks state on nuclio side.


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
tested on vmdev
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11335
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Before and after:
<img width="1890" height="645" alt="Screenshot 2025-10-27 at 14 23 07" src="https://github.com/user-attachments/assets/4bfaee23-5e32-4e88-927f-786297433c46" />
