### PR TITLE
[Deprecations] Change allow-cross-project flag default to False

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -203,7 +203,6 @@ def main():
 @click.option(
     "--allow-cross-project",
     is_flag=True,
-    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )
@@ -513,7 +512,6 @@ def run(
 @click.option(
     "--allow-cross-project",
     is_flag=True,
-    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )
@@ -672,7 +670,6 @@ def build(
 @click.option(
     "--allow-cross-project",
     is_flag=True,
-    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )
@@ -1008,7 +1005,6 @@ def logs(uid, project, offset, db):
 @click.option(
     "--allow-cross-project",
     is_flag=True,
-    default=True,  # TODO: remove this default in 1.11
     help="Override the loaded project name. This flag ensures awareness of loading an existing project yaml "
     "as a baseline for a new project with a different name",
 )


### PR DESCRIPTION
### 📝 Description
Change the default value of the `--allow-cross-project` CLI flag from True to False in version 1.11, making it an explicit opt-in flag. 
This aligns the CLI behavior with the updated `allow_cross_project` functionality ( https://iguazio.atlassian.net/browse/ML-10062 ) and removes the temporary backward-compatible default.

---

### 🛠️ Changes Made
Removed the default value True for the `--allow-cross-project` CLI flag.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10226
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
