### PR TITLE
[CI] fix pod log collection when EKS token expires

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -368,6 +368,16 @@ jobs:
       with:
         node-version: 18
 
+    # Configure AWS credentials in the test job as well, so the kubeconfig can use exec-based auth
+    # (aws eks get-token) and refresh tokens throughout long test runs. This prevents 401s during
+    # pod-log collection on failures.
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708
+      with:
+        role-to-assume: ${{ env.AWS_ROLE_ARN }}
+        role-session-name: mlrun-system-tests-${{ github.run_id }}
+        aws-region: ${{ env.AWS_REGION }}
+
     - uses: actions/checkout@v6
       # checking out to the resolved branch to run system tests on, as now we run the actual tests, we don't want to run
       # the system tests of the branch that triggered the system tests as it might be in a different version

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -580,8 +580,24 @@ class TestMLRunSystem:
         try:
             pods = self.kube_client.list_namespaced_pod(namespace)
         except Exception as e:
-            self._logger.warning(f"Failed to list pods in {namespace}: {e}")
-            return {}
+            # EKS exec tokens (aws eks get-token / aws-iam-authenticator) are short lived (~15 minutes).
+            # The kube client can hold a token loaded earlier in the test run, and long running tests can fail
+            # after it expires, causing 401 Unauthorized on log collection. If we detect 401, refresh kubeconfig
+            # (re-run exec) and retry once.
+            status = getattr(e, "status", None)
+            if status == 401 or "Unauthorized" in str(e) or "(401)" in str(e):
+                self._logger.info(
+                    f"Unauthorized listing pods in {namespace}, refreshing kube client and retrying once"
+                )
+                try:
+                    type(self)._setup_k8s_client()
+                    pods = self.kube_client.list_namespaced_pod(namespace)
+                except Exception as e2:
+                    self._logger.warning(f"Failed to list pods in {namespace}: {e2}")
+                    return {}
+            else:
+                self._logger.warning(f"Failed to list pods in {namespace}: {e}")
+                return {}
 
         for pod in pods.items:
             pod_name = pod.metadata.name


### PR DESCRIPTION
This PR improves system tests in MLRun by refreshing the Kubernetes client and retrying pod listing if an expired EKS token (401 error) is detected, and by configuring AWS credentials in the test job to support exec-based kubeconfig authentication. This helps prevent failures during long test runs on EKS.

- Retry listing pods after refreshing kubeconfig (exec) on 401
- Configure AWS credentials in test job for exec-based kubeconfig
