### PR TITLE
[CI] Fix periodic build

### DIFF
--- a/.github/workflows/periodic-rebuild.yaml
+++ b/.github/workflows/periodic-rebuild.yaml
@@ -37,13 +37,14 @@ jobs:
           # take last 2 elements (aka last 2 versions)
           # wrap each name with "" and join with ,
           # join with development
+          # output would be like - 1.3.x,1.4.x,development
           branches=$(curl --retry 3 --retry-all-errors --silent https://api.github.com/repos/mlrun/mlrun/branches \
-            | jq -r 'map(select(.name | test("^\\d+.\\d+.x$"))) | sort_by(.name) | .[-2:] | map(.name | tostring | "\"" + . + "\"") | join(",")' \
-          )
-          # output would be like
-          # 1.3.x,1.4.x,development
-          branches="$branches,\"development\""
-
+            | jq -r '.[].name | select(test("^\\d+\\.\\d+\\.x$"))' \
+            | sort -Vr \
+            | head -2 \
+            | tr '\n' ',' \
+            | sed 's/,$//' \
+            | awk '{print $0",development"}')
           matrix="{\"repo\": [\"mlrun\",\"ui\"], \"branch\": [$branches]}"
           echo "matrix=$(echo $matrix)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### 📝 Description

Periodic build runs every night takes 2 last branched-out versions and development and rebuild them to update their caches. since we have branched out 1.10, the sorting did not work as the semver comparison was syntaxly wrong and it returned 1.9.x, 1.8.x instead of 1.9.x, 1.10.x

---

### 🛠️ Changes Made

Fix the command getting the branches

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

ran command manually

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
