### PR TITLE
[Application Runtime] Validate probes health check

### DIFF
--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -27,6 +27,7 @@ from fastapi.concurrency import run_in_threadpool
 
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
+from mlrun.common.runtimes.constants import ProbeType
 from mlrun.common.schemas.serving import DeployResponse
 from mlrun.config import config
 from mlrun.utils import logger
@@ -485,6 +486,12 @@ def _deploy_function(
 
         # after saving function to DB, we need to restore the original config so that the sensitive data won't be stored
         fn.spec.config = raw_config
+
+        # Validate sidecar probe configurations before deployment
+        sidecars = fn.spec.config.get("spec.sidecars") or []
+        if sidecars:
+            _validate_sidecar_probes(sidecars)
+
         fn = _deploy_nuclio_runtime(
             auth_info,
             builder_env,
@@ -772,3 +779,30 @@ async def _add_functions_external_invocation_url(
         for function in function_names
     ]
     await asyncio.gather(*tasks)
+
+
+def _validate_sidecar_probes(sidecars: list[dict]) -> None:
+    """Validate probe configurations in sidecars against Kubernetes V1Probe schema.
+
+    Validates that each probe configuration has exactly one of the following:
+    httpGet, exec, tcpSocket, or grpc.
+    """
+    health_check_keys = ["httpGet", "exec", "tcpSocket", "grpc"]
+
+    for sidecar in sidecars:
+        for probe_type in (pt.key for pt in ProbeType):
+            probe_config = sidecar.get(probe_type)
+            if probe_config is None:
+                continue
+
+            # Count health check configuration keys
+            present_keys = [key for key in health_check_keys if key in probe_config]
+
+            if len(present_keys) != 1:
+                framework.api.utils.log_and_raise(
+                    HTTPStatus.BAD_REQUEST.value,
+                    reason=(
+                        f"Sidecar {probe_type} must have exactly one of "
+                        f"the following configuration sections: {', '.join(health_check_keys)}"
+                    ),
+                )

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -17,6 +17,7 @@ import json
 import os
 import typing
 import unittest.mock
+from http import HTTPStatus
 
 import deepdiff
 import kubernetes
@@ -42,6 +43,7 @@ from mlrun.utils import logger
 
 import services.api.crud.runtimes.nuclio.function
 import services.api.crud.runtimes.nuclio.helpers
+from services.api.api.endpoints.nuclio import _validate_sidecar_probes
 from services.api.tests.unit.conftest import APIK8sSecretsMock
 from services.api.tests.unit.runtimes.base import TestRuntimeBase
 from services.api.utils.functions import build_function
@@ -2147,6 +2149,91 @@ class TestNuclioRuntime(TestRuntimeBase):
             .startswith("mlrun-auth-secrets")
             for volume in volumes
         )
+
+    def test_validate_sidecar_probes_positive_flow(self):
+        # Test 3 sidecars, each with a different health check method
+        sidecars = [
+            {
+                "name": "sidecar-http",
+                "readinessProbe": {
+                    "httpGet": {
+                        "path": "/ready",
+                        "port": 8080,
+                    },
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 3,
+                },
+            },
+            {
+                "name": "sidecar-exec",
+                "livenessProbe": {
+                    "exec": {
+                        "command": ["/bin/sh", "-c", "cat /tmp/healthy"],
+                    },
+                    "initialDelaySeconds": 10,
+                    "periodSeconds": 5,
+                },
+            },
+            {
+                "name": "sidecar-tcp",
+                "startupProbe": {
+                    "tcpSocket": {
+                        "port": 9090,
+                    },
+                    "initialDelaySeconds": 15,
+                    "periodSeconds": 10,
+                },
+                "livenessProbe": {
+                    "grpc": {
+                        "port": 9091,
+                        "service": "health",
+                    },
+                    "initialDelaySeconds": 20,
+                    "periodSeconds": 5,
+                },
+            },
+        ]
+
+        _validate_sidecar_probes(sidecars)
+
+    def test_validate_sidecar_probes_invalid_configurations(self):
+        # Test various invalid probe configurations - should raise HTTPException
+        invalid_sidecar_configs = [
+            [
+                {
+                    "name": "test-sidecar-missing",
+                    "readinessProbe": {
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 3,
+                    },
+                }
+            ],
+            [
+                {
+                    "name": "test-sidecar-more-than-one_health-check",
+                    "readinessProbe": {
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 3,
+                        "tcpSocket": {
+                            "port": 9090,
+                        },
+                        "httpGet": {
+                            "path": "/ready",
+                            "port": 8080,
+                        },
+                    },
+                }
+            ],
+        ]
+
+        for sidecars in invalid_sidecar_configs:
+            with pytest.raises(HTTPException) as exception_result:
+                _validate_sidecar_probes(sidecars)
+
+            assert exception_result.value.status_code == HTTPStatus.BAD_REQUEST.value
+            assert "must have exactly one of" in str(
+                exception_result.value.detail.get("reason", "")
+            )
 
 
 # Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well


### PR DESCRIPTION
### 📝 Description
This change adds backend validation for sidecar probe configurations during Nuclio function deployment.

Before deploying the function, the API now validates that each configured sidecar probe (`readinessProbe`, `livenessProbe`, `startupProbe`) defines exactly one Kubernetes health-check mechanism (`httpGet`, `exec`, `tcpSocket`, or `grpc`). Configurations that are missing a health check or define multiple checks are rejected with a clear 400 Bad Request error.

This validation is intentionally minimal and aligned with the Kubernetes V1Probe schema, ensuring obvious misconfigurations are caught early while avoiding deep field-level validation.

---

### 🛠️ Changes Made
- Added backend validation for sidecar probes before deployment.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Dev test: tested both negative and positive flows
- Added unit tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11788
- Design docs links:
- External links: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- This PR follows up on https://github.com/mlrun/mlrun/pull/9043
