### PR TITLE
[Secrets] Remove labels param when reading secret in store_secrets() [feature/ig4-authentication]

### DIFF
--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -618,7 +618,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.read_secret(
                 secret_name=secret_name,
                 namespace=namespace,
-                labels=labels,
             )
         except (
             k8s_dynamic_exceptions.NotFoundError

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -279,6 +279,23 @@ def test_store_secret(
         assert data == secrets_to_store
 
 
+# Labels param in read_secret should be used only with IG4 secrets
+def test_store_secrets_does_not_pass_labels_to_read_secret(k8s_helper):
+    k8s_helper.read_secret = mock.MagicMock(
+        side_effect=k8s_dynamic_exceptions.NotFoundError(
+            k8s_client_rest.ApiException(status=404)
+        )
+    )
+    k8s_helper.store_secrets(
+        secret_name="my-secret",
+        secrets={"key1": "value1"},
+        namespace="default",
+    )
+    # Ensure 'labels' is not in the call arguments
+    for call in k8s_helper.read_secret.call_args_list:
+        assert "labels" not in call.kwargs
+
+
 @pytest.mark.parametrize(
     "k8s_secret_data, secrets_data, expected_action, expected_secret_data",
     [

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -279,8 +279,12 @@ def test_store_secret(
         assert data == secrets_to_store
 
 
-# Labels param in read_secret should be used only with IG4 secrets
+
 def test_store_secrets_does_not_pass_labels_to_read_secret(k8s_helper):
+    """
+        Test ensures that labels param is not passed to read_secret when storing secrets.
+        The labels param during read_secret is intended for IG4 secrets only.
+    """
     k8s_helper.read_secret = mock.MagicMock(
         side_effect=k8s_dynamic_exceptions.NotFoundError(
             k8s_client_rest.ApiException(status=404)

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -279,11 +279,10 @@ def test_store_secret(
         assert data == secrets_to_store
 
 
-
-def test_store_secrets_does_not_pass_labels_to_read_secret(k8s_helper):
+def test_store_secrets_no_labels(k8s_helper):
     """
-        Test ensures that labels param is not passed to read_secret when storing secrets.
-        The labels param during read_secret is intended for IG4 secrets only.
+    Test ensures that labels param is not passed to read_secret when storing secrets.
+    The labels param during read_secret is intended for IG4 secrets only.
     """
     k8s_helper.read_secret = mock.MagicMock(
         side_effect=k8s_dynamic_exceptions.NotFoundError(
@@ -295,9 +294,16 @@ def test_store_secrets_does_not_pass_labels_to_read_secret(k8s_helper):
         secrets={"key1": "value1"},
         namespace="default",
     )
-    # Ensure 'labels' is not in the call arguments
-    for call in k8s_helper.read_secret.call_args_list:
-        assert "labels" not in call.kwargs
+
+    try:
+        k8s_helper.read_secret.assert_called_once_with(
+            secret_name="my-secret", namespace="default"
+        )
+    except AssertionError:
+        raise AssertionError(
+            "Store secrets should not pass 'labels' to read_secret. Please review params that were "
+            "added to the read_secret call."
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

As part of https://github.com/mlrun/mlrun/pull/8484, `read_secret()` was refactored to (optionally) check for a label in the k8s secret. This is needed for IG4's secret tokens.
However, the labels parameter is not needed in `store_secrets` function (k8s.py). 

When running a workflow, the secret is initially created in k8s with the label `mlrun/username:admin` (for the admin user). However, when resolving KFP secret environment variables to k8s secrets, `store_secrets` is called with the label `mlrun/username:MLRUN_AUTH_SESSION`. Using this label with `read_secret` results in None being returned instead of the actual secret.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

- Remove `label` param when calling `read_secret` in `store_secrets`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

Regression test that was failing now works when run manually

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11330
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
