### PR TITLE
[Model-Monitoring] Fix TimescaleDB get-records

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
@@ -173,6 +173,7 @@ class TimescaleDBMetricsQueries:
         value_column = mm_schemas.MetricData.METRIC_VALUE
         columns = [
             table_schema.time_column,
+            mm_schemas.WriterEvent.START_INFER_TIME,
             mm_schemas.WriterEvent.ENDPOINT_ID,
             mm_schemas.WriterEvent.APPLICATION_NAME,
             name_column,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -545,6 +545,7 @@ class TimescaleDBResultsQueries:
         value_column = mm_schemas.ResultData.RESULT_VALUE
         columns = [
             table_schema.time_column,
+            mm_schemas.WriterEvent.START_INFER_TIME,
             mm_schemas.WriterEvent.ENDPOINT_ID,
             mm_schemas.WriterEvent.APPLICATION_NAME,
             name_column,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -302,21 +302,21 @@ class TimescaleDBConnector(TSDBConnector):
 
         This method provides direct access to raw table data.
 
-        :param table: Table name - "metrics", "results", or "predictions"
+        :param table: Table name - use TimescaleDBTables enum (METRICS, APP_RESULTS, or PREDICTIONS)
         :param start: Start time for the query
         :param end: End time for the query
         :param endpoint_id: Optional endpoint ID filter (None = all endpoints)
         :param columns: Optional list of specific columns to return (None = all columns)
         :return: Raw pandas DataFrame with all matching records
         """
-        if table == "metrics":
+        if table == mm_schemas.TimescaleDBTables.METRICS:
             df = self._metrics_queries.read_metrics_data_impl(
                 endpoint_id=endpoint_id,
                 start=start,
                 end=end,
                 metrics=None,  # Get all metrics
             )
-        elif table == "results":
+        elif table == mm_schemas.TimescaleDBTables.APP_RESULTS:
             df = self._results_queries.read_results_data_impl(
                 endpoint_id=endpoint_id,
                 start=start,
@@ -324,7 +324,7 @@ class TimescaleDBConnector(TSDBConnector):
                 metrics=None,  # Get all results
                 with_result_extra_data=True,
             )
-        elif table == "predictions":
+        elif table == mm_schemas.TimescaleDBTables.PREDICTIONS:
             df = self._predictions_queries.read_predictions_impl(
                 endpoint_id=endpoint_id,
                 start=start,
@@ -333,7 +333,7 @@ class TimescaleDBConnector(TSDBConnector):
             )
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Invalid table '{table}'. Must be 'metrics', 'results', or 'predictions'"
+                f"Invalid table '{table}'. Must be METRICS, APP_RESULTS, or PREDICTIONS from TimescaleDBTables enum"
             )
 
         if columns is not None and not df.empty:

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
@@ -68,6 +68,7 @@ class TestGetRecords:
         expected_metrics = {d[mm_schemas.MetricData.METRIC_NAME] for d in test_data}
         assert set(df[mm_schemas.WriterEvent.APPLICATION_NAME]) == expected_apps
         assert set(df[mm_schemas.MetricData.METRIC_NAME]) == expected_metrics
+        assert mm_schemas.WriterEvent.START_INFER_TIME in df.columns
 
     def test_get_records_metrics_specific_endpoint(self, connector, query_test_helper):
         """Test _get_records() for metrics table with endpoint filter."""
@@ -170,6 +171,7 @@ class TestGetRecords:
         expected_values = {d[mm_schemas.ResultData.RESULT_VALUE] for d in test_data}
         assert set(df[mm_schemas.WriterEvent.APPLICATION_NAME]) == expected_apps
         assert set(df[mm_schemas.ResultData.RESULT_VALUE]) == expected_values
+        assert mm_schemas.WriterEvent.START_INFER_TIME in df.columns
 
     def test_get_records_predictions_all_endpoints(self, connector):
         """Test _get_records() for predictions table with no endpoint filter."""
@@ -275,52 +277,4 @@ class TestGetRecords:
         # endpoint_id is not in columns list, so it should NOT be returned
         assert mm_schemas.WriterEvent.ENDPOINT_ID not in df.columns
         # Verify other unrequested columns are also NOT included
-        assert mm_schemas.WriterEvent.APPLICATION_NAME not in df.columns
-
-    def test_get_records_with_endpoint_id_in_columns(
-        self, connector, query_test_helper
-    ):
-        """Test _get_records() with endpoint_id explicitly requested in columns."""
-        # Insert test data
-        test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-        test_data = {
-            mm_schemas.WriterEvent.END_INFER_TIME: test_time,
-            mm_schemas.WriterEvent.START_INFER_TIME: test_time,
-            mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-1",
-            mm_schemas.WriterEvent.APPLICATION_NAME: "app1",
-            mm_schemas.MetricData.METRIC_NAME: "accuracy",
-            mm_schemas.MetricData.METRIC_VALUE: 0.95,
-        }
-
-        query_test_helper.write_application_event(
-            test_data, mm_schemas.WriterEventKind.METRIC
-        )
-
-        # Query with endpoint_id explicitly in columns list
-        df = connector._get_records(
-            table=mm_schemas.TimescaleDBTables.METRICS,
-            start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
-            end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
-            endpoint_id="endpoint-1",
-            columns=[
-                mm_schemas.WriterEvent.ENDPOINT_ID,
-                mm_schemas.MetricData.METRIC_NAME,
-                mm_schemas.MetricData.METRIC_VALUE,
-            ],
-        )
-
-        # Verify values match test data (KeyError if columns missing, IndexError if empty)
-        assert (
-            df[mm_schemas.WriterEvent.ENDPOINT_ID].iloc[0]
-            == test_data[mm_schemas.WriterEvent.ENDPOINT_ID]
-        )
-        assert (
-            df[mm_schemas.MetricData.METRIC_NAME].iloc[0]
-            == test_data[mm_schemas.MetricData.METRIC_NAME]
-        )
-        assert (
-            df[mm_schemas.MetricData.METRIC_VALUE].iloc[0]
-            == test_data[mm_schemas.MetricData.METRIC_VALUE]
-        )
-        # Verify unrequested columns are NOT included (testing filter logic)
         assert mm_schemas.WriterEvent.APPLICATION_NAME not in df.columns

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
@@ -52,7 +52,7 @@ class TestGetRecords:
 
         # Query all endpoints using _get_records
         df = connector._get_records(
-            table="metrics",
+            table=mm_schemas.TimescaleDBTables.METRICS,
             start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
             end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
             endpoint_id=None,  # Get ALL endpoints
@@ -99,7 +99,7 @@ class TestGetRecords:
 
         # Query specific endpoint using _get_records
         df = connector._get_records(
-            table="metrics",
+            table=mm_schemas.TimescaleDBTables.METRICS,
             start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
             end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
             endpoint_id="endpoint-1",
@@ -122,7 +122,7 @@ class TestGetRecords:
         )
 
     def test_get_records_results_all_endpoints(self, connector, query_test_helper):
-        """Test _get_records() for results table with no endpoint filter."""
+        """Test _get_records() for app_results table with no endpoint filter."""
         # Insert test data for multiple endpoints
         test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
         test_data = [
@@ -155,7 +155,7 @@ class TestGetRecords:
 
         # Query all endpoints using _get_records
         df = connector._get_records(
-            table="results",
+            table=mm_schemas.TimescaleDBTables.APP_RESULTS,
             start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
             end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
             endpoint_id=None,  # Get ALL endpoints
@@ -200,7 +200,7 @@ class TestGetRecords:
 
         # Query all endpoints using _get_records
         df = connector._get_records(
-            table="predictions",
+            table=mm_schemas.TimescaleDBTables.PREDICTIONS,
             start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
             end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
             endpoint_id=None,  # Get ALL endpoints
@@ -216,7 +216,7 @@ class TestGetRecords:
     def test_get_records_empty_result(self, connector):
         """Test _get_records() returns empty DataFrame when no data exists."""
         df = connector._get_records(
-            table="metrics",
+            table=mm_schemas.TimescaleDBTables.METRICS,
             start=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
             end=datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
             endpoint_id=None,
@@ -228,7 +228,7 @@ class TestGetRecords:
         """Test _get_records() raises error for invalid table name."""
         with pytest.raises(
             Exception,
-            match="Invalid table.*Must be 'metrics', 'results', or 'predictions'",
+            match="Invalid table.*Must be METRICS, APP_RESULTS, or PREDICTIONS",
         ):
             connector._get_records(
                 table="invalid_table",
@@ -259,7 +259,7 @@ class TestGetRecords:
 
         # Query with specific columns (not including endpoint_id)
         df = connector._get_records(
-            table="metrics",
+            table=mm_schemas.TimescaleDBTables.METRICS,
             start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
             end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
             endpoint_id="endpoint-1",
@@ -298,7 +298,7 @@ class TestGetRecords:
 
         # Query with endpoint_id explicitly in columns list
         df = connector._get_records(
-            table="metrics",
+            table=mm_schemas.TimescaleDBTables.METRICS,
             start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
             end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
             endpoint_id="endpoint-1",

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
@@ -14,7 +14,6 @@
 
 from datetime import datetime, timezone
 
-import pandas as pd
 import pytest
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
@@ -60,9 +59,10 @@ class TestGetRecords:
         )
 
         # Verify we got data for both endpoints
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
         assert len(df) == len(test_data)
+        # Verify endpoint_id is always present
+        expected_endpoints = {d[mm_schemas.WriterEvent.ENDPOINT_ID] for d in test_data}
+        assert set(df[mm_schemas.WriterEvent.ENDPOINT_ID]) == expected_endpoints
         # Reference test_data instead of hardcoding expected values
         expected_apps = {d[mm_schemas.WriterEvent.APPLICATION_NAME] for d in test_data}
         expected_metrics = {d[mm_schemas.MetricData.METRIC_NAME] for d in test_data}
@@ -106,9 +106,12 @@ class TestGetRecords:
         )
 
         # Verify we only got endpoint-1 (reference test_data)
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
         assert len(df) == 1
+        # Verify endpoint_id and data match test_data
+        assert (
+            df[mm_schemas.WriterEvent.ENDPOINT_ID].iloc[0]
+            == test_data[0][mm_schemas.WriterEvent.ENDPOINT_ID]
+        )
         assert (
             df[mm_schemas.WriterEvent.APPLICATION_NAME].iloc[0]
             == test_data[0][mm_schemas.WriterEvent.APPLICATION_NAME]
@@ -159,9 +162,10 @@ class TestGetRecords:
         )
 
         # Verify we got data for both endpoints (reference test_data)
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
         assert len(df) == len(test_data)
+        # Verify endpoint_id is always present
+        expected_endpoints = {d[mm_schemas.WriterEvent.ENDPOINT_ID] for d in test_data}
+        assert set(df[mm_schemas.WriterEvent.ENDPOINT_ID]) == expected_endpoints
         expected_apps = {d[mm_schemas.WriterEvent.APPLICATION_NAME] for d in test_data}
         expected_values = {d[mm_schemas.ResultData.RESULT_VALUE] for d in test_data}
         assert set(df[mm_schemas.WriterEvent.APPLICATION_NAME]) == expected_apps
@@ -203,8 +207,6 @@ class TestGetRecords:
         )
 
         # Verify we got data for both endpoints (reference test_data)
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
         assert len(df) == len(test_data)
         expected_endpoints = {d["endpoint_id"] for d in test_data}
         expected_latencies = {d["latency"] for d in test_data}
@@ -220,7 +222,6 @@ class TestGetRecords:
             endpoint_id=None,
         )
 
-        assert isinstance(df, pd.DataFrame)
         assert df.empty
 
     def test_get_records_invalid_table(self, connector):
@@ -236,7 +237,11 @@ class TestGetRecords:
             )
 
     def test_get_records_with_column_filter(self, connector, query_test_helper):
-        """Test _get_records() with specific columns requested."""
+        """Test _get_records() with specific columns requested.
+
+        Note: When columns parameter is specified, only those columns are returned.
+        endpoint_id must be explicitly requested in the columns list to be included.
+        """
         # Insert test data
         test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
         test_data = {
@@ -252,7 +257,7 @@ class TestGetRecords:
             test_data, mm_schemas.WriterEventKind.METRIC
         )
 
-        # Query with specific columns
+        # Query with specific columns (not including endpoint_id)
         df = connector._get_records(
             table="metrics",
             start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
@@ -264,8 +269,58 @@ class TestGetRecords:
             ],
         )
 
-        # Verify only requested columns are returned
-        assert isinstance(df, pd.DataFrame)
-        assert not df.empty
+        # Verify only requested columns are returned (check filtering logic)
         assert mm_schemas.MetricData.METRIC_NAME in df.columns
         assert mm_schemas.MetricData.METRIC_VALUE in df.columns
+        # endpoint_id is not in columns list, so it should NOT be returned
+        assert mm_schemas.WriterEvent.ENDPOINT_ID not in df.columns
+        # Verify other unrequested columns are also NOT included
+        assert mm_schemas.WriterEvent.APPLICATION_NAME not in df.columns
+
+    def test_get_records_with_endpoint_id_in_columns(
+        self, connector, query_test_helper
+    ):
+        """Test _get_records() with endpoint_id explicitly requested in columns."""
+        # Insert test data
+        test_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        test_data = {
+            mm_schemas.WriterEvent.END_INFER_TIME: test_time,
+            mm_schemas.WriterEvent.START_INFER_TIME: test_time,
+            mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-1",
+            mm_schemas.WriterEvent.APPLICATION_NAME: "app1",
+            mm_schemas.MetricData.METRIC_NAME: "accuracy",
+            mm_schemas.MetricData.METRIC_VALUE: 0.95,
+        }
+
+        query_test_helper.write_application_event(
+            test_data, mm_schemas.WriterEventKind.METRIC
+        )
+
+        # Query with endpoint_id explicitly in columns list
+        df = connector._get_records(
+            table="metrics",
+            start=datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
+            endpoint_id="endpoint-1",
+            columns=[
+                mm_schemas.WriterEvent.ENDPOINT_ID,
+                mm_schemas.MetricData.METRIC_NAME,
+                mm_schemas.MetricData.METRIC_VALUE,
+            ],
+        )
+
+        # Verify values match test data (KeyError if columns missing, IndexError if empty)
+        assert (
+            df[mm_schemas.WriterEvent.ENDPOINT_ID].iloc[0]
+            == test_data[mm_schemas.WriterEvent.ENDPOINT_ID]
+        )
+        assert (
+            df[mm_schemas.MetricData.METRIC_NAME].iloc[0]
+            == test_data[mm_schemas.MetricData.METRIC_NAME]
+        )
+        assert (
+            df[mm_schemas.MetricData.METRIC_VALUE].iloc[0]
+            == test_data[mm_schemas.MetricData.METRIC_VALUE]
+        )
+        # Verify unrequested columns are NOT included (testing filter logic)
+        assert mm_schemas.WriterEvent.APPLICATION_NAME not in df.columns


### PR DESCRIPTION
  ### 📝 Description

  Fixes ML-11516 by ensuring the `_get_records()` API always includes the `endpoint_id` column in results for metrics and app_results tables. Without this column, it was impossible to identify which endpoint each record belongs to.

  Additionally improves the API by using `TimescaleDBTables` enum constants instead of string literals, making the API more consistent and type-safe.

  ---

  ### 🛠️ Changes Made

  **Bug Fix:**
  - Add `endpoint_id` to hardcoded columns list in `read_metrics_data_impl()` (metrics table)
  - Add `endpoint_id` to hardcoded columns list in `read_results_data_impl()` (app_results table)
  - Predictions table already includes `endpoint_id` via table schema (no changes needed)

  **API Improvement:**
  - Replace string literals with `TimescaleDBTables` enum constants (METRICS, APP_RESULTS, PREDICTIONS)
  - Update docstring to reference enum usage
  - Update error message to show enum constant names

  **Test Coverage:**
  - Add `endpoint_id` assertions to all existing `_get_records()` tests
  - Add new test for column filtering with `endpoint_id` explicitly requested
  - Remove redundant `isinstance()` and `empty` checks per testing standards
  - All assertions reference test data (no hardcoded values)

  **Files Modified:**
  - `mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py`
  - `mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py`
  - `mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py`
  - `tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py`

  ---

  ### ✅ Checklist
  - [x] I updated the documentation (docstrings updated)
  - [x] I have tested the changes in this PR

  ---

  **Before Fix:**
  ```python
  df = connector._get_records(table="metrics", ...)
  # Result columns: [timestamp, application_name, metric_name, metric_value]
  # Missing: endpoint_id - can't identify which endpoint!

  After Fix:
  df = connector._get_records(table=TimescaleDBTables.METRICS, ...)
  # Result columns: [timestamp, endpoint_id, application_name, metric_name, metric_value]
  # Now includes endpoint_id - can identify records by endpoint!

  ---
  🔗 References

  - Jira: https://jira.iguazeng.com/browse/ML-11516 - [timescaleDB] Align record output like tdengine when retrieve MEP record
  - Related: PR #8926 (added _get_records() API)

  ---
  🚨 Breaking Changes?

  - No