### PR TITLE
[Automation] External demo list for get_demos [1.10.x]

### DIFF
--- a/automation/scripts/demos_config.json
+++ b/automation/scripts/demos_config.json
@@ -1,8 +1,28 @@
 {
-  "demos": [
-    "demo-fraud",
-    "demo-monitoring-and-feedback-loop",
-    "demo-call-center",
-    "demo-banking-agent"
-  ]
+  "1.10.0": {
+    "demos": [
+        "demo-fraud",
+        "demo-monitoring-and-feedback-loop",
+        "demo-call-center",
+        "demo-banking-agent"
+      ]
+  },
+  "1.9.2": {
+    "demos": [
+        "demo-fraud",
+        "demo-mask-detection",
+        "demo-monitoring-and-feedback-loop",
+        "demo-call-center",
+        "demo-sagemaker"
+      ]
+  },
+  "development": {
+    "demos": [
+        "demo-fraud",
+        "demo-mask-detection",
+        "demo-monitoring-and-feedback-loop",
+        "demo-call-center",
+        "demo-sagemaker"
+      ]
+  }
 }

--- a/automation/scripts/get_demos.py
+++ b/automation/scripts/get_demos.py
@@ -154,6 +154,10 @@ def validate_versions(all_versions):
     return valid_versions
 
 
+def normalize(v):
+    return re.sub(r"-rc(\d+)$", r"rc\1", v)
+
+
 def download_demo(demo_repo, mlrun_version):
     # Download exact given mlrun version
     log("Starting downloading process", demo_repo)
@@ -166,7 +170,9 @@ def download_demo(demo_repo, mlrun_version):
         )
 
     # Sorting versions
-    sorted_versions = sorted(all_releases, key=Version, reverse=True)
+    sorted_versions = sorted(
+        all_releases, key=lambda x: Version(normalize(x)), reverse=True
+    )
 
     # Check if mlrun version is in the form of x.x.x or x.x.x-rcX
     match = VERSION_PATTERN.match(mlrun_version)
@@ -188,7 +194,7 @@ def download_demo(demo_repo, mlrun_version):
     if matching_demo_releases:
         # Download the release or the latest rc for that mlrun version
         return download_release(demo_repo, mlrun_version) or download_release(
-            demo_repo, max(matching_demo_releases)
+            demo_repo, matching_demo_releases[0]
         )
 
     log(
@@ -196,7 +202,6 @@ def download_demo(demo_repo, mlrun_version):
         demo_repo,
     )
     log("Using latest release", demo_repo)
-
     return download_release(demo_repo, sorted_versions[0])
 
 
@@ -205,7 +210,9 @@ def detect_demo_version(repo, mlrun_version):
     try:
         all_releases = validate_versions(get_all_releases(repo))
         if all_releases:
-            sorted_versions = sorted(all_releases, key=Version, reverse=True)
+            sorted_versions = sorted(
+                all_releases, key=lambda x: Version(normalize(x)), reverse=True
+            )
             match = VERSION_PATTERN.match(mlrun_version)
             if match:
                 base_version = match.group(1)

--- a/automation/scripts/get_demos.py
+++ b/automation/scripts/get_demos.py
@@ -21,7 +21,6 @@ import sys
 import tarfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from pathlib import Path
 from time import sleep
 
 import requests
@@ -30,6 +29,14 @@ from tqdm import tqdm
 
 TIMEOUT = 30  # seconds
 VERSION_PATTERN = re.compile(r"^(\d+\.\d+\.\d+)(?:-rc\d+)?$")
+DEFAULT_CONFIG = {
+    "demos": [
+        "demo-fraud",
+        "demo-monitoring-and-feedback-loop",
+        "demo-call-center",
+        "demo-banking-agent",
+    ]
+}
 
 
 def download_with_retry(url, max_retries=3):
@@ -257,24 +264,36 @@ def create_manifest(mlrun_version, demo_versions):
 
 
 def get_demos(mlrun_version):
-    if not os.path.exists(CONFIG_PATH):
-        raise RuntimeError(f"Configuration file not found: {CONFIG_PATH}")
+    config_url = "https://raw.githubusercontent.com/mlrun/mlrun/refs/heads/development/automation/scripts/demos_config.json"
     try:
-        with Path(CONFIG_PATH).open("r", encoding="utf-8") as f:
-            config = json.load(f)
-    except json.JSONDecodeError as e:
-        raise RuntimeError(f"Invalid JSON in configuration file {CONFIG_PATH}: {e}")
-    except Exception as e:
-        raise RuntimeError(f"Failed to read configuration file {CONFIG_PATH}: {e}")
+        response = requests.get(config_url, timeout=10)
+        response.raise_for_status()  # raise HTTPError if not 200
+        config = json.loads(response.text)
 
