### PR TITLE
[Model Monitoring] Fix SQL WHERE clause bug in aggregate deletion

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
@@ -220,7 +220,7 @@ class TimescaleDBOperationsManager:
             if include_aggregates:
                 # Always try to discover and delete aggregates, regardless of config
                 all_deletion_statements.extend(
-                    self._get_aggregate_delete_statements(endpoint_ids)
+                    self._get_aggregate_delete_statements_by_endpoints(endpoint_ids)
                 )
 
             # Execute all deletions in a single transaction
@@ -268,7 +268,7 @@ class TimescaleDBOperationsManager:
 
         return statements
 
-    def _get_aggregate_delete_statements(
+    def _get_aggregate_delete_statements_by_endpoints(
         self, endpoint_ids: list[str]
     ) -> list[Statement]:
         """
@@ -277,10 +277,14 @@ class TimescaleDBOperationsManager:
         This approach discovers all existing aggregate tables rather than relying on configuration,
         ensuring we don't miss any aggregate data.
 
-        :param endpoint_ids: List of endpoint IDs to delete
+        :param endpoint_ids: List of endpoint IDs to delete (must be non-empty)
         :return: List of Statement objects for aggregate data deletion
         """
         statements = []
+
+        # Early return for empty endpoint list - nothing to delete
+        if not endpoint_ids:
+            return statements
 
         try:
             schema_name = self.tables[mm_schemas.TimescaleDBTables.PREDICTIONS].schema
@@ -299,7 +303,8 @@ class TimescaleDBOperationsManager:
             if not base_patterns:
                 return statements
 
-            # Build query to find all aggregate tables and views
+            # Build query to find all aggregate tables and continuous aggregate views
+            # TimescaleDB continuous aggregates appear as VIEWs in information_schema
             pattern_conditions = []
             parameters = [schema_name]
 
@@ -312,30 +317,16 @@ class TimescaleDBOperationsManager:
                 )
                 parameters.extend(TimescaleDBNaming.get_all_aggregate_patterns(pattern))
 
-            # Build separate pattern conditions for materialized views
-            view_pattern_conditions = []
-            view_parameters = [schema_name]
-
-            for pattern in base_patterns:
-                view_pattern_conditions.append("matviewname LIKE %s")
-                view_parameters.append(TimescaleDBNaming.get_cagg_pattern(pattern))
-
-            # Query for both tables and materialized views
             discovery_stmt = Statement(
                 f"""
                 SELECT table_name
                 FROM information_schema.tables
                 WHERE table_schema = %s
-                AND table_type = 'BASE TABLE'
+                AND table_type IN ('BASE TABLE', 'VIEW')
                 AND ({' OR '.join(pattern_conditions)})
-                UNION
-                SELECT matviewname as table_name
-                FROM pg_matviews
-                WHERE schemaname = %s
-                AND ({' OR '.join(view_pattern_conditions)})
                 ORDER BY table_name
                 """,
-                tuple([schema_name] + parameters[1:] + view_parameters[1:]),
+                tuple(parameters),
             )
 
             result = self._connection.run(query=discovery_stmt)
@@ -360,12 +351,12 @@ class TimescaleDBOperationsManager:
 
             # Create delete statements for all discovered aggregate objects
             for object_name in discovered_objects:
-                delete_sql = f"DELETE FROM {schema_name}.{object_name} WHERE "
+                delete_sql = f"DELETE FROM {schema_name}.{object_name} WHERE"
                 if len(endpoint_ids) == 1:
-                    f" {mm_schemas.WriterEvent.ENDPOINT_ID} = %s"
+                    delete_sql += f" {mm_schemas.WriterEvent.ENDPOINT_ID} = %s"
                     stmt = Statement(delete_sql, (endpoint_ids[0],))
                 else:
-                    f" {mm_schemas.WriterEvent.ENDPOINT_ID} = ANY(%s)"
+                    delete_sql += f" {mm_schemas.WriterEvent.ENDPOINT_ID} = ANY(%s)"
                     stmt = Statement(delete_sql, (endpoint_ids,))
 
                 statements.append(stmt)
