### PR TITLE
[Model Monitoring] Add timestamp_column parameter to TimescaleDB _get_records()

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
@@ -158,6 +158,7 @@ class TimescaleDBMetricsQueries:
         start: datetime,
         end: datetime,
         metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]] = None,
+        timestamp_column: Optional[str] = None,
     ) -> pd.DataFrame:
         """Read metrics data from TimescaleDB (metrics table only) - returns DataFrame.
 
@@ -165,6 +166,7 @@ class TimescaleDBMetricsQueries:
         :param start: Start time
         :param end: End time
         :param metrics: List of metrics to filter by, or None to get all metrics
+        :param timestamp_column: Optional timestamp column to use for time filtering
         :return: DataFrame with metrics data
         """
 
@@ -200,6 +202,7 @@ class TimescaleDBMetricsQueries:
             name_column=name_column,
             value_column=value_column,
             debug_name="read_metrics_data",
+            timestamp_column=timestamp_column,
         )
 
         if not df.empty:

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
@@ -74,6 +74,7 @@ class TimescaleDBPredictionsQueries:
         agg_funcs: Optional[list[str]] = None,
         limit: Optional[int] = None,
         use_pre_aggregates: bool = True,
+        timestamp_column: Optional[str] = None,
     ) -> pd.DataFrame:
         """Read predictions data from TimescaleDB (predictions table) - returns DataFrame.
 
@@ -85,6 +86,7 @@ class TimescaleDBPredictionsQueries:
         :param agg_funcs: Optional list of aggregation functions (e.g., ["avg", "max"])
         :param limit: Optional limit on number of results
         :param use_pre_aggregates: Whether to use pre-aggregates if available
+        :param timestamp_column: Optional timestamp column to use for time filtering
         :return: DataFrame with predictions data
         """
         if (agg_funcs and not aggregation_window) or (
@@ -119,6 +121,7 @@ class TimescaleDBPredictionsQueries:
             agg_funcs=agg_funcs if can_use_pre_aggregates else None,
             limit=limit,
             use_pre_aggregates=can_use_pre_aggregates,
+            timestamp_column=timestamp_column,
         )
 
         result = self._connection.run(query=query)

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -529,6 +529,7 @@ class TimescaleDBResultsQueries:
         end: datetime,
         metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]] = None,
         with_result_extra_data: bool = False,
+        timestamp_column: Optional[str] = None,
     ) -> pd.DataFrame:
         """Read results data from TimescaleDB (app_results table only) - returns DataFrame.
 
@@ -537,6 +538,7 @@ class TimescaleDBResultsQueries:
         :param end: End time
         :param metrics: List of metrics to filter by, or None to get all results
         :param with_result_extra_data: Whether to include extra data column
+        :param timestamp_column: Optional timestamp column to use for time filtering
         :return: DataFrame with results data
         """
 
@@ -575,6 +577,7 @@ class TimescaleDBResultsQueries:
             name_column=name_column,
             value_column=value_column,
             debug_name="read_results_data",
+            timestamp_column=timestamp_column,
         )
 
         if not df.empty:

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -296,6 +296,7 @@ class TimescaleDBConnector(TSDBConnector):
         end: datetime.datetime,
         endpoint_id: Optional[str] = None,
         columns: Optional[list[str]] = None,
+        timestamp_column: Optional[str] = None,
     ) -> pd.DataFrame:
         """
         Get raw records from TimescaleDB as pandas DataFrame.
@@ -307,6 +308,7 @@ class TimescaleDBConnector(TSDBConnector):
         :param end: End time for the query
         :param endpoint_id: Optional endpoint ID filter (None = all endpoints)
         :param columns: Optional list of specific columns to return (None = all columns)
+        :param timestamp_column: Optional timestamp column to use for time filtering (None = use table's default)
         :return: Raw pandas DataFrame with all matching records
         """
         if table == mm_schemas.TimescaleDBTables.METRICS:
@@ -315,6 +317,7 @@ class TimescaleDBConnector(TSDBConnector):
                 start=start,
                 end=end,
                 metrics=None,  # Get all metrics
