### PR TITLE
[Nuclio] Remove old nuclio code

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -372,17 +372,6 @@ def _resolve_env_vars(function, auth_info=None):
         _add_secrets_config_to_function_spec(function)
 
     env_dict, external_source_env_dict = function._get_nuclio_config_spec_env()
-
-    # In nuclio 1.6.0<=v<1.8.0, python runtimes default behavior was to not decode event strings
-    # Our code is counting on the strings to be decoded, so add the needed env var for those versions
-    if (
-        services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.6.0", "1.8.0"
-        )
-        and "NUCLIO_PYTHON_DECODE_EVENT_STRINGS" not in env_dict
-    ):
-        env_dict["NUCLIO_PYTHON_DECODE_EVENT_STRINGS"] = "true"
-
     mlrun.auth.utils.enrich_auth_env(env_dict, function._get_db(), auth_info)
 
     return env_dict, external_source_env_dict

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1082,23 +1082,16 @@ class TestNuclioRuntime(TestRuntimeBase):
     @pytest.mark.parametrize(
         "client_version,client_python_version,nuclio_version,expected_nuclio_runtime",
         [
-            ("1.2.0", None, "1.5.9", "python:3.6"),
-            ("1.2.0", None, "1.9.15", mlrun.mlconf.default_nuclio_runtime),
-            (None, None, "1.5.9", "python:3.6"),
-            (None, None, "1.9.15", mlrun.mlconf.default_nuclio_runtime),
-            ("1.3.0", "3.7", "1.11.9", "python:3.7"),
-            ("1.3.0", "3.9", "1.11.9", "python:3.9"),
-            ("1.3.0", "3.9", "1.5.9", "python:3.6"),
-            ("1.3.0-rc1", "3.9", "1.11.9", "python:3.9"),
-            ("1.3.0-rc1", "3.7", "1.11.9", "python:3.7"),
-            ("0.0.0-unstable", "3.7", "1.11.9", "python:3.7"),
-            ("0.0.0-unstable", "3.9", "1.11.9", "python:3.9"),
+            # explicit python version
+            ("1.11.0", "3.9", "1.14.14", "python:3.9"),
+            ("1.11.0", "3.11", "1.14.14", "python:3.11"),
+            # no explicit python version defaults to config
+            (None, None, "1.14.14", mlrun.mlconf.default_nuclio_runtime),
+            ("1.11.0", None, "1.14.14", mlrun.mlconf.default_nuclio_runtime),
+            # mlrun is known, not forcing any python version
+            ("0.0.0-unstable", "3.9", "1.14.14", "python:3.9"),
+            ("0.0.0-unstable", "3.11", "1.14.14", "python:3.11"),
         ],
-    )
-    # TODO: Un-skip and align test
-    #  once upgrading to Python 3.12 and resolving the Python version according to client python version
-    @pytest.mark.skip(
-        "Python version is not determined by the client version until python version is bumped to 3.12"
     )
     def test_deploy_with_runtime(
         self,
@@ -1247,37 +1240,46 @@ class TestNuclioRuntime(TestRuntimeBase):
         with pytest.raises(ValueError):
             mlrun.runtimes.nuclio.function.validate_nuclio_version_compatibility("")
 
-    def test_min_nuclio_versions_decorator_failure(self):
-        mlconf.nuclio_version = "1.6.10"
-
-        for case in [
+    @pytest.mark.parametrize(
+        "case",
+        [
             ["1.6.11"],
             ["2.6.11"],
             ["1.5.9", "1.6.11"],
-        ]:
+        ],
+    )
+    def test_min_nuclio_versions_decorator_failure(self, case):
+        mlconf.nuclio_version = "1.6.10"
 
-            @mlrun.runtimes.nuclio.function.min_nuclio_versions(*case)
-            def fail():
-                pytest.fail("Should not enter this function")
+        @mlrun.runtimes.nuclio.function.min_nuclio_versions(*case)
+        def fail():
+            pytest.fail("Should not enter this function")
 
-            with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
-                fail()
+        with pytest.raises(mlrun.errors.MLRunIncompatibleVersionError):
+            fail()
 
-    def test_min_nuclio_versions_decorator_success(self):
-        for nuclio_version in ["1.6.10", "2.2.1", "", "Gibberish"]:
-            mlconf.nuclio_version = nuclio_version
+    @pytest.mark.parametrize(
+        "nuclio_version",
+        ["1.6.10", "2.2.1", "", "Gibberish"],
+    )
+    @pytest.mark.parametrize(
+        "min_nuclio_versions_args",
+        [
+            ["1.6.9"],
+            ["1.5.9", "1.6.9"],
+            ["1.0.0", "0.9.81", "1.4.1"],
+        ],
+    )
+    def test_min_nuclio_versions_decorator_success(
+        self, nuclio_version, min_nuclio_versions_args
+    ):
+        mlconf.nuclio_version = nuclio_version
 
-            for case in [
-                ["1.6.9"],
-                ["1.5.9", "1.6.9"],
-                ["1.0.0", "0.9.81", "1.4.1"],
-            ]:
+        @mlrun.runtimes.nuclio.function.min_nuclio_versions(*min_nuclio_versions_args)
+        def success():
+            pass
 
-                @mlrun.runtimes.nuclio.function.min_nuclio_versions(*case)
-                def success():
-                    pass
-
-                success()
+        success()
 
     def test_load_function_with_source_archive_git(self):
         fn = self._generate_runtime(self.runtime_kind)

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1114,9 +1114,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_nuclio_runtime=expected_nuclio_runtime,
         )
 
