### PR TITLE
[Model Monitoring] Fix reading artifact using run_db when running on the server side

### DIFF
--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1496,7 +1496,9 @@ class ModelEndpoints:
             model_endpoint_object.spec.model_uri, db=run_db
         )
         if isinstance(model_obj, mlrun.artifacts.LLMPromptArtifact):
-            model_obj = model_obj.model_artifact
+            model_obj = mlrun.datastore.store_resources.get_store_resource(
+                model_obj.spec.model_uri, db=run_db
+            )
         feature_stats: dict = model_obj.spec.feature_stats or {}
         mlrun.common.model_monitoring.helpers.pad_features_hist(
             mlrun.common.model_monitoring.helpers.FeatureStats(feature_stats)


### PR DESCRIPTION
### 📝 Description

When fetching a model-endpoint with an LLM-prompt artifact as its model, the system attempted to read the referenced model using client-side logic on the server, which failed.
The fix ensures the model is now read through run_db on the server side.

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11346
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
