### PR TITLE
[CI] Push quay images to artifactory

### DIFF
--- a/.github/workflows/quay_to_artifactory.yaml
+++ b/.github/workflows/quay_to_artifactory.yaml
@@ -1,0 +1,61 @@
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - '*'
+
+jobs:
+  notify:
+    runs-on: [ self-hosted, Linux, mlrun-igz-ci ]
+    steps:
+      - uses: actions/checkout@v4
+#      - name: Install jq
+#        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: quay to artifactory
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Logging into Quay"
+          echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+          echo "Logging into Artifactory"
+          echo "$ARTI_PASSWORD" | docker login "$ARTIFACTORY_REGISTRY" -u "$ARTI_USERNAME" --password-stdin
+
+          echo "Fetching all repositories from quay.io/$ORG"
+          REPOS=$(curl -s -u "$QUAY_USERNAME:$QUAY_PASSWORD" \
+            "https://quay.io/api/v1/repository?namespace=$ORG&public=true" | jq -r '.repositories[].name')
+
+          for IMAGE in $REPOS; do
+              echo "Checking tag $VERSION_TAG for $IMAGE"
+              TAG_EXISTS=$(curl -s -u "$QUAY_USERNAME:$QUAY_PASSWORD" \
+                "https://quay.io/api/v1/repository/$ORG/${IMAGE}/tag/?specificTag=${VERSION_TAG}" | jq -r '.tags | length')
+
+              if [ "$TAG_EXISTS" -gt 0 ]; then
+                  QUAY_IMAGE="quay.io/$ORG/${IMAGE}:${VERSION_TAG}"
+                  ARTI_IMAGE="${ARTIFACTORY_REGISTRY}/$ORG/${IMAGE}:${VERSION_TAG}"
+                  docker pull "$QUAY_IMAGE"
+                  docker tag "$QUAY_IMAGE" "$ARTI_IMAGE"
+                  docker push "$ARTI_IMAGE"
+              fi
+
+              if [[ "$IMAGE" =~ ^(mlrun|mlrun-kfp|mlrun-gpu)$ ]]; then
+                  PY39_TAG="${VERSION_TAG}-py39"
+                  TAG_EXISTS=$(curl -s -u "$QUAY_USERNAME:$QUAY_PASSWORD" \
+                    "https://quay.io/api/v1/repository/$ORG/${IMAGE}/tag/?specificTag=${PY39_TAG}" | jq -r '.tags | length')
+                  if [ "$TAG_EXISTS" -gt 0 ]; then
+                      QUAY_IMAGE="quay.io/$ORG/${IMAGE}:${PY39_TAG}"
+                      ARTI_IMAGE="${ARTIFACTORY_REGISTRY}/$ORG/${IMAGE}:${PY39_TAG}"
+                      docker pull "$QUAY_IMAGE"
+                      docker tag "$QUAY_IMAGE" "$ARTI_IMAGE"
+                      docker push "$ARTI_IMAGE"
+                  fi
+              fi
+          done
+        env:
+          ORG: mlrun
+          QUAY_USERNAME: ${{ secrets.QUAY_IO_DOCKER_REGISTRY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_IO_DOCKER_REGISTRY_PASSWORD }}
+          ARTI_USERNAME: ${{ secrets.ARTIFACTORY_DOCKER_REGISTRY_USERNAME }}
+          ARTI_PASSWORD: ${{ secrets.ARTIFACTORY_DOCKER_REGISTRY_PASSWORD }}
+          ARTIFACTORY_REGISTRY: artifactory.iguazeng.com:6555
+          VERSION_TAG: ${{ github.ref_name }}

--- a/.github/workflows/quay_to_artifactory.yaml
+++ b/.github/workflows/quay_to_artifactory.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: [ self-hosted, Linux, mlrun-igz-ci ]


### PR DESCRIPTION
on rc release in https://github.com/mlrun/mlrun/tags run pull push of quay images to internal Arti. (requires self hosted nodes)

### 📝 Description
on rc release in https://github.com/mlrun/mlrun/tags run pull push of quay images to internal Arti, see: DEVOPS-1303

---

### 🛠️ Changes Made
added quay_to_artifactory.yaml

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
