### PR TITLE
[Nuclio] Inject deprecated MLRUN_DEFAULT_PROJECT for backward compatibility

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -831,9 +831,11 @@ class RemoteRuntime(KubeResource):
 
     def _get_runtime_env(self):
         # for runtime specific env var enrichment (before deploy)
+        active_project = self.metadata.project or mlconf.active_project
         runtime_env = {
-            mlrun.common.constants.MLRUN_ACTIVE_PROJECT: self.metadata.project
-            or mlconf.active_project,
+            mlrun.common.constants.MLRUN_ACTIVE_PROJECT: active_project,
+            # TODO: Remove this in 1.12.0 as MLRUN_DEFAULT_PROJECT is deprecated and should not be injected anymore
+            "MLRUN_DEFAULT_PROJECT": active_project,
         }
         if mlconf.httpdb.api_url:
             runtime_env["MLRUN_DBPATH"] = mlconf.httpdb.api_url

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -517,6 +517,8 @@ class TestNuclioRuntime(TestRuntimeBase):
                 "valueFrom": {"secretKeyRef": {"key": secret_key, "name": secret}},
             },
             {"name": name2, "value": value2},
+            # TODO: Remove this in 1.12.0 — deprecated MLRUN_DEFAULT_PROJECT injected for backward compatibility
+            {"name": "MLRUN_DEFAULT_PROJECT", "value": self.project},
         ]
 
         (


### PR DESCRIPTION
### 📝 Description
Inject the deprecated `MLRUN_DEFAULT_PROJECT` environment variable for backward compatibility with older clients.
This ensures older versions continue to function correctly while using the newer server version.

Added a TODO to remove the injection in 1.12.0.

---

### 🛠️ Changes Made

- Inject `MLRUN_DEFAULT_PROJECT` alongside `MLRUN_ACTIVE_PROJECT` in `_get_runtime_env` as part of nuclio deploy flow.
- Added a TODO comment to remove this in 1.12.0

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [x] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Added a unit test to validate `MLRUN_DEFAULT_PROJECT` injection.
-Manually tested on vmdev by patching the server and deploying a Nuclio function, verifying that the variable is injected into the pod.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11501
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