@@ -713,7 +704,9 @@ class TimescaleDBOperationsManager:
             app_filter = f"{mm_schemas.WriterEvent.APPLICATION_NAME} = %s"
             base_parameters = [application_name]
 
-            if endpoint_ids:
+            # Note: None means "delete all for this application" (no endpoint filter)
+            # Empty list [] would delete nothing, so we treat it same as None
+            if endpoint_ids:  # Non-empty list
                 if len(endpoint_ids) == 1:
                     endpoint_filter = f" AND {mm_schemas.WriterEvent.ENDPOINT_ID} = %s"
                     parameters = base_parameters + [endpoint_ids[0]]

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_operations.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_operations.py
@@ -641,17 +641,151 @@ class TestTimescaleDBOperationsManagerIntegration:
         test_endpoints = ["endpoint-1", "endpoint-2", "endpoint-3"]
 
         # Test aggregate delete statements generation
-        statements = operations_handler._get_aggregate_delete_statements(test_endpoints)
+        statements = operations_handler._get_aggregate_delete_statements_by_endpoints(
+            test_endpoints
+        )
 
         # Should return a list of statements
         assert isinstance(statements, list), "Should return a list of statements"
 
         # Should handle empty endpoint list gracefully
-        empty_statements = operations_handler._get_aggregate_delete_statements([])
+        empty_statements = (
+            operations_handler._get_aggregate_delete_statements_by_endpoints([])
+        )
         assert isinstance(empty_statements, list), "Should handle empty endpoint list"
 
         # Cleanup
         operations_handler.delete_tsdb_resources()
