### PR TITLE
[MPI] Auth secret token mounting for MPIJob

### DIFF
--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -49,7 +49,7 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
         meta = self._get_meta(runtime, run, True)
 
         self.add_secrets_to_spec_before_running(
-            runtime, project_name=run.metadata.project
+            runtime, project_name=run.metadata.project, token_name=(run.spec.auth or {}).get("token_name"), auth_info=auth_info
         )
 
         job = self._generate_mpi_job(runtime, run, execution, meta, auth_info=auth_info)

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -49,7 +49,10 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
         meta = self._get_meta(runtime, run, True)
 
         self.add_secrets_to_spec_before_running(
-            runtime, project_name=run.metadata.project, token_name=(run.spec.auth or {}).get("token_name"), auth_info=auth_info
+            runtime,
+            project_name=run.metadata.project,
+            token_name=(run.spec.auth or {}).get("token_name"),
+            auth_info=auth_info,
         )
 
         job = self._generate_mpi_job(runtime, run, execution, meta, auth_info=auth_info)


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
This PR mounts the auth secret token on the runtime so that later during the `run` method of MPI runtime handler `_generate_mpi_job` and `_configure_pod_template` can copy these volumes/volume mounts into the launcher/worker pod template. This allows the mpi pods to authentication with mlrun.

The auth token is already saved as part of the run's spec during the `_enrich_run` of the ServerSideLauncher.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Add `token_name` and `auth_info` to `add_secrets_to_spec_before_running()` in mpi runtime handler `run()` method

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Manual test in IG4 + ran system test on IG3

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11589
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
