### PR TITLE
[Pagination] Fix potential race condition

### DIFF
--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -1147,6 +1147,9 @@ class DBInterface(ABC):
         current_page: int,
         page_size: int,
         kwargs: dict,
+        pagination_cache_record: typing.Optional[
+            framework.db.sqldb.models.PaginationCache
+        ] = None,
     ):
         raise NotImplementedError
 
@@ -1154,6 +1157,7 @@ class DBInterface(ABC):
         self,
         session,
         key: str,
+        for_update: bool = False,
     ):
         raise NotImplementedError
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -7760,7 +7760,7 @@ class SQLDB(DBInterface):
         ).hexdigest()
 
         # it could be that the record was passed, but belongs to a different user
-        # therefor, we need to re-fetch for teh correct user.
+        # therefore, we need to re-fetch for the correct user.
         # the scenario where pagination_cache_record.user != user is when
         # user A (user) using token belongs to user B (pagination_cache_record.user).
         # in that case, ensure we retrieve the correct record for user A.

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -7758,16 +7758,10 @@ class SQLDB(DBInterface):
         key = hashlib.sha256(
             f"{user}/{function}/{page_size}/{kwargs}".encode()
         ).hexdigest()
-
-        # it could be that the record was passed, but belongs to a different user
-        # therefore, we need to re-fetch for the correct user.
-        # the scenario where pagination_cache_record.user != user is when
-        # user A (user) using token belongs to user B (pagination_cache_record.user).
-        # in that case, ensure we retrieve the correct record for user A.
-        # use case is covered by UT - "test_paginate_no_auth"
-        if not pagination_cache_record or pagination_cache_record.user != user:
+        if not pagination_cache_record:
+            # in this case, we just lock for update to make sure no one else is writing to it
             pagination_cache_record = self.get_paginated_query_cache_record(
-                session, key, for_update=True
+                session, key=key, for_update=True
             )
         if pagination_cache_record:
             pagination_cache_record.current_page = current_page

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -7743,6 +7743,9 @@ class SQLDB(DBInterface):
         current_page: int,
         page_size: int,
         kwargs: dict,
