### PR TITLE
[Model Monitoring] Add TimescaleDB database auto-creation

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -675,6 +675,12 @@ default_config = {
         "parquet_batching_max_events": 10_000,
         "parquet_batching_timeout_secs": timedelta(minutes=1).total_seconds(),
         "model_endpoint_creation_check_period": 15,
+        # TSDB (TimescaleDB) configuration
+        "tsdb": {
+            # When True, automatically create/generate database name using system_id if not explicitly
+            # specified in the connection string. When False, use the database from connection string as-is.
+            "auto_create_database": True,
+        },
     },
     "secret_stores": {
         # Use only in testing scenarios (such as integration tests) to avoid using k8s for secrets (will use in-memory

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -16,7 +16,7 @@ import ast
 import base64
 import json
 import typing
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, quote, unquote, urlparse
 
 import pydantic.v1
 from deprecated import deprecated
@@ -283,8 +283,9 @@ class DatastoreProfileRedis(DatastoreProfile):
 
     def url_with_credentials(self):
         parsed_url = urlparse(self.endpoint_url)
-        username = self.username
-        password = self.password
+        # URL-encode username and password to handle special characters like @, :, /
+        username = quote(self.username, safe="") if self.username else None
+        password = quote(self.password, safe="") if self.password else None
         netloc = parsed_url.hostname
         if username:
             if password:
@@ -464,7 +465,10 @@ class DatastoreProfileTDEngine(DatastoreProfile):
 
     def dsn(self) -> str:
         """Get the Data Source Name of the configured TDEngine profile."""
-        return f"{self.type}://{self.user}:{self.password}@{self.host}:{self.port}"
+        # URL-encode user and password to handle special characters like @, :, /
+        user = quote(self.user, safe="")
+        password = quote(self.password or "", safe="")
+        return f"{self.type}://{user}:{password}@{self.host}:{self.port}"
 
     @classmethod
     def from_dsn(cls, dsn: str, profile_name: str) -> "DatastoreProfileTDEngine":
@@ -476,10 +480,13 @@ class DatastoreProfileTDEngine(DatastoreProfile):
         :return:             The TDEngine profile.
         """
         parsed_url = urlparse(dsn)
+        # URL-decode username and password (urlparse doesn't decode them)
+        username = unquote(parsed_url.username) if parsed_url.username else None
+        password = unquote(parsed_url.password) if parsed_url.password else None
         return cls(
             name=profile_name,
-            user=parsed_url.username,
-            password=parsed_url.password,
+            user=username,
+            password=password,
             host=parsed_url.hostname,
             port=parsed_url.port,
         )
@@ -498,7 +505,7 @@ class DatastoreProfilePostgreSQL(DatastoreProfile):
     password: typing.Optional[str]
     host: str
     port: int
-    database: str = "postgres"  # Default to postgres maintenance database
+    database: str = "postgres"  # Default PostgreSQL admin database
 
     def dsn(self, database: typing.Optional[str] = None) -> str:
         """
@@ -509,15 +516,18 @@ class DatastoreProfilePostgreSQL(DatastoreProfile):
         :return: The DSN string.
         """
         db = database or self.database
-        return f"{self.type}://{self.user}:{self.password}@{self.host}:{self.port}/{db}"
+        # URL-encode credentials and database to handle special characters
+        user = quote(self.user, safe="")
+        password = quote(self.password or "", safe="")
+        db_encoded = quote(db, safe="")
+        return f"{self.type}://{user}:{password}@{self.host}:{self.port}/{db_encoded}"
 
     def admin_dsn(self) -> str:
         """
         Get DSN for administrative operations using the 'postgres' database.
 
-        PostgreSQL's 'postgres' database always exists and is used for admin
-        tasks like creating/dropping databases (you cannot connect to a database
-        while creating it).
+        Assumes the default 'postgres' database exists (standard PostgreSQL setup).
+        Used for admin tasks like creating/dropping databases.
 
         :return: DSN pointing to the 'postgres' database.
         """
@@ -534,13 +544,19 @@ class DatastoreProfilePostgreSQL(DatastoreProfile):
         :return:             The PostgreSQL profile.
         """
         parsed_url = urlparse(dsn)
+        # URL-decode username, password, and database (urlparse doesn't decode them)
+        username = unquote(parsed_url.username) if parsed_url.username else None
+        password = unquote(parsed_url.password) if parsed_url.password else None
+        database = (
+            unquote(parsed_url.path.lstrip("/")) if parsed_url.path else "postgres"
+        )
         return cls(
             name=profile_name,
-            user=parsed_url.username,
-            password=parsed_url.password,
+            user=username,
+            password=password,
             host=parsed_url.hostname,
             port=parsed_url.port,
-            database=parsed_url.path.lstrip("/") or "postgres",
+            database=database or "postgres",
         )
 
 

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -500,18 +500,37 @@ class DatastoreProfilePostgreSQL(DatastoreProfile):
     port: int
     database: str = pydantic.v1.Field(
         default="postgres"
-    )  # the default maintenance database
+    )  # Default to postgres maintenance database
 
