### PR TITLE
[Serving] Normalize function name in FunctionReference [1.10.x]

### DIFF
--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -801,8 +801,6 @@ def code_to_function(
         ignored_tags=ignored_tags,
     )
 
-    mlrun.utils.helpers.validate_function_name(name)
-
     spec["spec"]["env"].append(
         {
             "name": "MLRUN_HTTPDB__NUCLIO__EXPLICIT_ACK",

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -394,8 +394,6 @@ class BaseRuntime(ModelObj):
             )
         output_path = output_path or out_path or artifact_path
 
-        mlrun.utils.helpers.validate_function_name(self.metadata.name)
-
         launcher = mlrun.launcher.factory.LauncherFactory().create_launcher(
             self._is_remote, local=local, **launcher_kwargs
         )

--- a/mlrun/runtimes/function_reference.py
+++ b/mlrun/runtimes/function_reference.py
@@ -58,7 +58,7 @@ class FunctionReference(ModelObj):
         return True
 
     def fullname(self, parent):
-        return mlrun.utils.helpers.normalize_name(f"{parent.metadata.name}-{self.name}")
+        return f"{parent.metadata.name}-{self.name}"
 
     def uri(self, parent, tag=None, hash_key=None, fullname=True):
         name = self.fullname(parent) if fullname else self.name

--- a/mlrun/runtimes/function_reference.py
+++ b/mlrun/runtimes/function_reference.py
@@ -58,7 +58,7 @@ class FunctionReference(ModelObj):
         return True
 
     def fullname(self, parent):
-        return f"{parent.metadata.name}-{self.name}"
+        return mlrun.utils.helpers.normalize_name(f"{parent.metadata.name}-{self.name}")
 
     def uri(self, parent, tag=None, hash_key=None, fullname=True):
         name = self.fullname(parent) if fullname else self.name

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -400,7 +400,6 @@ class ApplicationRuntime(RemoteRuntime):
 
         :return: The default API gateway URL if created or True if the function is ready (deployed)
         """
-        mlrun.utils.helpers.validate_function_name(self.metadata.name)
 
         if (self.requires_build() and not self.spec.image) or force_build:
             self._fill_credentials()

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -655,8 +655,6 @@ class RemoteRuntime(KubeResource):
         if tag:
             self.metadata.tag = tag
 
-        mlrun.utils.helpers.validate_function_name(self.metadata.name)
-
         # Attempt auto-mounting, before sending to remote build
         self.try_auto_mount_based_on_config()
         self._fill_credentials()

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -665,8 +665,6 @@ class ServingRuntime(RemoteRuntime):
         :param builder_env: env vars dict for source archive config/credentials e.g. builder_env={"GIT_TOKEN": token}
         :param force_build: set True for force building the image
         """
-        # Validate function name before deploying to k8s
-        mlrun.utils.helpers.validate_function_name(self.metadata.name)
 
         load_mode = self.spec.load_mode
         if load_mode and load_mode not in ["sync", "async"]:


### PR DESCRIPTION
  📝 Description

  Remove premature client-side validation from deploy methods to allow Nuclio SDK to handle name normalization for Kubernetes compatibility.

  Problem: Client-side validation in deploy() methods was checking function names before Nuclio SDK's normalization step, potentially rejecting valid names that Nuclio would successfully normalize for
  Kubernetes (e.g., underscores → hyphens).

  Solution:
  - Remove validate_function_name() from all deploy() methods (nuclio/function.py, nuclio/serving.py, nuclio/application.py, base.py)
  - Keep validation only in new_function() where it's called AFTER normalize_name()
  - Rely on Nuclio SDK to normalize names for Kubernetes resource creation
  - Preserve original names in MLRun database (maintains existing behavior)


  ✅ Checklist

  - I have tested the changes in this PR - Verified via test execution with child_c naming
  - Existing behavior preserved - MLRun DB still stores original names with underscores
  - Tests passing - Nuclio SDK normalizes for Kubernetes compatibility



  🔗 References

  Ticket link: https://iguazio.atlassian.net/browse/ML-11407

  🚨 Breaking Changes?

  - No - removes validation that was preventing legitimate use cases

  ---