### PR TITLE
[Model Monitoring] Add _get_records() API for TimescaleDB connector

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
@@ -154,12 +154,19 @@ class TimescaleDBMetricsQueries:
     def read_metrics_data_impl(
         self,
         *,
-        endpoint_id: str,
+        endpoint_id: Optional[str] = None,
         start: datetime,
         end: datetime,
-        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]] = None,
     ) -> pd.DataFrame:
-        """Read metrics data from TimescaleDB (metrics table only) - returns DataFrame."""
+        """Read metrics data from TimescaleDB (metrics table only) - returns DataFrame.
+
+        :param endpoint_id: Endpoint ID to filter by, or None to get all endpoints
+        :param start: Start time
+        :param end: End time
+        :param metrics: List of metrics to filter by, or None to get all metrics
+        :return: DataFrame with metrics data
+        """
 
         table_schema = self.tables[mm_schemas.TimescaleDBTables.METRICS]
         name_column = mm_schemas.MetricData.METRIC_NAME
@@ -171,7 +178,7 @@ class TimescaleDBMetricsQueries:
             value_column,
         ]
 
-        # Build metrics condition using query builder utilities
+        # Build metrics condition using query builder utilities (accepts None)
         metrics_condition = TimescaleDBQueryBuilder.build_metrics_filter(metrics)
         endpoint_filter = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_id)
 

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
@@ -63,22 +63,30 @@ class TimescaleDBPredictionsQueries:
         self._pre_aggregate_manager = pre_aggregate_manager
         self.tables = tables
 
-    def read_predictions(
+    def read_predictions_impl(
         self,
         *,
-        endpoint_id: str,
+        endpoint_id: Optional[str] = None,
         start: datetime,
         end: datetime,
+        columns: Optional[list[str]] = None,
         aggregation_window: Optional[str] = None,
         agg_funcs: Optional[list[str]] = None,
         limit: Optional[int] = None,
         use_pre_aggregates: bool = True,
-    ) -> Union[
-        mm_schemas.ModelEndpointMonitoringMetricValues,
-        mm_schemas.ModelEndpointMonitoringMetricNoData,
-    ]:
-        """Read predictions with optional pre-aggregate optimization."""
+    ) -> pd.DataFrame:
+        """Read predictions data from TimescaleDB (predictions table) - returns DataFrame.
 
+        :param endpoint_id: Endpoint ID to filter by, or None to get all endpoints
+        :param start: Start time
+        :param end: End time
+        :param columns: Optional list of specific columns to return
+        :param aggregation_window: Optional aggregation window (e.g., "1h", "1d")
+        :param agg_funcs: Optional list of aggregation functions (e.g., ["avg", "max"])
+        :param limit: Optional limit on number of results
+        :param use_pre_aggregates: Whether to use pre-aggregates if available
+        :return: DataFrame with predictions data
+        """
         if (agg_funcs and not aggregation_window) or (
             aggregation_window and not agg_funcs
         ):
@@ -100,12 +108,7 @@ class TimescaleDBPredictionsQueries:
         )
 
         table_schema = self.tables[mm_schemas.TimescaleDBTables.PREDICTIONS]
-
         filter_query = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_id)
