### PR TITLE
[Requirements] Remove deprecated tf-keras dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -44,7 +44,4 @@ coverage[toml]~=7.8
 diff-cover~=9.2
 openai~=1.88
 transformers~=4.56
-# for hugging face image classifier test:
-#tf-keras~=2.19
-# TODO: once tf-keras upgrades their dependencies to support a newer version protobuf, we can uncomment this line
 pillow~=11.3


### PR DESCRIPTION
### 📝 Description
This PR removes the last remaining TensorFlow/Keras reference from `dev-requirements.txt`

---

### 🛠️ Changes Made
As part of the Python 3.11 migration, TensorFlow is not supported.
It was confirmed that no active customers require bundled TF, and users who need it will install it manually when upgrading. ( https://iguazio.atlassian.net/browse/ML-11549?focusedCommentId=195573 )

A corresponding note will be added to the changelog.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [x] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11549
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
