### PR TITLE
[CI] Run CI with specific commit sha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,11 +188,12 @@ jobs:
 
     - name: Run Dockerized tests
       run: |
+          MLRUN_VERSION=${{ github.sha }} \
           MLRUN_DOCKER_REGISTRY=ghcr.io/ \
           MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
           MLRUN_PYTHON_VERSION=${{ matrix.python-version }} \
           RUN_COVERAGE=$RUN_COVERAGE \
-          make test-integration-dockerized RUN_COVERAGE=$RUN_COVERAGE
+          make test-integration-dockerized
       timeout-minutes: 90
 
     - name: Upload coverage report
@@ -220,7 +221,11 @@ jobs:
           export unstable_tag=$(if [ -z "$version_suffix" ]; then echo "unstable-cache"; else echo "unstable-cache-$version_suffix";fi)
           echo "tag=$(echo $unstable_tag)" >> $GITHUB_OUTPUT
       - name: Run Dockerized DB Migration tests
-        run: MLRUN_DOCKER_REGISTRY=ghcr.io/ MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-migrations-dockerized RUN_COVERAGE=true
+        run: |
+          MLRUN_VERSION=${{ github.sha }} \
+          MLRUN_DOCKER_REGISTRY=ghcr.io/ \
+          MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+          make test-migrations-dockerized RUN_COVERAGE=true
       - name: Upload coverage report
         uses: actions/upload-artifact@v5
         with:
@@ -310,7 +315,9 @@ jobs:
       - name: Run Backward Compatibility Tests
         run: |
           cd head/mlrun
-          MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} make test-backward-compatibility-dockerized
+          MLRUN_VERSION=${{ github.sha }} \
+          MLRUN_DOCKER_CACHE_FROM_TAG=${{ steps.docker_cache.outputs.tag }} \
+          make test-backward-compatibility-dockerized
 
   verify-compatible-requirements-one-after-one:
     name: Verify compatible requirements (one after one)

--- a/Makefile
+++ b/Makefile
@@ -647,6 +647,8 @@ test-dockerized: build-test ## Run mlrun tests in docker container
 		--rm \
 		--network='host' \
 		-e MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
+		-e MLRUN_VERSION=$(MLRUN_VERSION) \
+		-e MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
 		-v /tmp:/tmp \
 		-v $$COVERAGE_MOUNT_PATH:/mlrun/tests/coverage_reports \
 		-v /var/run/docker.sock:/var/run/docker.sock \
@@ -709,6 +711,8 @@ test-integration-dockerized: build-test api ## Run mlrun integration tests in do
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $$COVERAGE_MOUNT_PATH:/mlrun/tests/coverage_reports \
 		-e RUN_COVERAGE=$(RUN_COVERAGE) \
+		-e MLRUN_VERSION=$(MLRUN_VERSION) \
+		-e MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
 		--add-host=host.docker.internal:host-gateway \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-integration
 
@@ -741,6 +745,8 @@ test-migrations-dockerized: build-test ## Run mlrun db migrations tests in docke
 		-v /tmp:/tmp \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-e RUN_COVERAGE=$(RUN_COVERAGE) \
+		-e MLRUN_VERSION=$(MLRUN_VERSION) \
+		-e MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
 		-v $$COVERAGE_MOUNT_PATH:/mlrun/tests/coverage_reports \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make RUN_COVERAGE=true test-migrations
 
@@ -944,6 +950,8 @@ endif
 	    -v /var/run/docker.sock:/var/run/docker.sock \
 	    --env MLRUN_BC_TESTS_BASE_CODE_PATH=$(MLRUN_BC_TESTS_BASE_CODE_PATH) \
 	    --env MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH=$(shell pwd) \
+		--env MLRUN_VERSION=$(MLRUN_VERSION) \
+		--env MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
 	    --workdir=$(shell pwd) \
 	    $(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-backward-compatibility
 

--- a/tests/integration/sdk_api/base.py
+++ b/tests/integration/sdk_api/base.py
@@ -156,7 +156,7 @@ class TestMLRunIntegration:
             env_vars["MLRUN_HTTPDB__REAL_PATH"] = real_path
 
         registry = os.getenv("MLRUN_DOCKER_REGISTRY", "ghcr.io/").rstrip("/")
-        tag = os.getenv("MLRUN_DOCKER_CACHE_FROM_TAG", "unstable")
+        tag = os.getenv("MLRUN_VERSION", "unstable")
         image = image or f"{registry}/mlrun/mlrun-api:{tag}"
 
         client = docker.from_env()


### PR DESCRIPTION
### 📝 Description

Currently, the CI runs with `unstable` and running api container from `usntable-cache` which makes PRs unstable when changing non-BC changes against API

---

### 🛠️ Changes Made

Injects unique-commit to ensure PRs running dockerized tests are building from PR and running against that PR

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
