### PR TITLE
[Serving] Normilize funtion name in FunctionReference

### DIFF
--- a/mlrun/runtimes/function_reference.py
+++ b/mlrun/runtimes/function_reference.py
@@ -58,7 +58,7 @@ class FunctionReference(ModelObj):
         return True
 
     def fullname(self, parent):
-        return f"{parent.metadata.name}-{self.name}"
+        return mlrun.utils.helpers.normalize_name(f"{parent.metadata.name}-{self.name}")
 
     def uri(self, parent, tag=None, hash_key=None, fullname=True):
         name = self.fullname(parent) if fullname else self.name


### PR DESCRIPTION
📝 Description
Fix child function deployment failure when function names contain underscores.

Problem: Child functions with underscores in their names (e.g., enrich_data) fail deployment with validation error

Solution: Normalize child function names in FunctionReference.fullname() where they are constructed for Kubernetes deployment. This ensures child functions follow the same pattern as parent functions (normalize at K8s boundary).

🛠️ Changes Made
Modified FunctionReference.fullname() in mlrun/runtimes/function_reference.py:
Added normalize_name() call when constructing child function Kubernetes names
Converts underscores to hyphens, lowercases, etc. to ensure DNS-1123 compliance
Preserves self.name (raw) for internal MLRun logic and graph routing comparisons
Key architectural decision: Normalize at the K8s boundary (in fullname()) rather than in __init__, to preserve internal identifiers for graph routing logic which relies on string equality comparisons (if self.function == current_function).

✅ Checklist
[x] I have tested the changes in this PR - Verified via stack trace analysis and code path verification
🧪 Testing

🔗 References
Ticket link: [ML-11407]
🚨 Breaking Changes?
[x] No


[ML-11407]: https://iguazio.atlassian.net/browse/ML-11407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