-        columns = [
-            table_schema.time_column,
-            mm_schemas.EventFieldType.ESTIMATED_PREDICTION_COUNT,
-        ]
 
         query = table_schema._get_records_query(
             start=start,
@@ -121,21 +124,69 @@ class TimescaleDBPredictionsQueries:
         result = self._connection.run(query=query)
         df = TimescaleDBDataFrameProcessor.from_query_result(result)
 
+        if not df.empty:
+            # Set up time index based on whether we used aggregation
+            if aggregation_window and can_use_pre_aggregates:
+                time_col = timescaledb_schema.TIME_BUCKET_COLUMN
+            else:
+                time_col = table_schema.time_column
+
+            if time_col in df.columns:
+                df[time_col] = pd.to_datetime(df[time_col])
+                df.set_index(time_col, inplace=True)
+
+        return df
+
+    def read_predictions(
+        self,
+        *,
+        endpoint_id: str,
+        start: datetime,
+        end: datetime,
+        aggregation_window: Optional[str] = None,
+        agg_funcs: Optional[list[str]] = None,
+        limit: Optional[int] = None,
+        use_pre_aggregates: bool = True,
+    ) -> Union[
+        mm_schemas.ModelEndpointMonitoringMetricValues,
+        mm_schemas.ModelEndpointMonitoringMetricNoData,
+    ]:
+        """Read predictions with optional pre-aggregate optimization."""
+
+        table_schema = self.tables[mm_schemas.TimescaleDBTables.PREDICTIONS]
+        columns = [
+            table_schema.time_column,
+            mm_schemas.EventFieldType.ESTIMATED_PREDICTION_COUNT,
+        ]
+
+        # Get raw DataFrame from read_predictions_impl
+        df = self.read_predictions_impl(
+            endpoint_id=endpoint_id,
+            start=start,
+            end=end,
+            columns=columns,
+            aggregation_window=aggregation_window,
+            agg_funcs=agg_funcs,
+            limit=limit,
+            use_pre_aggregates=use_pre_aggregates,
+        )
+
+        # Convert to domain objects
         full_name = get_invocations_fqn(self.project)
 
         if df.empty:
             return TimescaleDBDataFrameProcessor.handle_empty_dataframe(full_name)
 
-        # Set up time index based on whether we used aggregation
-        if aggregation_window and can_use_pre_aggregates:
-            time_col = timescaledb_schema.TIME_BUCKET_COLUMN
-        else:
-            time_col = table_schema.time_column
+        # Determine value column name based on whether aggregation was used
+        can_use_pre_aggregates = (
+            use_pre_aggregates
+            and aggregation_window
+            and agg_funcs
+            and self._pre_aggregate_manager.can_use_pre_aggregates(
+                interval=aggregation_window, agg_funcs=agg_funcs
+            )
+        )
 
-        df[time_col] = pd.to_datetime(df[time_col])
-        df.set_index(time_col, inplace=True)
-
-        # Determine value column name
         if agg_funcs and can_use_pre_aggregates:
             value_col = (
                 f"{agg_funcs[0]}_{mm_schemas.EventFieldType.ESTIMATED_PREDICTION_COUNT}"

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -524,13 +524,21 @@ class TimescaleDBResultsQueries:
     def read_results_data_impl(
         self,
         *,
-        endpoint_id: str,
+        endpoint_id: Optional[str] = None,
         start: datetime,
         end: datetime,
-        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]] = None,
         with_result_extra_data: bool = False,
     ) -> pd.DataFrame:
-        """Read results data from TimescaleDB (app_results table only) - returns DataFrame."""
+        """Read results data from TimescaleDB (app_results table only) - returns DataFrame.
+
+        :param endpoint_id: Endpoint ID to filter by, or None to get all endpoints
+        :param start: Start time
+        :param end: End time
+        :param metrics: List of metrics to filter by, or None to get all results
+        :param with_result_extra_data: Whether to include extra data column
+        :return: DataFrame with results data
+        """
 
         table_schema = self.tables[mm_schemas.TimescaleDBTables.APP_RESULTS]
         name_column = mm_schemas.ResultData.RESULT_NAME

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -298,9 +298,9 @@ class TimescaleDBConnector(TSDBConnector):
         columns: Optional[list[str]] = None,
     ) -> pd.DataFrame:
         """
-        Get raw records from TimescaleDB as pandas DataFrame (similar to TDEngine).
+        Get raw records from TimescaleDB as pandas DataFrame.
 
-        This method provides direct access to raw table data, matching TDEngine's _get_records() API.
+        This method provides direct access to raw table data.
 
         :param table: Table name - "metrics", "results", or "predictions"
         :param start: Start time for the query

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -289,6 +289,60 @@ class TimescaleDBConnector(TSDBConnector):
     def read_predictions(self, *args, **kwargs):
         return self._predictions_queries.read_predictions(*args, **kwargs)
 
+    def _get_records(
+        self,
+        table: str,
+        start: datetime.datetime,
+        end: datetime.datetime,
+        endpoint_id: Optional[str] = None,
+        columns: Optional[list[str]] = None,
+    ) -> pd.DataFrame:
+        """
+        Get raw records from TimescaleDB as pandas DataFrame (similar to TDEngine).
+
+        This method provides direct access to raw table data, matching TDEngine's _get_records() API.
+
+        :param table: Table name - "metrics", "results", or "predictions"
+        :param start: Start time for the query
+        :param end: End time for the query
+        :param endpoint_id: Optional endpoint ID filter (None = all endpoints)
+        :param columns: Optional list of specific columns to return (None = all columns)
+        :return: Raw pandas DataFrame with all matching records
+        """
+        if table == "metrics":
+            df = self._metrics_queries.read_metrics_data_impl(
+                endpoint_id=endpoint_id,
+                start=start,
+                end=end,
+                metrics=None,  # Get all metrics
+            )
+        elif table == "results":
+            df = self._results_queries.read_results_data_impl(
+                endpoint_id=endpoint_id,
+                start=start,
+                end=end,
+                metrics=None,  # Get all results
+                with_result_extra_data=True,
+            )
+        elif table == "predictions":
+            df = self._predictions_queries.read_predictions_impl(
+                endpoint_id=endpoint_id,
+                start=start,
+                end=end,
+                columns=columns,
+            )
+        else:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Invalid table '{table}'. Must be 'metrics', 'results', or 'predictions'"
+            )
+
+        if columns is not None and not df.empty:
+            # Filter to requested columns if specified
+            available_columns = [col for col in columns if col in df.columns]
+            df = df[available_columns]
+
+        return df
+
     def get_last_request(self, *args, **kwargs):
         return self._predictions_queries.get_last_request(*args, **kwargs)
 

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
@@ -30,13 +30,15 @@ class TimescaleDBQueryBuilder:
     """Utility class for building common SQL query components."""
 
     @staticmethod
-    def build_endpoint_filter(endpoint_ids: Union[str, list[str]]) -> str:
+    def build_endpoint_filter(endpoint_ids: Optional[Union[str, list[str]]]) -> str:
         """
         Generate SQL filter for endpoint IDs.
 
