### PR TITLE
[RemoteModel] Skip test_hf_2_models test if hf_token is not defined

### DIFF
--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -174,7 +174,7 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
         ["naive", "process_pool", "dedicated_process", "thread_pool"],
     )
     def test_hf_2_models(self, execution_mechanism):
-        if not os.environ.get("HF_TOKEN"):
+        if not os.getenv("HF_TOKEN"):
             pytest.skip("test_hf_2_models Requires HF_TOKEN")
         self.setup_datastore_profile()
         llm_model2 = "google/gemma-2b-it"

--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -174,6 +174,8 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
         ["naive", "process_pool", "dedicated_process", "thread_pool"],
     )
     def test_hf_2_models(self, execution_mechanism):
+        if not os.environ.get("HF_TOKEN"):
+            pytest.skip("test_hf_2_models Requires HF_TOKEN")
         self.setup_datastore_profile()
         llm_model2 = "google/gemma-2b-it"
         ep_name = "ep"


### PR DESCRIPTION
### 📝 Description
test_hf_2_models failed because `google/gemma-2b-it` requires authentication via `HF_TOKEN`.

---

### 🛠️ Changes Made
If HF_TOKEN is not exist, skip the test.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: [ML-11614](https://iguazio.atlassian.net/browse/ML-11614)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-11614]: https://iguazio.atlassian.net/browse/ML-11614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