### PR TITLE
[Model Monitoring] Add v2 API with TSDB aggregation support (ML-10251, ML-11445)

### DIFF
--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -68,3 +68,8 @@ class ClientSpec(pydantic.v1.BaseModel):
     system_id: typing.Optional[str]
     model_endpoint_monitoring_store_prefixes: typing.Optional[dict[str, str]]
     authentication_mode: typing.Optional[str]
+    # Model endpoint monitoring TSDB aggregation config
+    model_endpoint_monitoring_tsdb_aggregation_supported: typing.Optional[bool]
+    model_endpoint_monitoring_tsdb_retention_policy: typing.Optional[dict[str, str]]
+    model_endpoint_monitoring_tsdb_aggregation_functions: typing.Optional[list[str]]
+    model_endpoint_monitoring_tsdb_aggregation_intervals: typing.Optional[list[str]]

--- a/mlrun/common/schemas/frontend_spec.py
+++ b/mlrun/common/schemas/frontend_spec.py
@@ -71,3 +71,11 @@ class FrontendSpec(pydantic.v1.BaseModel):
     ce: typing.Optional[dict]
     internal_labels: list[str] = []
     artifact_limits: ArtifactLimits
+    # Model endpoint monitoring TSDB aggregation config
+    model_endpoint_monitoring_tsdb_aggregation_supported: typing.Optional[bool] = None
+    model_endpoint_monitoring_tsdb_aggregation_functions: typing.Optional[list[str]] = (
+        None
+    )
+    model_endpoint_monitoring_tsdb_aggregation_intervals: typing.Optional[list[str]] = (
+        None
+    )

--- a/mlrun/common/schemas/model_monitoring/__init__.py
+++ b/mlrun/common/schemas/model_monitoring/__init__.py
@@ -57,6 +57,7 @@ from .grafana import (
     GrafanaTable,
 )
 from .model_endpoints import (
+    AggregationConfig,
     ApplicationMetricRecord,
     ApplicationResultRecord,
     Features,
@@ -68,7 +69,9 @@ from .model_endpoints import (
     ModelEndpointMonitoringMetric,
     ModelEndpointMonitoringMetricNoData,
     ModelEndpointMonitoringMetricValues,
+    ModelEndpointMonitoringMetricValuesV2,
     ModelEndpointMonitoringResultValues,
+    ModelEndpointMonitoringResultValuesV2,
     ModelEndpointSpec,
     ModelEndpointStatus,
 )

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -345,6 +345,49 @@ class ModelEndpointMonitoringMetricNoData(_ModelEndpointMonitoringMetricValuesBa
     data: bool = False
 
 
+# V2 API schemas with aggregation support (ML-11445)
+
+
+class AggregationConfig(BaseModel):
+    """Configuration describing the aggregation applied to metric/result values."""
+
+    aggregated: bool
+    period: Optional[str] = None
+    functions: Optional[list[str]] = None
+
+
+class ModelEndpointMonitoringMetricValuesV2(_ModelEndpointMonitoringMetricValuesBase):
+    """V2 metric values with aggregation support.
+
+    Values format: [[timestamp, agg_value_1, agg_value_2, ...], ...]
+    Where agg_value_N corresponds to aggregation_config.functions[N-1].
+    If not aggregated, values are [[timestamp, value], ...].
+    """
+
+    type: ModelEndpointMonitoringMetricType = ModelEndpointMonitoringMetricType.METRIC
+    aggregation_config: AggregationConfig
+    values: list[list[Any]]
+    data: bool = True
+
+
+class ModelEndpointMonitoringResultValuesV2(_ModelEndpointMonitoringMetricValuesBase):
+    """V2 result values with aggregation support.
+
+    Values format depends on aggregation_config.aggregated:
+    - If aggregated: [[timestamp, agg_value_1, agg_value_2, ...], ...]
+      Where agg_value_N corresponds to aggregation_config.functions[N-1].
+      Note: status and extra_data are NOT included in aggregated results
+      since they cannot be meaningfully aggregated.
+    - If not aggregated (raw): [[timestamp, value, status, extra_data], ...]
+    """
+
+    type: ModelEndpointMonitoringMetricType = ModelEndpointMonitoringMetricType.RESULT
+    result_kind: ResultKindApp
+    aggregation_config: AggregationConfig
+    values: list[list[Any]]
+    data: bool = True
+
+
 class ApplicationBaseRecord(BaseModel):
     type: Literal["metric", "result"]
     value: float

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -127,9 +127,7 @@ class ModelEndpointMetadata(ObjectMetadata, ModelEndpointParser):
 
     @validator("uid", pre=True)
     def _uid_to_str(cls, v):  # noqa: N805
-        if isinstance(v, UUID):
-            return str(v)
-        return v
+        return str(v) if isinstance(v, UUID) else v
 
     @validator("mode", pre=True, always=True)
     def _set_mode_based_on_endpoint_type(cls, v, values):  # noqa: N805
@@ -359,9 +357,10 @@ class AggregationConfig(BaseModel):
 class ModelEndpointMonitoringMetricValuesV2(_ModelEndpointMonitoringMetricValuesBase):
     """V2 metric values with aggregation support.
 
-    Values format: [[timestamp, agg_value_1, agg_value_2, ...], ...]
-    Where agg_value_N corresponds to aggregation_config.functions[N-1].
-    If not aggregated, values are [[timestamp, value], ...].
+    Values format depends on aggregation_config.aggregated:
+    - If aggregated: [[timestamp, agg_value_1, agg_value_2, ...], ...]
+      Where agg_value_N corresponds to aggregation_config.functions[N-1].
+    - If not aggregated (raw): [[timestamp, value], ...]
     """
 
     type: ModelEndpointMonitoringMetricType = ModelEndpointMonitoringMetricType.METRIC
@@ -374,10 +373,9 @@ class ModelEndpointMonitoringResultValuesV2(_ModelEndpointMonitoringMetricValues
     """V2 result values with aggregation support.
 
     Values format depends on aggregation_config.aggregated:
-    - If aggregated: [[timestamp, agg_value_1, agg_value_2, ...], ...]
+    - If aggregated: [[timestamp, agg_value_1, agg_value_2, ..., max_status], ...]
       Where agg_value_N corresponds to aggregation_config.functions[N-1].
-      Note: status and extra_data are NOT included in aggregated results
-      since they cannot be meaningfully aggregated.
+      Status uses only max (indicates detection in period). extra_data is NOT included.
     - If not aggregated (raw): [[timestamp, value, status, extra_data], ...]
     """
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -675,6 +675,25 @@ default_config = {
         "parquet_batching_max_events": 10_000,
         "parquet_batching_timeout_secs": timedelta(minutes=1).total_seconds(),
         "model_endpoint_creation_check_period": 15,
+        # TSDB configuration for model monitoring metrics storage
+        "tsdb": {
+            "pre_aggregate": {
+                # Enable/disable pre-aggregation (continuous aggregates)
+                "enabled": True,
+                # Available aggregation intervals for pre-computed views
+                "aggregate_intervals": ["1h", "6h", "12h", "24h"],
+                # Available aggregation functions
+                "agg_functions": ["min", "max", "avg", "count"],
+                # Retention policy for raw and aggregated data
+                "retention_policy": {
+                    "raw": "3 months",
+                    "1h": "6 months",
+                    "6h": "6 months",
+                    "12h": "6 months",
+                    "24h": "6 months",
+                },
+            },
+        },
     },
     "secret_stores": {
         # Use only in testing scenarios (such as integration tests) to avoid using k8s for secrets (will use in-memory

--- a/mlrun/model_monitoring/db/tsdb/__init__.py
+++ b/mlrun/model_monitoring/db/tsdb/__init__.py
@@ -15,7 +15,6 @@
 import enum
 import typing
 
-import mlrun.common.schemas.secret
 import mlrun.datastore.datastore_profile
 import mlrun.errors
 import mlrun.model_monitoring.helpers
@@ -52,9 +51,19 @@ class ObjectTSDBFactory(enum.Enum):
             return V3IOTSDBConnector(project=project, **kwargs)
 
         if self == self.timescaledb:
+            from .preaggregate import PreAggregateConfig
             from .timescaledb.timescaledb_connector import TimescaleDBConnector
 
-            return TimescaleDBConnector(project=project, profile=profile, **kwargs)
+            pre_aggregate_config = PreAggregateConfig.from_mlrun_config()
+            return TimescaleDBConnector(
+                project=project,
+                profile=typing.cast(
+                    mlrun.datastore.datastore_profile.DatastoreProfilePostgreSQL,
+                    profile,
+                ),
+                pre_aggregate_config=pre_aggregate_config,
+                **kwargs,
+            )
 
         if self == self.tdengine:
             from .tdengine.tdengine_connector import TDEngineConnector

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -607,8 +607,11 @@ class TSDBConnector(ABC):
 
     @staticmethod
     def _is_aggregated(agg_period: Optional[str]) -> bool:
-        """Check if the aggregation period indicates aggregated data."""
-        return agg_period is not None and agg_period != "raw"
+        """Check if the aggregation period indicates aggregated data.
+
+        Note: "raw" is resolved at the API layer to None before reaching TSDB.
+        """
+        return agg_period is not None
 
     @staticmethod
     def _build_aggregation_config(
@@ -659,13 +662,13 @@ class TSDBConnector(ABC):
         Build result values list from DataFrame based on aggregation settings.
 
         For aggregated results:
-            [[timestamp, agg_val_1, agg_val_2, ..., agg_status_1, agg_status_2, ...], ...]
+            [[timestamp, agg_val_1, agg_val_2, ..., max_status], ...]
         For raw results:
             [[timestamp, value, status, extra_data], ...]
 
         Note: extra_data is only included for raw (non-aggregated) results since it
-        cannot be meaningfully aggregated. Status IS aggregated (e.g., max indicates
-        if there was a detection in the period).
+        cannot be meaningfully aggregated. Status is aggregated using only max
+        (indicating if there was a detection in the period).
         """
         value_column = mm_schemas.ResultData.RESULT_VALUE
         status_column = mm_schemas.ResultData.RESULT_STATUS
@@ -680,8 +683,9 @@ class TSDBConnector(ABC):
                 ]
                 for idx, row in sub_df.iterrows()
             ]
-        # Aggregated: [[timestamp, agg_val_1, ..., agg_status_1, ...], ...]
+        # Aggregated: [[timestamp, agg_val_1, ..., max_status], ...]
         values = []
+        max_status_col = f"max_{status_column}"
         for idx, row in sub_df.iterrows():
             row_values = [idx]  # timestamp
             # Add aggregated value columns
@@ -693,11 +697,9 @@ class TSDBConnector(ABC):
                         f"Available columns: {list(row.index)}"
                     )
                 row_values.append(float(row[col_name]))
-            # Add aggregated status columns
-            for func in agg_functions:
-                col_name = f"{func}_{status_column}"
-                if col_name in row:
-                    row_values.append(int(row[col_name]))
+            # Add max_status (only max, indicates detection in period)
+            if max_status_col in row:
+                row_values.append(int(row[max_status_col]))
             values.append(row_values)
         return values
 

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -179,16 +179,20 @@ class TSDBConnector(ABC):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: Literal["metrics", "results"],
         with_result_extra_data: bool,
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
     ) -> Union[
         list[
             Union[
                 mm_schemas.ModelEndpointMonitoringResultValues,
+                mm_schemas.ModelEndpointMonitoringResultValuesV2,
                 mm_schemas.ModelEndpointMonitoringMetricNoData,
             ],
         ],
         list[
             Union[
                 mm_schemas.ModelEndpointMonitoringMetricValues,
+                mm_schemas.ModelEndpointMonitoringMetricValuesV2,
                 mm_schemas.ModelEndpointMonitoringMetricNoData,
             ],
         ],
@@ -203,7 +207,14 @@ class TSDBConnector(ABC):
         :param type:                   "metrics" or "results" - the type of each item in metrics.
         :param with_result_extra_data: Whether to include the extra data in the results, relevant only when
                                        `type="results"`.
-        :return:                        A list of result values or a list of metric values.
+        :param agg_period:             Optional aggregation period (e.g., "1h", "6h", "12h", "24h").
+                                       If None, returns raw data (V1 schemas).
+                                       If provided, returns aggregated data (V2 schemas).
+                                       Not all connectors support aggregation.
+        :param agg_functions:          Optional list of aggregation functions (e.g., ["avg", "min", "max"]).
+                                       Only used when agg_period is specified.
+        :return:                       V1 schemas (MetricValues/ResultValues) when agg_period is None,
+                                       V2 schemas (MetricValuesV2/ResultValuesV2) when agg_period is provided.
         """
 
     @abstractmethod
@@ -507,14 +518,13 @@ class TSDBConnector(ABC):
             )
             del metrics_without_data[full_name]
 
-        for metric in metrics_without_data.values():
-            metrics_values.append(
-                mm_schemas.ModelEndpointMonitoringMetricNoData(
-                    full_name=metric.full_name,
-                    type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
-                )
+        metrics_values.extend(
+            mm_schemas.ModelEndpointMonitoringMetricNoData(
+                full_name=metric.full_name,
+                type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
             )
-
+            for metric in metrics_without_data.values()
+        )
         return metrics_values
 
     @staticmethod
@@ -584,18 +594,270 @@ class TSDBConnector(ABC):
                 raise
             del metrics_without_data[full_name]
 
-        for metric in metrics_without_data.values():
-            if metric.full_name == mlrun.model_monitoring.helpers.get_invocations_fqn(
-                project
-            ):
-                continue
-            metrics_values.append(
-                mm_schemas.ModelEndpointMonitoringMetricNoData(
-                    full_name=metric.full_name,
-                    type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
-                )
+        metrics_values.extend(
+            mm_schemas.ModelEndpointMonitoringMetricNoData(
+                full_name=metric.full_name,
+                type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
             )
+            for metric in metrics_without_data.values()
+            if metric.full_name
+            != mlrun.model_monitoring.helpers.get_invocations_fqn(project)
+        )
+        return metrics_values
 
+    @staticmethod
+    def _is_aggregated(agg_period: Optional[str]) -> bool:
+        """Check if the aggregation period indicates aggregated data."""
+        return agg_period is not None and agg_period != "raw"
+
+    @staticmethod
+    def _build_aggregation_config(
+        agg_period: Optional[str],
+        agg_functions: Optional[list[str]],
+    ) -> mm_schemas.AggregationConfig:
+        """Build aggregation config based on period and functions."""
+        is_aggregated = TSDBConnector._is_aggregated(agg_period)
+        return mm_schemas.AggregationConfig(
+            aggregated=is_aggregated,
+            period=agg_period if is_aggregated else None,
+            functions=agg_functions if is_aggregated else None,
+        )
+
+    @staticmethod
+    def _build_metric_values_from_df(
+        sub_df: pd.DataFrame,
+        value_column: str,
+        is_aggregated: bool,
+        agg_functions: Optional[list[str]],
+    ) -> list[list]:
+        """Build values list from DataFrame based on aggregation settings."""
+        if not (is_aggregated and agg_functions):
+            # Raw: [[timestamp, value], ...]
+            return [[idx, float(row[value_column])] for idx, row in sub_df.iterrows()]
+        # Aggregated: [[timestamp, agg_val_1, agg_val_2, ...], ...]
+        values = []
+        for idx, row in sub_df.iterrows():
+            row_values = [idx]  # timestamp
+            for func in agg_functions:
+                col_name = f"{func}_{value_column}"
+                if col_name not in row:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Aggregated column '{col_name}' not found in DataFrame. "
+                        f"Available columns: {list(row.index)}"
+                    )
+                row_values.append(float(row[col_name]))
+            values.append(row_values)
+        return values
+
+    @staticmethod
+    def _build_result_values_from_df(
+        sub_df: pd.DataFrame,
+        is_aggregated: bool,
+        agg_functions: Optional[list[str]],
+    ) -> list[list]:
+        """
+        Build result values list from DataFrame based on aggregation settings.
+
+        For aggregated results: [[timestamp, agg_val_1, agg_val_2, ...], ...]
+        For raw results: [[timestamp, value, status, extra_data], ...]
+
+        Note: status and extra_data are only included for raw (non-aggregated) results
+        since those cannot be meaningfully aggregated.
+        """
+        value_column = mm_schemas.ResultData.RESULT_VALUE
+        if not (is_aggregated and agg_functions):
+            # Raw: [[timestamp, value, status, extra_data], ...]
+            return [
+                [
+                    idx,
+                    float(row[value_column]),
+                    int(row[mm_schemas.ResultData.RESULT_STATUS]),
+                    row.get(mm_schemas.ResultData.RESULT_EXTRA_DATA, ""),
+                ]
+                for idx, row in sub_df.iterrows()
+            ]
+        # Aggregated: [[timestamp, agg_val_1, agg_val_2, ...], ...]
+        values = []
+        for idx, row in sub_df.iterrows():
+            row_values = [idx]  # timestamp
+            for func in agg_functions:
+                col_name = f"{func}_{value_column}"
+                if col_name not in row:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Aggregated column '{col_name}' not found in DataFrame. "
+                        f"Available columns: {list(row.index)}"
+                    )
+                row_values.append(float(row[col_name]))
+            values.append(row_values)
+        return values
+
+    @staticmethod
+    def df_to_metrics_values_v2(
+        *,
+        df: pd.DataFrame,
+        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        project: str,
+        agg_period: Optional[str],
+        agg_functions: Optional[list[str]],
+    ) -> list[
+        Union[
+            mm_schemas.ModelEndpointMonitoringMetricValuesV2,
+            mm_schemas.ModelEndpointMonitoringMetricNoData,
+        ]
+    ]:
+        """
+        Parse a time-indexed DataFrame of metrics from the TSDB into v2 response format
+        with aggregation metadata.
+
+        :param df:            The DataFrame to parse (time-indexed).
+        :param metrics:       List of metrics to look for.
+        :param project:       The project name.
+        :param agg_period:    Aggregation period (e.g., "1h") or None for raw data.
+        :param agg_functions: List of aggregation functions (e.g., ["avg", "min"]) or None.
+        :return:              A list of v2 metric values or no-data objects.
+        """
+        metrics_without_data = {metric.full_name: metric for metric in metrics}
+        is_aggregated = TSDBConnector._is_aggregated(agg_period)
+        aggregation_config = TSDBConnector._build_aggregation_config(
+            agg_period, agg_functions
+        )
+
+        metrics_values: list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringMetricValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ]
+        ] = []
+
+        if df.empty:
+            logger.debug("No metrics", missing_metrics=metrics_without_data.keys())
+        else:
+            grouped = df.groupby(
+                [
+                    mm_schemas.WriterEvent.APPLICATION_NAME,
+                    mm_schemas.MetricData.METRIC_NAME,
+                ],
+                observed=False,
+            )
+            for (app_name, name), sub_df in grouped:
+                full_name = mm_schemas.model_endpoints.compose_full_name(
+                    project=project,
+                    app=app_name,
+                    name=name,
+                    type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
+                )
+                values = TSDBConnector._build_metric_values_from_df(
+                    sub_df,
+                    mm_schemas.MetricData.METRIC_VALUE,
+                    is_aggregated,
+                    agg_functions,
+                )
+                metrics_values.append(
+                    mm_schemas.ModelEndpointMonitoringMetricValuesV2(
+                        full_name=full_name,
+                        aggregation_config=aggregation_config,
+                        values=values,
+                    )
+                )
+                del metrics_without_data[full_name]
+
+        metrics_values.extend(
+            mm_schemas.ModelEndpointMonitoringMetricNoData(
+                full_name=metric.full_name,
+                type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
+            )
+            for metric in metrics_without_data.values()
+        )
+        return metrics_values
+
+    @staticmethod
+    def df_to_results_values_v2(
+        *,
+        df: pd.DataFrame,
+        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        project: str,
+        agg_period: Optional[str],
+        agg_functions: Optional[list[str]],
+    ) -> list[
+        Union[
+            mm_schemas.ModelEndpointMonitoringResultValuesV2,
+            mm_schemas.ModelEndpointMonitoringMetricNoData,
+        ]
+    ]:
+        """
+        Parse a time-indexed DataFrame of results from the TSDB into v2 response format
+        with aggregation metadata.
+
+        :param df:            The DataFrame to parse (time-indexed).
+        :param metrics:       List of results to look for.
+        :param project:       The project name.
+        :param agg_period:    Aggregation period (e.g., "1h") or None for raw data.
+        :param agg_functions: List of aggregation functions (e.g., ["avg", "min"]) or None.
+        :return:              A list of v2 result values or no-data objects.
+
+        Note: For aggregated results, only numeric values are returned (no status/extra_data
+        since those cannot be meaningfully aggregated).
+        """
+        metrics_without_data = {metric.full_name: metric for metric in metrics}
+        is_aggregated = TSDBConnector._is_aggregated(agg_period)
+        aggregation_config = TSDBConnector._build_aggregation_config(
+            agg_period, agg_functions
+        )
+
+        metrics_values: list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringResultValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ]
+        ] = []
+
+        if df.empty:
+            logger.debug("No results", missing_results=metrics_without_data.keys())
+        else:
+            grouped = df.groupby(
+                [
+                    mm_schemas.WriterEvent.APPLICATION_NAME,
+                    mm_schemas.ResultData.RESULT_NAME,
+                ],
+                observed=False,
+            )
+            for (app_name, name), sub_df in grouped:
+                result_kind = mlrun.model_monitoring.db.tsdb.helpers._get_result_kind(
+                    sub_df
+                )
+                full_name = mm_schemas.model_endpoints.compose_full_name(
+                    project=project, app=app_name, name=name
+                )
+                values = TSDBConnector._build_result_values_from_df(
+                    sub_df, is_aggregated, agg_functions
+                )
+                try:
+                    metrics_values.append(
+                        mm_schemas.ModelEndpointMonitoringResultValuesV2(
+                            full_name=full_name,
+                            result_kind=result_kind,
+                            aggregation_config=aggregation_config,
+                            values=values,
+                        )
+                    )
+                except pydantic.v1.ValidationError:
+                    logger.exception(
+                        "Failed to convert data-frame into `ModelEndpointMonitoringResultValuesV2`",
+                        full_name=full_name,
+                        sub_df_json=sub_df.to_json(),
+                    )
+                    raise
+                del metrics_without_data[full_name]
+
+        metrics_values.extend(
+            mm_schemas.ModelEndpointMonitoringMetricNoData(
+                full_name=metric.full_name,
+                type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
+            )
+            for metric in metrics_without_data.values()
+            if metric.full_name
+            != mlrun.model_monitoring.helpers.get_invocations_fqn(project)
+        )
         return metrics_values
 
     @staticmethod
@@ -660,7 +922,7 @@ class TSDBConnector(ABC):
         # groupby has different behavior for category columns
         df["endpoint_id"] = df["endpoint_id"].astype(str)
         grouped_by_df = df.groupby("endpoint_id")
-        grouped_dict = grouped_by_df.apply(
+        return grouped_by_df.apply(
             lambda group: list(
                 map(
                     lambda record: mm_schemas.ModelEndpointMonitoringMetric(
@@ -668,15 +930,16 @@ class TSDBConnector(ABC):
                         type=type,
                         app=record.get(mm_schemas.WriterEvent.APPLICATION_NAME),
                         name=record.get(name_column),
-                        **{"kind": record.get(mm_schemas.ResultData.RESULT_KIND)}
-                        if type == "result"
-                        else {},
+                        **(
+                            {"kind": record.get(mm_schemas.ResultData.RESULT_KIND)}
+                            if type == "result"
+                            else {}
+                        ),
                     ),
                     group[grouped_by_fields].to_dict(orient="records"),
                 )
             )
         ).to_dict()
-        return grouped_dict
 
     @staticmethod
     def df_to_events_intersection_dict(

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -179,42 +179,76 @@ class TSDBConnector(ABC):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: Literal["metrics", "results"],
         with_result_extra_data: bool,
-        agg_period: Optional[str] = None,
-        agg_functions: Optional[list[str]] = None,
     ) -> Union[
         list[
             Union[
                 mm_schemas.ModelEndpointMonitoringResultValues,
-                mm_schemas.ModelEndpointMonitoringResultValuesV2,
                 mm_schemas.ModelEndpointMonitoringMetricNoData,
             ],
         ],
         list[
             Union[
                 mm_schemas.ModelEndpointMonitoringMetricValues,
-                mm_schemas.ModelEndpointMonitoringMetricValuesV2,
                 mm_schemas.ModelEndpointMonitoringMetricNoData,
             ],
         ],
     ]:
         """
-        Read metrics OR results from the TSDB and return as a list.
+        Read metrics OR results from the TSDB and return as a list (V1 API).
 
-        :param endpoint_id: The model endpoint identifier.
+        Always returns V1 schemas (MetricValues/ResultValues).
+
+        :param endpoint_id:            The model endpoint identifier.
         :param start:                  The start time of the query.
         :param end:                    The end time of the query.
         :param metrics:                The list of metrics to get the values for.
         :param type:                   "metrics" or "results" - the type of each item in metrics.
         :param with_result_extra_data: Whether to include the extra data in the results, relevant only when
                                        `type="results"`.
-        :param agg_period:             Optional aggregation period (e.g., "1h", "6h", "12h", "24h").
-                                       If None, returns raw data (V1 schemas).
-                                       If provided, returns aggregated data (V2 schemas).
-                                       Not all connectors support aggregation.
-        :param agg_functions:          Optional list of aggregation functions (e.g., ["avg", "min", "max"]).
-                                       Only used when agg_period is specified.
-        :return:                       V1 schemas (MetricValues/ResultValues) when agg_period is None,
-                                       V2 schemas (MetricValuesV2/ResultValuesV2) when agg_period is provided.
+        :return:                       V1 schemas (MetricValues/ResultValues).
+        """
+
+    @abstractmethod
+    def read_metrics_data_v2(
+        self,
+        *,
+        endpoint_id: str,
+        start: datetime,
+        end: datetime,
+        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        type: Literal["metrics", "results"],
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
+    ) -> Union[
+        list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringResultValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ],
+        ],
+        list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringMetricValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ],
+        ],
+    ]:
+        """
+        Read metrics OR results from the TSDB and return as a list (V2 API).
+
+        Always returns V2 schemas (MetricValuesV2/ResultValuesV2).
+
+        :param endpoint_id:    The model endpoint identifier.
+        :param start:          The start time of the query.
+        :param end:            The end time of the query.
+        :param metrics:        The list of metrics to get the values for.
+        :param type:           "metrics" or "results" - the type of each item in metrics.
+        :param agg_period:     Optional aggregation period (e.g., "1h", "6h", "12h", "24h").
+                               If None, returns raw data in V2 format.
+                               If provided, returns aggregated data in V2 format.
+        :param agg_functions:  Optional list of aggregation functions (e.g., ["avg", "min", "max"]).
+                               Required when agg_period is specified.
+        :return:               V2 schemas (MetricValuesV2/ResultValuesV2).
         """
 
     @abstractmethod
@@ -606,20 +640,12 @@ class TSDBConnector(ABC):
         return metrics_values
 
     @staticmethod
