### PR TITLE
[Application Runtime] Support setting probes for the application runtime sidecars

### DIFF
--- a/docs/runtimes/application.ipynb
+++ b/docs/runtimes/application.ipynb
@@ -612,6 +612,27 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": "**3. Set override:** Calling the set_probe repeatedly with the same probe type will replace the existing configuration."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "application.set_probe(\n",
+    "    type=\"liveness\",\n",
+    "    initial_delay_seconds=15,\n",
+    ")\n",
+    "\n",
+    "application.set_probe(type=\"liveness\", period_seconds=10)\n",
+    "\n",
+    "# The liveness probe configuration will now only have period_seconds=10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Deleting probes\n",
     "\n",

--- a/docs/runtimes/application.ipynb
+++ b/docs/runtimes/application.ipynb
@@ -517,6 +517,115 @@
    "source": [
     "application.invoke(\"/external\").json()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure Sidecar Kubernetes probes\n",
+    "\n",
+    "You can configure Kubernetes liveness, readiness, and startup probes for the sidecar container using the `set_probe()` and `delete_probe()` methods.\n",
+    "For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes\n",
+    "\n",
+    "### Setting probes\n",
+    "\n",
+    "The `set_probe()` method allows you to configure probes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Basic HTTP probe example:\n",
+    "application.set_probe(\n",
+    "    type=\"liveness\",\n",
+    "    http_path=\"/health\",\n",
+    "    http_port=8080,\n",
+    "    http_scheme=\"HTTPS\",\n",
+    "    initial_delay_seconds=15,\n",
+    "    period_seconds=10,\n",
+    "    failure_threshold=3,\n",
+    "    timeout_seconds=5,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Using the config parameter for advanced probe types:**\n",
+    "# For probe types not covered by the simple parameters (e.g., TCP socket, exec, or gRPC probes), you can use the `config` parameter to provide a full Kubernetes probe configuration:\n",
+    "\n",
+    "application.set_probe(\n",
+    "    type=\"liveness\",\n",
+    "    initial_delay_seconds=15,\n",
+    "    period_seconds=10,\n",
+    "    config={\n",
+    "        \"tcpSocket\": {\"port\": 8080},\n",
+    "        \"terminationGracePeriodSeconds\": 90,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Notes\n",
+    "**1. Parameter precedence:** When both `config` and explicit parameters are provided, the explicit parameters override values in the config. Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "application.set_probe(\n",
+    "    type=\"startup\",\n",
+    "    initial_delay_seconds=15,  # This will be used (not 20 from config)\n",
+    "    config={\n",
+    "        \"tcpSocket\": {\"port\": 8080},\n",
+    "        \"initialDelaySeconds\": 20,  # Overridden by parameter above\n",
+    "        \"periodSeconds\": 30,\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "**2. Port enrichment:** If you provide `http_path` without `http_port`, the port will be automatically enriched from the `internal_application_port` just before deployment. Example:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "application.set_internal_application_port(8050)\n",
+    "application.set_probe(\n",
+    "    type=\"readiness\",\n",
+    "    http_path=\"/health\",\n",
+    "    # Port will be enriched to 8050 before deployment\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deleting probes\n",
+    "\n",
+    "To remove a probe configuration, use the `delete_probe()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "application.delete_probe(type=\"readiness\")"
+   ]
   }
  ],
  "metadata": {

--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -374,15 +374,13 @@ class ProbeType(StrEnum):
     LIVENESS = "liveness"
     STARTUP = "startup"
 
+    @property
+    def key(self):
+        return f"{self.value}Probe"
 
-PROBE_KEYS = {
-    ProbeType.READINESS.value: "readinessProbe",
-    ProbeType.LIVENESS.value: "livenessProbe",
-    ProbeType.STARTUP.value: "startupProbe",
-}
 
-PROBE_TIMING_INITIAL_DELAY_SECONDS = "initialDelaySeconds"
-PROBE_TIMING_PERIOD_SECONDS = "periodSeconds"
-PROBE_TIMING_TIMEOUT_SECONDS = "timeoutSeconds"
-PROBE_TIMING_FAILURE_THRESHOLD = "failureThreshold"
-PROBE_TIMING_SUCCESS_THRESHOLD = "successThreshold"
+class ProbeTimeConfig(StrEnum):
+    INITIAL_DELAY_SECONDS = "initialDelaySeconds"
+    PERIOD_SECONDS = "periodSeconds"
+    TIMEOUT_SECONDS = "timeoutSeconds"
+    FAILURE_THRESHOLD = "failureThreshold"

--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -368,7 +368,7 @@ class FunctionEnvironmentVariables:
     auth_session = f"{_env_prefix}AUTH_SESSION"
 
 
-# Kubernetes probe type keys
+# Kubernetes probe types
 class ProbeType(StrEnum):
     READINESS = "readiness"
     LIVENESS = "liveness"
@@ -379,8 +379,13 @@ class ProbeType(StrEnum):
         return f"{self.value}Probe"
 
     @classmethod
-    def is_valid(cls, value: str) -> bool:
-        return value in cls._value2member_map_
+    def is_valid(cls, value: str, raise_on_error: bool = False) -> bool:
+        valid_value = value in cls._value2member_map_
+        if not valid_value and raise_on_error:
+            raise ValueError(
+                f"Invalid probe type: {value}. Must be one of: {[p.value for p in ProbeType]}"
+            )
+        return valid_value
 
 
 class ProbeTimeConfig(StrEnum):

--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -378,6 +378,10 @@ class ProbeType(StrEnum):
     def key(self):
         return f"{self.value}Probe"
 
+    @classmethod
+    def is_valid(cls, value: str) -> bool:
+        return value in cls._value2member_map_
+
 
 class ProbeTimeConfig(StrEnum):
     INITIAL_DELAY_SECONDS = "initialDelaySeconds"

--- a/mlrun/common/runtimes/constants.py
+++ b/mlrun/common/runtimes/constants.py
@@ -16,6 +16,7 @@ import typing
 
 import mlrun.common.constants as mlrun_constants
 import mlrun_pipelines.common.models
+from mlrun.common.types import StrEnum
 
 
 class PodPhases:
@@ -365,3 +366,23 @@ class NuclioIngressAddTemplatedIngressModes:
 class FunctionEnvironmentVariables:
     _env_prefix = "MLRUN_"
     auth_session = f"{_env_prefix}AUTH_SESSION"
+
+
+# Kubernetes probe type keys
+class ProbeType(StrEnum):
+    READINESS = "readiness"
+    LIVENESS = "liveness"
+    STARTUP = "startup"
+
+
+PROBE_KEYS = {
+    ProbeType.READINESS.value: "readinessProbe",
+    ProbeType.LIVENESS.value: "livenessProbe",
+    ProbeType.STARTUP.value: "startupProbe",
+}
+
+PROBE_TIMING_INITIAL_DELAY_SECONDS = "initialDelaySeconds"
+PROBE_TIMING_PERIOD_SECONDS = "periodSeconds"
+PROBE_TIMING_TIMEOUT_SECONDS = "timeoutSeconds"
+PROBE_TIMING_FAILURE_THRESHOLD = "failureThreshold"
+PROBE_TIMING_SUCCESS_THRESHOLD = "successThreshold"

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -330,9 +330,11 @@ class ApplicationRuntime(RemoteRuntime):
         :param failure_threshold:     Minimum consecutive failures for the probe to be considered failed
         :param timeout_seconds:       Number of seconds after which the probe times out
         :param http_path:            If provided, use an HTTP probe with this path
-        :param http_port:            If HTTP probe is used and no port provided, the internal application port will be used
+        :param http_port:            If HTTP probe is used and no port provided,
+                                     the internal application port will be used
         :param http_scheme:           "http" or "https" for HTTP probe. Defaults to "http"
-        :param config:                A full dict with the probe configuration (used as base, overridden by individual parameters)
+        :param config:                A full dict with the probe configuration
+                                     (used as base, overridden by individual parameters)
 
         :return: function object (self)
         """

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -22,12 +22,8 @@ import mlrun.common.schemas as schemas
 import mlrun.errors
 import mlrun.run
 from mlrun.common.runtimes.constants import (
-    PROBE_KEYS,
-    PROBE_TIMING_FAILURE_THRESHOLD,
-    PROBE_TIMING_INITIAL_DELAY_SECONDS,
-    PROBE_TIMING_PERIOD_SECONDS,
-    PROBE_TIMING_TIMEOUT_SECONDS,
     NuclioIngressAddTemplatedIngressModes,
+    ProbeTimeConfig,
     ProbeType,
 )
 from mlrun.runtimes import RemoteRuntime
@@ -362,18 +358,19 @@ class ApplicationRuntime(RemoteRuntime):
 
         # Override timing parameters from explicit arguments
         if initial_delay_seconds is not None:
-            probe_config[PROBE_TIMING_INITIAL_DELAY_SECONDS] = initial_delay_seconds
+            probe_config[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] = (
+                initial_delay_seconds
+            )
         if period_seconds is not None:
-            probe_config[PROBE_TIMING_PERIOD_SECONDS] = period_seconds
+            probe_config[ProbeTimeConfig.PERIOD_SECONDS.value] = period_seconds
         if failure_threshold is not None:
-            probe_config[PROBE_TIMING_FAILURE_THRESHOLD] = failure_threshold
+            probe_config[ProbeTimeConfig.FAILURE_THRESHOLD.value] = failure_threshold
         if timeout_seconds is not None:
-            probe_config[PROBE_TIMING_TIMEOUT_SECONDS] = timeout_seconds
+            probe_config[ProbeTimeConfig.TIMEOUT_SECONDS.value] = timeout_seconds
 
         # Store probe configuration in the sidecar
         sidecar = self._set_sidecar(self._get_sidecar_name())
-        probe_key = PROBE_KEYS[type.value]
-        sidecar[probe_key] = probe_config
+        sidecar[type.key] = probe_config
 
         return self
 
@@ -398,9 +395,8 @@ class ApplicationRuntime(RemoteRuntime):
 
         sidecar = self._get_sidecar()
         if sidecar:
-            probe_key = PROBE_KEYS[type.value]
-            if probe_key in sidecar:
-                del sidecar[probe_key]
+            if type.key in sidecar:
+                del sidecar[type.key]
 
         return self
 
@@ -1018,8 +1014,7 @@ class ApplicationRuntime(RemoteRuntime):
             return
 
         for probe_type in ProbeType:
-            probe_key = PROBE_KEYS[probe_type.value]
-            probe_config = sidecar.get(probe_key)
+            probe_config = sidecar.get(probe_type.key)
 
             if probe_config and isinstance(probe_config, dict):
                 http_get = probe_config.get("httpGet")
@@ -1031,7 +1026,7 @@ class ApplicationRuntime(RemoteRuntime):
                             "Please set the internal_application_port or provide http_port in set_probe()."
                         )
                     http_get["port"] = internal_port
-                    sidecar[probe_key] = probe_config
+                    sidecar[probe_type.key] = probe_config
 
     def _get_sidecar(self) -> dict | None:
         """Get the sidecar container for ApplicationRuntime

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -334,8 +334,7 @@ class ApplicationRuntime(RemoteRuntime):
 
         :return: function object (self)
         """
-        # Validate probe type
-        ProbeType.is_valid(type, raise_on_error=True)
+        self._validate_set_probes_input(locals())
         type = ProbeType(type)
 
         # Start with config as base
@@ -1038,5 +1037,19 @@ class ApplicationRuntime(RemoteRuntime):
 
         return None
 
-    def _get_sidecar_name(self):
+    def _get_sidecar_name(self) -> str:
         return f"{self.metadata.name}-sidecar"
+
+    @staticmethod
+    def _validate_set_probes_input(params: dict):
+        # Validate probe type
+        ProbeType.is_valid(params.get("type"), raise_on_error=True)
+
+        # At least one optional parameter must be provided
+        optional_params = {
+            k: v for k, v in params.items() if (k != "type" and k != "self")
+        }
+        if all(v is None for v in optional_params.values()):
+            raise ValueError(
+                "Empty probe configuration: at least one parameter must be set"
+            )

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -353,7 +353,7 @@ class ApplicationRuntime(RemoteRuntime):
             http_probe["path"] = http_path
             if http_port is not None:
                 http_probe["port"] = http_port
-            http_probe["scheme"] = http_scheme or http_probe.get("scheme", "http")
+            http_probe["scheme"] = http_scheme or http_probe.get("scheme", "HTTP")
             probe_config["httpGet"] = http_probe
 
         # Override timing parameters from explicit arguments

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -335,13 +335,10 @@ class ApplicationRuntime(RemoteRuntime):
         :return: function object (self)
         """
         # Validate probe type
-        if not isinstance(type, ProbeType):
-            try:
-                type = ProbeType(type.value if hasattr(type, "value") else type)
-            except (ValueError, AttributeError):
-                raise ValueError(
-                    f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
-                )
+        if not ProbeType.is_valid(type):
+            raise ValueError(
+                f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
+            )
 
         # Start with config as base
         probe_config = copy.deepcopy(config) if config else {}
@@ -357,16 +354,18 @@ class ApplicationRuntime(RemoteRuntime):
             probe_config["httpGet"] = http_probe
 
         # Override timing parameters from explicit arguments
-        if initial_delay_seconds is not None:
-            probe_config[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] = (
-                initial_delay_seconds
-            )
-        if period_seconds is not None:
-            probe_config[ProbeTimeConfig.PERIOD_SECONDS.value] = period_seconds
-        if failure_threshold is not None:
-            probe_config[ProbeTimeConfig.FAILURE_THRESHOLD.value] = failure_threshold
-        if timeout_seconds is not None:
-            probe_config[ProbeTimeConfig.TIMEOUT_SECONDS.value] = timeout_seconds
+        probe_config.update(
+            {
+                config.value: value
+                for config, value in {
+                    ProbeTimeConfig.INITIAL_DELAY_SECONDS: initial_delay_seconds,
+                    ProbeTimeConfig.PERIOD_SECONDS: period_seconds,
+                    ProbeTimeConfig.FAILURE_THRESHOLD: failure_threshold,
+                    ProbeTimeConfig.TIMEOUT_SECONDS: timeout_seconds,
+                }.items()
+                if value is not None
+            }
+        )
 
         # Store probe configuration in the sidecar
         sidecar = self._set_sidecar(self._get_sidecar_name())
@@ -385,13 +384,10 @@ class ApplicationRuntime(RemoteRuntime):
         :return: function object (self)
         """
         # Validate probe type
-        if not isinstance(type, ProbeType):
-            try:
-                type = ProbeType(type.value if hasattr(type, "value") else type)
-            except (ValueError, AttributeError):
-                raise ValueError(
-                    f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
-                )
+        if not ProbeType.is_valid(type):
+            raise ValueError(
+                f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
+            )
 
         sidecar = self._get_sidecar()
         if sidecar:
@@ -1004,10 +1000,6 @@ class ApplicationRuntime(RemoteRuntime):
         - Enrichment happens just before deployment to ensure the latest internal_application_port
           value is used, even if it was modified after set_probe() was called
         """
-        internal_port = None
-        if hasattr(self.spec, "internal_application_port"):
-            internal_port = self.spec.internal_application_port
-
         # Check each probe type and enrich missing HTTP ports
         sidecar = self._get_sidecar()
         if not sidecar:
@@ -1019,13 +1011,19 @@ class ApplicationRuntime(RemoteRuntime):
             if probe_config and isinstance(probe_config, dict):
                 http_get = probe_config.get("httpGet")
                 if http_get and isinstance(http_get, dict) and "port" not in http_get:
-                    if internal_port is None:
+                    if self.spec.internal_application_port is None:
                         raise ValueError(
                             f"Cannot enrich {probe_type.value} probe: HTTP probe requires a port, "
                             "but internal_application_port is not set. "
                             "Please set the internal_application_port or provide http_port in set_probe()."
                         )
-                    http_get["port"] = internal_port
+                    http_get["port"] = self.spec.internal_application_port
+                    logger.debug(
+                        "Enriched sidecar probe port",
+                        probe_type=probe_type.value,
+                        port=http_get["port"],
+                        application_name=self.metadata.name,
+                    )
                     sidecar[probe_type.key] = probe_config
 
     def _get_sidecar(self) -> dict | None:

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import pathlib
 import typing
 
@@ -21,6 +22,7 @@ import mlrun.common.schemas as schemas
 import mlrun.errors
 import mlrun.run
 from mlrun.common.runtimes.constants import NuclioIngressAddTemplatedIngressModes
+from mlrun.common.types import StrEnum
 from mlrun.runtimes import RemoteRuntime
 from mlrun.runtimes.nuclio import (
     min_nuclio_versions,
@@ -33,6 +35,19 @@ from mlrun.runtimes.nuclio.api_gateway import (
 )
 from mlrun.runtimes.nuclio.function import NuclioSpec, NuclioStatus
 from mlrun.utils import is_valid_port, logger, update_in
+
+
+class ProbeType(StrEnum):
+    READINESS = "readiness"
+    LIVENESS = "liveness"
+    STARTUP = "startup"
+
+
+PROBES_KEYS = {
+    ProbeType.READINESS.value: "readinessProbe",
+    ProbeType.LIVENESS.value: "livenessProbe",
+    ProbeType.STARTUP.value: "startupProbe",
+}
 
 
 class ApplicationSpec(NuclioSpec):
@@ -296,6 +311,103 @@ class ApplicationRuntime(RemoteRuntime):
     def set_internal_application_port(self, port: int):
         self.spec.internal_application_port = port
 
+    def set_probe(
+        self,
+        type: ProbeType,
+        initial_delay_seconds: int | None = None,
+        period_seconds: int | None = None,
+        failure_threshold: int | None = None,
+        timeout_seconds: int | None = None,
+        http_path: str | None = None,
+        http_port: int | None = None,
+        http_scheme: str | None = None,
+        config: dict | None = None,
+    ):
+        """Set a Kubernetes probe configuration for the sidecar container
+
+        The config parameter serves as the base configuration, and individual parameters
+        override values in config. If http_path is provided without http_port and config
+        is not provided, the port will be enriched from the internal application port
+        just before deployment.
+
+        :param type:                 Probe type - one of "readiness", "liveness", "startup"
+        :param initial_delay_seconds: Number of seconds after the container has started before probes are initiated
+        :param period_seconds:         How often (in seconds) to perform the probe
+        :param failure_threshold:     Minimum consecutive failures for the probe to be considered failed
+        :param timeout_seconds:       Number of seconds after which the probe times out
+        :param http_path:            If provided, use an HTTP probe with this path
+        :param http_port:            If HTTP probe is used and no port provided, the internal application port will be used
+        :param http_scheme:           "http" or "https" for HTTP probe. Defaults to "http"
+        :param config:                A full dict with the probe configuration (used as base, overridden by individual parameters)
+
+        :return: function object (self)
+        """
+        # Validate probe type
+        if not isinstance(type, ProbeType):
+            try:
+                type = ProbeType(type.value if hasattr(type, "value") else type)
+            except (ValueError, AttributeError):
+                raise ValueError(
+                    f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
+                )
+
+        # Start with config as base
+        probe_config = copy.deepcopy(config) if config else {}
+
+        # Build HTTP probe configuration if http_path is provided
+        # Note: If http_path is None, all HTTP-related parameters (http_port, http_scheme) are ignored
+        if http_path:
+            http_probe = probe_config.get("httpGet", {})
+            http_probe["path"] = http_path
+            if http_port is not None:
+                http_probe["port"] = http_port
+            http_probe["scheme"] = http_scheme or http_probe.get("scheme", "http")
+            probe_config["httpGet"] = http_probe
+
+        # Override timing parameters from explicit arguments
+        if initial_delay_seconds is not None:
+            probe_config["initialDelaySeconds"] = initial_delay_seconds
+        if period_seconds is not None:
+            probe_config["periodSeconds"] = period_seconds
+        if failure_threshold is not None:
+            probe_config["failureThreshold"] = failure_threshold
+        if timeout_seconds is not None:
+            probe_config["timeoutSeconds"] = timeout_seconds
+
+        # Store probe configuration in the sidecar
+        sidecar = self._set_sidecar(self._get_sidecar_name())
+        probe_key = PROBES_KEYS[type.value]
+        sidecar[probe_key] = probe_config
+
+        return self
+
+    def delete_probe(
+        self,
+        type: ProbeType,
+    ):
+        """Delete a Kubernetes probe configuration from the sidecar container
+
+        :param type: Probe type - one of "readiness", "liveness", "startup"
+
+        :return: function object (self)
+        """
+        # Validate probe type
+        if not isinstance(type, ProbeType):
+            try:
+                type = ProbeType(type.value if hasattr(type, "value") else type)
+            except (ValueError, AttributeError):
+                raise ValueError(
+                    f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
+                )
+
+        sidecar = self._get_sidecar()
+        if sidecar:
+            probe_key = PROBES_KEYS[type.value]
+            if probe_key in sidecar:
+                del sidecar[probe_key]
+
+        return self
+
     def with_sidecar(
         self,
         name: typing.Optional[str] = None,
@@ -423,6 +535,7 @@ class ApplicationRuntime(RemoteRuntime):
         self.spec.add_templated_ingress_host_mode = (
             NuclioIngressAddTemplatedIngressModes.never
         )
+        self._enrich_sidecar_probe_ports()
 
         super().deploy(
             project=project,
@@ -885,3 +998,60 @@ class ApplicationRuntime(RemoteRuntime):
         self.status.api_gateway = APIGateway.from_scheme(api_gateway_scheme)
         self.status.api_gateway.wait_for_readiness()
         self.url = self.status.api_gateway.invoke_url
+
+    def _enrich_sidecar_probe_ports(self):
+        """Enrich sidecar probe configurations with internal application port if needed
+
+        This method is called just before deployment to automatically enrich HTTP probes
+        in the sidecar container that were configured without an explicit port.
+
+        Enrichment logic:
+        - Only enriches HTTP probes (httpGet) that don't already have a port specified
+        - If the user explicitly provided http_port in set_probe(), enrichment is skipped
+        - If the user provided a port in the config dict, enrichment is skipped
+        - Enrichment happens just before deployment to ensure the latest internal_application_port
+          value is used, even if it was modified after set_probe() was called
+        """
+        internal_port = None
+        if hasattr(self.spec, "internal_application_port"):
+            internal_port = self.spec.internal_application_port
+
+        # Check each probe type and enrich missing HTTP ports
+        sidecar = self._get_sidecar()
+        if not sidecar:
+            return
+
+        for probe_type in ProbeType:
+            probe_key = PROBES_KEYS[probe_type.value]
+            probe_config = sidecar.get(probe_key)
+
+            if probe_config and isinstance(probe_config, dict):
+                http_get = probe_config.get("httpGet")
+                if http_get and isinstance(http_get, dict) and "port" not in http_get:
+                    if internal_port is None:
+                        raise ValueError(
+                            f"Cannot enrich {probe_type.value} probe: HTTP probe requires a port, "
+                            "but internal_application_port is not set. "
+                            "Please set the internal_application_port or provide http_port in set_probe()."
+                        )
+                    http_get["port"] = internal_port
+                    sidecar[probe_key] = probe_config
+
+    def _get_sidecar(self) -> dict | None:
+        """Get the sidecar container for ApplicationRuntime
+
+        Returns the sidecar dict if found, None otherwise.
+        """
+        sidecar_name = self._get_sidecar_name()
+        if not hasattr(self.spec, "config") or "spec.sidecars" not in self.spec.config:
+            return None
+
+        sidecars = self.spec.config["spec.sidecars"]
+        for sidecar in sidecars:
+            if sidecar.get("name") == sidecar_name:
+                return sidecar
+
+        return None
+
+    def _get_sidecar_name(self):
+        return f"{self.metadata.name}-sidecar"

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -21,8 +21,15 @@ import nuclio.auth
 import mlrun.common.schemas as schemas
 import mlrun.errors
 import mlrun.run
-from mlrun.common.runtimes.constants import NuclioIngressAddTemplatedIngressModes
-from mlrun.common.types import StrEnum
+from mlrun.common.runtimes.constants import (
+    PROBE_KEYS,
+    PROBE_TIMING_FAILURE_THRESHOLD,
+    PROBE_TIMING_INITIAL_DELAY_SECONDS,
+    PROBE_TIMING_PERIOD_SECONDS,
+    PROBE_TIMING_TIMEOUT_SECONDS,
+    NuclioIngressAddTemplatedIngressModes,
+    ProbeType,
+)
 from mlrun.runtimes import RemoteRuntime
 from mlrun.runtimes.nuclio import (
     min_nuclio_versions,
@@ -35,19 +42,6 @@ from mlrun.runtimes.nuclio.api_gateway import (
 )
 from mlrun.runtimes.nuclio.function import NuclioSpec, NuclioStatus
 from mlrun.utils import is_valid_port, logger, update_in
-
-
-class ProbeType(StrEnum):
-    READINESS = "readiness"
-    LIVENESS = "liveness"
-    STARTUP = "startup"
-
-
-PROBES_KEYS = {
-    ProbeType.READINESS.value: "readinessProbe",
-    ProbeType.LIVENESS.value: "livenessProbe",
-    ProbeType.STARTUP.value: "startupProbe",
-}
 
 
 class ApplicationSpec(NuclioSpec):
@@ -366,17 +360,17 @@ class ApplicationRuntime(RemoteRuntime):
 
         # Override timing parameters from explicit arguments
         if initial_delay_seconds is not None:
-            probe_config["initialDelaySeconds"] = initial_delay_seconds
+            probe_config[PROBE_TIMING_INITIAL_DELAY_SECONDS] = initial_delay_seconds
         if period_seconds is not None:
-            probe_config["periodSeconds"] = period_seconds
+            probe_config[PROBE_TIMING_PERIOD_SECONDS] = period_seconds
         if failure_threshold is not None:
-            probe_config["failureThreshold"] = failure_threshold
+            probe_config[PROBE_TIMING_FAILURE_THRESHOLD] = failure_threshold
         if timeout_seconds is not None:
-            probe_config["timeoutSeconds"] = timeout_seconds
+            probe_config[PROBE_TIMING_TIMEOUT_SECONDS] = timeout_seconds
 
         # Store probe configuration in the sidecar
         sidecar = self._set_sidecar(self._get_sidecar_name())
-        probe_key = PROBES_KEYS[type.value]
+        probe_key = PROBE_KEYS[type.value]
         sidecar[probe_key] = probe_config
 
         return self
@@ -402,7 +396,7 @@ class ApplicationRuntime(RemoteRuntime):
 
         sidecar = self._get_sidecar()
         if sidecar:
-            probe_key = PROBES_KEYS[type.value]
+            probe_key = PROBE_KEYS[type.value]
             if probe_key in sidecar:
                 del sidecar[probe_key]
 
@@ -1022,7 +1016,7 @@ class ApplicationRuntime(RemoteRuntime):
             return
 
         for probe_type in ProbeType:
-            probe_key = PROBES_KEYS[probe_type.value]
+            probe_key = PROBE_KEYS[probe_type.value]
             probe_config = sidecar.get(probe_key)
 
             if probe_config and isinstance(probe_config, dict):

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -303,7 +303,7 @@ class ApplicationRuntime(RemoteRuntime):
 
     def set_probe(
         self,
-        type: ProbeType,
+        type: str,
         initial_delay_seconds: int | None = None,
         period_seconds: int | None = None,
         failure_threshold: int | None = None,
@@ -335,10 +335,8 @@ class ApplicationRuntime(RemoteRuntime):
         :return: function object (self)
         """
         # Validate probe type
-        if not ProbeType.is_valid(type):
-            raise ValueError(
-                f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
-            )
+        ProbeType.is_valid(type, raise_on_error=True)
+        type = ProbeType(type)
 
         # Start with config as base
         probe_config = copy.deepcopy(config) if config else {}
@@ -375,7 +373,7 @@ class ApplicationRuntime(RemoteRuntime):
 
     def delete_probe(
         self,
-        type: ProbeType,
+        type: str,
     ):
         """Delete a Kubernetes probe configuration from the sidecar container
 
@@ -384,10 +382,8 @@ class ApplicationRuntime(RemoteRuntime):
         :return: function object (self)
         """
         # Validate probe type
-        if not ProbeType.is_valid(type):
-            raise ValueError(
-                f"Invalid probe type: {type}. Must be one of: {[p.value for p in ProbeType]}"
-            )
+        ProbeType.is_valid(type, raise_on_error=True)
+        type = ProbeType(type)
 
         sidecar = self._get_sidecar()
         if sidecar:

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1074,6 +1074,20 @@ class RemoteRuntime(KubeResource):
             sidecar["resources"] = self.spec.resources
             self.spec.resources = None
 
+    def set_probe(self, *args, **kwargs):
+        """Set a Kubernetes probe configuration for the sidecar container
+
+        This method is only available for ApplicationRuntime.
+        """
+        raise ValueError("set_probe() is only supported for ApplicationRuntime. ")
+
+    def delete_probe(self, *args, **kwargs):
+        """Delete a Kubernetes probe configuration from the sidecar container
+
+        This method is only available for ApplicationRuntime.
+        """
+        raise ValueError("delete_probe() is only supported for ApplicationRuntime.")
+
     def _set_sidecar(self, name: str) -> dict:
         self.spec.config.setdefault("spec.sidecars", [])
         sidecars = self.spec.config["spec.sidecars"]

--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -31,6 +31,13 @@ from mlrun.common.schemas.serving import DeployResponse
 from mlrun.config import config
 from mlrun.utils import logger
 from mlrun.utils.helpers import generate_object_uri
+from kubernetes.client import (
+    V1Probe,
+    V1HTTPGetAction,
+    V1ExecAction,
+    V1TCPSocketAction,
+    V1GRPCAction,
+)
 
 import framework.api.utils
 import framework.db.session
@@ -47,6 +54,153 @@ from services.api.crud.secrets import Secrets, SecretsClientType
 from services.api.utils.endpoints import start_model_endpoint_creation_background_task
 
 router = APIRouter()
+
+# Kubernetes probe validation
+_K8S_CLASSES = {
+    "V1HTTPGetAction": V1HTTPGetAction,
+    "V1ExecAction": V1ExecAction,
+    "V1TCPSocketAction": V1TCPSocketAction,
+    "V1GRPCAction": V1GRPCAction,
+    "V1Probe": V1Probe,
+}
+_SCHEMA_CACHE: dict[str, dict] = {}
+
+
+def _get_schema(class_name: str) -> dict:
+    """Get and cache Kubernetes class schema."""
+    if class_name in _SCHEMA_CACHE:
+        return _SCHEMA_CACHE[class_name]
+
+    k8s_class = _K8S_CLASSES.get(class_name)
+    if not k8s_class:
+        raise ValueError(f"Unknown Kubernetes class: {class_name}")
+
+    schema = getattr(k8s_class, "openapi_types", None) or getattr(
+        k8s_class, "swagger_types", None
+    )
+    if not schema:
+        raise RuntimeError(f"No schema found for {class_name}")
+
+    _SCHEMA_CACHE[class_name] = schema
+    return schema
+
+
+def _validate_schema(data: dict, schema: dict, schema_class_name: str) -> tuple[bool, str]:
+    """Recursively validate dict against Kubernetes API schema."""
+    _type_checkers = {
+        "str": lambda v: isinstance(v, str),
+        "int": lambda v: isinstance(v, int) or (isinstance(v, float) and v.is_integer()),
+        "bool": lambda v: isinstance(v, bool),
+        "datetime": lambda v: isinstance(v, (str, dict)),
+        "date": lambda v: isinstance(v, (str, dict)),
+        "object": lambda v: isinstance(v, (str, dict)),
+    }
+
+    def _is_compatible(field_value: typing.Any, expected_field_type: str) -> bool:
+        if field_value is None:
+            return True
+        if expected_field_type in _type_checkers:
+            return _type_checkers[expected_field_type](field_value)
+        return False
+
+    for key, value in data.items():
+        if key not in schema:
+            return False, f"{schema_class_name}: unknown field '{key}'"
+
+        expected_type = schema[key]
+
+        # Handle nested Kubernetes classes
+        if isinstance(expected_type, str) and expected_type in _K8S_CLASSES:
+            if value is None:
+                continue
+            if not isinstance(value, dict):
+                return False, f"{schema_class_name}.{key}: expected dict, got {type(value).__name__}"
+            try:
+                nested_schema = _get_schema(expected_type)
+                is_valid, error = _validate_schema(value, nested_schema, expected_type)
+                if not is_valid:
+                    return False, error
+            except (RuntimeError, ValueError) as e:
+                return False, f"{schema_class_name}.{key}: {str(e)}"
+
+        elif not _is_compatible(value, expected_type):
+            return False, f"{schema_class_name}.{key}: invalid type {type(value).__name__}"
+
+    return True, ""
+
+
+def _validate_http_probe(
+    http_get: dict, probe_type: str, sidecar_name: str
+) -> str | None:
+    """Validate HTTP probe configuration.
+    
+    Only path and port are mandatory if httpGet is configured.
+    
+    :param http_get: The httpGet configuration dict from the probe
+    :param probe_type: The type of probe (readinessProbe, livenessProbe, startupProbe)
+    :param sidecar_name: The name of the sidecar container
+    :return: Error message string if validation fails, None if validation passes
+    """
+    if not isinstance(http_get, dict):
+        return f"{probe_type} in sidecar '{sidecar_name}': httpGet must be a dict"
+    if not http_get.get("path"):
+        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.path is required"
+    if not http_get.get("port"):
+        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.port is required"
+    if not isinstance(http_get.get("port"), (int, str)):
+        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.port must be int or str"
+    scheme = http_get.get("scheme")
+    if scheme and scheme not in ["HTTP", "HTTPS"]:
+        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.scheme must be HTTP or HTTPS"
+    return None
+
+
+def _validate_sidecar_probes(sidecars: list[dict]) -> None:
+    """Validate probe configurations in sidecars against Kubernetes V1Probe schema."""
+    probe_types = ["readinessProbe", "livenessProbe", "startupProbe"]
+    # Minimum values are based on Kubernetes probe configuration documentation:
+    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+    timing_fields = {
+        "initialDelaySeconds": (lambda v: isinstance(v, int) and v >= 0, "non-negative integer (minimum 0)"),
+        "periodSeconds": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
+        "timeoutSeconds": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
+        "failureThreshold": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
+        "successThreshold": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
+    }
+
+    try:
+        probe_schema = _get_schema("V1Probe")
+    except (RuntimeError, ValueError) as e:
+        raise mlrun.errors.MLRunBadRequestError(f"Failed to load probe schema: {e}")
+
+    for sidecar in sidecars:
+        sidecar_name = sidecar.get("name", "unknown")
+
+        for probe_type in probe_types:
+            probe = sidecar.get(probe_type)
+            if not probe:
+                continue
+
+            # Schema validation
+            is_valid, error = _validate_schema(probe, probe_schema, "V1Probe")
+            if not is_valid:
+                raise mlrun.errors.MLRunBadRequestError(
+                    f"Invalid {probe_type} in sidecar '{sidecar_name}': {error}"
+                )
+
+            # HTTP probe validation - only path and port are mandatory if httpGet is configured
+            http_get = probe.get("httpGet")
+            if http_get:
+                error = _validate_http_probe(http_get, probe_type, sidecar_name)
+                if error:
+                    raise mlrun.errors.MLRunBadRequestError(error)
+
+            # Timing parameters validation
+            for field, (validator, desc) in timing_fields.items():
+                if field in probe and not validator(probe[field]):
+                    raise mlrun.errors.MLRunBadRequestError(
+                        f"{probe_type} in sidecar '{sidecar_name}': {field} must be a {desc} integer"
+                    )
 
 
 @router.get(
@@ -485,6 +639,12 @@ def _deploy_function(
 
         # after saving function to DB, we need to restore the original config so that the sensitive data won't be stored
         fn.spec.config = raw_config
+
+        # Validate sidecar probe configurations before deployment
+        sidecars = fn.spec.config.get("spec.sidecars") or []
+        if sidecars:
+            _validate_sidecar_probes(sidecars)
+
         fn = _deploy_nuclio_runtime(
             auth_info,
             builder_env,

--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -24,20 +24,28 @@ import semver
 import sqlalchemy.orm
 from fastapi import APIRouter, Depends, Header, Request, Response
 from fastapi.concurrency import run_in_threadpool
+from kubernetes.client import (
+    V1ExecAction,
+    V1GRPCAction,
+    V1HTTPGetAction,
+    V1Probe,
+    V1TCPSocketAction,
+)
 
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
+from mlrun.common.runtimes.constants import (
+    PROBE_KEYS,
+    PROBE_TIMING_FAILURE_THRESHOLD,
+    PROBE_TIMING_INITIAL_DELAY_SECONDS,
+    PROBE_TIMING_PERIOD_SECONDS,
+    PROBE_TIMING_SUCCESS_THRESHOLD,
+    PROBE_TIMING_TIMEOUT_SECONDS,
+)
 from mlrun.common.schemas.serving import DeployResponse
 from mlrun.config import config
 from mlrun.utils import logger
 from mlrun.utils.helpers import generate_object_uri
-from kubernetes.client import (
-    V1Probe,
-    V1HTTPGetAction,
-    V1ExecAction,
-    V1TCPSocketAction,
-    V1GRPCAction,
-)
 
 import framework.api.utils
 import framework.db.session
@@ -85,11 +93,14 @@ def _get_schema(class_name: str) -> dict:
     return schema
 
 
-def _validate_schema(data: dict, schema: dict, schema_class_name: str) -> tuple[bool, str]:
+def _validate_schema(
+    data: dict, schema: dict, schema_class_name: str
+) -> tuple[bool, str]:
     """Recursively validate dict against Kubernetes API schema."""
     _type_checkers = {
         "str": lambda v: isinstance(v, str),
-        "int": lambda v: isinstance(v, int) or (isinstance(v, float) and v.is_integer()),
+        "int": lambda v: isinstance(v, int)
+        or (isinstance(v, float) and v.is_integer()),
         "bool": lambda v: isinstance(v, bool),
         "datetime": lambda v: isinstance(v, (str, dict)),
         "date": lambda v: isinstance(v, (str, dict)),
@@ -114,7 +125,10 @@ def _validate_schema(data: dict, schema: dict, schema_class_name: str) -> tuple[
             if value is None:
                 continue
             if not isinstance(value, dict):
-                return False, f"{schema_class_name}.{key}: expected dict, got {type(value).__name__}"
+                return (
+                    False,
+                    f"{schema_class_name}.{key}: expected dict, got {type(value).__name__}",
+                )
             try:
                 nested_schema = _get_schema(expected_type)
                 is_valid, error = _validate_schema(value, nested_schema, expected_type)
@@ -124,7 +138,10 @@ def _validate_schema(data: dict, schema: dict, schema_class_name: str) -> tuple[
                 return False, f"{schema_class_name}.{key}: {str(e)}"
 
         elif not _is_compatible(value, expected_type):
-            return False, f"{schema_class_name}.{key}: invalid type {type(value).__name__}"
+            return (
+                False,
+                f"{schema_class_name}.{key}: invalid type {type(value).__name__}",
+            )
 
     return True, ""
 
@@ -133,9 +150,9 @@ def _validate_http_probe(
     http_get: dict, probe_type: str, sidecar_name: str
 ) -> str | None:
     """Validate HTTP probe configuration.
-    
+
     Only path and port are mandatory if httpGet is configured.
-    
+
     :param http_get: The httpGet configuration dict from the probe
     :param probe_type: The type of probe (readinessProbe, livenessProbe, startupProbe)
     :param sidecar_name: The name of the sidecar container
@@ -148,7 +165,9 @@ def _validate_http_probe(
     if not http_get.get("port"):
         return f"{probe_type} in sidecar '{sidecar_name}': httpGet.port is required"
     if not isinstance(http_get.get("port"), (int, str)):
-        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.port must be int or str"
+        return (
+            f"{probe_type} in sidecar '{sidecar_name}': httpGet.port must be int or str"
+        )
     scheme = http_get.get("scheme")
     if scheme and scheme not in ["HTTP", "HTTPS"]:
         return f"{probe_type} in sidecar '{sidecar_name}': httpGet.scheme must be HTTP or HTTPS"
@@ -157,15 +176,29 @@ def _validate_http_probe(
 
 def _validate_sidecar_probes(sidecars: list[dict]) -> None:
     """Validate probe configurations in sidecars against Kubernetes V1Probe schema."""
-    probe_types = ["readinessProbe", "livenessProbe", "startupProbe"]
     # Minimum values are based on Kubernetes probe configuration documentation:
     # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
     timing_fields = {
-        "initialDelaySeconds": (lambda v: isinstance(v, int) and v >= 0, "non-negative integer (minimum 0)"),
-        "periodSeconds": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
-        "timeoutSeconds": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
-        "failureThreshold": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
-        "successThreshold": (lambda v: isinstance(v, int) and v >= 1, "integer >= 1 (minimum 1)"),
+        PROBE_TIMING_INITIAL_DELAY_SECONDS: (
+            lambda v: isinstance(v, int) and v >= 0,
+            "non-negative integer (minimum 0)",
+        ),
+        PROBE_TIMING_PERIOD_SECONDS: (
+            lambda v: isinstance(v, int) and v >= 1,
+            "integer >= 1 (minimum 1)",
+        ),
+        PROBE_TIMING_TIMEOUT_SECONDS: (
+            lambda v: isinstance(v, int) and v >= 1,
+            "integer >= 1 (minimum 1)",
+        ),
+        PROBE_TIMING_FAILURE_THRESHOLD: (
+            lambda v: isinstance(v, int) and v >= 1,
+            "integer >= 1 (minimum 1)",
+        ),
+        PROBE_TIMING_SUCCESS_THRESHOLD: (
+            lambda v: isinstance(v, int) and v >= 1,
+            "integer >= 1 (minimum 1)",
+        ),
     }
 
     try:
@@ -176,7 +209,7 @@ def _validate_sidecar_probes(sidecars: list[dict]) -> None:
     for sidecar in sidecars:
         sidecar_name = sidecar.get("name", "unknown")
 
-        for probe_type in probe_types:
+        for probe_type in PROBE_KEYS:
             probe = sidecar.get(probe_type)
             if not probe:
                 continue

--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -102,9 +102,9 @@ def _validate_schema(
         "int": lambda v: isinstance(v, int)
         or (isinstance(v, float) and v.is_integer()),
         "bool": lambda v: isinstance(v, bool),
-        "datetime": lambda v: isinstance(v, (str, dict)),
-        "date": lambda v: isinstance(v, (str, dict)),
-        "object": lambda v: isinstance(v, (str, dict)),
+        "datetime": lambda v: isinstance(v, str | dict),
+        "date": lambda v: isinstance(v, str | dict),
+        "object": lambda v: isinstance(v, str | dict),
     }
 
     def _is_compatible(field_value: typing.Any, expected_field_type: str) -> bool:
@@ -164,7 +164,7 @@ def _validate_http_probe(
         return f"{probe_type} in sidecar '{sidecar_name}': httpGet.path is required"
     if not http_get.get("port"):
         return f"{probe_type} in sidecar '{sidecar_name}': httpGet.port is required"
-    if not isinstance(http_get.get("port"), (int, str)):
+    if not isinstance(http_get.get("port"), int | str):
         return (
             f"{probe_type} in sidecar '{sidecar_name}': httpGet.port must be int or str"
         )

--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -24,24 +24,9 @@ import semver
 import sqlalchemy.orm
 from fastapi import APIRouter, Depends, Header, Request, Response
 from fastapi.concurrency import run_in_threadpool
-from kubernetes.client import (
-    V1ExecAction,
-    V1GRPCAction,
-    V1HTTPGetAction,
-    V1Probe,
-    V1TCPSocketAction,
-)
 
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
-from mlrun.common.runtimes.constants import (
-    PROBE_KEYS,
-    PROBE_TIMING_FAILURE_THRESHOLD,
-    PROBE_TIMING_INITIAL_DELAY_SECONDS,
-    PROBE_TIMING_PERIOD_SECONDS,
-    PROBE_TIMING_SUCCESS_THRESHOLD,
-    PROBE_TIMING_TIMEOUT_SECONDS,
-)
 from mlrun.common.schemas.serving import DeployResponse
 from mlrun.config import config
 from mlrun.utils import logger
@@ -62,178 +47,6 @@ from services.api.crud.secrets import Secrets, SecretsClientType
 from services.api.utils.endpoints import start_model_endpoint_creation_background_task
 
 router = APIRouter()
-
-# Kubernetes probe validation
-_K8S_CLASSES = {
-    "V1HTTPGetAction": V1HTTPGetAction,
-    "V1ExecAction": V1ExecAction,
-    "V1TCPSocketAction": V1TCPSocketAction,
-    "V1GRPCAction": V1GRPCAction,
-    "V1Probe": V1Probe,
-}
-_SCHEMA_CACHE: dict[str, dict] = {}
-
-
-def _get_schema(class_name: str) -> dict:
-    """Get and cache Kubernetes class schema."""
-    if class_name in _SCHEMA_CACHE:
-        return _SCHEMA_CACHE[class_name]
-
-    k8s_class = _K8S_CLASSES.get(class_name)
-    if not k8s_class:
-        raise ValueError(f"Unknown Kubernetes class: {class_name}")
-
-    schema = getattr(k8s_class, "openapi_types", None) or getattr(
-        k8s_class, "swagger_types", None
-    )
-    if not schema:
-        raise RuntimeError(f"No schema found for {class_name}")
-
-    _SCHEMA_CACHE[class_name] = schema
-    return schema
-
-
-def _validate_schema(
-    data: dict, schema: dict, schema_class_name: str
-) -> tuple[bool, str]:
-    """Recursively validate dict against Kubernetes API schema."""
-    _type_checkers = {
-        "str": lambda v: isinstance(v, str),
-        "int": lambda v: isinstance(v, int)
-        or (isinstance(v, float) and v.is_integer()),
-        "bool": lambda v: isinstance(v, bool),
-        "datetime": lambda v: isinstance(v, str | dict),
-        "date": lambda v: isinstance(v, str | dict),
-        "object": lambda v: isinstance(v, str | dict),
-    }
-
-    def _is_compatible(field_value: typing.Any, expected_field_type: str) -> bool:
-        if field_value is None:
-            return True
-        if expected_field_type in _type_checkers:
-            return _type_checkers[expected_field_type](field_value)
-        return False
-
-    for key, value in data.items():
-        if key not in schema:
-            return False, f"{schema_class_name}: unknown field '{key}'"
-
-        expected_type = schema[key]
-
-        # Handle nested Kubernetes classes
-        if isinstance(expected_type, str) and expected_type in _K8S_CLASSES:
-            if value is None:
-                continue
-            if not isinstance(value, dict):
-                return (
-                    False,
-                    f"{schema_class_name}.{key}: expected dict, got {type(value).__name__}",
-                )
-            try:
-                nested_schema = _get_schema(expected_type)
-                is_valid, error = _validate_schema(value, nested_schema, expected_type)
-                if not is_valid:
-                    return False, error
-            except (RuntimeError, ValueError) as e:
-                return False, f"{schema_class_name}.{key}: {str(e)}"
-
-        elif not _is_compatible(value, expected_type):
-            return (
-                False,
-                f"{schema_class_name}.{key}: invalid type {type(value).__name__}",
-            )
-
-    return True, ""
-
-
-def _validate_http_probe(
-    http_get: dict, probe_type: str, sidecar_name: str
-) -> str | None:
-    """Validate HTTP probe configuration.
-
-    Only path and port are mandatory if httpGet is configured.
-
-    :param http_get: The httpGet configuration dict from the probe
-    :param probe_type: The type of probe (readinessProbe, livenessProbe, startupProbe)
-    :param sidecar_name: The name of the sidecar container
-    :return: Error message string if validation fails, None if validation passes
-    """
-    if not isinstance(http_get, dict):
-        return f"{probe_type} in sidecar '{sidecar_name}': httpGet must be a dict"
-    if not http_get.get("path"):
-        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.path is required"
-    if not http_get.get("port"):
-        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.port is required"
-    if not isinstance(http_get.get("port"), int | str):
-        return (
-            f"{probe_type} in sidecar '{sidecar_name}': httpGet.port must be int or str"
-        )
-    scheme = http_get.get("scheme")
-    if scheme and scheme not in ["HTTP", "HTTPS"]:
-        return f"{probe_type} in sidecar '{sidecar_name}': httpGet.scheme must be HTTP or HTTPS"
-    return None
-
-
-def _validate_sidecar_probes(sidecars: list[dict]) -> None:
-    """Validate probe configurations in sidecars against Kubernetes V1Probe schema."""
-    # Minimum values are based on Kubernetes probe configuration documentation:
-    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
-    timing_fields = {
-        PROBE_TIMING_INITIAL_DELAY_SECONDS: (
-            lambda v: isinstance(v, int) and v >= 0,
-            "non-negative integer (minimum 0)",
-        ),
-        PROBE_TIMING_PERIOD_SECONDS: (
-            lambda v: isinstance(v, int) and v >= 1,
-            "integer >= 1 (minimum 1)",
-        ),
-        PROBE_TIMING_TIMEOUT_SECONDS: (
-            lambda v: isinstance(v, int) and v >= 1,
-            "integer >= 1 (minimum 1)",
-        ),
-        PROBE_TIMING_FAILURE_THRESHOLD: (
-            lambda v: isinstance(v, int) and v >= 1,
-            "integer >= 1 (minimum 1)",
-        ),
-        PROBE_TIMING_SUCCESS_THRESHOLD: (
-            lambda v: isinstance(v, int) and v >= 1,
-            "integer >= 1 (minimum 1)",
-        ),
-    }
-
-    try:
-        probe_schema = _get_schema("V1Probe")
-    except (RuntimeError, ValueError) as e:
-        raise mlrun.errors.MLRunBadRequestError(f"Failed to load probe schema: {e}")
-
-    for sidecar in sidecars:
-        sidecar_name = sidecar.get("name", "unknown")
-
-        for probe_type in PROBE_KEYS:
-            probe = sidecar.get(probe_type)
-            if not probe:
-                continue
-
-            # Schema validation
-            is_valid, error = _validate_schema(probe, probe_schema, "V1Probe")
-            if not is_valid:
-                raise mlrun.errors.MLRunBadRequestError(
-                    f"Invalid {probe_type} in sidecar '{sidecar_name}': {error}"
-                )
-
-            # HTTP probe validation - only path and port are mandatory if httpGet is configured
-            http_get = probe.get("httpGet")
-            if http_get:
-                error = _validate_http_probe(http_get, probe_type, sidecar_name)
-                if error:
-                    raise mlrun.errors.MLRunBadRequestError(error)
-
-            # Timing parameters validation
-            for field, (validator, desc) in timing_fields.items():
-                if field in probe and not validator(probe[field]):
-                    raise mlrun.errors.MLRunBadRequestError(
-                        f"{probe_type} in sidecar '{sidecar_name}': {field} must be a {desc} integer"
-                    )
 
 
 @router.get(
@@ -672,12 +485,6 @@ def _deploy_function(
 
         # after saving function to DB, we need to restore the original config so that the sensitive data won't be stored
         fn.spec.config = raw_config
-
-        # Validate sidecar probe configurations before deployment
-        sidecars = fn.spec.config.get("spec.sidecars") or []
-        if sidecars:
-            _validate_sidecar_probes(sidecars)
-
         fn = _deploy_nuclio_runtime(
             auth_info,
             builder_env,

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -21,6 +21,7 @@ import mlrun
 import mlrun.common.schemas
 import mlrun.runtimes
 import mlrun.utils
+from mlrun.common.runtimes.constants import ProbeTimeConfig, ProbeType
 
 assets_path = pathlib.Path(__file__).absolute().parent / "assets"
 
@@ -445,3 +446,503 @@ def _assert_application_post_deploy_spec(fn, image):
     assert fn.get_env("SIDECAR_PORT") == "8050"
     assert fn.status.application_image == image
     assert not fn.spec.image
+
+
+def test_set_probe_readiness():
+    """Test setting a readiness probe with HTTP configuration"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type=ProbeType.READINESS,
+        http_path="/api/healthz",
+        initial_delay_seconds=10,
+        period_seconds=20,
+        timeout_seconds=30,
+        failure_threshold=40,
+    )
+
+    sidecar = fn._get_sidecar()
+    assert sidecar is not None
+    assert ProbeType.READINESS.key in sidecar
+    probe = sidecar[ProbeType.READINESS.key]
+    assert probe["httpGet"]["path"] == "/api/healthz"
+    assert probe["httpGet"]["scheme"] == "HTTP"
+    assert probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 10
+    assert probe[ProbeTimeConfig.PERIOD_SECONDS.value] == 20
+    assert probe[ProbeTimeConfig.TIMEOUT_SECONDS.value] == 30
+    assert probe[ProbeTimeConfig.FAILURE_THRESHOLD.value] == 40
+
+
+def test_set_probe_liveness_with_port():
+    """Test setting a liveness probe with explicit port"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type=ProbeType.LIVENESS,
+        http_path="/health",
+        http_port=8080,
+        http_scheme="HTTPS",
+        initial_delay_seconds=15,
+        period_seconds=10,
+        failure_threshold=3,
+        timeout_seconds=5,
+    )
+
+    sidecar = fn._get_sidecar()
+    assert sidecar is not None
+    assert ProbeType.LIVENESS.key in sidecar
+    probe = sidecar[ProbeType.LIVENESS.key]
+    assert probe["httpGet"]["path"] == "/health"
+    assert probe["httpGet"]["port"] == 8080
+    assert probe["httpGet"]["scheme"] == "HTTPS"
+    assert probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 15
+    assert probe[ProbeTimeConfig.PERIOD_SECONDS.value] == 10
+    assert probe[ProbeTimeConfig.FAILURE_THRESHOLD.value] == 3
+    assert probe[ProbeTimeConfig.TIMEOUT_SECONDS.value] == 5
+
+
+def test_set_probe_with_config_override():
+    """Test that explicit parameters override config dict values"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type=ProbeType.STARTUP,
+        initial_delay_seconds=15,
+        config={
+            "tcpSocket": {"port": 8080},
+            "initialDelaySeconds": 20,
+            "periodSeconds": 30,
+        },
+    )
+
+    sidecar = fn._get_sidecar()
+    assert sidecar is not None
+    assert ProbeType.STARTUP.key in sidecar
+    probe = sidecar[ProbeType.STARTUP.key]
+    assert probe["tcpSocket"]["port"] == 8080
+    assert probe[ProbeTimeConfig.PERIOD_SECONDS.value] == 30
+    assert probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 15
+
+
+def test_set_probe_replace_existing():
+    """Test that calling set_probe again replaces the existing configuration"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type=ProbeType.READINESS,
+        http_path="/old/path",
+        initial_delay_seconds=10,
+    )
+
+    fn.set_probe(
+        type=ProbeType.READINESS,
+        http_path="/new/path",
+        initial_delay_seconds=20,
+    )
+
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+    probe = sidecar[ProbeType.READINESS.key]
+    assert probe["httpGet"]["path"] == "/new/path"
+    assert probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 20
+
+
+def test_set_probe_invalid_type():
+    """Test that invalid probe type raises ValueError"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    with pytest.raises(ValueError, match="Invalid probe type"):
+        fn.set_probe(type="invalid_type")
+
+
+def test_set_probe_string_type():
+    """Test that string probe type is accepted and converted"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type="readiness",
+        http_path="/health",
+    )
+
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+
+
+def test_set_probe_no_http_path():
+    """Test setting probe without HTTP path (only timing parameters)"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type=ProbeType.READINESS,
+        initial_delay_seconds=10,
+        period_seconds=5,
+    )
+
+    sidecar = fn._get_sidecar()
+    probe = sidecar[ProbeType.READINESS.key]
+    assert "httpGet" not in probe
+    assert probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 10
+    assert probe[ProbeTimeConfig.PERIOD_SECONDS.value] == 5
+
+
+def test_set_probe_multiple_probes():
+    """Test setting multiple different probe types"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type=ProbeType.READINESS,
+        http_path="/readiness",
+        initial_delay_seconds=10,
+        period_seconds=5,
+    )
+    fn.set_probe(
+        type=ProbeType.LIVENESS,
+        http_path="/liveness",
+        initial_delay_seconds=15,
+        period_seconds=10,
+        timeout_seconds=3,
+    )
+
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+    readiness_probe = sidecar[ProbeType.READINESS.key]
+    assert readiness_probe["httpGet"]["path"] == "/readiness"
+    assert readiness_probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 10
+    assert readiness_probe[ProbeTimeConfig.PERIOD_SECONDS.value] == 5
+
+    assert ProbeType.LIVENESS.key in sidecar
+    liveness_probe = sidecar[ProbeType.LIVENESS.key]
+    assert liveness_probe["httpGet"]["path"] == "/liveness"
+    assert liveness_probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 15
+    assert liveness_probe[ProbeTimeConfig.PERIOD_SECONDS.value] == 10
+    assert liveness_probe[ProbeTimeConfig.TIMEOUT_SECONDS.value] == 3
+
+
+def test_delete_probe():
+    """Test deleting a probe configuration"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "config": {
+                    "spec.sidecars": [
+                        {
+                            "name": "application-test-sidecar",
+                            "readinessProbe": {
+                                "httpGet": {
+                                    "path": "/health",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+    fn.delete_probe(type=ProbeType.READINESS)
+    assert ProbeType.READINESS.key not in sidecar
+
+
+def test_delete_probe_nonexistent():
+    """Test deleting a probe that doesn't exist (should not raise error)"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.delete_probe(type=ProbeType.LIVENESS)
+    sidecar = fn._get_sidecar()
+    assert sidecar is None
+
+    fn.spec.config["spec.sidecars"] = [
+        {
+            "name": "application-test-sidecar",
+            "readinessProbe": {
+                "httpGet": {
+                    "path": "/readiness",
+                    "scheme": "HTTP",
+                }
+            },
+        }
+    ]
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+    fn.delete_probe(type=ProbeType.READINESS)
+    assert ProbeType.READINESS.key not in sidecar
+
+
+def test_delete_probe_invalid_type():
+    """Test that invalid probe type raises ValueError"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    with pytest.raises(ValueError, match="Invalid probe type"):
+        fn.delete_probe(type="invalid_type")
+
+
+def test_delete_probe_multiple_probes():
+    """Test deleting one probe while others remain"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "config": {
+                    "spec.sidecars": [
+                        {
+                            "name": "application-test-sidecar",
+                            "readinessProbe": {
+                                "httpGet": {
+                                    "path": "/readiness",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                            "livenessProbe": {
+                                "httpGet": {
+                                    "path": "/liveness",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                            "startupProbe": {
+                                "httpGet": {
+                                    "path": "/startup",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+    assert ProbeType.LIVENESS.key in sidecar
+    assert ProbeType.STARTUP.key in sidecar
+    fn.delete_probe(type=ProbeType.READINESS)
+    assert ProbeType.READINESS.key not in sidecar
+    assert ProbeType.LIVENESS.key in sidecar
+    assert ProbeType.STARTUP.key in sidecar
+
+
+def test_enrich_sidecar_probe_ports_without_port():
+    """Test enriching HTTP probe without port when internal_application_port is set"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "internal_application_port": 8080,
+                "config": {
+                    "spec.sidecars": [
+                        {
+                            "name": "application-test-sidecar",
+                            "readinessProbe": {
+                                "httpGet": {
+                                    "path": "/health",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                        }
+                    ]
+                },
+            }
+        },
+    )
+
+    fn._enrich_sidecar_probe_ports()
+
+    sidecar = fn._get_sidecar()
+    assert sidecar is not None
+    assert ProbeType.READINESS.key in sidecar
+    probe = sidecar[ProbeType.READINESS.key]
+    assert probe["httpGet"]["port"] == 8080
+    assert probe["httpGet"]["path"] == "/health"
+
+
+def test_enrich_sidecar_probe_ports_with_existing_port():
+    """Test that probes with existing ports are not enriched"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "internal_application_port": 8080,
+                "config": {
+                    "spec.sidecars": [
+                        {
+                            "name": "application-test-sidecar",
+                            "readinessProbe": {
+                                "httpGet": {
+                                    "path": "/health",
+                                    "port": 9090,
+                                    "scheme": "HTTP",
+                                }
+                            },
+                        }
+                    ]
+                },
+            }
+        },
+    )
+
+    fn._enrich_sidecar_probe_ports()
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+    probe = sidecar[ProbeType.READINESS.key]
+    assert probe["httpGet"]["port"] == 9090
+
+
+def test_enrich_sidecar_probe_ports_multiple_probes():
+    """Test enriching multiple probes, some with ports, some without"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "internal_application_port": 8080,
+                "config": {
+                    "spec.sidecars": [
+                        {
+                            "name": "application-test-sidecar",
+                            "readinessProbe": {
+                                "httpGet": {
+                                    "path": "/readiness",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                            "livenessProbe": {
+                                "httpGet": {
+                                    "path": "/liveness",
+                                    "port": 9090,
+                                    "scheme": "HTTP",
+                                }
+                            },
+                            "startupProbe": {
+                                "httpGet": {
+                                    "path": "/startup",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                        }
+                    ]
+                },
+            }
+        },
+    )
+
+    fn._enrich_sidecar_probe_ports()
+
+    sidecar = fn._get_sidecar()
+    assert ProbeType.READINESS.key in sidecar
+    readiness_probe = sidecar[ProbeType.READINESS.key]
+    assert readiness_probe["httpGet"]["port"] == 8080
+    assert ProbeType.LIVENESS.key in sidecar
+    liveness_probe = sidecar[ProbeType.LIVENESS.key]
+    assert liveness_probe["httpGet"]["port"] == 9090
+    assert ProbeType.STARTUP.key in sidecar
+    startup_probe = sidecar[ProbeType.STARTUP.key]
+    assert startup_probe["httpGet"]["port"] == 8080
+
+
+def test_enrich_sidecar_probe_ports_no_internal_port_error():
+    """Test that error is raised when internal_application_port is not set and probe needs enrichment"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "config": {
+                    "spec.sidecars": [
+                        {
+                            "name": "application-test-sidecar",
+                            "readinessProbe": {
+                                "httpGet": {
+                                    "path": "/health",
+                                    "scheme": "HTTP",
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    del fn.spec._internal_application_port
+    with pytest.raises(ValueError):
+        fn._enrich_sidecar_probe_ports()
+
+
+def test_enrich_sidecar_probe_ports_no_sidecar():
+    """Test that method returns early when there's no sidecar"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "internal_application_port": 8080,
+            }
+        },
+    )
+
+    fn._enrich_sidecar_probe_ports()
+    sidecar = fn._get_sidecar()
+    assert sidecar is None
+
+
+def test_enrich_sidecar_probe_ports_no_probes():
+    """Test that method handles sidecar with no probes"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        runtime={
+            "spec": {
+                "internal_application_port": 8080,
+                "config": {
+                    "spec.sidecars": [
+                        {
+                            "name": "application-test-sidecar",
+                        }
+                    ]
+                },
+            }
+        },
+    )
+
+    fn._enrich_sidecar_probe_ports()
+    sidecar = fn._get_sidecar()
+    assert sidecar is not None
+    assert ProbeType.READINESS.key not in sidecar
+    assert ProbeType.LIVENESS.key not in sidecar
+    assert ProbeType.STARTUP.key not in sidecar

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -574,23 +574,16 @@ def test_set_probe_invalid_type():
 
 
 def test_set_probe_empty_value():
-    """Test that empty values set overides existing probe values"""
+    """Test that empty values set raise an error"""
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
         "application-test", kind="application", image="mlrun/mlrun"
     )
 
-    fn.set_probe(
-        type="readiness",
-        initial_delay_seconds=10,
-        period_seconds=5,
-    )
-    fn.set_probe(type="readiness")
-
-    probe = fn._get_sidecar()
-    assert ProbeType.READINESS.key in probe
-    assert "httpGet" not in probe
-    assert ProbeTimeConfig.INITIAL_DELAY_SECONDS.value not in probe
-    assert ProbeTimeConfig.PERIOD_SECONDS.value not in probe
+    with pytest.raises(
+        ValueError,
+        match="Empty probe configuration: at least one parameter must be set",
+    ):
+        fn.set_probe(type="readiness")
 
 
 def test_set_probe_string_type():

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -455,7 +455,7 @@ def test_set_probe_readiness():
     )
 
     fn.set_probe(
-        type=ProbeType.READINESS,
+        type="readiness",
         http_path="/api/healthz",
         initial_delay_seconds=10,
         period_seconds=20,
@@ -482,7 +482,7 @@ def test_set_probe_liveness_with_port():
     )
 
     fn.set_probe(
-        type=ProbeType.LIVENESS,
+        type="liveness",
         http_path="/health",
         http_port=8080,
         http_scheme="HTTPS",
@@ -512,7 +512,7 @@ def test_set_probe_with_config_override():
     )
 
     fn.set_probe(
-        type=ProbeType.STARTUP,
+        type="startup",
         initial_delay_seconds=15,
         config={
             "tcpSocket": {"port": 8080},
@@ -537,14 +537,14 @@ def test_set_probe_replace_existing():
     )
 
     fn.set_probe(
-        type=ProbeType.READINESS,
+        type="readiness",
         http_path="/old/path",
         initial_delay_seconds=10,
         failure_threshold=5,
     )
 
     fn.set_probe(
-        type=ProbeType.READINESS,
+        type="readiness",
         http_path="/new/path",
         initial_delay_seconds=20,
     )
@@ -565,6 +565,32 @@ def test_set_probe_invalid_type():
 
     with pytest.raises(ValueError, match="Invalid probe type"):
         fn.set_probe(type="invalid_type")
+
+    with pytest.raises(ValueError, match="Invalid probe type"):
+        fn.set_probe(type=None)
+
+    with pytest.raises(ValueError, match="Invalid probe type"):
+        fn.set_probe(type="")
+
+
+def test_set_probe_empty_value():
+    """Test that empty values set overides existing probe values"""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="mlrun/mlrun"
+    )
+
+    fn.set_probe(
+        type="readiness",
+        initial_delay_seconds=10,
+        period_seconds=5,
+    )
+    fn.set_probe(type="readiness")
+
+    probe = fn._get_sidecar()
+    assert ProbeType.READINESS.key in probe
+    assert "httpGet" not in probe
+    assert ProbeTimeConfig.INITIAL_DELAY_SECONDS.value not in probe
+    assert ProbeTimeConfig.PERIOD_SECONDS.value not in probe
 
 
 def test_set_probe_string_type():
@@ -589,7 +615,7 @@ def test_set_probe_no_http_path():
     )
 
     fn.set_probe(
-        type=ProbeType.READINESS,
+        type="readiness",
         initial_delay_seconds=10,
         period_seconds=5,
     )
@@ -608,13 +634,13 @@ def test_set_probe_multiple_probes():
     )
 
     fn.set_probe(
-        type=ProbeType.READINESS,
+        type="readiness",
         http_path="/readiness",
         initial_delay_seconds=10,
         period_seconds=5,
     )
     fn.set_probe(
-        type=ProbeType.LIVENESS,
+        type="liveness",
         http_path="/liveness",
         initial_delay_seconds=15,
         period_seconds=10,
@@ -663,7 +689,7 @@ def test_delete_probe():
 
     sidecar = fn._get_sidecar()
     assert ProbeType.READINESS.key in sidecar
-    fn.delete_probe(type=ProbeType.READINESS)
+    fn.delete_probe(type="readiness")
     assert ProbeType.READINESS.key not in sidecar
 
 
@@ -673,7 +699,7 @@ def test_delete_probe_nonexistent():
         "application-test", kind="application", image="mlrun/mlrun"
     )
 
-    fn.delete_probe(type=ProbeType.LIVENESS)
+    fn.delete_probe(type="liveness")
     sidecar = fn._get_sidecar()
     assert sidecar is None
 
@@ -690,7 +716,7 @@ def test_delete_probe_nonexistent():
     ]
     sidecar = fn._get_sidecar()
     assert ProbeType.READINESS.key in sidecar
-    fn.delete_probe(type=ProbeType.READINESS)
+    fn.delete_probe(type="readiness")
     assert ProbeType.READINESS.key not in sidecar
 
 
@@ -745,7 +771,7 @@ def test_delete_probe_multiple_probes():
     assert ProbeType.READINESS.key in sidecar
     assert ProbeType.LIVENESS.key in sidecar
     assert ProbeType.STARTUP.key in sidecar
-    fn.delete_probe(type=ProbeType.READINESS)
+    fn.delete_probe(type="readiness")
     assert ProbeType.READINESS.key not in sidecar
     assert ProbeType.LIVENESS.key in sidecar
     assert ProbeType.STARTUP.key in sidecar
@@ -900,7 +926,7 @@ def test_enrich_sidecar_probe_ports_no_internal_port_error():
     )
 
     del fn.spec._internal_application_port
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         fn._enrich_sidecar_probe_ports()
 
 

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -540,6 +540,7 @@ def test_set_probe_replace_existing():
         type=ProbeType.READINESS,
         http_path="/old/path",
         initial_delay_seconds=10,
+        failure_threshold=5,
     )
 
     fn.set_probe(
@@ -553,6 +554,7 @@ def test_set_probe_replace_existing():
     probe = sidecar[ProbeType.READINESS.key]
     assert probe["httpGet"]["path"] == "/new/path"
     assert probe[ProbeTimeConfig.INITIAL_DELAY_SECONDS.value] == 20
+    assert ProbeTimeConfig.FAILURE_THRESHOLD.value not in probe
 
 
 def test_set_probe_invalid_type():

--- a/tests/system/runtimes/assets/function_with_delay_healthcheck.py
+++ b/tests/system/runtimes/assets/function_with_delay_healthcheck.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from time import sleep
+
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/health")
+def health():
+    sleep(20)
+    return "healthy"
+
+
+@app.route("/external")
+def external():
+    return "test message"

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -21,6 +21,7 @@ from nuclio.auth import AuthInfo as NuclioAuthInfo
 
 import mlrun.common.schemas
 import mlrun.runtimes
+import mlrun.runtimes.utils
 import tests.system.base
 
 
@@ -31,7 +32,11 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
     def custom_setup(self):
         super().custom_setup()
         self._vizro_app_code_filename = "vizro_app.py"
-        self._files_to_upload = [self._vizro_app_code_filename]
+        self._function_with_delay_healthcheck = "function_with_delay_healthcheck.py"
+        self._files_to_upload = [
+            self._vizro_app_code_filename,
+            self._function_with_delay_healthcheck,
+        ]
         self._source = os.path.join(self.remote_code_dir, self._vizro_app_code_filename)
 
     def test_deploy_application(self):
@@ -190,6 +195,35 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         function._get_state()
         assert len(function.status.external_invocation_urls) == 2
 
+    def test_application_probes(self):
+        self._upload_code_to_cluster()
+        self._logger.debug("Creating application")
+        function = self._create_delay_health_check_application("delay-health-check-app")
+        self._logger.debug("Deploying application with readiness probe (will fail)")
+        # The deployment should fail because the readiness probe have default timeout_seconds
+        # and the /health endpoint sleeps for 20 seconds, causing the probe to timeout
+        with pytest.raises(mlrun.runtimes.utils.RunError, match="deployment failed"):
+            function.deploy(with_mlrun=False)
+
+        # Add probes to the function - set timeout_seconds > 20 to allow health endpoint to respond
+        self._logger.debug("Adding probes to function")
+        function.set_probe(
+            type="readiness",
+            http_path="/health",
+            http_port=5000,  # Flask app runs on port 5000
+            period_seconds=5,
+            timeout_seconds=25,  # Wait 25 seconds (more than the 20 seconds sleep in /health)
+        )
+
+        # Redeploy with probes
+        self._logger.debug("Redeploying application with probes")
+        function.deploy(with_mlrun=False)
+
+        # Verify the application is running and healthy
+        self._logger.debug("Validating application is healthy")
+        response = function.invoke("/external", verify=False).content.decode("utf-8")
+        assert response == "test message"
+
     def _create_vizro_application(
         self, name="vizro-app", app_image=None, with_repo: bool = False
     ):
@@ -227,3 +261,44 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         output = new_stdout.getvalue()
         new_stdout.close()
         return output
+
+    def _create_delay_health_check_application(self, name="delay-app"):
+        function = self.project.set_function(
+            name=name,
+            kind="application",
+            requirements=["Flask==3.0.0"],
+            with_repo=False,
+        )
+        function.set_internal_application_port(5000)  # Match Flask port
+        function.spec.command = "python"
+        function.spec.args = [
+            "-m",
+            "flask",
+            "run",
+            "--host=0.0.0.0",
+            "--port=5000",
+        ]
+        function.spec.env = [
+            {"name": "FLASK_APP", "value": "function_with_delay_healthcheck.py"}
+        ]
+        function.with_http(workers=1, trigger_name="application-http")
+        delay_healthcheck_source = os.path.join(
+            self.remote_code_dir, self._function_with_delay_healthcheck
+        )
+        function.with_source_archive(source=delay_healthcheck_source)
+        function.spec.config["spec.sidecars"] = [
+            {
+                "name": f"{function.metadata.name}-sidecar",
+                "image": f".mlrun/func-{self.project.metadata.name}-{function.metadata.name}:latest",
+                "ports": [
+                    {
+                        "containerPort": 5000,
+                        "name": "application-t-0",
+                        "protocol": "TCP",
+                    }
+                ],
+                "readinessProbe": {"httpGet": {"path": "/health", "port": 5000}},
+            }
+        ]
+
+        return function


### PR DESCRIPTION
### 📝 Description
Add first-class support for configuring Kubernetes probes (readiness, liveness, startup) on the ApplicationRuntime sidecar.
This includes a clear API for setting and deleting probes, validation of probe types, and automatic enrichment of HTTP probe ports from the internal application port at deploy time.

---

### 🛠️ Changes Made
- Introduced `ProbeType` and `ProbeTimeConfig` enums for consistent probe configuration keys.
- Added `set_probe()` and `delete_probe()` APIs to `ApplicationRuntime` for managing sidecar probes.
- Implemented validation and safe handling of probe types (enum and string-based).
- Added automatic enrichment of HTTP probe ports using `internal_application_port` just before deployment.
- Explicitly blocked probe APIs on non-Application runtimes with clear errors.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Added unit tests covering all supported scenarios and edge cases
- Dev test: tested that probes changes are propagated properly to the Nuclio side:
  - Set a `sleep` as part of healthcheck function:
  
     ```
       @app.route("/internal")
       def internal():
           sleep(10)
           return "/internal"     
     ```
  - created application runtime and deployment failed (unhealthy):
  `Warning  Unhealthy  3m1s (x867 over 138m)  kubelet  Readiness probe failed: Get "http://10.233.67.57:5000/internal": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`
  
<img width="1861" height="171" alt="image" src="https://github.com/user-attachments/assets/e86fd65c-7f93-443e-94a2-7d3ef762b666" />

  - Configured probes:
  ```
  application.set_probe(type="readiness",
                      initial_delay_seconds=15,
                      period_seconds=10,
                      timeout_seconds=20,
                      http_path="/internal",
                      http_port=5000)
  ```
  - Than deployed again and the function deployed healthy:
  
<img width="1849" height="180" alt="image" src="https://github.com/user-attachments/assets/b123a30f-f5ea-4347-8abd-32119d580558" />



---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11708
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
