### PR TITLE
[CE] Delete V3IO credentials from mlrun.env file

### DIFF
--- a/dockerfiles/jupyter/mlrun.env
+++ b/dockerfiles/jupyter/mlrun.env
@@ -5,10 +5,6 @@
 # remote MLRun service address
 # MLRUN_DBPATH=https://mlrun-api.<cluster-address>
 
-# Iguazio cluster and V3IO credentials
-# V3IO_USERNAME=<user>
-# V3IO_ACCESS_KEY=<access-key>
-
 # AWS S3/services credentials
 # AWS_ACCESS_KEY_ID=<key-id>
 # AWS_SECRET_ACCESS_KEY=<access-key>


### PR DESCRIPTION
### 📝 Description
Delete V3IO credentials from mlrun.env file since V3IO is not being in use in CE env.
---

### 🛠️ Changes Made
Remove V3IO credentials from env file.

---

### ✅ Checklist
- [ X] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11488
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ X] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
