### PR TITLE
[DataStore] Fix timezone retrieving when checking partition directory [1.10.x]  

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -160,8 +160,8 @@ class DataStore(BaseRemoteClient):
 
     @staticmethod
     def _is_directory_in_range(
-        start_time: datetime.datetime,
-        end_time: datetime.datetime,
+        start_time: Union[datetime.datetime, None],
+        end_time: Union[datetime.datetime, None],
         year: int,
         month: Optional[int] = None,
         day: Optional[int] = None,
@@ -198,8 +198,8 @@ class DataStore(BaseRemoteClient):
     @staticmethod
     def _list_partition_paths_helper(
         paths: list[str],
-        start_time,
-        end_time,
+        start_time: Union[datetime.datetime, None],
+        end_time: Union[datetime.datetime, None],
         current_path: str,
         partition_level: str,
         filesystem,
@@ -243,8 +243,8 @@ class DataStore(BaseRemoteClient):
     @staticmethod
     def _list_partitioned_paths(
         base_url: str,
-        start_time: datetime.datetime,
-        end_time: datetime.datetime,
+        start_time: Union[datetime.datetime, None],
+        end_time: Union[datetime.datetime, None],
         partition_level: str,
         filesystem,
     ):
@@ -288,8 +288,8 @@ class DataStore(BaseRemoteClient):
     @staticmethod
     def _read_partitioned_parquet(
         base_url: str,
-        start_time: datetime.datetime,
-        end_time: datetime.datetime,
+        start_time: Union[datetime.datetime, None],
+        end_time: Union[datetime.datetime, None],
         partition_keys: list[str],
         df_module: ModuleType,
         filesystem: fsspec.AbstractFileSystem,
@@ -402,6 +402,7 @@ class DataStore(BaseRemoteClient):
                         and DataStore._verify_path_partition_level(
                             urlparse(url).path, partitions
                         )
+                        and (start_time or end_time)
                     ):
                         return DataStore._read_partitioned_parquet(
                             url,

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -176,7 +176,7 @@ class DataStore(BaseRemoteClient):
             month=month or 1,
             day=day or 1,
             hour=hour or 0,
-            tzinfo=start_time.tzinfo,
+            tzinfo=start_time.tzinfo if start_time else end_time.tzinfo,
         )
         partition_end = (
             partition_start
@@ -189,7 +189,9 @@ class DataStore(BaseRemoteClient):
             - datetime.timedelta(microseconds=1)
         )
 
-        if end_time < partition_start or start_time > partition_end:
+        if (end_time and end_time < partition_start) or (
+            start_time and start_time > partition_end
+        ):
             return False
         return True
 

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -160,8 +160,8 @@ class DataStore(BaseRemoteClient):
 
     @staticmethod
     def _is_directory_in_range(
-        start_time: Union[datetime.datetime, None],
-        end_time: Union[datetime.datetime, None],
+        start_time: Optional[datetime.datetime],
+        end_time: Optional[datetime.datetime],
         year: int,
         month: Optional[int] = None,
         day: Optional[int] = None,
@@ -198,8 +198,8 @@ class DataStore(BaseRemoteClient):
     @staticmethod
     def _list_partition_paths_helper(
         paths: list[str],
-        start_time: Union[datetime.datetime, None],
-        end_time: Union[datetime.datetime, None],
+        start_time: Optional[datetime.datetime],
+        end_time: Optional[datetime.datetime],
         current_path: str,
         partition_level: str,
         filesystem,
@@ -243,8 +243,8 @@ class DataStore(BaseRemoteClient):
     @staticmethod
     def _list_partitioned_paths(
         base_url: str,
-        start_time: Union[datetime.datetime, None],
-        end_time: Union[datetime.datetime, None],
+        start_time: Optional[datetime.datetime],
+        end_time: Optional[datetime.datetime],
         partition_level: str,
         filesystem,
     ):
@@ -288,8 +288,8 @@ class DataStore(BaseRemoteClient):
     @staticmethod
     def _read_partitioned_parquet(
         base_url: str,
-        start_time: Union[datetime.datetime, None],
-        end_time: Union[datetime.datetime, None],
+        start_time: Optional[datetime.datetime],
+        end_time: Optional[datetime.datetime],
         partition_keys: list[str],
         df_module: ModuleType,
         filesystem: fsspec.AbstractFileSystem,

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -449,6 +449,20 @@ def test_partition_filtering_year_month():
             dict(year=2024, month=6, day=10, hour=6),
             True,
         ),
+        (
+            "No start time",
+            None,
+            (2024, 6, 10, 8, 0),
+            dict(year=2024, month=6, day=10, hour=6),
+            True,
+        ),
+        (
+            "No end time",
+            (2024, 6, 10, 6, 0),
+            None,
+            dict(year=2024, month=6, day=10, hour=6),
+            True,
+        ),
     ],
 )
 def test_is_directory_in_range(
@@ -461,8 +475,8 @@ def test_is_directory_in_range(
 ):
     tz = pytz.UTC if with_time_zone else None
 
-    start_time = datetime(*start_time_args, tzinfo=tz)
-    end_time = datetime(*end_time_args, tzinfo=tz)
+    start_time = datetime(*start_time_args, tzinfo=tz) if start_time_args else None
+    end_time = datetime(*end_time_args, tzinfo=tz) if end_time_args else None
 
     result = mlrun.datastore.base.DataStore._is_directory_in_range(
         start_time, end_time, **partition_args


### PR DESCRIPTION
### 📝 Description
1. When calling _is_directory_in_range, either the start or end must exist, so now we retrieve the timezone from whichever one is available.
2. Adding check if `start_time or end_time` where given before calling to the new optimized flow
---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Added unit test

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11782
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-11782]: https://iguazio.atlassian.net/browse/ML-11782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