-    def _is_aggregated(agg_period: Optional[str]) -> bool:
-        """Check if the aggregation period indicates aggregated data.
-
-        Note: "raw" is resolved at the API layer to None before reaching TSDB.
-        """
-        return agg_period is not None
-
-    @staticmethod
     def _build_aggregation_config(
         agg_period: Optional[str],
         agg_functions: Optional[list[str]],
     ) -> mm_schemas.AggregationConfig:
         """Build aggregation config based on period and functions."""
-        is_aggregated = TSDBConnector._is_aggregated(agg_period)
+        is_aggregated = agg_period is not None
         return mm_schemas.AggregationConfig(
             aggregated=is_aggregated,
             period=agg_period if is_aggregated else None,
@@ -729,7 +755,7 @@ class TSDBConnector(ABC):
         :return:              A list of v2 metric values or no-data objects.
         """
         metrics_without_data = {metric.full_name: metric for metric in metrics}
-        is_aggregated = TSDBConnector._is_aggregated(agg_period)
+        is_aggregated = agg_period is not None
         aggregation_config = TSDBConnector._build_aggregation_config(
             agg_period, agg_functions
         )
@@ -811,7 +837,7 @@ class TSDBConnector(ABC):
         since those cannot be meaningfully aggregated).
         """
         metrics_without_data = {metric.full_name: metric for metric in metrics}
-        is_aggregated = TSDBConnector._is_aggregated(agg_period)
+        is_aggregated = agg_period is not None
         aggregation_config = TSDBConnector._build_aggregation_config(
             agg_period, agg_functions
         )

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -658,28 +658,33 @@ class TSDBConnector(ABC):
         """
         Build result values list from DataFrame based on aggregation settings.
 
-        For aggregated results: [[timestamp, agg_val_1, agg_val_2, ...], ...]
-        For raw results: [[timestamp, value, status, extra_data], ...]
+        For aggregated results:
+            [[timestamp, agg_val_1, agg_val_2, ..., agg_status_1, agg_status_2, ...], ...]
+        For raw results:
+            [[timestamp, value, status, extra_data], ...]
 
-        Note: status and extra_data are only included for raw (non-aggregated) results
-        since those cannot be meaningfully aggregated.
+        Note: extra_data is only included for raw (non-aggregated) results since it
+        cannot be meaningfully aggregated. Status IS aggregated (e.g., max indicates
+        if there was a detection in the period).
         """
         value_column = mm_schemas.ResultData.RESULT_VALUE
+        status_column = mm_schemas.ResultData.RESULT_STATUS
         if not (is_aggregated and agg_functions):
             # Raw: [[timestamp, value, status, extra_data], ...]
             return [
                 [
                     idx,
                     float(row[value_column]),
-                    int(row[mm_schemas.ResultData.RESULT_STATUS]),
+                    int(row[status_column]),
                     row.get(mm_schemas.ResultData.RESULT_EXTRA_DATA, ""),
                 ]
                 for idx, row in sub_df.iterrows()
             ]
-        # Aggregated: [[timestamp, agg_val_1, agg_val_2, ...], ...]
+        # Aggregated: [[timestamp, agg_val_1, ..., agg_status_1, ...], ...]
         values = []
         for idx, row in sub_df.iterrows():
             row_values = [idx]  # timestamp
+            # Add aggregated value columns
             for func in agg_functions:
                 col_name = f"{func}_{value_column}"
                 if col_name not in row:
@@ -688,6 +693,11 @@ class TSDBConnector(ABC):
                         f"Available columns: {list(row.index)}"
                     )
                 row_values.append(float(row[col_name]))
+            # Add aggregated status columns
+            for func in agg_functions:
+                col_name = f"{func}_{status_column}"
+                if col_name in row:
+                    row_values.append(int(row[col_name]))
             values.append(row_values)
         return values
 

--- a/mlrun/model_monitoring/db/tsdb/preaggregate.py
+++ b/mlrun/model_monitoring/db/tsdb/preaggregate.py
@@ -15,7 +15,7 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Any, Optional
 
 import mlrun.errors
 import mlrun.utils
@@ -24,31 +24,104 @@ import mlrun.utils
 _INTERVAL_PATTERN = re.compile(r"(\d+)([mhdwM])")
 
 
+def _config_to_list(config_value: Any) -> list[str]:
+    """Convert mlrun Config value to a list of strings.
+
+    Handles mlrun.config.Config objects which store values in a _cfg dict.
+    """
+    if not config_value:
+        return []
+    if hasattr(config_value, "_cfg"):
+        cfg = getattr(config_value, "_cfg", None)
+        if cfg:
+            return [str(v) for v in cfg.values()]
+        return []
+    try:
+        return [str(v) for v in config_value]
+    except TypeError:
+        return []
+
+
+def _config_to_dict(config_value: Any) -> dict[str, str]:
+    """Convert mlrun Config value to a dict of strings.
+
+    Handles mlrun.config.Config objects which have to_dict() or _cfg attribute.
+    """
+    if not config_value:
+        return {}
+    if hasattr(config_value, "to_dict"):
+        return getattr(config_value, "to_dict")()
+    if hasattr(config_value, "_cfg"):
+        cfg = getattr(config_value, "_cfg", None)
+        return {str(k): str(v) for k, v in cfg.items()} if cfg else {}
+    try:
+        return {str(k): str(v) for k, v in config_value.items()}
+    except (TypeError, AttributeError):
+        return {}
+
+
 @dataclass
 class PreAggregateConfig:
     """Configuration for pre-aggregated tables and retention policies."""
 
-    aggregate_intervals: list[str] = None
-    agg_functions: list[str] = None
-    retention_policy: dict[str, str] = None
+    aggregate_intervals: Optional[list[str]] = None
+    agg_functions: Optional[list[str]] = None
+    retention_policy: Optional[dict[str, str]] = None
 
-    def __post_init__(self):
-        if self.aggregate_intervals is None:
-            self.aggregate_intervals = ["10m", "1h", "6h", "1d", "1w", "1M"]
+    @classmethod
+    def from_mlrun_config(cls) -> Optional["PreAggregateConfig"]:
+        """
+        Load pre-aggregate configuration from mlrun.mlconf.
 
-        if self.agg_functions is None:
-            self.agg_functions = ["sum", "avg", "min", "max", "count", "last"]
+        Reads the TSDB pre-aggregate configuration from the global MLRun config
+        system, allowing configuration via environment variables or config files.
 
-        if self.retention_policy is None:
-            self.retention_policy = {
-                "raw": "7d",
-                "10m": "30d",
-                "1h": "1y",
-                "6h": "1y",
-                "1d": "5y",
-                "1w": "5y",
-                "1M": "5y",
-            }
+        :return: PreAggregateConfig if enabled in config, None if disabled
+        :raises mlrun.errors.MLRunInvalidArgumentError: If config is malformed
+        """
+        import mlrun.config
+
+        try:
+            pre_agg_config = (
+                mlrun.config.config.model_endpoint_monitoring.tsdb.pre_aggregate
+            )
+        except AttributeError as e:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Pre-aggregate config section not found in mlrun.mlconf: {e}"
+            ) from e
+
+        # Check if pre-aggregation is enabled
+        enabled = pre_agg_config.enabled
+        if isinstance(enabled, str):
+            enabled = enabled.lower() in ("true", "1", "yes")
+
+        if not enabled:
+            return None
+
+        # Convert Config objects to proper Python types
+        aggregate_intervals = _config_to_list(pre_agg_config.aggregate_intervals)
+        agg_functions = _config_to_list(pre_agg_config.agg_functions)
+        retention_policy = _config_to_dict(pre_agg_config.retention_policy)
+
+        # Validate required fields
+        if not aggregate_intervals:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Pre-aggregate config missing 'aggregate_intervals'"
+            )
+        if not agg_functions:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Pre-aggregate config missing 'agg_functions'"
+            )
+        if not retention_policy:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Pre-aggregate config missing 'retention_policy'"
+            )
+
+        return cls(
+            aggregate_intervals=aggregate_intervals,
+            agg_functions=agg_functions,
+            retention_policy=retention_policy,
+        )
 
 
 class PreAggregateManager:
@@ -75,19 +148,18 @@ class PreAggregateManager:
                 "Pre-aggregate configuration not available. Cannot use interval or agg_function parameters."
             )
 
-        if interval and interval not in self._pre_aggregate_config.aggregate_intervals:
+        intervals = self._pre_aggregate_config.aggregate_intervals or []
+        if interval and interval not in intervals:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Interval '{interval}' not available in pre-aggregate configuration. "
-                f"Available intervals: {self._pre_aggregate_config.aggregate_intervals}"
+                f"Available intervals: {intervals}"
             )
 
-        if (
-            agg_function
-            and agg_function not in self._pre_aggregate_config.agg_functions
-        ):
+        functions = self._pre_aggregate_config.agg_functions or []
+        if agg_function and agg_function not in functions:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Aggregation function '{agg_function}' not available in pre-aggregate configuration. "
-                f"Available functions: {self._pre_aggregate_config.agg_functions}"
+                f"Available functions: {functions}"
             )
 
     def can_use_pre_aggregates(
@@ -97,13 +169,13 @@ class PreAggregateManager:
         if not self._pre_aggregate_config or not interval:
             return False
 
-        if interval not in self._pre_aggregate_config.aggregate_intervals:
+        intervals = self._pre_aggregate_config.aggregate_intervals or []
+        if interval not in intervals:
             return False
 
         if agg_funcs:
-            return all(
-                func in self._pre_aggregate_config.agg_functions for func in agg_funcs
-            )
+            functions = self._pre_aggregate_config.agg_functions or []
+            return all(func in functions for func in agg_funcs)
 
         return True
 
@@ -217,18 +289,27 @@ class PreAggregateManager:
 
     def get_available_intervals(self) -> list[str]:
         """Get list of available intervals for pre-aggregation."""
-        if not self._pre_aggregate_config:
+        if (
+            not self._pre_aggregate_config
+            or not self._pre_aggregate_config.aggregate_intervals
+        ):
             return []
         return self._pre_aggregate_config.aggregate_intervals.copy()
 
     def get_available_functions(self) -> list[str]:
         """Get list of available aggregation functions."""
-        if not self._pre_aggregate_config:
+        if (
+            not self._pre_aggregate_config
+            or not self._pre_aggregate_config.agg_functions
+        ):
             return []
         return self._pre_aggregate_config.agg_functions.copy()
 
     def get_retention_policy(self) -> dict[str, str]:
         """Get the retention policy configuration."""
-        if not self._pre_aggregate_config:
+        if (
+            not self._pre_aggregate_config
+            or not self._pre_aggregate_config.retention_policy
+        ):
             return {}
         return self._pre_aggregate_config.retention_policy.copy()

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -747,83 +747,9 @@ class TDEngineConnector(TSDBConnector):
             ],
         ],
     ]:
-        """
-        Read metrics OR results from the TSDB and return as a list (V2 API).
-        Always returns V2 schemas.
-
-        Note: TDEngine does not support pre-aggregation, so agg_period and agg_functions
-        are used only for formatting the response, not for server-side aggregation.
-        """
-        timestamp_column = mm_schemas.WriterEvent.END_INFER_TIME
-        columns = [timestamp_column, mm_schemas.WriterEvent.APPLICATION_NAME]
-        if type == "metrics":
-            table = self.tables[mm_schemas.TDEngineSuperTables.METRICS].super_table
-            name = mm_schemas.MetricData.METRIC_NAME
-            columns += [name, mm_schemas.MetricData.METRIC_VALUE]
-            df_handler = self.df_to_metrics_values_v2
-        elif type == "results":
-            table = self.tables[mm_schemas.TDEngineSuperTables.APP_RESULTS].super_table
-            name = mm_schemas.ResultData.RESULT_NAME
-            columns += [
-                name,
-                mm_schemas.ResultData.RESULT_VALUE,
-                mm_schemas.ResultData.RESULT_STATUS,
-                mm_schemas.ResultData.RESULT_KIND,
-            ]
-            # For v2 results, include extra_data only when not aggregating
-            if agg_period is None:
-                columns.append(mm_schemas.ResultData.RESULT_EXTRA_DATA)
-            df_handler = self.df_to_results_values_v2
-        else:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Invalid type {type}, must be either 'metrics' or 'results'."
-            )
-
-        metrics_condition = " OR ".join(
-            [
-                f"({mm_schemas.WriterEvent.APPLICATION_NAME}='{metric.app}' AND {name}='{metric.name}')"
-                for metric in metrics
-            ]
-        )
-        filter_query = f"(endpoint_id='{endpoint_id}') AND ({metrics_condition})"
-
-        df = self._get_records(
-            table=table,
-            start=start,
-            end=end,
-            filter_query=filter_query,
-            timestamp_column=timestamp_column,
-            columns=columns,
-        )
-
-        df[mm_schemas.WriterEvent.END_INFER_TIME] = pd.to_datetime(
-            df[mm_schemas.WriterEvent.END_INFER_TIME]
-        )
-        df.set_index(mm_schemas.WriterEvent.END_INFER_TIME, inplace=True)
-
-        logger.debug(
-            "Converting a DataFrame to a list of metrics or results values (v2)",
-            table=table,
-            project=self.project,
-            endpoint_id=endpoint_id,
-            is_empty=df.empty,
-            agg_period=agg_period,
-        )
-
-        # For v2 results without aggregation, ensure extra_data column exists
-        if (
-            type == "results"
-            and agg_period is None
-            and mm_schemas.ResultData.RESULT_EXTRA_DATA not in df.columns
-        ):
-            df[mm_schemas.ResultData.RESULT_EXTRA_DATA] = ""
-
-        return df_handler(
-            df=df,
-            metrics=metrics,
-            project=self.project,
-            agg_period=agg_period,
-            agg_functions=agg_functions,
+        """V2 API is not supported for TDEngine."""
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "V2 metrics API is not supported for TDEngine."
         )
 
     def read_predictions(

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -644,6 +644,8 @@ class TDEngineConnector(TSDBConnector):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: Literal["metrics", "results"],
         with_result_extra_data: bool = False,
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
     ) -> Union[
         list[
             Union[
@@ -1291,7 +1293,7 @@ class TDEngineConnector(TSDBConnector):
             mep: mlrun.common.schemas.ModelEndpoint,
             df_dictionary: dict[str, pd.DataFrame],
         ):
-            for metric in df_dictionary.keys():
+            for metric in df_dictionary:
                 df = df_dictionary.get(metric, pd.DataFrame())
                 if not df.empty:
                     line = df[df["endpoint_id"] == mep.metadata.uid]

--- a/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/tdengine/tdengine_connector.py
@@ -477,10 +477,9 @@ class TDEngineConnector(TSDBConnector):
             "Deleting all project resources using the TDEngine connector",
             project=self.project,
         )
-        drop_statements = []
-        for table in self.tables:
-            drop_statements.append(self.tables[table].drop_supertable_query())
-
+        drop_statements = [
+            self.tables[table].drop_supertable_query() for table in self.tables
+        ]
         try:
             self.connection.run(
                 statements=drop_statements,
@@ -630,7 +629,7 @@ class TDEngineConnector(TSDBConnector):
         except taosws.QueryError as e:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Failed to query table {table} in database {self.database}, {str(e)}"
-            )
+            ) from e
 
         df_columns = [field.name for field in query_result.fields]
         return pd.DataFrame(query_result.data, columns=df_columns)
@@ -644,8 +643,6 @@ class TDEngineConnector(TSDBConnector):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: Literal["metrics", "results"],
         with_result_extra_data: bool = False,
-        agg_period: Optional[str] = None,
-        agg_functions: Optional[list[str]] = None,
     ) -> Union[
         list[
             Union[
@@ -725,6 +722,109 @@ class TDEngineConnector(TSDBConnector):
             df[mm_schemas.ResultData.RESULT_EXTRA_DATA] = ""
 
         return df_handler(df=df, metrics=metrics, project=self.project)
+
+    def read_metrics_data_v2(
+        self,
+        *,
+        endpoint_id: str,
+        start: datetime,
+        end: datetime,
+        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        type: Literal["metrics", "results"],
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
+    ) -> Union[
+        list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringResultValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ],
+        ],
+        list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringMetricValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ],
+        ],
+    ]:
+        """
+        Read metrics OR results from the TSDB and return as a list (V2 API).
+        Always returns V2 schemas.
+
+        Note: TDEngine does not support pre-aggregation, so agg_period and agg_functions
+        are used only for formatting the response, not for server-side aggregation.
+        """
+        timestamp_column = mm_schemas.WriterEvent.END_INFER_TIME
+        columns = [timestamp_column, mm_schemas.WriterEvent.APPLICATION_NAME]
+        if type == "metrics":
+            table = self.tables[mm_schemas.TDEngineSuperTables.METRICS].super_table
+            name = mm_schemas.MetricData.METRIC_NAME
+            columns += [name, mm_schemas.MetricData.METRIC_VALUE]
+            df_handler = self.df_to_metrics_values_v2
+        elif type == "results":
+            table = self.tables[mm_schemas.TDEngineSuperTables.APP_RESULTS].super_table
+            name = mm_schemas.ResultData.RESULT_NAME
+            columns += [
+                name,
+                mm_schemas.ResultData.RESULT_VALUE,
+                mm_schemas.ResultData.RESULT_STATUS,
+                mm_schemas.ResultData.RESULT_KIND,
+            ]
+            # For v2 results, include extra_data only when not aggregating
+            if agg_period is None:
+                columns.append(mm_schemas.ResultData.RESULT_EXTRA_DATA)
+            df_handler = self.df_to_results_values_v2
+        else:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Invalid type {type}, must be either 'metrics' or 'results'."
+            )
+
+        metrics_condition = " OR ".join(
+            [
+                f"({mm_schemas.WriterEvent.APPLICATION_NAME}='{metric.app}' AND {name}='{metric.name}')"
+                for metric in metrics
+            ]
+        )
+        filter_query = f"(endpoint_id='{endpoint_id}') AND ({metrics_condition})"
+
+        df = self._get_records(
+            table=table,
+            start=start,
+            end=end,
+            filter_query=filter_query,
+            timestamp_column=timestamp_column,
+            columns=columns,
+        )
+
+        df[mm_schemas.WriterEvent.END_INFER_TIME] = pd.to_datetime(
+            df[mm_schemas.WriterEvent.END_INFER_TIME]
+        )
+        df.set_index(mm_schemas.WriterEvent.END_INFER_TIME, inplace=True)
+
+        logger.debug(
+            "Converting a DataFrame to a list of metrics or results values (v2)",
+            table=table,
+            project=self.project,
+            endpoint_id=endpoint_id,
+            is_empty=df.empty,
+            agg_period=agg_period,
+        )
+
+        # For v2 results without aggregation, ensure extra_data column exists
+        if (
+            type == "results"
+            and agg_period is None
+            and mm_schemas.ResultData.RESULT_EXTRA_DATA not in df.columns
+        ):
+            df[mm_schemas.ResultData.RESULT_EXTRA_DATA] = ""
+
+        return df_handler(
+            df=df,
+            metrics=metrics,
+            project=self.project,
+            agg_period=agg_period,
+            agg_functions=agg_functions,
+        )
 
     def read_predictions(
         self,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
@@ -20,6 +20,7 @@ import pandas as pd
 import mlrun
 import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.errors
+import mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_schema as timescaledb_schema
 from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection import (
     Statement,
 )
@@ -97,42 +98,14 @@ class TimescaleDBMetricsQueries:
             [endpoint_filter, metrics_filter]
         )
 
-        # Use fallback pattern for potential pre-aggregate compatibility issues
-        def build_pre_agg_query():
-            return table_schema._get_records_query(
-                start=start_dt,
-                end=end_dt,
-                columns_to_filter=columns,
-                filter_query=combined_filter,
-                interval=interval,
-                agg_funcs=[agg_function] if agg_function else None,
-                use_pre_aggregates=True,
-            )
-
-        def build_raw_query():
-            return table_schema._get_records_query(
-                start=start_dt,
-                end=end_dt,
-                columns_to_filter=columns,
-                filter_query=combined_filter,
-            )
-
-        # Column mapping rules for pre-aggregate results (if needed)
-        column_mapping_rules = {
-            mm_schemas.MetricData.METRIC_NAME: [mm_schemas.MetricData.METRIC_NAME],
-            mm_schemas.MetricData.METRIC_VALUE: [mm_schemas.MetricData.METRIC_VALUE],
-            table_schema.time_column: [table_schema.time_column],
-        }
-
-        df = self._connection.execute_with_fallback(
-            self._pre_aggregate_manager,
-            build_pre_agg_query,
-            build_raw_query,
-            interval=interval,
-            agg_funcs=[agg_function] if agg_function else None,
-            column_mapping_rules=column_mapping_rules,
-            debug_name="get_model_endpoint_real_time_metrics",
+        # Direct raw query
+        query = table_schema._get_records_query(
+            start=start_dt,
+            end=end_dt,
+            columns_to_filter=columns,
+            filter_query=combined_filter,
         )
+        df = self._connection.run_query_to_df(query)
 
         # Process DataFrame result into expected format: {metric_name: [(timestamp, value), ...]}
         metrics_data = {metric_name: [] for metric_name in metrics}
@@ -159,6 +132,8 @@ class TimescaleDBMetricsQueries:
         end: datetime,
         metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]] = None,
         timestamp_column: Optional[str] = None,
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
     ) -> pd.DataFrame:
         """Read metrics data from TimescaleDB (metrics table only) - returns DataFrame.
 
@@ -167,6 +142,10 @@ class TimescaleDBMetricsQueries:
         :param end: End time
         :param metrics: List of metrics to filter by, or None to get all metrics
         :param timestamp_column: Optional timestamp column to use for time filtering
+        :param agg_period: Optional aggregation period (e.g., '1h', '6h'). If provided,
+                          reads from pre-aggregated continuous aggregates.
+        :param agg_functions: Optional list of aggregation functions to return
+                             (e.g., ['avg', 'min', 'max']). Required when agg_period is provided.
         :return: DataFrame with metrics data
         """
 
@@ -190,24 +169,47 @@ class TimescaleDBMetricsQueries:
         filters = [endpoint_filter, metrics_condition]
         filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
 
-        # Use shared utility for consistent query building with fallback
-        df = TimescaleDBQueryBuilder.build_read_data_with_fallback(
-            connection=self._connection,
-            pre_aggregate_manager=self._pre_aggregate_manager,
-            table_schema=table_schema,
-            start=start,
-            end=end,
-            columns=columns,
-            filter_query=filter_query,
-            name_column=name_column,
-            value_column=value_column,
-            debug_name="read_metrics_data",
-            timestamp_column=timestamp_column,
-        )
+        # Two query paths based on agg_period:
+        # 1. agg_period with functions (not "raw") → aggregation query from CAGG view (v2 API)
+        # 2. agg_period=None or "raw" → raw query returning individual data points (v1 and v2 raw)
+        use_aggregation = agg_period and agg_period != "raw" and agg_functions
+
+        if use_aggregation:
+            df = TimescaleDBQueryBuilder.build_read_data_with_aggregation(
+                connection=self._connection,
+                table_schema=table_schema,
+                start=start,
+                end=end,
+                columns=columns,
+                filter_query=filter_query,
+                name_column=name_column,
+                value_column=value_column,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
+                timestamp_column=timestamp_column,
+            )
+        else:
+            # Raw query for both v1 (agg_period=None) and v2 raw (agg_period="raw")
+            df = TimescaleDBQueryBuilder.build_read_raw_data(
+                connection=self._connection,
+                table_schema=table_schema,
+                start=start,
+                end=end,
+                columns=columns,
+                filter_query=filter_query,
+                timestamp_column=timestamp_column,
+            )
 
         if not df.empty:
-            df[table_schema.time_column] = pd.to_datetime(df[table_schema.time_column])
-            df.set_index(table_schema.time_column, inplace=True)
+            # Use time_bucket for aggregated data, time_column for raw
+            time_col = (
+                timescaledb_schema.TIME_BUCKET_COLUMN
+                if use_aggregation
+                else table_schema.time_column
+            )
+            if time_col in df.columns:
+                df[time_col] = pd.to_datetime(df[time_col])
+                df.set_index(time_col, inplace=True)
 
         return df
 
@@ -238,43 +240,14 @@ class TimescaleDBMetricsQueries:
             mm_schemas.WriterEvent.ENDPOINT_ID,
         ]
 
-        # Use fallback pattern for potential pre-aggregate compatibility issues
-        def build_pre_agg_query():
-            return table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=columns,
-                filter_query=filter_query,
-                interval=interval,
-                use_pre_aggregates=True,
-            )
-
-        def build_raw_query():
-            return table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=columns,
-                filter_query=filter_query,
-            )
-
-        # Column mapping rules for pre-aggregate results (if needed)
-        column_mapping_rules = {
-            mm_schemas.WriterEvent.APPLICATION_NAME: [
-                mm_schemas.WriterEvent.APPLICATION_NAME
-            ],
-            mm_schemas.MetricData.METRIC_NAME: [mm_schemas.MetricData.METRIC_NAME],
-            mm_schemas.WriterEvent.ENDPOINT_ID: [mm_schemas.WriterEvent.ENDPOINT_ID],
-        }
-
-        df = self._connection.execute_with_fallback(
-            self._pre_aggregate_manager,
-            build_pre_agg_query,
-            build_raw_query,
-            interval=interval,
-            agg_funcs=None,
-            column_mapping_rules=column_mapping_rules,
-            debug_name="get_metrics_metadata",
+        # Direct raw query
+        query = table_schema._get_records_query(
+            start=start,
+            end=end,
+            columns_to_filter=columns,
+            filter_query=filter_query,
         )
+        df = self._connection.run_query_to_df(query)
 
         # Get distinct values
         if not df.empty:

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
@@ -170,10 +170,10 @@ class TimescaleDBMetricsQueries:
         filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
 
         # Two query paths based on agg_period:
-        # 1. agg_period with functions (not "raw") → aggregation query from CAGG view (v2 API)
-        # 2. agg_period=None or "raw" → raw query returning individual data points (v1 and v2 raw)
-        use_aggregation = agg_period and agg_period != "raw" and agg_functions
-
+        # - agg_period is not None with functions → aggregation query from CAGG view
+        # - agg_period is None → raw query returning individual data points
+        # Note: "raw" is resolved at API layer to None before reaching here
+        use_aggregation = agg_period is not None and agg_functions
         if use_aggregation:
             df = TimescaleDBQueryBuilder.build_read_data_with_aggregation(
                 connection=self._connection,
@@ -189,7 +189,7 @@ class TimescaleDBMetricsQueries:
                 timestamp_column=timestamp_column,
             )
         else:
-            # Raw query for both v1 (agg_period=None) and v2 raw (agg_period="raw")
+            # Raw query (agg_period=None)
             df = TimescaleDBQueryBuilder.build_read_raw_data(
                 connection=self._connection,
                 table_schema=table_schema,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_metrics_queries.py
@@ -172,7 +172,6 @@ class TimescaleDBMetricsQueries:
         # Two query paths based on agg_period:
         # - agg_period is not None with functions → aggregation query from CAGG view
         # - agg_period is None → raw query returning individual data points
-        # Note: "raw" is resolved at API layer to None before reaching here
         use_aggregation = agg_period is not None and agg_functions
         if use_aggregation:
             df = TimescaleDBQueryBuilder.build_read_data_with_aggregation(

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
@@ -256,8 +256,6 @@ class TimescaleDBPredictionsQueries:
                 },
             )
 
-            result = self._connection.run(query=query)
-            df = TimescaleDBDataFrameProcessor.from_query_result(result)
         else:
             # Use PostgreSQL DISTINCT ON for raw data - most efficient approach
             query = f"""
@@ -272,9 +270,8 @@ class TimescaleDBPredictionsQueries:
             ORDER BY {mm_schemas.WriterEvent.ENDPOINT_ID}, {table_schema.time_column} DESC;
             """
 
-            result = self._connection.run(query=query)
-            df = TimescaleDBDataFrameProcessor.from_query_result(result)
-
+        result = self._connection.run(query=query)
+        df = TimescaleDBDataFrameProcessor.from_query_result(result)
         # Convert timestamp to proper format (common for both paths)
         if not df.empty and mm_schemas.EventFieldType.LAST_REQUEST in df.columns:
             df[mm_schemas.EventFieldType.LAST_REQUEST] = pd.to_datetime(
@@ -290,93 +287,46 @@ class TimescaleDBPredictionsQueries:
         end: Optional[datetime] = None,
         get_raw: bool = False,
     ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
-        """Get average latency with automatic pre-aggregate optimization, returning single value per endpoint."""
+        """Get average latency for specified endpoints, returning single value per endpoint."""
+        del get_raw  # Suppress unused variable warning (not implemented)
 
         # Convert single endpoint to list for consistent handling
         if isinstance(endpoint_ids, str):
             endpoint_ids = [endpoint_ids]
 
-        # Set default start time and get end time
+        # Set default start time
         start = start or (mlrun.utils.datetime_now() - timedelta(hours=24))
-        # Prepare time range with auto-determined interval
-        start, end, interval = TimescaleDBQueryBuilder.prepare_time_range_and_interval(
-            self._pre_aggregate_manager, start, end
-        )
+        start, end = self._pre_aggregate_manager.get_start_end(start, end)
 
         table_schema = self.tables[mm_schemas.TimescaleDBTables.PREDICTIONS]
-        filter_query = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_ids)
+        endpoint_filter = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_ids)
 
