### PR TITLE
[Datastore] Fix reading partitioned parquet datasets from non-V3IO datastores [1.10.x]

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import datetime
+import os
+import os.path
 import tempfile
 import urllib.parse
 from base64 import b64encode
 from copy import copy
-from os import path, remove
 from types import ModuleType
 from typing import Optional, Union
 from urllib.parse import urlparse
@@ -203,16 +204,16 @@ class DataStore(BaseRemoteClient):
         filesystem,
     ):
         directory_split = current_path.rsplit("/", 1)
-        timing = None
+        time_unit = None
         directory_start, directory_end = "", ""
         if len(directory_split) == 2:
             directory_start, directory_end = directory_split
-            timing = directory_end.split("=")[0] if "=" in directory_end else None
+            time_unit = directory_end.split("=")[0] if "=" in directory_end else None
 
-        if not timing and directory_end.endswith((".parquet", ".pq")):
+        if not time_unit and directory_end.endswith((".parquet", ".pq")):
             paths.append(directory_start.rstrip("/"))
             return
-        elif timing and timing == partition_level:
+        elif time_unit and time_unit == partition_level:
             paths.append(current_path.rstrip("/"))
             return
 
@@ -247,20 +248,32 @@ class DataStore(BaseRemoteClient):
         filesystem,
     ):
         paths = []
+        parsed_base_url = urlparse(base_url)
+        base_path = parsed_base_url.path
+
+        if parsed_base_url.scheme not in ["v3io", "v3ios"]:
+            base_path = parsed_base_url.netloc + base_path
 
         DataStore._list_partition_paths_helper(
-            paths, start_time, end_time, base_url, partition_level, filesystem
+            paths, start_time, end_time, base_path, partition_level, filesystem
         )
-        for i in range(len(paths)):
-            paths[i] = DataStore._reconstruct_path_from_base_url(base_url, paths[i])
+        paths = [
+            DataStore._reconstruct_path_from_base_url(parsed_base_url, path)
+            for path in paths
+        ]
         return paths
 
     @staticmethod
