### PR TITLE
[API] Fix smtp refresh configuration [1.10.x]

### DIFF
--- a/server/py/services/api/api/endpoints/operations.py
+++ b/server/py/services/api/api/endpoints/operations.py
@@ -194,26 +194,31 @@ def _create_refresh_smtp_configuration_background_task(
 
 
 async def _perform_refresh_smtp(session: str):
-    iguazio_client_instance = iguazio_client.Client()
-    try:
-        returned_smtp_configuration = iguazio_client_instance.get_smtp_configuration(
-            session
-        )
-    except mlrun.errors.MLRunInternalServerError as exc:
-        logger.warning(
-            "Failed to get SMTP configuration from Iguazio",
-            exc=mlrun.errors.err_to_str(exc),
-        )
-        raise
+    # if running in iguazio, get the SMTP configuration from iguazio and store it in k8s secret store
+    # on igz4 / ce - simply read the k8s secret and update the cache
+    if mlrun.mlconf.iguazio_api_url and not mlrun.mlconf.is_iguazio_v4_mode():
+        iguazio_client_instance = iguazio_client.Client()
+        try:
+            returned_smtp_configuration = (
+                iguazio_client_instance.get_smtp_configuration(session)
+            )
+        except mlrun.errors.MLRunInternalServerError as exc:
+            logger.warning(
+                "Failed to get SMTP configuration from Iguazio",
+                exc=mlrun.errors.err_to_str(exc),
+            )
+            raise
 
-    updated_params = {
-        "server_host": returned_smtp_configuration.host,
-        "server_port": str(returned_smtp_configuration.port),
-        "sender_address": returned_smtp_configuration.sender_address,
-        "username": returned_smtp_configuration.auth_username,
-        "password": returned_smtp_configuration.auth_password,
-    }
-    _store_mail_notifications_default_params_to_secret(updated_params)
+        updated_params = {
+            "server_host": returned_smtp_configuration.host,
+            "server_port": str(returned_smtp_configuration.port),
+            "sender_address": returned_smtp_configuration.sender_address,
+            "username": returned_smtp_configuration.auth_username,
+            "password": returned_smtp_configuration.auth_password,
+        }
+        _store_mail_notifications_default_params_to_secret(updated_params)
+
+    # refresh the mail notification pusher default params cache
     notification_pusher.RunNotificationPusher.get_mail_notification_default_params(
         refresh=True
     )

--- a/server/py/services/api/api/endpoints/operations.py
+++ b/server/py/services/api/api/endpoints/operations.py
@@ -195,8 +195,8 @@ def _create_refresh_smtp_configuration_background_task(
 
 async def _perform_refresh_smtp(session: str):
     # if running in iguazio, get the SMTP configuration from iguazio and store it in k8s secret store
-    # on igz4 / ce - simply read the k8s secret and update the cache
-    if mlrun.mlconf.iguazio_api_url and not mlrun.mlconf.is_iguazio_v4_mode():
+    # on ce - simply read the k8s secret and update the cache
+    if mlrun.mlconf.iguazio_api_url:
         iguazio_client_instance = iguazio_client.Client()
         try:
             returned_smtp_configuration = (

--- a/server/py/services/api/tests/unit/api/test_operations.py
+++ b/server/py/services/api/tests/unit/api/test_operations.py
@@ -152,6 +152,7 @@ async def test_perform_refresh_smtp(
     monkeypatch.setattr(
         framework.utils.singletons.k8s, "get_k8s_helper", lambda: k8s_secrets_mock
     )
+    mlrun.mlconf.iguazio_api_url = "https://some-iguazio-url.com"
     await services.api.api.endpoints.operations._perform_refresh_smtp("")
     mail_notification_default_params = (
         notification_pusher.RunNotificationPusher.mail_notification_default_params
@@ -177,6 +178,7 @@ async def test_failed_perform_refresh_smtp(
         "get_smtp_configuration",
         raise_exception,
     )
+    mlrun.mlconf.iguazio_api_url = "https://some-iguazio-url.com"
     with pytest.raises(mlrun.errors.MLRunInternalServerError):
         await services.api.api.endpoints.operations._perform_refresh_smtp("")
 


### PR DESCRIPTION
### 📝 Description

Refresh token fetches the smtp configuration from a secret and updates its cache. for iguazio 3 it fetches the information from the control plane first. This PR simply ensures that it goes to iguazio control plane, when iguazio api is set.

---

### 🛠️ Changes Made

verify we have iguazio url before fetching the smtp configuration from iguazio api.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
- [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
- [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

unit testings

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11610
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->

(cherry picked from commit a3396a27ab58e2345a663ce17c6289311f034d06)

