### PR TITLE
[Model Monitoring] Normalize END_INFER_TIME: remove space before timezone to fix datetime parsing

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -1057,8 +1057,6 @@ class TDEngineConnector(TSDBConnector):
             ]
         ):
             metric_objects = []
-            mlrun.utils.logger.info(f"[DD] application_names: {application_names}") # todo: delete
-            mlrun.utils.logger.info(f"[DD] df_results: {df_results.head(5)}")  # todo: delete
             if not df_results.empty:
                 df_results.rename(
                     columns={
@@ -1067,11 +1065,12 @@ class TDEngineConnector(TSDBConnector):
                     inplace=True,
                 )
                 for _, row in df_results.iterrows():
-                    mlrun.utils.logger.info(f"[DD] end-infer-time: {row[mm_schemas.WriterEvent.END_INFER_TIME]}") # todo: delete
                     metric_objects.append(
                         mm_schemas.ApplicationResultRecord(
                             time=datetime.fromisoformat(
-                                row[mm_schemas.WriterEvent.END_INFER_TIME]
+                                row[mm_schemas.WriterEvent.END_INFER_TIME].replace(
+                                    " +", "+"
+                                )
                             ),
                             result_name=row[mm_schemas.ResultData.RESULT_NAME],
                             kind=row[mm_schemas.ResultData.RESULT_KIND],
@@ -1091,7 +1090,9 @@ class TDEngineConnector(TSDBConnector):
                     metric_objects.append(
                         mm_schemas.ApplicationMetricRecord(
                             time=datetime.fromisoformat(
-                                row[mm_schemas.WriterEvent.END_INFER_TIME]
+                                row[mm_schemas.WriterEvent.END_INFER_TIME].replace(
+                                    " +", "+"
+                                )
                             ),
                             metric_name=row[mm_schemas.MetricData.METRIC_NAME],
                             value=row[mm_schemas.MetricData.METRIC_VALUE],

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -1057,7 +1057,8 @@ class TDEngineConnector(TSDBConnector):
             ]
         ):
             metric_objects = []
-
+            mlrun.utils.logger.info(f"[DD] application_names: {application_names}") # todo: delete
+            mlrun.utils.logger.info(f"[DD] df_results: {df_results.head(5)}")  # todo: delete
             if not df_results.empty:
                 df_results.rename(
                     columns={
@@ -1066,6 +1067,7 @@ class TDEngineConnector(TSDBConnector):
                     inplace=True,
                 )
                 for _, row in df_results.iterrows():
+                    mlrun.utils.logger.info(f"[DD] end-infer-time: {row[mm_schemas.WriterEvent.END_INFER_TIME]}") # todo: delete
                     metric_objects.append(
                         mm_schemas.ApplicationResultRecord(
                             time=datetime.fromisoformat(


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
Inside calculate_latest_metrics, the parsing of END_INFER_TIME values from TDengine fails for some results because their timestamp strings are not valid ISO format (three fractional digits instead of six). Removing the extra space before the timezone, as implemented in this PR, fixes the parsing issue.
<!-- Include any relevant context or background information. -->

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
Removing the extra space before the timezone in the results before parsing.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11366
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
