### PR TITLE
[Nuclio] Add batching support to with_http

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -120,7 +120,12 @@ from .frontend_spec import (
     PreemptionNodesFeatureFlag,
     ProjectMembershipFeatureFlag,
 )
-from .function import FunctionState, PreemptionModes, SecurityContextEnrichmentModes
+from .function import (
+    BatchingSpec,
+    FunctionState,
+    PreemptionModes,
+    SecurityContextEnrichmentModes,
+)
 from .http import HTTPSessionRetryMode
 from .hub import (
     HubCatalog,

--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -140,3 +140,26 @@ class Function(pydantic.v1.BaseModel):
 
     class Config:
         extra = pydantic.v1.Extra.allow
+
+
+class BatchingSpec(pydantic.v1.BaseModel):
+    # Set to True to enable batching
+    enabled: bool
+    # Maximal events to batch together
+    batch_size: typing.Optional[int]
+    # How long to wait before sending the batch
+    timeout: typing.Optional[str]
+
+    def get_nuclio_batch_config(self):
+        if not self.enabled:
+            return None
+
+        config = {"mode": "enable"}
+
+        if self.batch_size:
+            config["batchSize"] = self.batch_size
+
+        if self.timeout:
+            config["timeout"] = self.timeout
+
+        return config

--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -145,9 +145,9 @@ class Function(pydantic.v1.BaseModel):
 class BatchingSpec(pydantic.v1.BaseModel):
     # Set to True to enable batching
     enabled: bool
-    # Maximal events to batch together
+    # Maximal events to batch together. Default size is 10.
     batch_size: typing.Optional[int]
-    # The maximum amount of time to wait before processing the batch.
+    # The maximum amount of time to wait before processing the batch. Default timeout is 1s.
     # Once this time passes, the batch is processed even if it hasn’t reached the full batch size.
     timeout: typing.Optional[str]
 

--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -17,7 +17,7 @@ import typing
 import pydantic.v1
 
 import mlrun.common.types
-
+import mlrun.runtimes.nuclio
 
 # Ideally we would want this to be class FunctionState(mlrun.common.types.StrEnum) which is the
 # "FastAPI-compatible" way of creating schemas
@@ -141,7 +141,7 @@ class Function(pydantic.v1.BaseModel):
     class Config:
         extra = pydantic.v1.Extra.allow
 
-
+@mlrun.runtimes.nuclio.min_nuclio_versions("1.14.0")
 class BatchingSpec(pydantic.v1.BaseModel):
     # Set to True to enable batching
     enabled: bool

--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -17,7 +17,7 @@ import typing
 import pydantic.v1
 
 import mlrun.common.types
-import mlrun.runtimes.nuclio
+
 
 # Ideally we would want this to be class FunctionState(mlrun.common.types.StrEnum) which is the
 # "FastAPI-compatible" way of creating schemas
@@ -141,7 +141,7 @@ class Function(pydantic.v1.BaseModel):
     class Config:
         extra = pydantic.v1.Extra.allow
 
-@mlrun.runtimes.nuclio.min_nuclio_versions("1.14.0")
+
 class BatchingSpec(pydantic.v1.BaseModel):
     # Set to True to enable batching
     enabled: bool

--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -147,7 +147,8 @@ class BatchingSpec(pydantic.v1.BaseModel):
     enabled: bool
     # Maximal events to batch together
     batch_size: typing.Optional[int]
-    # How long to wait before sending the batch
+    # The maximum amount of time to wait before processing the batch.
+    # Once this time passes, the batch is processed even if it hasn’t reached the full batch size.
     timeout: typing.Optional[str]
 
     def get_nuclio_batch_config(self):

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -526,6 +526,10 @@ class RemoteRuntime(KubeResource):
         if batching_spec and (
             batching_config := batching_spec.get_nuclio_batch_config()
         ):
+            if not validate_nuclio_version_compatibility("1.14.0"):
+                raise mlrun.errors.MLRunValueError(
+                    "Batching is only supported on Nuclio 1.14.0 and higher"
+                )
             trigger._struct["batch"] = batching_config
 
         self.add_trigger(trigger_name or "http", trigger)

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -485,7 +485,7 @@ class RemoteRuntime(KubeResource):
         :param trigger_name:    alternative nuclio trigger name
         :param annotations:     key/value dict of ingress annotations
         :param extra_attributes: key/value dict of extra nuclio trigger attributes
-        :param batching_spec: BatchingSpec objects that defines batching configuration.
+        :param batching_spec: BatchingSpec object that defines batching configuration.
             By default, batching is disabled.
         :return: function object (self)
         """

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -485,7 +485,8 @@ class RemoteRuntime(KubeResource):
         :param trigger_name:    alternative nuclio trigger name
         :param annotations:     key/value dict of ingress annotations
         :param extra_attributes: key/value dict of extra nuclio trigger attributes
-        :param batching_spec: BatchingSpec objects that defines batching configuration. By default, batching is disabled.
+        :param batching_spec: BatchingSpec objects that defines batching configuration.
+            By default, batching is disabled.
         :return: function object (self)
         """
         if self.disable_default_http_trigger:

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -37,7 +37,7 @@ import mlrun.errors
 import mlrun.k8s_utils
 import mlrun.utils
 import mlrun.utils.helpers
-from mlrun.common.schemas import AuthInfo
+from mlrun.common.schemas import AuthInfo, BatchingSpec
 from mlrun.config import config as mlconf
 from mlrun.errors import err_to_str
 from mlrun.lists import RunList
@@ -463,6 +463,7 @@ class RemoteRuntime(KubeResource):
         trigger_name: typing.Optional[str] = None,
         annotations: typing.Optional[typing.Mapping[str, str]] = None,
         extra_attributes: typing.Optional[typing.Mapping[str, str]] = None,
+        batching_spec: typing.Optional[BatchingSpec] = None,
     ):
         """update/add nuclio HTTP trigger settings
 
@@ -484,6 +485,7 @@ class RemoteRuntime(KubeResource):
         :param trigger_name:    alternative nuclio trigger name
         :param annotations:     key/value dict of ingress annotations
         :param extra_attributes: key/value dict of extra nuclio trigger attributes
+        :param batching_spec: BatchingSpec objects that defines batching configuration. By default, batching is disabled.
         :return: function object (self)
         """
         if self.disable_default_http_trigger:
