### PR TITLE
[DOCS] Remove `Batch_Inference` V1 hub function from mlrun cheat-sheet

### DIFF
--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -689,6 +689,9 @@ addr = serve.deploy()
 
 ### Batch inferencing
 
+Docs: [Batch inference](./deployment/batch_inference.ipynb)
+
+
 ## Model monitoring and drift detection
 Docs: {ref}`model-monitoring-overview`, [Batch inference](./deployment/batch_inference.ipynb) 
 

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -689,17 +689,6 @@ addr = serve.deploy()
 
 ### Batch inferencing
 
-Docs: [Batch inference](./deployment/batch_inference.ipynb)
-
-```python
-batch_inference = mlrun.import_function("hub://batch_inference")
-batch_run = project.run_function(
-    batch_inference,
-    inputs={"dataset": prediction_set_path},
-    params={"model": model_artifact.uri},
-)
-```
-
 ## Model monitoring and drift detection
 Docs: {ref}`model-monitoring-overview`, [Batch inference](./deployment/batch_inference.ipynb) 
 


### PR DESCRIPTION
### 📝 Description
The `batch_inference` (v1) hub function is no longer used. To remove it from the hub, we need to remove it from the mlrun docs as well.

---

### 🛠️ Changes Made
- Delete example of using `batch_inference` in mlrun-cheat sheet.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/FHUB-172
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
