### PR TITLE
[CI] Fix CI to run against explicit api image

### DIFF
--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -155,10 +155,9 @@ class TestMLRunIntegration:
         if real_path := os.getenv("MLRUN_HTTPDB__REAL_PATH"):
             env_vars["MLRUN_HTTPDB__REAL_PATH"] = real_path
 
-        image = image or (
-            os.getenv("MLRUN_DOCKER_REGISTRY", "docker.io/")
-            + os.getenv("MLRUN_API_IMAGE_NAME_TAGGED", "mlrun/mlrun-api:unstable")
-        )
+        registry = os.getenv("MLRUN_DOCKER_REGISTRY", "ghcr.io/")
+        tag = os.getenv("MLRUN_DOCKER_CACHE_FROM_TAG", "unstable")
+        image = image or f"{registry}/mlrun/mlrun-api/{tag}"
 
         client = docker.from_env()
 

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -155,9 +155,9 @@ class TestMLRunIntegration:
         if real_path := os.getenv("MLRUN_HTTPDB__REAL_PATH"):
             env_vars["MLRUN_HTTPDB__REAL_PATH"] = real_path
 
-        registry = os.getenv("MLRUN_DOCKER_REGISTRY", "ghcr.io/")
+        registry = os.getenv("MLRUN_DOCKER_REGISTRY", "ghcr.io/").rstrip("/")
         tag = os.getenv("MLRUN_DOCKER_CACHE_FROM_TAG", "unstable")
-        image = image or f"{registry}/mlrun/mlrun-api/{tag}"
+        image = image or f"{registry}/mlrun/mlrun-api:{tag}"
 
         client = docker.from_env()
 


### PR DESCRIPTION
### 📝 Description

During integration CI we provide the image/tag to run api with. It seems that the correct envvar was not given, causing CI to run against unstable version only.

---

### 🛠️ Changes Made

chaged the envvar to be used to the one provided by CI against PR

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Checked against 1.10.x branch

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