+                timestamp_column=timestamp_column,
             )
         elif table == mm_schemas.TimescaleDBTables.APP_RESULTS:
             df = self._results_queries.read_results_data_impl(
@@ -323,6 +326,7 @@ class TimescaleDBConnector(TSDBConnector):
                 end=end,
                 metrics=None,  # Get all results
                 with_result_extra_data=True,
+                timestamp_column=timestamp_column,
             )
         elif table == mm_schemas.TimescaleDBTables.PREDICTIONS:
             df = self._predictions_queries.read_predictions_impl(
@@ -330,6 +334,7 @@ class TimescaleDBConnector(TSDBConnector):
                 start=start,
                 end=end,
                 columns=columns,
+                timestamp_column=timestamp_column,
             )
         else:
             raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_schema.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_schema.py
@@ -283,12 +283,17 @@ class TimescaleDBSchema:
         desc: Optional[bool] = None,
         use_pre_aggregates: bool = True,
         group_by: Optional[list[str]] = None,
+        timestamp_column: Optional[str] = None,
     ) -> str:
-        """Build query to get records from the table or its pre-aggregates."""
+        """Build query to get records from the table or its pre-aggregates.
+
+        :param timestamp_column: Optional timestamp column to use for time filtering.
+                                If not provided, uses the table's default time_column.
+        """
 
         # Determine table to query
         table_name = self.table_name
-        time_col = self.time_column
+        time_col = timestamp_column or self.time_column
 
         if interval and agg_funcs and use_pre_aggregates:
             # Use continuous aggregate if available
@@ -302,9 +307,10 @@ class TimescaleDBSchema:
                 if interval and agg_funcs and use_pre_aggregates:
                     # For pre-aggregates, use column names as-is since they should already be
                     # the correct names from the continuous aggregate view
+                    source_time_col = timestamp_column or self.time_column
                     modified_columns = []
                     for col in columns_to_filter:
-                        if col == self.time_column:
+                        if col == source_time_col:
                             modified_columns.append(TIME_BUCKET_COLUMN)
                         else:
                             # Use column name as-is - caller should provide correct pre-agg column names

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_schema.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_schema.py
@@ -18,6 +18,7 @@ from io import StringIO
 from typing import Optional
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
+import mlrun.errors
 from mlrun.model_monitoring.db.tsdb.preaggregate import PreAggregateConfig
 from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_query_builder import (
     TimescaleDBNaming,
@@ -285,17 +286,18 @@ class TimescaleDBSchema:
         group_by: Optional[list[str]] = None,
         timestamp_column: Optional[str] = None,
     ) -> str:
-        """Build query to get records from the table or its pre-aggregates.
-
-        :param timestamp_column: Optional timestamp column to use for time filtering.
-                                If not provided, uses the table's default time_column.
-        """
+        """Build query to get records from the table or its pre-aggregates."""
 
         # Determine table to query
         table_name = self.table_name
         time_col = timestamp_column or self.time_column
 
         if interval and agg_funcs and use_pre_aggregates:
+            if timestamp_column and timestamp_column != self.time_column:
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Cannot use custom timestamp_column='{timestamp_column}' with pre-aggregates. "
+                    "Pre-aggregates are built on the table's default time column."
+                )
             # Use continuous aggregate if available
             table_name = TimescaleDBNaming.get_cagg_view_name(self.table_name, interval)
             time_col = TIME_BUCKET_COLUMN
@@ -305,12 +307,9 @@ class TimescaleDBSchema:
 
             if columns_to_filter:
                 if interval and agg_funcs and use_pre_aggregates:
-                    # For pre-aggregates, use column names as-is since they should already be
-                    # the correct names from the continuous aggregate view
-                    source_time_col = timestamp_column or self.time_column
                     modified_columns = []
                     for col in columns_to_filter:
-                        if col == source_time_col:
+                        if col == time_col:
                             modified_columns.append(TIME_BUCKET_COLUMN)
                         else:
                             # Use column name as-is - caller should provide correct pre-agg column names

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
@@ -322,6 +322,7 @@ class TimescaleDBQueryBuilder:
         name_column: str,
         value_column: str,
         debug_name: str = "read_data",
