### PR TITLE
[CI] Run against mysql 8.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ MLRUN_ML_DOCKER_IMAGE_NAME_PREFIX ?= ml-
 # mainly used for mlrun and mlrun-gpu.
 MLRUN_PYTHON_VERSION ?= 3.11
 
+# Centralized MySQL image tag for tests and tooling (overridable)
+MLRUN_MYSQL_IMAGE ?= gcr.io/iguazio/mlrun-mysql:8.4
+
 # TODO: remove this once iguazio package is released to PyPI and move to requirements.txt
 IGUAZIO_PACKAGE_VERSION ?= 0.0.1a16
 
@@ -226,7 +229,7 @@ install-all-requirements: ## Install all requirements needed for development and
 
 .PHONY: create-migration-mysql
 create-migration-mysql: ## Create a DB migration (MLRUN_MIGRATION_MESSAGE must be set)
-	./automation/scripts/create_migration_mysql.sh
+	MLRUN_MYSQL_IMAGE=$(MLRUN_MYSQL_IMAGE) ./automation/scripts/create_migration_mysql.sh
 
 .PHONY: create-migration
 create-migration: create-migration-mysql
@@ -643,6 +646,7 @@ test-dockerized: build-test ## Run mlrun tests in docker container
 		-e MLRUN_PYTHON_VERSION=$(MLRUN_PYTHON_VERSION) \
 		-e MLRUN_VERSION=$(MLRUN_VERSION) \
 		-e MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
+		-e MLRUN_MYSQL_IMAGE=$(MLRUN_MYSQL_IMAGE) \
 		-v /tmp:/tmp \
 		-v $$COVERAGE_MOUNT_PATH:/mlrun/tests/coverage_reports \
 		-v /var/run/docker.sock:/var/run/docker.sock \
@@ -707,6 +711,7 @@ test-integration-dockerized: build-test api ## Run mlrun integration tests in do
 		-e RUN_COVERAGE=$(RUN_COVERAGE) \
 		-e MLRUN_VERSION=$(MLRUN_VERSION) \
 		-e MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
+		-e MLRUN_MYSQL_IMAGE=$(MLRUN_MYSQL_IMAGE) \
 		--add-host=host.docker.internal:host-gateway \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make test-integration
 
@@ -716,6 +721,7 @@ test-integration: clean ## Run mlrun integration tests
 	COVERAGE_FILE=$(COVERAGE_FILE) && \
 	COVERAGE_FILE=$${COVERAGE_FILE:-"tests/coverage_reports/integration_tests.coverage"} && \
 	$(SETUP_COVERAGE) && \
+	MLRUN_MYSQL_IMAGE=$(MLRUN_MYSQL_IMAGE) \
 	python $(COVERAGE_ADDITION) \
 		-m pytest -v \
 		--capture=no \
@@ -741,6 +747,7 @@ test-migrations-dockerized: build-test ## Run mlrun db migrations tests in docke
 		-e RUN_COVERAGE=$(RUN_COVERAGE) \
 		-e MLRUN_VERSION=$(MLRUN_VERSION) \
 		-e MLRUN_DOCKER_REGISTRY=$(MLRUN_DOCKER_REGISTRY) \
+		-e MLRUN_MYSQL_IMAGE=$(MLRUN_MYSQL_IMAGE) \
 		-v $$COVERAGE_MOUNT_PATH:/mlrun/tests/coverage_reports \
 		$(MLRUN_TEST_IMAGE_NAME_TAGGED) make RUN_COVERAGE=true test-migrations
 
@@ -749,7 +756,7 @@ test-migrations: clean ## Run mlrun db migrations tests
 	COVERAGE_FILE=$(COVERAGE_FILE) && \
 	COVERAGE_FILE=$${COVERAGE_FILE:-"tests/coverage_reports/migration_tests.coverage"} && \
 	export COVERAGE_FILE && \
-	$(SETUP_COVERAGE) && \
+	export MLRUN_MYSQL_IMAGE=$(MLRUN_MYSQL_IMAGE) && \
 	bash -c 'set -euo pipefail; \
 	  python -u $(COVERAGE_ADDITION) -m pytest -vvv \
 	    --capture=no --disable-warnings --durations=100 \

--- a/Makefile
+++ b/Makefile
@@ -755,8 +755,9 @@ test-migrations-dockerized: build-test ## Run mlrun db migrations tests in docke
 test-migrations: clean ## Run mlrun db migrations tests
 	COVERAGE_FILE=$(COVERAGE_FILE) && \
 	COVERAGE_FILE=$${COVERAGE_FILE:-"tests/coverage_reports/migration_tests.coverage"} && \
-	export COVERAGE_FILE && \
 	export MLRUN_MYSQL_IMAGE=$(MLRUN_MYSQL_IMAGE) && \
+	export COVERAGE_FILE && \
+	$(SETUP_COVERAGE) && \
 	bash -c 'set -euo pipefail; \
 	  python -u $(COVERAGE_ADDITION) -m pytest -vvv \
 	    --capture=no --disable-warnings --durations=100 \

