### PR TITLE
[Nuclio] Masking creds in rabbitmq url

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -19,6 +19,7 @@ import typing
 import warnings
 from datetime import datetime
 from time import sleep
+from urllib.parse import urlparse, urlunparse
 
 import inflection
 import nuclio
@@ -300,29 +301,16 @@ class RemoteRuntime(KubeResource):
             return {}
 
         raw_config = copy.deepcopy(self.spec.config)
-
         for key, value in self.spec.config.items():
             if key.startswith("spec.triggers"):
-                trigger_name = key.split(".")[-1]
-
-                for path in SENSITIVE_PATHS_IN_TRIGGER_CONFIG:
-                    # Handle nested keys
-                    nested_keys = path.split("/")
-                    target = value
-                    for sub_key in nested_keys[:-1]:
-                        target = target.get(sub_key, {})
-
-                    last_key = nested_keys[-1]
-                    if last_key in target:
-                        sensitive_field = target[last_key]
-                        if sensitive_field.startswith(
-                            mlrun.model.Credentials.secret_reference_prefix
-                        ):
-                            # already masked
-                            continue
-                        target[last_key] = (
-                            f"{mlrun.model.Credentials.secret_reference_prefix}/spec/triggers/{trigger_name}/{path}"
-                        )
+                # support both types depending on the way how it was set
+                # sometimes trigger name is in the same key, sometimes it's nested in the value dict
+                if key == "spec.triggers":
+                    for trigger_name, trigger_config in value.items():
+                        self._mask_trigger_config(trigger_name, trigger_config)
+                else:
+                    trigger_name = key.split(".")[-1]
+                    self._mask_trigger_config(trigger_name, value)
 
         return raw_config
 
@@ -1079,6 +1067,79 @@ class RemoteRuntime(KubeResource):
 
         sidecars.append({"name": name})
         return sidecars[-1]
+
+    def _mask_trigger_config(self, trigger_name, trigger_config):
+        self._mask_rabbitmq_url(trigger=trigger_config)
+        for path in SENSITIVE_PATHS_IN_TRIGGER_CONFIG:
+            # Handle nested keys
+            nested_keys = path.split("/")
+            target = trigger_config
+            for sub_key in nested_keys[:-1]:
+                target = target.get(sub_key, {})
+
+            last_key = nested_keys[-1]
+            if last_key in target:
+                sensitive_field = target[last_key]
+                if sensitive_field.startswith(
+                    mlrun.model.Credentials.secret_reference_prefix
+                ):
+                    # already masked
+                    continue
+                target[last_key] = (
+                    f"{mlrun.model.Credentials.secret_reference_prefix}/spec/triggers/{trigger_name}/{path}"
+                )
+
+    @staticmethod
+    def _mask_rabbitmq_url(trigger):
+        """
+        Extract credentials from RabbitMQ URL and move them to attributes dict.
+        This ensures credentials are not exposed in the URL.
+        """
+
+        # supported only for nuclio higher than 1.14.15
+        if not validate_nuclio_version_compatibility("1.14.15"):
+            return
+        if not isinstance(trigger, dict):
+            return
+
+        if trigger.get("kind") != "rabbit-mq":
+            return
+
+        url = trigger.get("url")
+        if not url or not isinstance(url, str):
+            return
+
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            raise mlrun.errors.MLRunValueError("invalid URL format")
+
+        # Only process if credentials are present in the URL
+        if not (parsed.username or parsed.password):
+            return
+
+        # Extract credentials
+        username = parsed.username or ""
+        password = parsed.password or ""
+
+        # Reconstruct clean URL
+        hostname = parsed.hostname or ""
+        netloc = f"{hostname}:{parsed.port}" if parsed.port else hostname
+
+        clean_url = urlunparse(
+            (
+                parsed.scheme,
+                netloc,
+                parsed.path,
+                parsed.params,
+                parsed.query,
+                parsed.fragment,
+            )
+        )
+
+        # Update trigger safely
+        trigger["url"] = clean_url
+        trigger.update({"username": username, "password": password})
 
     def _trigger_of_kind_exists(self, kind: str) -> bool:
         if not self.spec.config:

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1877,7 +1877,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         )
 
         def _validate_masked_trigger(masked_trigger):
