### PR TITLE
[Model Monitoring] Fix _get_records() to always include endpoint_id column

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
@@ -173,6 +173,7 @@ class TimescaleDBMetricsQueries:
         value_column = mm_schemas.MetricData.METRIC_VALUE
         columns = [
             table_schema.time_column,
+            mm_schemas.WriterEvent.ENDPOINT_ID,
             mm_schemas.WriterEvent.APPLICATION_NAME,
             name_column,
             value_column,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -545,6 +545,7 @@ class TimescaleDBResultsQueries:
         value_column = mm_schemas.ResultData.RESULT_VALUE
         columns = [
             table_schema.time_column,
+            mm_schemas.WriterEvent.ENDPOINT_ID,
             mm_schemas.WriterEvent.APPLICATION_NAME,
             name_column,
             value_column,


### PR DESCRIPTION
## Summary
Fixes ML-11516 by ensuring endpoint_id column is always returned from _get_records() API for metrics and results tables.

## Changes
- Add endpoint_id to hardcoded columns list in read_metrics_data_impl (metrics table)
- Add endpoint_id to hardcoded columns list in read_results_data_impl (results table)
- Predictions table already includes endpoint_id via table schema

## Problem
The _get_records() API (added in PR #8926) was missing endpoint_id column in output for metrics and results tables. This made it impossible to identify which endpoint records belong to.

## Solution
Add endpoint_id to the hardcoded columns lists in:
- mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py:176
- mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py:548

Predictions table already returns endpoint_id correctly since it queries all table columns by default.

## Testing
All 101 TimescaleDB tests pass (1 failure unrelated - database cleanup race condition).
All _get_records tests pass:
- test_get_records_metrics_all_endpoints
- test_get_records_metrics_specific_endpoint  
- test_get_records_results_all_endpoints
- test_get_records_predictions_all_endpoints
- test_get_records_empty_result
- test_get_records_invalid_table
- test_get_records_with_column_filter

Verified endpoint_id is present in all query results.

## Related Issues
- ML-11516