### PR TITLE
[Setup] Python 3.11 alignment and cleanups

### DIFF
--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -54,11 +54,6 @@ class Constants:
         mlrun_kfp: mlrun_kfp,
         log_collector: log_collector,
     }
-    python_39_suffix = "-py39"
-    python_39_targets = [
-        mlrun,
-        mlrun_kfp,
-    ]
 
 
 class MLRunPatcher:
@@ -70,7 +65,6 @@ class MLRunPatcher:
         image_tag: str,
         patch_log_collector_image: bool,
         patch_mlrun_image: bool,
-        build_py39: bool,
         skip_patch_api: bool,
         patch_alerts: bool,
         no_build: bool,
@@ -85,7 +79,6 @@ class MLRunPatcher:
         self._patch_log_collector_image = bool(patch_log_collector_image)
         self._validate_config()
         self._patch_mlrun_image = patch_mlrun_image
-        self._build_py39 = build_py39
         self._skip_patch_api = skip_patch_api
         self._patch_alerts = patch_alerts
         self._no_build = no_build
@@ -328,26 +321,6 @@ class MLRunPatcher:
             cmd = ["make"]
             cmd.extend(targets)
             self._exec_local(cmd, live=True, env=env)
-            if self._build_py39:
-                python_39_targets_to_build = []
-                for python_39_target in Constants.python_39_targets:
-                    if python_39_target in targets:
-                        target_to_image[
-                            f"{python_39_target}`{Constants.python_39_suffix}"
-                        ] = (
-                            f"{mlrun_docker_registry}/{Constants.targets_to_image_name[python_39_target]}:"
-                            f"{image_tag}{Constants.python_39_suffix}"
-                        )
-                        python_39_targets_to_build.append(python_39_target)
-                self._exec_local(
-                    ["make", *python_39_targets_to_build],
-                    live=True,
-                    env={
-                        **env,
-                        "MLRUN_PYTHON_VERSION": "3.9",
-                        "INCLUDE_PYTHON_VERSION_SUFFIX": "true",
-                    },
-                )
 
         return target_to_image
 
