### PR TITLE
[HUB] Add a HUB SDK for the `get_hub_item` API

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -38,7 +38,7 @@ from .datastore import DataItem, ModelProvider, store_manager
 from .db import get_run_db
 from .errors import MLRunInvalidArgumentError, MLRunNotFoundError
 from .execution import MLClientCtx
-from .hub import get_hub_module, get_hub_step, import_module
+from .hub import get_hub_item, get_hub_module, get_hub_step, import_module
 from .model import RunObject, RunTemplate, new_task
 from .package import ArtifactType, DefaultPackager, Packager, handler
 from .projects import (

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4443,7 +4443,7 @@ class HTTPRunDB(RunDBInterface):
         :param item_type: The type of item to retrieve from the hub source (e.g: functions, modules).
         :returns: :py:class:`~mlrun.common.schemas.hub.HubItem`.
         """
-        path = (f"hub/sources/{source_name}/items/{item_name}",)
+        path = f"hub/sources/{source_name}/items/{item_name}"
         params = {
             "version": version,
             "tag": tag,

--- a/mlrun/hub/__init__.py
+++ b/mlrun/hub/__init__.py
@@ -11,6 +11,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
+
+import mlrun
+from mlrun.common.schemas.hub import HubSourceType
 
 from .module import get_hub_module, import_module
 from .step import get_hub_step
+
+
+def get_hub_item(
+    source_name: str,
+    item_name: str,
+    version: Optional[str] = None,
+    tag: Optional[str] = "latest",
+    force_refresh: bool = False,
+    item_type: HubSourceType = HubSourceType.functions,
+) -> mlrun.common.schemas.hub.HubItem:
+    """
+    Retrieve a specific hub item.
+
+    :param source_name: Name of source.
+    :param item_name: Name of the item to retrieve, as it appears in the hub catalog.
+    :param version: Get a specific version of the item. Default is ``None``.
+    :param tag: Get a specific version of the item identified by tag. Default is ``latest``.
+    :param force_refresh: Make the server fetch the information from the actual hub
+        source, rather than
+        rely on cached information. Default is ``False``.
+    :param item_type: The type of item to retrieve from the hub source (e.g: functions, modules).
+    :returns: :py:class:`~mlrun.common.schemas.hub.HubItem`.
+    """
+    db = mlrun.get_run_db()
+    return db.get_hub_item(
+        source_name=source_name,
+        item_name=item_name,
+        version=version,
+        tag=tag,
+        force_refresh=force_refresh,
+        item_type=item_type,
+    )

--- a/tests/integration/sdk_api/hub/test_hub.py
+++ b/tests/integration/sdk_api/hub/test_hub.py
@@ -243,3 +243,40 @@ class TestHub(tests.integration.sdk_api.base.TestMLRunIntegration):
             mlrun.get_hub_step(
                 hub_prefix + source_name + "/" + name, local_path="./temp"
             )
+
+    def test_get_hub_item(self):
+        source_name = mlrun.mlconf.hub.default_source.name
+
+        # Test basic retrieval of a function item
+        hub_item = mlrun.get_hub_item(source_name=source_name, item_name="describe")
+        assert hub_item.metadata.name == "describe"
+        assert (
+            hub_item.metadata.source == mlrun.common.schemas.hub.HubSourceType.functions
+        )
+
+        # Test retrieval with explicit item_type parameter for functions
+        hub_item = mlrun.get_hub_item(
+            source_name=source_name,
+            item_name="describe",
+            item_type=mlrun.common.schemas.hub.HubSourceType.functions,
+        )
+        assert hub_item.metadata.name == "describe"
+        assert (
+            hub_item.metadata.source == mlrun.common.schemas.hub.HubSourceType.functions
+        )
+
+        # Test retrieval with force_refresh parameter
+        hub_item_refreshed = mlrun.get_hub_item(
+            source_name=source_name, item_name="describe", force_refresh=True
+        )
+        assert hub_item_refreshed.metadata.name == "describe"
+
+        # Test non-existent item raises MLRunNotFoundError
+        with pytest.raises(mlrun.errors.MLRunNotFoundError):
+            mlrun.get_hub_item(source_name=source_name, item_name="not-exist-function")
+
+        # Test non-existent source raises MLRunNotFoundError
+        with pytest.raises(mlrun.errors.MLRunNotFoundError):
+            mlrun.get_hub_item(
+                source_name=source_name + "-not-exist", item_name="describe"
+            )


### PR DESCRIPTION
### 📝 Description
Adds a HUB SDK for `get_hub_item` API that return `HubItem` object.  This PR also fixes a bug in the `get_hub_item` HTTP client API path, along with adding related integration tests.

---

### 🛠️ Changes Made
- Introduce a new HUB SDK api `get_hub_item` under `mlrun.hub`
- Fix the `get_hub_item` API path: `(f"hub/sources/{source_name}/items/{item_name}",)` -> `hub/sources/{source_name}/items/{item_name}`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- A new integration test `test_get_hub_item` was added to verify that the API works as expected.  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11865

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

