### PR TITLE
[Tests] Fix test_serving_as_a_job to handle batch suffix [1.10.x]

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1171,7 +1171,7 @@ class TestServingJobEndpoint(TestMLRunSystemModelMonitoring, _V3IORecordsChecker
         inputs = {"data": input_dataset.uri}
         params = {"timestamp_column": "index"}
         self.project.run_function(job, inputs=inputs, params=params)
-        return function
+        return job
 
     def _test_batch_ep_metrics(
         self, function_name: str, input_df: pd.DataFrame


### PR DESCRIPTION
Fixes ML-11478

After PR #8728, the `.to_job()` method automatically appends "-batch" suffix to job names. Updated `_run_serving_job()` to return the job object instead of the function object, ensuring the test receives the correct name with the suffix for model endpoint lookups.

### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
