### PR TITLE
[Notification] Make username/password optional params and allow connection to no-auth smtp server

### DIFF
--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -83,12 +83,6 @@ class MailNotification(base.NotificationBase):
         alert: typing.Optional[mlrun.common.schemas.AlertConfig] = None,
         event_data: typing.Optional[mlrun.common.schemas.Event] = None,
     ):
-        # Ensure username and password are set to None if not provided
-        if not self.params.get("username"):
-            self.params["username"] = None
-        if not self.params.get("password"):
-            self.params["password"] = None
-
         self.params["subject"] = f"[{severity}] {message}"
         message_body_override = self.params.get("message_body_override", None)
 

--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -34,17 +34,23 @@ class MailNotification(base.NotificationBase):
 
     boolean_params = ["use_tls", "start_tls", "validate_certs"]
 
+    optional_auth_params = ["username", "password"]
+
     required_params = [
         "server_host",
         "server_port",
         "sender_address",
-        "username",
-        "password",
         "email_addresses",
     ] + boolean_params
 
     @classmethod
     def validate_params(cls, params):
+        # Normalize empty string username/password to None
+        if not params.get("username"):
+            params["username"] = None
+        if not params.get("password"):
+            params["password"] = None
+
         for required_param in cls.required_params:
             if required_param not in params:
                 raise ValueError(
@@ -56,6 +62,13 @@ class MailNotification(base.NotificationBase):
                 raise ValueError(
                     f"Parameter '{boolean_param}' must be a boolean for MailNotification"
                 )
+
+        # Allow no auth, username only, or username + password
+        # Some SMTP servers allow username without password
+        if params["password"] and not params["username"]:
+            raise ValueError(
+                "Parameter 'username' is required when 'password' is provided for MailNotification"
+            )
 
         cls._validate_emails(params)
 
@@ -70,6 +83,12 @@ class MailNotification(base.NotificationBase):
         alert: typing.Optional[mlrun.common.schemas.AlertConfig] = None,
         event_data: typing.Optional[mlrun.common.schemas.Event] = None,
     ):
+        # Ensure username and password are set to None if not provided
+        if not self.params.get("username"):
+            self.params["username"] = None
+        if not self.params.get("password"):
+            self.params["password"] = None
+
         self.params["subject"] = f"[{severity}] {message}"
         message_body_override = self.params.get("message_body_override", None)
 
@@ -147,8 +166,8 @@ class MailNotification(base.NotificationBase):
         sender_address: str,
         server_host: str,
         server_port: int,
-        username: str,
-        password: str,
+        username: typing.Optional[str],
+        password: typing.Optional[str],
         use_tls: bool,
         start_tls: bool,
         validate_certs: bool,

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1578,50 +1578,50 @@ class TestMailNotification:
                     match="Parameter 'use_tls' must be a boolean for MailNotification",
                 ),
             ),
-            ( # missing username and password should pass validation - no auth case
-                    {
-                        "server_host": "smtp.gmail.com",
-                        "server_port": 587,
-                        "sender_address": "sender@example.com",
-                        "username": "",
-                        "password": "",
-                        "email_addresses": "a@example.com",
-                        "use_tls": True,
-                        "validate_certs": True,
-                        "start_tls": False,
-                    },
-                    does_not_raise(),
+            (  # missing username and password should pass validation - no auth case
+                {
+                    "server_host": "smtp.gmail.com",
+                    "server_port": 587,
+                    "sender_address": "sender@example.com",
+                    "username": "",
+                    "password": "",
+                    "email_addresses": "a@example.com",
+                    "use_tls": True,
+                    "validate_certs": True,
+                    "start_tls": False,
+                },
+                does_not_raise(),
             ),
             (  # missing password should pass validation - some servers allow username only auth
-                    {
-                        "server_host": "smtp.gmail.com",
-                        "server_port": 587,
-                        "sender_address": "sender@example.com",
-                        "username": "user",
-                        "password": "",
-                        "email_addresses": "a@example.com",
-                        "use_tls": True,
-                        "validate_certs": True,
-                        "start_tls": False,
-                    },
-                    does_not_raise(),
+                {
+                    "server_host": "smtp.gmail.com",
+                    "server_port": 587,
+                    "sender_address": "sender@example.com",
+                    "username": "user",
+                    "password": "",
+                    "email_addresses": "a@example.com",
+                    "use_tls": True,
+                    "validate_certs": True,
+                    "start_tls": False,
+                },
+                does_not_raise(),
             ),
-            ( # missing username and password provided should fail validation
-                    {
-                        "server_host": "smtp.gmail.com",
-                        "server_port": 587,
-                        "sender_address": "sender@example.com",
-                        "username": "",
-                        "password": "pass",
-                        "email_addresses": "a@example.com",
-                        "use_tls": True,
-                        "validate_certs": True,
-                        "start_tls": False,
-                    },
-                    pytest.raises(
-                        ValueError,
-                        match="Parameter 'username' is required when 'password' is provided for MailNotification",
-                    ),
+            (  # missing username and password provided should fail validation
+                {
+                    "server_host": "smtp.gmail.com",
+                    "server_port": 587,
+                    "sender_address": "sender@example.com",
+                    "username": "",
+                    "password": "pass",
+                    "email_addresses": "a@example.com",
+                    "use_tls": True,
+                    "validate_certs": True,
+                    "start_tls": False,
+                },
+                pytest.raises(
+                    ValueError,
+                    match="Parameter 'username' is required when 'password' is provided for MailNotification",
+                ),
             ),
         ],
     )