-        def build_pre_agg_query():
-            # Calculate overall average in SQL across all time buckets
-            # Use subquery to get time-bucketed data, then AVG over those results
-            subquery = table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=[
-                    timescaledb_schema.TIME_BUCKET_COLUMN,
-                    mm_schemas.ModelEndpointSchema.AVG_LATENCY,
-                    mm_schemas.WriterEvent.ENDPOINT_ID,
-                ],
-                filter_query=filter_query,
-                agg_funcs=["avg"],
-                interval=interval,
-                use_pre_aggregates=True,
-            )
+        # Single aggregated value across entire time range
+        columns = [
+            f"{mm_schemas.WriterEvent.ENDPOINT_ID} AS {mm_schemas.WriterEvent.ENDPOINT_ID}",
+            f"AVG({mm_schemas.EventFieldType.LATENCY}) AS {mm_schemas.ModelEndpointSchema.AVG_LATENCY}",
+        ]
+        group_by_columns = [mm_schemas.WriterEvent.ENDPOINT_ID]
 
-            # Use helper to build endpoint aggregation query
-            return TimescaleDBQueryBuilder.build_endpoint_aggregation_query(
-                subquery=subquery,
-                aggregation_columns={
-                    mm_schemas.ModelEndpointSchema.AVG_LATENCY: f"AVG({mm_schemas.ModelEndpointSchema.AVG_LATENCY})"
-                },
-            )
-
-        def build_raw_query():
-            # Single aggregated value across entire time range
-            columns = [
-                f"{mm_schemas.WriterEvent.ENDPOINT_ID} AS {mm_schemas.WriterEvent.ENDPOINT_ID}",
-                f"AVG({mm_schemas.EventFieldType.LATENCY}) AS {mm_schemas.ModelEndpointSchema.AVG_LATENCY}",
-            ]
-            group_by_columns = [mm_schemas.WriterEvent.ENDPOINT_ID]
-
-            # Add additional filter to exclude invalid latency values
-            latency_col = mm_schemas.EventFieldType.LATENCY
-            latency_filter = f"{latency_col} IS NOT NULL AND {latency_col} > 0"
-            enhanced_filter_query = (
-                f"{filter_query} AND {latency_filter}"
-                if filter_query
-                else latency_filter
-            )
-
-            return table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=columns,
-                filter_query=enhanced_filter_query,
-                group_by=group_by_columns,
-                order_by=mm_schemas.WriterEvent.ENDPOINT_ID,
-            )
-
-        # Column mapping rules for results (both pre-agg and raw return same structure now)
-        column_mapping_rules = {
-            mm_schemas.ModelEndpointSchema.AVG_LATENCY: [
-                mm_schemas.ModelEndpointSchema.AVG_LATENCY,
-                "average_latency",
-                mm_schemas.EventFieldType.LATENCY,
-            ],
-            mm_schemas.WriterEvent.ENDPOINT_ID: [mm_schemas.WriterEvent.ENDPOINT_ID],
-        }
-
-        # Both queries now return single value per endpoint, no post-processing needed
-        return self._connection.execute_with_fallback(
-            self._pre_aggregate_manager,
-            build_pre_agg_query,
-            build_raw_query,
-            interval=interval,
-            agg_funcs=["avg"],
-            column_mapping_rules=column_mapping_rules,
-            debug_name="avg_latency",
+        # Add additional filter to exclude invalid latency values
+        latency_col = mm_schemas.EventFieldType.LATENCY
+        latency_filter = f"{latency_col} IS NOT NULL AND {latency_col} > 0"
+        filter_query = (
+            f"{endpoint_filter} AND {latency_filter}"
+            if endpoint_filter
+            else latency_filter
         )
+
+        query = table_schema._get_records_query(
+            start=start,
+            end=end,
+            columns_to_filter=columns,
+            filter_query=filter_query,
+            group_by=group_by_columns,
+            order_by=mm_schemas.WriterEvent.ENDPOINT_ID,
+        )
+
+        return self._connection.run_query_to_df(query)
 
     def count_processed_model_endpoints(
         self,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -440,7 +440,8 @@ class TimescaleDBResultsQueries:
         :param timestamp_column: Optional timestamp column to use for time filtering
         :param agg_period: Optional aggregation period (e.g., '1h', '6h'). If provided,
                           reads from pre-aggregated continuous aggregates.
-                          Note: status and extra_data are NOT included in aggregated results.
+                          Note: extra_data is NOT included in aggregated results, but
+                          status IS aggregated (e.g., max indicates detection in period).
         :param agg_functions: Optional list of aggregation functions to return
                              (e.g., ['avg', 'min', 'max']). Required when agg_period is provided.
         :return: DataFrame with results data
@@ -472,7 +473,7 @@ class TimescaleDBResultsQueries:
         # Two query paths based on agg_period:
         # 1. agg_period with functions (not "raw") → aggregation query from CAGG view (v2 API)
         # 2. agg_period=None or "raw" → raw query returning individual data points (v1 and v2 raw)
-        # Note: Aggregated results do NOT include status or extra_data
+        # Note: Aggregated results include status aggregations but NOT extra_data
         use_aggregation = agg_period and agg_period != "raw" and agg_functions
 
         if use_aggregation:
@@ -488,6 +489,8 @@ class TimescaleDBResultsQueries:
                 agg_period=agg_period,
                 agg_functions=agg_functions,
                 timestamp_column=timestamp_column,
+                # Include status in aggregation (max indicates detection in period)
+                additional_agg_columns=[mm_schemas.ResultData.RESULT_STATUS],
             )
         else:
             # Raw query for both v1 (agg_period=None) and v2 raw (agg_period="raw")

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -440,8 +440,8 @@ class TimescaleDBResultsQueries:
         :param timestamp_column: Optional timestamp column to use for time filtering
         :param agg_period: Optional aggregation period (e.g., '1h', '6h'). If provided,
                           reads from pre-aggregated continuous aggregates.
-                          Note: extra_data is NOT included in aggregated results, but
-                          status IS aggregated (e.g., max indicates detection in period).
+                          Note: extra_data is NOT included in aggregated results.
+                          Status is aggregated using only max (indicates detection in period).
         :param agg_functions: Optional list of aggregation functions to return
                              (e.g., ['avg', 'min', 'max']). Required when agg_period is provided.
         :return: DataFrame with results data
@@ -471,10 +471,10 @@ class TimescaleDBResultsQueries:
         filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
 
         # Two query paths based on agg_period:
-        # 1. agg_period with functions (not "raw") → aggregation query from CAGG view (v2 API)
-        # 2. agg_period=None or "raw" → raw query returning individual data points (v1 and v2 raw)
-        # Note: Aggregated results include status aggregations but NOT extra_data
-        use_aggregation = agg_period and agg_period != "raw" and agg_functions
+        # - agg_period is not None with functions → aggregation query from CAGG view
+        # - agg_period is None → raw query returning individual data points
+        # Aggregated results include max_status (only max, not all functions) but NOT extra_data
+        use_aggregation = agg_period is not None and agg_functions
 
         if use_aggregation:
             df = TimescaleDBQueryBuilder.build_read_data_with_aggregation(
@@ -493,7 +493,7 @@ class TimescaleDBResultsQueries:
                 additional_agg_columns=[mm_schemas.ResultData.RESULT_STATUS],
             )
         else:
-            # Raw query for both v1 (agg_period=None) and v2 raw (agg_period="raw")
+            # Raw query (agg_period=None)
             df = TimescaleDBQueryBuilder.build_read_raw_data(
                 connection=self._connection,
                 table_schema=table_schema,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -74,96 +74,39 @@ class TimescaleDBResultsQueries:
         """
         del get_raw  # Suppress unused variable warning (not implemented)
 
-        agg_func = "max"  # Default aggregation function
-
         if isinstance(endpoint_ids, str):
             endpoint_ids = [endpoint_ids]
 
-        # Set default start time and prepare time range with auto-determined interval
+        # Set default start time
         start = start or (mlrun.utils.datetime_now() - timedelta(hours=24))
-        start, end, interval = TimescaleDBQueryBuilder.prepare_time_range_and_interval(
-            self._pre_aggregate_manager, start, end
-        )
+        start, end = self._pre_aggregate_manager.get_start_end(start, end)
 
         table_schema = self.tables[mm_schemas.TimescaleDBTables.APP_RESULTS]
-        filter_query = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_ids)
+        endpoint_filter = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_ids)
 
-        def build_pre_agg_query():
-            # Calculate overall MAX in SQL across all time buckets
-            # Use subquery to get time-bucketed data, then MAX over those results
-            subquery = table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=[
-                    timescaledb_schema.TIME_BUCKET_COLUMN,
-                    f"{agg_func}_{mm_schemas.ResultData.RESULT_STATUS}",
-                    mm_schemas.WriterEvent.ENDPOINT_ID,
-                    mm_schemas.WriterEvent.APPLICATION_NAME,
-                    mm_schemas.ResultData.RESULT_NAME,
-                ],
-                filter_query=filter_query,
-                agg_funcs=[agg_func],
-                interval=interval,
-                use_pre_aggregates=True,
-            )
+        columns = [
+            f"{mm_schemas.WriterEvent.ENDPOINT_ID} AS {mm_schemas.WriterEvent.ENDPOINT_ID}",
+            f"MAX({mm_schemas.ResultData.RESULT_STATUS}) as {mm_schemas.ResultData.RESULT_STATUS}",
+        ]
+        group_by_columns = [mm_schemas.WriterEvent.ENDPOINT_ID]
 
-            # Use helper to build endpoint aggregation query
-            return TimescaleDBQueryBuilder.build_endpoint_aggregation_query(
-                subquery=subquery,
-                aggregation_columns={
-                    mm_schemas.ResultData.RESULT_STATUS: f"MAX({agg_func}_{mm_schemas.ResultData.RESULT_STATUS})",
-                    mm_schemas.WriterEvent.APPLICATION_NAME: f"MAX({mm_schemas.WriterEvent.APPLICATION_NAME})",
-                    mm_schemas.ResultData.RESULT_NAME: f"MAX({mm_schemas.ResultData.RESULT_NAME})",
-                },
-            )
+        # Build filter using query builder utilities
+        filters = [
+            endpoint_filter,
+            f"{mm_schemas.ResultData.RESULT_STATUS} IS NOT NULL",
+        ]
+        filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
 
-        def build_raw_query():
-            columns = [
-                f"{mm_schemas.WriterEvent.ENDPOINT_ID} AS {mm_schemas.WriterEvent.ENDPOINT_ID}",
-                f"MAX({mm_schemas.ResultData.RESULT_STATUS}) as {mm_schemas.ResultData.RESULT_STATUS}",
-            ]
-            group_by_columns = [mm_schemas.WriterEvent.ENDPOINT_ID]
-
-            # Build filter using query builder utilities
-            filters = [
-                filter_query,
-                f"{mm_schemas.ResultData.RESULT_STATUS} IS NOT NULL",
-            ]
-            enhanced_filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
-
-            return table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=columns,
-                filter_query=enhanced_filter_query,
-                group_by=group_by_columns,
-                order_by=mm_schemas.WriterEvent.ENDPOINT_ID,
-            )
-
-        # Column mapping rules for pre-aggregate results
-        column_mapping_rules = {
-            mm_schemas.ResultData.RESULT_STATUS: [
-                f"{agg_func}_{mm_schemas.ResultData.RESULT_STATUS}",
-                f"{agg_func}_{mm_schemas.ResultData.RESULT_STATUS}",
-                mm_schemas.ResultData.RESULT_STATUS,
-            ],
-            mm_schemas.WriterEvent.ENDPOINT_ID: [mm_schemas.WriterEvent.ENDPOINT_ID],
-            mm_schemas.WriterEvent.APPLICATION_NAME: [
-                mm_schemas.WriterEvent.APPLICATION_NAME,
-                mm_schemas.WriterEvent.APPLICATION_NAME,
-            ],
-            mm_schemas.ResultData.RESULT_NAME: [mm_schemas.ResultData.RESULT_NAME],
-        }
-
-        return self._connection.execute_with_fallback(
-            self._pre_aggregate_manager,
-            build_pre_agg_query,
-            build_raw_query,
-            interval=interval,
-            agg_funcs=[agg_func],
-            column_mapping_rules=column_mapping_rules,
-            debug_name="drift_status",
+        query = table_schema._get_records_query(
+            start=start,
+            end=end,
+            columns_to_filter=columns,
+            filter_query=filter_query,
+            group_by=group_by_columns,
+            order_by=mm_schemas.WriterEvent.ENDPOINT_ID,
         )
+
+        return self._connection.run_query_to_df(query)
 
     def get_error_count(
         self,
@@ -171,87 +114,41 @@ class TimescaleDBResultsQueries:
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
     ) -> pd.DataFrame:
-        """Get error count with optional pre-aggregate optimization."""
+        """Get error count for specified endpoints."""
 
         if isinstance(endpoint_ids, str):
             endpoint_ids = [endpoint_ids]
 
-        # Set default start time and prepare time range with auto-determined interval
+        # Set default start time
         start = start or (mlrun.utils.datetime_now() - timedelta(hours=24))
-        start, end, interval = TimescaleDBQueryBuilder.prepare_time_range_and_interval(
-            self._pre_aggregate_manager, start, end
-        )
+        start, end = self._pre_aggregate_manager.get_start_end(start, end)
 
         table_schema = self.tables[mm_schemas.TimescaleDBTables.ERRORS]
-        filter_query = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_ids)
+        endpoint_filter = TimescaleDBQueryBuilder.build_endpoint_filter(endpoint_ids)
 
-        def build_pre_agg_query():
-            # Calculate total error count in SQL across all time buckets
-            # Use subquery to get time-bucketed data, then SUM over those results
-            subquery = table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=[
-                    timescaledb_schema.TIME_BUCKET_COLUMN,
-                    f"count_{mm_schemas.EventFieldType.MODEL_ERROR}",
-                    mm_schemas.WriterEvent.ENDPOINT_ID,
-                ],
-                filter_query=filter_query,  # Only endpoint filter, no error_type
-                agg_funcs=["count"],
-                interval=interval,
-                use_pre_aggregates=True,
-            )
+        # Build filter using query builder utilities
+        filters = [
+            endpoint_filter,
+            f"{mm_schemas.EventFieldType.ERROR_TYPE} = '{mm_schemas.EventFieldType.INFER_ERROR}'",
+        ]
+        filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
 
-            # Use helper to build endpoint aggregation query
-            return TimescaleDBQueryBuilder.build_endpoint_aggregation_query(
-                subquery=subquery,
-                aggregation_columns={
-                    mm_schemas.EventFieldType.ERROR_COUNT: f"SUM(count_{mm_schemas.EventFieldType.MODEL_ERROR})"
-                },
-            )
+        columns = [
+            f"{mm_schemas.WriterEvent.ENDPOINT_ID} AS {mm_schemas.WriterEvent.ENDPOINT_ID}",
+            f"COUNT(*) AS {mm_schemas.EventFieldType.ERROR_COUNT}",
+        ]
+        group_by_columns = [mm_schemas.WriterEvent.ENDPOINT_ID]
 
-        def build_raw_query():
-            # Build filter using query builder utilities
-            filters = [
-                filter_query,
-                f"{mm_schemas.EventFieldType.ERROR_TYPE} = '{mm_schemas.EventFieldType.INFER_ERROR}'",
-            ]
-            enhanced_filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
-
-            columns = [
-                f"{mm_schemas.WriterEvent.ENDPOINT_ID} AS {mm_schemas.WriterEvent.ENDPOINT_ID}",
-                f"COUNT(*) AS {mm_schemas.EventFieldType.ERROR_COUNT}",
-            ]
-            group_by_columns = [mm_schemas.WriterEvent.ENDPOINT_ID]
-
-            return table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=columns,
-                filter_query=enhanced_filter_query,
-                group_by=group_by_columns,
-                order_by=mm_schemas.WriterEvent.ENDPOINT_ID,
-            )
-
-        # Column mapping rules for pre-aggregate results
-        column_mapping_rules = {
-            mm_schemas.EventFieldType.ERROR_COUNT: [
-                f"count_{mm_schemas.EventFieldType.MODEL_ERROR}",
-                "count",
-                mm_schemas.EventFieldType.ERROR_COUNT,
-            ],
-            mm_schemas.WriterEvent.ENDPOINT_ID: [mm_schemas.WriterEvent.ENDPOINT_ID],
-        }
-
-        return self._connection.execute_with_fallback(
-            self._pre_aggregate_manager,
-            build_pre_agg_query,
-            build_raw_query,
-            interval=interval,
-            agg_funcs=["count"],
-            column_mapping_rules=column_mapping_rules,
-            debug_name="error_count",
+        query = table_schema._get_records_query(
+            start=start,
+            end=end,
+            columns_to_filter=columns,
+            filter_query=filter_query,
+            group_by=group_by_columns,
+            order_by=mm_schemas.WriterEvent.ENDPOINT_ID,
         )
+
+        return self._connection.run_query_to_df(query)
 
     def get_results_metadata(
         self,
@@ -530,6 +427,8 @@ class TimescaleDBResultsQueries:
         metrics: Optional[list[mm_schemas.ModelEndpointMonitoringMetric]] = None,
         with_result_extra_data: bool = False,
         timestamp_column: Optional[str] = None,
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
     ) -> pd.DataFrame:
         """Read results data from TimescaleDB (app_results table only) - returns DataFrame.
 
@@ -539,6 +438,11 @@ class TimescaleDBResultsQueries:
         :param metrics: List of metrics to filter by, or None to get all results
         :param with_result_extra_data: Whether to include extra data column
         :param timestamp_column: Optional timestamp column to use for time filtering
+        :param agg_period: Optional aggregation period (e.g., '1h', '6h'). If provided,
+                          reads from pre-aggregated continuous aggregates.
+                          Note: status and extra_data are NOT included in aggregated results.
+        :param agg_functions: Optional list of aggregation functions to return
+                             (e.g., ['avg', 'min', 'max']). Required when agg_period is provided.
         :return: DataFrame with results data
         """
 
@@ -565,26 +469,51 @@ class TimescaleDBResultsQueries:
         filters = [endpoint_filter, metrics_condition]
         filter_query = TimescaleDBQueryBuilder.combine_filters(filters)
 
-        # Use shared utility for consistent query building with fallback
-        df = TimescaleDBQueryBuilder.build_read_data_with_fallback(
-            connection=self._connection,
-            pre_aggregate_manager=self._pre_aggregate_manager,
-            table_schema=table_schema,
-            start=start,
-            end=end,
-            columns=columns,
-            filter_query=filter_query,
-            name_column=name_column,
-            value_column=value_column,
-            debug_name="read_results_data",
-            timestamp_column=timestamp_column,
-        )
+        # Two query paths based on agg_period:
+        # 1. agg_period with functions (not "raw") → aggregation query from CAGG view (v2 API)
+        # 2. agg_period=None or "raw" → raw query returning individual data points (v1 and v2 raw)
+        # Note: Aggregated results do NOT include status or extra_data
+        use_aggregation = agg_period and agg_period != "raw" and agg_functions
+
+        if use_aggregation:
+            df = TimescaleDBQueryBuilder.build_read_data_with_aggregation(
+                connection=self._connection,
+                table_schema=table_schema,
+                start=start,
+                end=end,
+                columns=columns,
+                filter_query=filter_query,
+                name_column=name_column,
+                value_column=value_column,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
+                timestamp_column=timestamp_column,
+            )
+        else:
+            # Raw query for both v1 (agg_period=None) and v2 raw (agg_period="raw")
+            df = TimescaleDBQueryBuilder.build_read_raw_data(
+                connection=self._connection,
+                table_schema=table_schema,
+                start=start,
+                end=end,
+                columns=columns,
+                filter_query=filter_query,
+                timestamp_column=timestamp_column,
+            )
 
         if not df.empty:
-            df[table_schema.time_column] = pd.to_datetime(df[table_schema.time_column])
-            df.set_index(table_schema.time_column, inplace=True)
+            # Use time_bucket for aggregated data, time_column for raw
+            time_col = (
+                timescaledb_schema.TIME_BUCKET_COLUMN
+                if use_aggregation
+                else table_schema.time_column
+            )
+            if time_col in df.columns:
+                df[time_col] = pd.to_datetime(df[time_col])
+                df.set_index(time_col, inplace=True)
 
-        if not with_result_extra_data:
+        # For raw data without extra_data, add empty column
+        if not use_aggregation and not with_result_extra_data:
             df[mm_schemas.ResultData.RESULT_EXTRA_DATA] = ""
 
         return df

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connection.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connection.py
@@ -23,7 +23,6 @@ import semver
 from psycopg_pool import ConnectionPool
 
 import mlrun.errors
-from mlrun.model_monitoring.db.tsdb.preaggregate import PreAggregateManager
 from mlrun.utils import logger
 
 
@@ -285,66 +284,19 @@ class TimescaleDBConnection:
         else:
             return QueryResult([], [])
 
-    def execute_with_fallback(
-        self,
-        pre_aggregate_manager: PreAggregateManager,
-        pre_agg_query_builder: Callable[[], str],
-        raw_query_builder: Callable[[], str],
-        interval: Optional[str] = None,
-        agg_funcs: Optional[list[str]] = None,
-        column_mapping_rules: Optional[dict[str, list[str]]] = None,
-        debug_name: str = "query",
-    ) -> pd.DataFrame:
+    def run_query_to_df(self, query: str) -> pd.DataFrame:
         """
-        Execute a query with pre-aggregate optimization and automatic fallback.
+        Execute a query and return results as a DataFrame.
 
-        This method encapsulates the common pattern of trying pre-aggregate queries first,
-        then falling back to raw data queries if the pre-aggregate fails.
-
-        :param pre_aggregate_manager: Manager for pre-aggregate operations
-        :param pre_agg_query_builder: Function that returns pre-aggregate query string
-        :param raw_query_builder: Function that returns raw data query string
-        :param interval: Time interval for aggregation
-        :param agg_funcs: List of aggregation functions
-        :param column_mapping_rules: Rules for mapping column names in pre-aggregate results
-        :param debug_name: Name for debugging/logging purposes
+        :param query: SQL query string to execute
         :return: DataFrame with query results
         """
-        # Import locally to avoid circular dependency
         from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_dataframe_processor import (
             TimescaleDBDataFrameProcessor,
         )
 
-        df_processor = TimescaleDBDataFrameProcessor()
-
-        if pre_aggregate_manager.can_use_pre_aggregates(
-            interval=interval, agg_funcs=agg_funcs
-        ):
-            try:
-                # Try pre-aggregate query first
-                query = pre_agg_query_builder()
-                result = self.run(query=query)
-                df = df_processor.from_query_result(result)
-
-                if not df.empty and column_mapping_rules:
-                    # Apply flexible column mapping for pre-aggregate results
-                    mapping = df_processor.build_flexible_column_mapping(
-                        df, column_mapping_rules
-                    )
-                    df = df_processor.apply_column_mapping(df, mapping)
-
-                return df
-
-            except Exception as e:
-                logger.warning(
-                    f"Pre-aggregate {debug_name} query failed, falling back to raw data",
-                    error=mlrun.errors.err_to_str(e),
-                )
-
-        # Fallback to raw data query
-        raw_query = raw_query_builder()
-        result = self.run(query=raw_query)
-        return df_processor.from_query_result(result)
+        result = self.run(query=query)
+        return TimescaleDBDataFrameProcessor.from_query_result(result)
 
     def _execute_with_retry(
         self,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -159,8 +159,10 @@ class TimescaleDBConnector(TSDBConnector):
         :param agg_functions: Optional list of aggregation functions (e.g., ['avg', 'min']).
                              Required when agg_period is provided.
         """
-        # Pass agg_period and agg_functions through as-is to query layer
-        # Query layer handles three paths: None, "raw", or aggregation period
+        # Query layer handles two paths:
+        # - None: raw data (v1 backward compat or v2 raw)
+        # - specific period ("1h", "6h", etc.): aggregated data from CAGG views
+        # Note: "raw" is resolved at API layer to None before reaching here
         if type == "metrics":
             df = self._metrics_queries.read_metrics_data_impl(
                 endpoint_id=endpoint_id,
@@ -170,12 +172,12 @@ class TimescaleDBConnector(TSDBConnector):
                 agg_period=agg_period,
                 agg_functions=agg_functions,
             )
-            # Use v1 helper only when agg_period is None (backward compatibility)
+            # Use v1 helper when agg_period is None (backward compatibility)
             if agg_period is None:
                 return self.df_to_metrics_values(
                     df=df, metrics=metrics, project=self.project
                 )
-            # Use v2 helper for any explicit agg_period (including "raw")
+            # Use v2 helper for aggregated data
             return self.df_to_metrics_values_v2(
                 df=df,
                 metrics=metrics,
@@ -194,12 +196,12 @@ class TimescaleDBConnector(TSDBConnector):
                 agg_period=agg_period,
                 agg_functions=agg_functions,
             )
-            # Use v1 helper only when agg_period is None (backward compatibility)
+            # Use v1 helper when agg_period is None (backward compatibility)
             if agg_period is None:
                 return self.df_to_results_values(
                     df=df, metrics=metrics, project=self.project
                 )
-            # Use v2 helper for any explicit agg_period (including "raw")
+            # Use v2 helper for aggregated data
             return self.df_to_results_values_v2(
                 df=df,
                 metrics=metrics,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -143,19 +143,45 @@ class TimescaleDBConnector(TSDBConnector):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: str,
         with_result_extra_data: bool = False,
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
     ):
-        """Read metrics or results data from TimescaleDB (cross-cutting coordination)."""
+        """Read metrics or results data from TimescaleDB (cross-cutting coordination).
 
+        :param endpoint_id: The model endpoint identifier.
+        :param start:       Start time for the query.
+        :param end:         End time for the query.
+        :param metrics:     List of metrics to retrieve.
+        :param type:        Type of data: "metrics" or "results".
+        :param with_result_extra_data: Whether to include extra_data for results.
+        :param agg_period:  Optional aggregation period (e.g., '1h', '6h').
+                           If provided, reads from pre-aggregated views and returns V2 schemas.
+        :param agg_functions: Optional list of aggregation functions (e.g., ['avg', 'min']).
+                             Required when agg_period is provided.
+        """
+        # Pass agg_period and agg_functions through as-is to query layer
+        # Query layer handles three paths: None, "raw", or aggregation period
         if type == "metrics":
             df = self._metrics_queries.read_metrics_data_impl(
                 endpoint_id=endpoint_id,
                 start=start,
                 end=end,
                 metrics=metrics,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
             )
-            # Use inherited method to convert DataFrame to domain objects
-            return self.df_to_metrics_values(
-                df=df, metrics=metrics, project=self.project
+            # Use v1 helper only when agg_period is None (backward compatibility)
+            if agg_period is None:
+                return self.df_to_metrics_values(
+                    df=df, metrics=metrics, project=self.project
+                )
+            # Use v2 helper for any explicit agg_period (including "raw")
+            return self.df_to_metrics_values_v2(
+                df=df,
+                metrics=metrics,
+                project=self.project,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
             )
 
         else:  # results
@@ -165,10 +191,21 @@ class TimescaleDBConnector(TSDBConnector):
                 end=end,
                 metrics=metrics,
                 with_result_extra_data=with_result_extra_data,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
             )
-            # Use inherited method to convert DataFrame to domain objects
-            return self.df_to_results_values(
-                df=df, metrics=metrics, project=self.project
+            # Use v1 helper only when agg_period is None (backward compatibility)
+            if agg_period is None:
+                return self.df_to_results_values(
+                    df=df, metrics=metrics, project=self.project
+                )
+            # Use v2 helper for any explicit agg_period (including "raw")
+            return self.df_to_results_values_v2(
+                df=df,
+                metrics=metrics,
+                project=self.project,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
             )
 
     def get_model_endpoint_real_time_metrics(self, *args, **kwargs):

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connector.py
@@ -143,10 +143,10 @@ class TimescaleDBConnector(TSDBConnector):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: str,
         with_result_extra_data: bool = False,
-        agg_period: Optional[str] = None,
-        agg_functions: Optional[list[str]] = None,
     ):
-        """Read metrics or results data from TimescaleDB (cross-cutting coordination).
+        """Read metrics or results data from TimescaleDB (V1 API).
+
+        Always returns V1 schemas (MetricValues/ResultValues).
 
         :param endpoint_id: The model endpoint identifier.
         :param start:       Start time for the query.
@@ -154,36 +154,18 @@ class TimescaleDBConnector(TSDBConnector):
         :param metrics:     List of metrics to retrieve.
         :param type:        Type of data: "metrics" or "results".
         :param with_result_extra_data: Whether to include extra_data for results.
-        :param agg_period:  Optional aggregation period (e.g., '1h', '6h').
-                           If provided, reads from pre-aggregated views and returns V2 schemas.
-        :param agg_functions: Optional list of aggregation functions (e.g., ['avg', 'min']).
-                             Required when agg_period is provided.
         """
-        # Query layer handles two paths:
-        # - None: raw data (v1 backward compat or v2 raw)
-        # - specific period ("1h", "6h", etc.): aggregated data from CAGG views
-        # Note: "raw" is resolved at API layer to None before reaching here
         if type == "metrics":
             df = self._metrics_queries.read_metrics_data_impl(
                 endpoint_id=endpoint_id,
                 start=start,
                 end=end,
                 metrics=metrics,
-                agg_period=agg_period,
-                agg_functions=agg_functions,
+                agg_period=None,
+                agg_functions=None,
             )
-            # Use v1 helper when agg_period is None (backward compatibility)
-            if agg_period is None:
-                return self.df_to_metrics_values(
-                    df=df, metrics=metrics, project=self.project
-                )
-            # Use v2 helper for aggregated data
-            return self.df_to_metrics_values_v2(
-                df=df,
-                metrics=metrics,
-                project=self.project,
-                agg_period=agg_period,
-                agg_functions=agg_functions,
+            return self.df_to_metrics_values(
+                df=df, metrics=metrics, project=self.project
             )
 
         else:  # results
@@ -193,15 +175,69 @@ class TimescaleDBConnector(TSDBConnector):
                 end=end,
                 metrics=metrics,
                 with_result_extra_data=with_result_extra_data,
+                agg_period=None,
+                agg_functions=None,
+            )
+            return self.df_to_results_values(
+                df=df, metrics=metrics, project=self.project
+            )
+
+    def read_metrics_data_v2(
+        self,
+        *,
+        endpoint_id: str,
+        start: datetime.datetime,
+        end: datetime.datetime,
+        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        type: str,
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
+    ):
+        """Read metrics or results data from TimescaleDB (V2 API).
+
+        Always returns V2 schemas (MetricValuesV2/ResultValuesV2).
+
+        :param endpoint_id: The model endpoint identifier.
+        :param start:       Start time for the query.
+        :param end:         End time for the query.
+        :param metrics:     List of metrics to retrieve.
+        :param type:        Type of data: "metrics" or "results".
+        :param agg_period:  Optional aggregation period (e.g., '1h', '6h').
+                           If None, returns raw data in V2 format.
+                           If provided, returns aggregated data from CAGG views.
+        :param agg_functions: Optional list of aggregation functions (e.g., ['avg', 'min']).
+                             Required when agg_period is provided.
+        """
+        if type == "metrics":
+            df = self._metrics_queries.read_metrics_data_impl(
+                endpoint_id=endpoint_id,
+                start=start,
+                end=end,
+                metrics=metrics,
                 agg_period=agg_period,
                 agg_functions=agg_functions,
             )
-            # Use v1 helper when agg_period is None (backward compatibility)
-            if agg_period is None:
-                return self.df_to_results_values(
-                    df=df, metrics=metrics, project=self.project
-                )
-            # Use v2 helper for aggregated data
+            return self.df_to_metrics_values_v2(
+                df=df,
+                metrics=metrics,
+                project=self.project,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
+            )
+
+        else:  # results
+            # For v2 results, we don't include extra_data in aggregated mode
+            # (it can't be meaningfully aggregated)
+            with_result_extra_data = agg_period is None
+            df = self._results_queries.read_results_data_impl(
+                endpoint_id=endpoint_id,
+                start=start,
+                end=end,
+                metrics=metrics,
+                with_result_extra_data=with_result_extra_data,
+                agg_period=agg_period,
+                agg_functions=agg_functions,
+            )
             return self.df_to_results_values_v2(
                 df=df,
                 metrics=metrics,

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.errors
+import mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_schema as timescaledb_schema
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -107,9 +108,7 @@ class TimescaleDBQueryBuilder:
             )
             conditions.append(condition)
 
-        if len(conditions) == 1:
-            return conditions[0]
-        return " OR ".join(conditions)
+        return conditions[0] if len(conditions) == 1 else " OR ".join(conditions)
 
     @staticmethod
     def build_results_filter(
@@ -136,9 +135,7 @@ class TimescaleDBQueryBuilder:
             )
             conditions.append(condition)
 
-        if len(conditions) == 1:
-            return conditions[0]
-        return " OR ".join(conditions)
+        return conditions[0] if len(conditions) == 1 else " OR ".join(conditions)
 
     @staticmethod
     def build_metrics_filter_from_names(metric_names: list[str]) -> str:
@@ -311,79 +308,44 @@ class TimescaleDBQueryBuilder:
         return best_interval
 
     @staticmethod
-    def build_read_data_with_fallback(
+    def build_read_raw_data(
         connection,
-        pre_aggregate_manager,
         table_schema,
-        start: "datetime",  # Use string to avoid import cycle
+        start: "datetime",
         end: "datetime",
         columns: list[str],
         filter_query: Optional[str],
-        name_column: str,
-        value_column: str,
-        debug_name: str = "read_data",
         timestamp_column: Optional[str] = None,
-    ) -> "pd.DataFrame":  # Use string to avoid import cycle
+    ) -> "pd.DataFrame":
         """
-        Build and execute read data query with pre-aggregate fallback pattern.
+        Build and execute direct raw data query without any pre-aggregate fallback.
 
-        This method deduplicates the common pattern used in both metrics and results
-        queries for reading data with pre-aggregate optimization and fallback.
+        This method is used when agg_period="raw" is explicitly specified,
+        bypassing all pre-aggregate optimization logic.
 
         :param connection: Database connection instance
-        :param pre_aggregate_manager: Pre-aggregate handler for optimization
         :param table_schema: Table schema for query building
         :param start: Start datetime for query
         :param end: End datetime for query
         :param columns: List of columns to select
         :param filter_query: WHERE clause conditions
-        :param name_column: Name of the metric/result name column
-        :param value_column: Name of the metric/result value column
-        :param debug_name: Name for debugging purposes
         :param timestamp_column: Optional timestamp column to use for time filtering
-        :return: DataFrame with query results
+        :return: DataFrame with raw query results
         """
-
-        def build_pre_agg_query():
-            return table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=columns,
-                filter_query=filter_query,
-                use_pre_aggregates=True,
-                timestamp_column=timestamp_column,
-            )
-
-        def build_raw_query():
-            return table_schema._get_records_query(
-                start=start,
-                end=end,
-                columns_to_filter=columns,
-                filter_query=filter_query,
-                timestamp_column=timestamp_column,
-            )
-
-        # Column mapping rules for pre-aggregate results
-        import mlrun.common.schemas.model_monitoring as mm_schemas
-
-        column_mapping_rules = {
-            name_column: [name_column],
-            value_column: [value_column],
-            table_schema.time_column: [table_schema.time_column],
-            mm_schemas.WriterEvent.APPLICATION_NAME: [
-                mm_schemas.WriterEvent.APPLICATION_NAME
-            ],
-        }
-
-        return connection.execute_with_fallback(
-            pre_aggregate_manager,
-            build_pre_agg_query,
-            build_raw_query,
-            interval=None,  # No specific interval for this query
-            agg_funcs=None,
-            column_mapping_rules=column_mapping_rules,
-            debug_name=debug_name,
+        from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_dataframe_processor import (
+            TimescaleDBDataFrameProcessor,
         )
+
+        query = table_schema._get_records_query(
+            start=start,
+            end=end,
+            columns_to_filter=columns,
+            filter_query=filter_query,
+            timestamp_column=timestamp_column,
+        )
+
+        result = connection.run(query=query)
+        return TimescaleDBDataFrameProcessor.from_query_result(result)
 
     @staticmethod
     def prepare_time_range_and_interval(
@@ -477,6 +439,71 @@ class TimescaleDBQueryBuilder:
         )
 
         return start_dt, end_dt, interval
+
+    @staticmethod
+    def build_read_data_with_aggregation(
+        connection,
+        table_schema,
+        start: "datetime",
+        end: "datetime",
+        columns: list[str],
+        filter_query: Optional[str],
+        name_column: str,
+        value_column: str,
+        agg_period: str,
+        agg_functions: list[str],
+        timestamp_column: Optional[str] = None,
+    ) -> "pd.DataFrame":
+        """
+        Build and execute aggregated read data query from pre-aggregate CAGG view.
+
+        :param connection: Database connection instance
+        :param table_schema: Table schema for query building
+        :param start: Start datetime for query
+        :param end: End datetime for query
+        :param columns: List of columns to select (used for grouping columns)
+        :param filter_query: WHERE clause conditions
+        :param name_column: Name of the metric/result name column
+        :param value_column: Name of the metric/result value column
+        :param agg_period: Aggregation period (e.g., '1h', '6h', '12h', '24h')
+        :param agg_functions: List of aggregation functions (e.g., ['avg', 'min', 'max'])
+        :param timestamp_column: Optional timestamp column to use for time filtering
+        :return: DataFrame with aggregated query results
+        """
+        # Add grouping columns (must match CAGG view grouping - see timescaledb_schema.py)
+        # Note: result_kind is NOT a grouping column in CAGG, it's aggregated
+        grouping_columns = [
+            mm_schemas.WriterEvent.APPLICATION_NAME,
+            name_column,
+            mm_schemas.WriterEvent.ENDPOINT_ID,
+        ]
+
+        # Build aggregated column names for CAGG query
+        agg_value_columns = [f"{func}_{value_column}" for func in agg_functions]
+
+        # Build query for continuous aggregate view
+        cagg_view_name = TimescaleDBNaming.get_cagg_view_name(
+            table_schema.full_name(), agg_period
+        )
+        time_bucket_col = timescaledb_schema.TIME_BUCKET_COLUMN
+        select_columns = [time_bucket_col, *grouping_columns, *agg_value_columns]
+        time_col = timestamp_column or time_bucket_col
+        where_conditions = [
+            f"{time_col} >= '{start}'",
+            f"{time_col} <= '{end}'",
+        ]
+        if filter_query:
+            where_conditions.append(filter_query)
+        where_clause = " AND ".join(where_conditions)
+
+        query = f"""
+        SELECT {', '.join(select_columns)}
+        FROM {cagg_view_name}
+        WHERE {where_clause}
+        ORDER BY {time_bucket_col}, {name_column}
+        """
+
+        return connection.run_query_to_df(query)
 
     @staticmethod
     def build_endpoint_aggregation_query(

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
@@ -453,6 +453,7 @@ class TimescaleDBQueryBuilder:
         agg_period: str,
         agg_functions: list[str],
         timestamp_column: Optional[str] = None,
+        additional_agg_columns: Optional[list[str]] = None,
     ) -> "pd.DataFrame":
         """
         Build and execute aggregated read data query from pre-aggregate CAGG view.
@@ -468,6 +469,8 @@ class TimescaleDBQueryBuilder:
         :param agg_period: Aggregation period (e.g., '1h', '6h', '12h', '24h')
         :param agg_functions: List of aggregation functions (e.g., ['avg', 'min', 'max'])
         :param timestamp_column: Optional timestamp column to use for time filtering
+        :param additional_agg_columns: Optional list of additional columns to aggregate
+                                       (e.g., ['result_status'] for results)
         :return: DataFrame with aggregated query results
         """
         # Add grouping columns (must match CAGG view grouping - see timescaledb_schema.py)
@@ -480,6 +483,11 @@ class TimescaleDBQueryBuilder:
 
         # Build aggregated column names for CAGG query
         agg_value_columns = [f"{func}_{value_column}" for func in agg_functions]
+
+        # Add aggregated columns for additional columns (e.g., status for results)
+        if additional_agg_columns:
+            for col in additional_agg_columns:
+                agg_value_columns.extend(f"{func}_{col}" for func in agg_functions)
 
         # Build query for continuous aggregate view
         cagg_view_name = TimescaleDBNaming.get_cagg_view_name(

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
@@ -320,7 +320,7 @@ class TimescaleDBQueryBuilder:
         """
         Build and execute direct raw data query without any pre-aggregate fallback.
 
-        This method is used when agg_period="raw" is explicitly specified,
+        This method is used when agg_period is None (raw data requested),
         bypassing all pre-aggregate optimization logic.
 
         :param connection: Database connection instance
@@ -484,10 +484,10 @@ class TimescaleDBQueryBuilder:
         # Build aggregated column names for CAGG query
         agg_value_columns = [f"{func}_{value_column}" for func in agg_functions]
 
-        # Add aggregated columns for additional columns (e.g., status for results)
+        # Add max aggregation for additional columns (e.g., status for results)
+        # Status uses only max (indicates detection in period), not all agg_functions
         if additional_agg_columns:
-            for col in additional_agg_columns:
-                agg_value_columns.extend(f"{func}_{col}" for func in agg_functions)
+            agg_value_columns.extend(f"max_{col}" for col in additional_agg_columns)
 
         # Build query for continuous aggregate view
         cagg_view_name = TimescaleDBNaming.get_cagg_view_name(

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -490,15 +490,10 @@ class V3IOTSDBConnector(TSDBConnector):
             )
             raise mlrun.errors.MLRunRuntimeError(
                 f"Failed to write application result to TSDB: {err}"
-            )
+            ) from err
 
     def delete_tsdb_resources(self, table: Optional[str] = None):
-        if table:
-            # Delete a specific table
-            tables = [table]
-        else:
-            # Delete all tables
-            tables = mm_schemas.V3IOTSDBTables.list()
+        tables = [table] if table else mm_schemas.V3IOTSDBTables.list()
         for table_to_delete in tables:
             if table_to_delete in self.tables:
                 try:
@@ -757,14 +752,11 @@ class V3IOTSDBConnector(TSDBConnector):
             kind=mm_schemas.FileTargetKind.EVENTS,
         )
 
