### PR TITLE
[Nuclio] Support Iguazio 4 authentication

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -21,6 +21,9 @@ import mlrun.common.schemas
 import mlrun.utils.helpers
 from mlrun.config import config as mlconf
 
+if typing.TYPE_CHECKING:
+    import mlrun.db
+
 
 def load_offline_token(raise_on_error=True) -> typing.Optional[str]:
     """
@@ -309,3 +312,39 @@ def translate_secret_tokens(
                 raise_on_error,
             )
     return tokens
+
+
+def enrich_auth_env(
+    env: dict,
+    db: "mlrun.db.RunDBInterface",
+    auth_info: mlrun.common.schemas.AuthInfo = None,
+):
+    """
+    Enrich the given environment dictionary with authentication information.
+
+    This function adds authentication-related environment variables to the provided
+    environment dictionary based on the given AuthInfo object.
+
+    :param env: The environment dictionary to enrich.
+    :param db: The RunDBInterface instance to retrieve secret tokens.
+    :param auth_info: The AuthInfo object containing authentication details.
+    """
+
+    # TODO: Remove this once we implement secret token mounting in jobs (ML-11292)
+    _default_token_name = "default"
+
+    if mlrun.mlconf.is_iguazio_v4_mode():
+        if auth_info and auth_info.username:
+            secret = db.get_secret_token(
+                token_name=_default_token_name,
+                username=auth_info.username,
+            )
+            env["MLRUN_AUTH_OFFLINE_TOKEN"] = secret.token
+
+        env["MLRUN_AUTH_WITH_OAUTH_TOKEN__ENABLED"] = "true"
+        env["MLRUN_AUTH_TOKEN_ENDPOINT"] = (
+            mlrun.mlconf.iguazio_api_url + "/api/v1/refresh-access-token"
+        )
+        env["MLRUN_HTTPDB__HTTP__VERIFY"] = str(
+            mlrun.mlconf.iguazio_api_ssl_verify
+        ).lower()

--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -178,10 +178,10 @@ class NuclioAuthInfoWithHeaders(NuclioAuthInfo):
     def to_requests_auth(self):
         # Return custom auth handler that applies headers
         base_auth = super().to_requests_auth()
-        return CustomAuthWithHeaders(base_auth, self._headers)
+        return _CustomAuthWithHeaders(base_auth, self._headers)
 
 
-class CustomAuthWithHeaders:
+class _CustomAuthWithHeaders:
     """
     Custom requests auth handler that applies additional headers to the request
     """
@@ -190,9 +190,9 @@ class CustomAuthWithHeaders:
         self.base_auth = base_auth
         self.headers = headers
 
-    def __call__(self, r):
+    def __call__(self, request):
         if self.base_auth:
-            r = self.base_auth(r)
-        for k, v in self.headers.items():
-            r.headers[k] = v
-        return r
+            request = self.base_auth(request)
+        for key, value in self.headers.items():
+            request.headers[key] = value
+        return request

--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -140,6 +140,8 @@ class AuthInfo(pydantic.v1.BaseModel):
     planes: list[str] = []
 
     def to_nuclio_auth_info(self):
+        if mlrun.mlconf.is_iguazio_v4_mode():
+            return NuclioAuthInfoWithHeaders(headers=self.request_headers)
         if self.session != "":
             return NuclioAuthInfo(password=self.session, mode=NuclioAuthKinds.iguazio)
         return None
@@ -160,3 +162,37 @@ class AuthInfo(pydantic.v1.BaseModel):
 
 class Credentials(pydantic.v1.BaseModel):
     access_key: typing.Optional[str]
+
+
+class NuclioAuthInfoWithHeaders(NuclioAuthInfo):
+    """ "
+    Nuclio AuthInfo subclass that supports custom headers.
+    This is needed because Nuclio Jupyter is using `to_requests_auth` method, but in Iguazio V4 we need to inject
+    the Auth headers instead of using basic auth
+    """
+
+    def __init__(self, headers=None, **kwargs):
+        super().__init__(**kwargs)
+        self._headers = headers or {}
+
+    def to_requests_auth(self):
+        # Return custom auth handler that applies headers
+        base_auth = super().to_requests_auth()
+        return CustomAuthWithHeaders(base_auth, self._headers)
+
+
+class CustomAuthWithHeaders:
+    """
+    Custom requests auth handler that applies additional headers to the request
+    """
+
+    def __init__(self, base_auth, headers):
+        self.base_auth = base_auth
+        self.headers = headers
+
+    def __call__(self, r):
+        if self.base_auth:
+            r = self.base_auth(r)
+        for k, v in self.headers.items():
+            r.headers[k] = v
+        return r

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -22,6 +22,7 @@ from typing import Callable, Optional, Union
 import requests.exceptions
 from nuclio.build import mlrun_footer
 
+import mlrun.auth.utils
 import mlrun.common.constants
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.formatters
@@ -461,21 +462,7 @@ class BaseRuntime(ModelObj):
             "MLRUN_DEFAULT_PROJECT": active_project,
         }
 
-        if config.is_iguazio_v4_mode():
-            if auth_info and auth_info.username:
-                secret = self._get_db().get_secret_token(
-                    token_name=self._default_token_name,
-                    username=auth_info.username,
-                )
-                runtime_env["MLRUN_AUTH_OFFLINE_TOKEN"] = secret.token
-
-            runtime_env["MLRUN_AUTH_WITH_OAUTH_TOKEN__ENABLED"] = "true"
-            runtime_env["MLRUN_AUTH_TOKEN_ENDPOINT"] = (
-                config.iguazio_api_url + "/api/v1/refresh-access-token"
-            )
-            runtime_env["MLRUN_HTTPDB__HTTP__VERIFY"] = str(
-                config.iguazio_api_ssl_verify
-            ).lower()
+        mlrun.auth.utils.enrich_auth_env(runtime_env, self._get_db(), auth_info)
 
         if runobj:
             runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json(

--- a/server/py/framework/utils/clients/async_nuclio.py
+++ b/server/py/framework/utils/clients/async_nuclio.py
@@ -38,11 +38,17 @@ NUCLIO_PROJECT_NAME_HEADER = "X-Nuclio-Project-Name"
 
 class Client:
     def __init__(self, auth_info: mlrun.common.schemas.AuthInfo):
-        self._session = None
-        login = auth_info.username
-        self._auth = aiohttp.BasicAuth(login, auth_info.session) if login else None
         self._logger = logger.get_child("nuclio-client")
         self._nuclio_dashboard_url = mlrun.mlconf.nuclio_dashboard_url
+        self._session = None
+        self._auth_headers = None
+        self._auth = None
+
+        if mlrun.mlconf.is_iguazio_v4_mode():
+            self._auth_headers = auth_info.request_headers
+        else:
+            login = auth_info.username
+            self._auth = aiohttp.BasicAuth(login, auth_info.session) if login else None
 
     async def __aenter__(self):
         await self._ensure_async_session()
@@ -216,10 +222,10 @@ class Client:
         self, method, path="/", error_message: str = "", **kwargs
     ):
         await self._ensure_async_session()
+        self._prepare_auth_kwargs(kwargs)
         response = await self._session.request(
             method=method,
             url=urllib.parse.urljoin(self._nuclio_dashboard_url, path),
-            auth=self._auth,
             verify_ssl=False,
             **kwargs,
         )
@@ -269,6 +275,12 @@ class Client:
         self._logger.warning("Request to nuclio failed. Reason:", **log_kwargs)
 
         mlrun.errors.raise_for_status(response, error_message)
+
+    def _prepare_auth_kwargs(self, kwargs):
+        if self._auth:
+            kwargs.setdefault("auth", self._auth)
+        if self._auth_headers:
+            kwargs.setdefault("headers", {}).update(self._auth_headers)
 
     def _enrich_nuclio_api_gateway(
         self,

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -22,6 +22,7 @@ import nuclio.utils
 import requests
 
 import mlrun
+import mlrun.auth.utils
 import mlrun.common.constants
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
@@ -250,7 +251,7 @@ def _compile_function_config(
     """
 
     # resolve env vars before compiling the nuclio spec, as we need to set them in the spec
