### PR TITLE
[Model Monitoring] Fix improve performance of parquet reading

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -159,12 +159,12 @@ class DataStore(BaseRemoteClient):
 
     @staticmethod
     def read_partitioned_parquet(
-            base_path,
-            start_time,
-            end_time,
-            partition_keys,
-            df_module,
-            **kwargs,
+        base_path,
+        start_time,
+        end_time,
+        partition_keys,
+        df_module,
+        **kwargs,
     ):
         """Read only the relevant partitions using pandas filters and concat."""
         logger.info("starting urls partition process")
@@ -173,7 +173,9 @@ class DataStore(BaseRemoteClient):
                 f"No partition structure found under {base_path}, while usage requires partition keys"
             )
 
-        def list_partitioned_urls(base_path: str, partition_keys: list[str], start_time, end_time):
+        def list_partitioned_urls(
+            base_path: str, partition_keys: list[str], start_time, end_time
+        ):
             """
             Build a list of URLs based on detected partitioning and time range.
 
@@ -248,14 +250,14 @@ class DataStore(BaseRemoteClient):
                     cleaned_filters.append(new_group)
             return cleaned_filters
 
-        urls = list_partitioned_urls(
-            base_path, partition_keys, start_time, end_time
-        )
+        urls = list_partitioned_urls(base_path, partition_keys, start_time, end_time)
 
         dfs = []
         for url in urls:
             try:
-                kwargs["filters"] = clean_filters_for_partitions(kwargs["filters"], partition_keys)
+                kwargs["filters"] = clean_filters_for_partitions(
+                    kwargs["filters"], partition_keys
+                )
                 df = df_module.read_parquet(url, **kwargs)
                 logger.info("Reading DataFrame", url=url, columns=df.columns)
                 dfs.append(df)
@@ -377,6 +379,7 @@ class DataStore(BaseRemoteClient):
                         return df_module.read_parquet(*args, **kwargs)
             else:
                 return df_module.read_parquet(*args, **kwargs)
+
         return reader
 
     def as_df(

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import tempfile
 import urllib.parse
 from base64 import b64encode
@@ -165,6 +166,7 @@ class DataStore(BaseRemoteClient):
         start_time,
         end_time,
         additional_filters,
+        use_pyarrow=True,
     ):
         from storey.utils import find_filters, find_partitions
 
@@ -212,7 +214,97 @@ class DataStore(BaseRemoteClient):
                     kwargs,
                 )
                 try:
-                    return df_module.read_parquet(*args, **kwargs)
+                    if use_pyarrow:
+                        logger.info("starting urls partition process")
+                        def list_partitioned_urls(
+                            base_path, partition_keys, start_time, end_time
+                        ):
+                            """Build a list of URLs based on detected partitioning and time range."""
+                            urls = []
+                            current = start_time
+                            while current <= end_time:
+                                path_parts = []
+                                for key in partition_keys:
+                                    if key == "year":
+                                        path_parts.append(f"year={current.year}")
+                                    elif key == "month":
+                                        path_parts.append(f"month={current.month:02d}")
+                                    elif key == "day":
+                                        path_parts.append(f"day={current.day:02d}")
+                                    elif key == "hour":
+                                        path_parts.append(f"hour={current.hour:02d}")
+
+                                urls.append(
+                                    f"{base_path.rstrip('/')}/" + "/".join(path_parts)
+                                )
+                                current += datetime.timedelta(hours=1)
+                            logger.info("URLS are", urls=urls)
+                            return urls
+
+                        def clean_filters_for_partitions(filters, partition_keys):
+                            """
+                            Remove partition keys from filters.
+
+                            Args:
+                                filters (list of list of tuples): pandas-style filters
+                                    Example: [[('year','=',2025),('month','=',11),('timestamp','>',ts1)]]
+                                partition_keys (list of str): partition columns handled via directory
+
+                            Returns:
+                                list of list of tuples: cleaned filters
+                            """
+                            cleaned_filters = []
+                            for group in filters:
+                                new_group = [f for f in group if f[0] not in partition_keys]
+                                if new_group:
+                                    cleaned_filters.append(new_group)
+                            return cleaned_filters
+
+                        def read_partitioned_parquet(
+                            base_path,
+                            start_time,
+                            end_time,
+                            partition_keys,
+                            **kwargs,
+                        ):
+                            """Read only the relevant partitions using pandas filters and concat."""
+                            if not partition_keys:
+                                raise ValueError(
+                                    f"No partition structure found under {base_path}"
+                                )
+
+                            urls = list_partitioned_urls(
+                                base_path, partition_keys, start_time, end_time
+                            )
+
+                            dfs = []
+                            for url in urls:
+                                try:
+                                    kwargs["filters"] = clean_filters_for_partitions(kwargs["filters"], partition_keys)
+                                    df = df_module.read_parquet(url, **kwargs)
+                                    logger.info("Reading DataFrame", url=url, columns=df.columns)
+                                    dfs.append(df)
+                                except Exception as e:
+                                    # Skip partitions that don't exist or have no data
+                                    logger.info("Failed to read DataFrame", url=url, exception=e)
+                                    continue
+
+                            if not dfs:
+                                return pd.DataFrame()
+                            final_df = pd.concat(dfs, ignore_index=True)
+                            logger.info("Finished reading DataFrame columns", columns=final_df.columns)
+                            return final_df
+
+                        return read_partitioned_parquet(
+                            url,
+                            start_time,
+                            end_time,
+                            partitions_time_attributes,
+                            **kwargs,
+                        )
+
+                    else:
+                        return df_module.read_parquet(*args, **kwargs)
                 except pyarrow.lib.ArrowInvalid as ex:
                     if not str(ex).startswith(
                         "Cannot compare timestamp with timezone to timestamp without timezone"

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -158,6 +158,119 @@ class DataStore(BaseRemoteClient):
         return {}
 
     @staticmethod
+    def read_partitioned_parquet(
+            base_path,
+            start_time,
+            end_time,
+            partition_keys,
+            df_module,
+            **kwargs,
+    ):
+        """Read only the relevant partitions using pandas filters and concat."""
+        logger.info("starting urls partition process")
+        if not partition_keys:
+            raise ValueError(
+                f"No partition structure found under {base_path}, while usage requires partition keys"
+            )
+
+        def list_partitioned_urls(base_path: str, partition_keys: list[str], start_time, end_time):
+            """
+            Build a list of URLs based on detected partitioning and time range.
+
+            Automatically adjusts iteration step based on deepest partition key.
+            """
+            # Determine smallest partition granularity
+            if "hour" in partition_keys:
+                step = datetime.timedelta(hours=1)
+                fmt_keys = ["year", "month", "day", "hour"]
+            elif "day" in partition_keys:
+                step = datetime.timedelta(days=1)
+                fmt_keys = ["year", "month", "day"]
+            elif "month" in partition_keys:
+                # Approximate month stepping
+                fmt_keys = ["year", "month"]
+
+                def next_step(dt):
+                    year = dt.year + (dt.month // 12)
+                    month = 1 if dt.month == 12 else dt.month + 1
+                    return dt.replace(year=year, month=month, day=1)
+            elif "year" in partition_keys:
+                fmt_keys = ["year"]
+
+                def next_step(dt):
+                    return dt.replace(year=dt.year + 1, month=1, day=1)
+            else:
+                raise ValueError("No recognized time-based partition key found")
+
+            urls = []
+            current = start_time
+
+            while current <= end_time:
+                # Build directory structure from partition keys
+                parts = []
+                for key in fmt_keys:
+                    if key == "year":
+                        parts.append(f"year={current.year}")
+                    elif key == "month":
+                        parts.append(f"month={current.month:02d}")
+                    elif key == "day":
+                        parts.append(f"day={current.day:02d}")
+                    elif key == "hour":
+                        parts.append(f"hour={current.hour:02d}")
+
+                urls.append(f"{base_path.rstrip('/')}/" + "/".join(parts))
+
+                # Advance to next period
+                if "hour" in partition_keys or "day" in partition_keys:
+                    current += step
+                else:
+                    current = next_step(current)
+
+            logger.info("Generated partitioned URLs", extra={"urls": urls})
+            return urls
+
+        def clean_filters_for_partitions(filters, partition_keys):
+            """
+            Remove partition keys from filters.
+
+            Args:
+                filters (list of list of tuples): pandas-style filters
+                    Example: [[('year','=',2025),('month','=',11),('timestamp','>',ts1)]]
+                partition_keys (list of str): partition columns handled via directory
+
+            Returns:
+                list of list of tuples: cleaned filters
+            """
+            cleaned_filters = []
+            for group in filters:
+                new_group = [f for f in group if f[0] not in partition_keys]
+                if new_group:
+                    cleaned_filters.append(new_group)
+            return cleaned_filters
+
+        urls = list_partitioned_urls(
+            base_path, partition_keys, start_time, end_time
+        )
+
+        dfs = []
+        for url in urls:
+            try:
+                kwargs["filters"] = clean_filters_for_partitions(kwargs["filters"], partition_keys)
+                df = df_module.read_parquet(url, **kwargs)
+                logger.info("Reading DataFrame", url=url, columns=df.columns)
+                dfs.append(df)
+            except Exception as e:
+                # Skip partitions that don't exist or have no data
+                logger.info("Failed to read DataFrame", url=url, exception=e)
+                continue
+
+        if not dfs:
+            return pd.DataFrame()
+        final_df = pd.concat(dfs, ignore_index=True)
+        logger.info("Finished reading DataFrame columns", columns=final_df.columns)
+        return final_df
+
+    @staticmethod
     def _parquet_reader(
         df_module,
         url,
@@ -166,7 +279,7 @@ class DataStore(BaseRemoteClient):
         start_time,
         end_time,
         additional_filters,
-        use_pyarrow=True,
+        create_partition_path,
     ):
         from storey.utils import find_filters, find_partitions
 
@@ -214,92 +327,13 @@ class DataStore(BaseRemoteClient):
                     kwargs,
                 )
                 try:
-                    if use_pyarrow:
-                        logger.info("starting urls partition process")
-                        def list_partitioned_urls(
-                            base_path, partition_keys, start_time, end_time
-                        ):
-                            """Build a list of URLs based on detected partitioning and time range."""
-                            urls = []
-                            current = start_time
-                            while current <= end_time:
-                                path_parts = []
-                                for key in partition_keys:
-                                    if key == "year":
-                                        path_parts.append(f"year={current.year}")
-                                    elif key == "month":
-                                        path_parts.append(f"month={current.month:02d}")
-                                    elif key == "day":
-                                        path_parts.append(f"day={current.day:02d}")
-                                    elif key == "hour":
-                                        path_parts.append(f"hour={current.hour:02d}")
-
-                                urls.append(
-                                    f"{base_path.rstrip('/')}/" + "/".join(path_parts)
-                                )
-                                current += datetime.timedelta(hours=1)
-                            logger.info("URLS are", urls=urls)
-                            return urls
-
-                        def clean_filters_for_partitions(filters, partition_keys):
-                            """
-                            Remove partition keys from filters.
-
-                            Args:
-                                filters (list of list of tuples): pandas-style filters
-                                    Example: [[('year','=',2025),('month','=',11),('timestamp','>',ts1)]]
-                                partition_keys (list of str): partition columns handled via directory
-
-                            Returns:
-                                list of list of tuples: cleaned filters
-                            """
-                            cleaned_filters = []
-                            for group in filters:
-                                new_group = [f for f in group if f[0] not in partition_keys]
-                                if new_group:
-                                    cleaned_filters.append(new_group)
-                            return cleaned_filters
-
-                        def read_partitioned_parquet(
-                            base_path,
-                            start_time,
-                            end_time,
-                            partition_keys,
-                            **kwargs,
-                        ):
-                            """Read only the relevant partitions using pandas filters and concat."""
-                            if not partition_keys:
-                                raise ValueError(
-                                    f"No partition structure found under {base_path}"
-                                )
-
-                            urls = list_partitioned_urls(
-                                base_path, partition_keys, start_time, end_time
-                            )
-
-                            dfs = []
-                            for url in urls:
-                                try:
-                                    kwargs["filters"] = clean_filters_for_partitions(kwargs["filters"], partition_keys)
-                                    df = df_module.read_parquet(url, **kwargs)
-                                    logger.info("Reading DataFrame", url=url, columns=df.columns)
-                                    dfs.append(df)
-                                except Exception as e:
-                                    # Skip partitions that don't exist or have no data
-                                    logger.info("Failed to read DataFrame", url=url, exception=e)
-                                    continue
-
-                            if not dfs:
-                                return pd.DataFrame()
-                            final_df = pd.concat(dfs, ignore_index=True)
-                            logger.info("Finished reading DataFrame columns", columns=final_df.columns)
-                            return final_df
-
-                        return read_partitioned_parquet(
+                    if create_partition_path and partitions_time_attributes:
+                        return DataStore.read_partitioned_parquet(
                             url,
                             start_time,
                             end_time,
                             partitions_time_attributes,
+                            df_module,
                             **kwargs,
                         )
 
@@ -330,10 +364,19 @@ class DataStore(BaseRemoteClient):
                         additional_filters,
                         kwargs,
                     )
-                    return df_module.read_parquet(*args, **kwargs)
+                    if create_partition_path and partitions_time_attributes:
+                        return DataStore.read_partitioned_parquet(
+                            url,
+                            start_time_inner,
+                            end_time_inner,
+                            partitions_time_attributes,
+                            df_module,
+                            **kwargs,
+                        )
+                    else:
+                        return df_module.read_parquet(*args, **kwargs)
             else:
                 return df_module.read_parquet(*args, **kwargs)
-
         return reader
 
     def as_df(
@@ -414,6 +457,7 @@ class DataStore(BaseRemoteClient):
                 start_time,
                 end_time,
                 additional_filters,
+                kwargs.get("create_partition_path", True),
             )
 
         elif file_url.endswith(".json") or format == "json":


### PR DESCRIPTION
### 📝 Description

Adding logic for more accurate url for timestamp shard, allow better performance in pandas read parquet

---

### 🛠️ Changes Made

url is created on the fly based on the filter start and end time

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