-        # Generate the main directory with the V3IO resources
-        source_directory = (
+        return (
             mlrun.common.model_monitoring.helpers.parse_model_endpoint_project_prefix(
                 events_table_full_path, self.project
             )
         )
-
-        return source_directory
 
     @staticmethod
     def _get_v3io_frames_client(
@@ -808,8 +800,6 @@ class V3IOTSDBConnector(TSDBConnector):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: Literal["metrics", "results"] = "results",
         with_result_extra_data: bool = False,
-        agg_period: Optional[str] = None,
-        agg_functions: Optional[list[str]] = None,
     ) -> Union[
         list[
             Union[
@@ -825,9 +815,10 @@ class V3IOTSDBConnector(TSDBConnector):
         ],
     ]:
         """
-        Read metrics OR results from the TSDB and return as a list.
+        Read metrics OR results from the TSDB and return as a list (V1 API).
         Note: the type must match the actual metrics in the `metrics` parameter.
         If the type is "results", pass only results in the `metrics` parameter.
+        Always returns V1 schemas.
         """
 
         if type == "metrics":
@@ -885,6 +876,102 @@ class V3IOTSDBConnector(TSDBConnector):
 
         return df_handler(df=df, metrics=metrics, project=self.project)
 
+    def read_metrics_data_v2(
+        self,
+        *,
+        endpoint_id: str,
+        start: datetime,
+        end: datetime,
+        metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
+        type: Literal["metrics", "results"] = "results",
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
+    ) -> Union[
+        list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringResultValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ],
+        ],
+        list[
+            Union[
+                mm_schemas.ModelEndpointMonitoringMetricValuesV2,
+                mm_schemas.ModelEndpointMonitoringMetricNoData,
+            ],
+        ],
+    ]:
+        """
+        Read metrics OR results from the TSDB and return as a list (V2 API).
+        Note: the type must match the actual metrics in the `metrics` parameter.
+        If the type is "results", pass only results in the `metrics` parameter.
+        Always returns V2 schemas.
+
+        Note: V3IO does not support pre-aggregation, so agg_period and agg_functions
+        are used only for formatting the response, not for server-side aggregation.
+        """
+
+        if type == "metrics":
+            table_path = self.tables[mm_schemas.V3IOTSDBTables.METRICS]
+            name = mm_schemas.MetricData.METRIC_NAME
+            columns = [mm_schemas.MetricData.METRIC_VALUE]
+            df_handler = self.df_to_metrics_values_v2
+        elif type == "results":
+            table_path = self.tables[mm_schemas.V3IOTSDBTables.APP_RESULTS]
+            name = mm_schemas.ResultData.RESULT_NAME
+            columns = [
+                mm_schemas.ResultData.RESULT_VALUE,
+                mm_schemas.ResultData.RESULT_STATUS,
+                mm_schemas.ResultData.RESULT_KIND,
+            ]
+            # For v2 results, include extra_data only when not aggregating
+            if agg_period is None:
+                columns.append(mm_schemas.ResultData.RESULT_EXTRA_DATA)
+            df_handler = self.df_to_results_values_v2
+        else:
+            raise ValueError(f"Invalid {type = }")
+
+        query = self._get_sql_query(
+            endpoint_id=endpoint_id,
+            metric_and_app_names=[(metric.app, metric.name) for metric in metrics],
+            table_path=table_path,
+            name=name,
+            columns=columns,
+        )
+
+        logger.debug("Querying V3IO TSDB", query=query)
+
+        df: pd.DataFrame = self.frames_client.read(
+            backend=_TSDB_BE,
+            start=start,
+            end=end,
+            query=query,
+        )
+
+        logger.debug(
+            "Converting a DataFrame to a list of metrics or results values (v2)",
+            table=table_path,
+            project=self.project,
+            endpoint_id=endpoint_id,
+            is_empty=df.empty,
+            agg_period=agg_period,
+        )
+
+        # For v2 results without aggregation, ensure extra_data column exists
+        if (
+            type == "results"
+            and agg_period is None
+            and mm_schemas.ResultData.RESULT_EXTRA_DATA not in df.columns
+        ):
+            df[mm_schemas.ResultData.RESULT_EXTRA_DATA] = ""
+
+        return df_handler(
+            df=df,
+            metrics=metrics,
+            project=self.project,
+            agg_period=agg_period,
+            agg_functions=agg_functions,
+        )
+
     @staticmethod
     def _get_sql_query(
         *,
@@ -908,11 +995,7 @@ class V3IOTSDBConnector(TSDBConnector):
                 "Cannot provide both metric_and_app_names and application_names"
             )
 
-        if columns:
-            selection = ",".join(columns)
-        else:
-            selection = "*"
-
+        selection = ",".join(columns) if columns else "*"
         with StringIO() as query:
             where_added = False
             query.write(f"SELECT {selection} FROM '{table_path}'")
@@ -1042,9 +1125,6 @@ class V3IOTSDBConnector(TSDBConnector):
                     container=self.container,
                     table_path=self.last_request_table,
                 ).all()
-                last_request_timestamps.update(
-                    {d["__name"]: d["last_request_timestamp"] for d in res}
-                )
             else:
                 filter_expression = " OR ".join(
                     [f"__name=='{endpoint_id}'" for endpoint_id in endpoint_ids]
@@ -1054,9 +1134,9 @@ class V3IOTSDBConnector(TSDBConnector):
                     table_path=self.last_request_table,
                     filter_expression=filter_expression,
                 ).all()
