### PR TITLE
[vectordb] Freeze langchain requirements [1.10.x]

### DIFF
--- a/mlrun/artifacts/document.py
+++ b/mlrun/artifacts/document.py
@@ -359,7 +359,12 @@ class DocumentArtifact(Artifact):
         self,
         splitter: Optional["TextSplitter"] = None,  # noqa: F821
     ) -> list["Document"]:  # noqa: F821
-        from langchain.schema import Document
+        # Try new langchain 1.0+ import path first
+        try:
+            from langchain_core.documents import Document
+        except ImportError:
+            # Fall back to old langchain <1.0 import path
+            from langchain.schema import Document
 
         """
         Create LC documents from the artifact

--- a/tests/system/datastore/test_vectorstore.py
+++ b/tests/system/datastore/test_vectorstore.py
@@ -302,7 +302,12 @@ class TestDatastoreProfile(TestMLRunSystem):
         collection.col.drop()
 
     def make_milvus_connection(self, collection_name, auto_id):
-        from langchain.embeddings import FakeEmbeddings
+        # Try new langchain 1.0+ import path first
+        try:
+            from langchain_core.embeddings import FakeEmbeddings
+        except ImportError:
+            # Fall back to old langchain <1.0 import path
+            from langchain.embeddings import FakeEmbeddings
         from langchain_community.vectorstores import Milvus
 
         embedding_model = FakeEmbeddings(size=3)
@@ -334,7 +339,12 @@ class TestDatastoreProfile(TestMLRunSystem):
         return vectorstore
 
     def test_vectorstore_splitter_and_ids(self):
-        from langchain.text_splitter import CharacterTextSplitter
+        # Try new langchain 1.0+ import path first
+        try:
+            from langchain_text_splitters import CharacterTextSplitter
+        except ImportError:
+            # Fall back to old langchain <1.0 import path
+            from langchain.text_splitter import CharacterTextSplitter
 
         splitter = CharacterTextSplitter(
             separator="",  # Empty string means split by pure character count


### PR DESCRIPTION
### 📝 Description

This PR adds backward-compatible support for both langchain 0.x and 1.0+ versions without freezing requirements to a specific version.

**Context:**
- Langchain 1.0 introduced breaking changes by moving modules to new packages (`langchain_core`, `langchain_text_splitters`)
- We cannot freeze langchain to 0.x because those are pre-release versions
- We cannot pin langchain to 1.0+ because it requires pydantic v2, which conflicts with KFP 1.8's pydantic v1 requirement
- Solution: Support both versions through conditional imports

This approach allows users to choose their langchain version based on their other dependencies without MLRun enforcing constraints.

---


**Backward compatibility:**
- If langchain 1.0+ is installed: Uses new import paths
- If langchain 0.x is installed: Falls back to old import paths
- If langchain is not installed: Tests are skipped (existing behavior)

---

### 🔗 References
- Ticket link: ML-11317

---

### 🚨 Breaking Changes?

- [x] No

This change is fully backward compatible and requires no downstream changes.

---

