### PR TITLE
[Automation] Pin PyNaCl to 1.6.0 to avoid cffi compatibility issues

### DIFF
--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,4 +1,6 @@
 click~=8.1
+# Pin to avoid PyNaCl 1.6.1 which breaks cffi compatibility
+PyNaCl==1.6.0
 paramiko~=3.5
 semver~=3.0
 requests~=2.32

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,5 +1,5 @@
 click~=8.1
-paramiko~=3.5
+paramiko~=4.0
 semver~=3.0
 requests~=2.32
 boto3>=1.28.0,<1.36

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,5 +1,5 @@
 click~=8.1
-paramiko~=4.0
+paramiko~=3.5
 semver~=3.0
 requests~=2.32
 boto3>=1.28.0,<1.36

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -23,8 +23,6 @@ azure-core~=1.24
 # function in Azure Blob File System functions (such as _ls and more).
 adlfs==2024.12.0
 azure-identity~=1.5
-# Pin to avoid PyNaCl 1.6.1 which requires cffi>=2.0.0 and breaks adlfs/azure-datalake-store
-PyNaCl==1.6.0
 azure-keyvault-secrets~=4.2
 # cryptography>=39, which is required by azure, needs this, or else we get
 # AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms' (ML-3471)

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -23,6 +23,8 @@ azure-core~=1.24
 # function in Azure Blob File System functions (such as _ls and more).
 adlfs==2024.12.0
 azure-identity~=1.5
+# Pin to avoid PyNaCl 1.6.1 which requires cffi>=2.0.0 and breaks adlfs/azure-datalake-store
+PyNaCl==1.6.0
 azure-keyvault-secrets~=4.2
 # cryptography>=39, which is required by azure, needs this, or else we get
 # AttributeError: module 'lib' has no attribute 'OpenSSL_add_all_algorithms' (ML-3471)


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
`paramiko` (used in automation) depends on `PyNaCl>=1.5`. Recent versions of `PyNaCl (>=1.6.1)` require `cffi>=2.0.0`, which can cause conflicts in our automation environment. Pinning to `1.6.0` ensures stable installations without breaking other dependencies.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