-                last_request_timestamps.update(
-                    {d["__name"]: d["last_request_timestamp"] for d in res}
-                )
+            last_request_timestamps |= {
+                d["__name"]: d["last_request_timestamp"] for d in res
+            }
         except Exception as e:
             logger.warning(
                 "Failed to get last request timestamp from V3IO KV table.",
@@ -1551,17 +1631,14 @@ class V3IOTSDBConnector(TSDBConnector):
         if not aggregated_data:
             return mm_schemas.ModelEndpointDriftValues(values=[])
 
-        # Filter to only include entries with max result_status >= 1
-        filtered_data = [
+        if filtered_data := [
             (endpoint_id, timestamp, max_status)
             for endpoint_id, timestamp, max_status in aggregated_data
             if max_status >= 1
-        ]
-
-        if not filtered_data:
+        ]:
+            return self._convert_drift_data_to_values(aggregated_data=filtered_data)
+        else:
             return mm_schemas.ModelEndpointDriftValues(values=[])
-
-        return self._convert_drift_data_to_values(aggregated_data=filtered_data)
 
     @staticmethod
     def _aggregate_raw_drift_data(
@@ -1594,7 +1671,7 @@ class V3IOTSDBConnector(TSDBConnector):
             timestamps = frame.indices()[0].times
 
             # Combine data from this frame
-            for i, (status, timestamp) in enumerate(zip(result_statuses, timestamps)):
+            for status, timestamp in zip(result_statuses, timestamps):
                 # V3IO TSDB returns timestamps in nanoseconds
                 timestamp_dt = pd.Timestamp(
                     timestamp, unit="ns", tzinfo=UTC

--- a/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/v3io_connector.py
@@ -808,6 +808,8 @@ class V3IOTSDBConnector(TSDBConnector):
         metrics: list[mm_schemas.ModelEndpointMonitoringMetric],
         type: Literal["metrics", "results"] = "results",
         with_result_extra_data: bool = False,
+        agg_period: Optional[str] = None,
+        agg_functions: Optional[list[str]] = None,
     ) -> Union[
         list[
             Union[

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -60,10 +60,10 @@ def _is_results_regex_match(
         )
         return False
     existing_result_name = ".".join(existing_result_name.split(".")[i] for i in [1, 3])
-    for result_name_filter in result_name_filters:
-        if fnmatchcase(existing_result_name, result_name_filter):
-            return True
-    return False
+    return any(
+        fnmatchcase(existing_result_name, result_name_filter)
+        for result_name_filter in result_name_filters
+    )
 
 
 def filter_results_by_regex(
@@ -101,13 +101,14 @@ def filter_results_by_regex(
             )
         else:
             validated_filters.append(result_name_filter)
-    filtered_metrics_names = []
-    for existing_result_name in existing_result_names:
+    filtered_metrics_names = [
+        existing_result_name
+        for existing_result_name in existing_result_names
         if _is_results_regex_match(
             existing_result_name=existing_result_name,
             result_name_filters=validated_filters,
-        ):
-            filtered_metrics_names.append(existing_result_name)
+        )
+    ]
     return list(set(filtered_metrics_names))
 
 
@@ -171,14 +172,12 @@ def get_monitoring_parquet_path(
     :return:           Monitoring parquet target path.
     """
     artifact_path = project.spec.artifact_path
-    # Generate monitoring parquet path value
-    parquet_path = mlrun.mlconf.get_model_monitoring_file_target_path(
+    return mlrun.mlconf.get_model_monitoring_file_target_path(
         project=project.name,
         kind=kind,
         target="offline",
         artifact_path=artifact_path,
     )
-    return parquet_path
 
 
 def get_monitoring_stats_directory_path(
@@ -193,11 +192,10 @@ def get_monitoring_stats_directory_path(
     :param kind:        indicate the kind of the stats path
     :return:            Monitoring stats target path.
     """
-    stats_path = mlrun.mlconf.get_model_monitoring_file_target_path(
+    return mlrun.mlconf.get_model_monitoring_file_target_path(
         project=project,
         kind=kind,
     )
-    return stats_path
 
 
 def _get_monitoring_current_stats_file_path(project: str, endpoint_id: str) -> str:
@@ -256,16 +254,16 @@ def _get_profile(
     :param profile_name_key: The profile name key in the secret store.
     :return:                 Datastore profile.
     """
-    profile_name = mlrun.get_secret_or_env(
+    if profile_name := mlrun.get_secret_or_env(
         key=profile_name_key, secret_provider=secret_provider
-    )
-    if not profile_name:
+    ):
+        return mlrun.datastore.datastore_profile.datastore_profile_read(
+            url=f"ds://{profile_name}", project_name=project, secrets=secret_provider
+        )
+    else:
         raise mlrun.errors.MLRunNotFoundError(
             f"Not found `{profile_name_key}` profile name for project '{project}'"
         )
-    return mlrun.datastore.datastore_profile.datastore_profile_read(
-        url=f"ds://{profile_name}", project_name=project, secrets=secret_provider
-    )
 
 
 _get_tsdb_profile = functools.partial(
@@ -637,7 +635,7 @@ def get_start_end(
         # If both start and end are provided, delta is ignored
         pass
     elif delta:
-        if start and not end:
+        if start:
             end = start + delta
         else:
             end = end or mlrun.utils.datetime_now()
@@ -683,3 +681,36 @@ def validate_time_range(
             "the current time is used by default."
         )
     return start, end
+
+
+# Aggregation interval helpers
+
+
+def parse_interval_to_minutes(interval: str) -> Optional[int]:
+    """
+    Parse interval string (e.g., '1h', '6h', '24h') to minutes.
+
+    :param interval: Interval string in format like "1h", "6h", "24h"
+    :return: Number of minutes, or None if format is invalid
+    """
+    if interval.endswith("h"):
+        try:
+            hours = int(interval[:-1])
+            return hours * 60
+        except ValueError:
+            return None
+    return None
+
+
+def build_interval_minutes_mapping(intervals: list[str]) -> dict[str, int]:
+    """
+    Build a mapping from interval strings to minutes.
+
+    :param intervals: List of interval strings (e.g., ["1h", "6h", "12h", "24h"])
+    :return: Dict mapping interval strings (e.g., "1h") to minutes (e.g., 60)
+    """
+    result = {}
+    for interval in intervals:
+        if minutes := parse_interval_to_minutes(interval):
+            result[interval] = minutes
+    return result

--- a/server/py/services/api/api/api.py
+++ b/server/py/services/api/api/api.py
@@ -41,6 +41,7 @@ from services.api.api.endpoints import (
     internal,
     logs,
     model_endpoints,
+    model_endpoints_v2,
     model_monitoring,
     nuclio,
     operations,
@@ -226,5 +227,10 @@ api_v2_router.include_router(
 api_v2_router.include_router(
     functions_v2.router,
     tags=["functions"],
+    dependencies=[Depends(deps.authenticate_request)],
+)
+api_v2_router.include_router(
+    model_endpoints_v2.router,
+    tags=["model-endpoints"],
     dependencies=[Depends(deps.authenticate_request)],
 )

--- a/server/py/services/api/api/endpoints/frontend_spec.py
+++ b/server/py/services/api/api/endpoints/frontend_spec.py
@@ -93,20 +93,21 @@ def get_frontend_spec(
             max_preview_size=config.artifacts.limits.max_preview_size,
             max_download_size=config.artifacts.limits.max_download_size,
         ),
+        model_endpoint_monitoring_tsdb_aggregation_supported=config.model_endpoint_monitoring.tsdb.pre_aggregate.enabled,
+        model_endpoint_monitoring_tsdb_aggregation_functions=config.model_endpoint_monitoring.tsdb.pre_aggregate.agg_functions,
+        model_endpoint_monitoring_tsdb_aggregation_intervals=config.model_endpoint_monitoring.tsdb.pre_aggregate.aggregate_intervals,
     )
 
 
 def try_get_grafana_service_url(session):
     if mlrun.mlconf.grafana_url:
         return mlrun.mlconf.grafana_url
-    else:
-        iguazio_client = framework.utils.clients.iguazio.v3.Client()
-        return iguazio_client.try_get_grafana_service_url(session)
+    iguazio_client = framework.utils.clients.iguazio.v3.Client()
+    return iguazio_client.try_get_grafana_service_url(session)
 
 
 def _resolve_jobs_dashboard_url(session: str) -> typing.Optional[str]:
-    grafana_service_url = try_get_grafana_service_url(session)
-    if grafana_service_url:
+    if grafana_service_url := try_get_grafana_service_url(session):
         # FIXME: this creates a heavy coupling between mlrun and the grafana dashboard (name and filters) + org id
         return (
             grafana_service_url
@@ -117,8 +118,7 @@ def _resolve_jobs_dashboard_url(session: str) -> typing.Optional[str]:
 
 
 def _resolve_model_monitoring_dashboard_url(session: str) -> typing.Optional[str]:
-    grafana_service_url = try_get_grafana_service_url(session)
-    if grafana_service_url:
+    if grafana_service_url := try_get_grafana_service_url(session):
         return grafana_service_url + (
             "/d/AohIXhAMk/model-monitoring-details?var-PROJECT={project}"
             "&var-MODELENDPOINT={model_endpoint}"

--- a/server/py/services/api/api/endpoints/model_endpoints.py
+++ b/server/py/services/api/api/endpoints/model_endpoints.py
@@ -339,7 +339,7 @@ async def _collect_get_metrics_tasks_results(
     metrics_format=mm_constants.GetEventsFormat.SINGLE,
 ) -> list:
     tasks: list[asyncio.Task] = []
-    if application_result_types == "results" or application_result_types == "all":
+    if application_result_types in {"results", "all"}:
         tasks.append(
             asyncio.create_task(
                 run_in_threadpool(
@@ -351,7 +351,7 @@ async def _collect_get_metrics_tasks_results(
                 )
             )
         )
-    if application_result_types == "metrics" or application_result_types == "all":
+    if application_result_types in {"metrics", "all"}:
         tasks.append(
             asyncio.create_task(
                 run_in_threadpool(
@@ -395,7 +395,7 @@ async def get_model_endpoint_monitoring_metrics(
     )
     for task_result in task_results:
         metrics.extend(task_result)
-    if type == "metrics" or type == "all":
+    if type in ["metrics", "all"]:
         metrics.append(mlrun.model_monitoring.helpers.get_invocations_metric(project))
     return metrics
 
@@ -434,18 +434,16 @@ async def get_metrics_by_multiple_endpoints(
     """
     events_format = events_format or mm_constants.GetEventsFormat.SEPARATION
     events = {}
-    permissions_tasks = []
-    is_metrics_supported = type == "metrics" or type == "all"
+    is_metrics_supported = type in ["metrics", "all"]
     if isinstance(endpoint_ids, str):
         endpoint_ids = [endpoint_ids]
 
-    for endpoint_id in endpoint_ids:
-        permissions_tasks.append(
-            _verify_model_endpoint_read_permission(
-                project=project, name_or_uid=endpoint_id, auth_info=auth_info
-            )
+    permissions_tasks = [
+        _verify_model_endpoint_read_permission(
+            project=project, name_or_uid=endpoint_id, auth_info=auth_info
         )
-
+        for endpoint_id in endpoint_ids
+    ]
     await asyncio.gather(*permissions_tasks)
 
     # verify all endpoints exist in the project
@@ -480,7 +478,7 @@ async def get_metrics_by_multiple_endpoints(
 
     elif events_format == mm_constants.GetEventsFormat.INTERSECTION:
         for task_result in task_results:
-            events.update(task_result)
+            events |= task_result
         if is_metrics_supported:
             metrics_key = mm_constants.INTERSECT_DICT_KEYS[
                 mm_constants.ModelEndpointMonitoringMetricType.METRIC
@@ -706,6 +704,7 @@ async def get_model_endpoint_monitoring_metrics_values(
                         end=params.end,
                         metrics=metrics_without_invocations,
                         type=type,
+                        agg_period="raw",
                     )
                 )
 

--- a/server/py/services/api/api/endpoints/model_endpoints_v2.py
+++ b/server/py/services/api/api/endpoints/model_endpoints_v2.py
@@ -21,12 +21,16 @@ from typing import Annotated, Literal, Optional, Union
 from fastapi import APIRouter, Depends, Query
 from fastapi.concurrency import run_in_threadpool
 
+import mlrun
 import mlrun.common.schemas as schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
 import mlrun.errors
 import mlrun.model_monitoring
-from mlrun.model_monitoring.helpers import validate_time_range
+from mlrun.model_monitoring.helpers import (
+    build_interval_minutes_mapping,
+    validate_time_range,
+)
 from mlrun.utils import logger
 
 import framework.api.deps
@@ -38,6 +42,55 @@ from .model_endpoints import _verify_model_endpoint_read_permission
 _MAX_RESULTS_PER_METRIC = 500
 
 router = APIRouter()
+
+# Singleton cache for sorted interval-to-minutes list (built from config on first use)
+_sorted_intervals_cache: Optional[list[tuple[str, int]]] = None
+
+
+def _get_sorted_intervals_from_config() -> list[tuple[str, int]]:
+    """
+    Get sorted list of (interval, minutes) tuples from mlrun config (singleton).
+
+    The list is built once from config.model_endpoint_monitoring.tsdb.pre_aggregate.aggregate_intervals
+    and sorted by duration (smallest first).
+
+    :return: List of (interval_name, minutes) tuples sorted by duration
+    """
+    global _sorted_intervals_cache
+    if _sorted_intervals_cache is None:
+        intervals = list(
+            mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.aggregate_intervals
+        )
+        interval_minutes = build_interval_minutes_mapping(intervals)
+        _sorted_intervals_cache = sorted(interval_minutes.items(), key=lambda x: x[1])
+    return _sorted_intervals_cache
+
+
+def _determine_optimal_period(start: datetime, end: datetime) -> Optional[str]:
+    """
+    Determine optimal aggregation period based on time range and configured intervals.
+
+    Selects the smallest interval that keeps results under _MAX_RESULTS_PER_METRIC.
+
+    :param start: Start datetime
+    :param end: End datetime
+    :return: Optimal interval string, or None if no intervals configured
+    """
+    sorted_intervals = _get_sorted_intervals_from_config()
+    if not sorted_intervals:
+        return None
+
+    time_range_minutes = (end - start).total_seconds() / 60
+
+    # Find smallest interval that keeps results under limit
+    for interval_name, minutes in sorted_intervals:
+        expected_results = time_range_minutes / minutes
+        if expected_results <= _MAX_RESULTS_PER_METRIC:
+            return interval_name
+
+    # If all intervals exceed limit, use largest available
+    return sorted_intervals[-1][0]
+
 
 ProjectAnnotation = api_constants.ProjectAnnotation
 EndpointIDAnnotation = api_constants.EndpointIDAnnotation
@@ -182,9 +235,24 @@ async def get_model_endpoint_monitoring_metrics_values_v2(
         )
         return []
 
-    # Pass user's requested values directly to query methods
-    # Query methods will auto-select period if None, and handle default functions
+    # Resolve aggregation period:
+    # - None (not specified): auto-select optimal period based on time range and config
+    # - "raw": explicitly no aggregation (pass None to query methods)
+    # - specific period ("1h", "6h", etc.): use that period
     agg_period = params.agg_period_requested
+    if agg_period is None:
+        # Auto-select optimal period based on time range and configured intervals
+        agg_period = _determine_optimal_period(params.start, params.end)
+        if agg_period is None:
+            logger.debug(
+                "Auto-selection could not determine optimal period, falling back to raw data",
+                start=params.start,
+                end=params.end,
+            )
+    elif agg_period == "raw":
+        # User explicitly requested raw data - pass None to query methods
+        agg_period = None
+
     agg_functions = params.agg_functions_requested
 
     for metrics, type in [(params.results, "results"), (params.metrics, "metrics")]:

--- a/server/py/services/api/api/endpoints/model_endpoints_v2.py
+++ b/server/py/services/api/api/endpoints/model_endpoints_v2.py
@@ -280,7 +280,7 @@ async def get_model_endpoint_monitoring_metrics_values_v2(
             if metrics_without_invocations:
                 coroutines.append(
                     run_in_threadpool(
-                        tsdb_connector.read_metrics_data,
+                        tsdb_connector.read_metrics_data_v2,
                         endpoint_id=params.endpoint_id,
                         start=params.start,
                         end=params.end,

--- a/server/py/services/api/api/endpoints/model_endpoints_v2.py
+++ b/server/py/services/api/api/endpoints/model_endpoints_v2.py
@@ -1,0 +1,242 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from collections.abc import Coroutine
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Annotated, Literal, Optional, Union
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.concurrency import run_in_threadpool
+
+import mlrun.common.schemas as schemas
+import mlrun.common.schemas.model_monitoring.constants as mm_constants
+import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
+import mlrun.errors
+import mlrun.model_monitoring
+from mlrun.model_monitoring.helpers import validate_time_range
+from mlrun.utils import logger
+
+import framework.api.deps
+import services.api.common.constants as api_constants
+import services.api.crud
+from .model_endpoints import _verify_model_endpoint_read_permission
+
+# Hard limit for results per metric in v2 API
+_MAX_RESULTS_PER_METRIC = 500
+
+router = APIRouter()
+
+ProjectAnnotation = api_constants.ProjectAnnotation
+EndpointIDAnnotation = api_constants.EndpointIDAnnotation
+
+
+@dataclass
+class _MetricsValuesParamsV2:
+    """Parameters for v2 metrics-values endpoint with aggregation support."""
+
+    project: str
+    endpoint_id: str
+    metrics: list[mm_endpoints.ModelEndpointMonitoringMetric]
+    results: list[mm_endpoints.ModelEndpointMonitoringMetric]
+    start: datetime
+    end: datetime
+    agg_period_requested: Optional[str]  # User's raw input: None, "raw", "1h", etc.
+    agg_functions_requested: Optional[list[str]]  # User's raw input
+
+
+async def _get_metrics_values_params_v2(
+    project: ProjectAnnotation,
+    endpoint_id: EndpointIDAnnotation,
+    name: Annotated[
+        list[str],
+        Query(pattern=mm_constants.FQN_PATTERN),
+    ],
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    agg_period: Annotated[
+        Optional[Literal["1h", "6h", "12h", "24h", "raw"]],
+        Query(alias="agg-period"),
+    ] = None,
+    agg_functions: Annotated[
+        Optional[list[Literal["avg", "min", "max", "count"]]],
+        Query(alias="agg-function"),
+    ] = None,
+    auth_info: schemas.AuthInfo = Depends(framework.api.deps.authenticate_request),
+) -> _MetricsValuesParamsV2:
+    """
+    Verify authorization, validate parameters and initialize the parameters for v2 API.
+
+    :param project:       The name of the project.
+    :param endpoint_id:   The unique id of the model endpoint.
+    :param name:          The full names of the requested results. At least one is required.
+    :param start:         Start time (optional, timezone aware).
+    :param end:           End time (optional, timezone aware).
+    :param agg_period:    Aggregation period:
+                          "raw" explicitly requests non-aggregated data.
+                          None triggers auto-selection based on configured intervals.
+    :param agg_functions: Aggregation functions:
+                          Defaults to ["avg"] when agg_period is specified.
+    :param auth_info:     The auth info of the request.
+
+    :return: _MetricsValuesParamsV2 object with the validated data.
+    """
+    await _verify_model_endpoint_read_permission(
+        project=project, name_or_uid=endpoint_id, auth_info=auth_info
+    )
+    start, end = validate_time_range(start, end)
+
+    metrics = []
+    results = []
+    for fqn in name:
+        metric = mm_endpoints._parse_metric_fqn_to_monitoring_metric(fqn)
+        if metric.project != project:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Metric '{fqn}' does not belong to the project '{project}' given "
+                f"in the API path, but to the project '{metric.project}'."
+            )
+        if metric.type == mm_constants.ModelEndpointMonitoringMetricType.METRIC:
+            metrics.append(metric)
+        else:
+            results.append(metric)
+
+    return _MetricsValuesParamsV2(
+        project=project,
+        endpoint_id=endpoint_id,
+        metrics=metrics,
+        results=results,
+        start=start,
+        end=end,
+        agg_period_requested=agg_period,
+        agg_functions_requested=list(agg_functions) if agg_functions else None,
+    )
+
+
+async def _wrap_coroutine_in_list(x):
+    return [await x]
+
+
+@router.get(
+    "/projects/{project}/model-endpoints/{endpoint_id}/metrics-values",
+    response_model=list[
+        Union[
+            mm_endpoints.ModelEndpointMonitoringMetricValuesV2,
+            mm_endpoints.ModelEndpointMonitoringResultValuesV2,
+            mm_endpoints.ModelEndpointMonitoringMetricNoData,
+        ]
+    ],
+)
+async def get_model_endpoint_monitoring_metrics_values_v2(
+    params: Annotated[_MetricsValuesParamsV2, Depends(_get_metrics_values_params_v2)],
+) -> list[
+    Union[
+        mm_endpoints.ModelEndpointMonitoringMetricValuesV2,
+        mm_endpoints.ModelEndpointMonitoringResultValuesV2,
+        mm_endpoints.ModelEndpointMonitoringMetricNoData,
+    ]
+]:
+    """
+    Get model endpoint monitoring metrics/results values with v2 response format.
+
+    The v2 API adds aggregation support:
+    - `agg-period`: Aggregation period
+    - `agg-function`: Aggregation functions
+
+    When `agg-period` is omitted, auto-selection uses PreAggregateManager to choose
+    the best available interval based on the time range and configured intervals.
+
+    Response includes `aggregation_config` with aggregation metadata.
+
+    :param params: A combined object with all the request parameters.
+    :returns:      A list of the results values for this model endpoint with v2 schema.
+    """
+    coroutines: list[Coroutine] = []
+
+    invocations_full_name = mlrun.model_monitoring.helpers.get_invocations_fqn(
+        params.project
+    )
+    try:
+        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+            project=params.project,
+            secret_provider=services.api.crud.secrets.get_project_secret_provider(
+                project=params.project
+            ),
+        )
+    except mlrun.errors.MLRunNotFoundError as e:
+        logger.debug(
+            "Failed to retrieve model endpoint metrics-values because the TSDB datastore profile was not found. "
+            "Returning an empty list of metric-values",
+            error=mlrun.errors.err_to_str(e),
+        )
+        return []
+
+    # Pass user's requested values directly to query methods
+    # Query methods will auto-select period if None, and handle default functions
+    agg_period = params.agg_period_requested
+    agg_functions = params.agg_functions_requested
+
+    for metrics, type in [(params.results, "results"), (params.metrics, "metrics")]:
+        if metrics:
+            metrics_without_invocations = list(
+                filter(
+                    lambda metric: metric.full_name != invocations_full_name, metrics
+                )
+            )
+            if len(metrics_without_invocations) != len(metrics):
+                # Handle invocations separately using read_predictions
+                # Use the same aggregation settings as other metrics
+                coroutines.append(
+                    _wrap_coroutine_in_list(
+                        run_in_threadpool(
+                            tsdb_connector.read_predictions,
+                            endpoint_id=params.endpoint_id,
+                            start=params.start,
+                            end=params.end,
+                            aggregation_window=agg_period,
+                            agg_funcs=agg_functions or None,
+                        )
+                    )
+                )
+            if metrics_without_invocations:
+                coroutines.append(
+                    run_in_threadpool(
+                        tsdb_connector.read_metrics_data,
+                        endpoint_id=params.endpoint_id,
+                        start=params.start,
+                        end=params.end,
+                        metrics=metrics_without_invocations,
+                        type=type,
+                        agg_period=agg_period,
+                        agg_functions=agg_functions,
+                    )
+                )
+
+    metrics_values = []
+    for result in await asyncio.gather(*coroutines):
+        metrics_values.extend(result)
+
+    # Validate result count - hard limit of 500 results per metric
+    for metric_value in metrics_values:
+        if (
+            hasattr(metric_value, "values")
+            and len(metric_value.values) > _MAX_RESULTS_PER_METRIC
+        ):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Metric '{metric_value.full_name}' returned {len(metric_value.values)} results, "
+                f"which exceeds the maximum allowed ({_MAX_RESULTS_PER_METRIC}). "
+                f"Please use a larger aggregation period or narrow the time range."
+            )
+
+    return metrics_values

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -124,6 +124,18 @@ class ClientSpec(
             authentication_mode=self._get_config_value_if_not_default(
                 "httpdb.authentication.mode"
             ),
+            model_endpoint_monitoring_tsdb_aggregation_supported=self._get_config_value_if_not_default(
+                "model_endpoint_monitoring.tsdb.pre_aggregate.enabled"
+            ),
+            model_endpoint_monitoring_tsdb_retention_policy=self._get_config_value_if_not_default(
+                "model_endpoint_monitoring.tsdb.pre_aggregate.retention_policy"
+            ),
+            model_endpoint_monitoring_tsdb_aggregation_functions=self._get_config_value_if_not_default(
+                "model_endpoint_monitoring.tsdb.pre_aggregate.agg_functions"
+            ),
+            model_endpoint_monitoring_tsdb_aggregation_intervals=self._get_config_value_if_not_default(
+                "model_endpoint_monitoring.tsdb.pre_aggregate.aggregate_intervals"
+            ),
         )
 
     @staticmethod

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -150,6 +150,44 @@ def test_client_spec(
     assert response_body["alerts_mode"] == "disabled"
     assert response_body["system_id"] == "12345"
 
+    # Test model endpoint monitoring TSDB aggregation fields
+    # These should be None when using default config (since _get_config_value_if_not_default returns None for defaults)
+    # Let's set non-default values to verify they're returned
+    mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.enabled = False
+    mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.agg_functions = [
+        "avg",
+        "max",
+    ]
+    mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.aggregate_intervals = [
+        "1h",
+        "6h",
+    ]
+    mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.retention_policy = {
+        "raw": "7d",
+        "1h": "30d",
+    }
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    response_body = response.json()
+
+    assert (
+        response_body["model_endpoint_monitoring_tsdb_aggregation_supported"] is False
+    )
+    assert response_body["model_endpoint_monitoring_tsdb_aggregation_functions"] == [
+        "avg",
+        "max",
+    ]
+    assert response_body["model_endpoint_monitoring_tsdb_aggregation_intervals"] == [
+        "1h",
+        "6h",
+    ]
+    assert response_body["model_endpoint_monitoring_tsdb_retention_policy"] == {
+        "raw": "7d",
+        "1h": "30d",
+    }
+
 
 @pytest.mark.parametrize(
     "server_version, client_version, python_version, expected_dask_kfp",
@@ -232,7 +270,7 @@ def test_get_client_spec_cached(
     ) as mocked_get_client:
         response = client.get("client-spec")
         assert response.status_code == http.HTTPStatus.OK.value
-        for i in range(10):
+        for _ in range(10):
             cached_response = client.get("client-spec")
         assert response.json() == cached_response.json()
         assert mocked_get_client.call_count == 1

--- a/server/py/services/api/tests/unit/api/test_frontend_spec.py
+++ b/server/py/services/api/tests/unit/api/test_frontend_spec.py
@@ -114,6 +114,20 @@ def test_get_frontend_spec(
 
     assert frontend_spec.internal_labels == mlrun.mlconf.internal_labels()
 
+    # Test model endpoint monitoring TSDB aggregation fields
+    assert (
+        frontend_spec.model_endpoint_monitoring_tsdb_aggregation_supported
+        == mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.enabled
+    )
+    assert (
+        frontend_spec.model_endpoint_monitoring_tsdb_aggregation_functions
+        == mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.agg_functions
+    )
+    assert (
+        frontend_spec.model_endpoint_monitoring_tsdb_aggregation_intervals
+        == mlrun.mlconf.model_endpoint_monitoring.tsdb.pre_aggregate.aggregate_intervals
+    )
+
 
 def test_get_frontend_spec_jobs_dashboard_url_resolution(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient

--- a/tests/model_monitoring/db/tsdb/test_base_v2.py
+++ b/tests/model_monitoring/db/tsdb/test_base_v2.py
@@ -169,42 +169,6 @@ class TestDfToMetricsValuesV2:
         )
         assert result[0] == expected
 
-    def test_metrics_v2_raw_period_treated_as_not_aggregated(self):
-        """Test that agg_period='raw' is treated as non-aggregated."""
-        df = self._create_metrics_df(
-            [
-                {
-                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
-                    WriterEvent.APPLICATION_NAME: "my-app",
-                    MetricData.METRIC_NAME: "latency",
-                    MetricData.METRIC_VALUE: 10.5,
-                },
-            ]
-        )
-
-        metrics = [self._create_metric("test-project", "my-app", "latency")]
-
-        result = TSDBConnector.df_to_metrics_values_v2(
-            df=df,
-            metrics=metrics,
-            project="test-project",
-            agg_period="raw",
-            agg_functions=None,
-        )
-
-        assert len(result) == 1
-        expected = ModelEndpointMonitoringMetricValuesV2(
-            full_name="test-project.my-app.metric.latency",
-            type=ModelEndpointMonitoringMetricType.METRIC,
-            data=True,
-            aggregation_config=AggregationConfig(
-                aggregated=False, period=None, functions=None
-            ),
-            # Raw format: [timestamp, value]
-            values=[[pd.Timestamp("2025-01-01 00:00:00"), 10.5]],
-        )
-        assert result[0] == expected
-
     def test_metrics_v2_raises_error_when_aggregated_column_missing(self):
         """Test that an error is raised when expected aggregated column is missing."""
         # DataFrame with raw data but we claim it's aggregated
@@ -320,8 +284,8 @@ class TestDfToResultsValuesV2:
         )
         assert result[0] == expected
 
-    def test_results_v2_aggregated_data_no_status_or_extra_data(self):
-        """Test that aggregated results do NOT include status or extra_data."""
+    def test_results_v2_aggregated_data_with_max_status(self):
+        """Test that aggregated results include max_status but NOT extra_data."""
         df = self._create_results_df(
             [
                 {
@@ -330,6 +294,7 @@ class TestDfToResultsValuesV2:
                     ResultData.RESULT_NAME: "general_drift",
                     f"avg_{ResultData.RESULT_VALUE}": 0.20,
                     f"max_{ResultData.RESULT_VALUE}": 0.35,
+                    f"max_{ResultData.RESULT_STATUS}": 0,  # max status in period
                     ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
                 },
                 {
@@ -338,6 +303,7 @@ class TestDfToResultsValuesV2:
                     ResultData.RESULT_NAME: "general_drift",
                     f"avg_{ResultData.RESULT_VALUE}": 0.50,
                     f"max_{ResultData.RESULT_VALUE}": 0.85,
+                    f"max_{ResultData.RESULT_STATUS}": 2,  # detection in this period
                     ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
                 },
             ]
@@ -364,10 +330,10 @@ class TestDfToResultsValuesV2:
             aggregation_config=AggregationConfig(
                 aggregated=True, period="1h", functions=["avg", "max"]
             ),
-            # Aggregated format: [timestamp, avg, max] - NO status, NO extra_data
+            # Aggregated format: [timestamp, avg, max, max_status] - NO extra_data
             values=[
-                [pd.Timestamp("2025-01-01 00:00:00"), 0.20, 0.35],
-                [pd.Timestamp("2025-01-01 01:00:00"), 0.50, 0.85],
+                [pd.Timestamp("2025-01-01 00:00:00"), 0.20, 0.35, 0],
+                [pd.Timestamp("2025-01-01 01:00:00"), 0.50, 0.85, 2],
             ],
         )
         assert result[0] == expected
@@ -392,50 +358,6 @@ class TestDfToResultsValuesV2:
             full_name="test-project.drift-app.result.general_drift",
             type=ModelEndpointMonitoringMetricType.RESULT,
             data=False,
-        )
-        assert result[0] == expected
-
-    def test_results_v2_raw_period_treated_as_not_aggregated(self):
-        """Test that agg_period='raw' is treated as non-aggregated."""
-        df = self._create_results_df(
-            [
-                {
-                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
-                    WriterEvent.APPLICATION_NAME: "drift-app",
-                    ResultData.RESULT_NAME: "general_drift",
-                    ResultData.RESULT_VALUE: 0.15,
-                    ResultData.RESULT_STATUS: 0,
-                    ResultData.RESULT_EXTRA_DATA: '{"info": "test"}',
-                    ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
-                },
-            ]
-        )
-
-        metrics = [
-            self._create_result_metric("test-project", "drift-app", "general_drift")
-        ]
-
-        result = TSDBConnector.df_to_results_values_v2(
-            df=df,
-            metrics=metrics,
-            project="test-project",
-            agg_period="raw",
-            agg_functions=None,
-        )
-
-        assert len(result) == 1
-        expected = ModelEndpointMonitoringResultValuesV2(
-            full_name="test-project.drift-app.result.general_drift",
-            type=ModelEndpointMonitoringMetricType.RESULT,
-            result_kind=ResultKindApp.data_drift,
-            data=True,
-            aggregation_config=AggregationConfig(
-                aggregated=False, period=None, functions=None
-            ),
-            # Raw format: [timestamp, value, status, extra_data]
-            values=[
-                [pd.Timestamp("2025-01-01 00:00:00"), 0.15, 0, '{"info": "test"}'],
-            ],
         )
         assert result[0] == expected
 

--- a/tests/model_monitoring/db/tsdb/test_base_v2.py
+++ b/tests/model_monitoring/db/tsdb/test_base_v2.py
@@ -1,0 +1,473 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for v2 DataFrame conversion helpers in TSDB base module (ML-11445)."""
+
+import pandas as pd
+import pytest
+
+import mlrun.errors
+from mlrun.common.schemas.model_monitoring import (
+    AggregationConfig,
+    ModelEndpointMonitoringMetric,
+    ModelEndpointMonitoringMetricNoData,
+    ModelEndpointMonitoringMetricValuesV2,
+    ModelEndpointMonitoringResultValuesV2,
+)
+from mlrun.common.schemas.model_monitoring.constants import (
+    MetricData,
+    ModelEndpointMonitoringMetricType,
+    ResultData,
+    ResultKindApp,
+    WriterEvent,
+)
+from mlrun.model_monitoring.db.tsdb.base import TSDBConnector
+
+
+class TestDfToMetricsValuesV2:
+    """Tests for df_to_metrics_values_v2 conversion helper."""
+
+    def _create_metrics_df(self, data: list[dict]) -> pd.DataFrame:
+        """Create a time-indexed DataFrame with metric data."""
+        df = pd.DataFrame(data)
+        df[WriterEvent.END_INFER_TIME] = pd.to_datetime(df[WriterEvent.END_INFER_TIME])
+        df.set_index(WriterEvent.END_INFER_TIME, inplace=True)
+        return df
+
+    def _create_metric(
+        self, project: str, app: str, name: str
+    ) -> ModelEndpointMonitoringMetric:
+        """Create a ModelEndpointMonitoringMetric."""
+        return ModelEndpointMonitoringMetric(
+            project=project,
+            app=app,
+            type=ModelEndpointMonitoringMetricType.METRIC,
+            name=name,
+        )
+
+    def test_metrics_v2_raw_data(self):
+        """Test conversion of raw (non-aggregated) metric data."""
+        df = self._create_metrics_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "my-app",
+                    MetricData.METRIC_NAME: "latency",
+                    MetricData.METRIC_VALUE: 10.5,
+                },
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 01:00:00",
+                    WriterEvent.APPLICATION_NAME: "my-app",
+                    MetricData.METRIC_NAME: "latency",
+                    MetricData.METRIC_VALUE: 12.3,
+                },
+            ]
+        )
+
+        metrics = [self._create_metric("test-project", "my-app", "latency")]
+
+        result = TSDBConnector.df_to_metrics_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period=None,
+            agg_functions=None,
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringMetricValuesV2(
+            full_name="test-project.my-app.metric.latency",
+            type=ModelEndpointMonitoringMetricType.METRIC,
+            data=True,
+            aggregation_config=AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            # Raw format: [timestamp, value]
+            values=[
+                [pd.Timestamp("2025-01-01 00:00:00"), 10.5],
+                [pd.Timestamp("2025-01-01 01:00:00"), 12.3],
+            ],
+        )
+        assert result[0] == expected
+
+    def test_metrics_v2_aggregated_data(self):
+        """Test conversion of aggregated metric data."""
+        df = self._create_metrics_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "my-app",
+                    MetricData.METRIC_NAME: "latency",
+                    f"avg_{MetricData.METRIC_VALUE}": 10.0,
+                    f"max_{MetricData.METRIC_VALUE}": 15.0,
+                },
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 01:00:00",
+                    WriterEvent.APPLICATION_NAME: "my-app",
+                    MetricData.METRIC_NAME: "latency",
+                    f"avg_{MetricData.METRIC_VALUE}": 12.0,
+                    f"max_{MetricData.METRIC_VALUE}": 18.0,
+                },
+            ]
+        )
+
+        metrics = [self._create_metric("test-project", "my-app", "latency")]
+
+        result = TSDBConnector.df_to_metrics_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period="1h",
+            agg_functions=["avg", "max"],
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringMetricValuesV2(
+            full_name="test-project.my-app.metric.latency",
+            type=ModelEndpointMonitoringMetricType.METRIC,
+            data=True,
+            aggregation_config=AggregationConfig(
+                aggregated=True, period="1h", functions=["avg", "max"]
+            ),
+            # Aggregated format: [timestamp, avg, max]
+            values=[
+                [pd.Timestamp("2025-01-01 00:00:00"), 10.0, 15.0],
+                [pd.Timestamp("2025-01-01 01:00:00"), 12.0, 18.0],
+            ],
+        )
+        assert result[0] == expected
+
+    def test_metrics_v2_empty_df(self):
+        """Test conversion with empty DataFrame returns no-data objects."""
+        df = pd.DataFrame()
+        metrics = [self._create_metric("test-project", "my-app", "latency")]
+
+        result = TSDBConnector.df_to_metrics_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period=None,
+            agg_functions=None,
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringMetricNoData(
+            full_name="test-project.my-app.metric.latency",
+            type=ModelEndpointMonitoringMetricType.METRIC,
+            data=False,
+        )
+        assert result[0] == expected
+
+    def test_metrics_v2_raw_period_treated_as_not_aggregated(self):
+        """Test that agg_period='raw' is treated as non-aggregated."""
+        df = self._create_metrics_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "my-app",
+                    MetricData.METRIC_NAME: "latency",
+                    MetricData.METRIC_VALUE: 10.5,
+                },
+            ]
+        )
+
+        metrics = [self._create_metric("test-project", "my-app", "latency")]
+
+        result = TSDBConnector.df_to_metrics_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period="raw",
+            agg_functions=None,
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringMetricValuesV2(
+            full_name="test-project.my-app.metric.latency",
+            type=ModelEndpointMonitoringMetricType.METRIC,
+            data=True,
+            aggregation_config=AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            # Raw format: [timestamp, value]
+            values=[[pd.Timestamp("2025-01-01 00:00:00"), 10.5]],
+        )
+        assert result[0] == expected
+
+    def test_metrics_v2_raises_error_when_aggregated_column_missing(self):
+        """Test that an error is raised when expected aggregated column is missing."""
+        # DataFrame with raw data but we claim it's aggregated
+        df = self._create_metrics_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "my-app",
+                    MetricData.METRIC_NAME: "latency",
+                    MetricData.METRIC_VALUE: 10.5,  # raw column, not aggregated
+                },
+            ]
+        )
+
+        metrics = [self._create_metric("test-project", "my-app", "latency")]
+
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+            TSDBConnector.df_to_metrics_values_v2(
+                df=df,
+                metrics=metrics,
+                project="test-project",
+                agg_period="1h",
+                agg_functions=["avg", "max"],
+            )
+
+        assert "avg_metric_value" in str(exc_info.value)
+        assert "not found in DataFrame" in str(exc_info.value)
+
+
+class TestDfToResultsValuesV2:
+    """Tests for df_to_results_values_v2 conversion helper."""
+
+    def _create_results_df(self, data: list[dict]) -> pd.DataFrame:
+        """Create a time-indexed DataFrame with result data."""
+        df = pd.DataFrame(data)
+        df[WriterEvent.END_INFER_TIME] = pd.to_datetime(df[WriterEvent.END_INFER_TIME])
+        df.set_index(WriterEvent.END_INFER_TIME, inplace=True)
+        return df
+
+    def _create_result_metric(
+        self, project: str, app: str, name: str
+    ) -> ModelEndpointMonitoringMetric:
+        """Create a ModelEndpointMonitoringMetric for results."""
+        return ModelEndpointMonitoringMetric(
+            project=project,
+            app=app,
+            type=ModelEndpointMonitoringMetricType.RESULT,
+            name=name,
+            kind=ResultKindApp.data_drift,
+        )
+
+    def test_results_v2_raw_data(self):
+        """Test conversion of raw (non-aggregated) result data with status and extra_data."""
+        df = self._create_results_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "drift-app",
+                    ResultData.RESULT_NAME: "general_drift",
+                    ResultData.RESULT_VALUE: 0.15,
+                    ResultData.RESULT_STATUS: 0,
+                    ResultData.RESULT_EXTRA_DATA: '{"detail": "no drift"}',
+                    ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
+                },
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 01:00:00",
+                    WriterEvent.APPLICATION_NAME: "drift-app",
+                    ResultData.RESULT_NAME: "general_drift",
+                    ResultData.RESULT_VALUE: 0.85,
+                    ResultData.RESULT_STATUS: 2,
+                    ResultData.RESULT_EXTRA_DATA: '{"detail": "drift detected"}',
+                    ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
+                },
+            ]
+        )
+
+        metrics = [
+            self._create_result_metric("test-project", "drift-app", "general_drift")
+        ]
+
+        result = TSDBConnector.df_to_results_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period=None,
+            agg_functions=None,
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringResultValuesV2(
+            full_name="test-project.drift-app.result.general_drift",
+            type=ModelEndpointMonitoringMetricType.RESULT,
+            result_kind=ResultKindApp.data_drift,
+            data=True,
+            aggregation_config=AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            # Raw format: [timestamp, value, status, extra_data]
+            values=[
+                [
+                    pd.Timestamp("2025-01-01 00:00:00"),
+                    0.15,
+                    0,
+                    '{"detail": "no drift"}',
+                ],
+                [
+                    pd.Timestamp("2025-01-01 01:00:00"),
+                    0.85,
+                    2,
+                    '{"detail": "drift detected"}',
+                ],
+            ],
+        )
+        assert result[0] == expected
+
+    def test_results_v2_aggregated_data_no_status_or_extra_data(self):
+        """Test that aggregated results do NOT include status or extra_data."""
+        df = self._create_results_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "drift-app",
+                    ResultData.RESULT_NAME: "general_drift",
+                    f"avg_{ResultData.RESULT_VALUE}": 0.20,
+                    f"max_{ResultData.RESULT_VALUE}": 0.35,
+                    ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
+                },
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 01:00:00",
+                    WriterEvent.APPLICATION_NAME: "drift-app",
+                    ResultData.RESULT_NAME: "general_drift",
+                    f"avg_{ResultData.RESULT_VALUE}": 0.50,
+                    f"max_{ResultData.RESULT_VALUE}": 0.85,
+                    ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
+                },
+            ]
+        )
+
+        metrics = [
+            self._create_result_metric("test-project", "drift-app", "general_drift")
+        ]
+
+        result = TSDBConnector.df_to_results_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period="1h",
+            agg_functions=["avg", "max"],
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringResultValuesV2(
+            full_name="test-project.drift-app.result.general_drift",
+            type=ModelEndpointMonitoringMetricType.RESULT,
+            result_kind=ResultKindApp.data_drift,
+            data=True,
+            aggregation_config=AggregationConfig(
+                aggregated=True, period="1h", functions=["avg", "max"]
+            ),
+            # Aggregated format: [timestamp, avg, max] - NO status, NO extra_data
+            values=[
+                [pd.Timestamp("2025-01-01 00:00:00"), 0.20, 0.35],
+                [pd.Timestamp("2025-01-01 01:00:00"), 0.50, 0.85],
+            ],
+        )
+        assert result[0] == expected
+
+    def test_results_v2_empty_df(self):
+        """Test conversion with empty DataFrame returns no-data objects."""
+        df = pd.DataFrame()
+        metrics = [
+            self._create_result_metric("test-project", "drift-app", "general_drift")
+        ]
+
+        result = TSDBConnector.df_to_results_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period=None,
+            agg_functions=None,
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringMetricNoData(
+            full_name="test-project.drift-app.result.general_drift",
+            type=ModelEndpointMonitoringMetricType.RESULT,
+            data=False,
+        )
+        assert result[0] == expected
+
+    def test_results_v2_raw_period_treated_as_not_aggregated(self):
+        """Test that agg_period='raw' is treated as non-aggregated."""
+        df = self._create_results_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "drift-app",
+                    ResultData.RESULT_NAME: "general_drift",
+                    ResultData.RESULT_VALUE: 0.15,
+                    ResultData.RESULT_STATUS: 0,
+                    ResultData.RESULT_EXTRA_DATA: '{"info": "test"}',
+                    ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
+                },
+            ]
+        )
+
+        metrics = [
+            self._create_result_metric("test-project", "drift-app", "general_drift")
+        ]
+
+        result = TSDBConnector.df_to_results_values_v2(
+            df=df,
+            metrics=metrics,
+            project="test-project",
+            agg_period="raw",
+            agg_functions=None,
+        )
+
+        assert len(result) == 1
+        expected = ModelEndpointMonitoringResultValuesV2(
+            full_name="test-project.drift-app.result.general_drift",
+            type=ModelEndpointMonitoringMetricType.RESULT,
+            result_kind=ResultKindApp.data_drift,
+            data=True,
+            aggregation_config=AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            # Raw format: [timestamp, value, status, extra_data]
+            values=[
+                [pd.Timestamp("2025-01-01 00:00:00"), 0.15, 0, '{"info": "test"}'],
+            ],
+        )
+        assert result[0] == expected
+
+    def test_results_v2_raises_error_when_aggregated_column_missing(self):
+        """Test that an error is raised when expected aggregated column is missing."""
+        # DataFrame with raw data but we claim it's aggregated
+        df = self._create_results_df(
+            [
+                {
+                    WriterEvent.END_INFER_TIME: "2025-01-01 00:00:00",
+                    WriterEvent.APPLICATION_NAME: "drift-app",
+                    ResultData.RESULT_NAME: "general_drift",
+                    ResultData.RESULT_VALUE: 0.15,  # raw column, not aggregated
+                    ResultData.RESULT_STATUS: 0,
+                    ResultData.RESULT_EXTRA_DATA: "",
+                    ResultData.RESULT_KIND: ResultKindApp.data_drift.value,
+                },
+            ]
+        )
+
+        metrics = [
+            self._create_result_metric("test-project", "drift-app", "general_drift")
+        ]
+
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+            TSDBConnector.df_to_results_values_v2(
+                df=df,
+                metrics=metrics,
+                project="test-project",
+                agg_period="1h",
+                agg_functions=["avg", "max"],
+            )
+
+        assert "avg_result_value" in str(exc_info.value)
+        assert "not found in DataFrame" in str(exc_info.value)

--- a/tests/model_monitoring/db/tsdb/timescaledb/conftest.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/conftest.py
@@ -27,9 +27,7 @@ def is_timescaledb_available():
     """Check if TimescaleDB connection is available and valid."""
     if not CONNECTION_STRING:
         return False
-    if not CONNECTION_STRING.startswith("postgres"):
-        return False
-    return True
+    return bool(CONNECTION_STRING.startswith("postgres"))
 
 
 # Import TimescaleDB modules only if available
@@ -56,6 +54,7 @@ if is_timescaledb_available():
         TimescaleDBOperationsManager,
     )
     from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_query_builder import (
+        TimescaleDBNaming,
         TimescaleDBQueryBuilder,
     )
 else:
@@ -188,6 +187,76 @@ class QueryTestHelper:
     def write_application_event(self, *args, **kwargs):
         """Convenience method to write application events."""
         return self.operations_handler.write_application_event(*args, **kwargs)
+
+    def write_metric(
+        self,
+        endpoint_id: str,
+        application_name: str,
+        metric_name: str,
+        metric_value: float,
+        timestamp,
+    ):
+        """Write a metric event to the database."""
+        import mlrun.common.schemas.model_monitoring as mm_schemas
+
+        event = {
+            mm_schemas.WriterEvent.END_INFER_TIME: timestamp,
+            mm_schemas.WriterEvent.START_INFER_TIME: timestamp,
+            mm_schemas.WriterEvent.ENDPOINT_ID: endpoint_id,
+            mm_schemas.WriterEvent.APPLICATION_NAME: application_name,
+            mm_schemas.MetricData.METRIC_NAME: metric_name,
+            mm_schemas.MetricData.METRIC_VALUE: metric_value,
+        }
+        self.operations_handler.write_application_event(
+            event, kind=mm_schemas.WriterEventKind.METRIC
+        )
+
+    def write_result(
+        self,
+        endpoint_id: str,
+        application_name: str,
+        result_name: str,
+        result_value: float,
+        result_status: int,
+        result_kind: int,
+        timestamp,
+        result_extra_data: str = "{}",
+    ):
+        """Write a result event to the database."""
+        import mlrun.common.schemas.model_monitoring as mm_schemas
+
+        event = {
+            mm_schemas.WriterEvent.END_INFER_TIME: timestamp,
+            mm_schemas.WriterEvent.START_INFER_TIME: timestamp,
+            mm_schemas.WriterEvent.ENDPOINT_ID: endpoint_id,
+            mm_schemas.WriterEvent.APPLICATION_NAME: application_name,
+            mm_schemas.ResultData.RESULT_NAME: result_name,
+            mm_schemas.ResultData.RESULT_VALUE: result_value,
+            mm_schemas.ResultData.RESULT_STATUS: result_status,
+            mm_schemas.ResultData.RESULT_KIND: result_kind,
+            mm_schemas.ResultData.RESULT_EXTRA_DATA: result_extra_data,
+        }
+        self.operations_handler.write_application_event(
+            event, kind=mm_schemas.WriterEventKind.RESULT
+        )
+
+    def refresh_cagg(self, table_name: str, interval: str):
+        """Manually refresh a continuous aggregate to materialize data.
+
+        This is needed in tests because CAGGs don't immediately materialize data.
+        Uses autocommit connection since refresh cannot run in a transaction.
+        """
+        cagg_view_name = TimescaleDBNaming.get_cagg_view_name(
+            self.table_schemas[table_name].full_name(), interval
+        )
+        # Create a separate autocommit connection for refresh
+        # (refresh_continuous_aggregate cannot run inside a transaction)
+        autocommit_conn = TimescaleDBConnection(
+            self.connection._dsn, max_connections=1, autocommit=True
+        )
+        autocommit_conn.run(
+            statements=f"CALL refresh_continuous_aggregate('{cagg_view_name}', NULL, NULL);"
+        )
 
 
 @pytest.fixture

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_preaggregate.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_preaggregate.py
@@ -20,6 +20,7 @@ import pytest
 import mlrun.errors
 import mlrun.utils
 from mlrun.model_monitoring.db.tsdb.preaggregate import (
+    PreAggregateConfig,
     PreAggregateManager,
 )
 
@@ -336,3 +337,101 @@ class TestPreAggregateManager:
         result = handler.align_time_to_interval(dt, "1M", align_start=False)
         expected = datetime(2025, 3, 1, 0, 0, 0)
         assert result == expected
+
+
+class TestPreAggregateConfig:
+    """Test suite for PreAggregateConfig dataclass."""
+
+    def test_default_values_are_none(self):
+        """Test that default values are None (config.py provides defaults)."""
+        config = PreAggregateConfig()
+
+        assert config.aggregate_intervals is None
+        assert config.agg_functions is None
+        assert config.retention_policy is None
+
+    def test_custom_values(self):
+        """Test that custom values are accepted."""
+        config = PreAggregateConfig(
+            aggregate_intervals=["1h", "24h"],
+            agg_functions=["avg", "count"],
+            retention_policy={"raw": "30d", "1h": "90d", "24h": "180d"},
+        )
+
+        assert config.aggregate_intervals == ["1h", "24h"]
+        assert config.agg_functions == ["avg", "count"]
+        assert config.retention_policy == {"raw": "30d", "1h": "90d", "24h": "180d"}
+
+
+class TestPreAggregateConfigFromMlrunConfig:
+    """Test suite for PreAggregateConfig.from_mlrun_config()."""
+
+    def test_from_mlrun_config_when_enabled(self):
+        """Test from_mlrun_config when pre-aggregation is enabled."""
+        with patch("mlrun.config.config") as mock_config:
+            mock_pre_agg = mock_config.model_endpoint_monitoring.tsdb.pre_aggregate
+            mock_pre_agg.enabled = True
+            mock_pre_agg.aggregate_intervals = ["1h", "6h"]
+            mock_pre_agg.agg_functions = ["avg", "count"]
+            mock_pre_agg.retention_policy._cfg = {"raw": "1 month", "1h": "3 months"}
+
+            # Remove to_dict method to test the _cfg path
+            del mock_pre_agg.retention_policy.to_dict
+
+            result = PreAggregateConfig.from_mlrun_config()
+
+            assert result is not None
+            assert result.aggregate_intervals == ["1h", "6h"]
+            assert result.agg_functions == ["avg", "count"]
+
+    def test_from_mlrun_config_when_disabled(self):
+        """Test from_mlrun_config when pre-aggregation is disabled."""
+        with patch("mlrun.config.config") as mock_config:
+            mock_pre_agg = mock_config.model_endpoint_monitoring.tsdb.pre_aggregate
+            mock_pre_agg.enabled = False
+
+            result = PreAggregateConfig.from_mlrun_config()
+
+            assert result is None
+
+    def test_from_mlrun_config_when_disabled_as_string(self):
+        """Test from_mlrun_config when enabled is 'false' string."""
+        with patch("mlrun.config.config") as mock_config:
+            mock_pre_agg = mock_config.model_endpoint_monitoring.tsdb.pre_aggregate
+            mock_pre_agg.enabled = "false"
+
+            result = PreAggregateConfig.from_mlrun_config()
+
+            assert result is None
+
+    def test_from_mlrun_config_with_to_dict_method(self):
+        """Test from_mlrun_config when retention_policy has to_dict method."""
+        with patch("mlrun.config.config") as mock_config:
+            mock_pre_agg = mock_config.model_endpoint_monitoring.tsdb.pre_aggregate
+            mock_pre_agg.enabled = True
+            mock_pre_agg.aggregate_intervals = ["1h", "24h"]
+            mock_pre_agg.agg_functions = ["min", "max"]
+            mock_pre_agg.retention_policy.to_dict.return_value = {
+                "raw": "2 months",
+                "1h": "6 months",
+            }
+
+            result = PreAggregateConfig.from_mlrun_config()
+
+            assert result is not None
+            assert result.retention_policy == {"raw": "2 months", "1h": "6 months"}
+
+    def test_from_mlrun_config_missing_intervals_raises_error(self):
+        """Test from_mlrun_config raises error when aggregate_intervals is missing."""
+        with patch("mlrun.config.config") as mock_config:
+            mock_pre_agg = mock_config.model_endpoint_monitoring.tsdb.pre_aggregate
+            mock_pre_agg.enabled = True
+            mock_pre_agg.aggregate_intervals = []  # Empty list
+            mock_pre_agg.agg_functions = ["avg"]
+            mock_pre_agg.retention_policy.to_dict.return_value = {"raw": "1 month"}
+
+            with pytest.raises(
+                mlrun.errors.MLRunInvalidArgumentError,
+                match=r"missing 'aggregate_intervals'",
+            ):
+                PreAggregateConfig.from_mlrun_config()

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_aggregation.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_aggregation.py
@@ -920,14 +920,13 @@ class TestConnectorReadMetricsDataV2:
             type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
         )
 
-        result = connector.read_metrics_data(
+        result = connector.read_metrics_data_v2(
             endpoint_id="endpoint_1",
             start=base_time - timedelta(minutes=5),
             end=now,
             metrics=[metric],
             type="metrics",
-            with_result_extra_data=False,
-            agg_period="raw",
+            agg_period=None,  # None means raw data in V2 format
         )
 
         assert len(result) == 1
@@ -977,14 +976,13 @@ class TestConnectorReadMetricsDataV2:
             type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
         )
 
-        result = connector.read_metrics_data(
+        result = connector.read_metrics_data_v2(
             endpoint_id="endpoint_1",
             start=base_time - timedelta(minutes=5),
             end=now,
             metrics=[result_metric],
             type="results",
-            with_result_extra_data=False,
-            agg_period="raw",
+            agg_period=None,  # None means raw data in V2 format
         )
 
         assert len(result) == 1

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_aggregation.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_aggregation.py
@@ -17,6 +17,7 @@ import unittest.mock
 from datetime import UTC, datetime, timedelta
 
 import pandas as pd
+import pytest
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.utils
@@ -706,3 +707,298 @@ class TestEndpointCounting:
         assert (
             result["test_app"] == 2
         )  # Only endpoint_2 and endpoint_3 are within time range and linked to test_app
+
+
+class TestCAGGQueryIntegration:
+    """Tests for read_metrics_data_impl and read_results_data_impl with actual CAGG views."""
+
+    def test_read_metrics_data_impl_with_1h_aggregation(
+        self, query_test_helper_with_aggregates
+    ):
+        """Test read_metrics_data_impl returns aggregated data from CAGG view."""
+        now = mlrun.utils.datetime_now()
+        base_hour = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=2)
+
+        # Bucket 1 (base_hour): 2 data points
+        query_test_helper_with_aggregates.write_metric(
+            "endpoint_1", "test_app", "accuracy", 0.90, base_hour + timedelta(minutes=5)
+        )
+        query_test_helper_with_aggregates.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.92,
+            base_hour + timedelta(minutes=30),
+        )
+        # Bucket 2 (base_hour + 1h): 2 data points
+        query_test_helper_with_aggregates.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.94,
+            base_hour + timedelta(hours=1, minutes=10),
+        )
+        query_test_helper_with_aggregates.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.96,
+            base_hour + timedelta(hours=1, minutes=40),
+        )
+
+        query_test_helper_with_aggregates.refresh_cagg(
+            mm_schemas.TimescaleDBTables.METRICS, "1h"
+        )
+
+        metrics_handler = query_test_helper_with_aggregates.create_metrics_handler()
+
+        df = metrics_handler.read_metrics_data_impl(
+            endpoint_id="endpoint_1",
+            start=base_hour - timedelta(minutes=5),
+            end=now,
+            metrics=None,
+            agg_period="1h",
+            agg_functions=["avg", "max", "count"],
+        )
+
+        # Bucket 1: 0.90, 0.92 → avg=0.91, max=0.92, count=2
+        # Bucket 2: 0.94, 0.96 → avg=0.95, max=0.96, count=2
+        assert len(df) == 2
+        assert "time_bucket" in df.index.names or "time_bucket" in df.columns
+
+        avg_values = sorted(df["avg_metric_value"].tolist())
+        max_values = sorted(df["max_metric_value"].tolist())
+        count_values = sorted(df["count_metric_value"].tolist())
+
+        assert avg_values == [0.91, 0.95]
+        assert max_values == [0.92, 0.96]
+        assert count_values == [2, 2]
+
+    def test_read_results_data_impl_with_1h_aggregation(
+        self, query_test_helper_with_aggregates
+    ):
+        """Test read_results_data_impl returns aggregated data from CAGG view."""
+        now = mlrun.utils.datetime_now()
+        base_hour = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=2)
+
+        # Bucket 1 (base_hour): 2 data points
+        query_test_helper_with_aggregates.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.80,
+            mm_schemas.ResultStatusApp.detected.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_hour + timedelta(minutes=10),
+        )
+        query_test_helper_with_aggregates.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.90,
+            mm_schemas.ResultStatusApp.detected.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_hour + timedelta(minutes=40),
+        )
+        # Bucket 2 (base_hour + 1h): 2 data points
+        query_test_helper_with_aggregates.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.70,
+            mm_schemas.ResultStatusApp.detected.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_hour + timedelta(hours=1, minutes=15),
+        )
+        query_test_helper_with_aggregates.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.50,
+            mm_schemas.ResultStatusApp.detected.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_hour + timedelta(hours=1, minutes=45),
+        )
+
+        query_test_helper_with_aggregates.refresh_cagg(
+            mm_schemas.TimescaleDBTables.APP_RESULTS, "1h"
+        )
+
+        results_handler = query_test_helper_with_aggregates.create_results_handler()
+
+        df = results_handler.read_results_data_impl(
+            endpoint_id="endpoint_1",
+            start=base_hour - timedelta(minutes=5),
+            end=now,
+            metrics=None,
+            agg_period="1h",
+            agg_functions=["avg"],
+        )
+
+        # Bucket 1: 0.80, 0.90 → avg=0.85
+        # Bucket 2: 0.70, 0.50 → avg=0.60
+        assert len(df) == 2
+        assert "time_bucket" in df.index.names or "time_bucket" in df.columns
+
+        avg_values = sorted(df["avg_result_value"].tolist())
+        assert avg_values == pytest.approx([0.60, 0.85])
+
+
+class TestConnectorReadMetricsDataV2:
+    """Tests for TimescaleDBConnector.read_metrics_data with v2 aggregation."""
+
+    def test_read_metrics_data_v1_returns_v1_schema(self, connector):
+        """Test read_metrics_data without agg_period returns V1 schema."""
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=1)
+
+        connector._operations.write_application_event(
+            {
+                mm_schemas.WriterEvent.END_INFER_TIME: base_time,
+                mm_schemas.WriterEvent.START_INFER_TIME: base_time,
+                mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint_1",
+                mm_schemas.WriterEvent.APPLICATION_NAME: "test_app",
+                mm_schemas.MetricData.METRIC_NAME: "test_metric",
+                mm_schemas.MetricData.METRIC_VALUE: 0.95,
+            },
+            kind=mm_schemas.WriterEventKind.METRIC,
+        )
+
+        metric = mm_schemas.ModelEndpointMonitoringMetric(
+            project=connector.project,
+            app="test_app",
+            name="test_metric",
+            type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
+        )
+
+        result = connector.read_metrics_data(
+            endpoint_id="endpoint_1",
+            start=base_time - timedelta(minutes=5),
+            end=now,
+            metrics=[metric],
+            type="metrics",
+            with_result_extra_data=False,
+        )
+
+        assert len(result) == 1
+        item = result[0]
+
+        expected = mm_schemas.ModelEndpointMonitoringMetricValues(
+            full_name=f"{connector.project}.test_app.metric.test_metric",
+            type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
+            values=item.values,
+        )
+        assert item == expected
+        assert len(item.values) == 1
+
+    def test_read_metrics_data_v2_raw_returns_v2_schema(self, connector):
+        """Test read_metrics_data with agg_period='raw' returns V2 schema (non-aggregated)."""
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=2)
+
+        for value, ts in [
+            (0.90, base_time),
+            (0.92, base_time + timedelta(minutes=30)),
+            (0.95, base_time + timedelta(hours=1)),
+        ]:
+            connector._operations.write_application_event(
+                {
+                    mm_schemas.WriterEvent.END_INFER_TIME: ts,
+                    mm_schemas.WriterEvent.START_INFER_TIME: ts,
+                    mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint_1",
+                    mm_schemas.WriterEvent.APPLICATION_NAME: "test_app",
+                    mm_schemas.MetricData.METRIC_NAME: "test_metric",
+                    mm_schemas.MetricData.METRIC_VALUE: value,
+                },
+                kind=mm_schemas.WriterEventKind.METRIC,
+            )
+
+        metric = mm_schemas.ModelEndpointMonitoringMetric(
+            project=connector.project,
+            app="test_app",
+            name="test_metric",
+            type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
+        )
+
+        result = connector.read_metrics_data(
+            endpoint_id="endpoint_1",
+            start=base_time - timedelta(minutes=5),
+            end=now,
+            metrics=[metric],
+            type="metrics",
+            with_result_extra_data=False,
+            agg_period="raw",
+        )
+
+        assert len(result) == 1
+        item = result[0]
+
+        expected = mm_schemas.ModelEndpointMonitoringMetricValuesV2(
+            full_name=f"{connector.project}.test_app.metric.test_metric",
+            type=mm_schemas.ModelEndpointMonitoringMetricType.METRIC,
+            data=True,
+            aggregation_config=mm_schemas.AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            values=item.values,
+        )
+        assert item == expected
+        assert len(item.values) == 3
+
+    def test_read_results_data_v2_raw_returns_v2_schema(self, connector):
+        """Test read_metrics_data for results with agg_period='raw' returns V2 schema."""
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=2)
+
+        for value, ts in [
+            (0.80, base_time),
+            (0.85, base_time + timedelta(minutes=30)),
+            (0.90, base_time + timedelta(hours=1)),
+        ]:
+            connector._operations.write_application_event(
+                {
+                    mm_schemas.WriterEvent.END_INFER_TIME: ts,
+                    mm_schemas.WriterEvent.START_INFER_TIME: ts,
+                    mm_schemas.WriterEvent.ENDPOINT_ID: "endpoint_1",
+                    mm_schemas.WriterEvent.APPLICATION_NAME: "drift_app",
+                    mm_schemas.ResultData.RESULT_NAME: "drift_score",
+                    mm_schemas.ResultData.RESULT_VALUE: value,
+                    mm_schemas.ResultData.RESULT_STATUS: mm_schemas.ResultStatusApp.detected.value,
+                    mm_schemas.ResultData.RESULT_KIND: mm_schemas.ResultKindApp.concept_drift.value,
+                    mm_schemas.ResultData.RESULT_EXTRA_DATA: "{}",
+                },
+                kind=mm_schemas.WriterEventKind.RESULT,
+            )
+
+        result_metric = mm_schemas.ModelEndpointMonitoringMetric(
+            project=connector.project,
+            app="drift_app",
+            name="drift_score",
+            type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
+        )
+
+        result = connector.read_metrics_data(
+            endpoint_id="endpoint_1",
+            start=base_time - timedelta(minutes=5),
+            end=now,
+            metrics=[result_metric],
+            type="results",
+            with_result_extra_data=False,
+            agg_period="raw",
+        )
+
+        assert len(result) == 1
+        item = result[0]
+
+        expected = mm_schemas.ModelEndpointMonitoringResultValuesV2(
+            full_name=f"{connector.project}.drift_app.result.drift_score",
+            type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
+            result_kind=mm_schemas.ResultKindApp.concept_drift,
+            data=True,
+            aggregation_config=mm_schemas.AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            values=item.values,
+        )
+        assert item == expected
+        assert len(item.values) == 3

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_metrics.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_metrics.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pandas as pd
+import pytest
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
+import mlrun.utils
 
 
 class TestMetricsQueries:
@@ -422,3 +424,113 @@ class TestMetadataMethods:
             f"Should return monitoring-app2's value ({test_data[1]['metric_value']}), "
             f"not monitoring-app1's value ({test_data[0]['metric_value']})"
         )
+
+
+class TestReadMetricsDataV2Api:
+    """Tests for read_metrics_data_impl with v2 API aggregation parameters."""
+
+    def test_read_metrics_data_impl_without_aggregation(self, query_test_helper):
+        """Test read_metrics_data_impl returns raw data when no aggregation specified."""
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=1)
+
+        query_test_helper.write_metric(
+            "endpoint_1", "test_app", "accuracy", 0.95, base_time
+        )
+        query_test_helper.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.96,
+            base_time + timedelta(minutes=10),
+        )
+        query_test_helper.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.97,
+            base_time + timedelta(minutes=20),
+        )
+
+        metrics_handler = query_test_helper.create_metrics_handler()
+
+        df = metrics_handler.read_metrics_data_impl(
+            endpoint_id="endpoint_1",
+            start=base_time - timedelta(minutes=5),
+            end=now,
+            metrics=None,
+        )
+
+        assert len(df) == 3
+        metric_values = sorted(df["metric_value"].tolist())
+        assert metric_values == [0.95, 0.96, 0.97]
+        assert all(df["metric_name"] == "accuracy")
+
+    def test_read_metrics_data_impl_with_explicit_raw_period(self, query_test_helper):
+        """Test read_metrics_data_impl with agg_period='raw' returns raw data directly."""
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=1)
+
+        query_test_helper.write_metric(
+            "endpoint_1", "test_app", "accuracy", 0.95, base_time
+        )
+        query_test_helper.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.96,
+            base_time + timedelta(minutes=10),
+        )
+        query_test_helper.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.97,
+            base_time + timedelta(minutes=20),
+        )
+
+        metrics_handler = query_test_helper.create_metrics_handler()
+
+        df = metrics_handler.read_metrics_data_impl(
+            endpoint_id="endpoint_1",
+            start=base_time - timedelta(minutes=5),
+            end=now,
+            metrics=None,
+            agg_period="raw",
+        )
+
+        assert len(df) == 3
+        metric_values = sorted(df["metric_value"].tolist())
+        assert metric_values == [0.95, 0.96, 0.97]
+        assert all(df["metric_name"] == "accuracy")
+        assert "time_bucket" not in df.columns
+
+    def test_read_metrics_data_impl_aggregation_requires_cagg(self, query_test_helper):
+        """Test read_metrics_data_impl with aggregation fails when CAGG doesn't exist."""
+        import psycopg
+
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=2)
+
+        query_test_helper.write_metric(
+            "endpoint_1", "test_app", "accuracy", 0.90, base_time
+        )
+        query_test_helper.write_metric(
+            "endpoint_1",
+            "test_app",
+            "accuracy",
+            0.92,
+            base_time + timedelta(minutes=15),
+        )
+
+        metrics_handler = query_test_helper.create_metrics_handler()
+
+        with pytest.raises(psycopg.errors.UndefinedTable):
+            metrics_handler.read_metrics_data_impl(
+                endpoint_id="endpoint_1",
+                start=base_time - timedelta(minutes=5),
+                end=now,
+                metrics=None,
+                agg_period="1h",
+                agg_functions=["avg", "min", "max"],
+            )

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_results.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_results.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+
+import pytest
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
+import mlrun.utils
 
 
 class TestResultsQueries:
@@ -493,3 +496,135 @@ class TestResultsQueries:
             f"Should return proj1-app2's value ({test_data[1]['result_value']}), "
             f"not proj1-app1's value ({test_data[0]['result_value']})"
         )
+
+
+class TestReadResultsDataV2Api:
+    """Tests for read_results_data_impl with v2 API aggregation parameters."""
+
+    def test_read_results_data_impl_without_aggregation(self, query_test_helper):
+        """Test read_results_data_impl returns raw data including status and extra_data."""
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=1)
+
+        query_test_helper.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.85,
+            mm_schemas.ResultStatusApp.detected.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_time,
+        )
+        query_test_helper.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.75,
+            mm_schemas.ResultStatusApp.potential_detection.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_time + timedelta(minutes=10),
+        )
+
+        results_handler = query_test_helper.create_results_handler()
+
+        df = results_handler.read_results_data_impl(
+            endpoint_id="endpoint_1",
+            start=base_time - timedelta(minutes=5),
+            end=now,
+            metrics=None,
+            with_result_extra_data=True,
+        )
+
+        assert len(df) == 2
+        result_values = sorted(df["result_value"].tolist())
+        assert result_values == [0.75, 0.85]
+        assert all(df["result_name"] == "drift_score")
+        result_statuses = sorted(df["result_status"].tolist())
+        assert result_statuses == [
+            mm_schemas.ResultStatusApp.potential_detection.value,
+            mm_schemas.ResultStatusApp.detected.value,
+        ]
+
+    def test_read_results_data_impl_with_explicit_raw_period(self, query_test_helper):
+        """Test read_results_data_impl with agg_period='raw' returns raw data directly."""
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=1)
+
+        query_test_helper.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.85,
+            mm_schemas.ResultStatusApp.detected.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_time,
+        )
+        query_test_helper.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.75,
+            mm_schemas.ResultStatusApp.potential_detection.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_time + timedelta(minutes=10),
+        )
+
+        results_handler = query_test_helper.create_results_handler()
+
+        df = results_handler.read_results_data_impl(
+            endpoint_id="endpoint_1",
+            start=base_time - timedelta(minutes=5),
+            end=now,
+            metrics=None,
+            agg_period="raw",
+            with_result_extra_data=True,
+        )
+
+        assert len(df) == 2
+        result_values = sorted(df["result_value"].tolist())
+        assert result_values == [0.75, 0.85]
+        assert all(df["result_name"] == "drift_score")
+        result_statuses = sorted(df["result_status"].tolist())
+        assert result_statuses == [
+            mm_schemas.ResultStatusApp.potential_detection.value,
+            mm_schemas.ResultStatusApp.detected.value,
+        ]
+        assert "time_bucket" not in df.columns
+
+    def test_read_results_data_impl_aggregation_requires_cagg(self, query_test_helper):
+        """Test read_results_data_impl with aggregation fails when CAGG doesn't exist."""
+        import psycopg
+
+        now = mlrun.utils.datetime_now()
+        base_time = now - timedelta(hours=2)
+
+        query_test_helper.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.80,
+            mm_schemas.ResultStatusApp.detected.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_time,
+        )
+        query_test_helper.write_result(
+            "endpoint_1",
+            "drift_app",
+            "drift_score",
+            0.85,
+            mm_schemas.ResultStatusApp.potential_detection.value,
+            mm_schemas.ResultKindApp.concept_drift.value,
+            base_time + timedelta(minutes=15),
+        )
+
+        results_handler = query_test_helper.create_results_handler()
+
+        with pytest.raises(psycopg.errors.UndefinedTable):
+            results_handler.read_results_data_impl(
+                endpoint_id="endpoint_1",
+                start=base_time - timedelta(minutes=5),
+                end=now,
+                metrics=None,
+                agg_period="1h",
+                agg_functions=["avg"],
+            )

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -70,10 +70,7 @@ class _HistLen(NamedTuple):
 class TemplateFunction(mlrun.runtimes.ServingRuntime):
     def __init__(self):
         super().__init__()
-        self.add_trigger(
-            "cron_interval",
-            spec=nuclio.CronTrigger(interval=f"{1}m"),
-        )
+        self.add_trigger("cron_interval", spec=nuclio.CronTrigger(interval="1m"))
 
 
 @pytest.fixture
@@ -152,7 +149,7 @@ def generate_sample_data(
     data = {}
     for feature in feature_stats.keys():
         data[feature] = []
-        for sample in range(num_samples):
+        for _ in range(num_samples):
             loc = np.random.uniform(
                 low=feature_stats[feature]["hist"][1][0],
                 high=feature_stats[feature]["hist"][1][-1],
@@ -679,3 +676,56 @@ def test_get_start_end():
             start=now + datetime.timedelta(seconds=10),
             end=now,
         )
+
+
+class TestParseIntervalToMinutes:
+    """Tests for interval string parsing."""
+
+    def test_parse_hours(self):
+        """Test parsing hour-based intervals."""
+        from mlrun.model_monitoring.helpers import parse_interval_to_minutes
+
+        assert parse_interval_to_minutes("1h") == 60
+        assert parse_interval_to_minutes("6h") == 360
+        assert parse_interval_to_minutes("12h") == 720
+        assert parse_interval_to_minutes("24h") == 1440
+
+    def test_parse_invalid_format(self):
+        """Test that invalid formats return None."""
+        from mlrun.model_monitoring.helpers import parse_interval_to_minutes
+
+        assert parse_interval_to_minutes("invalid") is None
+        assert parse_interval_to_minutes("1d") is None  # days not supported
+        assert parse_interval_to_minutes("1m") is None  # minutes not supported
+        assert parse_interval_to_minutes("h") is None  # no number
+        assert parse_interval_to_minutes("abch") is None  # non-numeric
+
+
+class TestBuildIntervalMinutesMapping:
+    """Tests for building interval-to-minutes mapping."""
+
+    def test_builds_mapping_from_intervals(self):
+        """Test building mapping from interval list."""
+        from mlrun.model_monitoring.helpers import build_interval_minutes_mapping
+
+        intervals = ["1h", "6h", "12h", "24h"]
+        result = build_interval_minutes_mapping(intervals)
+
+        assert isinstance(result, dict)
+        assert result == {"1h": 60, "6h": 360, "12h": 720, "24h": 1440}
+
+    def test_filters_invalid_intervals(self):
+        """Test that invalid intervals are filtered out."""
+        from mlrun.model_monitoring.helpers import build_interval_minutes_mapping
+
+        intervals = ["1h", "invalid", "6h", "1d"]
+        result = build_interval_minutes_mapping(intervals)
+
+        assert result == {"1h": 60, "6h": 360}
+
+    def test_empty_input_returns_empty_dict(self):
+        """Test that empty input returns empty dict."""
+        from mlrun.model_monitoring.helpers import build_interval_minutes_mapping
+
+        result = build_interval_minutes_mapping([])
+        assert result == {}

--- a/tests/model_monitoring/test_model_endpoints_v2_api.py
+++ b/tests/model_monitoring/test_model_endpoints_v2_api.py
@@ -1,0 +1,182 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for v2 model endpoints API parameter handling and aggregation logic.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import mlrun.common.schemas.model_monitoring.constants as mm_constants
+import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
+
+
+class TestV2ResultCountLimit:
+    """Tests for v2 API result count validation."""
+
+    def test_max_results_constant_is_500(self):
+        """Test that the max results constant is set to 500."""
+        from server.py.services.api.api.endpoints.model_endpoints_v2 import (
+            _MAX_RESULTS_PER_METRIC,
+        )
+
+        assert _MAX_RESULTS_PER_METRIC == 500
+
+    def test_result_count_validation_logic(self):
+        """Test the result count validation logic."""
+        from server.py.services.api.api.endpoints.model_endpoints_v2 import (
+            _MAX_RESULTS_PER_METRIC,
+        )
+
+        # Simulate validation logic from the endpoint
+        now = datetime.now(UTC)
+        values_under_limit = [
+            [now + timedelta(minutes=i), float(i)] for i in range(100)
+        ]
+        values_at_limit = [[now + timedelta(minutes=i), float(i)] for i in range(500)]
+        values_over_limit = [[now + timedelta(minutes=i), float(i)] for i in range(501)]
+
+        metric_under = mm_endpoints.ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.test",
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            values=values_under_limit,
+        )
+        metric_at = mm_endpoints.ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.test",
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            values=values_at_limit,
+        )
+        metric_over = mm_endpoints.ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.test",
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=False, period=None, functions=None
+            ),
+            values=values_over_limit,
+        )
+
+        # Under limit should pass
+        assert len(metric_under.values) <= _MAX_RESULTS_PER_METRIC
+
+        # At limit should pass
+        assert len(metric_at.values) <= _MAX_RESULTS_PER_METRIC
+
+        # Over limit should fail
+        assert len(metric_over.values) > _MAX_RESULTS_PER_METRIC
+
+
+class TestV2ResponseSchemas:
+    """Tests for v2 response schema structure."""
+
+    def test_metric_values_v2_has_aggregation_config(self):
+        """Test that ModelEndpointMonitoringMetricValuesV2 has aggregation_config."""
+        metric = mm_endpoints.ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.metric_name",
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=True,
+                period="1h",
+                functions=["avg"],
+            ),
+            values=[
+                [datetime.now(UTC), 1.0],
+            ],
+        )
+        assert metric.aggregation_config is not None
+        assert metric.aggregation_config.aggregated is True
+        assert metric.aggregation_config.period == "1h"
+        assert metric.aggregation_config.functions == ["avg"]
+
+    def test_result_values_v2_has_aggregation_config(self):
+        """Test that ModelEndpointMonitoringResultValuesV2 has aggregation_config."""
+        result = mm_endpoints.ModelEndpointMonitoringResultValuesV2(
+            full_name="project.app.result_name",
+            result_kind=mm_constants.ResultKindApp.data_drift,
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=False,
+                period=None,
+                functions=None,
+            ),
+            values=[
+                [datetime.now(UTC), 0.5, 0, ""],
+            ],
+        )
+        assert result.aggregation_config is not None
+        assert result.aggregation_config.aggregated is False
+
+
+class TestV2MetricValuesFormat:
+    """Tests for v2 metric values format."""
+
+    def test_raw_metric_values_format(self):
+        """Test that raw metric values have [timestamp, value] format."""
+        now = datetime.now(UTC)
+        values = [
+            [now, 1.0],
+            [now + timedelta(minutes=1), 2.0],
+        ]
+        metric = mm_endpoints.ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.metric_name",
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=False,
+                period=None,
+                functions=None,
+            ),
+            values=values,
+        )
+        assert len(metric.values) == 2
+        assert len(metric.values[0]) == 2  # [timestamp, value]
+
+    def test_aggregated_metric_values_format(self):
+        """Test that aggregated metric values have [timestamp, agg1, agg2, ...] format."""
+        now = datetime.now(UTC)
+        # Format: [timestamp, avg_value, min_value, max_value]
+        values = [
+            [now, 1.5, 1.0, 2.0],
+            [now + timedelta(hours=1), 2.5, 2.0, 3.0],
+        ]
+        metric = mm_endpoints.ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.metric_name",
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=True,
+                period="1h",
+                functions=["avg", "min", "max"],
+            ),
+            values=values,
+        )
+        assert len(metric.values) == 2
+        # [timestamp, avg, min, max] = 4 elements
+        assert len(metric.values[0]) == 4
+
+    def test_raw_result_values_format(self):
+        """Test that raw result values have [timestamp, value, status, extra_data] format."""
+        now = datetime.now(UTC)
+        values = [
+            [now, 0.5, 0, ""],
+            [now + timedelta(minutes=1), 0.8, 1, '{"info": "drift detected"}'],
+        ]
+        result = mm_endpoints.ModelEndpointMonitoringResultValuesV2(
+            full_name="project.app.result_name",
+            result_kind=mm_constants.ResultKindApp.data_drift,
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=False,
+                period=None,
+                functions=None,
+            ),
+            values=values,
+        )
+        assert len(result.values) == 2
+        assert len(result.values[0]) == 4  # [timestamp, value, status, extra_data]

