### PR TITLE
[Bugfix] client-side block on mounting auth/project secrets; validateenv/volumes in KubeResourceSpec (#8759) [1.10.x]

### DIFF
--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -11,10 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import re
 from abc import ABC, abstractmethod
 
 import mlrun.common.schemas
+from mlrun.config import config as mlconf
+
+_AUTH_SECRET_NAME_TEMPLATE = re.escape(
+    mlconf.secret_stores.kubernetes.auth_secret_name.format(
+        hashed_access_key="",
+    )
+)
+AUTH_SECRET_PATTERN = re.compile(f"^{_AUTH_SECRET_NAME_TEMPLATE}.*")
 
 
 class SecretProviderInterface(ABC):

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -29,6 +29,7 @@ import pydantic.v1.error_wrappers
 import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas.notification
+import mlrun.common.secrets
 import mlrun.utils.regex
 
 from .utils import (
@@ -1616,7 +1617,14 @@ class RunTemplate(ModelObj):
 
         :returns: The RunTemplate object
         """
-
+        if kind == "azure_vault" and isinstance(source, dict):
+            candidate_secret_name = (source.get("k8s_secret") or "").strip()
+            if candidate_secret_name and mlrun.common.secrets.AUTH_SECRET_PATTERN.match(
+                candidate_secret_name
+            ):
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Forbidden secret '{candidate_secret_name}' matches MLRun auth-secret pattern."
+                )
         if kind == "vault" and isinstance(source, list):
             source = {"project": self.metadata.project, "secrets": source}
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -45,6 +45,7 @@ import mlrun.common.runtimes.constants
 import mlrun.common.schemas.alert
 import mlrun.common.schemas.artifact
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
+import mlrun.common.secrets
 import mlrun.datastore.datastore_profile
 import mlrun.db
 import mlrun.errors
@@ -3418,7 +3419,12 @@ class MlrunProject(ModelObj):
         self._initialized = True
         return self.spec._function_objects
 
-    def with_secrets(self, kind, source, prefix=""):
+    def with_secrets(
+        self,
+        kind,
+        source,
+        prefix="",
+    ):
         """register a secrets source (file, env or dict)
 
         read secrets from a source provider to be used in workflows, example::
@@ -3440,12 +3446,21 @@ class MlrunProject(ModelObj):
 
         This will enable access to all secrets in vault registered to the current project.
 
-        :param kind:   secret type (file, inline, env, vault)
+        :param kind:   secret type (file, inline, env, vault, azure_vault)
         :param source: secret data or link (see example)
         :param prefix: add a prefix to the keys in this source
 
         :returns: project object
         """
+        # Block using mlrun-auth-secrets.* via azure_vault's k8s_secret param (client-side only)
+        if kind == "azure_vault" and isinstance(source, dict):
+            candidate_secret_name = (source.get("k8s_secret") or "").strip()
+            if candidate_secret_name and mlrun.common.secrets.AUTH_SECRET_PATTERN.match(
+                candidate_secret_name
+            ):
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Forbidden secret '{candidate_secret_name}' matches MLRun auth-secret pattern."
+                )
 
         if kind == "vault" and isinstance(source, list):
             source = {"project": self.metadata.name, "secrets": source}

--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -17,6 +17,8 @@ import typing
 import warnings
 from collections import namedtuple
 
+import mlrun.common.secrets
+import mlrun.errors
 from mlrun.config import config
 from mlrun.config import config as mlconf
 from mlrun.errors import MLRunInvalidArgumentError
@@ -411,6 +413,13 @@ def mount_secret(
                          If specified, the listed keys will be projected into
                          the specified paths, and unlisted keys will not be
                          present."""
+
+    if secret_name and mlrun.common.secrets.AUTH_SECRET_PATTERN.match(
+        secret_name.strip()
+    ):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Forbidden secret '{secret_name}' matches MLRun auth-secret pattern."
+        )
 
     def _mount_secret(runtime: "KubeResource"):
         # Define the secret volume source

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -44,6 +44,7 @@ from mlrun.serving.states import (
 )
 from mlrun.utils import get_caller_globals, logger, set_paths
 
+from ...common.secrets import AUTH_SECRET_PATTERN
 from .. import KubejobRuntime
 from ..pod import KubeResourceSpec
 from .function import NuclioSpec, RemoteRuntime, min_nuclio_versions
@@ -635,7 +636,14 @@ class ServingRuntime(RemoteRuntime):
 
         :returns: The Runtime (function) object
         """
-
+        if kind == "azure_vault" and isinstance(source, dict):
+            candidate_secret_name = (source.get("k8s_secret") or "").strip()
+            if candidate_secret_name and AUTH_SECRET_PATTERN.match(
+                candidate_secret_name
+            ):
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Forbidden secret '{candidate_secret_name}' matches MLRun auth-secret pattern."
+                )
         if kind == "vault" and isinstance(source, list):
             source = {"project": self.metadata.project, "secrets": source}
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -20,6 +20,7 @@ import typing
 import warnings
 from collections.abc import Iterable
 from enum import Enum
+from typing import Optional
 
 import dotenv
 import kubernetes.client as k8s_client
@@ -34,6 +35,7 @@ from mlrun.common.schemas import (
     SecurityContextEnrichmentModes,
 )
 
+from ..common.secrets import AUTH_SECRET_PATTERN
 from ..config import config as mlconf
 from ..k8s_utils import (
     generate_preemptible_nodes_affinity_terms,
@@ -708,19 +710,44 @@ class KubeResource(BaseRuntime):
     def spec(self, spec):
         self._spec = self._verify_dict(spec, "spec", KubeResourceSpec)
 
-    def set_env_from_secret(self, name, secret=None, secret_key=None):
-        """set pod environment var from secret"""
+    def set_env_from_secret(
+        self,
+        name: str,
+        secret: Optional[str] = None,
+        secret_key: Optional[str] = None,
+    ):
+        """Set env var from secret; block auth-secret usage on client side."""
+        self._validate_no_auth_secret(
+            secret_name=secret,
+        )
         secret_key = secret_key or name
         value_from = k8s_client.V1EnvVarSource(
-            secret_key_ref=k8s_client.V1SecretKeySelector(name=secret, key=secret_key)
+            secret_key_ref=k8s_client.V1SecretKeySelector(
+                name=secret,
+                key=secret_key,
+            )
         )
-        return self._set_env(name, value_from=value_from)
+        return self._set_env(
+            name=name,
+            value_from=value_from,
+        )
 
-    def set_env(self, name, value=None, value_from=None):
-        """set pod environment var from value"""
-        if value is not None:
-            return self._set_env(name, value=str(value))
-        return self._set_env(name, value_from=value_from)
+    def set_env(
+        self,
+        name: str,
+        value: Optional[str] = None,
+        value_from: Optional[typing.Any] = None,
+    ):
+        """Set env var; block auth-secret usage when coming from a secret."""
+        if value_from is not None:
+            secret_name = self._extract_secret_name_from_value_from(
+                value_from=value_from,
+            )
+            self._validate_no_auth_secret(
+                secret_name=secret_name,
+            )
+            return self._set_env(name, value_from=value_from)
+        return self._set_env(name, value=str(value) if value is not None else None)
 
     def with_annotations(self, annotations: dict):
         """set a key/value annotations in the metadata of the pod"""
@@ -1365,6 +1392,37 @@ class KubeResource(BaseRuntime):
                     offset += len(text)
 
         return self.status.state
+
+    @staticmethod
+    def _validate_no_auth_secret(
+        secret_name: Optional[str],
+    ):
+        """Raise if secret name matches MLRun auth-secret pattern."""
+        if secret_name and AUTH_SECRET_PATTERN.match(secret_name):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Forbidden secret '{secret_name}' matches MLRun auth-secret pattern."
+            )
+
+    @staticmethod
+    def _extract_secret_name_from_value_from(
+        value_from: typing.Any,
+    ) -> Optional[str]:
+        """Extract secret name from a V1EnvVarSource or dict representation."""
+        if isinstance(value_from, k8s_client.V1EnvVarSource):
+            if value_from.secret_key_ref:
+                return value_from.secret_key_ref.name
+        elif isinstance(value_from, dict):
+            value_from = (
+                value_from.get("valueFrom")
+                or value_from.get("value_from")
+                or value_from
+            )
+            secret_key_ref = (value_from or {}).get("secretKeyRef") or (
+                value_from or {}
+            ).get("secret_key_ref")
+            if isinstance(secret_key_ref, dict):
+                return secret_key_ref.get("name")
+        return None
 
 
 def _resolve_if_type_sanitized(attribute_name, attribute):

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2592,3 +2592,63 @@ class TestModelMonitoring:
             mlrun.projects.MlrunProject().create_model_monitoring_function(
                 name="my-invalid-app-name-batch", application_class="NoApp"
             )
+
+
+def _auth_prefix() -> str:
+    # Matches how the code builds the pattern: format(hashed_access_key="")
+    return mlrun.mlconf.secret_stores.kubernetes.auth_secret_name.format(
+        hashed_access_key=""
+    )
+
+
+class _StubAzureVaultStore:
+    """No-op stub to avoid real Azure config and network."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def get_secrets(self, secrets):
+        # Return empty dict; we only care that client-side validation didn't block.
+        return {}
+
+
+def test_with_secrets_azure_vault_blocks_auth_secret_name(tmp_path, monkeypatch):
+    # Ensure we never touch the real Azure implementation
+    monkeypatch.setattr(mlrun.secrets, "AzureVaultStore", _StubAzureVaultStore)
+
+    project = mlrun.new_project("proj-auth-block", context=str(tmp_path), save=False)
+
+    forbidden = _auth_prefix() + "anything"
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc:
+        project.with_secrets(
+            "azure_vault",
+            {
+                "name": "vault1",
+                "k8s_secret": forbidden,
+                "tenant_id": "t",
+                "vault_url": "https://x",
+                "secrets": [],  # required by secrets store path
+            },
+        )
+    assert "Forbidden secret" in str(exc.value)
+    assert forbidden in str(exc.value)
+
+
+def test_with_secrets_azure_vault_allows_non_auth_secret(tmp_path, monkeypatch):
+    # Stub Azure so we don't require tenant/client_id config
+    monkeypatch.setattr(mlrun.secrets, "AzureVaultStore", _StubAzureVaultStore)
+
+    project = mlrun.new_project("proj-auth-allow", context=str(tmp_path), save=False)
+
+    allowed = "my-regular-k8s-secret"
+    # Should not raise
+    project.with_secrets(
+        "azure_vault",
+        {
+            "name": "vault1",
+            "k8s_secret": allowed,
+            "tenant_id": "t",
+            "vault_url": "https://x",
+            "secrets": [],  # minimal valid payload for add_source
+        },
+    )

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -359,3 +359,69 @@ def test_mount_import_backwards_compatibility(mount, args, kwargs):
     assert type(mount(*args, **kwargs)) is type(
         getattr(mlrun.runtimes.mounts, mount._new_target)(*args, **kwargs)
     )
+
+
+def _auth_prefix() -> str:
+    # Matches how the code builds the pattern: format(hashed_access_key="")
+    return mlrun.mlconf.secret_stores.kubernetes.auth_secret_name.format(
+        hashed_access_key=""
+    )
+
+
+def test_mount_secret_blocks_auth_secret_name():
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    forbidden = _auth_prefix() + "anything"
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc:
+        function.apply(
+            mlrun.runtimes.mounts.mount_secret(
+                secret_name=forbidden,
+                mount_path="/mnt/secret",
+                volume_name="my-secret-vol",
+            )
+        )
+    assert "Forbidden secret" in str(exc.value)
+    assert forbidden in str(exc.value)
+
+
+def test_mount_secret_allows_regular_secret_and_sets_volume():
+    expected_volume = {
+        "secret": {
+            "secretName": "my-secret",
+            "items": [{"key": "k", "path": "p"}],
+        },
+        "name": "my-volume",
+    }
+    expected_volume_mount = {"mountPath": "/mnt/secret", "name": "my-volume"}
+
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+
+    function.apply(
+        mlrun.runtimes.mounts.mount_secret(
+            secret_name="my-secret",
+            mount_path="/mnt/secret",
+            volume_name="my-volume",
+            items=[{"key": "k", "path": "p"}],
+        )
+    )
+
+    assert (
+        deepdiff.DeepDiff(
+            [expected_volume],
+            function.spec.volumes,
+            ignore_order=True,
+        )
+        == {}
+    )
+    assert (
+        deepdiff.DeepDiff(
+            [expected_volume_mount],
+            function.spec.volume_mounts,
+            ignore_order=True,
+        )
+        == {}
+    )

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -433,3 +433,109 @@ def test_with_node_selection_warnings(
             f"Expected no warnings, but found: {warning_messages}"
             "Expected no warnings, but found: {warning_messages}"
         )
+
+
+def _auth_prefix() -> str:
+    return mlrun.mlconf.secret_stores.kubernetes.auth_secret_name.format(
+        hashed_access_key=""
+    )
+
+
+def _new_job_runtime(project: str = "p") -> mlrun.runtimes.KubejobRuntime:
+    # Avoid nuclio path; this creates a plain KubejobRuntime without touching files or API
+    fn = mlrun.new_function(
+        name="f",
+        project=project,
+        kind="job",
+        image="mlrun/mlrun",
+    )
+    assert hasattr(fn, "set_env"), "Expected runtime to expose set_env"
+    return fn
+
+
+def test_set_env_from_secret_blocks_auth_secret():
+    fn = _new_job_runtime()
+    forbidden = _auth_prefix() + "xyz"
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc:
+        fn.set_env_from_secret(name="MY_ENV", secret=forbidden)
+
+    assert "Forbidden secret" in str(exc.value)
+    assert forbidden in str(exc.value)
+
+
+def test_set_env_from_secret_allows_regular_secret():
+    fn = _new_job_runtime()
+    # Should not raise
+    fn.set_env_from_secret(name="MY_ENV", secret="regular-secret", secret_key="k")
+
+
+def test_set_env_blocks_when_value_from_contains_auth_secret_object():
+    fn = _new_job_runtime()
+    forbidden = _auth_prefix() + "abc"
+
+    value_from = k8s_client.V1EnvVarSource(
+        secret_key_ref=k8s_client.V1SecretKeySelector(name=forbidden, key="token")
+    )
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc:
+        fn.set_env(name="MY_ENV", value_from=value_from)
+
+    assert "Forbidden secret" in str(exc.value)
+    assert forbidden in str(exc.value)
+
+
+def test_set_env_blocks_when_value_from_contains_auth_secret_dict_variants():
+    fn = _new_job_runtime()
+    forbidden = _auth_prefix() + "def"
+
+    # CamelCase variant
+    value_from_camel = {
+        "valueFrom": {
+            "secretKeyRef": {
+                "name": forbidden,
+                "key": "token",
+            }
+        }
+    }
+
+    # snake_case variant
+    value_from_snake = {
+        "value_from": {
+            "secret_key_ref": {
+                "name": forbidden,
+                "key": "token",
+            }
+        }
+    }
+
+    for payload in (value_from_camel, value_from_snake):
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc:
+            fn.set_env(name="MY_ENV", value_from=payload)
+        assert "Forbidden secret" in str(exc.value)
+        assert forbidden in str(exc.value)
+
+
+def test_set_env_allows_value_literal_and_non_secret_value_from():
+    fn = _new_job_runtime()
+
+    # Plain value should pass
+    fn.set_env(name="PLAIN_ENV", value="ok")
+
+    # Non-secret valueFrom (ConfigMap) should also pass
+    value_from_config_map = k8s_client.V1EnvVarSource(
+        config_map_key_ref=k8s_client.V1ConfigMapKeySelector(
+            name="my-configmap", key="cfg"
+        )
+    )
+    fn.set_env(name="FROM_CM", value_from=value_from_config_map)
+
+
+def test_set_env_blocks_top_level_secret_key_ref_dict():
+    fn = _new_job_runtime()
+    forbidden = _auth_prefix() + "top"
+    payload = {
+        "secretKeyRef": {"name": forbidden, "key": "k"},
+    }
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        fn.set_env(name="MY_ENV", value_from=payload)

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -930,3 +930,61 @@ def test_execute_graph_dataitem_parameter_validation():
         match=r".*data.*DataItem.*inputs.*params.*",
     ):
         execute_graph(context, data=123, batching=False)
