### PR TITLE
[Docs] Fix scikit-learn confusion matrix link

### DIFF
--- a/docs/training/working-with-data-and-model-artifacts.md
+++ b/docs/training/working-with-data-and-model-artifacts.md
@@ -242,7 +242,7 @@ run = func.run(
 Storing plots is useful to visualize the data and to show any information regarding the model performance. For example, you can store 
 scatter plots, histograms and cross-correlation of the data, and for the model store the ROC curve and confusion matrix.
 
-The following code creates a confusion matrix plot using [sklearn.metrics.plot_confusion_matrix](https://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html#confusion-matrix) 
+The following code creates a confusion matrix plot using [sklearn.metrics.plot_confusion_matrix](https://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html#evaluate-the-performance-of-a-classifier-with-confusion-matrix) 
 and stores the plot in the artifact repository:
 
 ``` python


### PR DESCRIPTION
### 📝 Description

Scikit-learn changed an anchor in documentation that broke the `linkcheck` CI.

---

### 🛠️ Changes Made
Replace https://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html#confusion-matrix with https://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html#evaluate-the-performance-of-a-classifier-with-confusion-matrix

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Ran `make linkcheck` locally.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
