### PR TITLE
[Notifications] Fix passing notification params missing username / password [1.10.x]

### DIFF
--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -45,12 +45,7 @@ class MailNotification(base.NotificationBase):
 
     @classmethod
     def validate_params(cls, params):
-        # Normalize empty string username/password to None
-        if not params.get("username"):
-            params["username"] = None
-        if not params.get("password"):
-            params["password"] = None
-
+        cls._enrich_params(params)
         for required_param in cls.required_params:
             if required_param not in params:
                 raise ValueError(
@@ -90,6 +85,8 @@ class MailNotification(base.NotificationBase):
             message, severity, runs, custom_html, alert, event_data
         )
         self.params["body"] = runs_html
+
+        self._enrich_params(self.params)
 
         if message_body_override:
             self.params["body"] = message_body_override.replace(
@@ -176,14 +173,27 @@ class MailNotification(base.NotificationBase):
         message["Subject"] = subject
         message.attach(MIMEText(body, "html"))
 
-        # Send the email
-        await aiosmtplib.send(
-            message,
-            hostname=server_host,
-            port=server_port,
-            username=username,
-            password=password,
-            use_tls=use_tls,
-            validate_certs=validate_certs,
-            start_tls=start_tls,
-        )
+        send_kwargs = {
+            "hostname": server_host,
+            "port": server_port,
+            "use_tls": use_tls,
+            "validate_certs": validate_certs,
+            "start_tls": start_tls,
+        }
+
+        # Only include auth parameters when provided to avoid forcing SMTP AUTH
+        if username is not None:
+            send_kwargs["username"] = username
+        if password is not None:
+            send_kwargs["password"] = password
+
+        await aiosmtplib.send(message, **send_kwargs)
+
+    @staticmethod
+    def _enrich_params(params):
+        # if username/password are not provided or empty strings, set them to None.
+        # this ensures consistent behavior in _send_email and avoids
+        # forcing SMTP auth when the server does not require authentication.
+        for param in ["username", "password"]:
+            if param not in params or not params[param]:
+                params[param] = None

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1673,6 +1673,19 @@ class TestMailNotification:
         ["name", "params", "message", "severity", "expected"],
         [
             (
+                "no_username_or_password",
+                {},
+                "test-message",
+                "info",
+                {
+                    "subject": "[info] test-message",
+                    "body": MOCKED_HTML,
+                    # commented out to reflect the fact that username and password are not required
+                    # "username": None,
+                    # "password": None,
+                },
+            ),
+            (
                 "empty_params",
                 {},
                 "test-message",
@@ -1723,13 +1736,67 @@ class TestMailNotification:
         ],
     )
     async def test_push(self, name, params, message, severity, expected):
-        mlrun.utils.logger.debug(f"Testing {name}")
+        params.update(
+            {
+                "sender_address": "test@example.com",
+                "server_host": "smtp.example.com",
+            }
+        )
         notification = mail.MailNotification(params=params)
-        notification._send_email = unittest.mock.AsyncMock()
         notification._get_html = unittest.mock.MagicMock(return_value=self.MOCKED_HTML)
-        await notification.push(message, severity, [])
+
+        with unittest.mock.patch(
+            "aiosmtplib.send", new_callable=unittest.mock.AsyncMock
+        ):
+            await notification.push(message, severity, [])
         assert notification.params["subject"] == expected["subject"]
         assert notification.params["body"] == expected["body"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ["username", "password", "expected_auth_kwargs"],
+        [
+            ("", "", {}),
+            (None, None, {}),
+            ("user", None, {"username": "user"}),
+            ("user", "pass", {"username": "user", "password": "pass"}),
+        ],
+    )
+    async def test_send_email_auth_handling(
+        self, username, password, expected_auth_kwargs, monkeypatch: pytest.MonkeyPatch
+    ):
+        send_mock = unittest.mock.AsyncMock()
+        monkeypatch.setattr(mail.aiosmtplib, "send", send_mock)
+
+        await mail.MailNotification(
+            params={
+                "server_host": "smtp.example.com",
+                "server_port": 25,
+                "sender_address": "",
+                "username": username,
+                "password": password,
+                "use_tls": False,
+                "validate_certs": True,
+                "start_tls": False,
+            }
+        ).push(
+            message="Test Message",
+            severity="info",
+        )
+
+        assert send_mock.await_count == 1
+        assert send_mock.await_args.kwargs["hostname"] == "smtp.example.com"
+        assert send_mock.await_args.kwargs["port"] == 25
+        assert send_mock.await_args.kwargs["use_tls"] is False
+        assert send_mock.await_args.kwargs["start_tls"] is False
+        assert send_mock.await_args.kwargs["validate_certs"] is True
+
+        for key, value in expected_auth_kwargs.items():
+            assert send_mock.await_args.kwargs.get(key) == value
+
+        for key in ("username", "password"):
+            if key not in expected_auth_kwargs:
+                assert key not in send_mock.await_args.kwargs
 
 
 class DummyResponse:


### PR DESCRIPTION
### 📝 Description
Allow mail notifications to work with SMTP servers that don’t require authentication by only sending auth params when provided and normalizing empty credentials.

---

### 🛠️ Changes Made
- Permit SMTP no-auth and username-only flows in `MailNotification` validation.
- Send SMTP auth credentials only when present to avoid forcing AUTH.
- Added coverage for no-auth/username-only/full-auth mail notification scenarios.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
- [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
- [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Unit testings

---

### 🔗 References
- Ticket link: [ML-10488](https://iguazio.atlassian.net/browse/ML-10488)
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes

Covers SMTP servers that skip AUTH; new tests verify no-auth, username-only, and full-auth cases.

[ML-10488]:
https://iguazio.atlassian.net/browse/ML-10488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

(cherry picked from commit 6e0a1d24aab3aa76531cf0639cab502a7059567e)


[ML-10488]: https://iguazio.atlassian.net/browse/ML-10488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