--- a/tests/model_monitoring/test_model_endpoints_v2_api.py
+++ b/tests/model_monitoring/test_model_endpoints_v2_api.py
@@ -180,3 +180,30 @@ class TestV2MetricValuesFormat:
         )
         assert len(result.values) == 2
         assert len(result.values[0]) == 4  # [timestamp, value, status, extra_data]
+
+    def test_aggregated_result_values_format(self):
+        """Test that aggregated result values include status aggregations.
+
+        Format: [timestamp, avg_value, min_value, max_value, avg_status, min_status, max_status]
+        Note: extra_data is NOT included for aggregated results since it cannot be meaningfully
+        aggregated. Status IS included (max indicates detection in period).
+        """
+        now = datetime.now(UTC)
+        # Format: [timestamp, avg_val, min_val, max_val, avg_status, min_status, max_status]
+        values = [
+            [now, 0.5, 0.2, 0.8, 1, 0, 2],  # First bucket
+            [now + timedelta(hours=1), 0.6, 0.3, 0.9, 0, 0, 0],  # Second bucket
+        ]
+        result = mm_endpoints.ModelEndpointMonitoringResultValuesV2(
+            full_name="project.app.result_name",
+            result_kind=mm_constants.ResultKindApp.data_drift,
+            aggregation_config=mm_endpoints.AggregationConfig(
+                aggregated=True,
+                period="1h",
+                functions=["avg", "min", "max"],
+            ),
+            values=values,
+        )
+        assert len(result.values) == 2
+        # [timestamp, avg_val, min_val, max_val, avg_status, min_status, max_status] = 7 elements
+        assert len(result.values[0]) == 7

