### PR TITLE
[DataStore] Fix call to `find_partitions` [1.10.x]

### DIFF
--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -4607,8 +4607,8 @@ starlette==0.50.0 ; python_full_version >= '3.10' \
     --hash=sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca \
     --hash=sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca
     # via fastapi
-storey==1.10.19 \
-    --hash=sha256:774eefa0ff2abec455cdedba7308099d387a112ec76edf382d75c4b8e4a0e75a
+storey==1.10.20 \
+    --hash=sha256:14b9428adbe311d460ec05d36ffe67ce353e8ef585080d4b771bb91894b9f8e7
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -397,7 +397,7 @@ class DataStore(BaseRemoteClient):
 
             if start_time or end_time or additional_filters:
                 partitions_time_attributes, partitions = find_partitions(
-                    url, file_system
+                    url, file_system, True
                 )
                 logger.debug("Partitioned parquet read", partitions=partitions)
                 set_filters(

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2025.5.1, <=2025.7.0
 v3iofs~=0.1.17
-storey~=1.10.19
+storey~=1.10.20
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -126,7 +126,7 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"~=1.10.19"},
+        "storey": {"~=1.10.20"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "scipy": {"~=1.13.0"},


### PR DESCRIPTION
### 📝 Description

Fix reacts to the change in storey util `find_partitions`

---

### 🛠️ Changes Made

Added a flag return_full_partitioning=True for `find_partitions` call

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

`test_app_flow[True, True]`

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11803
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
