### PR TITLE
[Automation] Get latest demos list [1.10.x]

### DIFF
--- a/automation/scripts/update_demos.sh
+++ b/automation/scripts/update_demos.sh
@@ -300,12 +300,8 @@ except Exception:
     raise SystemExit(1)
 PY
 
-# Determine which ref to fetch scripts from (tag matching version or development)
-if [ -n "$mlrun_version" ] && echo "$mlrun_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
-    RAW_REF="refs/tags/v${mlrun_version}"
-else
-    RAW_REF="development"
-fi
+# Using development to get most updated demo list
+RAW_REF="development"
 
 # Fetch get_demos.py and its config
 GET_DEMOS_URL="https://raw.githubusercontent.com/mlrun/mlrun/${RAW_REF}/automation/scripts/get_demos.py"


### PR DESCRIPTION
### 📝 Description
To enable dynamic demos list for get_demos we use development branch to map mlrun versions to a demos list.

This is also a fix for trying to use new update_demos.sh script with older versions for example when version is 1.9.2 (default fallback) and you have a new (1.10.x+) update_demos.sh script - it fails finding the get_demos.py and demos_config.json mapping flie

---

### 🛠️ Changes Made

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Manually testing

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No


---

### 🔍️ Additional Notes

