### PR TITLE
[Serving] Adding max threads/processes configuration for `ModelRunnerStep` 

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1876,14 +1876,6 @@ class ModelRunnerStep(MonitoredStep):
                 otherwise block the main event loop thread.
             * "asyncio" – To run in an asyncio task. This is appropriate for I/O tasks that use asyncio, allowing the
                 event loop to continue running while waiting for a response.
-            * "shared_executor" – Reuses an external executor (typically managed by the flow or context) to execute the
-                runnable. Should be used only if you have multiply `ParallelExecution` in the same flow and especially
-                useful when:
-                - You want to share a heavy resource like a large model loaded onto a GPU.
-                - You want to centralize task scheduling or coordination for multiple lightweight tasks.
-                - You aim to minimize overhead from creating new executors or processes/threads per runnable.
-                The runnable is expected to be pre-initialized and reused across events, enabling efficient use of
-                memory and hardware accelerators.
             * "naive" – To run in the main event loop. This is appropriate only for trivial computation and/or file I/O.
                 It means that the runnable will not actually be run in parallel to anything else.
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1662,7 +1662,7 @@ class ModelRunnerStep(MonitoredStep):
     the default language model class (LLModel) during function deployment.
 
     Note ModelRunnerStep can only be added to a graph that has the flow topology and running with async engine.
-    For default number of max threads and max processes, see config_pool_resource() method documentation.
+    Note see config_pool_resource method documentation for default number of max threads and max processes.
 
     :param model_selector: ModelSelector instance whose select() method will be used to select models to run on each
       event. Optional. If not passed, all models will be run.

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -2104,7 +2104,7 @@ class ModelRunnerStep(MonitoredStep):
                 "Monitoring data must be a dictionary."
             )
 