@@ -1680,6 +1680,8 @@ class TestMailNotification:
                 {
                     "subject": "[info] test-message",
                     "body": MOCKED_HTML,
+                    "username": None,
+                    "password": None,
                 },
             ),
             (
@@ -1690,6 +1692,32 @@ class TestMailNotification:
                 {
                     "subject": "[warning] test-message",
                     "body": f"runs: {MOCKED_HTML}",
+                    "username": None,
+                    "password": None,
+                },
+            ),
+            (
+                "empty_auth_params",
+                {"username": "", "password": ""},
+                "test-message",
+                "info",
+                {
+                    "subject": "[info] test-message",
+                    "body": MOCKED_HTML,
+                    "username": None,
+                    "password": None,
+                },
+            ),
+            (
+                "with_auth_params",
+                {"username": "user", "password": "pass"},
+                "test-message",
+                "info",
+                {
+                    "subject": "[info] test-message",
+                    "body": MOCKED_HTML,
+                    "username": "user",
+                    "password": "pass",
                 },
             ),
         ],
@@ -1702,6 +1730,8 @@ class TestMailNotification:
         await notification.push(message, severity, [])
         assert notification.params["subject"] == expected["subject"]
         assert notification.params["body"] == expected["body"]
+        assert notification.params["username"] == expected["username"]
+        assert notification.params["password"] == expected["password"]
 
 
 class DummyResponse:

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1730,8 +1730,6 @@ class TestMailNotification:
         await notification.push(message, severity, [])
         assert notification.params["subject"] == expected["subject"]
         assert notification.params["body"] == expected["body"]
-        assert notification.params["username"] == expected["username"]
-        assert notification.params["password"] == expected["password"]
 
 
 class DummyResponse:

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1578,6 +1578,51 @@ class TestMailNotification:
                     match="Parameter 'use_tls' must be a boolean for MailNotification",
                 ),
             ),
+            ( # missing username and password should pass validation - no auth case
+                    {
+                        "server_host": "smtp.gmail.com",
+                        "server_port": 587,
+                        "sender_address": "sender@example.com",
+                        "username": "",
+                        "password": "",
+                        "email_addresses": "a@example.com",
+                        "use_tls": True,
+                        "validate_certs": True,
+                        "start_tls": False,
+                    },
+                    does_not_raise(),
+            ),
+            (  # missing password should pass validation - some servers allow username only auth
+                    {
+                        "server_host": "smtp.gmail.com",
+                        "server_port": 587,
+                        "sender_address": "sender@example.com",
+                        "username": "user",
+                        "password": "",
+                        "email_addresses": "a@example.com",
+                        "use_tls": True,
+                        "validate_certs": True,
+                        "start_tls": False,
+                    },
+                    does_not_raise(),
+            ),
+            ( # missing username and password provided should fail validation
+                    {
+                        "server_host": "smtp.gmail.com",
+                        "server_port": 587,
+                        "sender_address": "sender@example.com",
+                        "username": "",
+                        "password": "pass",
+                        "email_addresses": "a@example.com",
+                        "use_tls": True,
+                        "validate_certs": True,
+                        "start_tls": False,
+                    },
+                    pytest.raises(
+                        ValueError,
+                        match="Parameter 'username' is required when 'password' is provided for MailNotification",
+                    ),
+            ),
         ],
     )
     def test_validate_mail_params(self, params, expectation):


### PR DESCRIPTION
### 📝 Description
Changes the username/password params from required to optional during params validation. Validation now allows:
- no auth (username and password empty)
- username only (password empty)
- username and password values

Empty auth values are normalized to `None` in order for `aiosmtplib` to be able to send to an smtp server that doesn't require authentication.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Changed username and password from required to optional params
- Refactor `validate_params` function to correctly handle empty auth values

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Added cases for `validate_params` unit test
- Manual testing of a no auth smtp server. Implementation details in the Jira

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10488
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
