### PR TITLE
[Tests] Fix test_serving_as_a_job to handle batch suffix

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1182,7 +1182,7 @@ class TestServingJobEndpoint(TestMLRunSystemModelMonitoring, _V3IORecordsChecker
         inputs = {"data": input_dataset.uri}
         params = {"timestamp_column": "index"}
         self.project.run_function(job, inputs=inputs, params=params)
-        return function
+        return job
 
     def _test_batch_ep_metrics(
         self, function_name: str, input_df: pd.DataFrame


### PR DESCRIPTION
### Description

Fixes test failure after PR #8728 introduced automatic "-batch" suffix appending to job names created via `.to_job()`.

Updated `_run_serving_job()` to return the `job` object instead of `function` object (line 1185), ensuring the test receives the correct function name with the "-batch" suffix for model endpoint lookups.

### Checklist
- [x] I have tested the changes in this PR
- [x] I updated the documentation (if applicable)

### Testing

**Manual testing:**
- Reproduced the original failure by running test WITHOUT the fix: FAILED with expected error
- Verified the fix by running test WITH the fix: PASSED (exit code 0, test duration: 4.5 minutes)

**Test command:**
```bash
pytest tests/system/model_monitoring/test_app.py::TestServingJobEndpoint::test_serving_as_a_job -v
```

### References
- Ticket link: https://jira.iguazeng.com/browse/ML-11478
- Related PR: #8728 (introduced `-batch` suffix)

### Breaking Changes?

- [x] No

### Additional Notes

This is a test-only change with no functional impact on production code. The test was failing because it was using the function object (name="test") instead of the job object (name="test-batch") for model endpoint lookups.