+
+
+class _StubAzureVaultStore:
+    """
+    Minimal stub for mlrun.secrets.AzureVaultStore so tests never touch Azure.
+    Only needs to be constructible and expose add_source; behavior is irrelevant
+    for these validation tests since we assert before any real call is needed.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def add_source(self, *args, **kwargs):
+        return None
+
+
+def test_function_with_secrets_azure_vault_blocks_auth_secret_name(monkeypatch):
+    # Ensure we never touch the real Azure implementation
+    monkeypatch.setattr(mlrun.secrets, "AzureVaultStore", _StubAzureVaultStore)
+
+    serving_function_under_test = mlrun.new_function("tests", kind="serving")
+
+    forbidden_k8s_secret_name = "mlrun-auth-secrets.anything"
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as raised_exception_info:
+        serving_function_under_test.with_secrets(
+            "azure_vault",
+            {
+                "name": "vault1",
+                "k8s_secret": forbidden_k8s_secret_name,
+                "tenant_id": "t",
+                "vault_url": "https://x",
+                "secrets": [],  # required by secrets store path
+            },
+        )
+
+    raised_exception_text = str(raised_exception_info.value)
+    assert "Forbidden secret" in raised_exception_text
+    assert forbidden_k8s_secret_name in raised_exception_text
+
+
+def test_function_with_secrets_azure_vault_allows_non_auth_secret(monkeypatch):
+    # Stub Azure so we don't require tenant/client_id config
+    monkeypatch.setattr(mlrun.secrets, "AzureVaultStore", _StubAzureVaultStore)
+
+    serving_function_under_test = mlrun.new_function("tests", kind="serving")
+
+    allowed_k8s_secret_name = "regular-k8s-secret-name"
+    # Should not raise
+    serving_function_under_test.with_secrets(
+        "azure_vault",
+        {
+            "name": "vault1",
+            "k8s_secret": allowed_k8s_secret_name,
+            "tenant_id": "t",
+            "vault_url": "https://x",
+            "secrets": [],  # minimal valid payload for add_source
+        },
+    )


### PR DESCRIPTION
### 📝 Description
(cherry picked from commit 0664dadece6215829b7a21f3d76483a4bc746cd9)

Block client-side use of **MLRun internal auth secrets** when:
- Setting env vars from secrets in pod runtimes (`set_env_from_secret`, `set_env(value_from=...)`).
- Configuring Azure Key Vault via `with_secrets(kind="azure_vault", source={"k8s_secret": ...})` on **Projects**, **RunTemplates**, and **Serving** runtimes.

This update **centralizes** the pattern in `mlrun.common.secrets.AUTH_SECRET_PATTERN` (built from `mlconf.secret_stores.kubernetes.auth_secret_name`), and **reuses** it across all call sites—no duplicate regex construction.

---

### 🛠️ Changes Made
- **mlrun/common/secrets.py**
  - Add config-aware, compiled regex: `AUTH_SECRET_PATTERN` (derived from `mlconf.secret_stores.kubernetes.auth_secret_name.format(hashed_access_key="")`).
  - New lightweight import of `mlrun.config` and `re`.

- **mlrun/runtimes/pod.py**
  - Guardrails:
    - `set_env_from_secret(...)` → rejects secrets matching `AUTH_SECRET_PATTERN`.
    - `set_env(..., value_from=...)` → extracts secret name from `V1EnvVarSource` **or** dict payloads (supports `valueFrom.secretKeyRef` and `value_from.secret_key_ref`, plus top-level `secretKeyRef`) and rejects if matched.
  - Helpers:
    - `_validate_no_auth_secret(secret_name: Optional[str])`
    - `_extract_secret_name_from_value_from(value_from: typing.Any) -> Optional[str>`
  - Added type hints; no behavioral change except validation.

- **mlrun/projects/project.py**
  - Docstring: add `azure_vault` to supported kinds.
  - `with_secrets(...)`: when `kind="azure_vault"`, block `source["k8s_secret"]` if it matches `AUTH_SECRET_PATTERN`.

- **mlrun/model.py (RunTemplate)**
  - `with_secrets(...)`: same `azure_vault` guard as above.

- **mlrun/runtimes/nuclio/serving.py**
  - `with_secrets(...)`: same `azure_vault` guard as above.

- **tests/**
  - **tests/projects/test_project.py**
    - Block/allow cases for `Project.with_secrets("azure_vault", ...)` using a stubbed `AzureVaultStore`.
  - **tests/serving/test_serving.py**
    - Same block/allow coverage for serving runtime; stubbed `AzureVaultStore`.
  - **tests/runtimes/test_pod.py**
    - Blocks:
      - `set_env_from_secret(...)` with forbidden secret.
      - `set_env(..., value_from=...)` with:
        - `V1EnvVarSource(secret_key_ref=...)`
        - dict `valueFrom.secretKeyRef` (camelCase)
        - dict `value_from.secret_key_ref` (snake_case)
        - top-level `secretKeyRef` dict
    - Allows:
      - Literal env values and non-secret `value_from` (e.g., ConfigMap).

---

### ✅ Checklist
- [x] Unit tests added and passing  
- [x] No server/API surface changes (client-side validation only)  
- [x] Pattern is config-driven, not hard-coded  
- [x] Clear error messaging (`MLRunInvalidArgumentError`)  
- [ ] (Docs) Note that `mlrun-auth-secrets.*` (config-derived) is reserved

---

### 🧪 Testing
**Blocked (expect `MLRunInvalidArgumentError`):**
- Any secret name matching the configured template (e.g., `mlrun-auth-secrets.*`) via:
  - `Project.with_secrets("azure_vault", {"k8s_secret": ...})`
  - `RunTemplate.with_secrets("azure_vault", {"k8s_secret": ...})`
  - `ServingRuntime.with_secrets("azure_vault", {"k8s_secret": ...})`
  - `set_env_from_secret(...)`
  - `set_env(value_from=...)` (dict & `V1EnvVarSource`)

**Allowed:**
- Regular project/K8s secrets
- ConfigMap-derived envs
- Non-secret literal env values

---

### 🔗 References
- Jira: https://iguazio.atlassian.net/browse/ML-11226

---

### 🚨 Breaking Changes?
- [ ] Yes  
- [x] No

---

### 🔍 Additional Notes
- Validation is **client-side only**, preventing unsafe exposure before submitting specs to the API.
- `with_secrets` and runtime env helpers now share a **single compiled regex** (`AUTH_SECRET_PATTERN`) to ensure consistent behavior.