-    def _reconstruct_path_from_base_url(base_path: str, returned_path: str) -> str:
-        parsed_url = urlparse(base_path)
-        scheme = parsed_url.scheme
-        authority = parsed_url.netloc
-        return f'{scheme}://{authority}/{returned_path.lstrip("/")}'
+    def _reconstruct_path_from_base_url(
+        parsed_base_url: urllib.parse.ParseResult, returned_path: str
+    ) -> str:
+        scheme = parsed_base_url.scheme
+        authority = parsed_base_url.netloc
+        returned_path = returned_path.lstrip("/")
+        if scheme == "v3io":
+            return f"{scheme}://{authority}/{returned_path}"
+        else:
+            return f"{scheme}://{returned_path}"
 
     @staticmethod
     def _clean_filters_for_partitions(
@@ -569,7 +582,7 @@ class DataStore(BaseRemoteClient):
             temp_file = tempfile.NamedTemporaryFile(delete=False)
             self.download(self._join(subpath), temp_file.name)
             df = reader(temp_file.name, **kwargs)
-            remove(temp_file.name)
+            os.remove(temp_file.name)
 
         if is_json or is_csv:
             # for parquet file the time filtering is executed in `reader`
@@ -681,7 +694,7 @@ class DataItem:
     @property
     def suffix(self):
         """DataItem suffix (file extension) e.g. '.png'"""
-        _, file_ext = path.splitext(self._path)
+        _, file_ext = os.path.splitext(self._path)
         return file_ext
 
     @property
@@ -790,7 +803,7 @@ class DataItem:
             return
 
         if self._local_path:
-            remove(self._local_path)
+            os.remove(self._local_path)
             self._local_path = ""
 
     def as_df(

--- a/mlrun/datastore/datastore.py
+++ b/mlrun/datastore/datastore.py
@@ -47,7 +47,7 @@ from .v3io import V3ioStore
 in_memory_store = InMemoryStore()
 
 
-def schema_to_store(schema) -> DataStore.__subclasses__():
+def schema_to_store(schema) -> type[DataStore]:
     # import store classes inside to enable making their dependencies optional (package extras)
 
     if not schema or schema in get_local_file_schema():

--- a/tests/datastore/test_base.py
+++ b/tests/datastore/test_base.py
@@ -54,15 +54,9 @@ def test_http_fs_parquet_with_params_as_df():
     data_item.as_df()
 
 
-# ML-10075
-# TODO: find another dataset and re-enable this test
-@pytest.mark.skip(
-    reason="Starting with PyArrow 17, this test causes a conflict between partition data and parquet data"
-)
 def test_s3_fs_parquet_as_df():
     data_item = mlrun.datastore.store_manager.object(
-        "s3://aws-public-blockchain/v1.0/btc/blocks/date=2023-02-27/"
-        "part-00000-7de4c87e-242f-4568-b5d7-aae4cc75e9ad-c000.snappy.parquet"
+        "s3://coiled-datasets/timeseries/20-years/parquet/part.0.parquet"
     )
     data_item.as_df()
 

--- a/tests/system/datastore/test_aws_s3.py
+++ b/tests/system/datastore/test_aws_s3.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import tempfile
+import time
 import uuid
+from datetime import datetime, timedelta
 
 import fsspec
 import pandas as pd
 import pytest
+import pytz
 from pandas.testing import assert_frame_equal
 
 import mlrun
@@ -73,6 +76,7 @@ class TestAwsS3(TestMLRunSystem):
         self._bucket_name = test_environment["AWS_BUCKET_NAME"]
         self._access_key_id = test_environment["AWS_ACCESS_KEY_ID"]
         self._secret_access_key = test_environment["AWS_SECRET_ACCESS_KEY"]
+        self._endpoint_url = test_environment.get("AWS_ENDPOINT_URL")
 
         object_sub_dir = f"dir_{uuid.uuid4()}"
 
@@ -91,12 +95,15 @@ class TestAwsS3(TestMLRunSystem):
             access_key_id=self._access_key_id,
             secret_key=self._secret_access_key,
             bucket=self._bucket_name,
+            endpoint_url=self._endpoint_url,
         )
         register_temporary_client_datastore_profile(profile)
 
     def custom_teardown(self):
         s3_fs = fsspec.filesystem(
-            "s3", key=self._access_key_id, secret=self._secret_access_key
+            "s3",
+            key=self._access_key_id,
+            secret=self._secret_access_key,
         )
         full_path = self.s3["s3"]["test_dir_path"]
         if s3_fs.exists(full_path):
@@ -110,7 +117,10 @@ class TestAwsS3(TestMLRunSystem):
     def test_ingest_with_parquet_source(self, url_type, target_path):
         #  create source
         s3_fs = fsspec.filesystem(
-            "s3", key=self._access_key_id, secret=self._secret_access_key
+            "s3",
+            key=self._access_key_id,
+            secret=self._secret_access_key,
+            endpoint_url=self._endpoint_url,
         )
         param = self.s3[url_type]
         logger.info(f"Using URL {param['object_sub_dir_url']}")
@@ -156,7 +166,10 @@ class TestAwsS3(TestMLRunSystem):
 
     def test_ingest_ds_default_target(self):
         s3_fs = fsspec.filesystem(
-            "s3", key=self._access_key_id, secret=self._secret_access_key
+            "s3",
+            key=self._access_key_id,
+            secret=self._secret_access_key,
+            endpoint_url=self._endpoint_url,
         )
         param = self.s3["ds_with_bucket"]
         logger.info(f"Using URL {param['parquets_url']}")
@@ -207,3 +220,115 @@ class TestAwsS3(TestMLRunSystem):
         ):
             target.purge()
         assert s3_fs.ls(f"{self._bucket_name}")
