### PR TITLE
[Dockerfiles] Jupyter remove demos_config argument

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -108,7 +108,7 @@ ARG MLRUN_CACHE_DATE
 # Download demos aligned with installed MLRun version using get_demos.py
 RUN python -m pip install --no-cache-dir requests packaging tqdm && \
     MLVER=$(python -c "import mlrun; print(mlrun.__version__)") && \
-    python get_demos.py "$MLVER" --config_path "$HOME/demos_config.json" --dest "$HOME/demos" && \
+    python get_demos.py "$MLVER" --dest "$HOME/demos" && \
     rm -rf "$HOME/demos_config.json" "$HOME/get_demos.py"
 
 ENV JUPYTER_ENABLE_LAB=yes \


### PR DESCRIPTION
### 📝 Description

Removing the demos_config argument from the get_demos.py script cause this issue to happen.
Needed to update the function call with the right parameters

---

### 🛠️ Changes Made

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR
- [X] I confirmed whether my changes are covered by system tests
  - [X] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
If still fails, mlrun fails to release
---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No


---

### 🔍️ Additional Notes