+
+    def test_aggregate_deletion_sql_where_clause_completeness(
+        self, query_test_helper_with_aggregates
+    ):
+        """Verify DELETE statements for aggregates have proper WHERE clause.
+
+        Uses the existing query_test_helper_with_aggregates fixture which
+        creates continuous aggregates via the standard API.
+        """
+        operations_handler = query_test_helper_with_aggregates.operations_handler
+
+        # Get aggregate delete statements - fixture creates _cagg_ views
+        statements = operations_handler._get_aggregate_delete_statements_by_endpoints(
+            ["test-endpoint-1"]
+        )
+
+        # Should have discovered aggregate objects (continuous aggregates)
+        assert len(statements) > 0, (
+            "Expected to find aggregate objects for deletion. "
+            "Fixture should have created continuous aggregates."
+        )
+
+        # Verify each statement has a complete WHERE clause with endpoint_id = %s
+        for stmt in statements:
+            sql = stmt.sql
+            assert sql.endswith("WHERE endpoint_id = %s"), (
+                f"DELETE statement should end with 'WHERE endpoint_id = %s', "
+                f"got: {sql}"
+            )
+
+        # Also test with multiple endpoints (uses ANY(%s) syntax)
+        multi_statements = (
+            operations_handler._get_aggregate_delete_statements_by_endpoints(
+                ["test-endpoint-1", "test-endpoint-2"]
+            )
+        )
+        assert len(multi_statements) > 0, "Expected statements for multiple endpoints"
+
+        for stmt in multi_statements:
+            sql = stmt.sql
+            assert sql.endswith("WHERE endpoint_id = ANY(%s)"), (
+                f"DELETE statement should end with 'WHERE endpoint_id = ANY(%s)', "
+                f"got: {sql}"
+            )
+
+    def test_aggregate_data_deletion_integration(
+        self, query_test_helper_with_aggregates, admin_connection
+    ):
+        """Integration test: verify data is actually deleted from aggregate tables.
+
+        This test inserts data into the raw table, refreshes continuous aggregates
+        to materialize the data, then deletes by endpoint and verifies data is
+        gone from both raw and aggregate tables.
+
+        Uses admin_connection (autocommit=True) for refresh_continuous_aggregate
+        which cannot run inside a transaction block.
+        """
+        operations_handler = query_test_helper_with_aggregates.operations_handler
+        connection = query_test_helper_with_aggregates.connection
+        predictions_table = operations_handler.tables[
+            mm_schemas.TimescaleDBTables.PREDICTIONS
+        ]
+        schema_name = predictions_table.schema
+
+        test_endpoint = "test-endpoint-for-agg-deletion"
+        other_endpoint = "other-endpoint-keep"
+
+        # Insert test data into raw predictions table for both endpoints
+        for endpoint in [test_endpoint, other_endpoint]:
+            self._insert_prediction_data(connection, predictions_table, endpoint)
+
+        # Verify raw data exists
+        self._verify_table_data(
+            connection, predictions_table, 1, f"endpoint_id = '{test_endpoint}'"
+        )
+        self._verify_table_data(
+            connection, predictions_table, 1, f"endpoint_id = '{other_endpoint}'"
+        )
+
+        # Refresh continuous aggregates to materialize the data
+        # Using admin_connection with autocommit=True (required for CALL statements)
+        cagg_result = connection.run(
+            query=f"""
+            SELECT view_name FROM timescaledb_information.continuous_aggregates
+            WHERE hypertable_schema = '{schema_name}'
+            AND view_name LIKE 'predictions_%'
+            """
+        )
+
+        for row in cagg_result.data:
+            cagg_name = row[0]
+            admin_connection.run(
+                statements=[
+                    f"CALL refresh_continuous_aggregate('{schema_name}.{cagg_name}', NULL, NULL);"
+                ]
+            )
+
+        # Find a predictions continuous aggregate to verify deletion
+        predictions_cagg = next(
+            (row[0] for row in cagg_result.data if "_cagg_" in row[0]),
+            None,
+        )
+        assert (
+            predictions_cagg is not None
+        ), "Expected to find a predictions continuous aggregate"
+
+        # Delete records for test_endpoint including aggregates
+        operations_handler.delete_tsdb_records([test_endpoint], include_aggregates=True)
+
+        # Verify test_endpoint data is deleted from raw table
+        self._verify_table_data(
+            connection, predictions_table, 0, f"endpoint_id = '{test_endpoint}'"
+        )
+
+        # Verify other_endpoint data is NOT deleted from raw table
+        self._verify_table_data(
+            connection, predictions_table, 1, f"endpoint_id = '{other_endpoint}'"
+        )
+
+        # Verify test_endpoint data is deleted from continuous aggregate
+        result = connection.run(
+            query=f"""
+            SELECT COUNT(*) FROM {schema_name}.{predictions_cagg}
+            WHERE endpoint_id = '{test_endpoint}'
+            """
+        )
+        assert result.data[0][0] == 0, (
+            f"Expected 0 records for {test_endpoint} in {predictions_cagg} after deletion, "
+            f"got {result.data[0][0]}"
+        )
 
     def test_application_deletion_statements_generation(self, query_test_helper):
         """Test generation of application-specific deletion statements."""


### PR DESCRIPTION
## Summary

- Fix SQL WHERE clause bug in TimescaleDB aggregate deletion where the condition was constructed but not appended to the DELETE statement
- Fix aggregate discovery query to find continuous aggregates (which appear as VIEWs, not BASE TABLEs)
- Add integration test that verifies data is actually deleted from both raw and aggregate tables

## Root Cause

The bug was hidden by multiple issues:
1. WHERE clause was constructed as f-string but not assigned: `f" endpoint_id = %s"` instead of `delete_sql += f" endpoint_id = %s"`
2. Discovery query had parameter mismatch (11 placeholders, 10 parameters) causing silent failure
3. Discovery query only looked for `BASE TABLE` but TimescaleDB continuous aggregates appear as `VIEW` in information_schema
4. Existing tests only verified raw table deletion, not aggregate deletion

## Test plan

- [x] Run `make fmt` - passed
- [x] Run `make lint` on changed files - passed
- [x] Run all TimescaleDB tests (105 tests) - passed
- [x] New test `test_aggregate_deletion_sql_where_clause_completeness` verifies SQL correctness
- [x] New test `test_aggregate_data_deletion_integration` verifies actual data deletion from aggregates

Reference: ML-11642