### PR TITLE
[Hub] Fix UT `test_list_sources_with_filters` to use verified hub function version

### DIFF
--- a/server/py/services/api/tests/unit/api/hub/test_hub.py
+++ b/server/py/services/api/tests/unit/api/hub/test_hub.py
@@ -447,7 +447,7 @@ def test_list_sources_with_filters(
 
     # verifying filtering by item name and good version:
     sources = client.get(
-        "hub/sources", params={"item-name": good_name, "version": "1.1.0"}
+        "hub/sources", params={"item-name": good_name, "version": "1.8.0"}
     ).json()
     assert len(sources) == 1
 
@@ -456,5 +456,5 @@ def test_list_sources_with_filters(
     assert response.status_code == http.HTTPStatus.BAD_REQUEST.value
 
     # verifying bad filtering with version and without item name:
-    response = client.get("hub/sources", params={"version": "1.1.0"})
+    response = client.get("hub/sources", params={"version": "1.8.0"})
     assert response.status_code == http.HTTPStatus.BAD_REQUEST.value


### PR DESCRIPTION
### 📝 Description
As part of cleaning up outdated functions from the hub (https://iguazio.atlassian.net/browse/FHUB-64), we removed old versions of the `auto_trainer` function, including version `1.1.0`. This test was using that version to validate the returned metadata, which caused it to fail. In this PR, we fix the issue by updating to a valid version of auto_trainer - `1.8.0`.

---

### 🛠️ Changes Made
- Update the test to check version `1.8.0` of `auto_trainer` function instead of `1.1.0`. 

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- `test_list_sources_with_filters` passed successfully 

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/FHUB-64


---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
---

### 🔍️ Additional Notes
- Existing hub unit tests that make calls to the external hub APIs (such as `test_list_sources_with_filters` should be listed as integration test. 
