### PR TITLE
[Model Monitoring] Make sure each TSDB call wrapped with run_in_threadpool

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -451,6 +451,8 @@ class TSDBConnector(ABC):
         run_in_threadpool: Callable,
         metric_list: Optional[list[str]] = None,
     ) -> list[mlrun.common.schemas.ModelEndpoint]:
+        """Note that each call to this method may add multiple TSDB calls,
+        and each one of them shouldn't run on the main thread."""
         raise NotImplementedError()
 
     @staticmethod

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import Callable, ClassVar, Literal, Optional, Union
+from typing import ClassVar, Literal, Optional, Union
 
 import pandas as pd
 import pydantic.v1
@@ -444,11 +444,9 @@ class TSDBConnector(ABC):
                                    ]
         """
 
-    async def add_basic_metrics(
+    def add_basic_metrics(
         self,
         model_endpoint_objects: list[mlrun.common.schemas.ModelEndpoint],
-        project: str,
-        run_in_threadpool: Callable,
         metric_list: Optional[list[str]] = None,
     ) -> list[mlrun.common.schemas.ModelEndpoint]:
         """Note that each call to this method may add multiple TSDB calls,

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -14,7 +14,7 @@
 
 import threading
 from datetime import datetime, timedelta
-from typing import Callable, Final, Literal, Optional, Union
+from typing import Final, Literal, Optional, Union
 
 import pandas as pd
 import taosws
@@ -1248,11 +1248,9 @@ class TDEngineConnector(TSDBConnector):
             df.dropna(inplace=True)
         return df
 
