### PR TITLE
[Automation] get_demos external demo list [1.10.x]

### DIFF
--- a/automation/scripts/get_demos.py
+++ b/automation/scripts/get_demos.py
@@ -270,12 +270,14 @@ def get_demos(mlrun_version):
         response = requests.get(config_url, timeout=10)
         response.raise_for_status()  # raise HTTPError if not 200
         config = json.loads(response.text)
-        if mlrun_version not in config.keys():
+
+        version_to_use = VERSION_PATTERN.match(mlrun_version).group(1)
+        if version_to_use not in config.keys():
             config = config.get("development")
             log(f"Using development tag for demos list", "get_demos")
         else:
-            config = config.get(mlrun_version)
-            log(f"Using {mlrun_version} tag for demos list", "get_demos")
+            config = config.get(version_to_use)
+            log(f"Using {version_to_use} tag for demos list", "get_demos")
 
     except json.JSONDecodeError as e:
         raise RuntimeError(f"Invalid JSON in configuration file {config_url}: {e}")

--- a/automation/scripts/get_demos.py
+++ b/automation/scripts/get_demos.py
@@ -19,10 +19,8 @@ import re
 import shutil
 import sys
 import tarfile
-import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from pathlib import Path
 from time import sleep
 
 import requests
@@ -274,7 +272,7 @@ def get_demos(mlrun_version):
         version_to_use = VERSION_PATTERN.match(mlrun_version).group(1)
         if version_to_use not in config.keys():
             config = config.get("development")
-            log(f"Using development tag for demos list", "get_demos")
+            log("Using development tag for demos list", "get_demos")
         else:
             config = config.get(version_to_use)
             log(f"Using {version_to_use} tag for demos list", "get_demos")

--- a/automation/scripts/get_demos.py
+++ b/automation/scripts/get_demos.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import sys
 import tarfile
+import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
@@ -257,24 +258,40 @@ def create_manifest(mlrun_version, demo_versions):
 
 
 def get_demos(mlrun_version):
-    if not os.path.exists(CONFIG_PATH):
-        raise RuntimeError(f"Configuration file not found: {CONFIG_PATH}")
+    # Ignoring given demos_config path
+    # if not os.path.exists(CONFIG_PATH):
+    #     raise RuntimeError(f"Configuration file not found: {CONFIG_PATH}")
+    # try:
+    #     with Path(CONFIG_PATH).open("r", encoding="utf-8") as f:
+    #         config = json.load(f)
+
+    config_url = "https://raw.githubusercontent.com/mlrun/demos/refs/heads/1.7.x/demos_config.json"
     try:
-        with Path(CONFIG_PATH).open("r", encoding="utf-8") as f:
-            config = json.load(f)
+        response = requests.get(config_url, timeout=10)
+        response.raise_for_status()  # raise HTTPError if not 200
+        config = json.loads(response.text)
+        if mlrun_version not in config.keys():
+            config = config.get("development")
+            log(f"Using development tag for demos list", "get_demos")
+        else:
+            config = config.get(mlrun_version)
+            log(f"Using {mlrun_version} tag for demos list", "get_demos")
+
     except json.JSONDecodeError as e:
-        raise RuntimeError(f"Invalid JSON in configuration file {CONFIG_PATH}: {e}")
+        raise RuntimeError(f"Invalid JSON in configuration file {config_url}: {e}")
+    except requests.RequestException as e:
+        raise RuntimeError(f"Failed to download configuration file {config_url}: {e}")
     except Exception as e:
-        raise RuntimeError(f"Failed to read configuration file {CONFIG_PATH}: {e}")
+        raise RuntimeError(f"Failed to read configuration file {config_url}: {e}")
 
     os.makedirs(DEST_DIR, exist_ok=True)
     repositories = config.get("demos")
     if not repositories:
-        raise RuntimeError(f"No 'demos' key found in {CONFIG_PATH}")
+        raise RuntimeError(f"No 'demos' key found in {config_url}")
     if not isinstance(repositories, list):
-        raise RuntimeError(f"'demos' must be a list in {CONFIG_PATH}")
+        raise RuntimeError(f"'demos' must be a list in {config_url}")
     if not all(isinstance(r, str) for r in repositories):
-        raise RuntimeError(f"All demo entries must be strings in {CONFIG_PATH}")
+        raise RuntimeError(f"All demo entries must be strings in {config_url}")
 
     errors = []
     demo_versions = {}


### PR DESCRIPTION
### 📝 Description

Moving demos_config.json to mlrun/demos repository.
enabling dynamic demo list
problem raised is when we want to add/remove a demo from a released version.
update_demos.sh uses the demos list from the given mlrun version (i.e in 1.10.0-rc40 it will use the demos list from 1.10.0-rc40 tag which is already released and can't be changed)
---

### 🛠️ Changes Made

updated get_demos.py to get demos list from mlrun/demos/demos_config.json

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Manually tested

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No


---

### 🔍️ Additional Notes
