### PR TITLE
[Serving] Avoid creating an output artifact in serving job without `respond()` [1.10.x]

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -649,7 +649,7 @@ async def async_execute_graph(
 
     if df.empty:
         context.logger.warn("Job terminated due to empty inputs (0 rows)")
-        return []
+        return
 
     track_models = spec.get("track_models")
 
@@ -779,30 +779,49 @@ async def async_execute_graph(
         model_endpoint_uids=model_endpoint_uids,
     )
 
-    # log the results as artifacts
-    num_of_meps_in_the_graph = len(server.graph.model_endpoints_names)
-    artifact_path = None
-    if (
-        "{{run.uid}}" not in context.artifact_path
-    ):  # TODO: delete when IG-22841 is resolved
-        artifact_path = "+/{{run.uid}}"  # will be concatenated to the context's path in extend_artifact_path
-    if num_of_meps_in_the_graph <= 1:
+    has_responder = False
+    for step in server.graph.steps.values():
+        if getattr(step, "responder", False):
+            has_responder = True
+            break
+
+    if has_responder:
+        # log the results as a dataset artifact
+        artifact_path = None
+        if (
+            "{{run.uid}}" not in context.artifact_path
+        ):  # TODO: delete when IG-22841 is resolved
+            artifact_path = "+/{{run.uid}}"  # will be concatenated to the context's path in extend_artifact_path
         context.log_dataset(
             "prediction", df=pd.DataFrame(responses), artifact_path=artifact_path
         )
-    else:
-        # turn this list of samples into a dict of lists, one per model endpoint
-        grouped = defaultdict(list)
-        for sample in responses:
-            for model_name, features in sample.items():
-                grouped[model_name].append(features)
-        # create a dataframe per model endpoint and log it
-        for model_name, features in grouped.items():
-            context.log_dataset(
-                f"prediction_{model_name}",
-                df=pd.DataFrame(features),
-                artifact_path=artifact_path,
-            )
+
+        # if we got responses that appear to be in the right format, try to log per-model datasets too
+        if (
+            responses
+            and responses[0]
+            and isinstance(responses[0], dict)
+            and isinstance(next(iter(responses[0].values())), (dict, list))
+        ):
+            try:
+                # turn this list of samples into a dict of lists, one per model endpoint
+                grouped = defaultdict(list)
+                for sample in responses:
+                    for model_name, features in sample.items():
+                        grouped[model_name].append(features)
+                # create a dataframe per model endpoint and log it
+                for model_name, features in grouped.items():
+                    context.log_dataset(
+                        f"prediction_{model_name}",
+                        df=pd.DataFrame(features),
+                        artifact_path=artifact_path,
+                    )
+            except Exception as e:
+                context.logger.warning(
+                    "Failed to log per-model prediction datasets",
+                    error=err_to_str(e),
+                )
+
     context.log_result("num_rows", run_call_count)
 
 

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -29,6 +29,7 @@ import mlrun.feature_store.common
 import mlrun.model
 import tests.system.base
 from mlrun.runtimes.function_reference import FunctionReference
+from mlrun.serving import ModelRunnerStep
 
 
 def exec_cli(args, action="run"):
@@ -697,17 +698,13 @@ def print_df(df):
     )
     @pytest.mark.parametrize("local", [True, False])
     def test_job_from_serving_with_mrs(self, execution_mechanism: str, local: bool):
-        import mlrun.serving.states
-
         serving_func_obj = self.project.set_function(
             func=str(self.assets_path / "function_with_model.py"),
             name="srv_fn",
             kind="serving",
             image=self.image,
         )
-        mode_runner_obj = mlrun.serving.states.ModelRunnerStep(
-            name="model_runner_step_name"
-        )
+        mode_runner_obj = ModelRunnerStep(name="model_runner_step_name")
         mode_runner_obj.add_model(
             endpoint_name="my-endpoint",
             model_class="DummyModel",
@@ -734,6 +731,51 @@ def print_df(df):
         assert run_object.status.results == {
             "num_rows": 1,
         }
+        assert run_object.artifact("prediction").as_df().to_dict(orient="records") == [
+            {"x": "a", "y": 1, "extra": 123}
+        ]
+        assert run_object.artifact("prediction_my-endpoint") is None
+
+    def test_job_from_serving_with_multiple_mrs(self):
+        serving_func_obj = self.project.set_function(
+            func=str(self.assets_path / "function_with_model.py"),
+            name="srv_fn",
+            kind="serving",
+            image=self.image,
+        )
+        mode_runner_obj = ModelRunnerStep(name="model_runner_step_name")
+        mode_runner_obj.add_model(
+            endpoint_name="my-endpoint",
+            model_class="DummyModel",
+            execution_mechanism="naive",
+        )
+        mode_runner_obj.add_model(
+            endpoint_name="my-other-endpoint",
+            model_class="DummyModel",
+            execution_mechanism="naive",
+        )
+        graph_obj = serving_func_obj.set_topology("flow", engine="async")
+        graph_obj.to(mode_runner_obj).respond()
+        job = serving_func_obj.to_job()
+        local_input_path = str(self.assets_path / "in.csv")
+        input_path = local_input_path
+        inputs = {"data": input_path}
+        run_object = self.project.run_function(job, inputs=inputs, local=True)
+        assert run_object.status.results == {
+            "num_rows": 1,
+        }
+        assert run_object.artifact("prediction").as_df().to_dict(orient="records") == [
+            {
+                "my-endpoint": {"extra": 123, "x": "a", "y": 1},
+                "my-other-endpoint": {"extra": 123, "x": "a", "y": 1},
+            }
+        ]
+        assert run_object.artifact("prediction_my-endpoint").as_df().to_dict(
+            orient="records"
+        ) == [{"x": "a", "y": 1, "extra": 123}]
+        assert run_object.artifact("prediction_my-other-endpoint").as_df().to_dict(
+            orient="records"
+        ) == [{"x": "a", "y": 1, "extra": 123}]
 
     @pytest.mark.parametrize("local", [True, False])
     @pytest.mark.parametrize("deploy_original", [True, False])


### PR DESCRIPTION
[ML-11400](https://iguazio.atlassian.net/browse/ML-11400)

Also:
* Avoid creating per-model artifacts when the output schema doesn't fit
* Avoid failing the job if per-model artifact creation fails
* Expand tests to cover output artifacts
* Fix minor static code analysis warning

[ML-11400]: https://iguazio.atlassian.net/browse/ML-11400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