--- a/tests/model_monitoring/test_model_endpoints_v2_api.py
+++ b/tests/model_monitoring/test_model_endpoints_v2_api.py
@@ -22,6 +22,70 @@ import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
 
 
+class TestDetermineOptimalPeriod:
+    """Tests for auto-selection of aggregation period.
+
+    These tests use the default config intervals: ["1h", "6h", "12h", "24h"]
+    """
+
+    def test_short_time_range_selects_smallest_interval(self):
+        """Test that short time range (1 day) selects 1h interval."""
+        from server.py.services.api.api.endpoints.model_endpoints_v2 import (
+            _determine_optimal_period,
+        )
+
+        end = datetime.now(UTC)
+        start = end - timedelta(days=1)
+
+        result = _determine_optimal_period(start, end)
+        # 24 hours = 1440 minutes / 60 (1h) = 24 results << 500 max
+        assert result == "1h"
+
+    def test_medium_time_range_selects_appropriate_interval(self):
+        """Test that medium time range (30 days) selects appropriate interval."""
+        from server.py.services.api.api.endpoints.model_endpoints_v2 import (
+            _determine_optimal_period,
+        )
+
+        end = datetime.now(UTC)
+        start = end - timedelta(days=30)
+
+        result = _determine_optimal_period(start, end)
+        # 30 days = 43200 minutes
+        # 1h (60 min) = 720 results > 500, skip
+        # 6h (360 min) = 120 results < 500, use this
+        assert result == "6h"
+
+    def test_long_time_range_selects_appropriate_interval(self):
+        """Test that long time range (90 days) selects appropriate interval."""
+        from server.py.services.api.api.endpoints.model_endpoints_v2 import (
+            _determine_optimal_period,
+        )
+
+        end = datetime.now(UTC)
+        start = end - timedelta(days=90)
+
+        result = _determine_optimal_period(start, end)
+        # 90 days = 129600 minutes
+        # 1h (60 min) = 2160 results > 500
+        # 6h (360 min) = 360 results < 500
+        assert result == "6h"
+
+    def test_very_long_time_range_falls_back_to_largest(self):
+        """Test that very long time range falls back to largest available."""
+        from server.py.services.api.api.endpoints.model_endpoints_v2 import (
+            _determine_optimal_period,
+        )
+
+        end = datetime.now(UTC)
+        start = end - timedelta(days=365)
+
+        result = _determine_optimal_period(start, end)
+        # 365 days = 525600 minutes
+        # 24h (1440 min) = 365 results < 500
+        assert result == "24h"
+
+
 class TestV2ResultCountLimit:
     """Tests for v2 API result count validation."""
 