@@ -684,12 +657,6 @@ class MLRunPatcher:
     help="Deploy the mlrun image",
 )
 @click.option(
-    "-39",
-    "--py39",
-    is_flag=True,
-    help="Build Python 3.9 MLRun image",
-)
-@click.option(
     "-sa",
     "--skip-api",
     is_flag=True,
@@ -726,7 +693,6 @@ def main(
     tag: str,
     log_collector: bool,
     mlrun: bool,
-    py39: bool,
     skip_api: bool,
     alerts: bool,
     no_build: bool,
@@ -743,7 +709,6 @@ def main(
         image_tag=tag,
         patch_log_collector_image=log_collector,
         patch_mlrun_image=mlrun,
-        build_py39=py39,
         skip_patch_api=skip_api,
         patch_alerts=alerts,
         no_build=no_build,

--- a/mlrun/common/types.py
+++ b/mlrun/common/types.py
@@ -14,18 +14,10 @@
 
 import enum
 
-
-# TODO: From python 3.11 StrEnum is built-in and this will not be needed
-class StrEnum(str, enum.Enum):
-    def __str__(self):
-        return self.value
-
-    def __repr__(self):
-        return self.value
+# Alias to Python's built-in StrEnum (Python 3.11+)
+StrEnum = enum.StrEnum
 
 
-# Partial backport from Python 3.11
-# https://docs.python.org/3/library/http.html#http.HTTPMethod
 class HTTPMethod(StrEnum):
     GET = "GET"
     POST = "POST"

--- a/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
@@ -92,8 +92,12 @@ class TDEngineSchema:
         self.database = database or _MODEL_MONITORING_DATABASE
 
     def _create_super_table_query(self) -> str:
-        columns = ", ".join(f"{col} {val}" for col, val in self.columns.items())
-        tags = ", ".join(f"{col} {val}" for col, val in self.tags.items())
+        columns = ", ".join(
+            f"{col} {getattr(val, 'value', val)}" for col, val in self.columns.items()
+        )
+        tags = ", ".join(
+            f"{col} {getattr(val, 'value', val)}" for col, val in self.tags.items()
+        )
         return f"CREATE STABLE if NOT EXISTS {self.database}.{self.super_table} ({columns}) TAGS ({tags});"
 
     def _create_subtable_sql(

--- a/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/schemas.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import enum
 from dataclasses import dataclass
 from io import StringIO
 from typing import Optional, Union
@@ -40,7 +41,7 @@ class _TDEngineColumnType:
             return self.data_type
 
 
-class _TDEngineColumn(mlrun.common.types.StrEnum):
+class _TDEngineColumn(enum.Enum):
     TIMESTAMP = _TDEngineColumnType("TIMESTAMP")
     FLOAT = _TDEngineColumnType("FLOAT")
     INT = _TDEngineColumnType("INT")

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlrun-pipelines-kfp-common"
 version = "0.5.9"
 description = "MLRun Pipelines adapter package for providing KFP common functionality"
 readme = "README.md"
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.11, <3.12"
 authors = [
   { name = "Yaron Haviv", email = "yaronh@iguazio.com" }
 ]

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-common"
-version = "0.5.9"
+version = "0.6.0"
 description = "MLRun Pipelines adapter package for providing KFP common functionality"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.5.9"
+version = "0.6.0"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlrun-pipelines-kfp-v1-8"
 version = "0.5.8"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.11, <3.12"
 authors = [
   { name = "Yaron Haviv", email = "yaronh@iguazio.com" }
 ]
@@ -17,8 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 kfp = [
-  "kfp~=1.8.22; python_version < '3.11'",
-  "kfp~=1.8.23; python_version >= '3.11'",
+  "kfp~=1.8.23",
 ]
 
 [build-system]

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.5.8"
+version = "0.5.9"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
@@ -3,7 +3,7 @@ name = "mlrun-pipelines-kfp-v2"
 version = "0.5.3"
 description = "MLRun Pipelines adapter package for providing KFP 2.* compatibility"
 readme = "README.md"
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.11, <3.12"
 authors = [
   { name = "Yaron Haviv", email = "yaronh@iguazio.com" }
 ]

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v2"
-version = "0.5.4"
+version = "0.6.0"
 description = "MLRun Pipelines adapter package for providing KFP 2.* compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v2"
-version = "0.5.3"
+version = "0.5.4"
 description = "MLRun Pipelines adapter package for providing KFP 2.* compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -268,8 +268,6 @@ class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
             mlrun_constants.MLRunInternalLabels.client_python_version
         )
         # TODO: Remove this when KFP 1 support is removed
-        # Until KFP 2 - The runner always runs with python 3.9 therefore we need to explicitly
-        # specify the user client python version
         if client_python_version:
             runner.set_env("MLRUN_PYTHON_VERSION", client_python_version)
             labels[mlrun_constants.MLRunInternalLabels.client_python_version] = (

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "machine-learning",
         "experiment-tracking",
     ],
-    python_requires=">=3.9, <3.12",
+    python_requires=">=3.11, <3.12",
     install_requires=dependencies.base_requirements(),
     extras_require=dependencies.extra_requirements(),
     classifiers=[
@@ -82,7 +82,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
### 📝 Description
This PR removes all remaining Python 3.9 support from the our codebase (following the PR: https://github.com/mlrun/mlrun/pull/8948 ).

---

### 🛠️ Changes Made
- Dropped Python 3.9 support by requiring Python 3.11+ in `setup.py` and removing the Python 3.9 classifier.
- Patch remote script: remove building and pushing of python 3.9 images.
- Pipelines-adapters: updated the python requires constraint from `>=3.9, <3.12` to `>=3.11, <3.12`
- Replaced the custom `StrEnum` with an alias to Python 3.11’s built-in `enum.StrEnum`
- Use Enum instead of StrEnum in `_TDEngineColumn` because the enum members hold _TDEngineColumnType objects not strings which StrEnum in Python 3.11 no longer accepts.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Verified locally that installing MLRun under Python 3.9 fails as expected:

<img width="2132" height="356" alt="image" src="https://github.com/user-attachments/assets/85886b88-d6d1-4086-a829-212bbfa649ca" />


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11421
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