--- a/automation/scripts/create_migration_mysql.sh
+++ b/automation/scripts/create_migration_mysql.sh
@@ -39,7 +39,7 @@ docker run \
 	-e MYSQL_ROOT_HOST="%" \
 	-e MYSQL_DATABASE="mlrun" \
 	-d \
-	gcr.io/iguazio/mlrun-mysql:8.0 \
+	"$MLRUN_MYSQL_IMAGE" \
 	--character-set-server=utf8 \
 	--collation-server=utf8_bin
 

--- a/server/py/services/api/migrations/tests/mysql/conftest.py
+++ b/server/py/services/api/migrations/tests/mysql/conftest.py
@@ -18,6 +18,7 @@ from collections.abc import Generator, Iterator
 import pytest
 import pytest_mock_resources
 import sqlalchemy
+import sqlalchemy.event
 from _pytest.config import Config
 
 import mlrun
@@ -26,6 +27,22 @@ import framework.utils.db.utils
 import framework.utils.singletons.db
 
 mysql_engine = pytest_mock_resources.create_mysql_fixture(scope="session")
+
+
+# TODO: Remove me once we squash all old alembic revisions that create FKs
+# that reference non-unique columns.
+def _set_mysql_session_variables(dbapi_connection, connection_record):
+    """
+    Event listener to set MySQL session variables on every new connection.
+    This ensures FK constraints can reference non-unique columns (MySQL 8.4+).
+    """
+    cursor = dbapi_connection.cursor()
+    try:
+        # MySQL 8.4+ requires unique keys for FK references by default.
+        # Disable this restriction at session level for each connection.
+        cursor.execute("SET SESSION restrict_fk_on_non_standard_key = OFF")
+    finally:
+        cursor.close()
 
 
 @pytest.fixture(scope="session")
@@ -51,7 +68,13 @@ def alembic_engine(
     with admin_engine.connect() as conn:
         conn.execute(sqlalchemy.text(f"DROP DATABASE IF EXISTS `{db_name}`"))
         conn.execute(sqlalchemy.text(f"CREATE DATABASE `{db_name}`"))
-    admin_engine.dispose()
+
+    # Register event listener to set MySQL session variables on every connection.
+    # This ensures FK constraints can reference non-unique columns (MySQL 8.4+).
+    sqlalchemy.event.listen(mysql_engine, "connect", _set_mysql_session_variables)
+
+    # Force any existing connections to be closed so new ones get the event listener
+    mysql_engine.dispose()
 
     os.environ["MLRUN_HTTPDB__DSN"] = db_url.render_as_string(hide_password=False)
     mlrun.mlconf.reload()

--- a/server/py/services/api/migrations/tests/mysql/conftest.py
+++ b/server/py/services/api/migrations/tests/mysql/conftest.py
@@ -31,7 +31,7 @@ mysql_engine = pytest_mock_resources.create_mysql_fixture(scope="session")
 @pytest.fixture(scope="session")
 def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
     return pytest_mock_resources.MysqlConfig(
-        image="mysql:8.4",
+        image=os.getenv("MLRUN_MYSQL_IMAGE", "gcr.io/iguazio/mlrun-mysql:8.4"),
         port=3306,
         username="root",
         password="pass",

--- a/server/py/services/api/migrations/tests/mysql/conftest.py
+++ b/server/py/services/api/migrations/tests/mysql/conftest.py
@@ -31,7 +31,7 @@ mysql_engine = pytest_mock_resources.create_mysql_fixture(scope="session")
 @pytest.fixture(scope="session")
 def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
     return pytest_mock_resources.MysqlConfig(
-        image="mysql:8.0",
+        image="mysql:8.4",
         port=3306,
         username="root",
         password="pass",

--- a/server/py/services/api/migrations/tests/mysql/test_mysql_migrations.py
+++ b/server/py/services/api/migrations/tests/mysql/test_mysql_migrations.py
@@ -25,3 +25,6 @@ from services.api.migrations.tests.base.migrations_tests import (  # noqa
     test_upgrade,
     test_notification_params_to_secret_params,
 )
+
+if __name__ == "__main__":
+    pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def pmr_mysql_container(
 @pytest.fixture(scope="session")
 def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
     return pytest_mock_resources.MysqlConfig(
-        image="mysql:8.4",
+        image=os.getenv("MLRUN_MYSQL_IMAGE", "gcr.io/iguazio/mlrun-mysql:8.4"),
         port=3306,
         username="root",
         password="pass",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def pmr_mysql_container(
 @pytest.fixture(scope="session")
 def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
     return pytest_mock_resources.MysqlConfig(
-        image="mysql:8.0",
+        image="mysql:8.4",
         port=3306,
         username="root",
         password="pass",


### PR DESCRIPTION
### 📝 Description

Run CI and schema migrations against mysql:8.4 instances

---

### 🛠️ Changes Made

1. CI to run against mysql 8.4
2. Data migration to be created using mysql 8.4

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

CI testings

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11665
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
