### PR TITLE
[Automation] Fix AttributeError when overwrite_registry is None

### DIFF
--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -631,10 +631,10 @@ class MLRunPatcher:
     def _resolve_overwrite_registry(self):
         docker_registry = self._config["DOCKER_REGISTRY"]
         overwrite_registry = self._config["OVERWRITE_IMAGE_REGISTRY"]
-        if docker_registry.endswith("/"):
-            docker_registry = docker_registry[:-1]
-        if overwrite_registry and overwrite_registry.endswith("/"):
-            overwrite_registry = overwrite_registry[:-1]
+        if docker_registry:
+            docker_registry = docker_registry.rstrip("/")
+        if overwrite_registry:
+            overwrite_registry = overwrite_registry.rstrip("/")
 
         return docker_registry, overwrite_registry
 

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -633,7 +633,7 @@ class MLRunPatcher:
         overwrite_registry = self._config["OVERWRITE_IMAGE_REGISTRY"]
         if docker_registry.endswith("/"):
             docker_registry = docker_registry[:-1]
-        if overwrite_registry.endswith("/"):
+        if overwrite_registry and overwrite_registry.endswith("/"):
             overwrite_registry = overwrite_registry[:-1]
 
         return docker_registry, overwrite_registry


### PR DESCRIPTION
## Problem
The `patch_remote.py` script crashes with AttributeError when `overwrite_registry` is None.

**Reference**: ML-11462

## Solution
Add None check before calling `.endswith()` on `overwrite_registry` parameter.

## Changes
- `automation/patch_igz/patch_remote.py:636` - Added None check: `if overwrite_registry and overwrite_registry.endswith("/")`