### PR TITLE
[Frontend spec] Add iguazio v4 authentication mode

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -113,7 +113,6 @@ from .feature_store import (
 )
 from .frontend_spec import (
     ArtifactLimits,
-    AuthenticationFeatureFlag,
     FeatureFlags,
     FrontendSpec,
     NuclioStreamsFeatureFlag,

--- a/mlrun/common/schemas/frontend_spec.py
+++ b/mlrun/common/schemas/frontend_spec.py
@@ -31,13 +31,6 @@ class PreemptionNodesFeatureFlag(mlrun.common.types.StrEnum):
     disabled = "disabled"
 
 
-class AuthenticationFeatureFlag(mlrun.common.types.StrEnum):
-    none = "none"
-    basic = "basic"
-    bearer = "bearer"
-    iguazio = "iguazio"
-
-
 class NuclioStreamsFeatureFlag(mlrun.common.types.StrEnum):
     enabled = "enabled"
     disabled = "disabled"
@@ -45,7 +38,7 @@ class NuclioStreamsFeatureFlag(mlrun.common.types.StrEnum):
 
 class FeatureFlags(pydantic.v1.BaseModel):
     project_membership: ProjectMembershipFeatureFlag
-    authentication: AuthenticationFeatureFlag
+    authentication: mlrun.common.types.AuthenticationMode
     nuclio_streams: NuclioStreamsFeatureFlag
     preemption_nodes: PreemptionNodesFeatureFlag
 

--- a/server/py/services/api/api/endpoints/frontend_spec.py
+++ b/server/py/services/api/api/endpoints/frontend_spec.py
@@ -18,6 +18,7 @@ import fastapi
 import semver
 
 import mlrun.common.schemas
+import mlrun.common.types
 import mlrun.runtimes
 import mlrun.runtimes.utils
 import mlrun.utils.helpers
@@ -129,7 +130,7 @@ def _resolve_feature_flags() -> mlrun.common.schemas.FeatureFlags:
     project_membership = mlrun.common.schemas.ProjectMembershipFeatureFlag.disabled
     if mlrun.mlconf.httpdb.authorization.mode == "opa":
         project_membership = mlrun.common.schemas.ProjectMembershipFeatureFlag.enabled
-    authentication = mlrun.common.schemas.AuthenticationFeatureFlag(
+    authentication = mlrun.common.types.AuthenticationMode(
         mlrun.mlconf.httpdb.authentication.mode
     )
     nuclio_streams = mlrun.common.schemas.NuclioStreamsFeatureFlag.disabled

--- a/server/py/services/api/tests/unit/api/test_frontend_spec.py
+++ b/server/py/services/api/tests/unit/api/test_frontend_spec.py
@@ -20,6 +20,7 @@ import fastapi.testclient
 import sqlalchemy.orm
 
 import mlrun.common.schemas
+import mlrun.common.types
 import mlrun.errors
 import mlrun.runtimes
 from mlrun.config import config as mlconf
@@ -44,6 +45,9 @@ def test_get_frontend_spec(
     mlrun.mlconf.default_function_pod_resources = default_function_pod_resources
     mlrun.mlconf.httpdb.allowed_file_paths = "s3://some/s3/path"
     mlrun.mlconf.httpdb.real_path = "/some/real/path"
+    mlrun.mlconf.httpdb.authentication.mode = (
+        mlrun.common.types.AuthenticationMode.BASIC
+    )
 
     response = client.get("frontend-spec")
     assert response.status_code == http.HTTPStatus.OK.value
@@ -61,7 +65,7 @@ def test_get_frontend_spec(
     )
     assert (
         frontend_spec.feature_flags.authentication
-        == mlrun.common.schemas.AuthenticationFeatureFlag.none
+        == mlrun.common.types.AuthenticationMode.BASIC
     )
     assert (
         frontend_spec.feature_flags.nuclio_streams


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
This PR exposes the authentication mode in frontend-spec to support secret tokens.
The authentication mode was already passed through `feature_flags.authentication`, so we only needed to add the `iguazio-v4` option, which was already defined in `mlrun.common.types.AuthenticationMode`.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
We now use mlrun.common.types.AuthenticationMode instead of AuthenticationFeatureFlag.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Unit test

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10718
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
