### PR TITLE
[Hub] Normalizing the backend categories of the hub items before returning the catalog

### DIFF
--- a/server/py/services/api/crud/hub.py
+++ b/server/py/services/api/crud/hub.py
@@ -107,6 +107,7 @@ class Hub(metaclass=mlrun.utils.singleton.Singleton):
             if (tag is None or item.metadata.tag == tag) and (
                 version is None or item.metadata.version == version
             ):
+                self._normalize_categories(item)
                 result_catalog.catalog.append(item)
 
         return result_catalog
@@ -396,3 +397,35 @@ class Hub(metaclass=mlrun.utils.singleton.Singleton):
         """
         normalized_name = mlrun.utils.helpers.normalize_name(item_name)
         return [item for item in catalog if item.metadata.name == normalized_name]
+
+    @staticmethod
+    def _normalize_categories(item: mlrun.common.schemas.hub.HubItem):
+        """
+        Normalize the item categories to UI format using a predefined mapping,
+        falling back to default (title) formatting when no match is found.
+        """
+
+        unique_mapping = {
+            "etl": "ETL",
+            "genai": "GenAI",
+            "NLP": "NLP",
+            "pytorch": "PyTorch",
+            "huggingface": "Hugging Face",
+            "structured-ML": "Structured ML",
+        }
+
+        categories = getattr(item.metadata, "categories", [])
+        normalized_categories = []
+
+        for s in categories:
+            if not isinstance(s, str):
+                continue
+
+            if s in unique_mapping:
+                normalized_categories.append(unique_mapping[s])
+                continue
+
+            normalized = s.replace("-", " ").title().strip()
+            normalized_categories.append(normalized)
+
+        setattr(item.metadata, "categories", normalized_categories)


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
Map the backend categories of the hub items to their UI form before returning the catalog.
(First check in a dictionary for unique mapping then fallback is standard title normalization). 
<!-- Include any relevant context or background information. -->

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
ran all the hub unit & integration tests
---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/FHUB-11
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
