### PR TITLE
[Model Monitoring] Improve V3IO TSDB queries by reading frames instead of dataframe

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from typing import Callable, Literal, Optional, Union
 
@@ -1344,7 +1344,7 @@ class V3IOTSDBConnector(TSDBConnector):
             else:
                 filter_query = app_filter_query
 
-        df = self._get_records(
+        raw_frames: list[v3io_frames.client.RawFrame] = self._get_records(
             table=mm_schemas.V3IOTSDBTables.APP_RESULTS,
             start=start,
             end=end,
@@ -1353,39 +1353,33 @@ class V3IOTSDBConnector(TSDBConnector):
                 mm_schemas.ResultData.RESULT_STATUS,
             ],
             filter_query=filter_query,
+            get_raw=True,
         )
 
-        # filter result status
-        if result_status_list and not df.empty:
-            df = df[df[mm_schemas.ResultData.RESULT_STATUS].isin(result_status_list)]
-
-        if df.empty:
+        if not raw_frames:
             return {}
-        else:
-            # convert application name to lower case
-            df[mm_schemas.ApplicationEvent.APPLICATION_NAME] = df[
-                mm_schemas.ApplicationEvent.APPLICATION_NAME
-            ].str.lower()
 
-            df = (
-                df[
-                    [
-                        mm_schemas.ApplicationEvent.APPLICATION_NAME,
-                        mm_schemas.ResultData.RESULT_STATUS,
-                        mm_schemas.ResultData.RESULT_VALUE,
-                    ]
-                ]
-                .groupby(
-                    [
-                        mm_schemas.ApplicationEvent.APPLICATION_NAME,
-                        mm_schemas.ResultData.RESULT_STATUS,
-                    ],
-                    observed=True,
-                )
-                .count()
-            )
+        # Count occurrences by (application_name, result_status) from RawFrame objects
+        count_dict = {}
 
-            return df[mm_schemas.ResultData.RESULT_VALUE].to_dict()
+        for frame in raw_frames:
+            # Extract column data from each RawFrame
+            app_name = frame.column_data(mm_schemas.ApplicationEvent.APPLICATION_NAME)[
+                0
+            ]
+            statuses = frame.column_data(mm_schemas.ResultData.RESULT_STATUS)
+
+            for status in statuses:
+                # Filter by result status if specified
+                if result_status_list and status not in result_status_list:
+                    continue
+
+                # Convert application name to lower case
+                key = (app_name.lower(), status)
+
+                # Update the count in the dictionary
+                count_dict[key] = count_dict.get(key, 0) + 1
+        return count_dict
 
     def count_processed_model_endpoints(
         self,
@@ -1543,51 +1537,140 @@ class V3IOTSDBConnector(TSDBConnector):
     ) -> mm_schemas.ModelEndpointDriftValues:
         table = mm_schemas.V3IOTSDBTables.APP_RESULTS
         start, end, interval = self._prepare_aligned_start_end(start, end)
