### PR TITLE
[Model Monitoring] Fix reading artifact using run_db when running on the server side [1.10.x]

### DIFF
--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -1496,7 +1496,9 @@ class ModelEndpoints:
             model_endpoint_object.spec.model_uri, db=run_db
         )
         if isinstance(model_obj, mlrun.artifacts.LLMPromptArtifact):
-            model_obj = model_obj.model_artifact
+            model_obj = mlrun.datastore.store_resources.get_store_resource(
+                model_obj.spec.model_uri, db=run_db
+            )
         feature_stats: dict = model_obj.spec.feature_stats or {}
         mlrun.common.model_monitoring.helpers.pad_features_hist(
             mlrun.common.model_monitoring.helpers.FeatureStats(feature_stats)


### PR DESCRIPTION
(cherry picked from commit c7f1c6b71a8403341019b7d093057bc249acb6cb)

https://iguazio.atlassian.net/browse/ML-11346