### PR TITLE
[Model Monitoring] Add graph-level deduplication for predictions

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/stream_graph_steps.py
+++ b/mlrun/model_monitoring/db/tsdb/stream_graph_steps.py
@@ -16,6 +16,7 @@ from datetime import datetime
 
 import mlrun.feature_store.steps
 from mlrun.common.schemas.model_monitoring import EventFieldType
+from mlrun.common.schemas.model_monitoring.constants import StreamProcessingEvent
 
 # Import the authoritative database schema constant
 from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_schema import (
@@ -25,6 +26,52 @@ from mlrun.utils import logger
 
 # Error truncation log message
 ERROR_TRUNCATION_MESSAGE = "Error message truncated for storage"
+
+
+class DeduplicateSubEvents(mlrun.feature_store.steps.MapClass):
+    """
+    Deduplicate sub-events from batch inference before writing to TSDB (ML-11639).
+
+    When a model invocation processes N samples (batch inference), ProcessEndpointEvent
+    creates N sub-events with identical (endpoint_id, timestamp). This step filters out
+    duplicates, allowing only the first event per (endpoint_id, timestamp) to pass through.
+
+    This improves performance for all TSDB backends by reducing:
+    - Network I/O (N-1 fewer writes)
+    - Serialization overhead
+    - Database operations (even for backends with implicit upsert)
+
+    :returns: Event as a dictionary, or None if duplicate
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Track last seen timestamp per endpoint for deduplication
+        # Key: endpoint_id, Value: last timestamp
+        self._last_timestamp: dict[str, str] = {}
+
+    def do(self, event):
+        endpoint_id = event.get(EventFieldType.ENDPOINT_ID)
+
+        # Determine the timestamp for this event
+        if StreamProcessingEvent.WHEN in event:
+            timestamp = event[StreamProcessingEvent.WHEN]
+        elif EventFieldType.TIMESTAMP in event:
+            timestamp = event[EventFieldType.TIMESTAMP]
+        else:
+            timestamp = None
+
+        # Deduplication: drop sub-events with same (endpoint_id, timestamp) as previous event
+        # This handles batch inference where N samples create N identical sub-events
+        if endpoint_id and timestamp:
+            last_ts = self._last_timestamp.get(endpoint_id)
+            if last_ts == timestamp:
+                # Duplicate sub-event from same batch inference - drop it
+                return None
+            # Update last seen timestamp for this endpoint
+            self._last_timestamp[endpoint_id] = timestamp
+
+        return event
 
 
 class BaseErrorExtractor(mlrun.feature_store.steps.MapClass):

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -251,7 +251,7 @@ class TDEngineConnector(TSDBConnector):
             graph.add_step(
                 "mlrun.model_monitoring.db.tsdb.tdengine.stream_graph_steps.ProcessBeforeTDEngine",
                 name="ProcessBeforeTDEngine",
-                after="FilterNOP",
+                after="DeduplicateSubEvents",
             )
 
         def apply_tdengine_target(name, after):

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_stream.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_stream.py
@@ -85,7 +85,7 @@ class TimescaleDBStreamProcessor:
             graph.add_step(
                 "mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_stream_graph_steps.ProcessBeforeTimescaleDB",
                 name="ProcessBeforeTimescaleDB",
-                after="FilterNOP",
+                after="DeduplicateSubEvents",
             )
 
         def apply_timescaledb_target(name: str, after: str):

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -242,7 +242,7 @@ class V3IOTSDBConnector(TSDBConnector):
                     }
                 ],
                 name=EventFieldType.LATENCY,
-                after="FilterNOP",
+                after="DeduplicateSubEvents",
                 step_name="Aggregates",
                 table=".",
                 key_field=EventFieldType.ENDPOINT_ID,
@@ -263,7 +263,7 @@ class V3IOTSDBConnector(TSDBConnector):
         graph.add_step(
             "storey.TSDBTarget",
             name="tsdb_predictions",
-            after="FilterNOP",
+            after="DeduplicateSubEvents",
             path=f"{self.container}/{self.tables[mm_schemas.V3IOTSDBTables.PREDICTIONS]}",
             time_col=mm_schemas.EventFieldType.TIMESTAMP,
             container=self.container,

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -232,6 +232,14 @@ class EventStreamProcessor:
             _fn="(event.get('kind', " ") == 'nop_event')",
         )
 
+        # Deduplicate sub-events from batch inference before TSDB writes (ML-11639)
+        # This improves performance for all backends by reducing N writes to 1 per invocation
+        graph.add_step(
+            "mlrun.model_monitoring.db.tsdb.stream_graph_steps.DeduplicateSubEvents",
+            name="DeduplicateSubEvents",
+            after="FilterNOP",
+        )
+
         tsdb_connector.apply_monitoring_stream_steps(
             graph=graph,
             aggregate_windows=self.aggregate_windows,

--- a/tests/model_monitoring/db/tsdb/test_stream_graph_steps.py
+++ b/tests/model_monitoring/db/tsdb/test_stream_graph_steps.py
@@ -1,0 +1,206 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for shared TSDB stream graph steps.
+"""
+
+from mlrun.model_monitoring.db.tsdb.stream_graph_steps import DeduplicateSubEvents
+
+
+class TestDeduplicateSubEvents:
+    """
+    Tests for DeduplicateSubEvents graph step (ML-11639).
+
+    This step deduplicates sub-events from batch inference before writing to TSDB,
+    improving performance for all backends (TimescaleDB, TDEngine, V3IO).
+    """
+
+    def test_first_event_passes_through(self):
+        """Test that the first event for an endpoint passes through."""
+        deduplicator = DeduplicateSubEvents()
+
+        endpoint_id = "ep1"
+        event = {
+            "endpoint_id": endpoint_id,
+            "when": "2024-06-15T10:00:00+00:00",
+        }
+
+        result = deduplicator.do(event)
+
+        assert result is not None
+        assert result["endpoint_id"] == endpoint_id
+
+    def test_duplicate_sub_events_filtered(self):
+        """
+        Test that duplicate sub-events from batch inference are filtered (ML-11639).
+        Simulates N sub-events with same (endpoint_id, timestamp).
+        """
+        deduplicator = DeduplicateSubEvents()
+
+        # Simulate 32 sub-events from batch inference - all have same timestamp
+        batch_size = 32
+        timestamp = "2024-06-15T10:00:00+00:00"
+        endpoint_id = "ep_batch"
+
+        results = [
+            deduplicator.do(
+                {
+                    "endpoint_id": endpoint_id,
+                    "when": timestamp,
+                    "features": [1.0, 2.0, 3.0],
+                    "prediction": [0.5],
+                }
+            )
+            for _ in range(batch_size)
+        ]
+        passed_results = [r for r in results if r is not None]
+
+        # Only 1 should pass through (deduplication)
+        assert len(passed_results) == 1
+        assert passed_results[0]["endpoint_id"] == endpoint_id
+
+    def test_different_timestamps_all_pass(self):
+        """Test that events with different timestamps all pass through."""
+        deduplicator = DeduplicateSubEvents()
+
+        endpoint_id = "ep1"
+        timestamps = [
+            "2024-06-15T10:00:00+00:00",
+            "2024-06-15T10:01:00+00:00",
+            "2024-06-15T10:02:00+00:00",
+        ]
+
+        results = [
+            deduplicator.do(
+                {
+                    "endpoint_id": endpoint_id,
+                    "when": ts,
+                }
+            )
+            for ts in timestamps
+        ]
+        passed_results = [r for r in results if r is not None]
+
+        # All events with different timestamps should pass
+        assert len(passed_results) == len(timestamps)
+
+    def test_different_endpoints_same_timestamp_all_pass(self):
+        """Test that different endpoints with same timestamp all pass."""
+        deduplicator = DeduplicateSubEvents()
+
+        timestamp = "2024-06-15T10:00:00+00:00"
+        endpoints = ["ep1", "ep2", "ep3"]
+
+        results = [
+            deduplicator.do(
+                {
+                    "endpoint_id": ep,
+                    "when": timestamp,
+                }
+            )
+            for ep in endpoints
+        ]
+        passed_results = [r for r in results if r is not None]
+
+        # All different endpoints should pass even with same timestamp
+        assert len(passed_results) == len(endpoints)
+        passed_endpoint_ids = [r["endpoint_id"] for r in passed_results]
+        assert passed_endpoint_ids == endpoints
+
+    def test_interleaved_endpoints_dedup_correctly(self):
+        """
+        Test deduplication with interleaved events from multiple endpoints.
+        Each endpoint gets batch inference (N sub-events with same timestamp).
+        """
+        deduplicator = DeduplicateSubEvents()
+
+        ts1 = "2024-06-15T10:00:00+00:00"
+        ts2 = "2024-06-15T10:01:00+00:00"
+
+        # Simulate interleaved events: ep1 batch, ep2 batch, ep1 new batch
+        events = [
+            # ep1 batch 1 (3 sub-events with same timestamp)
+            {"endpoint_id": "ep1", "when": ts1},
+            {"endpoint_id": "ep1", "when": ts1},
+            {"endpoint_id": "ep1", "when": ts1},
+            # ep2 batch (2 sub-events with same timestamp)
+            {"endpoint_id": "ep2", "when": ts1},
+            {"endpoint_id": "ep2", "when": ts1},
+            # ep1 batch 2 - new timestamp (2 sub-events)
+            {"endpoint_id": "ep1", "when": ts2},
+            {"endpoint_id": "ep1", "when": ts2},
+        ]
+
+        results = [deduplicator.do(e) for e in events]
+        passed_results = [r for r in results if r is not None]
+
+        # Should pass: ep1@ts1, ep2@ts1, ep1@ts2 = 3 unique (endpoint, timestamp) pairs
+        expected_passed = [
+            ("ep1", ts1),
+            ("ep2", ts1),
+            ("ep1", ts2),
+        ]
+        actual_passed = [(r["endpoint_id"], r["when"]) for r in passed_results]
+
+        assert len(actual_passed) == len(expected_passed)
+        assert actual_passed == expected_passed
+
+    def test_timestamp_field_fallback(self):
+        """Test that 'timestamp' field is used when 'when' is not present."""
+        deduplicator = DeduplicateSubEvents()
+
+        timestamp = "2024-06-15T10:00:00+00:00"
+        endpoint_id = "ep1"
+
+        # First event with 'timestamp' field
+        result1 = deduplicator.do(
+            {
+                "endpoint_id": endpoint_id,
+                "timestamp": timestamp,
+            }
+        )
+
+        # Second event with same timestamp - should be filtered
+        result2 = deduplicator.do(
+            {
+                "endpoint_id": endpoint_id,
+                "timestamp": timestamp,
+            }
+        )
+
+        assert result1 is not None
+        assert result2 is None
+
+    def test_event_without_timestamp_passes(self):
+        """Test that events without timestamp field pass through without dedup."""
+        deduplicator = DeduplicateSubEvents()
+
+        # Events without timestamp should all pass (can't deduplicate without timestamp)
+        results = [deduplicator.do({"endpoint_id": "ep1", "data": i}) for i in range(5)]
+        passed_results = [r for r in results if r is not None]
+
+        assert len(passed_results) == 5
+
+    def test_event_without_endpoint_passes(self):
+        """Test that events without endpoint_id field pass through without dedup."""
+        deduplicator = DeduplicateSubEvents()
+
+        timestamp = "2024-06-15T10:00:00+00:00"
+
+        # Events without endpoint_id should all pass (can't deduplicate without endpoint)
+        results = [deduplicator.do({"when": timestamp, "data": i}) for i in range(5)]
+        passed_results = [r for r in results if r is not None]
+
+        assert len(passed_results) == 5

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_stream_graph_steps.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_stream_graph_steps.py
@@ -1,0 +1,98 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for TimescaleDB stream graph steps.
+"""
+
+import json
+
+from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_stream_graph_steps import (
+    ProcessBeforeTimescaleDB,
+)
+
+
+class TestProcessBeforeTimescaleDB:
+    """Tests for ProcessBeforeTimescaleDB graph step."""
+
+    def test_event_fields_populated(self):
+        """Test that required fields are populated from event."""
+        processor = ProcessBeforeTimescaleDB()
+
+        endpoint_id = "ep1"
+        timestamp = "2024-06-15T10:00:00+00:00"
+        project = "my_project"
+        function = "my_function"
+        metrics = {"accuracy": 0.95}
+
+        event = {
+            "endpoint_id": endpoint_id,
+            "when": timestamp,
+            "function_uri": f"{project}/{function}",
+            "metrics": metrics,
+        }
+
+        result = processor.do(event)
+
+        assert result["project"] == project
+        assert result["end_infer_time"] == timestamp
+        assert result["custom_metrics"] == json.dumps(metrics)
+        assert result["table_column"] == f"_{endpoint_id}"
+
+    def test_timestamp_field_fallback(self):
+        """Test that timestamp field is used when 'when' is not present."""
+        processor = ProcessBeforeTimescaleDB()
+
+        timestamp = "2024-06-15T11:00:00+00:00"
+        event = {
+            "endpoint_id": "ep1",
+            "timestamp": timestamp,
+            "function_uri": "project/function",
+            "metrics": {},
+        }
+
+        result = processor.do(event)
+
+        assert result["end_infer_time"] == timestamp
+
+    def test_empty_metrics_serialized(self):
+        """Test that empty metrics dict is serialized correctly."""
+        processor = ProcessBeforeTimescaleDB()
+
+        metrics = {}
+        event = {
+            "endpoint_id": "ep1",
+            "when": "2024-06-15T10:00:00+00:00",
+            "function_uri": "project/function",
+            "metrics": metrics,
+        }
+
+        result = processor.do(event)
+
+        assert result["custom_metrics"] == json.dumps(metrics)
+
+    def test_missing_metrics_handled(self):
+        """Test that missing metrics field is handled gracefully."""
+        processor = ProcessBeforeTimescaleDB()
+
+        event = {
+            "endpoint_id": "ep1",
+            "when": "2024-06-15T10:00:00+00:00",
+            "function_uri": "project/function",
+        }
+
+        result = processor.do(event)
+
+        # Missing metrics should default to empty dict
+        assert result["custom_metrics"] == json.dumps({})


### PR DESCRIPTION
## Summary

Fix for TimescaleDB predictions table showing incorrect record counts due to duplicate sub-events from batch inference.

When a model invocation processes N samples (batch inference), `ProcessEndpointEvent` creates N sub-events with identical `(endpoint_id, timestamp)`. Previously all N events were written to TSDB backends, resulting in N rows instead of 1.

## Solution

Refactored from TimescaleDB-specific to a **generic graph-level deduplication** that benefits all TSDB backends:

```
FilterNOP → DeduplicateSubEvents → [TimescaleDB | TDEngine | V3IO]
                                    (1 row per invocation)
         → ProcessBeforeParquet → ParquetTarget
                                  (N rows preserved for raw data)
```

- **DeduplicateSubEvents**: New generic step that filters duplicate sub-events before any TSDB writes
- **Performance improvement**: Reduces N network writes to 1 per batch invocation for all backends
- **Parquet unaffected**: Raw sample data branch bypasses deduplication

## Changes Made

- Add `DeduplicateSubEvents` class to `stream_graph_steps.py`
- Add step to main graph in `stream_processing.py` after `FilterNOP`
- Update TSDB connectors (TimescaleDB, TDEngine, V3IO) to chain after `DeduplicateSubEvents`
- Simplify `ProcessBeforeTimescaleDB` (remove dedup logic, keep field mapping only)
- Add 8 unit tests for `DeduplicateSubEvents`
- Reduce TimescaleDB tests to 4 (field population only)

## Testing

- **12/12 unit tests passing**:
  - 8 tests for `DeduplicateSubEvents` (deduplication logic)
  - 4 tests for `ProcessBeforeTimescaleDB` (field population)
- Tests cover: first event pass-through, batch deduplication, different timestamps, different endpoints, interleaved events, timestamp field fallback, missing fields handling

## Reference

- Jira: [ML-11639](https://iguazio.atlassian.net/browse/ML-11639)

[ML-11639]: https://iguazio.atlassian.net/browse/ML-11639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