-            if nuclio_version >= "1.14.15":
+            if nuclio_version == "1.14.15":
                 assert (
                     masked_trigger["url"]
                     == "amqp://my-rabbitmq.default-tenant.svc.cluster.local:5672"

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1863,6 +1863,75 @@ class TestNuclioRuntime(TestRuntimeBase):
         )
 
     @pytest.mark.parametrize(
+        "nuclio_version",
+        [
+            "1.14.15",
+            "1.14.11",
+        ],
+    )
+    def test_masking_rabbitmq_url(self, nuclio_version):
+        """Test that RabbitMQ URL credentials are extracted and masked properly."""
+        password = "rabbit123"
+        url = (
+            f"amqp://user:{password}@my-rabbitmq.default-tenant.svc.cluster.local:5672"
+        )
+
+        def _validate_masked_trigger(masked_trigger):
+            if nuclio_version >= "1.14.15":
+                assert (
+                    masked_trigger["url"]
+                    == "amqp://my-rabbitmq.default-tenant.svc.cluster.local:5672"
+                )
+
+                # Assert: Password is masked in attributes
+                assert masked_trigger["password"] != password
+
+                # Assert: Username is in attributes
+                assert masked_trigger["username"] == "user"
+            else:
+                # should not mask for versions less than 1.14.15
+                assert masked_trigger["url"] == url
+
+            # should not be masked in raw_config (this is config we send to nuclio)
+            if "spec.triggers" in raw_config:
+                assert (
+                    raw_config.get("spec.triggers").get("rabbit-trigger").get("url")
+                    == url
+                )
+            else:
+                assert raw_config.get("spec.triggers.rabbit-trigger").get("url") == url
+
+        mlconf.nuclio_version = nuclio_version
+        function = self._generate_runtime(self.runtime_kind)
+        attributes = {
+            "exchangeName": "input_ex",
+            "queueName": "input_queue",
+        }
+
+        # Option 1: set trigger via add_trigger
+        function.add_trigger(
+            "rabbit-trigger",
+            {"kind": "rabbit-mq", "url": url, "attributes": attributes},
+        )
+
+        raw_config = function.mask_sensitive_data_in_config()
+        masked_trigger = function.spec.config.get("spec.triggers.rabbit-trigger")
+        _validate_masked_trigger(masked_trigger)
+
+        # Option 2: set trigger via set_config
+        triggers = {
+            "rabbit-trigger": {
+                "kind": "rabbit-mq",
+                "url": url,
+                "attributes": attributes,
+            },
+        }
+        function.set_config("spec.triggers", triggers)
+        raw_config = function.mask_sensitive_data_in_config()
+        masked_trigger = function.spec.config.get("spec.triggers").get("rabbit-trigger")
+        _validate_masked_trigger(masked_trigger)
+
+    @pytest.mark.parametrize(
         "inside_k8s,force_external,internal_urls,external_urls,address,expected_url,expected_exception,disable_default_http_trigger",
         [
             # Prefer internal when inside k8s and not forcing external


### PR DESCRIPTION
### 📝 Description

Parses url and password from rabbitmq url if it contains such. We leave url in the mlrun config without creds and put username/password in separate fields.  Then procedure is the same as with other sensitive fields in nuclio, meaning that once we send them, mlrun doesn't have them and we keep everything in a nuclio secret. 

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
unit + vmdev (screenshots are in additional notes section)

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11382
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
MLRun spec:
<img width="691" height="343" alt="image" src="https://github.com/user-attachments/assets/51c12153-0d9c-44fa-86b4-d49def2e92e1" />
Successful deploy/redeploy and etc:

<img width="1294" height="1017" alt="image" src="https://github.com/user-attachments/assets/e93e861f-7146-4516-9060-c77f6d45e647" />