-    env_dict, external_source_env_dict = _resolve_env_vars(function)
+    env_dict, external_source_env_dict = _resolve_env_vars(function, auth_info)
 
     project = function.metadata.project
     tag = function.metadata.tag
@@ -361,7 +362,7 @@ def _apply_escaped_config(config, parent_key, items: dict):
         mlrun.utils.update_in(config, f"{parent_key}.\\{key}\\", value)
 
 
-def _resolve_env_vars(function):
+def _resolve_env_vars(function, auth_info=None):
     # Add secret configurations to function's pod spec, if secret sources were added.
     # Needs to be here, since it adds env params, which are handled in the next lines.
     # This only needs to run if we're running within k8s context. If running in Docker, for example, skip.
@@ -381,6 +382,8 @@ def _resolve_env_vars(function):
         and "NUCLIO_PYTHON_DECODE_EVENT_STRINGS" not in env_dict
     ):
         env_dict["NUCLIO_PYTHON_DECODE_EVENT_STRINGS"] = "true"
+
+    mlrun.auth.utils.enrich_auth_env(env_dict, function._get_db(), auth_info)
 
     return env_dict, external_source_env_dict
 


### PR DESCRIPTION
### 📝 Description

This PR adds support for Iguazio 4 authentication to Nuclio runtimes.
MLRun communicates with Nuclio in in multiple ways:
- Synchronous client
- Asynchronous client
- [nuclio-jupyter](https://github.com/nuclio/nuclio-jupyter) package

In Iguazio 3, using the `auth_info` session or basic auth with the session as the password was enough.
In Iguazio 4, we need instead to pass the request headers, that contain the `Authorization` header with the user's access token for the authentication info to be passed to Nuclio.

---

### 🛠️ Changes Made

- Implemented the `NuclioAuthInfoWithHeaders` class that injects a request object with the request headers from `auth_info`.
  - This applies both to the sync client and nuclio-jupyter usage, as they both call the `to_request_headers` method.
- For the async client, we inject the headers manually as it is implemented differently since it doesn't use the `requests` package, but `aiohttp`.
- To support nuclio function handlers that use MLRun, moved the Offline Token env var enrichment to a common location `mlrun.auth.utils.enrich_auth_env` , and called in both BaseRuntime and Nuclio function.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes

---

### 🧪 Testing

This was tested manually against a running IG4 system.
Successfully managed projects and functions.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/NUC-503
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