-    def dsn(self) -> str:
-        """Get the Data Source Name of the configured PostgreSQL profile."""
-        return f"{self.type}://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
+    def dsn(self, database: typing.Optional[str] = None) -> str:
+        """
+        Get the Data Source Name of the configured PostgreSQL profile.
+
+        :param database: Optional database name to use instead of the configured one.
+                        If None, uses the configured database.
+        :return: The DSN string.
+        """
+        db = database if database is not None else self.database
+        return f"{self.type}://{self.user}:{self.password}@{self.host}:{self.port}/{db}"
+
+    def admin_dsn(self) -> str:
+        """
+        Get DSN for administrative operations using the 'postgres' maintenance database.
+
+        This is useful for operations that need to create/drop databases,
+        as you cannot connect to a database while creating it.
+
+        :return: DSN pointing to the 'postgres' maintenance database.
+        """
+        return self.dsn(database="postgres")
 
     @classmethod
     def from_dsn(cls, dsn: str, profile_name: str) -> "DatastoreProfilePostgreSQL":
         """
         Construct a PostgreSQL profile from DSN (connection string) and a name for the profile.
 
-        :param dsn:          The DSN (Data Source Name) of the PostgreSQL database, e.g.: ``"postgresql://user:password@localhost:5432/mydb"``.
+        :param dsn:          The DSN (Data Source Name) of the PostgreSQL database,
+                            e.g.: ``"postgresql://user:password@localhost:5432/mydb"``.
         :param profile_name: The new profile's name.
         :return:             The PostgreSQL profile.
         """

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -498,9 +498,7 @@ class DatastoreProfilePostgreSQL(DatastoreProfile):
     password: typing.Optional[str]
     host: str
     port: int
-    database: str = pydantic.v1.Field(
-        default="postgres"
-    )  # Default to postgres maintenance database
+    database: str = "postgres"  # Default to postgres maintenance database
 
     def dsn(self, database: typing.Optional[str] = None) -> str:
         """
@@ -510,17 +508,18 @@ class DatastoreProfilePostgreSQL(DatastoreProfile):
                         If None, uses the configured database.
         :return: The DSN string.
         """
-        db = database if database is not None else self.database
+        db = database or self.database
         return f"{self.type}://{self.user}:{self.password}@{self.host}:{self.port}/{db}"
 
     def admin_dsn(self) -> str:
         """
-        Get DSN for administrative operations using the 'postgres' maintenance database.
+        Get DSN for administrative operations using the 'postgres' database.
 
-        This is useful for operations that need to create/drop databases,
-        as you cannot connect to a database while creating it.
+        PostgreSQL's 'postgres' database always exists and is used for admin
+        tasks like creating/dropping databases (you cannot connect to a database
+        while creating it).
 
-        :return: DSN pointing to the 'postgres' maintenance database.
+        :return: DSN pointing to the 'postgres' database.
         """
         return self.dsn(database="postgres")
 
@@ -541,7 +540,7 @@ class DatastoreProfilePostgreSQL(DatastoreProfile):
             password=parsed_url.password,
             host=parsed_url.hostname,
             port=parsed_url.port,
-            database=parsed_url.path.lstrip("/") if parsed_url.path else "postgres",
+            database=parsed_url.path.lstrip("/") or "postgres",
         )
 
 

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connection.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connection.py
@@ -131,6 +131,12 @@ class TimescaleDBConnection:
             )
         return self._pool
 
+    def close(self) -> None:
+        """Close the connection pool if it exists."""
+        if self._pool is not None:
+            self._pool.close()
+            self._pool = None
+
     def _parse_version(self, version_string: str) -> semver.VersionInfo:
         """Parse TimescaleDB version string using semver."""
         try:

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -78,7 +78,7 @@ class TimescaleDBConnector(TSDBConnector):
 
         self.profile = profile
 
-        # Determine the target database name
+        # Determine the monitoring database name
         self.database = self._determine_database_name(profile)
 
         # Update profile to use the determined database name

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -56,9 +56,16 @@ class TimescaleDBConnector(TSDBConnector):
     - TimescaleDBMetricsQueries, TimescaleDBPredictionsQueries, TimescaleDBResultsQueries: Direct query operations
     - TimescaleDBOperationsManager: Table management and write operations
     - TimescaleDBStreamProcessor: Stream processing operations
