### PR TITLE
[CI] Use requirements.txt to install services dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,14 @@ updates:
     commit-message:
       prefix: "[Dependabot-automated] "
     open-pull-requests-limit: 6
+
+  # python pip dependencies
+  - package-ecosystem: "pip"
+
+    # do not create PRs for dockerfile requirements.txt files
+    open-pull-requests-limit: 0
+    directory: "/dockerfiles/**"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - "requirements.txt"


### PR DESCRIPTION
### 📝 Description

Add dockerfiles pypi to Dependabot to ignore requirements.txt as they are top-level dependency for mlrun services and not the actual dependencies. This is aimed to avoid cases where false-positive security vulnerabilities are opened.

note: we dont need dependabot to create PRs as we use our internal flows to update dependencies on weekly basis.

---

### 🛠️ Changes Made


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Configuration file syntax validated
- No runtime testing required (GitHub-managed feature)

---

### 🔗 References
- Ticket link: Ticket link: https://iguazio.atlassian.net/browse/DEVOPS-1510
- Design docs links:
- External links: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
