### PR TITLE
[Config] Remove old ui_url config

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -67,7 +67,6 @@ default_config = {
     "nuclio_version": "",
     "default_nuclio_runtime": "python:3.11",
     "nest_asyncio_enabled": "",  # enable import of nest_asyncio for corner cases with old jupyter, set "1"
-    "ui_url": "",  # remote/external mlrun UI url (for hyperlinks) (This is deprecated in favor of the ui block)
     "remote_host": "",
     "api_base_version": "v1",
     "version": "",  # will be set to current version
@@ -1297,10 +1296,7 @@ class Config:
 
     @staticmethod
     def resolve_ui_url():
-        # ui_url is deprecated in favor of the ui.url (we created the ui block)
-        # since the config class is used in a "recursive" way, we can't use property like we used in other places
-        # since the property will need to be url, which exists in other structs as well
-        return config.ui.url or config.ui_url
+        return config.ui.url
 
     def is_api_running_on_k8s(self):
         # determine if the API service is attached to K8s cluster
@@ -1599,7 +1595,6 @@ def read_env(env=None, prefix=env_prefix):
             "https://mlrun-api.", "https://framesd."
         )
 
-    uisvc = env.get("MLRUN_UI_SERVICE_HOST")
     igz_domain = env.get("IGZ_NAMESPACE_DOMAIN")
 
     # workaround to try and detect IGZ domain
@@ -1624,10 +1619,6 @@ def read_env(env=None, prefix=env_prefix):
     # effort" to try and determine the URL, we want this "best effort" so overriding the "disabled" value
     if config.get("nuclio_dashboard_url") == "disabled":
         config["nuclio_dashboard_url"] = ""
-
-    if uisvc and not config.get("ui_url"):
-        if igz_domain:
-            config["ui_url"] = f"https://mlrun-ui.{igz_domain}"
 
     if log_level := config.get("log_level"):
         import mlrun.utils.logger


### PR DESCRIPTION
### 📝 Description
Remove the usage of the deprecated `ui_url` config. 
The `config.ui.url` property is now the sole source for ui url config, ensuring consistency and removing legacy fallbacks.  

---

### 🛠️ Changes Made
- Removed the `ui_url` attribute from `config.py`.
- Updated `resolve_ui_url()` to return only `config.ui.url`.
- Cleaned up legacy fallback code in environment loading that used `ui_url`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
tested on vmdev - after updaing the client that the value of mlconf.ui is: 
" https://dashboard.default-tenant.app.... "

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11545
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