+
+    Database naming (controlled by mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database):
+    - When auto_create_database=True (default): generates database name using system_id: 'mlrun_mm_{system_id}'
+    - When auto_create_database=False: uses the database from the profile/connection string as-is
     """
 
     type: str = mm_schemas.TSDBTarget.TimescaleDB
+
+    # Default database name prefix for auto-generated names
+    _DEFAULT_DB_PREFIX = "mlrun_mm"
 
     def __init__(
         self,
@@ -70,6 +77,28 @@ class TimescaleDBConnector(TSDBConnector):
         super().__init__(project=project)
 
         self.profile = profile
+
+        # Determine the target database name
+        self.database = self._determine_database_name(profile)
+
+        # Update profile to use the determined database name
+        # This ensures the connection uses the correct database
+        if profile.database != self.database:
+            logger.info(
+                "Auto-generated database name for TimescaleDB",
+                original_database=profile.database,
+                target_database=self.database,
+            )
+            # Create a new profile with the target database
+            profile = DatastoreProfilePostgreSQL(
+                name=profile.name,
+                user=profile.user,
+                password=profile.password,
+                host=profile.host,
+                port=profile.port,
+                database=self.database,
+            )
+            self.profile = profile
 
         # Create shared connection
         self._connection = TimescaleDBConnection(
@@ -110,6 +139,7 @@ class TimescaleDBConnector(TSDBConnector):
             project=project,
             connection=self._connection,
             pre_aggregate_config=pre_aggregate_config,
+            profile=profile,
         )
 
         self._stream = TimescaleDBStreamProcessor(
@@ -117,6 +147,34 @@ class TimescaleDBConnector(TSDBConnector):
         )
 
         self._pre_aggregate_config = pre_aggregate_config
+
+    def _determine_database_name(self, profile: DatastoreProfilePostgreSQL) -> str:
+        """
+        Determine the database name to use.
+
+        Behavior depends on `mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database`:
+        - When True (default): auto-generate database name using system_id
+        - When False: use the database from the profile as-is
+
+        :param profile: The PostgreSQL profile
+        :return: The database name to use
+        """
+        auto_create = mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database
+
+        if not auto_create:
+            # Use database from profile as-is
+            return profile.database or "postgres"
+
+        # Auto-create mode: generate database name using system_id
+        if not mlrun.mlconf.system_id:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "system_id is not set in mlrun.mlconf. "
+                "TimescaleDBConnector requires system_id for auto-generating database name "
+                "when auto_create_database is enabled. "
+                "Either set system_id in MLRun configuration or disable auto_create_database "
+                "and provide an explicit database in the PostgreSQL connection string."
+            )
+        return f"{self._DEFAULT_DB_PREFIX}_{mlrun.mlconf.system_id}"
 
     # Delegate operations methods
     def create_tables(self, *args, **kwargs) -> None:

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -87,9 +87,9 @@ class TimescaleDBConnector(TSDBConnector):
             logger.info(
                 "Auto-generated database name for TimescaleDB",
                 original_database=profile.database,
-                target_database=self.database,
+                database=self.database,
             )
-            # Create a new profile with the target database
+            # Create a new profile with the generated database
             profile = DatastoreProfilePostgreSQL(
                 name=profile.name,
                 user=profile.user,
@@ -163,7 +163,7 @@ class TimescaleDBConnector(TSDBConnector):
 
         if not auto_create:
             # Use database from profile as-is
-            return profile.database or "postgres"
+            return profile.database
 
         # Auto-create mode: generate database name using system_id
         if not mlrun.mlconf.system_id:

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
@@ -116,30 +116,34 @@ class TimescaleDBOperationsManager:
             autocommit=True,  # DDL requires autocommit
         )
 
-        # Check if database exists using parameterized Statement
-        check_stmt = Statement(
-            sql="SELECT 1 FROM pg_database WHERE datname = %s",
-            parameters=(database_name,),
-        )
-        result = admin_connection.run(query=check_stmt)
+        try:
+            # Check if database exists using parameterized Statement
+            check_stmt = Statement(
+                sql="SELECT 1 FROM pg_database WHERE datname = %s",
+                parameters=(database_name,),
+            )
+            result = admin_connection.run(query=check_stmt)
 
-        if not result or not result.data:
-            # Database doesn't exist, create it
-            # Note: CREATE DATABASE cannot be parameterized, but database_name
-            # comes from our own profile, not user input
-            admin_connection.run(statements=[f'CREATE DATABASE "{database_name}"'])
-            logger.info(
-                "Created TimescaleDB database",
-                project=self.project,
-                database=database_name,
-            )
-        else:
-            logger.debug(
-                "TimescaleDB database already exists",
-                project=self.project,
-                database=database_name,
-            )
-        # Note: TimescaleDBConnection uses connection pooling - no explicit close needed
+            if not result or not result.data:
+                # Database doesn't exist, create it
+                # Note: CREATE DATABASE cannot be parameterized, but database_name
+                # comes from our own profile, not user input
+                admin_connection.run(statements=[f'CREATE DATABASE "{database_name}"'])
+                logger.info(
+                    "Created TimescaleDB database",
+                    project=self.project,
+                    database=database_name,
+                )
+            else:
+                logger.debug(
+                    "TimescaleDB database already exists",
+                    project=self.project,
+                    database=database_name,
+                )
+        finally:
+            # Close the admin connection pool to avoid resource leak
+            if admin_connection._pool:
+                admin_connection._pool.close()
 
     def create_tables(
         self, pre_aggregate_config: Optional[PreAggregateConfig] = None

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
@@ -87,9 +87,9 @@ class TimescaleDBOperationsManager:
         """
         Create the database if it does not exist.
 
