### PR TITLE
[API] Improve async functions

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.6.1"
+version = "0.6.2"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
@@ -517,7 +517,6 @@ class Client(
         :param run_id: The unique ID of the run to retrieve.
         :return: An ApiRun object with the run details.
         """
-        self.logger.info("Getting details for run", run_id=run_id)
         return self._run_api.get_run(
             run_id=run_id,
         )
@@ -935,16 +934,6 @@ class Client(
         page_token = page_token or ""
         filter_json = filter_json or ""
         sort_by = sort_by or ""
-
-        self.logger.debug(
-            "Listing runs from KFP",
-            page_token=page_token,
-            page_size=page_size,
-            sort_by=sort_by,
-            experiment_id=experiment_id,
-            namespace=namespace,
-            filter_json=filter_json,
-        )
 
         if experiment_id is not None:
             response = self._run_api.list_runs(

--- a/server/py/framework/db/session.py
+++ b/server/py/framework/db/session.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import contextlib
 import inspect
 
-import fastapi.concurrency
 from sqlalchemy.orm import Session
 
-import mlrun.utils.helpers
+import mlrun.utils
 
 import framework.db.sqldb.sql_session
 
@@ -36,12 +37,8 @@ def run_function_with_new_db_session(func, *args, **kwargs):
     However, any changes made by the new session will not be visible to old sessions until the old sessions commit
     due to isolation level.
     """
-    session = create_session()
-    try:
-        result = func(session, *args, **kwargs)
-        return result
-    finally:
-        close_session(session)
+    with get_db_session(commit=False) as session:
+        return func(session, *args, **kwargs)
 
 
 async def run_async_function_with_new_db_session(func, *args, **kwargs):
@@ -56,18 +53,52 @@ async def run_async_function_with_new_db_session(func, *args, **kwargs):
 
     # function is async. wrap its execution with a new db session
     if inspect.iscoroutinefunction(func):
-        session = await mlrun.utils.helpers.run_in_threadpool(create_session)
-        try:
-            result = await func(session, *args, **kwargs)
-            return result
-        finally:
-            await mlrun.utils.helpers.run_in_threadpool(close_session, session)
+        # commit is set to False as this function lets the caller handle committing/rolling back the session
+        async with get_db_session_async(commit=False) as session:
+            return await func(session, *args, **kwargs)
 
     # function is sync running in async context,
     # move all together to a thread and execute it non-blocking
-    return await fastapi.concurrency.run_in_threadpool(
-        framework.db.session.run_function_with_new_db_session,
+    return await mlrun.utils.run_in_threadpool(
+        run_function_with_new_db_session,
         func,
         *args,
         **kwargs,
     )
+
+
+@contextlib.asynccontextmanager
+async def get_db_session_async(commit=True):
+    """
+    Async context manager that provides a database session and handles commit/rollback.
+    :param commit: Whether to commit the session on successful completion. Defaults to True.
+    """
+    session = await asyncio.to_thread(create_session)
+    try:
+        yield session
+        if commit:
+            await asyncio.to_thread(session.commit)
+    except Exception:
+        await asyncio.to_thread(session.rollback)
+        raise
+    finally:
+        await asyncio.to_thread(session.close)
+
+
+@contextlib.contextmanager
+def get_db_session(commit=True):
+    """
+    Context manager that provides a database session and handles commit/rollback.
+
+    :param commit: Whether to commit the session on successful completion. Defaults to True.
+    """
+    session = create_session()
+    try:
+        yield session
+        if commit:
+            session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -22,7 +22,6 @@ import anyio
 import anyio.lowlevel
 import anyio.to_thread
 import fastapi
-import fastapi.concurrency
 import fastapi.exception_handlers
 import semver
 from dependency_injector import containers, providers
@@ -34,13 +33,13 @@ import mlrun.utils.version
 from mlrun import mlconf
 
 import framework.api.utils
+import framework.db.session
 import framework.middlewares
 import framework.utils.clients.chief
 import framework.utils.clients.messaging
 import framework.utils.pagination
 import framework.utils.periodic
-from framework.db.session import run_async_function_with_new_db_session
-from framework.utils.singletons.db import initialize_db
+import framework.utils.singletons.db
 
 
 class Service(ABC):
@@ -66,7 +65,9 @@ class Service(ABC):
 
     async def move_service_to_online(self):
         self._logger.info("Moving service to online", service_name=self.service_name)
-        await run_async_function_with_new_db_session(self._sync_system_metadata)
+        await framework.db.session.run_async_function_with_new_db_session(
+            self._sync_system_metadata
+        )
         await self._move_service_to_online()
 
     # https://fastapi.tiangolo.com/advanced/events/
@@ -180,7 +181,7 @@ class Service(ABC):
             max_workers=anyio.to_thread.current_default_thread_limiter().total_tokens,
         )
 
-        await fastapi.concurrency.run_in_threadpool(initialize_db)
+        await mlrun.utils.run_in_threadpool(framework.utils.singletons.db.initialize_db)
         await self._custom_setup_service()
 
         if (

--- a/server/py/framework/tests/unit/db/test_session.py
+++ b/server/py/framework/tests/unit/db/test_session.py
@@ -65,7 +65,7 @@ class TestRunAsyncFunctionWithNewDbSession(TestDatabaseBase):
 
     @pytest.mark.asyncio
     async def test_run_async_function_with_new_db_session_async_func_with_exception(
-            self,
+        self,
     ):
         """Test that exceptions in async functions are properly propagated"""
         error_msg = "Test error"
@@ -80,7 +80,7 @@ class TestRunAsyncFunctionWithNewDbSession(TestDatabaseBase):
 
     @pytest.mark.asyncio
     async def test_run_async_function_with_new_db_session_sync_func_with_exception(
-            self,
+        self,
     ):
         """Test that exceptions in sync functions are properly propagated"""
         error_msg = "Test error"
@@ -132,7 +132,7 @@ class TestRunAsyncFunctionWithNewDbSession(TestDatabaseBase):
 
     @pytest.mark.asyncio
     async def test_run_async_function_with_new_db_session_session_cleanup_on_error(
-            self,
+        self,
     ):
         """Test that session context manager properly handles cleanup on error"""
         session = None

--- a/server/py/framework/tests/unit/db/test_session.py
+++ b/server/py/framework/tests/unit/db/test_session.py
@@ -150,4 +150,4 @@ class TestRunAsyncFunctionWithNewDbSession(TestDatabaseBase):
             await framework.db.session.run_async_function_with_new_db_session(
                 async_func
             )
-            assert session.rollback.called, "Session rollback should be called on error"
+        assert session.rollback.called, "Session rollback should be called on error"

--- a/server/py/framework/tests/unit/db/test_session.py
+++ b/server/py/framework/tests/unit/db/test_session.py
@@ -1,0 +1,153 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest.mock
+
+import pytest
+import sqlalchemy.orm
+
+import framework.db.session
+from framework.tests.unit.db.common_fixtures import TestDatabaseBase
+
+
+class TestRunAsyncFunctionWithNewDbSession(TestDatabaseBase):
+    @pytest.mark.asyncio
+    async def test_run_async_function_with_new_db_session_async_func(self):
+        """Test that async functions get a new session and execute correctly"""
+        session_received = None
+        result_value = "test_result"
+
+        async def async_func(session, *args, **kwargs):
+            nonlocal session_received
+            session_received = session
+            assert isinstance(session, sqlalchemy.orm.Session)
+            return result_value
+
+        result = await framework.db.session.run_async_function_with_new_db_session(
+            async_func, "arg1", kwarg1="value1"
+        )
+
+        assert result == result_value
+        assert session_received is not None
+        assert isinstance(session_received, sqlalchemy.orm.Session)
+
+    @pytest.mark.asyncio
+    async def test_run_async_function_with_new_db_session_sync_func(self):
+        """Test that sync functions are run in threadpool with a new session"""
+        session_received = None
+        result_value = "test_result"
+
+        def sync_func(session, *args, **kwargs):
+            nonlocal session_received
+            session_received = session
+            assert isinstance(session, sqlalchemy.orm.Session)
+            return result_value
+
+        result = await framework.db.session.run_async_function_with_new_db_session(
+            sync_func, "arg1", kwarg1="value1"
+        )
+
+        assert result == result_value
+        assert session_received is not None
+        assert isinstance(session_received, sqlalchemy.orm.Session)
+
+    @pytest.mark.asyncio
+    async def test_run_async_function_with_new_db_session_async_func_with_exception(
+            self,
+    ):
+        """Test that exceptions in async functions are properly propagated"""
+        error_msg = "Test error"
+
+        async def async_func(session, *args, **kwargs):
+            raise ValueError(error_msg)
+
+        with pytest.raises(ValueError, match=error_msg):
+            await framework.db.session.run_async_function_with_new_db_session(
+                async_func
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_async_function_with_new_db_session_sync_func_with_exception(
+            self,
+    ):
+        """Test that exceptions in sync functions are properly propagated"""
+        error_msg = "Test error"
+
+        def sync_func(session, *args, **kwargs):
+            raise ValueError(error_msg)
+
+        with pytest.raises(ValueError, match=error_msg):
+            await framework.db.session.run_async_function_with_new_db_session(sync_func)
+
+    @pytest.mark.asyncio
+    async def test_run_async_function_with_new_db_session_session_isolation(self):
+        """Test that each call gets a different session"""
+        sessions_received = []
+
+        async def async_func(session, *args, **kwargs):
+            sessions_received.append(session)
+            return "result"
+
+        # Call twice concurrently
+        results = await asyncio.gather(
+            framework.db.session.run_async_function_with_new_db_session(async_func),
+            framework.db.session.run_async_function_with_new_db_session(async_func),
+        )
+
+        assert len(sessions_received) == 2
+        # Sessions should be different objects
+        assert sessions_received[0] is not sessions_received[1]
+        assert results == ["result", "result"]
+
+    @pytest.mark.asyncio
+    async def test_run_async_function_with_new_db_session_args_kwargs_passed(self):
+        """Test that args and kwargs are properly passed to the function"""
+        received_args = None
+        received_kwargs = None
+
+        async def async_func(session, *args, **kwargs):
+            nonlocal received_args, received_kwargs
+            received_args = args
+            received_kwargs = kwargs
+            return "result"
+
+        await framework.db.session.run_async_function_with_new_db_session(
+            async_func, "arg1", "arg2", kwarg1="value1", kwarg2="value2"
+        )
+
+        assert received_args == ("arg1", "arg2")
+        assert received_kwargs == {"kwarg1": "value1", "kwarg2": "value2"}
+
+    @pytest.mark.asyncio
+    async def test_run_async_function_with_new_db_session_session_cleanup_on_error(
+            self,
+    ):
+        """Test that session context manager properly handles cleanup on error"""
+        session = None
+
+        async def async_func(session_, *args, **kwargs):
+            # Verify session is valid before error
+            assert isinstance(session_, sqlalchemy.orm.Session)
+            session_.rollback = unittest.mock.MagicMock()
+
+            nonlocal session
+            session = session_
+            raise ValueError("Test error")
+
+        with pytest.raises(ValueError, match="Test error"):
+            await framework.db.session.run_async_function_with_new_db_session(
+                async_func
+            )
+            assert session.rollback.called, "Session rollback should be called on error"

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -17,7 +17,6 @@ import datetime
 import typing
 
 import sqlalchemy.orm
-from fastapi.concurrency import run_in_threadpool
 
 import mlrun.common.types
 
@@ -125,18 +124,20 @@ async def run_with_time_window_tracker(
 
     try:
         async with framework.db.session.get_db_session_async() as session:
-            last_update_time = await run_in_threadpool(
+            last_update_time = await mlrun.utils.run_in_threadpool(
                 initialize_and_get_window, session
             )
             now = datetime.datetime.now(datetime.UTC)
             await callback(session, last_update_time, *args, **kwargs)
-            await run_in_threadpool(cycle_tracker.update_window, session, now)
+            await mlrun.utils.run_in_threadpool(
+                cycle_tracker.update_window, session, now
+            )
         # The window update succeeded above, no need to ensure it
         ensure_window_update = False
     finally:
         if ensure_window_update:
             # Sessions are not thread-safe, so we need to create a new one
-            await run_in_threadpool(
+            await mlrun.utils.run_in_threadpool(
                 framework.db.session.run_function_with_new_db_session,
                 cycle_tracker.update_window,
                 now,

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import datetime
 import typing
 
@@ -109,19 +110,18 @@ async def run_with_time_window_tracker(
         key=key,
         max_window_size_seconds=max_window_size_seconds,
     )
-    # Although the methods below would not be using the db_session in parallel, for some reason, reusing it
-    # causes a segmentation fault so we create new ones for the time window ops
-    await run_in_threadpool(
-        framework.db.session.run_function_with_new_db_session, cycle_tracker.initialize
-    )
+
+    def initialize_and_get_window(session):
+        cycle_tracker.initialize(session)
+        return cycle_tracker.get_window(session)
+
     last_update_time = await run_in_threadpool(
-        framework.db.session.run_function_with_new_db_session, cycle_tracker.get_window
+        framework.db.session.run_function_with_new_db_session, initialize_and_get_window
     )
     now = datetime.datetime.now(datetime.UTC)
-    db_session = await run_in_threadpool(framework.db.session.create_session)
     try:
-        await framework.utils.asyncio.maybe_coroutine(
-            callback(db_session, last_update_time, *args, **kwargs)
+        await framework.db.session.run_async_function_with_new_db_session(
+            callback, last_update_time, *args, **kwargs
         )
         await run_in_threadpool(
             framework.db.session.run_function_with_new_db_session,
@@ -131,7 +131,6 @@ async def run_with_time_window_tracker(
         # The window update succeeded above, no need to ensure it
         ensure_window_update = False
     finally:
-        await run_in_threadpool(framework.db.session.close_session, db_session)
         if ensure_window_update:
             # Sessions are not thread-safe, so we need to create a new one
             await run_in_threadpool(
@@ -139,3 +138,34 @@ async def run_with_time_window_tracker(
                 cycle_tracker.update_window,
                 now,
             )
+
+
+def run_with_time_window_tracker_sync(
+        key: TimeWindowTrackerKeys,
+        max_window_size_seconds: int,
+        ensure_window_update: bool,
+        callback: typing.Callable,
+        *args,
+        **kwargs,
+):
+    cycle_tracker = TimeWindowTracker(
+        key=key,
+        max_window_size_seconds=max_window_size_seconds,
+    )
+
+    # ensure callback is not synchronous
+    if asyncio.iscoroutinefunction(callback):
+        raise ValueError("callback must be a synchronous function")
+
+    with framework.db.session.get_db_session() as session:
+        cycle_tracker.initialize(session)
+        last_update_time = cycle_tracker.get_window(session)
+        now = datetime.datetime.now(datetime.UTC)
+        try:
+            callback(session, last_update_time, *args, **kwargs)
+            cycle_tracker.update_window(session, now)
+            # The window update succeeded above, no need to ensure it
+            ensure_window_update = False
+        finally:
+            if ensure_window_update:
+                cycle_tracker.update_window(session, now)

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -106,28 +106,29 @@ async def run_with_time_window_tracker(
     *args,
     **kwargs,
 ):
+    """
+    Runs the given callback within a time window tracked by TimeWindowTracker.
+    Use this function when you are in an async context and your callback is async.
+    """
     cycle_tracker = TimeWindowTracker(
         key=key,
         max_window_size_seconds=max_window_size_seconds,
     )
 
-    def initialize_and_get_window(session):
-        cycle_tracker.initialize(session)
-        return cycle_tracker.get_window(session)
+    # ensure callback is not synchronous
+    if not asyncio.iscoroutinefunction(callback):
+        raise ValueError("callback must be an asynchronous function")
 
-    last_update_time = await run_in_threadpool(
-        framework.db.session.run_function_with_new_db_session, initialize_and_get_window
-    )
-    now = datetime.datetime.now(datetime.UTC)
+    def initialize_and_get_window(session_):
+        cycle_tracker.initialize(session_)
+        return cycle_tracker.get_window(session_)
+
     try:
-        await framework.db.session.run_async_function_with_new_db_session(
-            callback, last_update_time, *args, **kwargs
-        )
-        await run_in_threadpool(
-            framework.db.session.run_function_with_new_db_session,
-            cycle_tracker.update_window,
-            now,
-        )
+        async with framework.db.session.get_db_session_async() as session:
+            last_update_time = await run_in_threadpool(initialize_and_get_window, session)
+            now = datetime.datetime.now(datetime.UTC)
+            await callback(session, last_update_time, *args, **kwargs)
+            await run_in_threadpool(cycle_tracker.update_window, session, now)
         # The window update succeeded above, no need to ensure it
         ensure_window_update = False
     finally:
@@ -148,12 +149,18 @@ def run_with_time_window_tracker_sync(
     *args,
     **kwargs,
 ):
+    """
+    Synchronous version of run_with_time_window_tracker
+    This function reduces the overhead of running synchronous code in an async context by
+    avoiding unnecessary thread switching.
+    Use this function when your callback is synchronous.
+    """
     cycle_tracker = TimeWindowTracker(
         key=key,
         max_window_size_seconds=max_window_size_seconds,
     )
 
-    # ensure callback is not synchronous
+    # ensure callback is synchronous
     if asyncio.iscoroutinefunction(callback):
         raise ValueError("callback must be a synchronous function")
 

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -125,7 +125,9 @@ async def run_with_time_window_tracker(
 
     try:
         async with framework.db.session.get_db_session_async() as session:
-            last_update_time = await run_in_threadpool(initialize_and_get_window, session)
+            last_update_time = await run_in_threadpool(
+                initialize_and_get_window, session
+            )
             now = datetime.datetime.now(datetime.UTC)
             await callback(session, last_update_time, *args, **kwargs)
             await run_in_threadpool(cycle_tracker.update_window, session, now)
@@ -144,16 +146,17 @@ async def run_with_time_window_tracker(
 def run_with_time_window_tracker_sync(
     key: TimeWindowTrackerKeys,
     max_window_size_seconds: int,
-    ensure_window_update: bool,
     callback: typing.Callable,
     *args,
     **kwargs,
 ):
     """
-    Synchronous version of run_with_time_window_tracker
-    This function reduces the overhead of running synchronous code in an async context by
-    avoiding unnecessary thread switching.
-    Use this function when your callback is synchronous.
+    Synchronous version of run_with_time_window_tracker with some differences:
+    1. This function reduces the overhead of running synchronous code in an async context by avoiding unnecessary
+    thread switching.
+    2. No need for ensure_window_update parameter.
+
+    NOTE: Use this function when your callback is synchronous.
     """
     cycle_tracker = TimeWindowTracker(
         key=key,
@@ -168,11 +171,5 @@ def run_with_time_window_tracker_sync(
         cycle_tracker.initialize(session)
         last_update_time = cycle_tracker.get_window(session)
         now = datetime.datetime.now(datetime.UTC)
-        try:
-            callback(session, last_update_time, *args, **kwargs)
-            cycle_tracker.update_window(session, now)
-            # The window update succeeded above, no need to ensure it
-            ensure_window_update = False
-        finally:
-            if ensure_window_update:
-                cycle_tracker.update_window(session, now)
+        callback(session, last_update_time, *args, **kwargs)
+        cycle_tracker.update_window(session, now)

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -141,12 +141,12 @@ async def run_with_time_window_tracker(
 
 
 def run_with_time_window_tracker_sync(
-        key: TimeWindowTrackerKeys,
-        max_window_size_seconds: int,
-        ensure_window_update: bool,
-        callback: typing.Callable,
-        *args,
-        **kwargs,
+    key: TimeWindowTrackerKeys,
+    max_window_size_seconds: int,
+    ensure_window_update: bool,
+    callback: typing.Callable,
+    *args,
+    **kwargs,
 ):
     cycle_tracker = TimeWindowTracker(
         key=key,

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -614,9 +614,9 @@ class Service(framework.service.Service):
                 self._generate_events,
             )
 
-    async def _generate_events(self):
+    def _generate_events(self):
         try:
-            await framework.utils.time_window_tracker.run_with_time_window_tracker(
+            framework.utils.time_window_tracker.run_with_time_window_tracker_sync(
                 key=framework.utils.time_window_tracker.TimeWindowTrackerKeys.events_generation,
                 max_window_size_seconds=int(
                     # TODO: This needs to be aligned with chief

--- a/server/py/services/alerts/main.py
+++ b/server/py/services/alerts/main.py
@@ -622,7 +622,6 @@ class Service(framework.service.Service):
                     # TODO: This needs to be aligned with chief
                     mlconf.runtime_resources_deletion_grace_period
                 ),
-                ensure_window_update=False,
                 callback=self._generate_event_on_failed_runs,
             )
         except Exception as exc:

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -118,7 +118,7 @@ class Service(framework.service.Service):
 
     async def _base_handler(
         self,
-            request,
+        request,
         *args,
         **kwargs,
     ):
@@ -401,9 +401,9 @@ class Service(framework.service.Service):
                 _run_uid_start_log_request_counters.pop(run_uid, None)
 
     def _list_runs_uids_to_collect_logs(
-            self,
-            db_session: sqlalchemy.orm.Session,
-            last_update_time: typing.Optional[datetime.datetime] = None,
+        self,
+        db_session: sqlalchemy.orm.Session,
+        last_update_time: typing.Optional[datetime.datetime] = None,
     ):
         # list all the runs currently still running in the system which we didn't request logs collection for yet
         runs_uids = get_db().list_distinct_runs_uids(
@@ -842,7 +842,7 @@ class Service(framework.service.Service):
                 services.api.crud.Runs().abort_run(session, **stale_run)
 
         with concurrent.futures.ThreadPoolExecutor(
-                max_workers=semaphore,
+            max_workers=semaphore,
         ) as pool:
             futures = [pool.submit(abort_run, _stale_run) for _stale_run in stale_runs]
             for future in concurrent.futures.as_completed(futures):

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -70,6 +70,9 @@ from services.api.utils.singletons.scheduler import (
     start_scheduler,
 )
 
+if typing.TYPE_CHECKING:
+    import fastapi
+
 # This is a dictionary which holds the number of consecutive start log requests for each run uid.
 # We use this dictionary to make sure that we don't get stuck in an endless loop of trying to collect logs for a runs
 # that keep failing start logs requests.
@@ -118,7 +121,7 @@ class Service(framework.service.Service):
 
     async def _base_handler(
         self,
-        request,
+        request: "fastapi.Request",
         *args,
         **kwargs,
     ):

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -14,12 +14,11 @@
 
 import asyncio
 import collections
+import concurrent.futures
 import datetime
 import traceback
 import typing
 
-import fastapi
-import fastapi.concurrency
 import sqlalchemy.orm
 
 import mlrun
@@ -102,7 +101,7 @@ class Service(framework.service.Service):
         # In general, it makes more sense to initialize the project member before the scheduler but in 1.1.0 in follower
         # we've added the full sync on the project member initialization (see code there for details) which might delete
         # projects which requires the scheduler to be set
-        await fastapi.concurrency.run_in_threadpool(initialize_project_member)
+        await mlrun.utils.run_in_threadpool(initialize_project_member)
         get_project_member().start()
 
         # maintenance periodic functions should only run on the chief instance
@@ -110,7 +109,7 @@ class Service(framework.service.Service):
             mlconf.httpdb.clusterization.role
             == mlrun.common.schemas.ClusterizationRole.chief
         ):
-            await fastapi.concurrency.run_in_threadpool(
+            await mlrun.utils.run_in_threadpool(
                 services.api.initial_data.update_default_configuration_data
             )
             await self._start_periodic_functions()
@@ -119,7 +118,7 @@ class Service(framework.service.Service):
 
     async def _base_handler(
         self,
-        request: fastapi.Request,
+            request,
         *args,
         **kwargs,
     ):
@@ -139,7 +138,7 @@ class Service(framework.service.Service):
 
     async def _custom_setup_service(self):
         initialize_logs_dir()
-        await fastapi.concurrency.run_in_threadpool(self._initialize_data)
+        await mlrun.utils.run_in_threadpool(self._initialize_data)
 
     async def _custom_teardown_service(self):
         if get_project_member():
@@ -246,30 +245,13 @@ class Service(framework.service.Service):
         self, db_session, last_update_time: datetime.datetime, start_logs_limit
     ):
         self._logger.debug(
-            "Getting all runs which are in non terminal state and require logs collection"
-        )
-        runs_uids = await fastapi.concurrency.run_in_threadpool(
-            get_db().list_distinct_runs_uids,
-            db_session,
-            requested_logs_modes=[None, False],
-            only_uids=True,
-            states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
-        )
-        self._logger.debug(
-            "Getting all runs which might have reached terminal state while the API was down",
+            "Getting all runs which are in non terminal state and require logs collection",
             api_downtime_grace_period=mlconf.log_collector.api_downtime_grace_period,
         )
-        runs_uids.extend(
-            await fastapi.concurrency.run_in_threadpool(
-                get_db().list_distinct_runs_uids,
-                db_session,
-                requested_logs_modes=[None, False],
-                # get only uids as there might be many runs which reached terminal state while the API was down, the
-                # run objects will be fetched in the next step
-                only_uids=True,
-                last_update_time_from=last_update_time,
-                states=mlrun.common.runtimes.constants.RunStates.terminal_states(),
-            )
+        runs_uids = await mlrun.utils.run_in_threadpool(
+            self._list_runs_uids_to_collect_logs,
+            db_session,
+            last_update_time,
         )
         if runs_uids:
             skipped_run_uids = []
@@ -305,7 +287,7 @@ class Service(framework.service.Service):
             )
 
             if skipped_run_uids:
-                await fastapi.concurrency.run_in_threadpool(
+                await mlrun.utils.run_in_threadpool(
                     get_db().update_runs_requested_logs,
                     db_session,
                     uids=skipped_run_uids,
@@ -318,34 +300,11 @@ class Service(framework.service.Service):
         are in a state which requires logs collection and will initiate the logs collection process for each of them.
         :param start_logs_limit: a semaphore which limits the number of concurrent logs collection processes
         """
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-        try:
+
+        async with framework.db.session.get_db_session_async() as db_session:
             # list all the runs currently still running in the system which we didn't request logs collection for yet
-            runs_uids = await fastapi.concurrency.run_in_threadpool(
-                get_db().list_distinct_runs_uids,
-                db_session,
-                requested_logs_modes=[False],
-                only_uids=True,
-                states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
-            )
-
-            last_update_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
-                seconds=int(mlconf.runtime_resources_deletion_grace_period)
-            )
-
-            # Add all the completed/failed runs in the system which we didn't request logs collection for yet.
-            # Aborted means the pods were deleted and logs were already fetched.
-            run_states = mlrun.common.runtimes.constants.RunStates.terminal_states()
-            run_states.remove(mlrun.common.runtimes.constants.RunStates.aborted)
-            runs_uids.extend(
-                await fastapi.concurrency.run_in_threadpool(
-                    get_db().list_distinct_runs_uids,
-                    db_session,
-                    requested_logs_modes=[False],
-                    only_uids=True,
-                    last_update_time_from=last_update_time,
-                    states=run_states,
-                )
+            runs_uids = await mlrun.utils.run_in_threadpool(
+                self._list_runs_uids_to_collect_logs, db_session
             )
             if runs_uids:
                 self._logger.debug(
@@ -358,9 +317,6 @@ class Service(framework.service.Service):
                     runs_uids=runs_uids,
                 )
 
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
-
     async def _start_log_and_update_runs(
         self,
         start_logs_limit: asyncio.Semaphore,
@@ -372,7 +328,7 @@ class Service(framework.service.Service):
             return
 
         # get the runs from the DB
-        runs = await fastapi.concurrency.run_in_threadpool(
+        runs = await mlrun.utils.run_in_threadpool(
             get_db().list_runs,
             db_session,
             uid=runs_uids,
@@ -434,7 +390,7 @@ class Service(framework.service.Service):
                 runs_uids=runs_to_mark_as_requested_logs,
             )
             # update the runs to indicate that we have requested log collection for them
-            await fastapi.concurrency.run_in_threadpool(
+            await mlrun.utils.run_in_threadpool(
                 get_db().update_runs_requested_logs,
                 db_session,
                 uids=runs_to_mark_as_requested_logs,
@@ -443,6 +399,40 @@ class Service(framework.service.Service):
             # remove the counters for the runs we updated
             for run_uid in runs_to_mark_as_requested_logs:
                 _run_uid_start_log_request_counters.pop(run_uid, None)
+
+    def _list_runs_uids_to_collect_logs(
+            self,
+            db_session: sqlalchemy.orm.Session,
+            last_update_time: typing.Optional[datetime.datetime] = None,
+    ):
+        # list all the runs currently still running in the system which we didn't request logs collection for yet
+        runs_uids = get_db().list_distinct_runs_uids(
+            db_session,
+            requested_logs_modes=[None, False],
+            only_uids=True,
+            states=mlrun.common.runtimes.constants.RunStates.non_terminal_states(),
+        )
+
+        if not last_update_time:
+            last_update_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+                seconds=int(mlconf.runtime_resources_deletion_grace_period)
+            )
+
+        # Add all the completed/failed runs in the system which we didn't request logs collection for yet.
+        # Aborted means the pods were deleted and logs were already fetched.
+        run_states = mlrun.common.runtimes.constants.RunStates.terminal_states()
+        run_states.remove(mlrun.common.runtimes.constants.RunStates.aborted)
+
+        runs_uids.extend(
+            get_db().list_distinct_runs_uids(
+                db_session,
+                requested_logs_modes=[None, False],
+                only_uids=True,
+                last_update_time_from=last_update_time,
+                states=run_states,
+            )
+        )
+        return runs_uids
 
     async def _start_log_for_run(
         self,
@@ -634,7 +624,7 @@ class Service(framework.service.Service):
 
     @staticmethod
     async def _manage_partitions(table_name, retention_days):
-        await fastapi.concurrency.run_in_threadpool(
+        await mlrun.utils.run_in_threadpool(
             framework.db.session.run_function_with_new_db_session,
             services.api.utils.db.partitioner.DBPartitioner().create_and_drop_partitions,
             table_name=table_name,
@@ -699,9 +689,8 @@ class Service(framework.service.Service):
             "Getting current log collected runs which have reached terminal state and already have logs requested",
             run_uids_in_progress_count=len(run_uids_in_progress),
         )
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-        try:
-            runs = await fastapi.concurrency.run_in_threadpool(
+        async with framework.db.session.get_db_session_async() as db_session:
+            runs = await mlrun.utils.run_in_threadpool(
                 get_db().list_distinct_runs_uids,
                 db_session,
                 requested_logs_modes=[True],
@@ -715,22 +704,19 @@ class Service(framework.service.Service):
                 specific_uids=run_uids_in_progress,
             )
 
-            if len(runs) > 0:
-                self._logger.debug(
-                    "Stopping logs for runs which reached terminal state before startup",
-                    runs_count=len(runs),
-                )
-                await self._stop_logs_for_runs(runs)
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
+        if len(runs) > 0:
+            self._logger.debug(
+                "Stopping logs for runs which reached terminal state before startup",
+                runs_count=len(runs),
+            )
+            await self._stop_logs_for_runs(runs)
 
-    async def _monitor_runs(self):
-        stale_runs = await framework.db.session.run_async_function_with_new_db_session(
-            self._monitor_runs_and_push_terminal_notifications
-        )
-        await self._abort_stale_runs(stale_runs)
+    def _monitor_runs(self):
+        with framework.db.session.get_db_session() as db_session:
+            stale_runs = self._monitor_runs_and_push_terminal_notifications(db_session)
+        self._abort_stale_runs(stale_runs)
 
-    async def _monitor_runs_and_push_terminal_notifications(self, db_session):
+    def _monitor_runs_and_push_terminal_notifications(self, db_session):
         db = get_db()
         stale_runs = []
         for kind in RuntimeKinds.runtime_with_handlers():
@@ -745,7 +731,7 @@ class Service(framework.service.Service):
                     kind=kind,
                 )
         try:
-            await framework.utils.time_window_tracker.run_with_time_window_tracker(
+            framework.utils.time_window_tracker.run_with_time_window_tracker_sync(
                 key=framework.utils.time_window_tracker.TimeWindowTrackerKeys.run_monitoring,
                 max_window_size_seconds=int(
                     mlconf.runtime_resources_deletion_grace_period
@@ -842,32 +828,30 @@ class Service(framework.service.Service):
             run_notification_pusher_class.resolve_notifications_default_params(),
         ).push()
 
-    async def _abort_stale_runs(self, stale_runs: list[dict]):
-        semaphore = asyncio.Semaphore(
-            int(mlrun.mlconf.monitoring.runs.concurrent_abort_stale_runs_workers)
+    def _abort_stale_runs(self, stale_runs: list[dict]):
+        semaphore = int(
+            mlrun.mlconf.monitoring.runs.concurrent_abort_stale_runs_workers
         )
 
-        async def abort_run(stale_run):
-            # Using semaphore to limit the chunk we get from the thread pool for run aborting
-            async with semaphore:
-                # mark abort as internal, it doesn't have a background task
-                stale_run["new_background_task_id"] = (
-                    framework.constants.internal_abort_task_id
-                )
-                await fastapi.concurrency.run_in_threadpool(
-                    framework.db.session.run_function_with_new_db_session,
-                    services.api.crud.Runs().abort_run,
-                    **stale_run,
-                )
+        def abort_run(stale_run):
+            # mark abort as internal, it doesn't have a background task
+            stale_run["new_background_task_id"] = (
+                framework.constants.internal_abort_task_id
+            )
+            with framework.db.session.get_db_session() as session:
+                services.api.crud.Runs().abort_run(session, **stale_run)
 
-        coroutines = [abort_run(_stale_run) for _stale_run in stale_runs]
-        if coroutines:
-            results = await asyncio.gather(*coroutines, return_exceptions=True)
-            for result in results:
-                if isinstance(result, Exception):
+        with concurrent.futures.ThreadPoolExecutor(
+                max_workers=semaphore,
+        ) as pool:
+            futures = [pool.submit(abort_run, _stale_run) for _stale_run in stale_runs]
+            for future in concurrent.futures.as_completed(futures):
+                try:
+                    future.result()
+                except Exception as exc:
                     self._logger.warning(
                         "Failed aborting stale run. Ignoring",
-                        exc=err_to_str(result),
+                        exc=err_to_str(exc),
                     )
 
     async def _stop_logs(
@@ -880,9 +864,8 @@ class Service(framework.service.Service):
             "Getting all runs which reached terminal state in the previous interval and have logs requested",
             interval_seconds=int(mlconf.log_collector.stop_logs_interval),
         )
-        db_session = await fastapi.concurrency.run_in_threadpool(create_session)
-        try:
-            runs = await fastapi.concurrency.run_in_threadpool(
+        async with framework.db.session.get_db_session_async() as db_session:
+            runs = await mlrun.utils.run_in_threadpool(
                 get_db().list_distinct_runs_uids,
                 db_session,
                 requested_logs_modes=[True],
@@ -900,8 +883,6 @@ class Service(framework.service.Service):
                     runs_count=len(runs),
                 )
                 await self._stop_logs_for_runs(runs)
-        finally:
-            await fastapi.concurrency.run_in_threadpool(close_session, db_session)
 
     async def _stop_logs_for_runs(self, runs: list, chunk_size: int = 10):
         project_to_run_uids = collections.defaultdict(list)
@@ -942,7 +923,7 @@ class Service(framework.service.Service):
         now = datetime.datetime.now(datetime.UTC)
         try:
             offset = 0
-            while runs := await fastapi.concurrency.run_in_threadpool(
+            while runs := await mlrun.utils.run_in_threadpool(
                 framework.db.session.run_function_with_new_db_session,
                 get_db().list_runs,
                 project="*",
@@ -970,7 +951,7 @@ class Service(framework.service.Service):
                                 now=now,
                             )
                             futures.append(
-                                fastapi.concurrency.run_in_threadpool(
+                                mlrun.utils.run_in_threadpool(
                                     framework.db.session.run_function_with_new_db_session,
                                     services.api.crud.Runs().abort_run,
                                     project=run.metadata.project,
@@ -1000,7 +981,7 @@ class Service(framework.service.Service):
                             max_retry_count=run.spec.retry.count,
                         )
                         futures.append(
-                            fastapi.concurrency.run_in_threadpool(
+                            mlrun.utils.run_in_threadpool(
                                 framework.db.session.run_function_with_new_db_session,
                                 get_db().update_run,
                                 updates={

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -739,7 +739,6 @@ class Service(framework.service.Service):
                 max_window_size_seconds=int(
                     mlconf.runtime_resources_deletion_grace_period
                 ),
-                ensure_window_update=False,
                 callback=self._push_terminal_run_notifications,
                 db=db,
             )

--- a/server/py/services/api/tests/unit/test_collect_runs_logs.py
+++ b/server/py/services/api/tests/unit/test_collect_runs_logs.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import contextlib
+import datetime
 import time
 import unittest.mock
 
@@ -684,6 +686,301 @@ class TestCollectRunSLogs:
             )
             == {}
         )
+
+    @pytest.mark.asyncio
+    async def test_verify_log_collection_started_no_runs(
+            self,
+            db: sqlalchemy.orm.session.Session,
+            client: fastapi.testclient.TestClient,
+            monkeypatch,
+    ):
+        """Test _verify_log_collection_started when there are no runs to collect"""
+        update_runs_requested_logs_mock = unittest.mock.Mock()
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(),
+            "update_runs_requested_logs",
+            update_runs_requested_logs_mock,
+        )
+
+        # Mock _list_runs_uids_to_collect_logs to return empty list
+        list_runs_uids_mock = unittest.mock.Mock(return_value=[])
+        with unittest.mock.patch.object(
+                daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+        ):
+            await daemon.service._verify_log_collection_started(
+                db, datetime.datetime.now(datetime.UTC), self.start_log_limit
+            )
+
+        # Should not call update_runs_requested_logs when there are no runs
+        assert update_runs_requested_logs_mock.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_verify_log_collection_started_with_runs(
+            self,
+            db: sqlalchemy.orm.session.Session,
+            client: fastapi.testclient.TestClient,
+            monkeypatch,
+    ):
+        """Test _verify_log_collection_started with runs that need log collection"""
+        log_collector = framework.utils.clients.log_collector.LogCollectorClient()
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=BaseLogCollectorResponse(True, "")
+        )
+        monkeypatch.setattr(
+            framework.utils.clients.log_collector,
+            "LogCollectorClient",
+            lambda: log_collector,
+        )
+
+        project_name = "some-project"
+        for run_uid in ["uid1", "uid2", "uid3"]:
+            _create_new_run(
+                db,
+                project_name,
+                uid=run_uid,
+                name=run_uid,
+                kind="job",
+                state=mlrun.common.runtimes.constants.RunStates.running,
+            )
+
+        runs = framework.utils.singletons.db.get_db().list_distinct_runs_uids(
+            db,
+            requested_logs_modes=[None, False],
+            only_uids=False,
+        )
+
+        update_runs_requested_logs_mock = unittest.mock.Mock()
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(),
+            "update_runs_requested_logs",
+            update_runs_requested_logs_mock,
+        )
+        list_runs_mock = unittest.mock.Mock(return_value=runs)
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(), "list_runs", list_runs_mock
+        )
+
+        # Use real _list_runs_uids_to_collect_logs to get actual run UIDs
+        last_update_time = datetime.datetime.now(datetime.UTC)
+        await daemon.service._verify_log_collection_started(
+            db, last_update_time, self.start_log_limit
+        )
+
+        # Should call update_runs_requested_logs at least once for the successful runs
+        # (may be called multiple times if runs are processed in batches)
+        assert update_runs_requested_logs_mock.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_verify_log_collection_started_with_runs_over_limit(
+            self,
+            db: sqlalchemy.orm.session.Session,
+            client: fastapi.testclient.TestClient,
+            monkeypatch,
+    ):
+        """Test _verify_log_collection_started when runs exceed the startup limit"""
+        log_collector = framework.utils.clients.log_collector.LogCollectorClient()
+
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=BaseLogCollectorResponse(True, "")
+        )
+        monkeypatch.setattr(
+            framework.utils.clients.log_collector,
+            "LogCollectorClient",
+            lambda: log_collector,
+        )
+
+        project_name = "some-project"
+        num_runs = int(mlrun.mlconf.log_collector.start_logs_startup_run_limit) + 5
+        run_uids = [f"uid_{i}" for i in range(num_runs)]
+        for run_uid in run_uids:
+            _create_new_run(
+                db,
+                project_name,
+                uid=run_uid,
+                name=run_uid,
+                kind="job",
+                state=mlrun.common.runtimes.constants.RunStates.running,
+            )
+
+        runs = framework.utils.singletons.db.get_db().list_distinct_runs_uids(
+            db,
+            requested_logs_modes=[None, False],
+            only_uids=False,
+        )
+        # Sort runs to ensure consistent ordering
+        runs = sorted(runs, key=lambda run: run["metadata"]["uid"])
+
+        update_runs_requested_logs_mock = unittest.mock.Mock()
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(),
+            "update_runs_requested_logs",
+            update_runs_requested_logs_mock,
+        )
+        list_runs_mock = unittest.mock.Mock(
+            return_value=runs[
+                : int(mlrun.mlconf.log_collector.start_logs_startup_run_limit)
+            ]
+        )
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(), "list_runs", list_runs_mock
+        )
+
+        last_update_time = datetime.datetime.now(datetime.UTC)
+        await daemon.service._verify_log_collection_started(
+            db, last_update_time, self.start_log_limit
+        )
+
+        # Should call update_runs_requested_logs twice:
+        # 1. For runs within limit that were processed
+        # 2. For skipped runs that exceeded the limit
+        assert update_runs_requested_logs_mock.call_count == 2
+
+        # First call should be for runs within limit
+        first_call_uids = update_runs_requested_logs_mock.call_args_list[0][1]["uids"]
+        assert len(first_call_uids) == int(
+            mlrun.mlconf.log_collector.start_logs_startup_run_limit
+        )
+
+        # Second call should be for skipped runs
+        second_call_uids = update_runs_requested_logs_mock.call_args_list[1][1]["uids"]
+        assert len(second_call_uids) == 5  # The excess runs
+
+    @pytest.mark.asyncio
+    async def test_initiate_logs_collection_no_runs(
+            self,
+            db: sqlalchemy.orm.session.Session,
+            client: fastapi.testclient.TestClient,
+            monkeypatch,
+    ):
+        """Test _initiate_logs_collection when there are no runs to collect"""
+        update_runs_requested_logs_mock = unittest.mock.Mock()
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(),
+            "update_runs_requested_logs",
+            update_runs_requested_logs_mock,
+        )
+
+        # Mock _list_runs_uids_to_collect_logs to return empty list
+        list_runs_uids_mock = unittest.mock.Mock(return_value=[])
+        with unittest.mock.patch.object(
+                daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+        ):
+            await daemon.service._initiate_logs_collection(self.start_log_limit)
+
+        # Should not call update_runs_requested_logs when there are no runs
+        assert update_runs_requested_logs_mock.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_initiate_logs_collection_with_runs(
+            self,
+            db: sqlalchemy.orm.session.Session,
+            client: fastapi.testclient.TestClient,
+            monkeypatch,
+    ):
+        """Test _initiate_logs_collection with runs that need log collection"""
+
+        log_collector = framework.utils.clients.log_collector.LogCollectorClient()
+        log_collector._call = unittest.mock.AsyncMock(
+            return_value=BaseLogCollectorResponse(True, "")
+        )
+
+        project_name = "some-project"
+        run_uids = ["uid1", "uid2", "uid3"]
+        for run_uid in run_uids:
+            _create_new_run(
+                db,
+                project_name,
+                uid=run_uid,
+                name=run_uid,
+                kind="job",
+                state=mlrun.common.runtimes.constants.RunStates.running,
+            )
+
+        runs = framework.utils.singletons.db.get_db().list_distinct_runs_uids(
+            db,
+            requested_logs_modes=[None, False],
+            only_uids=False,
+        )
+
+        update_runs_requested_logs_mock = unittest.mock.Mock()
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(),
+            "update_runs_requested_logs",
+            update_runs_requested_logs_mock,
+        )
+        list_runs_mock = unittest.mock.Mock(return_value=runs)
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(), "list_runs", list_runs_mock
+        )
+
+        # Use real _list_runs_uids_to_collect_logs - it will be called via run_in_threadpool
+        await daemon.service._initiate_logs_collection(self.start_log_limit)
+
+        # Should call update_runs_requested_logs at least once for the successful runs
+        assert update_runs_requested_logs_mock.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_initiate_logs_collection_uses_async_session(
+            self,
+            db: sqlalchemy.orm.session.Session,
+            client: fastapi.testclient.TestClient,
+            monkeypatch,
+    ):
+        """Test that _initiate_logs_collection uses async session context manager"""
+        # Mock get_db_session_async to track if it's called
+        get_db_session_async_called = False
+        original_get_db_session_async = framework.db.session.get_db_session_async
+
+        @contextlib.asynccontextmanager
+        async def mock_get_db_session_async(commit=True):
+            nonlocal get_db_session_async_called
+            get_db_session_async_called = True
+            async with original_get_db_session_async(commit=commit) as session:
+                yield session
+
+        with unittest.mock.patch(
+                "framework.db.session.get_db_session_async", mock_get_db_session_async
+        ):
+            # Mock _list_runs_uids_to_collect_logs to return empty list
+            list_runs_uids_mock = unittest.mock.Mock(return_value=[])
+            with unittest.mock.patch.object(
+                    daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+            ):
+                await daemon.service._initiate_logs_collection(self.start_log_limit)
+
+        # Verify that async session context manager was used
+        assert get_db_session_async_called
+
+    @pytest.mark.asyncio
+    async def test_verify_log_collection_started_with_last_update_time(
+            self,
+            db: sqlalchemy.orm.session.Session,
+            client: fastapi.testclient.TestClient,
+            monkeypatch,
+    ):
+        """Test _verify_log_collection_started with a specific last_update_time"""
+        update_runs_requested_logs_mock = unittest.mock.Mock()
+        monkeypatch.setattr(
+            framework.utils.singletons.db.get_db(),
+            "update_runs_requested_logs",
+            update_runs_requested_logs_mock,
+        )
+
+        # Mock _list_runs_uids_to_collect_logs to verify it's called with correct params
+        list_runs_uids_mock = unittest.mock.Mock(return_value=[])
+        with unittest.mock.patch.object(
+                daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+        ):
+            last_update_time = datetime.datetime.now(datetime.UTC)
+            await daemon.service._verify_log_collection_started(
+                db, last_update_time, self.start_log_limit
+            )
+
+        # Verify _list_runs_uids_to_collect_logs was called with correct parameters
+        assert list_runs_uids_mock.call_count == 1
+        call_args = list_runs_uids_mock.call_args
+        assert call_args[0][0] == db  # db_session
+        assert call_args[0][1] == last_update_time  # last_update_time
 
 
 def _create_new_run(

--- a/server/py/services/api/tests/unit/test_collect_runs_logs.py
+++ b/server/py/services/api/tests/unit/test_collect_runs_logs.py
@@ -689,10 +689,10 @@ class TestCollectRunSLogs:
 
     @pytest.mark.asyncio
     async def test_verify_log_collection_started_no_runs(
-            self,
-            db: sqlalchemy.orm.session.Session,
-            client: fastapi.testclient.TestClient,
-            monkeypatch,
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+        monkeypatch,
     ):
         """Test _verify_log_collection_started when there are no runs to collect"""
         update_runs_requested_logs_mock = unittest.mock.Mock()
@@ -705,7 +705,7 @@ class TestCollectRunSLogs:
         # Mock _list_runs_uids_to_collect_logs to return empty list
         list_runs_uids_mock = unittest.mock.Mock(return_value=[])
         with unittest.mock.patch.object(
-                daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+            daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
         ):
             await daemon.service._verify_log_collection_started(
                 db, datetime.datetime.now(datetime.UTC), self.start_log_limit
@@ -716,10 +716,10 @@ class TestCollectRunSLogs:
 
     @pytest.mark.asyncio
     async def test_verify_log_collection_started_with_runs(
-            self,
-            db: sqlalchemy.orm.session.Session,
-            client: fastapi.testclient.TestClient,
-            monkeypatch,
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+        monkeypatch,
     ):
         """Test _verify_log_collection_started with runs that need log collection"""
         log_collector = framework.utils.clients.log_collector.LogCollectorClient()
@@ -772,10 +772,10 @@ class TestCollectRunSLogs:
 
     @pytest.mark.asyncio
     async def test_verify_log_collection_started_with_runs_over_limit(
-            self,
-            db: sqlalchemy.orm.session.Session,
-            client: fastapi.testclient.TestClient,
-            monkeypatch,
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+        monkeypatch,
     ):
         """Test _verify_log_collection_started when runs exceed the startup limit"""
         log_collector = framework.utils.clients.log_collector.LogCollectorClient()
@@ -847,10 +847,10 @@ class TestCollectRunSLogs:
 
     @pytest.mark.asyncio
     async def test_initiate_logs_collection_no_runs(
-            self,
-            db: sqlalchemy.orm.session.Session,
-            client: fastapi.testclient.TestClient,
-            monkeypatch,
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+        monkeypatch,
     ):
         """Test _initiate_logs_collection when there are no runs to collect"""
         update_runs_requested_logs_mock = unittest.mock.Mock()
@@ -863,7 +863,7 @@ class TestCollectRunSLogs:
         # Mock _list_runs_uids_to_collect_logs to return empty list
         list_runs_uids_mock = unittest.mock.Mock(return_value=[])
         with unittest.mock.patch.object(
-                daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+            daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
         ):
             await daemon.service._initiate_logs_collection(self.start_log_limit)
 
@@ -872,10 +872,10 @@ class TestCollectRunSLogs:
 
     @pytest.mark.asyncio
     async def test_initiate_logs_collection_with_runs(
-            self,
-            db: sqlalchemy.orm.session.Session,
-            client: fastapi.testclient.TestClient,
-            monkeypatch,
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+        monkeypatch,
     ):
         """Test _initiate_logs_collection with runs that need log collection"""
 
@@ -921,10 +921,10 @@ class TestCollectRunSLogs:
 
     @pytest.mark.asyncio
     async def test_initiate_logs_collection_uses_async_session(
-            self,
-            db: sqlalchemy.orm.session.Session,
-            client: fastapi.testclient.TestClient,
-            monkeypatch,
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+        monkeypatch,
     ):
         """Test that _initiate_logs_collection uses async session context manager"""
         # Mock get_db_session_async to track if it's called
@@ -939,12 +939,12 @@ class TestCollectRunSLogs:
                 yield session
 
         with unittest.mock.patch(
-                "framework.db.session.get_db_session_async", mock_get_db_session_async
+            "framework.db.session.get_db_session_async", mock_get_db_session_async
         ):
             # Mock _list_runs_uids_to_collect_logs to return empty list
             list_runs_uids_mock = unittest.mock.Mock(return_value=[])
             with unittest.mock.patch.object(
-                    daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+                daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
             ):
                 await daemon.service._initiate_logs_collection(self.start_log_limit)
 
@@ -953,10 +953,10 @@ class TestCollectRunSLogs:
 
     @pytest.mark.asyncio
     async def test_verify_log_collection_started_with_last_update_time(
-            self,
-            db: sqlalchemy.orm.session.Session,
-            client: fastapi.testclient.TestClient,
-            monkeypatch,
+        self,
+        db: sqlalchemy.orm.session.Session,
+        client: fastapi.testclient.TestClient,
+        monkeypatch,
     ):
         """Test _verify_log_collection_started with a specific last_update_time"""
         update_runs_requested_logs_mock = unittest.mock.Mock()
@@ -969,7 +969,7 @@ class TestCollectRunSLogs:
         # Mock _list_runs_uids_to_collect_logs to verify it's called with correct params
         list_runs_uids_mock = unittest.mock.Mock(return_value=[])
         with unittest.mock.patch.object(
-                daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
+            daemon.service, "_list_runs_uids_to_collect_logs", list_runs_uids_mock
         ):
             last_update_time = datetime.datetime.now(datetime.UTC)
             await daemon.service._verify_log_collection_started(


### PR DESCRIPTION
### 📝 Description

This PR addresses [ML-11432](https://iguazio.atlassian.net/browse/ML-11432) by ensuring proper session lifecycle management in async contexts, preventing potential resource leaks and improving code maintainability.

---

### 🛠️ Changes Made

- Added `get_db_session_async()` async context manager for proper database session management in async contexts
- Refactored `_initiate_logs_collection()` to use async session context manager instead of manual session handling
- Improved log collection handling with proper session commit/rollback semantics
- Added comprehensive unit tests for async session management and log collection functionality
- Updated `run_async_function_with_new_db_session()` to support both coroutine functions and sync functions in async contexts
- Enhanced `TimeWindowTracker` to work with async session context managers
- Removed spammy get kfp runs
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Added comprehensive unit tests in `test_collect_runs_logs.py` covering:
  - Async session context manager usage in log collection
  - Verification of log collection started with last update time
  - Proper session lifecycle management
- All existing unit tests pass
- Manual testing verified proper session commit/rollback behavior

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11432
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---


[ML-11432]: https://iguazio.atlassian.net/browse/ML-11432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