-    os.makedirs(DEST_DIR, exist_ok=True)
-    repositories = config.get("demos")
+        version_to_use = VERSION_PATTERN.match(mlrun_version).group(1)
+        if version_to_use not in config.keys():
+            config = config.get("development")
+            log("Using development tag for demos list", "get_demos")
+        else:
+            config = config.get(version_to_use)
+            log(f"Using {version_to_use} tag for demos list", "get_demos")
+
+    except Exception:
+        log("Failed getting config json, using default", "get_demos")
+        config = DEFAULT_CONFIG
+
+    try:
+        os.makedirs(DEST_DIR, exist_ok=True)
+        repositories = config.get("demos")
+    except AttributeError:
+        raise AttributeError("Failed to read configuration file")
+
     if not repositories:
-        raise RuntimeError(f"No 'demos' key found in {CONFIG_PATH}")
+        raise RuntimeError(f"No 'demos' key found in {config_url}")
     if not isinstance(repositories, list):
-        raise RuntimeError(f"'demos' must be a list in {CONFIG_PATH}")
+        raise RuntimeError(f"'demos' must be a list in {config_url}")
     if not all(isinstance(r, str) for r in repositories):
-        raise RuntimeError(f"All demo entries must be strings in {CONFIG_PATH}")
+        raise RuntimeError(f"All demo entries must be strings in {config_url}")
 
     errors = []
     demo_versions = {}
@@ -330,19 +349,13 @@ if __name__ == "__main__":
     # Optional argument
     parser.add_argument("--org", default="mlrun", help="GitHub org")
     parser.add_argument(
-        "--config_path", default="demos_config.json", help="Path to demos config file"
-    )
-    parser.add_argument(
         "--dest", default="demos", help="Folder name to extract demos to"
     )
 
     args = parser.parse_args()
 
     GITHUB_ORG = args.org
-    CONFIG_PATH = args.config_path
     DEST_DIR = args.dest
-
-    get_demos(args.mlrun_version)
 
     try:
         get_demos(args.mlrun_version)

--- a/automation/scripts/update_demos.sh
+++ b/automation/scripts/update_demos.sh
@@ -300,16 +300,10 @@ except Exception:
     raise SystemExit(1)
 PY
 
-# Determine which ref to fetch scripts from (tag matching version or development)
-if [ -n "$mlrun_version" ] && echo "$mlrun_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
-    RAW_REF="refs/tags/v${mlrun_version}"
-else
-    RAW_REF="development"
-fi
-
 # Fetch get_demos.py and its config
-GET_DEMOS_URL="https://raw.githubusercontent.com/mlrun/mlrun/${RAW_REF}/automation/scripts/get_demos.py"
-DEMOS_CONFIG_URL="https://raw.githubusercontent.com/mlrun/mlrun/${RAW_REF}/automation/scripts/demos_config.json"
+GET_DEMOS_URL="https://raw.githubusercontent.com/mlrun/mlrun/development/automation/scripts/get_demos.py"
+DEMOS_CONFIG_URL="https://raw.githubusercontent.com/mlrun/mlrun/development/automation/scripts/demos_config.json"
+# This demos_config_url is hard coded also in get_demos.py
 
 fetch_file() {
     local url="$1"; local out="$2"
@@ -328,7 +322,6 @@ temp_demos_dir=$(mktemp -d /tmp/demos.XXXXXXXXXX)
 
 echo "Running get_demos.py (dest=${temp_demos_dir}) ..."
 GITHUB_TOKEN="$GITHUB_TOKEN" $PYTHON_BIN "$work_dir/get_demos.py" ${mlrun_version:+"$mlrun_version"} \
-    --config_path "$work_dir/demos_config.json" \
     --dest "$temp_demos_dir"
 
 if [ -z "${dry_run}" ]; then
@@ -350,7 +343,7 @@ if [ -z "${dry_run}" ]; then
     
     # Add update_demos.sh to the demos directory for future updates
     echo "Adding update_demos.sh to ${demos_dir} for future updates..."
-    UPDATE_DEMOS_URL="https://raw.githubusercontent.com/mlrun/mlrun/${RAW_REF}/automation/scripts/update_demos.sh"
+    UPDATE_DEMOS_URL="https://raw.githubusercontent.com/mlrun/mlrun/development/automation/scripts/update_demos.sh"
     fetch_file "$UPDATE_DEMOS_URL" "${demos_dir}/update_demos.sh" && chmod +x "${demos_dir}/update_demos.sh" || \
         echo "Warning: Could not download update_demos.sh to demos directory"
 else


### PR DESCRIPTION
### 📝 Description
Moving demos_config.json to mlrun/demos repository.
enabling dynamic demo list

problem raised is when we want to add/remove a demo from a released version.
update_demos.sh uses the demos list from the given mlrun version (i.e in 1.10.0-rc40 it will use the demos list from 1.10.0-rc40 tag which is already released and can't be changed)

---

### 🛠️ Changes Made
updated get_demos.py to get demos list from mlrun/demos/demos_config.json

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Manually tested

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No


---

### 🔍️ Additional Notes