+        timestamp_column: Optional[str] = None,
     ) -> "pd.DataFrame":  # Use string to avoid import cycle
         """
         Build and execute read data query with pre-aggregate fallback pattern.
@@ -339,6 +340,7 @@ class TimescaleDBQueryBuilder:
         :param name_column: Name of the metric/result name column
         :param value_column: Name of the metric/result value column
         :param debug_name: Name for debugging purposes
+        :param timestamp_column: Optional timestamp column to use for time filtering
         :return: DataFrame with query results
         """
 
@@ -349,6 +351,7 @@ class TimescaleDBQueryBuilder:
                 columns_to_filter=columns,
                 filter_query=filter_query,
                 use_pre_aggregates=True,
+                timestamp_column=timestamp_column,
             )
 
         def build_raw_query():
@@ -357,6 +360,7 @@ class TimescaleDBQueryBuilder:
                 end=end,
                 columns_to_filter=columns,
                 filter_query=filter_query,
+                timestamp_column=timestamp_column,
             )
 
         # Column mapping rules for pre-aggregate results

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_get_records.py
@@ -278,3 +278,53 @@ class TestGetRecords:
         assert mm_schemas.WriterEvent.ENDPOINT_ID not in df.columns
         # Verify other unrequested columns are also NOT included
         assert mm_schemas.WriterEvent.APPLICATION_NAME not in df.columns
+
+    def test_get_records_with_custom_timestamp_column(
+        self, connector, query_test_helper
+    ):
+        """Test _get_records() with custom timestamp_column parameter.
+
+        Verifies that timestamp_column parameter correctly controls which
+        timestamp column is used for time range filtering in WHERE clause.
+        """
+        # Insert test data with different start and end times
+        start_time = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+        end_time = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+        test_data = {
+            mm_schemas.WriterEvent.START_INFER_TIME: start_time,
+            mm_schemas.WriterEvent.END_INFER_TIME: end_time,
+            mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint-1",
+            mm_schemas.WriterEvent.APPLICATION_NAME: "app1",
+            mm_schemas.MetricData.METRIC_NAME: "accuracy",
+            mm_schemas.MetricData.METRIC_VALUE: 0.95,
+        }
+
+        query_test_helper.write_application_event(
+            test_data, mm_schemas.WriterEventKind.METRIC
+        )
+
+        # Test 1: Query using start_infer_time (should find the record)
+        df_start = connector._get_records(
+            table=mm_schemas.TimescaleDBTables.METRICS,
+            start=datetime(2024, 1, 15, 9, 0, 0, tzinfo=UTC),
+            end=datetime(2024, 1, 15, 11, 0, 0, tzinfo=UTC),
+            endpoint_id="endpoint-1",
+            timestamp_column=mm_schemas.WriterEvent.START_INFER_TIME,
+        )
+
+        # Should find the record because start_infer_time (10:00) is within range
+        assert len(df_start) == 1
+        assert df_start[mm_schemas.MetricData.METRIC_NAME].iloc[0] == "accuracy"
+
+        # Test 2: Query using end_infer_time (should NOT find the record)
+        df_end = connector._get_records(
+            table=mm_schemas.TimescaleDBTables.METRICS,
+            start=datetime(2024, 1, 15, 9, 0, 0, tzinfo=UTC),
+            end=datetime(2024, 1, 15, 11, 0, 0, tzinfo=UTC),
+            endpoint_id="endpoint-1",
+            timestamp_column=mm_schemas.WriterEvent.END_INFER_TIME,
+        )
+
+        # Should NOT find the record because end_infer_time (12:00) is outside range
+        assert len(df_end) == 0


### PR DESCRIPTION
## Summary

Add `timestamp_column` parameter to TimescaleDB `_get_records()` method to allow flexible time filtering. The parameter specifies which timestamp column to use in the WHERE clause for time range filtering.

## Changes

- Add `timestamp_column` parameter throughout query chain (connector -> queries -> builder -> schema)
- Default to `None` to use each table's default time column
- Update WHERE clause logic in `_get_records_query()` to use custom or default timestamp column
- Add comprehensive test to verify functionality with custom timestamp columns

## Use Case

Enables filtering by one timestamp while sorting by another:

```python
df = connector._get_records(
    table="app_results",
    start=datetime.min,
    end=datetime.now(),
    timestamp_column="start_infer_time"  # Filter using this column
).sort_values(by="end_infer_time")       # Sort using different column
```

## Reference

ML-11516
