### PR TITLE
[Serving] Allow LLModel + LLMPromptArtifact without ModelArtifact instance

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -269,7 +269,9 @@ class ModelRunnerError(MLRunBaseError):
         super().__init__(self.__repr__(), *args)
 
     def __repr__(self):
-        return f"ModelRunnerError: {repr(self.models_errors)}"
+        return "ModelRunnerError: " + "; ".join(
+            f"{model} {msg}" for model, msg in self.models_errors.items()
+        )
 
     def __copy__(self):
         return type(self)(models_errors=self.models_errors)

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -269,7 +269,7 @@ class ModelRunnerError(MLRunBaseError):
         super().__init__(self.__repr__(), *args)
 
     def __repr__(self):
-        return "ModelRunnerError: " + "; ".join(
+        return "ModelRunnerError: " + ";\n ".join(
             f"{model} {msg}" for model, msg in self.models_errors.items()
         )
 

--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -269,7 +269,7 @@ class ModelRunnerError(MLRunBaseError):
         super().__init__(self.__repr__(), *args)
 
     def __repr__(self):
-        return "ModelRunnerError: " + ";\n ".join(
+        return "ModelRunnerError: " + ";\n".join(
             f"{model} {msg}" for model, msg in self.models_errors.items()
         )
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1184,14 +1184,18 @@ class Model(storey.ParallelExecutionRunnable, ModelObj):
         if self._execution_mechanism == storey.ParallelExecutionMechanisms.asyncio:
             if self.__class__.predict_async is Model.predict_async:
                 raise mlrun.errors.ModelRunnerError(
-                    f"{self.name} is running with {self._execution_mechanism} execution_mechanism but predict_async() "
-                    f"is not implemented"
+                    {
+                        self.name: f"is running with {self._execution_mechanism} "
+                        f"execution_mechanism but predict_async() is not implemented"
+                    }
                 )
         else:
             if self.__class__.predict is Model.predict:
                 raise mlrun.errors.ModelRunnerError(
-                    f"{self.name} is running with {self._execution_mechanism} execution_mechanism but predict() "
-                    f"is not implemented"
+                    {
+                        self.name: f"is running with {self._execution_mechanism} execution_mechanism but predict() "
+                        f"is not implemented"
+                    }
                 )
 
     def _load_artifacts(self) -> None:

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1210,7 +1210,9 @@ class Model(storey.ParallelExecutionRunnable, ModelObj):
         uri = proxy_uri or self.artifact_uri
         if uri:
             if mlrun.datastore.is_store_uri(uri):
-                artifact, _ = mlrun.store_manager.get_store_artifact(uri)
+                artifact, _ = mlrun.store_manager.get_store_artifact(
+                    uri, allow_empty_resources=True
+                )
                 return artifact
             else:
                 raise ValueError(
@@ -1418,6 +1420,13 @@ class LLModel(Model):
                 model_provider_type=type(self.model_provider).__name__,
             )
         return body
+
+    def init(self):
+        super().init()
+        if not self.model_provider and type(self).predict is LLModel.predict:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"Model provider could not be determined for model {self.name}"
+            )
 
     def run(self, body: Any, path: str, origin_name: Optional[str] = None) -> Any:
         llm_prompt_artifact = self._get_invocation_artifact(origin_name)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1423,9 +1423,13 @@ class LLModel(Model):
 
     def init(self):
         super().init()
-        if not self.model_provider and type(self).predict is LLModel.predict:
+        if not self.model_provider and (
+            type(self).predict is LLModel.predict
+            and type(self).predict_async is LLModel.predict_async
+        ):
             raise mlrun.errors.MLRunRuntimeError(
-                f"Model provider could not be determined for model {self.name}"
+                f"Model provider could not be determined for model '{self.name}',"
+                f" and the predict functions was not overridden."
             )
 
     def run(self, body: Any, path: str, origin_name: Optional[str] = None) -> Any:

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1428,20 +1428,20 @@ class LLModel(Model):
     def init(self):
         super().init()
 
-        unchanged_predict = (
-            type(self).predict is LLModel.predict
-            and self._execution_mechanism != storey.ParallelExecutionMechanisms.asyncio
-        )
-        unchanged_async_predict = (
-            type(self).predict_async is LLModel.predict_async
-            and self._execution_mechanism == storey.ParallelExecutionMechanisms.asyncio
-        )
-        if not self.model_provider and (unchanged_predict or unchanged_async_predict):
-            predict_function_name = "predict" if unchanged_predict else "predict_async"
-            raise mlrun.errors.MLRunRuntimeError(
-                f"Model provider could not be determined for model '{self.name}',"
-                f" and the {predict_function_name} function was not overridden."
-            )
+        if not self.model_provider:
+            if self._execution_mechanism != storey.ParallelExecutionMechanisms.asyncio:
+                unchanged_predict = self.__class__.predict is LLModel.predict
+                predict_function_name = "predict"
+            else:
+                unchanged_predict = (
+                    self.__class__.predict_async is LLModel.predict_async
+                )
+                predict_function_name = "predict_async"
+            if unchanged_predict:
+                raise mlrun.errors.MLRunRuntimeError(
+                    f"Model provider could not be determined for model '{self.name}',"
+                    f" and the {predict_function_name} function was not overridden."
+                )
 
     def run(self, body: Any, path: str, origin_name: Optional[str] = None) -> Any:
         llm_prompt_artifact = self._get_invocation_artifact(origin_name)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1427,13 +1427,20 @@ class LLModel(Model):
 
     def init(self):
         super().init()
-        if not self.model_provider and (
+
+        unchanged_predict = (
             type(self).predict is LLModel.predict
-            and type(self).predict_async is LLModel.predict_async
-        ):
+            and self._execution_mechanism != storey.ParallelExecutionMechanisms.asyncio
+        )
+        unchanged_async_predict = (
+            type(self).predict_async is LLModel.predict_async
+            and self._execution_mechanism == storey.ParallelExecutionMechanisms.asyncio
+        )
+        if not self.model_provider and (unchanged_predict or unchanged_async_predict):
+            predict_function_name = "predict" if unchanged_predict else "predict_async"
             raise mlrun.errors.MLRunRuntimeError(
                 f"Model provider could not be determined for model '{self.name}',"
-                f" and the predict functions was not overridden."
+                f" and the {predict_function_name} function was not overridden."
             )
 
     def run(self, body: Any, path: str, origin_name: Optional[str] = None) -> Any:

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1177,8 +1177,8 @@ def test_using_model_without_predict_implementation(execution_mechanism: str):
         function.to_mock_server()
     method_name = "predict()" if execution_mechanism != "asyncio" else "predict_async()"
     expected_msg = (
-        f"'model_without_predict is running with {execution_mechanism} execution_mechanism but "
-        f"{method_name} is not implemented'"
+        f"model_without_predict is running with {execution_mechanism} execution_mechanism but "
+        f"{method_name} is not implemented"
     )
     assert expected_msg in str(exc_info.value)
 
@@ -1218,8 +1218,8 @@ def test_shared_using_model_without_predict_implementation(execution_mechanism: 
             "predict()" if execution_mechanism != "asyncio" else "predict_async()"
         )
         expected_msg = (
-            f"'model_without_predict_shared is running with {execution_mechanism} execution_mechanism but "
-            f"{method_name} is not implemented'"
+            f"model_without_predict_shared is running with {execution_mechanism} execution_mechanism but "
+            f"{method_name} is not implemented"
         )
         assert expected_msg in str(exc_info.value)
 

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1315,16 +1315,14 @@ def test_configure_model_runner_step_max_threads_processes(concurrency: str):
 @pytest.mark.parametrize(
     "model_class, raise_exception",
     [
-        ("LLModel", True),
+        ("LLModel", True), #  LLModel should raise error because predict was not overridden
+        #  DummyAsyncLLMWithoutAsyncPredict should raise error because async_predict was not overridden:
         ("DummyAsyncLLMWithoutAsyncPredict", True),
         ("DummyLLM", False),
         ("DummyAsyncLLM", False),
     ],
 )
 def test_llmodel_without_model_artifact(model_class, raise_exception):
-    #  LLModel should raise error because predict was not overridden
-    #  DummyAsyncLLMWithoutAsyncPredict should raise error because async_predict was not overridden
-
     is_async = model_class in ("DummyAsyncLLM", "DummyAsyncLLMWithoutAsyncPredict")
     execution_mechanism = "asyncio" if is_async else "naive"
     predict_function_name = "predict_async" if is_async else "predict"

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -263,6 +263,16 @@ class MyLLM(LLModel):
         return body
 
 
+class DummyLLM(LLModel):
+    def predict(self, body: typing.Any, **kwargs):
+        return body
+
+
+class DummyAsyncLLM(LLModel):
+    async def predict_async(self, body: typing.Any, **kwargs):
+        return body
+
+
 class MyPklModel(Model):
     def __init__(self, name, raise_exception, artifact_uri, **kwargs):
         super().__init__(
@@ -1295,3 +1305,49 @@ def test_configure_model_runner_step_max_threads_processes(concurrency: str):
         ), "Max threads not configured properly"
     server.test(body={"n": 1})
     server.wait_for_completion()
+
+
+@pytest.mark.parametrize(
+    "model_class, raise_exception",
+    [("LLModel", True), ("DummyLLM", False), ("DummyAsyncLLM", False)],
+)
+def test_llmodel_without_model_artifact(model_class, raise_exception):
+    execution_mechanism = "asyncio" if model_class == "DummyAsyncLLM" else "naive"
+    function = mlrun.new_function("tests", kind="serving")
+    graph = function.set_topology("flow", engine="async")
+    model_runner_step = ModelRunnerStep(name="model-runner")
+    project = mlrun.new_project("llmodel-without-model-artifact", save=False)
+    llm_artifact = project.log_llm_prompt(
+        "my_llm",
+        prompt_template=[
+            {"role": "user", "content": "What is the capital city of {country}?"}
+        ],
+        prompt_legend={"country": {"field": None, "description": "Great"}},
+    )
+
+    model_runner_step.add_model(
+        model_class=model_class,
+        execution_mechanism=execution_mechanism,
+        endpoint_name="my-model",
+        model_artifact=llm_artifact,
+    )
+    graph.to(model_runner_step).respond()
+    server = None
+    with unittest.mock.patch(
+        "mlrun.datastore.datastore.get_store_resource",
+        return_value=llm_artifact,
+    ):
+        try:
+            if raise_exception:
+                with pytest.raises(
+                    mlrun.errors.MLRunRuntimeError,
+                    match="Model provider could not be determined for model",
+                ):
+                    server = function.to_mock_server()
+            else:
+                server = function.to_mock_server()
+                resp = server.test(body={"country": "france"})
+                assert resp == {"country": "france"}
+        finally:
+            if server:
+                server.wait_for_completion()

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1315,7 +1315,10 @@ def test_configure_model_runner_step_max_threads_processes(concurrency: str):
 @pytest.mark.parametrize(
     "model_class, raise_exception",
     [
-        ("LLModel", True), #  LLModel should raise error because predict was not overridden
+        (
+            "LLModel",
+            True,
+        ),  #  LLModel should raise error because predict was not overridden
         #  DummyAsyncLLMWithoutAsyncPredict should raise error because async_predict was not overridden:
         ("DummyAsyncLLMWithoutAsyncPredict", True),
         ("DummyLLM", False),

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -273,6 +273,11 @@ class DummyAsyncLLM(LLModel):
         return body
 
 
+class DummyAsyncLLMWithoutAsyncPredict(LLModel):
+    def predict(self, body: typing.Any, **kwargs):
+        return body
+
+
 class MyPklModel(Model):
     def __init__(self, name, raise_exception, artifact_uri, **kwargs):
         super().__init__(
@@ -1309,10 +1314,20 @@ def test_configure_model_runner_step_max_threads_processes(concurrency: str):
 
 @pytest.mark.parametrize(
     "model_class, raise_exception",
-    [("LLModel", True), ("DummyLLM", False), ("DummyAsyncLLM", False)],
+    [
+        ("LLModel", True),
+        ("DummyAsyncLLMWithoutAsyncPredict", True),
+        ("DummyLLM", False),
+        ("DummyAsyncLLM", False),
+    ],
 )
 def test_llmodel_without_model_artifact(model_class, raise_exception):
-    execution_mechanism = "asyncio" if model_class == "DummyAsyncLLM" else "naive"
+    #  LLModel should raise error because predict was not overridden
+    #  DummyAsyncLLMWithoutAsyncPredict should raise error because async_predict was not overridden
+
+    is_async = model_class in ("DummyAsyncLLM", "DummyAsyncLLMWithoutAsyncPredict")
+    execution_mechanism = "asyncio" if is_async else "naive"
+    predict_function_name = "predict_async" if is_async else "predict"
     function = mlrun.new_function("tests", kind="serving")
     graph = function.set_topology("flow", engine="async")
     model_runner_step = ModelRunnerStep(name="model-runner")
@@ -1341,7 +1356,8 @@ def test_llmodel_without_model_artifact(model_class, raise_exception):
             if raise_exception:
                 with pytest.raises(
                     mlrun.errors.MLRunRuntimeError,
-                    match="Model provider could not be determined for model",
+                    match=f"Model provider could not be determined for model 'my-model', and the"
+                    f" {predict_function_name} function was not overridden",
                 ):
                     server = function.to_mock_server()
             else:


### PR DESCRIPTION
### 📝 Description
`get_store_artifact` in the Store Manager does not allow empty resources by default. This includes cases such as:

- An empty target path for a PKL-based artifact
- A missing model_uri (ModelArtifact) for an LLMPromptArtifact

---

### 🛠️ Changes Made
1) Allow `_get_artifact_object` in the `Model` class to return artifacts with empty resources by passing `allow_empty_resources=True`.
2) Raise an error if predict and async_predict are not overridden and there is no ModelArtifact.
3) Fix all `MLRunInvalidArgumentError` raises (required dict instead of str)

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: [ML-11767](https://iguazio.atlassian.net/browse/ML-11767)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-11767]: https://iguazio.atlassian.net/browse/ML-11767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