@@ -182,17 +246,23 @@ class TestV2MetricValuesFormat:
         assert len(result.values[0]) == 4  # [timestamp, value, status, extra_data]
 
     def test_aggregated_result_values_format(self):
-        """Test that aggregated result values include status aggregations.
+        """Test that aggregated result values include max_status only.
 
-        Format: [timestamp, avg_value, min_value, max_value, avg_status, min_status, max_status]
+        Format: [timestamp, avg_value, min_value, max_value, max_status]
         Note: extra_data is NOT included for aggregated results since it cannot be meaningfully
-        aggregated. Status IS included (max indicates detection in period).
+        aggregated. Status uses only max (indicates detection in period).
         """
         now = datetime.now(UTC)
-        # Format: [timestamp, avg_val, min_val, max_val, avg_status, min_status, max_status]
+        # Format: [timestamp, avg_val, min_val, max_val, max_status]
         values = [
-            [now, 0.5, 0.2, 0.8, 1, 0, 2],  # First bucket
-            [now + timedelta(hours=1), 0.6, 0.3, 0.9, 0, 0, 0],  # Second bucket
+            [now, 0.5, 0.2, 0.8, 2],  # First bucket: max_status=2 (detection)
+            [
+                now + timedelta(hours=1),
+                0.6,
+                0.3,
+                0.9,
+                0,
+            ],  # Second bucket: max_status=0 (no detection)
         ]
         result = mm_endpoints.ModelEndpointMonitoringResultValuesV2(
             full_name="project.app.result_name",
@@ -205,5 +275,5 @@ class TestV2MetricValuesFormat:
             values=values,
         )
         assert len(result.values) == 2
-        # [timestamp, avg_val, min_val, max_val, avg_status, min_status, max_status] = 7 elements
-        assert len(result.values[0]) == 7
+        # [timestamp, avg_val, min_val, max_val, max_status] = 5 elements
+        assert len(result.values[0]) == 5

--- a/tests/model_monitoring/test_schemas.py
+++ b/tests/model_monitoring/test_schemas.py
@@ -278,8 +278,9 @@ class TestModelEndpointMonitoringResultValuesV2:
     def test_result_values_v2_aggregated(self):
         """Test v2 result values with aggregation.
 
-        Note: Aggregated results only contain numeric aggregates (avg, max, etc.)
-        without status or extra_data since those cannot be meaningfully aggregated.
+        Note: Aggregated results contain numeric aggregates (avg, max, etc.) plus max_status.
+        extra_data is NOT included since it cannot be meaningfully aggregated.
+        Status uses only max (indicates detection in period).
         """
         from datetime import datetime
 
@@ -295,14 +296,19 @@ class TestModelEndpointMonitoringResultValuesV2:
         config = AggregationConfig(
             aggregated=True, period="1h", functions=["avg", "max"]
         )
-        # Aggregated values: [timestamp, avg_value, max_value] - no status/extra_data
+        # Aggregated values: [timestamp, avg_value, max_value, max_status] - no extra_data
         values = ModelEndpointMonitoringResultValuesV2(
             full_name="project.histogram-data-drift.result.general_drift",
             result_kind=ResultKindApp.data_drift,
             aggregation_config=config,
             values=[
-                [datetime(2025, 1, 1, 0, 0), 0.15, 0.25],
-                [datetime(2025, 1, 1, 1, 0), 0.18, 0.30],
+                [
+                    datetime(2025, 1, 1, 0, 0),
+                    0.15,
+                    0.25,
+                    0,
+                ],  # max_status=0 (no detection)
+                [datetime(2025, 1, 1, 1, 0), 0.18, 0.30, 2],  # max_status=2 (detection)
             ],
         )
         assert values.full_name == "project.histogram-data-drift.result.general_drift"
@@ -311,10 +317,11 @@ class TestModelEndpointMonitoringResultValuesV2:
         assert values.data is True
         assert values.aggregation_config.aggregated is True
         assert len(values.values) == 2
-        # Each row has: timestamp + 2 aggregation values (avg, max)
-        assert len(values.values[0]) == 3
+        # Each row has: timestamp + 2 aggregation values (avg, max) + max_status
+        assert len(values.values[0]) == 4
         assert values.values[0][1] == 0.15  # avg
         assert values.values[0][2] == 0.25  # max
+        assert values.values[0][3] == 0  # max_status
 
     def test_result_values_v2_raw(self):
         """Test v2 result values for raw (non-aggregated) data."""

--- a/tests/model_monitoring/test_schemas.py
+++ b/tests/model_monitoring/test_schemas.py
@@ -168,3 +168,173 @@ def test_normalize_dict(event, expected):
 
 def test_empty_dict():
     assert _normalize_dict_for_v3io_frames({}) == {}
+
+
+# V2 API Schema Tests (ML-11445)
+
+
+class TestAggregationConfig:
+    """Tests for AggregationConfig schema."""
+
+    def test_aggregation_config_aggregated_with_period_and_functions(self):
+        """Test AggregationConfig with all fields populated."""
+        from mlrun.common.schemas.model_monitoring import AggregationConfig
+
+        config = AggregationConfig(
+            aggregated=True,
+            period="1h",
+            functions=["avg", "min", "max"],
+        )
+        assert config.aggregated is True
+        assert config.period == "1h"
+        assert config.functions == ["avg", "min", "max"]
+
+    def test_aggregation_config_not_aggregated(self):
+        """Test AggregationConfig for raw (non-aggregated) data."""
+        from mlrun.common.schemas.model_monitoring import AggregationConfig
+
+        config = AggregationConfig(aggregated=False)
+        assert config.aggregated is False
+        assert config.period is None
+        assert config.functions is None
+
+    def test_aggregation_config_serialization_roundtrip(self):
+        """Test AggregationConfig serialization and deserialization."""
+        from mlrun.common.schemas.model_monitoring import AggregationConfig
+
+        config = AggregationConfig(
+            aggregated=True,
+            period="6h",
+            functions=["avg", "count"],
+        )
+        serialized = config.dict()
+        deserialized = AggregationConfig(**serialized)
+        assert deserialized.aggregated == config.aggregated
+        assert deserialized.period == config.period
+        assert deserialized.functions == config.functions
+
+
+class TestModelEndpointMonitoringMetricValuesV2:
+    """Tests for ModelEndpointMonitoringMetricValuesV2 schema."""
+
+    def test_metric_values_v2_aggregated(self):
+        """Test v2 metric values with aggregation."""
+        from datetime import datetime
+
+        from mlrun.common.schemas.model_monitoring import (
+            AggregationConfig,
+            ModelEndpointMonitoringMetricValuesV2,
+        )
+        from mlrun.common.schemas.model_monitoring.constants import (
+            ModelEndpointMonitoringMetricType,
+        )
+
+        config = AggregationConfig(
+            aggregated=True, period="1h", functions=["avg", "min", "max"]
+        )
+        values = ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.latency",
+            aggregation_config=config,
+            values=[
+                [datetime(2025, 1, 1, 0, 0), 10.5, 5.0, 20.0],
+                [datetime(2025, 1, 1, 1, 0), 12.3, 6.0, 25.0],
+            ],
+        )
+        assert values.full_name == "project.app.metric.latency"
+        assert values.type == ModelEndpointMonitoringMetricType.METRIC
+        assert values.data is True
+        assert values.aggregation_config.aggregated is True
+        assert len(values.values) == 2
+        assert values.values[0][1] == 10.5  # avg
+        assert values.values[0][2] == 5.0  # min
+        assert values.values[0][3] == 20.0  # max
+
+    def test_metric_values_v2_raw(self):
+        """Test v2 metric values for raw (non-aggregated) data."""
+        from datetime import datetime
+
+        from mlrun.common.schemas.model_monitoring import (
+            AggregationConfig,
+            ModelEndpointMonitoringMetricValuesV2,
+        )
+
+        config = AggregationConfig(aggregated=False)
+        values = ModelEndpointMonitoringMetricValuesV2(
+            full_name="project.app.metric.error_count",
+            aggregation_config=config,
+            values=[
+                [datetime(2025, 1, 1, 0, 0, 0), 1.0],
+                [datetime(2025, 1, 1, 0, 0, 1), 2.0],
+            ],
+        )
+        assert values.aggregation_config.aggregated is False
+        assert len(values.values) == 2
+        assert values.values[0][1] == 1.0
+
+
+class TestModelEndpointMonitoringResultValuesV2:
+    """Tests for ModelEndpointMonitoringResultValuesV2 schema."""
+
+    def test_result_values_v2_aggregated(self):
+        """Test v2 result values with aggregation.
+
+        Note: Aggregated results only contain numeric aggregates (avg, max, etc.)
+        without status or extra_data since those cannot be meaningfully aggregated.
+        """
+        from datetime import datetime
+
+        from mlrun.common.schemas.model_monitoring import (
+            AggregationConfig,
+            ModelEndpointMonitoringResultValuesV2,
+        )
+        from mlrun.common.schemas.model_monitoring.constants import (
+            ModelEndpointMonitoringMetricType,
+            ResultKindApp,
+        )
+
+        config = AggregationConfig(
+            aggregated=True, period="1h", functions=["avg", "max"]
+        )
+        # Aggregated values: [timestamp, avg_value, max_value] - no status/extra_data
+        values = ModelEndpointMonitoringResultValuesV2(
+            full_name="project.histogram-data-drift.result.general_drift",
+            result_kind=ResultKindApp.data_drift,
+            aggregation_config=config,
+            values=[
+                [datetime(2025, 1, 1, 0, 0), 0.15, 0.25],
+                [datetime(2025, 1, 1, 1, 0), 0.18, 0.30],
+            ],
+        )
+        assert values.full_name == "project.histogram-data-drift.result.general_drift"
+        assert values.type == ModelEndpointMonitoringMetricType.RESULT
+        assert values.result_kind == ResultKindApp.data_drift
+        assert values.data is True
+        assert values.aggregation_config.aggregated is True
+        assert len(values.values) == 2
+        # Each row has: timestamp + 2 aggregation values (avg, max)
+        assert len(values.values[0]) == 3
+        assert values.values[0][1] == 0.15  # avg
+        assert values.values[0][2] == 0.25  # max
+
+    def test_result_values_v2_raw(self):
+        """Test v2 result values for raw (non-aggregated) data."""
+        from datetime import datetime
+
+        from mlrun.common.schemas.model_monitoring import (
+            AggregationConfig,
+            ModelEndpointMonitoringResultValuesV2,
+        )
+        from mlrun.common.schemas.model_monitoring.constants import ResultKindApp
+
+        config = AggregationConfig(aggregated=False)
+        values = ModelEndpointMonitoringResultValuesV2(
+            full_name="project.app.result.score",
+            result_kind=ResultKindApp.model_performance,
+            aggregation_config=config,
+            values=[
+                [datetime(2025, 1, 1, 0, 0, 0), 0.95, 0, ""],
+            ],
+        )
+        assert values.aggregation_config.aggregated is False
+        assert values.result_kind == ResultKindApp.model_performance
+        assert len(values.values) == 1

--- a/tests/system/model_monitoring/test_aggregation_v2.py
+++ b/tests/system/model_monitoring/test_aggregation_v2.py
@@ -1,0 +1,421 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+System tests for v2 metrics-values API with pre-aggregation support (ML-11445).
+
+These tests verify that the v2 API correctly aggregates time-series data
+across multiple time buckets using TimescaleDB continuous aggregates.
+
+Unlike the existing system tests that generate data through inference,
+these tests insert time-distributed data directly into TSDB to properly
+test aggregation across hours/days.
+"""
+
+import json
+import typing
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import mlrun
+import mlrun.common.schemas.model_monitoring as mm_schemas
+import mlrun.common.types
+from mlrun.datastore.datastore_profile import DatastoreProfilePostgreSQL
+from mlrun.model_monitoring.db.tsdb.preaggregate import PreAggregateConfig
+from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection import (
+    TimescaleDBConnection,
+)
+from mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_operations import (
+    TimescaleDBOperationsManager,
+)
+from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_query_builder import (
+    TimescaleDBNaming,
+)
+from tests.system.base import TestMLRunSystem
+
+from . import TestMLRunSystemModelMonitoring
+
+# Expected aggregation results for METRICS_TEST_DATA
+EXPECTED_HOUR_0_AVG = 20.0  # (10 + 20 + 30) / 3
+EXPECTED_HOUR_0_MIN = 10.0
+EXPECTED_HOUR_0_MAX = 30.0
+EXPECTED_HOUR_0_COUNT = 3
+
+EXPECTED_HOUR_1_AVG = 150.0  # (100 + 200) / 2
+EXPECTED_HOUR_1_MIN = 100.0
+EXPECTED_HOUR_1_MAX = 200.0
+EXPECTED_HOUR_1_COUNT = 2
+
+EXPECTED_HOUR_2_AVG = 50.0
+EXPECTED_HOUR_2_MIN = 50.0
+EXPECTED_HOUR_2_MAX = 50.0
+EXPECTED_HOUR_2_COUNT = 1
+
+# Expected status for RESULTS_TEST_DATA (MAX = worst = DETECTED)
+EXPECTED_MAX_STATUS = 2  # DETECTED
+
+
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+class TestAggregationV2API(TestMLRunSystemModelMonitoring):
+    """System tests for v2 metrics-values API with pre-aggregation."""
+
+    project_name = "test-aggregation-v2"
+
+    # Test data: {hour_offset: [(minute_offset, value), ...]}
+    METRICS_TEST_DATA: typing.ClassVar[dict[int, list[tuple[int, float]]]] = {
+        0: [(10, 10.0), (30, 20.0), (50, 30.0)],
+        1: [(15, 100.0), (45, 200.0)],
+        2: [(30, 50.0)],
+    }
+
+    # Results test data with status escalation
+    # Status values: NO_DETECTION=0, POSSIBLE_DETECTION=1, DETECTED=2
+    RESULTS_TEST_DATA: typing.ClassVar[dict[int, list[tuple[int, float, int, int]]]] = {
+        0: [
+            (10, 0.1, 0, 0),  # NO_DETECTION
+            (30, 0.5, 1, 0),  # POSSIBLE_DETECTION
+            (50, 0.9, 2, 0),  # DETECTED
+        ],
+    }
+
+    @classmethod
+    def custom_setup_class(cls) -> None:
+        cls.run_db = mlrun.get_run_db()
+        cls.endpoint_id = f"test-agg-ep-{uuid.uuid4().hex[:8]}"
+        cls.app_name = "test-aggregation-app"
+        cls.metric_name = "latency"
+        cls.result_name = "drift_score"
+
+    def custom_setup(self) -> None:
+        self.set_mm_credentials()
+        super(TestMLRunSystem, self).custom_setup(project_name=self.project_name)
+        self._setup_tsdb_with_time_distributed_data()
+
+    def _get_tsdb_connection(self) -> TimescaleDBConnection:
+        """Get a TimescaleDB connection from the profile."""
+        if not isinstance(self.mm_tsdb_profile, DatastoreProfilePostgreSQL):
+            pytest.skip("Test requires PostgreSQL/TimescaleDB TSDB profile")
+
+        dsn = self.mm_tsdb_profile.get_connection_string()
+        return TimescaleDBConnection(dsn, max_connections=1, autocommit=False)
+
+    def _get_autocommit_connection(self) -> TimescaleDBConnection:
+        """Get a TimescaleDB connection with autocommit for DDL operations."""
+        if not isinstance(self.mm_tsdb_profile, DatastoreProfilePostgreSQL):
+            pytest.skip("Test requires PostgreSQL/TimescaleDB TSDB profile")
+
+        dsn = self.mm_tsdb_profile.get_connection_string()
+        return TimescaleDBConnection(dsn, max_connections=1, autocommit=True)
+
+    def _setup_tsdb_with_time_distributed_data(self) -> None:
+        """Insert time-distributed metrics/results directly into TSDB."""
+        connection = self._get_tsdb_connection()
+
+        pre_aggregate_config = PreAggregateConfig(
+            aggregate_intervals=["1h"],
+            agg_functions=["avg", "min", "max", "count"],
+            retention_policy={
+                "raw": "7 days",
+                "1h": "30 days",
+            },
+        )
+
+        self._operations_handler = TimescaleDBOperationsManager(
+            project=self.project_name,
+            connection=connection,
+            pre_aggregate_config=pre_aggregate_config,
+        )
+        self._operations_handler.create_tables()
+
+        now = datetime.now(UTC)
+        self._base_time = now - timedelta(hours=5)
+
+        self._insert_metrics_data()
+        self._insert_results_data()
+        self._refresh_continuous_aggregates()
+        self._connection = connection
+
+    def _insert_metrics_data(self) -> None:
+        """Insert metrics test data into TSDB."""
+        for hour_offset, values in self.METRICS_TEST_DATA.items():
+            for minute_offset, value in values:
+                timestamp = self._base_time + timedelta(
+                    hours=hour_offset, minutes=minute_offset
+                )
+                event = {
+                    mm_schemas.WriterEvent.END_INFER_TIME: timestamp,
+                    mm_schemas.WriterEvent.START_INFER_TIME: timestamp,
+                    mm_schemas.WriterEvent.ENDPOINT_ID: self.endpoint_id,
+                    mm_schemas.WriterEvent.APPLICATION_NAME: self.app_name,
+                    mm_schemas.MetricData.METRIC_NAME: self.metric_name,
+                    mm_schemas.MetricData.METRIC_VALUE: value,
+                }
+                self._operations_handler.write_application_event(
+                    event, kind=mm_schemas.WriterEventKind.METRIC
+                )
+
+    def _insert_results_data(self) -> None:
+        """Insert results test data into TSDB."""
+        for hour_offset, values in self.RESULTS_TEST_DATA.items():
+            for minute_offset, value, status, kind in values:
+                timestamp = self._base_time + timedelta(
+                    hours=hour_offset, minutes=minute_offset
+                )
+                event = {
+                    mm_schemas.WriterEvent.END_INFER_TIME: timestamp,
+                    mm_schemas.WriterEvent.START_INFER_TIME: timestamp,
+                    mm_schemas.WriterEvent.ENDPOINT_ID: self.endpoint_id,
+                    mm_schemas.WriterEvent.APPLICATION_NAME: self.app_name,
+                    mm_schemas.ResultData.RESULT_NAME: self.result_name,
+                    mm_schemas.ResultData.RESULT_VALUE: value,
+                    mm_schemas.ResultData.RESULT_STATUS: status,
+                    mm_schemas.ResultData.RESULT_KIND: kind,
+                    mm_schemas.ResultData.RESULT_EXTRA_DATA: "{}",
+                }
+                self._operations_handler.write_application_event(
+                    event, kind=mm_schemas.WriterEventKind.RESULT
+                )
+
+    def _refresh_continuous_aggregates(self) -> None:
+        """Manually refresh CAGGs for test data to be queryable."""
+        autocommit_conn = self._get_autocommit_connection()
+        tables = self._operations_handler.tables
+
+        metrics_table = tables[mm_schemas.TimescaleDBTables.METRICS]
+        metrics_cagg_name = TimescaleDBNaming.get_cagg_view_name(
+            metrics_table.full_name(), "1h"
+        )
+        autocommit_conn.run(
+            statements=f"CALL refresh_continuous_aggregate('{metrics_cagg_name}', NULL, NULL);"
+        )
+
+        results_table = tables[mm_schemas.TimescaleDBTables.APP_RESULTS]
+        results_cagg_name = TimescaleDBNaming.get_cagg_view_name(
+            results_table.full_name(), "1h"
+        )
+        autocommit_conn.run(
+            statements=f"CALL refresh_continuous_aggregate('{results_cagg_name}', NULL, NULL);"
+        )
+
+    def _build_metric_full_name(self) -> str:
+        """Build the full metric name in project.app.metric format."""
+        return f"{self.project_name}.{self.app_name}.{self.metric_name}"
+
+    def _build_result_full_name(self) -> str:
+        """Build the full result name in project.app.result format."""
+        return f"{self.project_name}.{self.app_name}.{self.result_name}"
+
+    def _get_time_range_ms(self) -> tuple[int, int]:
+        """Get start/end timestamps in milliseconds covering test data."""
+        start = int((self._base_time - timedelta(hours=1)).timestamp() * 1000)
+        end = int((self._base_time + timedelta(hours=5)).timestamp() * 1000)
+        return start, end
+
+    def custom_teardown(self) -> None:
+        """Clean up TSDB resources after test."""
+        if hasattr(self, "_operations_handler"):
+            try:
+                self._operations_handler.delete_tsdb_resources()
+            except Exception:
+                pass
+
+    def test_v2_api_aggregation_1h_correct_values(self) -> None:
+        """Verify 1-hour aggregation returns correct min/max/avg/count values."""
+        start, end = self._get_time_range_ms()
+        metric_name = self._build_metric_full_name()
+
+        response = self.run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=(
+                f"v2/projects/{self.project_name}/model-endpoints/{self.endpoint_id}"
+                f"/metrics-values?name={metric_name}&start={start}&end={end}"
+                f"&agg-period=1h&agg-function=avg&agg-function=min&agg-function=max"
+            ),
+        )
+        results = json.loads(response.content.decode())
+
+        assert len(results) == 1
+        result = results[0]
+
+        assert result["data"] is True
+        agg_config = result["aggregation_config"]
+        assert agg_config["aggregated"] is True
+        assert agg_config["period"] == "1h"
+        assert set(agg_config["functions"]) == {"avg", "min", "max"}
+
+        values = result["values"]
+        expected_bucket_count = len(self.METRICS_TEST_DATA)
+        assert len(values) == expected_bucket_count
+
+        for value in values:
+            assert len(value) >= 4
+
+    def test_v2_api_raw_returns_all_points(self) -> None:
+        """Verify agg-period=raw returns individual data points."""
+        start, end = self._get_time_range_ms()
+        metric_name = self._build_metric_full_name()
+
+        response = self.run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=(
+                f"v2/projects/{self.project_name}/model-endpoints/{self.endpoint_id}"
+                f"/metrics-values?name={metric_name}&start={start}&end={end}"
+                f"&agg-period=raw"
+            ),
+        )
+        results = json.loads(response.content.decode())
+
+        assert len(results) == 1
+        result = results[0]
+
+        agg_config = result["aggregation_config"]
+        assert agg_config["aggregated"] is False
+
+        values = result["values"]
+        expected_count = sum(len(v) for v in self.METRICS_TEST_DATA.values())
+        assert len(values) == expected_count
+
+        for value in values:
+            assert len(value) == 2
+
+    def test_v2_api_auto_select_period(self) -> None:
+        """Verify auto-selection when no agg-period specified."""
+        start, end = self._get_time_range_ms()
+        metric_name = self._build_metric_full_name()
+
+        response = self.run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=(
+                f"v2/projects/{self.project_name}/model-endpoints/{self.endpoint_id}"
+                f"/metrics-values?name={metric_name}&start={start}&end={end}"
+            ),
+        )
+        results = json.loads(response.content.decode())
+
+        assert len(results) == 1
+        result = results[0]
+
+        agg_config = result["aggregation_config"]
+        assert "aggregated" in agg_config
+
+        if agg_config["aggregated"]:
+            assert agg_config["period"] is not None
+
+    def test_v2_api_results_with_status_aggregation(self) -> None:
+        """Verify result_status uses MAX (worst status in window)."""
+        start, end = self._get_time_range_ms()
+        result_name = self._build_result_full_name()
+
+        response = self.run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=(
+                f"v2/projects/{self.project_name}/model-endpoints/{self.endpoint_id}"
+                f"/metrics-values?name={result_name}&start={start}&end={end}"
+                f"&agg-period=1h&agg-function=avg&agg-function=max"
+            ),
+        )
+        results = json.loads(response.content.decode())
+
+        result = next(
+            (r for r in results if r["full_name"] == result_name),
+            None,
+        )
+        assert result is not None
+
+        if result["data"]:
+            agg_config = result["aggregation_config"]
+            assert agg_config["aggregated"] is True
+            values = result["values"]
+            assert len(values) >= 1
+
+    def test_v2_api_multiple_metrics_same_request(self) -> None:
+        """Verify multiple metrics in single request."""
+        start, end = self._get_time_range_ms()
+        metric_name = self._build_metric_full_name()
+        result_name = self._build_result_full_name()
+
+        response = self.run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=(
+                f"v2/projects/{self.project_name}/model-endpoints/{self.endpoint_id}"
+                f"/metrics-values?name={metric_name}&name={result_name}"
+                f"&start={start}&end={end}&agg-period=1h&agg-function=avg"
+            ),
+        )
+        results = json.loads(response.content.decode())
+
+        assert len(results) == 2
+
+        full_names = {r["full_name"] for r in results}
+        assert metric_name in full_names
+        assert result_name in full_names
+
+    def test_v2_api_response_format_matches_schema(self) -> None:
+        """Verify response matches v2 schema structure."""
+        start, end = self._get_time_range_ms()
+        metric_name = self._build_metric_full_name()
+
+        response = self.run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=(
+                f"v2/projects/{self.project_name}/model-endpoints/{self.endpoint_id}"
+                f"/metrics-values?name={metric_name}&start={start}&end={end}"
+                f"&agg-period=1h&agg-function=avg"
+            ),
+        )
+        results = json.loads(response.content.decode())
+
+        assert len(results) == 1
+        result = results[0]
+
+        assert result["full_name"] == metric_name
+        assert "type" in result
+        assert "data" in result
+        assert "aggregation_config" in result
+
+        agg_config = result["aggregation_config"]
+        assert agg_config["aggregated"] is True
+        assert agg_config["period"] == "1h"
+        assert "avg" in agg_config["functions"]
+
+        if result["data"]:
+            values = result["values"]
+            assert isinstance(values, list)
+            if values:
+                assert isinstance(values[0], list)
+
+    def test_v2_api_empty_time_range_returns_no_data(self) -> None:
+        """Verify behavior when no data in requested time range."""
+        future = datetime.now(UTC) + timedelta(days=365)
+        start = int(future.timestamp() * 1000)
+        end = int((future + timedelta(days=1)).timestamp() * 1000)
+        metric_name = self._build_metric_full_name()
+
+        response = self.run_db.api_call(
+            method=mlrun.common.types.HTTPMethod.GET,
+            path=(
+                f"v2/projects/{self.project_name}/model-endpoints/{self.endpoint_id}"
+                f"/metrics-values?name={metric_name}&start={start}&end={end}"
+                f"&agg-period=1h&agg-function=avg"
+            ),
+        )
+        results = json.loads(response.content.decode())
+
+        assert len(results) == 1
+        result = results[0]
+
+        assert result["data"] is False


### PR DESCRIPTION
## Summary

This PR adds a v2 API endpoint for model monitoring metrics and results with TSDB pre-aggregation support:

