### PR TITLE
[Auth] Change user token auth secret naming convention

### DIFF
--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -99,7 +99,8 @@ class MLRunInternalLabels:
     workflow = "workflow"
     feature_vector = "feature-vector"
 
-    user_token_secret_label_key = "mlrun/user"
+    auth_username = f"{MLRUN_LABEL_PREFIX}user"
+    auth_token_name = f"{MLRUN_LABEL_PREFIX}token"
 
     @classmethod
     def all(cls):

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -703,7 +703,6 @@ default_config = {
             "auto_add_project_secrets": True,
             "project_secret_name": "mlrun-project-secrets-{project}",
             "auth_secret_name": "mlrun-auth-secrets.{hashed_access_key}",
-            "user_token_secret_name": "mlrun-auth-{username}-{token_name}",
             "env_variable_prefix": "",
             "global_function_env_secret_name": None,
         },

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -108,19 +108,11 @@ class Client(BaseClient, project_follower.Member):
                 f"Offline tokens are empty for: {', '.join(empty_tokens)}"
             )
 
-        self._logger.info(
-            "Refreshing multiple access tokens via Iguazio", token_names=token_names
-        )
+        self._logger.debug("Refreshing access tokens", token_names=token_names)
 
         def _refresh_access_tokens():
             options = RefreshAccessTokensOptionsV1(refresh_tokens=token_values)
-            # Call Iguazio batch refresh
             self._client.refresh_access_tokens(options=options)
-
-            self._logger.info(
-                "Successfully refreshed multiple access tokens via Iguazio",
-                token_names=token_names,
-            )
 
         return self._try_callback_with_httpx_exceptions(
             _refresh_access_tokens,

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1205,7 +1205,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         }
 
         create = False
-        secret_data = self._encode_user_token(token_name, token, expiration)
         k8s_secret = self._get_user_token_secret(username, token_name, namespace)
         if not k8s_secret:
             create = True
@@ -1216,7 +1215,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 labels=labels,
                 namespace=namespace,
                 secret_name=self._resolve_auth_secret_name(username, token_name),
-                secrets=secret_data,
+                secrets=self._encode_user_token(token_name, token, expiration),
                 encoded=True,
             )
             return mlrun.common.schemas.SecretEventActions.created
@@ -1227,7 +1226,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 k8s_secret=k8s_secret,
                 namespace=namespace,
                 secret_name=self._resolve_auth_secret_name(username, token_name),
-                secrets=secret_data,
+                secrets=self._encode_user_token(token_name, token, expiration),
                 encoded=True,
             )
             return mlrun.common.schemas.SecretEventActions.updated

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -733,6 +733,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :param encoded: Whether the secret values are already base64-encoded. Defaults to False.
         """
         logger.debug("Creating secret", secret_name=secret_name)
+        namespace = self.resolve_namespace(namespace)
 
         secret_data = (
             secrets

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1199,34 +1199,23 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :param namespace: Kubernetes namespace for the secret.
         :return: SecretEventActions.{created, updated, skipped}
         """
-        namespace = self.resolve_namespace(namespace)
-        secret_name = self._resolve_user_token_secret_name(username, token_name)
         labels = {
-            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: username
+            mlrun_constants.MLRunInternalLabels.auth_username: username,
+            mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
         }
 
-        logger.debug(
-            "Preparing to store user token secret",
-            secret_name=secret_name,
-            namespace=namespace,
-        )
-
+        create = False
         secret_data = self._encode_user_token(token_name, token, expiration)
-
-        # Try to read existing secret (may return None if not found or labels mismatch)
-        k8s_secret = self.read_secret(
-            secret_name=secret_name,
-            namespace=namespace,
-            labels=labels,
-            silent=True,
-        )
-
+        k8s_secret = self._get_user_token_secret(username, token_name, namespace)
         if not k8s_secret:
+            create = True
+
+        if create:
             # Secret does not exist (or labels mismatch) → create it
             self._create_secret(
                 labels=labels,
                 namespace=namespace,
-                secret_name=secret_name,
+                secret_name=self._resolve_auth_secret_name(username, token_name),
                 secrets=secret_data,
                 encoded=True,
             )
@@ -1237,15 +1226,17 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self._update_secret(
                 k8s_secret=k8s_secret,
                 namespace=namespace,
-                secret_name=secret_name,
+                secret_name=self._resolve_auth_secret_name(username, token_name),
                 secrets=secret_data,
                 encoded=True,
             )
             return mlrun.common.schemas.SecretEventActions.updated
 