-        This method connects to the 'postgres' maintenance database to create
-        the target database if it doesn't already exist. It also ensures the
-        TimescaleDB extension is enabled in the target database.
+        This method connects to the default 'postgres' database to create
+        the monitoring database if it doesn't already exist. It also ensures the
+        TimescaleDB extension is enabled in the monitoring database.
 
         Note: Requires a profile to be set during initialization.
         """
@@ -108,7 +108,7 @@ class TimescaleDBOperationsManager:
             database=database_name,
         )
 
-        # Connect to postgres maintenance database to create our target database
+        # Connect to default postgres database to create the monitoring database
         admin_connection = TimescaleDBConnection(
             dsn=self._profile.admin_dsn(),
             min_connections=1,
@@ -142,8 +142,7 @@ class TimescaleDBOperationsManager:
                 )
         finally:
             # Close the admin connection pool to avoid resource leak
-            if admin_connection._pool:
-                admin_connection._pool.close()
+            admin_connection.close()
 
     def create_tables(
         self, pre_aggregate_config: Optional[PreAggregateConfig] = None

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
@@ -19,6 +19,7 @@ import psycopg
 import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.errors
 import mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_schema as timescaledb_schema
+from mlrun.datastore.datastore_profile import DatastoreProfilePostgreSQL
 from mlrun.model_monitoring.db.tsdb.preaggregate import PreAggregateConfig
 from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection import (
     Statement,
@@ -59,17 +60,19 @@ class TimescaleDBOperationsManager:
         project: str,
         connection: TimescaleDBConnection,
         pre_aggregate_config: Optional[PreAggregateConfig] = None,
+        profile: Optional[DatastoreProfilePostgreSQL] = None,
     ):
         """
         Initialize operations handler with a shared connection.
 
         :param project: The project name
-        :param profile: Datastore profile for connection (used for table initialization)
         :param connection: Shared TimescaleDBConnection instance
         :param pre_aggregate_config: Optional pre-aggregation configuration