-    def test_deploy_python_decode_string_env_var_enrichment(
-        self, db: Session, client: TestClient
-    ):
+    def test_deploy_python_version_validations(self, db: Session, client: TestClient):
         mlconf.default_nuclio_runtime = "python:3.7"
 
         logger.info("Function runtime is golang - do nothing")
@@ -1172,7 +1170,6 @@ class TestNuclioRuntime(TestRuntimeBase):
             ("1.7.2", "1.7.0", "1.3.1", False),
             ("1.7.2", "1.7.3", "1.8.5", False),
             ("1.7.2", "1.7.2", "1.7.2", False),
-            ("1.7.2", "1.7.2", "1.7.3", True),
             ("1.7.2", "1.7.2", "1.7.3", True),
             ("1.7.2", "1.7.0", "1.7.3", True),
             ("1.7.2", "1.5.5", "1.7.3", True),

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1125,17 +1125,15 @@ class TestNuclioRuntime(TestRuntimeBase):
         self, db: Session, client: TestClient
     ):
         mlconf.default_nuclio_runtime = "python:3.7"
-        decode_event_strings_env_var_name = "NUCLIO_PYTHON_DECODE_EVENT_STRINGS"
 
         logger.info("Function runtime is golang - do nothing")
         function = self._generate_runtime(self.runtime_kind)
         function.spec.nuclio_runtime = "golang"
         self.execute_function(function)
-        deploy_configs = self._assert_deploy_called_basic_config(
+        self._assert_deploy_called_basic_config(
             expected_class=self.class_name,
             expected_nuclio_runtime=function.spec.nuclio_runtime,
         )
-        assert decode_event_strings_env_var_name not in deploy_configs[0]["spec"]["env"]
 
         logger.info(
             "Function runtime is configured to python:3.7, nuclio version > 1.14.0 and no base image - explode"
@@ -1159,70 +1157,47 @@ class TestNuclioRuntime(TestRuntimeBase):
             expected_class=self.class_name,
             expected_nuclio_runtime=mlconf.default_nuclio_runtime,
         )
-        assert decode_event_strings_env_var_name not in deploy_configs[0]["spec"]["env"]
 
         logger.info(
             "Function runtime is python, nuclio version in range, but already has the env var set - do nothing"
         )
         self._reset_mock()
-        mlconf.nuclio_version = "1.7.5"
+        mlconf.nuclio_version = "1.14.14"
         function = self._generate_runtime(self.runtime_kind)
-        function.set_env(decode_event_strings_env_var_name, "false")
+        function.set_env("something", "false")
         self.execute_function(function)
         self._assert_deploy_called_basic_config(
             expected_class=self.class_name,
             expected_nuclio_runtime=mlconf.default_nuclio_runtime,
-            expected_env={decode_event_strings_env_var_name: "false"},
+            expected_env={"something": "false"},
         )
 
-        logger.info(
-            "Function runtime is python, nuclio version in range, env var not set - add it"
-        )
-        self._reset_mock()
-        mlconf.nuclio_version = "1.7.5"
-        function = self._generate_runtime(self.runtime_kind)
-        self.execute_function(function)
-        self._assert_deploy_called_basic_config(
-            expected_class=self.class_name,
-            expected_nuclio_runtime=mlconf.default_nuclio_runtime,
-            expected_env={decode_event_strings_env_var_name: "true"},
-        )
-
-    def test_is_nuclio_version_in_range(self):
-        mlconf.nuclio_version = "1.7.2"
-
-        assert not services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.6.11", "1.7.2"
-        )
-        assert not services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.7.0", "1.3.1"
-        )
-        assert not services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.7.3", "1.8.5"
-        )
-        assert not services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.7.2", "1.7.2"
-        )
-        assert services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.7.2", "1.7.3"
-        )
-        assert services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.7.0", "1.7.3"
-        )
-        assert services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.5.5", "1.7.3"
-        )
-        assert services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.5.5", "2.3.4"
-        )
-
-        # best effort - assumes compatibility
-        mlconf.nuclio_version = ""
-        assert services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.5.5", "2.3.4"
-        )
-        assert services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
-            "1.7.2", "1.7.2"
+    @pytest.mark.parametrize(
+        "nuclio_version,min_version,max_version,expected_result",
+        [
+            ("1.7.2", "1.6.11", "1.7.2", False),
+            ("1.7.2", "1.7.0", "1.3.1", False),
+            ("1.7.2", "1.7.3", "1.8.5", False),
+            ("1.7.2", "1.7.2", "1.7.2", False),
+            ("1.7.2", "1.7.2", "1.7.3", True),
+            ("1.7.2", "1.7.2", "1.7.3", True),
+            ("1.7.2", "1.7.0", "1.7.3", True),
+            ("1.7.2", "1.5.5", "1.7.3", True),
+            ("1.7.2", "1.5.5", "2.3.4", True),
+            # best effort - assumes compatibility
+            ("", "1.5.5", "2.3.4", True),
+            ("", "1.7.2", "1.7.2", True),
+        ],
+    )
+    def test_is_nuclio_version_in_range(
+        self, nuclio_version, min_version, max_version, expected_result
+    ):
+        mlconf.nuclio_version = nuclio_version
+        assert (
+            services.api.crud.runtimes.nuclio.helpers.is_nuclio_version_in_range(
+                min_version, max_version
+            )
+            is expected_result
         )
 
     def test_validate_nuclio_version_compatibility(self):


### PR DESCRIPTION
### 📝 Description

Remove handling of NUCLIO_PYTHON_DECODE_EVENT_STRINGS which was relevant for nuclio 1.6 to 1.8.

---

### 🛠️ Changes Made

1. remove needless code
2. updated test_nuclio to use `@pytest.mark.parametrize` rather than inline function use-cases.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

UT coverage

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes

