### PR TITLE
[Serving] Fix fail client side if sync serving graph includes branches

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -2506,6 +2506,11 @@ class FlowStep(BaseStep):
             step._next = None
             step._visited = False
             if step.after:
+                has_illegal_branches = len(step.after) > 1 and self.engine == "sync"
+                if has_illegal_branches:
+                    raise GraphError(
+                        f"synchronous flow engine doesnt support branches use async for step {step.name}"
+                    )
                 loop_step = has_loop(step, [])
                 if loop_step:
                     raise GraphError(

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -476,3 +476,15 @@ def test_model_runner_with_selector():
 
     with pytest.raises(mlrun.serving.states.GraphError):
         graph.to(name="s1", handler="(event + 1)").to(model_runner_step)
+
+
+def test_sync_flow_with_branches():
+    fn = mlrun.new_function("tests", kind="serving", project="x")
+    graph = fn.set_topology("flow", engine="sync")
+    graph.to(name="s1", class_name="Mul")
+    graph.to(name="s2", class_name="Mul")
+    graph.add_step(name="gather", class_name="Gather", after=["s1", "s2"])
+    with pytest.raises(mlrun.serving.states.GraphError):
+        fn.to_mock_server()
+
+

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -486,5 +486,3 @@ def test_sync_flow_with_branches():
     graph.add_step(name="gather", class_name="Gather", after=["s1", "s2"])
     with pytest.raises(mlrun.serving.states.GraphError):
         fn.to_mock_server()
-
-


### PR DESCRIPTION
### 📝 Description

Added a verification in `FlowStep:check_and_process_graph` for branches in serving graph with sync engine,in this case we fail the the deployment stage more specific in `init_object`.
This allow the user to get the error on the client side

---


### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Added unit test

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11580
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