-        :param endpoint_ids: Single endpoint ID or list of endpoint IDs
-        :return: SQL WHERE clause fragment for endpoint filtering
+        :param endpoint_ids: Single endpoint ID, list of endpoint IDs, or None for no filtering
+        :return: SQL WHERE clause fragment for endpoint filtering, or empty string if None
         """
+        if endpoint_ids is None:
+            return ""
         if isinstance(endpoint_ids, str):
             return f"{mm_schemas.WriterEvent.ENDPOINT_ID}='{endpoint_ids}'"
         elif isinstance(endpoint_ids, list):
@@ -81,14 +83,16 @@ class TimescaleDBQueryBuilder:
 
     @staticmethod
     def build_metrics_filter(
-        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]],
     ) -> str:
         """
         Generate SQL filter for metrics using both application_name and metric_name columns.
 
-        :param metrics: List of ModelEndpointMonitoringMetric objects
-        :return: SQL WHERE clause fragment for metrics filtering
+        :param metrics: List of ModelEndpointMonitoringMetric objects, or None for no filtering
+        :return: SQL WHERE clause fragment for metrics filtering, or empty string if None
         """
+        if metrics is None:
+            return ""
         if not metrics:
             raise mlrun.errors.MLRunInvalidArgumentError("Metrics list cannot be empty")
 
@@ -109,13 +113,15 @@ class TimescaleDBQueryBuilder:
 
     @staticmethod
     def build_results_filter(
-        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]],
     ) -> str:
         """
         Generate SQL filter for results using both application_name and result_name columns.
