### PR TITLE
[Model Monitoring] Fix function name normalization in the function summary API

### DIFF
--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1158,14 +1158,15 @@ class MonitoringDeployment:
         )
         # Iterate over each function and get the stream stats
         for function in function_summaries:
+            normalized_function_name = mlrun.utils.normalize_name(function.name)
             topic = mlrun.common.model_monitoring.helpers.get_kafka_topic(
-                project=self.project, function_name=function.name
+                project=self.project, function_name=normalized_function_name
             )
             try:
                 partitions = consumer.partitions_for_topic(topic)
                 if not partitions:
                     logger.warning(
-                        f"No partitions found for topic {topic} in function {function.name}"
+                        f"No partitions found for topic {topic} in function {normalized_function_name}"
                     )
                     continue
 
@@ -1202,7 +1203,7 @@ class MonitoringDeployment:
                 logger.warning(
                     "Failed to get topic stats",
                     project=self.project,
-                    function_name=function.name,
+                    function_name=normalized_function_name,
                     topic=topic,
                     error_message=mlrun.errors.err_to_str(exc),
                 )

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1103,9 +1103,11 @@ class MonitoringDeployment:
             self.auth_info
         ) as client:
             for function in function_summaries:
+                normalized_function_name = mlrun.utils.normalize_name(function.name)
+
                 stream_path = mlrun.model_monitoring.get_stream_path(
                     project=self.project,
-                    function_name=function.name,
+                    function_name=normalized_function_name,
                     secret_provider=self._secret_provider,
                     profile=self.__stream_profile,
                 )
@@ -1118,7 +1120,7 @@ class MonitoringDeployment:
 
                 stream_stats = await client.get_v3io_shard_lags(
                     project_name=self.project,
-                    function_name=function.name,
+                    function_name=normalized_function_name,
                     stream_path=stream_path,
                     container_name=container,
                 )
@@ -1227,8 +1229,9 @@ class MonitoringDeployment:
             logger.info("No model monitoring applications found")
             return []
         if names:
-            # generate a list of lowercase names for filtering
-            lower_names = [name.lower() for name in names]
+            # generate a list of normalized lowercase names for filtering
+            lower_names = [mlrun.utils.normalize_name(name.lower()) for name in names]
+
             mm_functions_list = [
                 fn for fn in mm_functions_list if fn["metadata"]["name"] in lower_names
             ]


### PR DESCRIPTION
### 📝 Description
Fix an issue where providing a non-normalized function name caused errors in both the nuclio `get_shard_lags` API and when fetching a specific function summary. The fix ensures the function name is normalized before processing.

---

### 🛠️ Changes Made
- Normalize function name before calling `get_shard_lags` nuclio API
- Normalize function name when calling get monitoring function summary API with function name/names

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- No new tests were added because once https://iguazio.atlassian.net/browse/ML-11414 is implemented (next release), clients won't be able to define function that does not match the expected normalized format.  
- Verified with both v3io stream and kafka topic (also expects the normalized format)

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11530
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- We couldn't normalize the function.name of the FunctionSummary schema because it's important to keep the original name for listing the function artifacts