@@ -519,6 +521,12 @@ class RemoteRuntime(KubeResource):
             trigger._struct["workerAvailabilityTimeoutMilliseconds"] = (
                 worker_timeout
             ) * 1000
+
+        if batching_spec and (
+            batching_config := batching_spec.get_nuclio_batch_config()
+        ):
+            trigger._struct["batch"] = batching_config
+
         self.add_trigger(trigger_name or "http", trigger)
         return self
 

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -875,6 +875,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         self._assert_v3io_trigger(v3io_trigger)
 
     def test_deploy_with_batching(self, db: Session, client: TestClient):
+        mlconf.nuclio_version = "1.14.0"
         function = self._generate_runtime(self.runtime_kind)
 
         http_trigger = {
@@ -902,6 +903,12 @@ class TestNuclioRuntime(TestRuntimeBase):
         # disable again
         function.with_http(batching_spec=None)
         self._assert_batching_spec(function, enabled=False)
+
+        mlconf.nuclio_version = "1.13.9"
+        with pytest.raises(mlrun.errors.MLRunValueError):
+            function.with_http(
+                batching_spec=mlrun.common.schemas.BatchingSpec(enabled=True)
+            )
 
     def test_deploy_with_v3io(self, db: Session, client: TestClient):
         function = self._generate_runtime(self.runtime_kind)

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -235,6 +235,22 @@ class TestNuclioRuntime(TestRuntimeBase):
 
         return deploy_configs
 
+    def _assert_batching_spec(
+        self,
+        function,
+        enabled,
+        expected_size=None,
+        expected_timeout=None,
+    ):
+        batch_info = function.spec.config["spec.triggers.http"].get("batch")
+        if enabled:
+            assert batch_info["mode"] == "enable"
+        else:
+            assert batch_info is None
+            return
+        assert batch_info.get("batchSize") == expected_size
+        assert batch_info.get("timeout") == expected_timeout
+
     def _assert_http_trigger(self, http_trigger):
         args, _ = nuclio.deploy.deploy_config.call_args
         triggers_config = args[0]["spec"]["triggers"]
@@ -857,6 +873,35 @@ class TestNuclioRuntime(TestRuntimeBase):
         self._assert_deploy_called_basic_config(expected_class=self.class_name)
         self._assert_http_trigger(http_trigger)
         self._assert_v3io_trigger(v3io_trigger)
+
+    def test_deploy_with_batching(self, db: Session, client: TestClient):
+        function = self._generate_runtime(self.runtime_kind)
+
+        http_trigger = {
+            "batching_spec": mlrun.common.schemas.BatchingSpec(
+                enabled=True, batch_size=2, timeout="1s"
+            ),
+        }
+
+        # create http trigger with full batching spec
+        function.with_http(**http_trigger)
+        self._assert_batching_spec(
+            function, enabled=True, expected_size=2, expected_timeout="1s"
+        )
+
+        # disable batching
+        function.with_http(batching_spec=None)
+        self._assert_batching_spec(function, enabled=False)
+
+        # enable batching again, but without setting size/timeout (will be set to Nuclio's defaults)
+        function.with_http(
+            batching_spec=mlrun.common.schemas.BatchingSpec(enabled=True)
+        )
+        self._assert_batching_spec(function, enabled=True)
+
+        # disable again
+        function.with_http(batching_spec=None)
+        self._assert_batching_spec(function, enabled=False)
 
     def test_deploy_with_v3io(self, db: Session, client: TestClient):
         function = self._generate_runtime(self.runtime_kind)

--- a/tests/system/runtimes/assets/nuclio_function_batching.py
+++ b/tests/system/runtimes/assets/nuclio_function_batching.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def handler(context, batch: list):
+    context.logger.info_with("Got batched event!")
+    batched_response = []
+    for item in batch:
+        event_id = item.id
+        batched_response.append(
+            context.Response(
+                body=f"Hello {event_id}",
+                headers={},
+                content_type="text/plain",
+                status_code=200,
+                event_id=event_id,
+            )
+        )
+    return batched_response

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -16,6 +16,7 @@ import json
 import os
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import pandas as pd
 import pytest
@@ -491,6 +492,33 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         serving_func_deploy = self.project.deploy_function("serving-handler-func")
 
         serving_func_deploy.function.invoke("/")
+
+    def test_nuclio_function_handler_with_batching(self):
+        code_path = str(self.assets_path / "nuclio_function_batching.py")
+
+        function = self.project.set_function(
+            name="batching-handler-func",
+            func=code_path,
+            image=self.image,
+            kind="nuclio",
+        )
+        function.with_http(
+            batching_spec=mlrun.common.schemas.BatchingSpec(
+                enabled=True, size=5, timeout="5s"
+            )
+        )
+        function.deploy()
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            responses = list(pool.map(lambda _: function.invoke("/"), range(10)))
+
+        assert len(responses) == 10
+
+        for resp in responses:
+            assert b"Hello" in resp
+
+        # unique IDs expected
+        assert len(set(responses)) == 10
 
     @pytest.mark.parametrize("async_mode", [True, False])
     async def test_list_mep_through_api_step(self, async_mode: bool):


### PR DESCRIPTION
### 📝 Description
Adds batching support to `with_http`. By default, the `NuclioSpec` still work with no batching, and does not serialize this object at all if batching is not enabled, to support older versions of nuclio.

The `RemoteRuntime.with_http` method accept a new parameter `batching_spec: BatchingSpec` which allows setting batching mode on the HTTP trigger (nuclio only supports a single HTTP trigger per function).

Disabling this mode can be done by either calling `with_http` and setting `batching_spec.enabled=False`, or setting `batching_spec=None` which will nullify any configuration of the async spec in the function’s spec and will revert to the default configuration (i.e. no batching).

---

### ✅ Checklist
- [x] I updated the documentation (with_http docs)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
system(tested on my system and made sure config in nuclio is correct - screenshot attached below), unit tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11434
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<img width="1098" height="845" alt="image" src="https://github.com/user-attachments/assets/3f8708c8-0c62-4faa-8872-63a10dc5b345" />