+        :param profile: Optional datastore profile for admin operations (database creation)
         """
         self.project = project
         self._pre_aggregate_config = pre_aggregate_config
+        self._profile = profile
 
         # Use the injected shared connection
         self._connection = connection
@@ -79,6 +82,64 @@ class TimescaleDBOperationsManager:
 
     def _init_tables(self) -> None:
         self.tables = timescaledb_schema.create_table_schemas(self.project)
+
+    def _create_db_if_not_exists(self) -> None:
+        """
+        Create the database if it does not exist.
+
+        This method connects to the 'postgres' maintenance database to create
+        the target database if it doesn't already exist. It also ensures the
+        TimescaleDB extension is enabled in the target database.
+
+        Note: Requires a profile to be set during initialization.
+        """
+        if not self._profile:
+            logger.debug(
+                "No profile provided, skipping database creation",
+                project=self.project,
+            )
+            return
+
+        database_name = self._profile.database
+
+        logger.debug(
+            "Checking/creating TimescaleDB database",
+            project=self.project,
+            database=database_name,
+        )
+
+        # Connect to postgres maintenance database to create our target database
+        admin_connection = TimescaleDBConnection(
+            dsn=self._profile.admin_dsn(),
+            min_connections=1,
+            max_connections=1,
+            autocommit=True,  # DDL requires autocommit
+        )
+
+        # Check if database exists using parameterized Statement
+        check_stmt = Statement(
+            sql="SELECT 1 FROM pg_database WHERE datname = %s",
+            parameters=(database_name,),
+        )
+        result = admin_connection.run(query=check_stmt)
+
+        if not result or not result.data:
+            # Database doesn't exist, create it
+            # Note: CREATE DATABASE cannot be parameterized, but database_name
+            # comes from our own profile, not user input
+            admin_connection.run(statements=[f'CREATE DATABASE "{database_name}"'])
+            logger.info(
+                "Created TimescaleDB database",
+                project=self.project,
+                database=database_name,
+            )
+        else:
+            logger.debug(
+                "TimescaleDB database already exists",
+                project=self.project,
+                database=database_name,
+            )
+        # Note: TimescaleDBConnection uses connection pooling - no explicit close needed
 
     def create_tables(
         self, pre_aggregate_config: Optional[PreAggregateConfig] = None
@@ -90,6 +151,10 @@ class TimescaleDBOperationsManager:
             project=self.project,
             with_pre_aggregates=config is not None,
         )
+
+        # Create database if it doesn't exist
+        self._create_db_if_not_exists()
+
         # Try to create extension, ignore if already exists
         try:
             self._connection.run(

--- a/tests/datastore/test_datastore_profile.py
+++ b/tests/datastore/test_datastore_profile.py
@@ -176,6 +176,49 @@ class TestDatastoreProfilePostgreSQL:
         assert profile.database == "postgres"  # Should default to "postgres"
 
     @staticmethod
+    def test_dsn_with_database_override() -> None:
+        """Test dsn() method with database parameter override."""
+        profile = DatastoreProfilePostgreSQL(
+            name="test-profile",
+            user="postgres",
+            password="password123",
+            host="localhost",
+            port=5432,
+            database="mydb",
+        )
+        # Default behavior - use configured database
+        assert profile.dsn() == "postgresql://postgres:password123@localhost:5432/mydb"
+
+        # Override with different database
+        assert (
+            profile.dsn(database="otherdb")
+            == "postgresql://postgres:password123@localhost:5432/otherdb"
+        )
+
+        # Original database is unchanged
+        assert profile.database == "mydb"
+
+    @staticmethod
+    def test_admin_dsn() -> None:
+        """Test admin_dsn() returns DSN pointing to postgres maintenance database."""
+        profile = DatastoreProfilePostgreSQL(
+            name="test-profile",
+            user="postgres",
+            password="password123",
+            host="localhost",
+            port=5432,
+            database="mydb",
+        )
+        # admin_dsn should point to 'postgres' database for administrative operations
+        assert (
+            profile.admin_dsn()
+            == "postgresql://postgres:password123@localhost:5432/postgres"
+        )
+
+        # Original database is unchanged
+        assert profile.database == "mydb"
+
+    @staticmethod
     def test_datastore_profile_read_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         profile_name = "test-profile"
         project_name = "test-project"

--- a/tests/datastore/test_datastore_profile.py
+++ b/tests/datastore/test_datastore_profile.py
@@ -27,6 +27,7 @@ from mlrun.datastore.datastore_profile import (
     DatastoreProfileKafkaStream,
     DatastoreProfileKafkaTarget,
     DatastoreProfilePostgreSQL,
+    DatastoreProfileRedis,
     DatastoreProfileTDEngine,
     DatastoreProfileV3io,
     datastore_profile_read,
@@ -118,6 +119,40 @@ class TestTDEngineProfile:
         ), "Converting the profile back to DSN did not work as expected"
 
     @staticmethod
+    def test_url_encoding_special_characters() -> None:
+        """Test that special characters in user/password are properly URL encoded/decoded."""
+        profile = DatastoreProfileTDEngine(
+            name="test-profile",
+            user="user@domain",
+            password="p@ss:word/123",
+            host="localhost",
+            port=6041,
+        )
+        dsn = profile.dsn()
+        assert dsn == "taosws://user%40domain:p%40ss%3Aword%2F123@localhost:6041"
+
+        # Round-trip: from_dsn should decode back to original values
+        restored = DatastoreProfileTDEngine.from_dsn(dsn=dsn, profile_name="restored")
+        assert restored.user == "user@domain"
+        assert restored.password == "p@ss:word/123"
+
+    @staticmethod
+    def test_url_encoding_round_trip() -> None:
+        """Test that from_dsn -> dsn produces consistent results."""
+        # Start with an encoded DSN
+        encoded_dsn = "taosws://user%40domain:p%40ss%3Aword@localhost:6041"
+        profile = DatastoreProfileTDEngine.from_dsn(
+            dsn=encoded_dsn, profile_name="test"
+        )
+
+        # Verify decoded values
+        assert profile.user == "user@domain"
+        assert profile.password == "p@ss:word"
+
+        # Round-trip should produce the same DSN
+        assert profile.dsn() == encoded_dsn
+
+    @staticmethod
     def test_datastore_profile_read_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
         profile_name = "test-profile"
         project_name = "test-project"
@@ -162,6 +197,62 @@ class TestDatastoreProfilePostgreSQL:
         ), "Converting the profile back to DSN did not work as expected"
 
     @staticmethod
+    def test_url_encoding_special_characters() -> None:
+        """Test that special characters in user/password are properly URL encoded/decoded."""
+        profile = DatastoreProfilePostgreSQL(
+            name="test-profile",
+            user="user@domain",
+            password="p@ss:word/123",
+            host="localhost",
+            port=5432,
+            database="mydb",
+        )
+        dsn = profile.dsn()
+        assert (
+            dsn == "postgresql://user%40domain:p%40ss%3Aword%2F123@localhost:5432/mydb"
+        )
+
+        # Round-trip: from_dsn should decode back to original values
+        restored = DatastoreProfilePostgreSQL.from_dsn(dsn=dsn, profile_name="restored")
+        assert restored.user == "user@domain"
+        assert restored.password == "p@ss:word/123"
+        assert restored.database == "mydb"
+
+    @staticmethod
+    def test_url_encoding_round_trip() -> None:
+        """Test that from_dsn -> dsn produces consistent results."""
+        # Start with an encoded DSN
+        encoded_dsn = "postgresql://user%40domain:p%40ss%3Aword@localhost:5432/mydb"
+        profile = DatastoreProfilePostgreSQL.from_dsn(
+            dsn=encoded_dsn, profile_name="test"
+        )
+
+        # Verify decoded values
+        assert profile.user == "user@domain"
+        assert profile.password == "p@ss:word"
+
+        # Round-trip should produce the same DSN
+        assert profile.dsn() == encoded_dsn
+
+    @staticmethod
+    def test_url_encoding_database_with_special_chars() -> None:
+        """Test that database names with special characters are properly encoded."""
+        profile = DatastoreProfilePostgreSQL(
+            name="test-profile",
+            user="postgres",
+            password="password",
+            host="localhost",
+            port=5432,
+            database="my/db?name",
+        )
+        dsn = profile.dsn()
+        assert dsn == "postgresql://postgres:password@localhost:5432/my%2Fdb%3Fname"
+
+        # Round-trip should preserve the database name
+        restored = DatastoreProfilePostgreSQL.from_dsn(dsn=dsn, profile_name="restored")
+        assert restored.database == "my/db?name"
+
+    @staticmethod
     def test_from_dsn_without_database() -> None:
         dsn = "postgresql://postgres:password123@localhost:5432"
         profile_name = "test-timescaledb-no-db"
@@ -200,7 +291,7 @@ class TestDatastoreProfilePostgreSQL:
 
     @staticmethod
     def test_admin_dsn() -> None:
-        """Test admin_dsn() returns DSN pointing to postgres maintenance database."""
+        """Test admin_dsn() returns DSN pointing to default postgres database."""
         profile = DatastoreProfilePostgreSQL(
             name="test-profile",
             user="postgres",
@@ -242,6 +333,58 @@ class TestDatastoreProfilePostgreSQL:
 
         assert profile_read.type == "postgresql", "Wrong profile type"
         assert profile_read.password == "password123", "Wrong password"
+
+
+class TestDatastoreProfileRedis:
+    @staticmethod
+    def test_url_with_credentials_basic() -> None:
+        """Test url_with_credentials with simple credentials."""
+        profile = DatastoreProfileRedis(
+            name="test-redis",
+            endpoint_url="redis://localhost:6379/0",
+            username="user",
+            password="pass",
+        )
+        url = profile.url_with_credentials()
+        assert url == "redis://user:pass@localhost:6379/0"
+
+    @staticmethod
+    def test_url_with_credentials_special_characters() -> None:
+        """Test that special characters in username/password are properly URL encoded."""
+        profile = DatastoreProfileRedis(
+            name="test-redis",
+            endpoint_url="redis://localhost:6379/0",
+            username="user@domain",
+            password="p@ss:word/123",
+        )
+        assert (
+            profile.url_with_credentials()
+            == "redis://user%40domain:p%40ss%3Aword%2F123@localhost:6379/0"
+        )
+
+    @staticmethod
+    def test_url_with_credentials_username_only() -> None:
+        """Test url_with_credentials with username only (no password)."""
+        profile = DatastoreProfileRedis(
+            name="test-redis",
+            endpoint_url="redis://localhost:6379/0",
+            username="user@domain",
+            password=None,
+        )
+        url = profile.url_with_credentials()
+        assert url == "redis://user%40domain@localhost:6379/0"
+
+    @staticmethod
+    def test_url_with_credentials_no_credentials() -> None:
+        """Test url_with_credentials without any credentials."""
+        profile = DatastoreProfileRedis(
+            name="test-redis",
+            endpoint_url="redis://localhost:6379/0",
+            username=None,
+            password=None,
+        )
+        url = profile.url_with_credentials()
+        assert url == "redis://localhost:6379/0"
 
 
 @pytest.fixture

--- a/tests/model_monitoring/db/tsdb/timescaledb/conftest.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/conftest.py
@@ -280,11 +280,20 @@ def statement(connection_string):
 
 @pytest.fixture
 def connector(connection_string, project_name):
-    """Create TimescaleDBConnector instance for cross-query testing."""
+    """Create TimescaleDBConnector instance for cross-query testing.
+
+    Uses the database from connection string directly (auto_create_database=False)
+    for faster test execution. Database auto-creation is tested explicitly
+    in test_timescaledb_connector.py.
+    """
+    import mlrun
     from mlrun.datastore.datastore_profile import DatastoreProfilePostgreSQL
     from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connector import (
         TimescaleDBConnector,
     )
+
+    # Disable auto_create_database for faster tests - use database from connection string
+    mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database = False
 
     # Create profile from DSN
     profile = DatastoreProfilePostgreSQL.from_dsn(

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connector.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connector.py
@@ -20,6 +20,7 @@ import uuid
 import pytest
 
 import mlrun
+from mlrun.utils import logger
 
 
 class TestTimescaleDBConnectorDatabaseCreation:
@@ -43,14 +44,14 @@ class TestTimescaleDBConnectorDatabaseCreation:
     def _force_drop_database(admin_connection, database_name):
         """Force drop a database by terminating all connections first.
 