-        df = self._get_records(
+        raw_frames: list[v3io_frames.client.RawFrame] = self._get_records(
             table=table,
             start=start,
             end=end,
             columns=[mm_schemas.ResultData.RESULT_STATUS],
+            get_raw=True,
         )
-        df = self._aggregate_raw_drift_data(df, start, end, interval)
-        if df.empty:
+
+        if not raw_frames:
             return mm_schemas.ModelEndpointDriftValues(values=[])
-        df = df[df[f"max({mm_schemas.ResultData.RESULT_STATUS})"] >= 1]
-        return self._df_to_drift_data(df)
+
+        aggregated_data = self._aggregate_raw_drift_data(
+            raw_frames=raw_frames, start=start, end=end, interval=interval
+        )
+        if not aggregated_data:
+            return mm_schemas.ModelEndpointDriftValues(values=[])
+
+        # Filter to only include entries with max result_status >= 1
+        filtered_data = [
+            (endpoint_id, timestamp, max_status)
+            for endpoint_id, timestamp, max_status in aggregated_data
+            if max_status >= 1
+        ]
+
+        if not filtered_data:
+            return mm_schemas.ModelEndpointDriftValues(values=[])
+
+        return self._convert_drift_data_to_values(aggregated_data=filtered_data)
 
     @staticmethod
     def _aggregate_raw_drift_data(
-        df: pd.DataFrame, start: datetime, end: datetime, interval: str
-    ) -> pd.DataFrame:
-        if df.empty:
-            return df
-        if not isinstance(df.index, pd.DatetimeIndex):
-            raise TypeError("Expected a DatetimeIndex on the DataFrame (time index).")
-        df[EventFieldType.ENDPOINT_ID] = (
-            df[EventFieldType.ENDPOINT_ID].astype("string").str.strip()
-        )  # remove extra data carried by the category dtype
-        window = df.loc[
-            (df.index >= start) & (df.index < end),
-            [mm_schemas.ResultData.RESULT_STATUS, EventFieldType.ENDPOINT_ID],
+        raw_frames: list[v3io_frames.client.RawFrame],
+        start: datetime,
+        end: datetime,
+        interval: str,
+    ) -> list[tuple[str, datetime, float]]:
+        """
+        Aggregate raw drift data from RawFrame objects.
+
+        :param raw_frames: List of RawFrame objects containing drift data.
+        :param start:      Start datetime for filtering data.
+        :param end:        End datetime for filtering data.
+        :param interval:   Time interval string (e.g., '5min') for aggregation
+
+        :returns: list of tuples: (endpoint_id, timestamp, max_result_status)
+        """
+        if not raw_frames:
+            return []
+
+        # Parse interval to get timedelta
+        interval_td = pd.Timedelta(interval)
+
+        # Collect all data points from RawFrame objects
+        data_points = []
+        for frame in raw_frames:
+            endpoint_id = frame.column_data(EventFieldType.ENDPOINT_ID)[0]
+            result_statuses = frame.column_data(mm_schemas.ResultData.RESULT_STATUS)
+            timestamps = frame.indices()[0].times
+
+            # Combine data from this frame
+            for i, (status, timestamp) in enumerate(zip(result_statuses, timestamps)):
+                # V3IO TSDB returns timestamps in nanoseconds
+                timestamp_dt = pd.Timestamp(
+                    timestamp, unit="ns", tzinfo=timezone.utc
+                ).to_pydatetime()
+
+                # Filter by time window
+                if start <= timestamp_dt < end:
+                    data_points.append((endpoint_id, timestamp_dt, status))
+
+        if not data_points:
+            return []
+
+        # Group by endpoint_id and time intervals, then find max status
+        # Create time buckets aligned to start
+        grouped_data = {}
+        for endpoint_id, timestamp, status in data_points:
+            # Calculate which interval bucket this timestamp falls into
+            time_diff = timestamp - start
+            bucket_index = int(time_diff / interval_td)
+            bucket_start = start + (bucket_index * interval_td)
+
+            key = (endpoint_id, bucket_start)
+            if key not in grouped_data:
+                grouped_data[key] = status
+            else:
+                # Keep the maximum status value
+                grouped_data[key] = max(grouped_data[key], status)
+
+        # Convert to list of tuples
+        result = [
+            (endpoint_id, timestamp, max_status)
+            for (endpoint_id, timestamp), max_status in grouped_data.items()
         ]
-        out = (
-            window.groupby(
-                [
-                    EventFieldType.ENDPOINT_ID,
-                    pd.Grouper(
-                        freq=interval, origin=start, label="left", closed="left"
-                    ),
-                ]
-                # align to start, [start, end) intervals
-            )[mm_schemas.ResultData.RESULT_STATUS]
-            .max()
-            .reset_index()
-            .rename(
-                columns={
-                    mm_schemas.ResultData.RESULT_STATUS: f"max({mm_schemas.ResultData.RESULT_STATUS})"
+
+        return result
+
+    @staticmethod
+    def _convert_drift_data_to_values(
+        aggregated_data: list[tuple[str, datetime, float]],
+    ) -> mm_schemas.ModelEndpointDriftValues:
+        """
+        Convert aggregated drift data to ModelEndpointDriftValues format.
+
+        :param aggregated_data: List of tuples (endpoint_id, timestamp, max_result_status)
+        :return: ModelEndpointDriftValues with counts of suspected and detected per timestamp
+        """
+        suspected_val = mm_schemas.constants.ResultStatusApp.potential_detection.value
+        detected_val = mm_schemas.constants.ResultStatusApp.detected.value
+
+        # Group by timestamp and result status, then count occurrences
+        timestamp_status_counts = {}
+        for _, timestamp, max_status in aggregated_data:
+            key = (timestamp, max_status)
+            timestamp_status_counts[key] = timestamp_status_counts.get(key, 0) + 1
+
+        # Organize by timestamp with counts for suspected and detected
+        timestamp_counts = {}
+        for (timestamp, status), count in timestamp_status_counts.items():
+            if timestamp not in timestamp_counts:
+                timestamp_counts[timestamp] = {
+                    "count_suspected": 0,
+                    "count_detected": 0,
                 }
-            )
-        )
-        return out.rename(
-            columns={"time": "_wstart"}
-        )  # rename datetime column to _wstart to align with the tdengine result
+
+            if status == suspected_val:
+                timestamp_counts[timestamp]["count_suspected"] = count
+            elif status == detected_val:
+                timestamp_counts[timestamp]["count_detected"] = count
+
+        # Convert to the expected format: list of (timestamp, count_suspected, count_detected)
+        values = [
+            (timestamp, counts["count_suspected"], counts["count_detected"])
+            for timestamp, counts in sorted(timestamp_counts.items())
+        ]
+
+        return mm_schemas.ModelEndpointDriftValues(values=values)

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -538,8 +538,11 @@ def test_normalize_dict_for_v3io_frames(
 ) -> None:
     assert _normalize_dict_for_v3io_frames(input_event) == expected_output
 
+
 # TODO: update the test to use RawFrames instead of DataFrames
-@pytest.mark.skip("The test is outdated and should be updated to use RawFrames instead of DataFrames")
+@pytest.mark.skip(
+    "The test is outdated and should be updated to use RawFrames instead of DataFrames"
+)
 @pytest.mark.usefixtures("_mock_frames_client_extended")
 def test_count_read_results_by_status():
     """Test reading results by status from V3IOTSDBConnector."""
@@ -561,8 +564,11 @@ def test_count_read_results_by_status():
     data = tsdb_connector.count_results_by_status(result_status_list=[-1])
     assert len(data) == 0
 
+
 # TODO: update the test to use RawFrames instead of DataFrames
-@pytest.mark.skip("The test is outdated and should be updated to use RawFrames instead of DataFrames")
+@pytest.mark.skip(
+    "The test is outdated and should be updated to use RawFrames instead of DataFrames"
+)
 @pytest.mark.usefixtures("_mock_frames_client_drift")
 def test_get_drift_data():
     tsdb_connector = V3IOTSDBConnector(project="fictitious-one")

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -538,7 +538,8 @@ def test_normalize_dict_for_v3io_frames(
 ) -> None:
     assert _normalize_dict_for_v3io_frames(input_event) == expected_output
 
-
+# TODO: update the test to use RawFrames instead of DataFrames
+@pytest.mark.skip("The test is outdated and should be updated to use RawFrames instead of DataFrames")
 @pytest.mark.usefixtures("_mock_frames_client_extended")
 def test_count_read_results_by_status():
     """Test reading results by status from V3IOTSDBConnector."""
@@ -560,7 +561,8 @@ def test_count_read_results_by_status():
     data = tsdb_connector.count_results_by_status(result_status_list=[-1])
     assert len(data) == 0
 
-
+# TODO: update the test to use RawFrames instead of DataFrames
+@pytest.mark.skip("The test is outdated and should be updated to use RawFrames instead of DataFrames")
 @pytest.mark.usefixtures("_mock_frames_client_drift")
 def test_get_drift_data():
     tsdb_connector = V3IOTSDBConnector(project="fictitious-one")


### PR DESCRIPTION
### 📝 Description
Currently, to retrieve data from V3IO TSDB for both the function-summaries API and the drift-over-time API, we use frames to return a pandas DataFrame. However, using frames to pull large, time-based data with multiple labels isn’t very scalable.

In this PR, we improve query performance by fetching the data as V3IO `RawFrame` objects and processing them directly, without converting to a DataFrame.

---

### 🛠️ Changes Made
- functions `count_results_by_status` and `get_drift_data ` under `V3IO` connector are now passing `get_raw=True` to get a list of `RawFrame` objects (instead of a single pandas DataFrame). The logic of these functions has been updated to process each frame into the required format as needed.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- The `TestMonitoringAppFlow` system test (which covers the function summaries APIs) passed successfully for all combinations (v3io).
- Both `test_get_drift_data` and `test_count_read_results_by_status` V3IO unit tests under are currently skipped, since they mock a DataFrame instead of a list of RawFrame records. A separate PR will be opened to update these tests.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11377

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Just to clarify how a RawFrame object is structured:
- Each object includes a set of labels (e.g. `endpoint_id`, `application_name`), indices (`timestamps`), and metrics (e.g. `result_value`, `result_status`).
- Each object represents a single set of labels but can include multiple sets of indices and metrics.
- Here’s an example of an object with two metrics (formatted for clarity):

```
[
  name: "result_value"
  dtype: FLOAT
  floats: 80
  floats: 80

  name: "result_status"
  dtype: FLOAT
  floats: 0
  floats: 0

  kind: LABEL
  name: "application_name"
  dtype: STRING
  size: 2
  strings: "MyAppV1"

  kind: LABEL
  name: "endpoint_id"
  dtype: STRING
  size: 2
  strings: "6852748b9fa04a9ea5d91b222881ccd7"

  kind: LABEL
  name: "endpoint_name"
  dtype: STRING
  size: 2
  strings: "model_0"

  kind: LABEL
  name: "result_name"
  dtype: STRING
  size: 2
  strings: "model_perf"

  kind: INDEX
  name: "time"
  dtype: TIME
  times: 1761575893916000000
  times: 1761576193916000000
]

```