-        :param metrics: List of ModelEndpointMonitoringMetric objects
-        :return: SQL WHERE clause fragment for results filtering
+        :param metrics: List of ModelEndpointMonitoringMetric objects, or None for no filtering
+        :return: SQL WHERE clause fragment for results filtering, or empty string if None
         """
+        if metrics is None:
+            return ""
         if not metrics:
             raise mlrun.errors.MLRunInvalidArgumentError("Metrics list cannot be empty")
 

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
@@ -1,0 +1,227 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+import mlrun.common.schemas.model_monitoring as mm_schemas
+
+
+class TestGetRecords:
+    """Tests for TimescaleDBConnector._get_records() method - API parity with TDEngine."""
+
+    def test_get_records_metrics_all_endpoints(self, connector, query_test_helper):
+        """Test _get_records() for metrics table with no endpoint filter."""
+        # Insert test data for multiple endpoints
+        test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        test_data = [
+            {
+                mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-1",
+                mm_schemas.WriterEvent.APPLICATION_NAME: "app1",
+                mm_schemas.MetricData.METRIC_NAME: "accuracy",
+                mm_schemas.MetricData.METRIC_VALUE: 0.95,
+            },
+            {
+                mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-2",
+                mm_schemas.WriterEvent.APPLICATION_NAME: "app2",
+                mm_schemas.MetricData.METRIC_NAME: "precision",
+                mm_schemas.MetricData.METRIC_VALUE: 0.87,
+            },
+        ]
+
+        for data in test_data:
+            query_test_helper.write_application_event(
+                data, mm_schemas.WriterEventKind.METRIC
+            )
+
+        # Query all endpoints using _get_records
+        df = connector._get_records(
+            table="metrics",
+            start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
+            endpoint_id=None,  # Get ALL endpoints
+        )
+
+        # Verify we got data for both endpoints
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert len(df) == len(test_data)
+        # Reference test_data instead of hardcoding expected values
+        expected_apps = {d[mm_schemas.WriterEvent.APPLICATION_NAME] for d in test_data}
+        expected_metrics = {d[mm_schemas.MetricData.METRIC_NAME] for d in test_data}
+        assert set(df[mm_schemas.WriterEvent.APPLICATION_NAME]) == expected_apps
+        assert set(df[mm_schemas.MetricData.METRIC_NAME]) == expected_metrics
+
+    def test_get_records_metrics_specific_endpoint(self, connector, query_test_helper):
+        """Test _get_records() for metrics table with endpoint filter."""
+        # Insert test data for multiple endpoints
+        test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        test_data = [
+            {
+                mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-1",
+                mm_schemas.WriterEvent.APPLICATION_NAME: "app1",
+                mm_schemas.MetricData.METRIC_NAME: "accuracy",
+                mm_schemas.MetricData.METRIC_VALUE: 0.95,
+            },
+            {
+                mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-2",
+                mm_schemas.WriterEvent.APPLICATION_NAME: "app2",
+                mm_schemas.MetricData.METRIC_NAME: "precision",
+                mm_schemas.MetricData.METRIC_VALUE: 0.87,
+            },
+        ]
+
+        for data in test_data:
+            query_test_helper.write_application_event(
+                data, mm_schemas.WriterEventKind.METRIC
+            )
+
+        # Query specific endpoint using _get_records
+        df = connector._get_records(
+            table="metrics",
+            start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
+            endpoint_id="endpoint-1",
+        )
+
+        # Verify we only got endpoint-1 (reference test_data)
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert len(df) == 1
+        assert (
+            df[mm_schemas.WriterEvent.APPLICATION_NAME].iloc[0]
+            == test_data[0][mm_schemas.WriterEvent.APPLICATION_NAME]
+        )
+        assert (
+            df[mm_schemas.MetricData.METRIC_NAME].iloc[0]
+            == test_data[0][mm_schemas.MetricData.METRIC_NAME]
+        )
+
+    def test_get_records_results_all_endpoints(self, connector, query_test_helper):
+        """Test _get_records() for results table with no endpoint filter."""
+        # Insert test data for multiple endpoints
+        test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        test_data = [
+            {
+                mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-1",
+                mm_schemas.WriterEvent.APPLICATION_NAME: "drift-app1",
+                mm_schemas.ResultData.RESULT_NAME: "drift_detection",
+                mm_schemas.ResultData.RESULT_VALUE: 10.0,
+                mm_schemas.ResultData.RESULT_STATUS: mm_schemas.ResultStatusApp.detected.value,
+                mm_schemas.ResultData.RESULT_KIND: mm_schemas.ResultKindApp.data_drift.value,
+            },
+            {
+                mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+                mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-2",
+                mm_schemas.WriterEvent.APPLICATION_NAME: "drift-app2",
+                mm_schemas.ResultData.RESULT_NAME: "drift_detection",
+                mm_schemas.ResultData.RESULT_VALUE: 20.0,
+                mm_schemas.ResultData.RESULT_STATUS: mm_schemas.ResultStatusApp.detected.value,
+                mm_schemas.ResultData.RESULT_KIND: mm_schemas.ResultKindApp.concept_drift.value,
+            },
+        ]
+
+        for data in test_data:
+            query_test_helper.write_application_event(
+                data, mm_schemas.WriterEventKind.RESULT
+            )
+
+        # Query all endpoints using _get_records
+        df = connector._get_records(
+            table="results",
+            start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
+            endpoint_id=None,  # Get ALL endpoints
+        )
+
+        # Verify we got data for both endpoints (reference test_data)
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert len(df) == len(test_data)
+        expected_apps = {d[mm_schemas.WriterEvent.APPLICATION_NAME] for d in test_data}
+        expected_values = {d[mm_schemas.ResultData.RESULT_VALUE] for d in test_data}
+        assert set(df[mm_schemas.WriterEvent.APPLICATION_NAME]) == expected_apps
+        assert set(df[mm_schemas.ResultData.RESULT_VALUE]) == expected_values
+
+    def test_get_records_empty_result(self, connector):
+        """Test _get_records() returns empty DataFrame when no data exists."""
+        df = connector._get_records(
+            table="metrics",
+            start=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+            endpoint_id=None,
+        )
+
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+    def test_get_records_invalid_table(self, connector):
+        """Test _get_records() raises error for invalid table name."""
+        with pytest.raises(
+            Exception,
+            match="Invalid table.*Must be 'metrics', 'results', or 'predictions'",
+        ):
+            connector._get_records(
+                table="invalid_table",
+                start=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+                end=datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+            )
+
+    def test_get_records_with_column_filter(self, connector, query_test_helper):
+        """Test _get_records() with specific columns requested."""
+        # Insert test data
+        test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        test_data = {
+            mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+            mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+            mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-1",
+            mm_schemas.WriterEvent.APPLICATION_NAME: "app1",
+            mm_schemas.MetricData.METRIC_NAME: "accuracy",
+            mm_schemas.MetricData.METRIC_VALUE: 0.95,
+        }
+
+        query_test_helper.write_application_event(
+            test_data, mm_schemas.WriterEventKind.METRIC
+        )
+
+        # Query with specific columns
+        df = connector._get_records(
+            table="metrics",
+            start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
+            endpoint_id="endpoint-1",
+            columns=[
+                mm_schemas.MetricData.METRIC_NAME,
+                mm_schemas.MetricData.METRIC_VALUE,
+            ],
+        )
+
+        # Verify only requested columns are returned
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert mm_schemas.MetricData.METRIC_NAME in df.columns
+        assert mm_schemas.MetricData.METRIC_VALUE in df.columns

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
@@ -21,7 +21,7 @@ import mlrun.common.schemas.model_monitoring as mm_schemas
 
 
 class TestGetRecords:
-    """Tests for TimescaleDBConnector._get_records() method - API parity with TDEngine."""
+    """Tests for TimescaleDBConnector._get_records() method."""
 
     def test_get_records_metrics_all_endpoints(self, connector, query_test_helper):
         """Test _get_records() for metrics table with no endpoint filter."""
@@ -166,6 +166,50 @@ class TestGetRecords:
         expected_values = {d[mm_schemas.ResultData.RESULT_VALUE] for d in test_data}
         assert set(df[mm_schemas.WriterEvent.APPLICATION_NAME]) == expected_apps
         assert set(df[mm_schemas.ResultData.RESULT_VALUE]) == expected_values
+
+    def test_get_records_predictions_all_endpoints(self, connector):
+        """Test _get_records() for predictions table with no endpoint filter."""
+        # Insert test data for multiple endpoints directly into predictions table
+        test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        predictions_table = connector._metrics_queries.tables[
+            mm_schemas.TimescaleDBTables.PREDICTIONS
+        ]
+
+        # Define test data
+        test_data = [
+            {"endpoint_id": "endpoint-1", "latency": 0.15},
+            {"endpoint_id": "endpoint-2", "latency": 0.25},
+        ]
+
+        # Insert test data
+        for data in test_data:
+            connector._connection.run(
+                statements=[
+                    f"""
+                    INSERT INTO {predictions_table.full_name()}
+                    (end_infer_time, endpoint_id, latency, custom_metrics,
+                     estimated_prediction_count, effective_sample_count)
+                    VALUES ('{test_time}', '{data["endpoint_id"]}', {data["latency"]}, '{{}}', 1.0, 1)
+                    """
+                ]
+            )
+
+        # Query all endpoints using _get_records
+        df = connector._get_records(
+            table="predictions",
+            start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
+            endpoint_id=None,  # Get ALL endpoints
+        )
+
+        # Verify we got data for both endpoints (reference test_data)
+        assert isinstance(df, pd.DataFrame)
+        assert not df.empty
+        assert len(df) == len(test_data)
+        expected_endpoints = {d["endpoint_id"] for d in test_data}
+        expected_latencies = {d["latency"] for d in test_data}
+        assert set(df[mm_schemas.WriterEvent.ENDPOINT_ID]) == expected_endpoints
+        assert set(df["latency"]) == expected_latencies
 
     def test_get_records_empty_result(self, connector):
         """Test _get_records() returns empty DataFrame when no data exists."""


### PR DESCRIPTION
## Description

Implements API parity between TimescaleDB and TDEngine connectors by adding `_get_records()` method to `TimescaleDBConnector`.

The TDEngine connector already has a `_get_records()` method that allows querying raw DataFrame data without specifying metrics upfront and supports querying all endpoints. This PR adds the same capability to TimescaleDB.

**Note**: `_get_records()` is an internal function used by tests and internal tooling only, not part of the public API.

## Ticket
Fixes: ML-11516