### PR TITLE
[Datastore] Fix ResourceCache table caching key bug [1.10.x]

### DIFF
--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -76,9 +76,9 @@ class ResourceCache:
             return self._tabels[uri]
 
         if uri.startswith("v3io://") or uri.startswith("v3ios://"):
-            endpoint, uri = parse_path(uri)
+            endpoint, path = parse_path(uri)
             self._tabels[uri] = Table(
-                uri,
+                path,
                 V3ioDriver(webapi=endpoint or mlrun.mlconf.v3io_api),
                 flush_interval_secs=mlrun.mlconf.feature_store.flush_interval,
             )
@@ -87,10 +87,10 @@ class ResourceCache:
         if uri.startswith("redis://") or uri.startswith("rediss://"):
             from storey.redis_driver import RedisDriver
 
-            endpoint, uri = parse_path(uri)
+            endpoint, path = parse_path(uri)
             endpoint = endpoint or mlrun.mlconf.redis.url
             self._tabels[uri] = Table(
-                uri,
+                path,
                 RedisDriver(redis_url=endpoint, key_prefix="/"),
                 flush_interval_secs=mlrun.mlconf.feature_store.flush_interval,
             )

--- a/tests/datastore/test_datastores.py
+++ b/tests/datastore/test_datastores.py
@@ -14,7 +14,7 @@
 
 import os
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
 import pytest
@@ -24,6 +24,7 @@ import mlrun.errors
 from mlrun.artifacts import ModelArtifact
 from mlrun.artifacts.base import LinkArtifact
 from mlrun.datastore.inmem import InMemoryStore
+from mlrun.datastore.store_resources import ResourceCache
 from tests.conftest import rundb_path
 
 mlrun.mlconf.dbpath = rundb_path
@@ -380,3 +381,20 @@ def test_item_to_real_path_map(virtual_path: str, tmpdir: Path) -> None:
     assert data.get() == b"abc", "failed put/get test"
     assert data.stat().size == 3, "got wrong file size"
     assert os.path.isfile(os.path.join(tmpdir, "test1.txt"))
+
+
+def test_resource_cache_get_table_caches_by_original_uri():
+    """Test that ResourceCache.get_table() caches tables under the original URI."""
+    cache = ResourceCache()
+    test_uri = "v3io://webapi.default-tenant.app.cluster/container/path/to/table"
+    mock_table_instance = MagicMock(name="MockTable")
+
+    with patch("storey.Table", return_value=mock_table_instance) as mock_table_class:
+        with patch("storey.V3ioDriver"):
+            first_result = cache.get_table(test_uri)
+            mock_table_class.assert_called_once()
+            assert first_result is mock_table_instance
+
+            second_result = cache.get_table(test_uri)
+            assert mock_table_class.call_count == 1
+            assert second_result is first_result


### PR DESCRIPTION
## Summary
- Fix bug in `ResourceCache.get_table()` where `parse_path(uri)` overwrote the `uri` variable
- Tables were being stored under the parsed path instead of the original URI, causing cache misses
- This led to duplicate Table objects being created on subsequent calls with the same URI

Backport of https://github.com/mlrun/mlrun/pull/9085