-        Silently ignores all errors to ensure cleanup doesn't fail tests.
+        Logs warnings on errors but doesn't fail tests.
         """
         from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection import (
             Statement,
         )
 
         # Terminate all connections to the database
-        with contextlib.suppress(Exception):
+        try:
             admin_connection.run(
                 query=Statement(
                     sql="""
@@ -61,10 +62,23 @@ class TestTimescaleDBConnectorDatabaseCreation:
                     parameters=(database_name,),
                 )
             )
+        except Exception as e:
+            logger.warning(
+                "Failed to terminate connections during test cleanup",
+                database=database_name,
+                error=str(e),
+            )
+
         # Now drop the database
-        with contextlib.suppress(Exception):
+        try:
             admin_connection.run(
                 statements=[f'DROP DATABASE IF EXISTS "{database_name}"']
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to drop database during test cleanup",
+                database=database_name,
+                error=str(e),
             )
 
     @staticmethod

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connector.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connector.py
@@ -1,0 +1,232 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for TimescaleDBConnector database auto-creation functionality."""
+
+import contextlib
+import uuid
+
+import pytest
+
+
+class TestTimescaleDBConnectorDatabaseCreation:
+    """Test database auto-creation functionality in TimescaleDBConnector."""
+
+    @pytest.fixture
+    def test_system_id(self):
+        """Generate unique system_id for test isolation."""
+        return f"test_{uuid.uuid4().hex[:8]}"
+
+    @pytest.fixture
+    def profile(self, connection_string):
+        """Create profile from connection string."""
+        from mlrun.datastore.datastore_profile import DatastoreProfilePostgreSQL
+
+        return DatastoreProfilePostgreSQL.from_dsn(
+            dsn=connection_string, profile_name="test_profile"
+        )
+
+    def _force_drop_database(self, admin_connection, database_name):
+        """Force drop a database by terminating all connections first.
+
+        Silently ignores all errors to ensure cleanup doesn't fail tests.
+        """
+        from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection import (
+            Statement,
+        )
+
+        # Terminate all connections to the database
+        with contextlib.suppress(Exception):
+            admin_connection.run(
+                query=Statement(
+                    sql="""
+                    SELECT pg_terminate_backend(pid)
+                    FROM pg_stat_activity
+                    WHERE datname = %s AND pid <> pg_backend_pid()
+                    """,
+                    parameters=(database_name,),
+                )
+            )
+        # Now drop the database
+        with contextlib.suppress(Exception):
+            admin_connection.run(
+                statements=[f'DROP DATABASE IF EXISTS "{database_name}"']
+            )
+
+    @contextlib.contextmanager
+    def _config_context(self, system_id=None, auto_create=None):
+        """Context manager that saves and restores mlrun config.
+
+        Always restores config even if test fails.
+        """
+        import mlrun
+
+        original_system_id = mlrun.mlconf.system_id
+        original_auto_create = (
+            mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database
+        )
+
+        try:
+            if system_id is not None:
+                mlrun.mlconf.system_id = system_id
+            if auto_create is not None:
+                mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database = (
+                    auto_create
+                )
+            yield
+        finally:
+            mlrun.mlconf.system_id = original_system_id
+            mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database = (
+                original_auto_create
+            )
+
+    def test_auto_create_database_creates_new_database(
+        self, project_name, test_system_id, profile, admin_connection
+    ):
+        """Test that auto_create_database=True creates a new database."""
+        from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection import (
+            Statement,
+        )
+        from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connector import (
+            TimescaleDBConnector,
+        )
+
+        expected_db_name = f"mlrun_mm_{test_system_id}"
+        connector = None
+
+        with self._config_context(system_id=test_system_id, auto_create=True):
+            try:
+                # Create connector - should create database
+                connector = TimescaleDBConnector(
+                    project=project_name,
+                    profile=profile,
+                )
+                connector.create_tables()
+
+                # Verify database was created by querying pg_database
+                result = admin_connection.run(
+                    query=Statement(
+                        sql="SELECT 1 FROM pg_database WHERE datname = %s",
+                        parameters=(expected_db_name,),
+                    )
+                )
+                assert result.data, f"Database {expected_db_name} should exist"
+
+            finally:
+                # Cleanup resources - ignore errors
+                if connector:
+                    with contextlib.suppress(Exception):
+                        connector.delete_tsdb_resources()
+                # Force drop database
+                self._force_drop_database(admin_connection, expected_db_name)
+
+    def test_auto_create_database_disabled_uses_existing_database(
+        self, project_name, profile
+    ):
+        """Test that auto_create_database=False uses database from connection string."""
+        from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connector import (
+            TimescaleDBConnector,
+        )
+
+        connector = None
+
+        with self._config_context(auto_create=False):
+            try:
+                # Create connector - should use database from profile
+                connector = TimescaleDBConnector(
+                    project=project_name,
+                    profile=profile,
+                )
+
+                # Verify the connector uses the database from the profile
+                # The profile should not be modified when auto_create is disabled
+                assert profile.database == "postgres"
+
+                connector.create_tables()
+
+            finally:
+                # Cleanup resources - ignore errors
+                if connector:
+                    with contextlib.suppress(Exception):
+                        connector.delete_tsdb_resources()
+
+    def test_auto_create_database_without_system_id_raises_error(
+        self, project_name, profile
+    ):
+        """Test that auto_create_database=True without system_id raises error."""
+        import mlrun
+        from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connector import (
+            TimescaleDBConnector,
+        )
+
+        with self._config_context(system_id="", auto_create=True):
+            # Should raise error - no cleanup needed since connector creation fails
+            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+                TimescaleDBConnector(
+                    project=project_name,
+                    profile=profile,
+                )
+
+            assert "system_id is not set" in str(exc_info.value)
+
+    def test_auto_create_database_idempotent(
+        self, project_name, test_system_id, profile, admin_connection
+    ):
+        """Test that creating database multiple times is idempotent."""
+        from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection import (
+            Statement,
+        )
+        from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connector import (
+            TimescaleDBConnector,
+        )
+
+        expected_db_name = f"mlrun_mm_{test_system_id}"
+        connector1 = None
+        connector2 = None
+
+        with self._config_context(system_id=test_system_id, auto_create=True):
+            try:
+                # Create first connector
+                connector1 = TimescaleDBConnector(
+                    project=project_name,
+                    profile=profile,
+                )
+                connector1.create_tables()
+
+                # Create second connector with same system_id - should not fail
+                connector2 = TimescaleDBConnector(
+                    project=f"{project_name}-2",
+                    profile=profile,
+                )
+                connector2.create_tables()
+
+                # Both should work - verify database exists
+                result = admin_connection.run(
+                    query=Statement(
+                        sql="SELECT 1 FROM pg_database WHERE datname = %s",
+                        parameters=(expected_db_name,),
+                    )
+                )
+                assert result.data, f"Database {expected_db_name} should exist"
+
+            finally:
+                # Cleanup resources - ignore errors
+                if connector1:
+                    with contextlib.suppress(Exception):
+                        connector1.delete_tsdb_resources()
+                if connector2:
+                    with contextlib.suppress(Exception):
+                        connector2.delete_tsdb_resources()
+                # Force drop database
+                self._force_drop_database(admin_connection, expected_db_name)

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connector.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connector.py
@@ -19,6 +19,8 @@ import uuid
 
 import pytest
 
+import mlrun
+
 
 class TestTimescaleDBConnectorDatabaseCreation:
     """Test database auto-creation functionality in TimescaleDBConnector."""
@@ -37,7 +39,8 @@ class TestTimescaleDBConnectorDatabaseCreation:
             dsn=connection_string, profile_name="test_profile"
         )
 
-    def _force_drop_database(self, admin_connection, database_name):
+    @staticmethod
+    def _force_drop_database(admin_connection, database_name):
         """Force drop a database by terminating all connections first.
 
         Silently ignores all errors to ensure cleanup doesn't fail tests.