+
+    @pytest.mark.parametrize(
+        ("partition_keys", "granularity"),
+        [
+            (["year"], "year"),
+            (["year", "month"], "month"),
+            (["year", "month", "day"], "day"),
+            (["year", "month", "day", "hour"], "hour"),
+        ],
+    )
+    @pytest.mark.parametrize("with_tz", [True, False])
+    # Copied from test_feature_store.py for equivalent testing on S3
+    # ML-11732
+    def test_partitioned_parquet_as_df_time_filtering_optimization(
+        self, partition_keys, granularity, with_tz
+    ):
+        """
+        test reading partitioned parquet target as_df method with time filtering
+        covers:
+          - Partitioned parquet writing via ParquetTarget
+          - Reading & filtering via start_time/end_time
+          - Empty/out-of-range case
+        """
+        key = "patient_id"
+        base_time = datetime(2020, 12, 1, 17, 0)
+        if with_tz:
+            base_time = base_time.replace(tzinfo=pytz.UTC)
+
+        df = pd.DataFrame(
+            [
+                {
+                    key: i + 1,
+                    "timestamp": base_time + timedelta(hours=i),
+                    "value": i * 10,
+                }
+                for i in range(4)
+            ]
+        )
+
+        run_id = uuid.uuid4()
+        target_path = f"s3://{self._bucket_name}/partition_test_{run_id}"
+
+        target = ParquetTarget(
+            name="parquet_target",
+            path=target_path,
+            partitioned=True,
+            time_partitioning_granularity=granularity,
+        )
+
+        start_time = base_time + timedelta(hours=1)
+        end_time = base_time + timedelta(hours=2, minutes=1)
+
+        target.write_dataframe(df, timestamp_key="timestamp")
+
+        expected_df = df[
+            (df["timestamp"] > start_time) & (df["timestamp"] <= end_time)
+        ].copy()
+
+        result_df = target.as_df(
+            start_time=start_time,
+            end_time=end_time,
+            time_column="timestamp",
+        )
+
+        if with_tz:
+            result_df["timestamp"] = (
+                pd.to_datetime(result_df["timestamp"])
+                .dt.tz_convert("UTC")
+                .astype("datetime64[ns, UTC]")
+            )
+        else:
+            result_df["timestamp"] = pd.to_datetime(result_df["timestamp"]).astype(
+                "datetime64[ns]"
+            )
+
+        result_df = result_df.sort_values(key).reset_index(drop=True)
+        expected_df = expected_df.sort_values(key).reset_index(drop=True)
+        assert_frame_equal(result_df, expected_df)
+
+        large_base_period_start = base_time - timedelta(days=365)
+        large_base_period_end = base_time + timedelta(days=1)
+        start = time.monotonic()
+        result_df = target.as_df(
+            start_time=large_base_period_start,
+            end_time=large_base_period_end,
+            time_column="timestamp",
+        )
+        end = time.monotonic()
+        assert end - start < 10, "Reading large period took too long"
+        if with_tz:
+            result_df["timestamp"] = (
+                pd.to_datetime(result_df["timestamp"])
+                .dt.tz_convert("UTC")
+                .astype("datetime64[ns, UTC]")
+            )
+        else:
+            result_df["timestamp"] = pd.to_datetime(result_df["timestamp"]).astype(
+                "datetime64[ns]"
+            )
+
+        result_df = result_df.sort_values(key).reset_index(drop=True)
+        assert_frame_equal(result_df, df.sort_values(key).reset_index(drop=True))
+
+        late_start = base_time + timedelta(days=2)
+        late_end = late_start + timedelta(days=1)
+
+        empty_df = target.as_df(
+            start_time=late_start,
+            end_time=late_end,
+            time_column="timestamp",
+        )
+        assert empty_df.empty, "df should be empty for out-of-range time filter"


### PR DESCRIPTION
Backport of #9072.

Following regression introduced in #9006 / v1.10.0-rc1.

[ML-11732](https://iguazio.atlassian.net/browse/ML-11732)

Includes some small tangential improvements / fixes.

A system test was added to `test_aws_s3.py`. I ran it against MinIO and it
* failed without the fix in this PR
* passed with the fix

[ML-11732]: https://iguazio.atlassian.net/browse/ML-11732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