### PR TITLE
[RemoteModels] Support MRS Hf thread pool with 2 models [1.10.x]

### DIFF
--- a/mlrun/datastore/model_provider/huggingface_provider.py
+++ b/mlrun/datastore/model_provider/huggingface_provider.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import threading
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import mlrun
@@ -40,6 +40,9 @@ class HuggingFaceProvider(ModelProvider):
     Note: The pipeline object will download the model (if not already cached) and load it
     into memory for inference. Ensure you have the required CPU/GPU and memory to use this operation.
     """
+
+    #  locks for threading use cases
+    _client_lock = threading.Lock()
 
     def __init__(
         self,
@@ -224,7 +227,8 @@ class HuggingFaceProvider(ModelProvider):
 
             self.options["model_kwargs"] = self.options.get("model_kwargs", {})
             self.options["model_kwargs"]["local_files_only"] = True
-            self._client = pipeline(model=self.model, **self.options)
+            with self._client_lock:
+                self._client = pipeline(model=self.model, **self.options)
             self._expected_operation_type = Pipeline
         except ImportError as exc:
             raise ImportError("transformers package is not installed") from exc

--- a/tests/datastore/remote_model/remote_model_utils.py
+++ b/tests/datastore/remote_model/remote_model_utils.py
@@ -27,6 +27,12 @@ from mlrun.datastore.model_provider.model_provider import (
 from mlrun.serving import ModelRunnerStep
 from mlrun.serving.states import LLModel  # noqa
 
+PROMPT_LEGEND = {
+    "question": {"field": None, "description": None},
+    "depth_level": {"field": None, "description": None},
+    "persona": {"field": None, "description": None},
+    "tone": {"field": None, "description": None},
+}
 INPUT_DATA = [
     {
         "question": "What is the capital of France? Answer with one word first, then provide a historical overview.",
@@ -97,12 +103,7 @@ def setup_remote_model_test(
             "my_llm_prompt",
             prompt_template=PROMPT_TEMPLATE,
             model_artifact=model_artifact,
-            prompt_legend={
-                "question": {"field": None, "description": None},
-                "depth_level": {"field": None, "description": None},
-                "persona": {"field": None, "description": None},
-                "tone": {"field": None, "description": None},
-            },
+            prompt_legend=PROMPT_LEGEND,
         )
     else:
         llm_prompt_artifact = None

--- a/tests/integration/model_providers/huggingface/test_huggingface.py
+++ b/tests/integration/model_providers/huggingface/test_huggingface.py
@@ -36,6 +36,8 @@ from mlrun.datastore.model_provider.model_provider import (
 from tests.datastore.remote_model.remote_model_utils import (
     EXPECTED_RESULTS,
     INPUT_DATA,
+    PROMPT_LEGEND,
+    PROMPT_TEMPLATE,
     formatted_messages,
     setup_remote_model_test,
 )
@@ -366,5 +368,100 @@ class TestHuggingFaceAIModel(TestBasicHuggingFaceProvider):
                 assert "score" in result
                 assert isinstance(result["score"], float)
                 assert 0 <= result["score"] <= 1
+        finally:
+            server.wait_for_completion()
+
+    @pytest.mark.parametrize(
+        "execution_mechanism",
+        ["naive", "process_pool", "dedicated_process", "thread_pool"],
+    )
+    def test_hf_2_models(self, execution_mechanism):
+        proj_obj = mlrun.new_project("test-hf-model", save=False)
+        llm_model2 = "google/gemma-2b-it"
+        ep_name = "ep1"
+        second_ep_name = "ep2"
+        model_class = "mlrun.serving.states.LLModel"
+
+        model_url = self.url_prefix + self.basic_llm_model
+        second_model_url = self.url_prefix + llm_model2
+
+        model1 = proj_obj.log_model(
+            "model_key", model_url=model_url, default_config={"max_new_tokens": 50}
+        )
+
+        model2 = proj_obj.log_model(
+            "model_key2",
+            model_url=second_model_url,
+            default_config={"max_new_tokens": 50},
+        )
+        llm_art1 = proj_obj.log_llm_prompt(
+            "llm_artifact",
+            prompt_template=PROMPT_TEMPLATE,
+            description="remote_model_open_ai-llm-prompt-prompt",
+            prompt_legend=PROMPT_LEGEND,
+            model_artifact=model1,
+        )
+
+        llm_art2 = proj_obj.log_llm_prompt(
+            "llm_artifact2",
+            prompt_template=PROMPT_TEMPLATE,
+            description="remote_model_open_ai-llm-prompt-prompt",
+            prompt_legend=PROMPT_LEGEND,
+            model_artifact=model2,
+        )
+
+        function = proj_obj.set_function(
+            name="function_with_llm_hf",
+            kind="serving",
+            requirements=[
+                "--extra-index-url",
+                "https://download.pytorch.org/whl/cpu",
+                "torch==2.7.1+cpu",
+                "transformers==4.53.2",
+                "pillow~=11.3",
+            ],
+        )
+        model_runner_step = mlrun.serving.states.ModelRunnerStep(name="mrs")
+        model_runner_step.add_model(
+            endpoint_name=ep_name,
+            model_class=model_class,
+            execution_mechanism=execution_mechanism,
+            model_artifact=llm_art1,
+            result_path="output",
+        )
+        model_runner_step.add_model(
+            endpoint_name=second_ep_name,
+            model_class=model_class,
+            execution_mechanism=execution_mechanism,
+            model_artifact=llm_art2,
+            result_path="output",
+        )
+
+        llm_graph = function.set_topology("flow", engine="async")
+        llm_graph.to(model_runner_step).respond()
+        mocked_get_store_artifact = create_mocked_get_store_artifact(
+            {
+                model1.uri: model1,
+                model2.uri: model2,
+                llm_art1.uri: llm_art1,
+                llm_art2.uri: llm_art2,
+            }
+        )
+        with (
+            unittest.mock.patch(
+                "mlrun.artifacts.llm_prompt.mlrun.datastore.store_manager.get_store_artifact",
+                side_effect=lambda *args, **kwargs: mocked_get_store_artifact(
+                    *args, **kwargs
+                ),
+            ),
+        ):
+            server = function.to_mock_server()
+        try:
+            results = server.test(body=INPUT_DATA[0])
+            # Verify we got the expected number of results
+
+            assert sorted(list(results.keys())) == sorted([ep_name, second_ep_name])
+            for model_result in results.values():
+                assert "paris" in model_result["output"]["answer"].lower()
         finally:
             server.wait_for_completion()

--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -174,6 +174,8 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
         ["naive", "process_pool", "dedicated_process", "thread_pool"],
     )
     def test_hf_2_models(self, execution_mechanism):
+        if not os.getenv("HF_TOKEN"):
+            pytest.skip("test_hf_2_models Requires HF_TOKEN")
         self.setup_datastore_profile()
         llm_model2 = "google/gemma-2b-it"
         ep_name = "ep"

--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -18,6 +18,7 @@ import os
 import pytest
 from transformers import AutoTokenizer
 
+import mlrun.serving.states
 from mlrun.datastore.datastore_profile import (
     HuggingFaceProfile,
 )
@@ -25,6 +26,8 @@ from mlrun.datastore.model_provider.model_provider import UsageResponseKeys
 from tests.datastore.remote_model.remote_model_utils import (
     EXPECTED_RESULTS,
     INPUT_DATA,
+    PROMPT_LEGEND,
+    PROMPT_TEMPLATE,
     setup_remote_model_test,
 )
 from tests.system.base import TestMLRunSystem
@@ -56,7 +59,7 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
 
     @pytest.mark.parametrize(
         "execution_mechanism",
-        ["naive", "process_pool", "dedicated_process", "thread_pool"],
+        ["thread_pool"],
     )
     def test_basic_huggingface_model_runner(self, execution_mechanism):
         self.setup_datastore_profile()
@@ -81,12 +84,16 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
         # The default Nuclio resource configuration is:
         # {"requests": {"cpu": "25m", "memory": "1Mi"}, "limits": {"cpu": "2", "memory": "20Gi"}}
         function.spec.resources = {
-            "limits": {"cpu": "5", "memory": "30Gi"},
-            "requests": {"cpu": "3", "memory": "1Mi"},
+            "limits": {"cpu": "7", "memory": "20Gi"},
+            "requests": {"cpu": "25m", "memory": "1Mi"},
         }
         function.spec.max_replicas = (
             1  # to avoid allocating extended resources to multiple pods
         )
+        # Set workers=None to avoid using the default value of 8 workers
+        function.with_http(gateway_timeout=600, worker_timeout=500, workers=None)
+        function.spec.readiness_timeout = 600
+
         function.deploy()
         response = function.invoke(
             f"v2/models/{mlrun_model_name}/infer",
@@ -161,3 +168,90 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
             assert "score" in result
             assert isinstance(result["score"], float)
             assert 0 <= result["score"] <= 1
+
+    @pytest.mark.parametrize(
+        "execution_mechanism",
+        ["naive", "process_pool", "dedicated_process", "thread_pool"],
+    )
+    def test_hf_2_models(self, execution_mechanism):
+        self.setup_datastore_profile()
+        llm_model2 = "google/gemma-2b-it"
+        ep_name = "ep"
+        second_ep_name = "ep2"
+        model_class = "mlrun.serving.states.LLModel"
+        second_model_url = self.url_prefix + llm_model2
+
+        model1 = self.project.log_model(
+            "model_key", model_url=self.model_url, default_config={"max_new_tokens": 50}
+        )
+
+        model2 = self.project.log_model(
+            "model_key2",
+            model_url=second_model_url,
+            default_config={"max_new_tokens": 50},
+        )
+        llm_art1 = self.project.log_llm_prompt(
+            "llm_artifact",
+            prompt_template=PROMPT_TEMPLATE,
+            description="remote_model_open_ai-llm-prompt-prompt",
+            prompt_legend=PROMPT_LEGEND,
+            model_artifact=model1,
+        )
+
+        llm_art2 = self.project.log_llm_prompt(
+            "llm_artifact2",
+            prompt_template=PROMPT_TEMPLATE,
+            description="remote_model_open_ai-llm-prompt-prompt",
+            prompt_legend=PROMPT_LEGEND,
+            model_artifact=model2,
+        )
+
+        function = self.project.set_function(
+            name="function_with_llm_hf",
+            kind="serving",
+            requirements=[
+                "--extra-index-url",
+                "https://download.pytorch.org/whl/cpu",
+                "torch==2.8.0+cpu",
+                "transformers==4.56.2",
+                "pillow~=11.3",
+            ],
+            image=self.image,
+        )
+
+        function.spec.resources = {
+            "limits": {"cpu": "7", "memory": "20Gi"},
+            "requests": {"cpu": "25m", "memory": "1Mi"},
+        }
+        function.spec.readiness_timeout = 600
+        function.spec.max_replicas = (
+            1  # to avoid allocating extended resources to multiple pods
+        )
+        # Set workers=None to avoid using the default value of 8 workers
+        function.with_http(gateway_timeout=1100, worker_timeout=1000, workers=None)
+        model_runner_step = mlrun.serving.states.ModelRunnerStep(name="mrs")
+        model_runner_step.add_model(
+            endpoint_name=ep_name,
+            model_class=model_class,
+            execution_mechanism=execution_mechanism,
+            model_artifact=llm_art1,
+            result_path="output",
+        )
+        model_runner_step.add_model(
+            endpoint_name=second_ep_name,
+            model_class=model_class,
+            execution_mechanism=execution_mechanism,
+            model_artifact=llm_art2,
+            result_path="output",
+        )
+
+        llm_graph = function.set_topology("flow", engine="async")
+        llm_graph.to(model_runner_step).respond()
+        function.deploy()
+
+        results = function.invoke("/", json.dumps(INPUT_DATA[0]))
+        # Verify we got the expected number of results
+
+        assert sorted(list(results.keys())) == sorted([ep_name, second_ep_name])
+        for model_result in results.values():
+            assert "paris" in model_result["output"]["answer"].lower()

--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -84,7 +84,7 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
         # The default Nuclio resource configuration is:
         # {"requests": {"cpu": "25m", "memory": "1Mi"}, "limits": {"cpu": "2", "memory": "20Gi"}}
         function.spec.resources = {
-            "limits": {"cpu": "7", "memory": "20Gi"},
+            "limits": {"cpu": "6", "memory": "20Gi"},
             "requests": {"cpu": "25m", "memory": "1Mi"},
         }
         function.spec.max_replicas = (

--- a/tests/system/datastore/model_providers/test_huggingface.py
+++ b/tests/system/datastore/model_providers/test_huggingface.py
@@ -59,7 +59,7 @@ class TestHuggingFaceModelRunner(TestMLRunSystem):
 
     @pytest.mark.parametrize(
         "execution_mechanism",
-        ["thread_pool"],
+        ["naive", "process_pool", "dedicated_process", "thread_pool"],
     )
     def test_basic_huggingface_model_runner(self, execution_mechanism):
         self.setup_datastore_profile()


### PR DESCRIPTION
### 📝 Description
Issue: When loading two different pipelines in a thread pool, we encountered a race condition that caused problems during client creation.
Fix: Add a thread-level lock to prevent concurrent pipeline initialization.

---

### 🛠️ Changes Made
Add a thread lock to address the race in client creation.
Add system + integration tests.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
System and integration test of 2 models in MRS, with all execution mechanisms.

---

### 🔗 References
- Ticket link: [ML-11517](https://iguazio.atlassian.net/browse/ML-11517) [ML-11614](https://iguazio.atlassian.net/browse/ML-11614)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
cherry pick of https://github.com/mlrun/mlrun/pull/8969


[ML-11517]: https://iguazio.atlassian.net/browse/ML-11517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