### PR TITLE
[CI] Included a step to install aws-iam-authenticator

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -369,10 +369,12 @@ jobs:
       # Required when kubeconfig uses exec auth with `command: aws-iam-authenticator`
       run: |
         set -euo pipefail
+        export PATH="/usr/local/bin:$PATH"
         curl -fsSL \
           -o /usr/local/bin/aws-iam-authenticator \
           https://amazon-eks.s3-us-west-2.amazonaws.com/1.34.2/2025-11-13/bin/linux/amd64/aws-iam-authenticator
         chmod +x /usr/local/bin/aws-iam-authenticator
+        command -v aws-iam-authenticator
         aws-iam-authenticator version
 
     - uses: actions/setup-node@v6

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -371,7 +371,7 @@ jobs:
         set -euo pipefail
         curl -fsSL \
           -o /usr/local/bin/aws-iam-authenticator \
-          https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator
+          https://amazon-eks.s3-us-west-2.amazonaws.com/1.34.2/2025-11-13/bin/linux/amd64/aws-iam-authenticator
         chmod +x /usr/local/bin/aws-iam-authenticator
         aws-iam-authenticator version
 

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -357,12 +357,23 @@ jobs:
         # gcc, make     for installing python packages
         apt-get update -qqy && \
           apt-get install -y \
+            curl \
             gnupg \
             nodejs \
             graphviz \
             git-core \
             gcc \
             make
+
+    - name: Install aws-iam-authenticator
+      # Required when kubeconfig uses exec auth with `command: aws-iam-authenticator`
+      run: |
+        set -euo pipefail
+        curl -fsSL \
+          -o /usr/local/bin/aws-iam-authenticator \
+          https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator
+        chmod +x /usr/local/bin/aws-iam-authenticator
+        aws-iam-authenticator version
 
     - uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
### 📝 Description
Fix MLRun enterprise system-tests pod log collection failures caused by EKS exec-auth issues:
Ensure the system-tests CI container has the required aws-iam-authenticator binary (kubeconfig exec plugin).
Make pod-log collection more robust on long runs by refreshing kubeconfig and retrying once on 401 Unauthorized (expired EKS token).

---

### 🛠️ Changes Made
CI: Install aws-iam-authenticator into the run-system-tests-enterprise-ci container and add curl dependency (required by kubeconfig exec auth).
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Ran enterprise system tests in CI and validated:
kubeconfig exec auth no longer fails with No such file or directory: aws-iam-authenticator
on test failures after long runtime, pod log collection no longer fails with 401 Unauthorized and logs are printed

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