@@ -64,14 +67,13 @@ class TestTimescaleDBConnectorDatabaseCreation:
                 statements=[f'DROP DATABASE IF EXISTS "{database_name}"']
             )
 
+    @staticmethod
     @contextlib.contextmanager
-    def _config_context(self, system_id=None, auto_create=None):
+    def _config_context(system_id=None, auto_create=None):
         """Context manager that saves and restores mlrun config.
 
         Always restores config even if test fails.
         """
-        import mlrun
-
         original_system_id = mlrun.mlconf.system_id
         original_auto_create = (
             mlrun.mlconf.model_endpoint_monitoring.tsdb.auto_create_database
@@ -103,15 +105,13 @@ class TestTimescaleDBConnectorDatabaseCreation:
         )
 
         expected_db_name = f"mlrun_mm_{test_system_id}"
-        connector = None
 
         with self._config_context(system_id=test_system_id, auto_create=True):
+            connector = TimescaleDBConnector(
+                project=project_name,
+                profile=profile,
+            )
             try:
-                # Create connector - should create database
-                connector = TimescaleDBConnector(
-                    project=project_name,
-                    profile=profile,
-                )
                 connector.create_tables()
 
                 # Verify database was created by querying pg_database
@@ -125,10 +125,8 @@ class TestTimescaleDBConnectorDatabaseCreation:
 
             finally:
                 # Cleanup resources - ignore errors
