### PR TITLE
[Tests] Use unique project name in alerts system tests

### DIFF
--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -41,7 +41,11 @@ from tests.system.model_monitoring import TestMLRunSystemModelMonitoring
 
 @TestMLRunSystem.skip_test_if_env_not_configured
 class TestAlerts(TestMLRunSystem):
-    project_name = "alerts-test-project"
+    def setup_method(self, method):
+        # unique per-test project name
+        unique_suffix = method.__name__.replace("_", "-")
+        self.project_name = f"alert-{unique_suffix}"
+        super().setup_method(method)
 
     # Set image to "<repo>/mlrun:<tag>" for local testing
     image: typing.Optional[str] = None
@@ -243,7 +247,7 @@ class TestAlerts(TestMLRunSystem):
             expected_endpoint_alerts_count=4,
         )
 
-    def test_job_failure_alert_sliding_window(self):
+    def test_sliding_window_alert(self):
         """
 
         This test simulates a scenario where a job is expected to fail twice within a two-minute window,

--- a/tests/system/common/helpers/notifications.py
+++ b/tests/system/common/helpers/notifications.py
@@ -27,7 +27,7 @@ def deploy_notification_nuclio(
     project: mlrun.projects.MlrunProject, image: typing.Optional[str] = None
 ) -> str:
     nuclio_function = project.set_function(
-        name="notification-nuclio-function",
+        name="alert-notify",
         func=str(assets_path / "notification_nuclio_function.py"),
         image="mlrun/mlrun" if image is None else image,
         kind="nuclio",


### PR DESCRIPTION
### 📝 Description
This PR fixes an alert system test failure by ensuring each test uses a unique project name. 
The previous failures were caused by incomplete tear down in earlier test, which prevented the project from being deleted.

---

### 🛠️ Changes Made
- Added per-test unique project names in TestAlerts suite.
- Shortened the failing test name to `test_sliding_window_alert`.
- Renamed the Nuclio function to `alert-notify` to comply with Kubernetes naming limits.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11528
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
