### PR TITLE
[Serving] Change the `Model.predict` and `Model.predict_async` method to raise error if it was not implemented

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1221,11 +1221,11 @@ class Model(storey.ParallelExecutionRunnable, ModelObj):
 
     def predict(self, body: Any, **kwargs) -> Any:
         """Override to implement prediction logic. If the logic requires asyncio, override predict_async() instead."""
-        return body
+        raise NotImplementedError("predict() method not implemented")
 
     async def predict_async(self, body: Any, **kwargs) -> Any:
         """Override to implement prediction logic if the logic requires asyncio."""
-        return body
+        raise NotImplementedError("predict_async() method not implemented")
 
     def run(self, body: Any, path: str, origin_name: Optional[str] = None) -> Any:
         return self.predict(body)

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -232,6 +232,11 @@ class MyPklModel(Model):
         return body
 
 
+class ModelWithoutPredict(Model):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
 def test_model_runner():
     function = mlrun.new_function("tests", kind="serving")
     graph = function.set_topology("flow", engine="async")
@@ -1016,3 +1021,35 @@ def test_llm_with_missing_llm_prompt():
         )
         server.wait_for_completion()
         assert resp["prompt"] == expected_prompt
+
+
+@pytest.mark.parametrize("execution_mechanism", ("naive", "thread_pool", "asyncio"))
+def test_using_model_without_predict_implementation(execution_mechanism: str):
+    function = mlrun.new_function("tests", kind="serving")
+    graph = function.set_topology("flow", engine="async")
+    model_runner_step = ModelRunnerStep(name="model-runner")
+    model_runner_step.add_model(
+        model_class="ModelWithoutPredict",
+        execution_mechanism=execution_mechanism,
+        endpoint_name="model_without_predict",
+    )
+    graph.to(model_runner_step).respond()
+
+    server = function.to_mock_server()
+    try:
+        with pytest.raises(RuntimeError) as exc_info:
+            server.test(body={})
+
+        method_name = (
+            "predict()" if execution_mechanism != "asyncio" else "predict_async()"
+        )
+        expected_msg = (
+            "ModelRunnerError: "
+            "{'model_without_predict': "
+            f"'NotImplementedError: {method_name} method not implemented"
+            "'}"
+        )
+        assert expected_msg in str(exc_info.value)
+
+    finally:
+        server.wait_for_completion()


### PR DESCRIPTION
### 📝 Description
To prevent unexpected behavior, we raise a RuntimeError when the user’s Model does not implement the relevant predict method.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11341
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