-    def _resolve_user_token_secret_name(self, username: str, token: str) -> str:
-        return mlrun.mlconf.secret_stores.kubernetes.user_token_secret_name.format(
-            username=username, token_name=token
+        return None
+
+    def _resolve_auth_secret_name(self, username: str, token: str) -> str:
+        return mlrun.mlconf.secret_stores.kubernetes.auth_secret_name.format(
+            hashed_access_key=hashlib.sha224((username + token).encode()).hexdigest()
         )
 
     def _encode_user_token(
@@ -1296,20 +1287,14 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :return: List of SecretTokenInfo objects, each containing the token name and expiration.
         """
         namespace = self.resolve_namespace(namespace)
-        labels = {
-            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: username
-        }
-
-        logger.debug(
-            "Listing user token secrets", username=username, namespace=namespace
-        )
+        labels = {mlrun_constants.MLRunInternalLabels.auth_username: username}
 
         k8s_secrets = self.list_secrets(namespace=namespace, labels=labels)
 
         secret_tokens: list[mlrun.common.schemas.SecretTokenInfo] = []
 
         for k8s_secret in k8s_secrets:
-            token_info = self._convert_secret_to_token_info(k8s_secret, username)
+            token_info = self._convert_secret_to_token_info(k8s_secret)
             if token_info:
                 secret_tokens.append(token_info)
 
@@ -1357,28 +1342,18 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return secrets_list.items or []
 
     def _convert_secret_to_token_info(
-        self, k8s_secret, username: str
+        self,
+        k8s_secret: client.V1Secret,
     ) -> typing.Optional[mlrun.common.schemas.SecretTokenInfo]:
         """
         Convert a Kubernetes secret to a SecretTokenInfo object if valid.
 
         :param k8s_secret: Kubernetes secret object.
-        :param username: Expected username for validation.
         :return: SecretTokenInfo object or None if invalid/expired.
         """
-        secret_name = k8s_secret.metadata.name
-        prefix = mlrun.mlconf.secret_stores.kubernetes.user_token_secret_name.format(
-            username=username, token_name=""
+        token_name = k8s_secret.metadata.labels.get(
+            mlrun_constants.MLRunInternalLabels.auth_token_name
         )
-
-        if not secret_name.startswith(prefix):
-            logger.warning(
-                "Skipping secret with unexpected name format",
-                secret_name=secret_name,
-            )
-            return None
-
-        token_name = secret_name[len(prefix) :]
 
         expiration = self._decode_secret_expiration(k8s_secret)
         if expiration is None:
@@ -1444,71 +1419,33 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :raises mlrun.errors.MLRunRuntimeError: If decoding or parsing the secret
             data fails.
         """
-        namespace = self.resolve_namespace(namespace)
-        secret_name = self._resolve_user_token_secret_name(username, token_name)
-        labels = {
-            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: username
-        }
 
-        logger.debug(
-            "Reading user token secret from Kubernetes",
-            username=username,
-            token_name=token_name,
-            secret_name=secret_name,
-            namespace=namespace,
-            labels=labels,
-        )
-
-        k8s_secret = self.read_secret(
-            secret_name=secret_name,
-            namespace=namespace,
-            labels=labels,
-            silent=True,
-        )
+        k8s_secret = self._get_user_token_secret(username, token_name, namespace)
         if not k8s_secret:
-            logger.warning(
-                "User token secret not found",
-                username=username,
-                token_name=token_name,
-                secret_name=secret_name,
-                namespace=namespace,
-            )
             raise mlrun.errors.MLRunNotFoundError(
                 f"Token '{token_name}' not found for user '{username}'"
             )
-
-        logger.debug(
-            "Successfully retrieved Kubernetes secret, extracting token",
-            username=username,
-            token_name=token_name,
-            secret_name=secret_name,
-        )
-
-        return self._extract_token_from_secret(k8s_secret, token_name, username)
+        return self._extract_token_from_secret(k8s_secret)
 
     def _extract_token_from_secret(
         self,
         k8s_secret: client.V1Secret,
-        token_name: str,
-        username: str,
     ) -> str:
         """
         Extract a single offline token string from a Kubernetes secret object.
 
         :param k8s_secret: The V1Secret object containing the tokensFile.
-        :param token_name: The logical name of the token to extract.
-        :param username: Owner of the token (used for error messages).
         :return: The offline token string.
         :raises mlrun.errors.MLRunNotFoundError: If the token is not found in the secret.
         :raises mlrun.errors.MLRunRuntimeError: If decoding/parsing fails.
         """
+        username = k8s_secret.metadata.labels[
+            mlrun_constants.MLRunInternalLabels.auth_username
+        ]
+        token_name = k8s_secret.metadata.labels[
+            mlrun_constants.MLRunInternalLabels.auth_token_name
+        ]
         try:
-            logger.debug(
-                "Extracting offline token from Kubernetes secret",
-                username=username,
-                token_name=token_name,
-            )
-
             encoded_tokens_file = k8s_secret.data.get("tokensFile")
             if not encoded_tokens_file:
                 raise mlrun.errors.MLRunNotFoundError(
@@ -1521,11 +1458,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             token_entry = next((t for t in tokens if t.get("name") == token_name), None)
 
             if not token_entry or not token_entry.get("token"):
-                logger.debug(
-                    "Token not found in secret",
-                    username=username,
-                    token_name=token_name,
-                )
                 raise mlrun.errors.MLRunNotFoundError(
                     f"Token '{token_name}' not found in secret for user '{username}'"
                 )
@@ -1566,7 +1498,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :raises mlrun.errors.MLRunRuntimeError: If deletion fails for any reason.
         """
         namespace = self.resolve_namespace(namespace)
-        secret_name = self._resolve_user_token_secret_name(username, token_name)
+        secret_name = self._resolve_auth_secret_name(username, token_name)
 
         logger.debug(
             "Deleting user token secret from Kubernetes",
@@ -1599,6 +1531,25 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             raise mlrun.errors.MLRunRuntimeError(
                 f"Unexpected error deleting secret for token '{token_name}' for user '{username}'"
             ) from exc
+
+    def _get_user_token_secret(
+        self,
+        username: str,
+        token_name: str,
+        namespace: typing.Optional[str] = None,
+    ):
+        namespace = self.resolve_namespace(namespace)
+        labels = {
+            mlrun_constants.MLRunInternalLabels.auth_username: username,
+            mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
+        }
+
+        k8s_secrets = self.list_secrets(namespace=namespace, labels=labels)
+
+        if not k8s_secrets:
+            return None
+
+        return k8s_secrets[0]
 
 
 class BasePod:

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1433,12 +1433,17 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :raises mlrun.errors.MLRunNotFoundError: If the token is not found in the secret.
         :raises mlrun.errors.MLRunRuntimeError: If decoding/parsing fails.
         """
-        username = k8s_secret.metadata.labels[
-            mlrun_constants.MLRunInternalLabels.auth_username
-        ]
-        token_name = k8s_secret.metadata.labels[
-            mlrun_constants.MLRunInternalLabels.auth_token_name
-        ]
+        try:
+            username = k8s_secret.metadata.labels[
+                mlrun_constants.MLRunInternalLabels.auth_username
+            ]
+            token_name = k8s_secret.metadata.labels[
+                mlrun_constants.MLRunInternalLabels.auth_token_name
+            ]
+        except KeyError as exc:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"Secret {k8s_secret.metadata.name} is missing required labels for username or token name"
+            ) from exc
         try:
             encoded_tokens_file = k8s_secret.data.get("tokensFile")
             if not encoded_tokens_file:

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1319,12 +1319,6 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             ",".join(f"{k}={v}" for k, v in labels.items()) if labels else None
         )
 
-        logger.debug(
-            "Listing secrets from Kubernetes",
-            namespace=namespace,
-            label_selector=label_selector,
-        )
-
         try:
             secrets_list = self.v1api.list_namespaced_secret(
                 namespace=namespace,

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -443,7 +443,7 @@ class Secrets(
             )
 
         logger.debug(
-            "Starting to store secret tokens",
+            "Storing secret tokens",
             username=auth_info.username,
             token_count=len(secret_tokens),
         )
@@ -475,15 +475,16 @@ class Secrets(
             if action is not None:
                 token_actions[action].append(token_name)
 
-        logger.debug(
-            "Finished storing tokens",
-            created_tokens=token_actions[
-                mlrun.common.schemas.SecretEventActions.created
-            ],
-            updated_tokens=token_actions[
-                mlrun.common.schemas.SecretEventActions.updated
-            ],
-        )
+        if token_actions:
+            logger.debug(
+                "Finished storing tokens",
+                created_tokens=token_actions[
+                    mlrun.common.schemas.SecretEventActions.created
+                ],
+                updated_tokens=token_actions[
+                    mlrun.common.schemas.SecretEventActions.updated
+                ],
+            )
 
         return mlrun.common.schemas.StoreSecretTokensResponse(
             created_tokens=token_actions[

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -482,7 +482,7 @@ def test_list_pod_events(k8s_helper):
 
 
 def test_store_user_token_secret_created(k8s_helper):
-    k8s_helper.read_secret = mock.MagicMock(return_value=None)
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[])
 
     username = "test-user"
     token_name = "my-token"
@@ -524,7 +524,7 @@ def test_store_user_token_secret_updated(k8s_helper):
     token_name = "my-token"
     token_value = "abc123"
     new_expiration = 2000
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     # Existing secret with older expiration
     existing_secret = _make_user_token_secret(
@@ -581,7 +581,7 @@ def test_store_user_token_secret_skipped_and_force_update(
     username = "test-user"
     token_name = "my-token"
     token_value = "abc123"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     existing_secret = _make_user_token_secret(
         secret_name,
@@ -589,7 +589,7 @@ def test_store_user_token_secret_skipped_and_force_update(
         token_value=token_value,
         expiration=5000,
     )
-    k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[existing_secret])
 
     result = k8s_helper.store_user_token_secret(
         username=username,
@@ -617,13 +617,13 @@ def test_list_secrets_with_labels(k8s_helper):
     secret1 = _make_k8s_secret(
         "secret1",
         labels={
-            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: "test-user"
+            mlrun_constants.MLRunInternalLabels.auth_username: "test-user",
         },
     )
     secret2 = _make_k8s_secret(
         "secret2",
         labels={
-            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: "test-user"
+            mlrun_constants.MLRunInternalLabels.auth_username: "test-user",
         },
     )
 
@@ -636,9 +636,7 @@ def test_list_secrets_with_labels(k8s_helper):
 
     result = k8s_helper.list_secrets(
         namespace="default",
-        labels={
-            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: "test-user"
-        },
+        labels={mlrun_constants.MLRunInternalLabels.auth_username: "test-user"},
     )
 
     assert result == [secret1, secret2]
@@ -683,10 +681,14 @@ def test_list_user_token_secrets_valid(k8s_helper):
     token1_name = "token1"
     token2_name = "token2"
     username = "test-user"
-    secret1_name = k8s_helper._resolve_user_token_secret_name(username, token1_name)
-    secret2_name = k8s_helper._resolve_user_token_secret_name(username, token2_name)
-    secret1 = _make_user_token_secret(secret1_name, expiration=1111)
-    secret2 = _make_user_token_secret(secret2_name, expiration=2222)
+    secret1_name = k8s_helper._resolve_auth_secret_name(username, token1_name)
+    secret2_name = k8s_helper._resolve_auth_secret_name(username, token2_name)
+    secret1 = _make_user_token_secret(
+        secret1_name, token_name=token1_name, expiration=1111
+    )
+    secret2 = _make_user_token_secret(
+        secret2_name, token_name=token2_name, expiration=2222
+    )
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.list_secrets = mock.MagicMock(return_value=[secret1, secret2])
@@ -701,28 +703,13 @@ def test_list_user_token_secrets_valid(k8s_helper):
 
     k8s_helper.list_secrets.assert_called_once_with(
         namespace="default",
-        labels={
-            mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: "test-user"
-        },
+        labels={mlrun_constants.MLRunInternalLabels.auth_username: "test-user"},
     )
-
-
-def test_list_user_token_secrets_unexpected_name(k8s_helper):
-    bad_secret = _make_user_token_secret("some-other-secret", expiration=1234)
-
-    k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
-    k8s_helper.list_secrets = mock.MagicMock(return_value=[bad_secret])
-
-    result = k8s_helper.list_user_token_secrets(
-        username="test-user", namespace="default"
-    )
-
-    assert result == []
 
 
 def test_list_user_token_secrets_invalid_expiration(k8s_helper):
     username = "test-user"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, "token1")
+    secret_name = k8s_helper._resolve_auth_secret_name(username, "token1")
     bad_secret = _make_user_token_secret(
         secret_name=secret_name, expiration=b"not-a-number"
     )
@@ -737,7 +724,7 @@ def test_get_user_token_secret_value_valid(k8s_helper):
     username = "test-user"
     token_name = "my-token"
     token_value = "abc123"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     # Create a Kubernetes secret with properly encoded tokensFile
     existing_secret = _make_user_token_secret(
@@ -748,7 +735,7 @@ def test_get_user_token_secret_value_valid(k8s_helper):
     )
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
-    k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[existing_secret])
 
     token_value_from_k8s = k8s_helper.get_user_token_secret_value(
         username=username,
@@ -757,7 +744,7 @@ def test_get_user_token_secret_value_valid(k8s_helper):
     )
 
     assert token_value_from_k8s == token_value
-    k8s_helper.read_secret.assert_called_once()
+    k8s_helper.list_secrets.assert_called_once()
 
 
 def test_get_user_token_secret_value_not_found(k8s_helper):
@@ -765,23 +752,7 @@ def test_get_user_token_secret_value_not_found(k8s_helper):
     token_name = "my-token"
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
-    k8s_helper.read_secret = mock.MagicMock(return_value=None)
-
-    with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        k8s_helper.get_user_token_secret_value(
-            username, token_name, namespace="default"
-        )
-
-
-def test_get_user_token_secret_value_token_missing(k8s_helper):
-    username = "test-user"
-    token_name = "my-token"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
-
-    # Secret exists but tokensFile does not contain the requested token
-    secret = _make_user_token_secret(secret_name, token_name="other-token")
-    k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
-    k8s_helper.read_secret = mock.MagicMock(return_value=secret)
+    k8s_helper.list_secrets = mock.MagicMock(return_value=None)
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
         k8s_helper.get_user_token_secret_value(
@@ -792,7 +763,7 @@ def test_get_user_token_secret_value_token_missing(k8s_helper):
 def test_get_user_token_secret_value_invalid_base64(k8s_helper):
     username = "test-user"
     token_name = "my-token"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     # Create a secret with an invalid base64 tokensFile
     bad_secret = _make_k8s_secret(secret_name)
@@ -813,7 +784,7 @@ def test_get_user_token_secret_value_invalid_base64(k8s_helper):
 def test_get_user_token_secret_value_invalid_yaml(k8s_helper):
     username = "test-user"
     token_name = "my-token"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     # Base64 encoded string but invalid YAML
     bad_yaml = base64.b64encode(b"{invalid_yaml: ]").decode()
@@ -831,7 +802,7 @@ def test_get_user_token_secret_value_invalid_yaml(k8s_helper):
 def test_delete_user_token_secret_success(k8s_helper):
     username = "test-user"
     token_name = "token1"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock()
@@ -849,7 +820,7 @@ def test_delete_user_token_secret_success(k8s_helper):
 def test_delete_user_token_secret_not_found(k8s_helper):
     username = "test-user"
     token_name = "missing"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock(
@@ -872,7 +843,7 @@ def test_delete_user_token_secret_not_found(k8s_helper):
 def test_delete_user_token_secret_api_error(k8s_helper):
     username = "test-user"
     token_name = "badtoken"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock(
@@ -895,7 +866,7 @@ def test_delete_user_token_secret_api_error(k8s_helper):
 def test_delete_user_token_secret_unexpected_error(k8s_helper):
     username = "test-user"
     token_name = "oops"
-    secret_name = k8s_helper._resolve_user_token_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock(
@@ -923,7 +894,8 @@ def _make_user_token_secret(
     labels=None,
 ):
     labels = labels or {
-        mlrun_constants.MLRunInternalLabels.user_token_secret_label_key: "test-user"
+        mlrun_constants.MLRunInternalLabels.auth_username: "test-user",
+        mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
     }
     secret = _make_k8s_secret(secret_name, labels)
 


### PR DESCRIPTION
### 📝 Description

The current implementation assumes username and token name part of the secret name - which can lead to k8s validation issues when username contains @ or token name has some `_` characters which is not k8s valid for secret names.

---

### 🛠️ Changes Made

- Changed secret name to be hashed-base rather than username/token name
- To allow retrieving user tokens or user secrets, we leverage secret labels and getting those secret by using username/token name labels. this change is opaque to end users.
- Relaxed some spammy logs


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Unit testings
- Manual testings

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11576 https://iguazio.atlassian.net/browse/ML-11510
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [n] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