-    async def add_basic_metrics(
+    def add_basic_metrics(
         self,
         model_endpoint_objects: list[mlrun.common.schemas.ModelEndpoint],
-        project: str,
-        run_in_threadpool: Callable,
         metric_list: Optional[list[str]] = None,
     ) -> list[mlrun.common.schemas.ModelEndpoint]:
         """
@@ -1280,8 +1278,9 @@ class TDEngineConnector(TSDBConnector):
                 if metric_name not in metric_list:
                     del metric_name_to_function[metric_name]
 
+        # TODO: Optimize by parallelizing calls if needed
         metric_name_to_df = {
-            metric_name: await run_in_threadpool(function, endpoint_ids=uids)
+            metric_name: function(endpoint_ids=uids)
             for metric_name, function in metric_name_to_function.items()
         }
 

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -1281,7 +1281,7 @@ class TDEngineConnector(TSDBConnector):
                     del metric_name_to_function[metric_name]
 
         metric_name_to_df = {
-            metric_name: function(endpoint_ids=uids)
+            metric_name: await run_in_threadpool(function, endpoint_ids=uids)
             for metric_name, function in metric_name_to_function.items()
         }
 

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -198,9 +198,9 @@ class TimescaleDBConnector(TSDBConnector):
 
         :return: A list of `ModelEndpointMonitoringMetric` objects.
         """
-        # Note: project and run_in_threadpool parameters are part of the interface
-        # but unused in TimescaleDB implementation (uses self.project, synchronous operations)
-        del project, run_in_threadpool  # Suppress unused variable warnings
+        # Note: project param is part of the interface
+        # but unused in TimescaleDB implementation (uses self.project)
+        del project  # Suppress unused variable warnings
 
         uids = [mep.metadata.uid for mep in model_endpoint_objects]
 
@@ -218,7 +218,7 @@ class TimescaleDBConnector(TSDBConnector):
                     del metric_name_to_function[metric_name]
 
         metric_name_to_df = {
-            metric_name: function(endpoint_ids=uids)
+            metric_name: await run_in_threadpool(function, endpoint_ids=uids)
             for metric_name, function in metric_name_to_function.items()
         }
 

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import datetime
-from typing import Callable, Optional
+from typing import Optional
 
 import pandas as pd
 
@@ -179,11 +179,9 @@ class TimescaleDBConnector(TSDBConnector):
     def get_metrics_metadata(self, *args, **kwargs):
         return self._metrics_queries.get_metrics_metadata(*args, **kwargs)
 
-    async def add_basic_metrics(
+    def add_basic_metrics(
         self,
         model_endpoint_objects: list[mlrun.common.schemas.ModelEndpoint],
-        project: str,
-        run_in_threadpool: Callable,
         metric_list: Optional[list[str]] = None,
     ) -> list[mlrun.common.schemas.ModelEndpoint]:
         """
@@ -191,16 +189,10 @@ class TimescaleDBConnector(TSDBConnector):
 
         :param model_endpoint_objects: A list of `ModelEndpoint` objects that will
                                         be filled with the relevant basic metrics.
-        :param project:                The name of the project (unused - uses self.project from constructor).
-        :param run_in_threadpool:      A function that runs another function in a thread pool
         :param metric_list:            List of metrics to include from the time series DB. Defaults to all metrics.
 
         :return: A list of `ModelEndpointMonitoringMetric` objects.
         """
-        # Note: project param is part of the interface
-        # but unused in TimescaleDB implementation (uses self.project)
-        del project  # Suppress unused variable warnings
-
         uids = [mep.metadata.uid for mep in model_endpoint_objects]
 
         # Access methods directly from the respective query classes
@@ -216,8 +208,9 @@ class TimescaleDBConnector(TSDBConnector):
                 if metric_name not in metric_list:
                     del metric_name_to_function[metric_name]
 
+        # TODO: Optimize by parallelizing calls if needed
         metric_name_to_df = {
-            metric_name: await run_in_threadpool(function, endpoint_ids=uids)
+            metric_name: function(endpoint_ids=uids)
             for metric_name, function in metric_name_to_function.items()
         }
 

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -193,7 +193,6 @@ class TimescaleDBConnector(TSDBConnector):
                                         be filled with the relevant basic metrics.
         :param project:                The name of the project (unused - uses self.project from constructor).
         :param run_in_threadpool:      A function that runs another function in a thread pool
-                                       (unused - TimescaleDB operations are synchronous).
         :param metric_list:            List of metrics to include from the time series DB. Defaults to all metrics.
 
         :return: A list of `ModelEndpointMonitoringMetric` objects.

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -14,7 +14,7 @@
 import math
 from datetime import datetime, timedelta
 from io import StringIO
-from typing import Callable, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 import pandas as pd
 import v3io_frames
@@ -1230,11 +1230,9 @@ class V3IOTSDBConnector(TSDBConnector):
             )
         return df.reset_index(drop=True)
 
-    async def add_basic_metrics(
+    def add_basic_metrics(
         self,
         model_endpoint_objects: list[mlrun.common.schemas.ModelEndpoint],
-        project: str,
-        run_in_threadpool: Callable,
         metric_list: Optional[list[str]] = None,
     ) -> list[mlrun.common.schemas.ModelEndpoint]:
         """
@@ -1268,12 +1266,12 @@ class V3IOTSDBConnector(TSDBConnector):
 
         metric_name_to_result = {}
 
+        # TODO: Optimize by parallelizing calls if needed
         for metric_name, (
             function,
             _,
         ) in metric_name_to_function_and_column_name.items():
-            metric_name_to_result[metric_name] = await run_in_threadpool(
-                function,
+            metric_name_to_result[metric_name] = function(
                 endpoint_ids=uids,
                 get_raw=True,
             )

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -351,7 +351,7 @@ async def _collect_get_metrics_tasks_results(
         tasks.append(
             asyncio.create_task(
                 run_in_threadpool(
-                    services.api.crud.ModelEndpoints.get_model_xendpoints_metrics,
+                    services.api.crud.ModelEndpoints.get_model_endpoints_metrics,
                     endpoint_id=endpoint_ids,
                     type=mm_constants.ModelEndpointMonitoringMetricType.METRIC,
                     project=project,

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -548,7 +548,8 @@ async def get_model_endpoint(
         project=project, name_or_uid=name, auth_info=auth_info
     )
 
-    return await services.api.crud.ModelEndpoints().get_model_endpoint(
+    return await run_in_threadpool(
+        services.api.crud.ModelEndpoints().get_model_endpoint,
         name=name,
         project=project,
         function_name=function_name,

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -351,7 +351,7 @@ async def _collect_get_metrics_tasks_results(
         tasks.append(
             asyncio.create_task(
                 run_in_threadpool(
-                    services.api.crud.ModelEndpoints.get_model_endpoints_metrics,
+                    services.api.crud.ModelEndpoints.get_model_xendpoints_metrics,
                     endpoint_id=endpoint_ids,
                     type=mm_constants.ModelEndpointMonitoringMetricType.METRIC,
                     project=project,

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -174,7 +174,7 @@ async def enable_model_monitoring(
     :param fetch_credentials_from_sys_config: Deprecated. If true, fetch the credentials from the system configuration.
 
     """
-    commons.get_monitoring_deployment().deploy_monitoring_functions(
+    await commons.get_monitoring_deployment().deploy_monitoring_functions(
         image=image,
         base_period=base_period,
         deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
@@ -310,7 +310,7 @@ async def delete_model_monitoring_function(
 
 
 @router.put("/credentials")
-def set_model_monitoring_credentials(
+async def set_model_monitoring_credentials(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     tsdb_profile_name: str,
     stream_profile_name: str,
@@ -326,7 +326,7 @@ def set_model_monitoring_credentials(
                                       The profile can be V3IO or KafkaSource.
     :param replace_creds:             If True, it will force the credentials update. By default, False.
     """
-    commons.get_monitoring_deployment().set_credentials(
+    await commons.get_monitoring_deployment().set_credentials(
         tsdb_profile_name=tsdb_profile_name,
         stream_profile_name=stream_profile_name,
         replace_creds=replace_creds,

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -132,7 +132,7 @@ class MonitoringDeployment:
             )
         return self.__tsdb_connector
 
-    def deploy_monitoring_functions(
+    async def deploy_monitoring_functions(
         self,
         base_period: int = 10,
         image: str = "mlrun/mlrun",
@@ -152,7 +152,7 @@ class MonitoringDeployment:
         """
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
-            self.set_credentials()
+            await self.set_credentials()
         # reject the request if controller and/or writer pods are already deployed.
         # stream-pod is not checked since by default it is not deleted by disable_model_monitoring.
         if deployed_functions := [
@@ -849,7 +849,7 @@ class MonitoringDeployment:
                 app_data=fn.to_dict(),
             )
 
-    def _create_tsdb_tables(
+    async def _create_tsdb_tables(
         self, tsdb_profile: mlrun.datastore.datastore_profile.DatastoreProfile
     ) -> None:
         """
@@ -858,9 +858,11 @@ class MonitoringDeployment:
         - metrics: a basic key value that represents a numeric metric.
         - predictions: latency of each prediction.
         """
-        mlrun.model_monitoring.get_tsdb_connector(
-            project=self.project, profile=tsdb_profile
-        ).create_tables()
+        await run_in_threadpool(
+            mlrun.model_monitoring.get_tsdb_connector(
+                project=self.project, profile=tsdb_profile
+            ).create_tables
+        )
 
     def list_model_monitoring_functions(
         self,
@@ -1792,7 +1794,7 @@ class MonitoringDeployment:
             container, path, raise_for_status=[HTTPStatus.OK, HTTPStatus.NOT_FOUND]
         )
 
-    def set_credentials(
+    async def set_credentials(
         self,
         *,
         tsdb_profile_name: typing.Optional[str] = None,
@@ -1860,7 +1862,7 @@ class MonitoringDeployment:
                 )
 
         # Create TSDB tables that will be used for storing the model monitoring data
-        self._create_tsdb_tables(tsdb_profile)
+        await self._create_tsdb_tables(tsdb_profile=tsdb_profile)
 
         services.api.crud.Secrets().store_project_secrets(
             project=self.project,
@@ -2555,8 +2557,10 @@ class MonitoringDeployment:
             application_name=application_name,
             endpoint_ids=endpoint_ids,
         )
-        self._tsdb_connector.delete_application_records(
-            application_name=application_name, endpoint_ids=endpoint_ids
+        run_in_threadpool(
+            self._tsdb_connector.delete_application_records,
+            application_name=application_name,
+            endpoint_ids=endpoint_ids,
         )
 
         if not application_name.endswith(mlrun_constants.RESERVED_BATCH_JOB_SUFFIX):

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -2557,7 +2557,7 @@ class MonitoringDeployment:
             application_name=application_name,
             endpoint_ids=endpoint_ids,
         )
-        run_in_threadpool(
+        await run_in_threadpool(
             self._tsdb_connector.delete_application_records,
             application_name=application_name,
             endpoint_ids=endpoint_ids,

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -903,6 +903,7 @@ class ModelEndpoints:
 
     @staticmethod
     async def delete_tsdb_records(project: str, uids: list[str]):
+        """Use only in background task to delete TSDB records of model endpoints."""
         try:
             tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
                 project=project,
@@ -910,7 +911,7 @@ class ModelEndpoints:
                     project=project
                 ),
             )
-            run_in_threadpool(tsdb_connector.delete_tsdb_records, endpoint_ids=uids)
+            tsdb_connector.delete_tsdb_records(endpoint_ids=uids)
             logger.info("TSDB resources were deleted")
         except mlrun.errors.MLRunInvalidMMStoreTypeError as e:
             logger.info(
@@ -1200,7 +1201,7 @@ class ModelEndpoints:
             )
             tsdb_connector = None
         if tsdb_connector:
-            run_in_threadpool(tsdb_connector.delete_tsdb_resources)
+            tsdb_connector.delete_tsdb_resources()
         cls._delete_model_monitoring_stream_resources(
             project_name=project_name,
             model_monitoring_applications=model_monitoring_applications,

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -910,7 +910,7 @@ class ModelEndpoints:
                     project=project
                 ),
             )
-            tsdb_connector.delete_tsdb_records(endpoint_ids=uids)
+            run_in_threadpool(tsdb_connector.delete_tsdb_records, endpoint_ids=uids)
             logger.info("TSDB resources were deleted")
         except mlrun.errors.MLRunInvalidMMStoreTypeError as e:
             logger.info(
@@ -1200,7 +1200,7 @@ class ModelEndpoints:
             )
             tsdb_connector = None
         if tsdb_connector:
-            tsdb_connector.delete_tsdb_resources()
+            run_in_threadpool(tsdb_connector.delete_tsdb_resources)
         cls._delete_model_monitoring_stream_resources(
             project_name=project_name,
             model_monitoring_applications=model_monitoring_applications,
@@ -1236,6 +1236,8 @@ class ModelEndpoints:
         :param metrics_format:  Determines the format of the result, which can be `single`, `separation`, or
                                 `intersection`.
         :return: metrics in the chosen format.
+
+        Note should be called only on different thread than the main fastapi thread
         """
         try:
             tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
@@ -1359,7 +1361,7 @@ class ModelEndpoints:
             )
 
     @staticmethod
-    def _get_real_time_metrics(
+    async def _get_real_time_metrics(
         model_endpoint_object: mlrun.common.schemas.ModelEndpoint,
         metrics: typing.Optional[list[str]] = None,
         start: str = "now-1h",
@@ -1402,9 +1404,10 @@ class ModelEndpoints:
                 " Returning without adding real time metrics.",
                 error=mlrun.errors.err_to_str(e),
             )
-            return model_endpoint_object
+            return {}
 
-        endpoint_metrics = tsdb_connector.get_model_endpoint_real_time_metrics(
+        endpoint_metrics = await run_in_threadpool(
+            tsdb_connector.get_model_endpoint_real_time_metrics,
             endpoint_id=model_endpoint_object.metadata.uid,
             metrics=metrics,
             start=start,

--- a/server/py/services/api/crud/model_monitoring/model_endpoints.py
+++ b/server/py/services/api/crud/model_monitoring/model_endpoints.py
@@ -919,7 +919,7 @@ class ModelEndpoints:
                 error=mlrun.errors.err_to_str(e),
             )
 
-    async def get_model_endpoint(
+    def get_model_endpoint(
         self,
         name: str,
         project: str,
@@ -964,21 +964,22 @@ class ModelEndpoints:
         )
 
         # Get the model endpoint record
-        model_endpoint_object = await run_in_threadpool(
-            framework.utils.singletons.db.get_db().get_model_endpoint,
-            session=db_session,
-            project=project,
-            name=name,
-            function_name=function_name,
-            function_tag=function_tag,
-            uid=endpoint_id,
+        model_endpoint_object = (
+            framework.utils.singletons.db.get_db().get_model_endpoint(
+                session=db_session,
+                project=project,
+                name=name,
+                function_name=function_name,
+                function_tag=function_tag,
+                uid=endpoint_id,
+            )
         )
 
         # If time metrics were provided, retrieve the results from the time series DB
         if tsdb_metrics:
             logger.info("Adding real time metrics to the model endpoint")
             model_endpoint_object = (
-                await self._add_basic_metrics(
+                self._add_basic_metrics(
                     model_endpoint_objects=[model_endpoint_object],
                     project=project,
                     metric_list=metric_list,
@@ -987,25 +988,26 @@ class ModelEndpoints:
         if feature_analysis:
             logger.info("Adding feature analysis to the model endpoint")
             if config.model_endpoint_monitoring.writer_graph.writer_version != "v1":
-                parquet_target = await run_in_threadpool(
-                    framework.db.session.run_function_with_new_db_session,
+                parquet_target = framework.db.session.run_function_with_new_db_session(
                     services.api.crud.model_monitoring.helpers.get_monitoring_parquet_path,
                     project=project,
                     kind="parquet_stats",
                 )
-                drift_measures, drift_measures_timestamp = await run_in_threadpool(
-                    self._get_mep_stats_dict_from_parquet,
-                    parquet_target=parquet_target,
-                    project=project,
-                    uid=model_endpoint_object.metadata.uid,
-                    kind=mm_constants.StatsKind.DRIFT_MEASURES,
+                drift_measures, drift_measures_timestamp = (
+                    self._get_mep_stats_dict_from_parquet(
+                        parquet_target=parquet_target,
+                        project=project,
+                        uid=model_endpoint_object.metadata.uid,
+                        kind=mm_constants.StatsKind.DRIFT_MEASURES,
+                    )
                 )
-                current_stats, current_stats_timestamp = await run_in_threadpool(
-                    self._get_mep_stats_dict_from_parquet,
-                    parquet_target=parquet_target,
-                    project=project,
-                    uid=model_endpoint_object.metadata.uid,
-                    kind=mm_constants.StatsKind.CURRENT_STATS,
+                current_stats, current_stats_timestamp = (
+                    self._get_mep_stats_dict_from_parquet(
+                        parquet_target=parquet_target,
+                        project=project,
+                        uid=model_endpoint_object.metadata.uid,
+                        kind=mm_constants.StatsKind.CURRENT_STATS,
+                    )
                 )
             else:
                 current_stats, current_stats_timestamp = {}, None
@@ -1030,8 +1032,7 @@ class ModelEndpoints:
                 (
                     model_endpoint_object,
                     _,
-                ) = await run_in_threadpool(
-                    framework.db.session.run_function_with_new_db_session,
+                ) = framework.db.session.run_function_with_new_db_session(
                     self._add_feature_stats,
                     model_endpoint_object=model_endpoint_object,
                 )
@@ -1123,7 +1124,7 @@ class ModelEndpoints:
         )
 
         if tsdb_metrics and endpoint_list.endpoints:
-            endpoint_list.endpoints = await self._add_basic_metrics(
+            endpoint_list.endpoints = self._add_basic_metrics(
                 model_endpoint_objects=endpoint_list.endpoints,
                 project=project,
                 metric_list=metric_list,
@@ -1441,7 +1442,7 @@ class ModelEndpoints:
                 )
         return model_endpoint_objects
 
-    async def _add_basic_metrics(
+    def _add_basic_metrics(
         self,
         model_endpoint_objects: list[mlrun.common.schemas.ModelEndpoint],
         project: str,
@@ -1475,10 +1476,8 @@ class ModelEndpoints:
             )
             return model_endpoint_objects
 
-        return await tsdb_connector.add_basic_metrics(
+        return tsdb_connector.add_basic_metrics(
             model_endpoint_objects,
-            project,
-            run_in_threadpool,
             metric_list,
         )
 

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_cross.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_cross.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 from datetime import datetime, timezone
 from typing import Optional
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -225,15 +223,10 @@ class TestTimescaleDBCrossQueries:
 
     def test_add_basic_metrics_empty_data(self, connector, sample_model_endpoints):
         """Test add_basic_metrics with no data in database."""
-        mock_run_in_threadpool = AsyncMock()
 
         # Run the async method
-        result = asyncio.run(
-            connector.add_basic_metrics(
-                model_endpoint_objects=sample_model_endpoints,
-                project=connector.project,
-                run_in_threadpool=mock_run_in_threadpool,
-            )
+        result = connector.add_basic_metrics(
+            model_endpoint_objects=sample_model_endpoints,
         )
 
         # Verify all endpoints are returned with empty data using helper
@@ -259,15 +252,9 @@ class TestTimescaleDBCrossQueries:
         self._write_test_predictions_data(connector, endpoint_ids)
         self._write_test_results_data(connector, endpoint_ids)
 
-        mock_run_in_threadpool = AsyncMock()
-
         # Run the async method
-        result = asyncio.run(
-            connector.add_basic_metrics(
-                model_endpoint_objects=sample_model_endpoints,
-                project=connector.project,
-                run_in_threadpool=mock_run_in_threadpool,
-            )
+        result = connector.add_basic_metrics(
+            model_endpoint_objects=sample_model_endpoints,
         )
 
         # Verify all endpoints are returned with data using helpers
@@ -297,16 +284,10 @@ class TestTimescaleDBCrossQueries:
         self._write_test_predictions_data(connector, endpoint_ids)
         self._write_test_results_data(connector, endpoint_ids)
 
-        mock_run_in_threadpool = AsyncMock()
-
         # Run with filtered metrics - only error_count and last_request
-        result = asyncio.run(
-            connector.add_basic_metrics(
-                model_endpoint_objects=sample_model_endpoints,
-                project=connector.project,
-                run_in_threadpool=mock_run_in_threadpool,
-                metric_list=["error_count", "last_request"],
-            )
+        result = connector.add_basic_metrics(
+            model_endpoint_objects=sample_model_endpoints,
+            metric_list=["error_count", "last_request"],
         )
 
         # Verify filtered metrics using helper - only error_count and last_request should be set

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -99,7 +99,7 @@ class TestModelEndpointsOperations(TestMLRunSystemModelMonitoring):
     """Applying basic model endpoint CRUD operations through MLRun API"""
 
     project_name = "mm-app-project"
-    image = "mlrun/mlrun"
+    image = "artifactory.iguazeng.com:10557/mlrun/mlrun:unstable"
 
     def setup_method(self, method):
         super().setup_method(method)


### PR DESCRIPTION
### 📝 Description
To prevent the `mlrun-api-worker` from becoming unresponsive, this PR moves all TSDB calls to run in a separate thread instead of the main FastAPI thread.

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11350
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
