### PR TITLE
[Workflows] Fix Python version suffix enrichment for images with existing tags

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -970,8 +970,15 @@ def enrich_image_url(
         else:
             image_url = "mlrun/mlrun"
 
-    if is_mlrun_image and tag and ":" not in image_url:
-        image_url = f"{image_url}:{tag}"
+    if is_mlrun_image and tag:
+        if ":" not in image_url:
+            image_url = f"{image_url}:{tag}"
+        elif enrich_kfp_python_version:
+            # For mlrun-kfp >= 1.10.0-rc0, append python suffix to existing tag
+            python_suffix = resolve_image_tag_suffix(
+                mlrun_version, client_python_version
+            )
+            image_url = f"{image_url}{python_suffix}" if python_suffix else image_url
 
     registry = (
         config.images_registry if is_mlrun_image else config.vendor_images_registry

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -272,6 +272,9 @@ class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
         # specify the user client python version
         if client_python_version:
             runner.set_env("MLRUN_PYTHON_VERSION", client_python_version)
+            labels[mlrun_constants.MLRunInternalLabels.client_python_version] = (
+                client_python_version
+            )
 
     @staticmethod
     def _enrich_runner_node_selector(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -878,6 +878,14 @@ def test_validate_v3io_consumer_group(value, expected):
             "expected_output": "mlrun/mlrun-kfp:1.9.0",
             "images_to_enrich_registry": "",
         },
+        {
+            "image": "mlrun/mlrun-kfp:1.10.0-rc37",
+            "client_version": "1.10.0-rc37",
+            "client_python_version": "3.9.13",
+            "images_tag": None,
+            "expected_output": "mlrun/mlrun-kfp:1.10.0-rc37-py39",
+            "images_to_enrich_registry": "",
+        },
     ],
 )
 def test_enrich_image(case):


### PR DESCRIPTION
### 📝 Description
This PR Fixes a bug where Python version suffixes (e.g., `-py39`) were not being appended to `mlrun-kfp` images that already had tags specified. This was causing workflows to use incorrect image versions when the client's Python version needed to be reflected in the image tag.

Additionally, ensured that workflow runners now include the client's Python version as a label, which was previously missing.

---

### 🛠️ Changes Made
- Fixed `enrich_image_url()` to append Python version suffix to `mlrun-kfp` images (>= 1.10.0-rc0) even when they already have a tag
- Added client Python version label to workflow runner configuration
- Updated image enrichment logic to handle the special case of `mlrun-kfp` images while preserving existing behavior for other mlrun images
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Manually tested + added this case to the UT coverage

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11351
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
