### PR TITLE
[CI] Fix system test python 3.11 compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
         echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
 
     - name: Install automation scripts dependencies
-      run: pip install -r automation/requirements.txt
+      run: make install-automation-requirements
     - name: Set test suite
       run: |
           if [[ "${{ matrix.test-suite }}" == "server" ]]; then
@@ -181,7 +181,7 @@ jobs:
         echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
 
     - name: Install automation scripts dependencies
-      run: pip install -r automation/requirements.txt
+      run: make install-automation-requirements
 
     - name: Set RUN_COVERAGE environment variable
       run: echo "RUN_COVERAGE=true" >> $GITHUB_ENV
@@ -244,7 +244,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
     - name: Install automation scripts dependencies and add mlrun to dev packages
-      run: pip install -r automation/requirements.txt && pip install -e .
+      run: make install-automation-requirements && pip install -e .
       # Install KFP v2 only when the adapter is kfp-v2
     - name: Install KFP Adapter if required
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -271,8 +271,7 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r automation/requirements.txt
+          make install-automation-requirements
       - name: Generate release notes
         id: release-notes
         run: |

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -17,6 +17,9 @@ name: System Tests Enterprise
 permissions:
   contents: read
 
+env:
+  MLRUN_PYTHON_PACKAGE_INSTALLER: uv
+
 on:
   push:
     branches:
@@ -107,6 +110,13 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: 18
+    - name: Install uv
+      uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # 7.1.2
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          **/*requirements*.txt
+
     - name: Copy state branch file from remote
       run: |
         sshpass \
@@ -341,6 +351,13 @@ jobs:
       # than the mlrun version we deployed on the previous job (can have features that the resolved branch doesn't have)
       with:
         ref: ${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunBranch }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # 7.1.2
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          **/*requirements*.txt
 
     - uses: actions/download-artifact@v6
       with:

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -114,6 +114,7 @@ jobs:
       uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # 7.1.2
       with:
         enable-cache: true
+        python-version: 3.11
         cache-dependency-glob: |
           **/*requirements*.txt
 
@@ -356,6 +357,7 @@ jobs:
       uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # 7.1.2
       with:
         enable-cache: true
+        python-version: 3.11
         cache-dependency-glob: |
           **/*requirements*.txt
 

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -171,7 +171,7 @@ jobs:
 
     - name: Install automation scripts dependencies
       run: |
-        python -m pip install -r automation/requirements.txt
+        make install-automation-requirements
 
     - name: Extract git hashes from upstream and latest version
       id: git_upstream_info

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -94,7 +94,7 @@ jobs:
     name: Prepare System Tests Enterprise
     runs-on: [ self-hosted, Linux, mlrun-igz-ci ]
     container:
-      image: gcr.io/iguazio/python:3.9
+      image: gcr.io/iguazio/python:3.11
     needs: [system-test-cleanup]
     # let's not run this on every fork, change to your fork when developing
     if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
@@ -296,7 +296,7 @@ jobs:
     needs: [prepare-system-tests-enterprise-ci]
     runs-on: [ self-hosted, Linux, mlrun-igz-ci ]
     container:
-      image: gcr.io/iguazio/python:3.9
+      image: gcr.io/iguazio/python:3.11
     # let's not run this on every fork, change to your fork when developing
     if: github.repository == 'mlrun/mlrun' || github.event_name == 'workflow_dispatch'
     strategy:

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -182,6 +182,8 @@ jobs:
 
     - name: Install automation scripts dependencies
       run: |
+        uv venv venv --seed
+        source venv/bin/activate
         make install-automation-requirements
 
     - name: Extract git hashes from upstream and latest version
@@ -386,6 +388,8 @@ jobs:
         # https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
         # ensure mlrun git is safe to use
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        uv venv venv --seed
+        source venv/bin/activate
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
           make install-requirements install-complete-kfp-requirements update-version-file
 

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -183,7 +183,7 @@ jobs:
     - name: Install automation scripts dependencies
       run: |
         uv venv venv --seed
-        source venv/bin/activate
+        . venv/bin/activate
         make install-automation-requirements
 
     - name: Extract git hashes from upstream and latest version
@@ -389,7 +389,7 @@ jobs:
         # ensure mlrun git is safe to use
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
         uv venv venv --seed
-        source venv/bin/activate
+        . venv/bin/activate
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
           make install-requirements install-complete-kfp-requirements update-version-file
 

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -244,6 +244,7 @@ jobs:
         IP_ADDR_PREFIX: ${{ secrets.IP_ADDR_PREFIX }}
       timeout-minutes: 50
       run: |
+        . venv/bin/activate
         python automation/system_test/prepare.py run \
           --data-cluster-ip "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
           --data-cluster-ssh-username "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}" \
@@ -262,6 +263,7 @@ jobs:
     - name: Prepare System Test env.yml and MLRun installation from current branch
       timeout-minutes: 5
       run: |
+        . venv/bin/activate
         python automation/system_test/prepare.py env \
           --data-cluster-ip "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}" \
           --data-cluster-ssh-username "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}" \
@@ -395,6 +397,7 @@ jobs:
 
     - name: Run System Tests
       run: |
+        . venv/bin/activate
         MLRUN_SYSTEM_TESTS_GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
         MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunSystemTestsCleanResources }}" \
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,17 @@ install-dev-requirements: ## Install dev-requirements relevant for pytest and co
 		$(MLRUN_PIP_NO_CACHE_FLAG) \
 		-r dev-requirements.txt
 
+.PHONY: install-dev-requirements
+install-automation-requirements: ## Install automation-requirements relevant for CI and automation scripts
+	# relevant for pip package installer only
+	@if [ "$(MLRUN_PYTHON_PACKAGE_INSTALLER)" = "pip" ]; then \
+		$(MLRUN_PYTHON_VENV_PIP_INSTALL) --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION); \
+	fi
+
+	$(MLRUN_PYTHON_VENV_PIP_INSTALL) \
+		$(MLRUN_PIP_NO_CACHE_FLAG) \
+		-r automation/requirements.txt
+
 .PHONY: install-docs-requirements
 install-docs-requirements: ## Install all requirements needed for compiling mlrun docs
 	$(MLRUN_PYTHON_VENV_PIP_INSTALL) --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)

--- a/automation/patch_igz/README.md
+++ b/automation/patch_igz/README.md
@@ -5,7 +5,7 @@ In order to deploy your current code (for debugging), you need the following:
 
 * Install automation/requirements.txt 
 ~~~
-pip install -r automation/requirements.txt
+make install-automation-requirements
 ~~~
 * Create a patch_env.yml based on patch_env_template.yml
 * Have a docker registry you can push to (e.g. docker.io via account on docker.com) as well as a public mlrun-api repo on it


### PR DESCRIPTION
### 📝 Description

Some of MLRun's 1.11 (development) requires python >= 3.11 packages. This PR will ensure we run python 3.11 for running the test framework and tests themselves.

---

### 🛠️ Changes Made

1. Using `uv` to install packages - moving from 10m to 30s
2. Using python 3.11 image to run the tests
3. Added `install-automation-requirements` to simplify installing automation scripts dependencies

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Run system tests against my upstream branch to see them running

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