-    def config_pool_resource(
+    def configure_pool_resource(
         self,
         max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,
@@ -3026,7 +3026,7 @@ class RootFlowStep(FlowStep):
                 return model_name, model_class, model_params
         return None, None, None
 
-    def config_pool_resource(
+    def configure_pool_resource(
         self,
         max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -2113,9 +2113,10 @@ class ModelRunnerStep(MonitoredStep):
         """
         Configure the resource limits for the shared models in the graph.
         :param max_processes: Maximum number of processes to spawn (excluding dedicated processes).
-                             Defaults to the number of CPUs or 16 if undetectable.
+                              defaults to the number of CPUs or 16 if undetectable.
         :param max_threads: Maximum number of threads to spawn. Defaults to 32.
         :param pool_factor: Multiplier to scale the number of process/thread workers per runnable. Defaults to 1.
+
         """
         self.max_processes = max_processes
         self.max_threads = max_threads

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -2112,11 +2112,11 @@ class ModelRunnerStep(MonitoredStep):
     ) -> None:
         """
         Configure the resource limits for the shared models in the graph.
+
         :param max_processes: Maximum number of processes to spawn (excluding dedicated processes).
-                              defaults to the number of CPUs or 16 if undetectable.
+            Defaults to the number of CPUs or 16 if undetectable.
         :param max_threads: Maximum number of threads to spawn. Defaults to 32.
         :param pool_factor: Multiplier to scale the number of process/thread workers per runnable. Defaults to 1.
-
         """
         self.max_processes = max_processes
         self.max_threads = max_threads

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1662,7 +1662,7 @@ class ModelRunnerStep(MonitoredStep):
     the default language model class (LLModel) during function deployment.
 
     Note ModelRunnerStep can only be added to a graph that has the flow topology and running with async engine.
-    For default number of threads and processes, see ModelRunnerStep:config_pool_resource() method documentation.
+    For default number of max threads and max processes, see config_pool_resource() method documentation.
 
     :param model_selector: ModelSelector instance whose select() method will be used to select models to run on each
       event. Optional. If not passed, all models will be run.

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -3026,7 +3026,7 @@ class RootFlowStep(FlowStep):
                 return model_name, model_class, model_params
         return None, None, None
 
-    def configure_pool_resource(
+    def configure_shared_pool_resource(
         self,
         max_processes: Optional[int] = None,
         max_threads: Optional[int] = None,

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1662,6 +1662,7 @@ class ModelRunnerStep(MonitoredStep):
     the default language model class (LLModel) during function deployment.
 
     Note ModelRunnerStep can only be added to a graph that has the flow topology and running with async engine.
+    For default number of threads and processes, see ModelRunnerStep:config_pool_resource() method documentation.
 
     :param model_selector: ModelSelector instance whose select() method will be used to select models to run on each
       event. Optional. If not passed, all models will be run.
@@ -1675,7 +1676,12 @@ class ModelRunnerStep(MonitoredStep):
     """
 
     kind = "model_runner"
-    _dict_fields = MonitoredStep._dict_fields + ["_shared_proxy_mapping"]
+    _dict_fields = MonitoredStep._dict_fields + [
+        "_shared_proxy_mapping",
+        "max_processes",
+        "max_threads",
+        "pool_factor",
+    ]
 
     def __init__(
         self,
@@ -1686,6 +1692,10 @@ class ModelRunnerStep(MonitoredStep):
         raise_exception: bool = True,
         **kwargs,
     ):
+        self.max_processes = None
+        self.max_threads = None
+        self.pool_factor = None
+
         if isinstance(model_selector, ModelSelector) and model_selector_parameters:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Cannot provide a model_selector object as argument to `model_selector` and also provide "
@@ -2093,6 +2103,23 @@ class ModelRunnerStep(MonitoredStep):
                 "Monitoring data must be a dictionary."
             )
 
+    def config_pool_resource(
+        self,
+        max_processes: Optional[int] = None,
+        max_threads: Optional[int] = None,
+        pool_factor: Optional[int] = None,
+    ) -> None:
+        """
+        Configure the resource limits for the shared models in the graph.
+        :param max_processes: Maximum number of processes to spawn (excluding dedicated processes).
+                             Defaults to the number of CPUs or 16 if undetectable.
+        :param max_threads: Maximum number of threads to spawn. Defaults to 32.
+        :param pool_factor: Multiplier to scale the number of process/thread workers per runnable. Defaults to 1.
+        """
+        self.max_processes = max_processes
+        self.max_threads = max_threads
+        self.pool_factor = pool_factor
+
     def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
         self.context = context
         if not self._is_local_function(context):
@@ -2141,6 +2168,9 @@ class ModelRunnerStep(MonitoredStep):
             shared_proxy_mapping=self._shared_proxy_mapping or None,
             name=self.name,
             context=context,
+            max_processes=self.max_processes,
+            max_threads=self.max_threads,
+            pool_factor=self.pool_factor,
         )
 
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1662,6 +1662,7 @@ class ModelRunnerStep(MonitoredStep):
     the default language model class (LLModel) during function deployment.
 
     Note ModelRunnerStep can only be added to a graph that has the flow topology and running with async engine.
+
     Note see config_pool_resource method documentation for default number of max threads and max processes.
 
     :param model_selector: ModelSelector instance whose select() method will be used to select models to run on each

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -25,7 +25,6 @@ import pytest
 
 import mlrun
 import mlrun.common.schemas as schemas
-from mlrun import new_function
 from mlrun.artifacts.llm_prompt import LLMPromptArtifact
 from mlrun.artifacts.model import ModelArtifact
 from mlrun.errors import MLRunInvalidArgumentError, ModelRunnerError
@@ -1218,7 +1217,7 @@ def test_configure_model_runner_step_max_threads_processes(concurrency: str):
         inc=1,
     )
 
-    function = new_function("tests", kind="serving")
+    function = mlrun.new_function("tests", kind="serving")
     graph = function.set_topology("flow", engine="async")
     model_runner_step = ModelRunnerStep(
         name="my_model_runner",

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1231,9 +1231,9 @@ def test_configure_model_runner_step_max_threads_processes(concurrency: str):
         else "process_pool",
     )
     if concurrency == "max_threads":
-        model_runner_step.config_pool_resource(max_threads=48)
+        model_runner_step.configure_pool_resource(max_threads=48)
     elif concurrency == "max_processes":
-        model_runner_step.config_pool_resource(max_processes=32)
+        model_runner_step.configure_pool_resource(max_processes=32)
 
     graph.to(model_runner_step).respond()
     server = function.to_mock_server()

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -25,6 +25,7 @@ import pytest
 
 import mlrun
 import mlrun.common.schemas as schemas
+from mlrun import new_function
 from mlrun.artifacts.llm_prompt import LLMPromptArtifact
 from mlrun.artifacts.model import ModelArtifact
 from mlrun.errors import MLRunInvalidArgumentError, ModelRunnerError
@@ -1201,3 +1202,49 @@ def test_model_runner_add_proxy_model_failure():
             shared_model_name="my_model_1",
         )
         graph.to(model_runner_step).respond()
+
+
+@pytest.mark.parametrize(
+    "concurrency",
+    (
+        "max_threads",
+        "max_processes",
+    ),
+)
+def test_configure_model_runner_step_max_threads_processes(concurrency: str):
+    m1 = MyModel(
+        name="m1",
+        execution_mechanism="naive",
+        inc=1,
+    )
+
+    function = new_function("tests", kind="serving")
+    graph = function.set_topology("flow", engine="async")
+    model_runner_step = ModelRunnerStep(
+        name="my_model_runner",
+    )
+    model_runner_step.add_model(
+        endpoint_name=m1.name,
+        model_class=m1,
+        execution_mechanism="thread_pool"
+        if concurrency == "max_threads"
+        else "process_pool",
+    )
+    if concurrency == "max_threads":
+        model_runner_step.config_pool_resource(max_threads=48)
+    elif concurrency == "max_processes":
+        model_runner_step.config_pool_resource(max_processes=32)
+
+    graph.to(model_runner_step).respond()
+    server = function.to_mock_server()
+
+    if concurrency == "max_processes":
+        assert (
+            server.graph["my_model_runner"]._async_object.max_processes == 32
+        ), "Max processes not configured properly"
+    elif concurrency == "max_threads":
+        assert (
+            server.graph["my_model_runner"]._async_object.max_threads == 48
+        ), "Max threads not configured properly"
+    server.test(body={"n": 1})
+    server.wait_for_completion()


### PR DESCRIPTION
### 📝 Description

1. Adding `ModelRunnerStep:configure_pool_resource` allowing to modify the thread/process pool for the ModelRunnerStep and added documentation for the default case.
2. Renaming the RootFlowStep configuration method to  configure_shared_pool_resource
3. Deleting docs of shared_excecutor option from `ModelRunnerStep:add_model`
---

### ✅ Checklist

- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Tested manually + added unit test - `test_configure_model_runner_step_max_threads_processes`

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11358
- Related link: CR ML-11359
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No