+        pagination_cache_record: typing.Optional[
+            framework.db.sqldb.models.PaginationCache
+        ] = None,
     ):
         self._validate_integer_max_value(
             PaginationCache.__table__.c.current_page, current_page
@@ -7755,11 +7758,21 @@ class SQLDB(DBInterface):
         key = hashlib.sha256(
             f"{user}/{function}/{page_size}/{kwargs}".encode()
         ).hexdigest()
-        existing_record = self.get_paginated_query_cache_record(session, key)
-        if existing_record:
-            existing_record.current_page = current_page
-            existing_record.last_accessed = datetime.now(UTC)
-            param_record = existing_record
+
+        # it could be that the record was passed, but belongs to a different user
+        # therefor, we need to re-fetch for teh correct user.
+        # the scenario where pagination_cache_record.user != user is when
+        # user A (user) using token belongs to user B (pagination_cache_record.user).
+        # in that case, ensure we retrieve the correct record for user A.
+        # use case is covered by UT - "test_paginate_no_auth"
+        if not pagination_cache_record or pagination_cache_record.user != user:
+            pagination_cache_record = self.get_paginated_query_cache_record(
+                session, key, for_update=True
+            )
+        if pagination_cache_record:
+            pagination_cache_record.current_page = current_page
+            pagination_cache_record.last_accessed = datetime.now(UTC)
+            param_record = pagination_cache_record
         else:
             param_record = PaginationCache(
                 key=key,
@@ -7777,8 +7790,12 @@ class SQLDB(DBInterface):
         self,
         session,
         key: str,
-    ):
-        return self._query(session, PaginationCache, key=key).one_or_none()
+        for_update: bool = False,
+    ) -> typing.Optional[PaginationCache]:
+        query = self._query(session, PaginationCache, key=key)
+        if for_update:
+            query = query.populate_existing().with_for_update()
+        return query.one_or_none()
 
     def list_paginated_query_cache_record(
         self,

--- a/server/py/framework/utils/pagination.py
+++ b/server/py/framework/utils/pagination.py
@@ -267,6 +267,11 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             page_size = pagination_cache_record.page_size
             user = pagination_cache_record.user
 
+            if not user and auth_info:
+                raise mlrun.errors.MLRunAccessDeniedError(
+                    "Token is not associated with any user, access denied"
+                )
+
             if user and (not auth_info or auth_info.user_id != user):
                 raise mlrun.errors.MLRunAccessDeniedError(
                     "User is not allowed to access this token"

--- a/server/py/framework/utils/pagination.py
+++ b/server/py/framework/utils/pagination.py
@@ -267,7 +267,9 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             page_size = pagination_cache_record.page_size
             user = pagination_cache_record.user
 
-            if not user and auth_info:
+            # NOTE: the current heuristic of checking on user_id allows us
+            # to detect token misuse between different users.
+            if not user and auth_info and auth_info.user_id:
                 raise mlrun.errors.MLRunAccessDeniedError(
                     "Token is not associated with any user, access denied"
                 )
@@ -290,6 +292,9 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
         )
         token = self._pagination_cache.store_pagination_cache_record(
             session,
+            # NOTE: this works when authentication allows multiple users.
+            # when having single user authentication mode (read: BASIC) and having multiple clients
+            # then this needs to be rethought, perhaps using remote address or client id in addition to user id.
             user=auth_info.user_id if auth_info else None,
             method=method,
             current_page=page,

--- a/server/py/framework/utils/pagination.py
+++ b/server/py/framework/utils/pagination.py
@@ -232,12 +232,30 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
         page_size: typing.Optional[int] = None,
         **method_kwargs,
     ) -> tuple[str, int, int, typing.Callable, dict]:
+        """
+        This function creates or updates a pagination cache record.
+        To avoid race conditions between multiple requests using the same token, when a token is provided,
+        the existing pagination cache record is locked for update.
+        If no token is provided, a new pagination cache record is created.
+
+        :param session: The database session to use for the operation.
+        :param method: The function method to paginate.
+        :param auth_info: The authentication information of the user making the request.
+        :param token: The pagination token.
+        :param page: The page number to retrieve.
+        :param page_size: The number of items per page.
+        :param method_kwargs: The keyword arguments to pass to the method.
+        :return: A tuple containing the pagination token, page number, page size, method, and method keyword arguments.
+        """
+        pagination_cache_record = None
         if token:
             self._logger.debug(
                 "Token provided, updating pagination cache record", token=token
             )
             pagination_cache_record = (
-                self._pagination_cache.get_pagination_cache_record(session, key=token)
+                self._pagination_cache.get_pagination_cache_record(
+                    session, key=token, for_update=True
+                )
             )
             if pagination_cache_record is None:
                 raise mlrun.errors.MLRunPaginationEndOfResultsError(
@@ -272,6 +290,7 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             current_page=page,
             page_size=page_size,
             kwargs=kwargs_schema.json(exclude_none=True),
+            pagination_cache_record=pagination_cache_record,
         )
         return token, page, page_size, method, kwargs_schema.dict(exclude_none=True)
 

--- a/server/py/framework/utils/pagination_cache.py
+++ b/server/py/framework/utils/pagination_cache.py
@@ -113,7 +113,22 @@ class PaginationCache(metaclass=mlrun.utils.singleton.Singleton):
         all_records_query = db.list_paginated_query_cache_record(session, as_query=True)
         table_size = all_records_query.count()
         if table_size > table_max_size:
-            records = all_records_query.limit(table_size - table_max_size)
-            for record in records:
-                session.delete(record)
+            # Create a subquery to get the keys of the oldest records to delete
+            # This executes as a single SQL DELETE with subquery, no Python iteration needed
+            oldest_records_subquery = (
+                db.list_paginated_query_cache_record(
+                    session,
+                    order_by=mlrun.common.schemas.OrderType.asc,
+                    as_query=True,
+                )
+                .with_entities(framework.db.sqldb.models.PaginationCache.key)
+                .limit(table_size - table_max_size)
+            )
+
+            # Delete records in a single SQL query using the subquery directly
+            session.query(framework.db.sqldb.models.PaginationCache).filter(
+                framework.db.sqldb.models.PaginationCache.key.in_(
+                    oldest_records_subquery
+                )
+            ).delete(synchronize_session=False)
             session.commit()

--- a/server/py/framework/utils/pagination_cache.py
+++ b/server/py/framework/utils/pagination_cache.py
@@ -21,6 +21,7 @@ import mlrun.common.schemas
 import mlrun.utils.singleton
 from mlrun import mlconf
 
+import framework.db.sqldb.models
 import framework.utils.singletons.db
 
 
@@ -33,16 +34,36 @@ class PaginationCache(metaclass=mlrun.utils.singleton.Singleton):
         current_page: int,
         page_size: int,
         kwargs: dict,
+        pagination_cache_record: typing.Optional[
+            framework.db.sqldb.models.PaginationCache
+        ] = None,
     ):
         db = framework.utils.singletons.db.get_db()
         return db.store_paginated_query_cache_record(
-            session, user, method.__name__, current_page, page_size, kwargs
+            session,
+            user,
+            method.__name__,
+            current_page,
+            page_size,
+            kwargs,
+            pagination_cache_record,
         )
 
     @staticmethod
-    def get_pagination_cache_record(session: sqlalchemy.orm.Session, key: str):
+    def get_pagination_cache_record(
+        session: sqlalchemy.orm.Session,
+        key: str,
+        for_update: bool = False,
+    ) -> typing.Optional[framework.db.sqldb.models.PaginationCache]:
+        """
+        Retrieve a pagination cache record by its key.
+        :param session: The database session to use for the operation.
+        :param key: The unique key of the pagination cache record.
+        :param for_update: Whether to lock the record for update.
+        :return: The pagination cache record if found, else None.
+        """
         db = framework.utils.singletons.db.get_db()
-        return db.get_paginated_query_cache_record(session, key)
+        return db.get_paginated_query_cache_record(session, key, for_update)
 
     @staticmethod
     def list_pagination_cache_records(

--- a/server/py/services/api/tests/unit/api/utils.py
+++ b/server/py/services/api/tests/unit/api/utils.py
@@ -88,7 +88,9 @@ def assert_pagination_info(
     entity_name: str,
     entity_identifier_name: str,
 ):
-    assert response.status_code == HTTPStatus.OK.value
+    assert (
+        response.status_code == HTTPStatus.OK.value
+    ), f"Unexpected status code: {response.status_code}, response: {response.text}"
 
     pagination = response.json().get("pagination")
     assert (

--- a/server/py/services/api/tests/unit/crud/test_pagination_cache.py
+++ b/server/py/services/api/tests/unit/crud/test_pagination_cache.py
@@ -31,7 +31,7 @@ def test_pagination_cache_monitor_ttl(db: sqlalchemy.orm.Session):
     Create paginated cache records with last_accessed time older than cache TTL, and check that they are removed
     when calling monitor_pagination_cache
     """
-    ttl = 5
+    ttl = 0.1
     mlconf.httpdb.pagination.pagination_cache.ttl = ttl
 
     method = services.api.crud.Projects().list_projects
@@ -57,7 +57,9 @@ def test_pagination_cache_monitor_ttl(db: sqlalchemy.orm.Session):
     logger.debug(
         "Sleeping for cache TTL so that records will be removed in the monitor"
     )
-    time.sleep(ttl + 2)
+
+    # a minimum of 1.1 is required because `monitor_pagination_cache` adds 1 second buffer to the TTL check
+    time.sleep(ttl + 1.1)
 
     logger.debug("Creating new paginated cache record that won't be expired")
     new_key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(

--- a/server/py/services/api/tests/unit/crud/test_pagination_cache.py
+++ b/server/py/services/api/tests/unit/crud/test_pagination_cache.py
@@ -196,6 +196,290 @@ def test_pagination_cleanup(db: sqlalchemy.orm.Session):
     )
 
 
+def test_pagination_cache_monitor_max_table_size_multiple_deletions(
+    db: sqlalchemy.orm.Session,
+):
+    """
+    Test that when table size exceeds max_size by multiple records, the subquery correctly
+    deletes the oldest records (ordered by last_accessed ascending) in a single operation.
+    """
+    max_size = 5
+    mlconf.httpdb.pagination.pagination_cache.max_size = max_size
+    mlconf.httpdb.pagination.pagination_cache.ttl = (
+        3600  # Set high TTL to avoid TTL-based deletion
+    )
+
+    method = services.api.crud.Projects().list_projects
+    page = 1
+    page_size = 10
+    kwargs = {}
+
+    # Create 8 records (3 more than max_size)
+    # We'll create them with small delays to ensure different last_accessed times
+    logger.debug("Creating multiple paginated cache records with time differences")
+    keys = []
+    for i in range(8):
+        key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+            db, f"user{i}", method, page, page_size, kwargs
+        )
+        keys.append(key)
+        if i < 7:  # Don't sleep after the last one
+            time.sleep(0.1)  # Small delay to ensure different timestamps
+
+    assert (
+        len(
+            framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+                db
+            )
+        )
+        == 8
+    )
+
+    # sanity, ensure keys are all unique
+    assert len(keys) == len(set(keys))
+
+    logger.debug("Monitoring pagination cache - should remove 3 oldest records")
+    framework.utils.pagination_cache.PaginationCache().monitor_pagination_cache(db)
+
+    # Should have exactly max_size records remaining
+    remaining_records = framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+        db
+    )
+    assert len(remaining_records) == max_size
+
+    # The 3 oldest records (first 3 created) should be deleted
+    # The 5 newest records (last 5 created) should remain
+    for i in range(3):  # First 3 should be deleted
+        assert (
+            framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+                db, keys[i]
+            )
+            is None
+        )
+
+    for i in range(3, 8):  # Last 5 should remain
+        assert (
+            framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+                db, keys[i]
+            )
+            is not None
+        )
+
+
+def test_pagination_cache_monitor_max_table_size_exact_match(
+    db: sqlalchemy.orm.Session,
+):
+    """
+    Test that when table_size exactly equals max_size, no records are deleted.
+    """
+    max_size = 5
+    mlconf.httpdb.pagination.pagination_cache.max_size = max_size
+    mlconf.httpdb.pagination.pagination_cache.ttl = (
+        3600  # Set high TTL to avoid TTL-based deletion
+    )
+
+    method = services.api.crud.Projects().list_projects
+    page = 1
+    page_size = 10
+    kwargs = {}
+
+    logger.debug("Creating exactly max_size records")
+    keys = []
+    for i in range(max_size):
+        key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+            db, f"user{i}", method, page, page_size, kwargs
+        )
+        keys.append(key)
+
+    assert (
+        len(
+            framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+                db
+            )
+        )
+        == max_size
+    )
+
+    logger.debug("Monitoring pagination cache - should not delete any records")
+    framework.utils.pagination_cache.PaginationCache().monitor_pagination_cache(db)
+
+    # All records should still exist
+    assert (
+        len(
+            framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+                db
+            )
+        )
+        == max_size
+    )
+
+    for key in keys:
+        assert (
+            framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+                db, key
+            )
+            is not None
+        )
+
+
+def test_pagination_cache_monitor_max_table_size_large_excess(
+    db: sqlalchemy.orm.Session,
+):
+    """
+    Test that when table_size significantly exceeds max_size, the subquery correctly
+    deletes all excess records in a single operation.
+    """
+    max_size = 3
+    total_records = 10  # 7 records to delete
+    mlconf.httpdb.pagination.pagination_cache.max_size = max_size
+    mlconf.httpdb.pagination.pagination_cache.ttl = (
+        3600  # Set high TTL to avoid TTL-based deletion
+    )
+
+    method = services.api.crud.Projects().list_projects
+    page = 1
+    page_size = 10
+    kwargs = {}
+
+    logger.debug(f"Creating {total_records} records (max_size is {max_size})")
+    keys = []
+    for i in range(total_records):
+        key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+            db, f"user{i}", method, page, page_size, kwargs
+        )
+        keys.append(key)
+        if i < total_records - 1:
+            time.sleep(0.05)  # Small delay to ensure different timestamps
+
+    assert (
+        len(
+            framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+                db
+            )
+        )
+        == total_records
+    )
+
+    logger.debug(
+        f"Monitoring pagination cache - should remove {total_records - max_size} oldest records"
+    )
+    framework.utils.pagination_cache.PaginationCache().monitor_pagination_cache(db)
+
+    # Should have exactly max_size records remaining
+    remaining_records = framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+        db
+    )
+    assert len(remaining_records) == max_size
+
+    # The oldest records (first total_records - max_size) should be deleted
+    # The newest records (last max_size) should remain
+    deleted_count = total_records - max_size
+    for i in range(deleted_count):
+        assert (
+            framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+                db, keys[i]
+            )
+            is None
+        )
+
+    for i in range(deleted_count, total_records):
+        assert (
+            framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+                db, keys[i]
+            )
+            is not None
+        )
+
+
+def test_pagination_cache_monitor_ttl_and_max_size_combined(
+    db: sqlalchemy.orm.Session,
+):
+    """
+    Test that monitor_pagination_cache correctly handles both TTL-based deletion
+    and max_size-based deletion in a single call.
+    """
+    ttl = 0.1
+    max_size = 5
+    mlconf.httpdb.pagination.pagination_cache.ttl = ttl
+    mlconf.httpdb.pagination.pagination_cache.max_size = max_size
+
+    method = services.api.crud.Projects().list_projects
+    page = 1
+    page_size = 10
+    kwargs = {}
+
+    logger.debug("Creating old records that will expire by TTL")
+    old_keys = []
+    for i in range(3):
+        key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+            db, f"old_user{i}", method, page, page_size, kwargs
+        )
+        old_keys.append(key)
+
+    # Wait for TTL to expire
+    time.sleep(ttl + 1.1)
+
+    logger.debug("Creating new records that exceed max_size")
+    new_keys = []
+    for i in range(max_size + 2):  # Create 2 more than max_size
+        key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+            db, f"new_user{i}", method, page, page_size, kwargs
+        )
+        new_keys.append(key)
+        if i < max_size + 1:
+            time.sleep(0.1)  # Small delay to ensure different timestamps
+
+    total_before = len(
+        framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+            db
+        )
+    )
+    assert total_before == 3 + max_size + 2  # old + new records
+
+    logger.debug(
+        "Monitoring pagination cache - should remove TTL-expired and oldest new records"
+    )
+    framework.utils.pagination_cache.PaginationCache().monitor_pagination_cache(db)
+
+    # Old records (expired by TTL) should be deleted
+    for old_key in old_keys:
+        assert (
+            framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+                db, old_key
+            )
+            is None
+        )
+
+    # Should have exactly max_size new records remaining (oldest 2 new records deleted)
+    remaining_records = framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+        db
+    )
+    assert len(remaining_records) == max_size
+
+    # The 2 oldest new records should be deleted
+    assert (
+        framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+            db, new_keys[0]
+        )
+        is None
+    )
+    assert (
+        framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+            db, new_keys[1]
+        )
+        is None
+    )
+
+    # The newest max_size records should remain
+    for i in range(2, len(new_keys)):
+        assert (
+            framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+                db, new_keys[i]
+            )
+            is not None
+        )
+
+
 @pytest.mark.parametrize(
     "page, page_size",
     [

--- a/server/py/services/api/tests/unit/utils/test_pagination.py
+++ b/server/py/services/api/tests/unit/utils/test_pagination.py
@@ -317,6 +317,7 @@ async def test_paginate_no_auth(
 
     paginator = framework.utils.pagination.Paginator()
 
+    # no-user request
     logger.info("Requesting first page")
     response, pagination_info = await paginator.paginate_request(
         db, paginated_method, None, None, 1, page_size, **method_kwargs
@@ -337,39 +338,49 @@ async def test_paginate_no_auth(
         )
     )
     _assert_cache_record(cache_record, None, paginated_method, 1, page_size)
+    no_auth_user_token = pagination_info.page_token
 
-    logger.info("Requesting second page with auth info of some user")
+    logger.info(
+        "Requesting second page with auth info of some user, token from no-auth request"
+    )
     auth_info = mlrun.common.schemas.AuthInfo(user_id="any-user")
-    # save token as it will be overridden with None on the last page
-    old_token = pagination_info.page_token
+
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        # user cannot access a token that was created without auth info
+        await paginator.paginate_request(
+            db,
+            paginated_method,
+            auth_info,
+            no_auth_user_token,
+        )
+
+    logger.info("Requesting first page with auth info of some user")
     response, pagination_info = await paginator.paginate_request(
-        db, paginated_method, auth_info, pagination_info.page_token
+        db, paginated_method, auth_info, None, 1, page_size, **method_kwargs
     )
     _assert_paginated_response(
         response,
         pagination_info,
-        2,
+        1,
         page_size,
-        ["item3", "item4"],
+        ["item0", "item1", "item2"],
         method_kwargs["since"],
-        last_page=True,
+        last_page=False,
     )
 
     logger.info("Checking old db cache record")
     cache_record = (
         framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
-            db, old_token
+            db, no_auth_user_token
         )
     )
     # The request with AuthInfo creates a new cache record, therefore the old one
     # should still be on page 1 and without a user.
-    # The new one should be on page 2 and with the user, however, since it's on the last page,
-    # we don't get a token back to check.
     _assert_cache_record(cache_record, None, paginated_method, 1, page_size)
 
     logger.info("Requesting second page without auth info")
     response, pagination_info = await paginator.paginate_request(
-        db, paginated_method, None, old_token
+        db, paginated_method, None, no_auth_user_token
     )
     _assert_paginated_response(
         response,
@@ -384,7 +395,7 @@ async def test_paginate_no_auth(
     logger.info("Checking old db cache record again")
     cache_record = (
         framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
-            db, old_token
+            db, no_auth_user_token
         )
     )
     _assert_cache_record(cache_record, None, paginated_method, 2, page_size)
@@ -789,16 +800,26 @@ def _assert_paginated_response(
     since,
     last_page=False,
 ):
-    assert len(response) == len(expected_items)
+    assert len(response) == len(
+        expected_items
+    ), f"Expected {len(expected_items)} items, got {len(response)}"
     for i, item in enumerate(expected_items):
-        assert response[i]["name"] == item
-        assert response[i]["since"] == since
+        assert (
+            response[i]["name"] == item
+        ), f"Expected item name {item}, got {response[i]['name']}"
+        assert (
+            response[i]["since"] == since
+        ), f"Expected since {since}, got {response[i]['since']}"
     if not last_page:
         assert pagination_info.page_token is not None
     else:
         assert pagination_info.page_token is None
-    assert pagination_info.page == page
-    assert pagination_info.page_size == page_size
+    assert (
+        pagination_info.page == page
+    ), f"Expected page {page}, got {pagination_info.page}"
+    assert (
+        pagination_info.page_size == page_size
+    ), f"Expected page size {page_size}, got {pagination_info.page_size}"
 
 
 def _assert_cache_record(
@@ -808,8 +829,14 @@ def _assert_cache_record(
     current_page: int,
     page_size: int,
 ):
-    assert cache_record is not None
-    assert cache_record.user == user
-    assert cache_record.function == method.__name__
-    assert cache_record.current_page == current_page
-    assert cache_record.page_size == page_size
+    assert cache_record is not None, "Cache record should not be None"
+    assert cache_record.user == user, f"Expected user {user}, got {cache_record.user}"
+    assert (
+        cache_record.function == method.__name__
+    ), f"Expected function {method.__name__}, got {cache_record.function}"
+    assert (
+        cache_record.current_page == current_page
+    ), f"Expected current page {current_page}, got {cache_record.current_page}"
+    assert (
+        cache_record.page_size == page_size
+    ), f"Expected page size {page_size}, got {cache_record.page_size}"

--- a/server/py/services/api/tests/unit/utils/test_pagination.py
+++ b/server/py/services/api/tests/unit/utils/test_pagination.py
@@ -25,6 +25,7 @@ from mlrun.utils import logger
 import framework.db.sqldb.models
 import framework.utils.pagination
 import framework.utils.pagination_cache
+import framework.utils.singletons.db
 
 
 def paginated_method(
@@ -44,13 +45,6 @@ def paginated_method(
 
 @pytest.fixture()
 def mock_paginated_method(monkeypatch):
-    class Schema:
-        def __init__(self, **kwargs):
-            self._dict = kwargs
-
-        def dict(self):
-            return self._dict
-
     monkeypatch.setattr(
         framework.utils.pagination.PaginatedMethods,
         "_method_map",
@@ -243,6 +237,70 @@ async def test_paginate_other_users_token(
 
 
 @pytest.mark.asyncio
+async def test_paginate_call_get_token_once(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+    monkeypatch,
+):
+    """
+    Test that the paginate_request calls get_paginated_query_cache_record only once per request.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
+    page_size = 3
+    method_kwargs = {"total_amount": 5, "since": datetime.datetime.now()}
+
+    # Get the DB instance to mock its method
+    db_instance = framework.utils.singletons.db.get_db()
+    original_get_paginated_query_cache_record = (
+        db_instance.get_paginated_query_cache_record
+    )
+    call_count = 0
+
+    def mocked_get_paginated_query_cache_record(session, key, for_update=False):
+        nonlocal call_count
+        call_count += 1
+        return original_get_paginated_query_cache_record(session, key, for_update)
+
+    # Patch the DB instance's method to track calls
+    monkeypatch.setattr(
+        db_instance,
+        "get_paginated_query_cache_record",
+        mocked_get_paginated_query_cache_record,
+    )
+
+    paginator = framework.utils.pagination.Paginator()
+
+    logger.info("Requesting first page")
+    # First request with token=None calls get_paginated_query_cache_record once
+    # when creating/checking the pagination cache record
+    response, pagination_info = await paginator.paginate_request(
+        db, paginated_method, auth_info, None, 1, page_size, **method_kwargs
+    )
+    assert (
+        call_count == 1
+    ), "First request with token=None should call get_paginated_query_cache_record once when creating cache record"
+
+    logger.info("Requesting second page")
+    # Second request with token should call get_paginated_query_cache_record once more
+    await paginator.paginate_request(
+        db, paginated_method, auth_info, pagination_info.page_token
+    )
+    assert (
+        call_count == 2
+    ), "Second request with token should call get_paginated_query_cache_record once"
+
+    logger.info("Requesting third page")
+    # Third request with token should call get_paginated_query_cache_record once more
+    await paginator.paginate_request(
+        db, paginated_method, auth_info, pagination_info.page_token
+    )
+    assert (
+        call_count == 3
+    ), "Third request with token should call get_paginated_query_cache_record once more"
+
+
+@pytest.mark.asyncio
 async def test_paginate_no_auth(
     mock_paginated_method,
     cleanup_pagination_cache_on_teardown,
@@ -390,7 +448,7 @@ async def test_pagination_not_supported(
     with pytest.raises(NotImplementedError):
         await paginator.paginate_request(
             db,
-            lambda: paginated_method(5, 1, 3),
+            lambda: None,
             auth_info,
             token=None,
             page=1,


### PR DESCRIPTION
### 📝 Description

When two users are trying to create same token it might be that they will fail on db conflict since record was just created by another user.

---

### 🛠️ Changes Made

- Used `for_update` notion to ensure GET/UPDATE operation locked for its critical path for ensuring pagination token.
- Reduce DB calls from 2 to 1 when updating existing tokens
- Improved UT coverage
- 
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

UT coverage and sanity for pagination

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11468
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
