### PR TITLE
[Images] Ensure ml-base image replacement works with Python suffixes [1.10.x]

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1025,8 +1025,10 @@ def enrich_image_url(
         # use the tag from image URL if available, else fallback to the given tag
         tag = image_tag or tag
         if tag:
+            # Remove '-pyXY' suffix if present, since the compatibility check expects a valid semver string
+            tag_for_compatibility = re.sub(r"-py\d+$", "", tag)
             if mlrun.utils.helpers.validate_component_version_compatibility(
-                "mlrun-client", "1.10.0-rc0", mlrun_client_version=tag
+                "mlrun-client", "1.10.0-rc0", mlrun_client_version=tag_for_compatibility
             ):
                 warnings.warn(
                     "'mlrun/ml-base' image is deprecated in 1.10.0 and will be removed in 1.12.0, "

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -808,6 +808,14 @@ def test_validate_v3io_consumer_group(value, expected):
             "images_registry": "",
             "expected_output": "mlrun/mlrun:1.11.0",
         },
+        {
+            "image": "mlrun/ml-base",
+            "client_version": "1.10.0",
+            "client_python_version": "3.9.13",
+            "images_tag": None,
+            "expected_output": "mlrun/mlrun:1.10.0-py39",
+            "images_to_enrich_registry": "",
+        },
         # version < 1.10.0 — ml-base image is still valid, image should remain unchanged
         {
             "image": "mlrun/ml-base",


### PR DESCRIPTION
### 📝 Description
This PR fixes an issue where the `mlrun/ml-base` image was not correctly replaced with `mlrun/mlrun` when the tag included a Python version suffix (e.g., `-py39`).

---

### 🛠️ Changes Made
- Strip the -pyXY suffix from the tag only for the version compatibility check.
- Keep the original tag intact when forming the final image URL.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Added unit test
- Tested on vmdev, patched mlrun 1.10.0 and updated the server code with my change, after running the NB attached in the ticket ( on python 3.9 ) , the `mlrun/ml-base` image is being replaced with `mlrun/mlrun` as expected :
<img width="2938" height="556" alt="image" src="https://github.com/user-attachments/assets/d24f4d95-e65a-4dec-9b85-dd63ebb803a2" />


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11602
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
