### PR TITLE
[CI] Fix kfp18 dependency version conflict

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -84,7 +84,7 @@ def extra_requirements() -> dict[str, list[str]]:
     extras_require.update(
         {
             "dev-postgres": ["pytest-mock-resources[postgres]~=2.12"],
-            "kfp18": ["mlrun_pipelines_kfp_v1_8[kfp]~=0.5.8"],
+            "kfp18": ["mlrun_pipelines_kfp_v1_8[kfp]~=0.6.0"],
             # TODO uncomment when KFP 1.8 support is removed
             # "kfp2": ["mlrun_pipelines_kfp_v2[kfp]>=0.5.0 ; python_version >= '3.11'"],
             "api": api_deps,


### PR DESCRIPTION
## Summary
Fix dependency version conflict between requirements.txt and dependencies.py for mlrun-pipelines-kfp-v1-8. Dependabot PR #8999 updated requirements.txt to ~=0.6.0 but missed dependencies.py, causing CI failures when installing mlrun[kfp18].

## Changes Made
- Update dependencies.py:87 kfp18 extra from ~=0.5.8 to ~=0.6.0

## Testing
- CI should pass with mlrun[kfp18] installation

## Reference
- Jira: [ML-11661](https://iguazio.atlassian.net/browse/ML-11661)

[ML-11661]: https://iguazio.atlassian.net/browse/ML-11661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