-                if connector:
-                    with contextlib.suppress(Exception):
-                        connector.delete_tsdb_resources()
-                # Force drop database
+                with contextlib.suppress(Exception):
+                    connector.delete_tsdb_resources()
                 self._force_drop_database(admin_connection, expected_db_name)
 
     def test_auto_create_database_disabled_uses_existing_database(
@@ -165,20 +163,19 @@ class TestTimescaleDBConnectorDatabaseCreation:
         self, project_name, profile
     ):
         """Test that auto_create_database=True without system_id raises error."""
-        import mlrun
         from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connector import (
             TimescaleDBConnector,
         )
 
         with self._config_context(system_id="", auto_create=True):
             # Should raise error - no cleanup needed since connector creation fails
-            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+            with pytest.raises(
+                mlrun.errors.MLRunInvalidArgumentError, match="system_id is not set"
+            ):
                 TimescaleDBConnector(
                     project=project_name,
                     profile=profile,
                 )
-
-            assert "system_id is not set" in str(exc_info.value)
 
     def test_auto_create_database_idempotent(
         self, project_name, test_system_id, profile, admin_connection
@@ -228,5 +225,4 @@ class TestTimescaleDBConnectorDatabaseCreation:
                 if connector2:
                     with contextlib.suppress(Exception):
                         connector2.delete_tsdb_resources()
-                # Force drop database
                 self._force_drop_database(admin_connection, expected_db_name)


### PR DESCRIPTION
TITLE: [Model Monitoring] Add TimescaleDB database auto-creation

## Summary
Add automatic database creation for TimescaleDB connector. When `auto_create_database` is enabled (default), the connector generates a database name using `system_id` and creates it if it does not exist.


## Changes Made
- Add `tsdb.auto_create_database` config option to `mlrun/config.py` (default: True)
- Add `admin_dsn()` method to `DatastoreProfilePostgreSQL` for connecting to postgres maintenance database
- Add `dsn(database=...)` parameter to override database in DSN
- Add `_determine_database_name()` to `TimescaleDBConnector`
- Add `_create_db_if_not_exists()` to `TimescaleDBOperationsManager`
- Add unit tests for database auto-creation functionality (4 tests)
- Add unit tests for `admin_dsn()` and `dsn()` methods (2 tests)

## Testing
- 107/107 TimescaleDB tests pass
- 5/5 PostgreSQL datastore profile tests pass
- Tested database creation, idempotency, and error handling

## Checklist
- [x] Code follows project style guidelines
- [x] Tests added for new functionality
- [x] All tests pass locally
- [x] Documentation updated (internal docstrings)

## Reference
- Jira: [ML-11662](https://iguazio.atlassian.net/browse/ML-11662)


[ML-11662]: https://iguazio.atlassian.net/browse/ML-11662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