### PR TITLE
[API] Allow storing user secrets when pending migration

### DIFF
--- a/server/py/framework/api/deps.py
+++ b/server/py/framework/api/deps.py
@@ -69,12 +69,18 @@ def verify_api_state(request: Request):
         mlrun.common.schemas.APIStates.waiting_for_chief,
     ]:
         enabled_endpoints = [
+            # allow healthz requests
             "healthz",
+            # for migration purposes
             "background-tasks",
-            "client-spec",
             "migrations",
+            # clusterization purposes
+            "client-spec",
             "clusterization-spec",
+            # debug purposes
             "memory-reports",
+            # allow authentication
+            "user-secrets/tokens",
         ]
         if not any(enabled_endpoint in path for enabled_endpoint in enabled_endpoints):
             message = mlrun.common.schemas.APIStates.description(


### PR DESCRIPTION
### 📝 Description

Allow storing user secret tokens when pending migration to allow user to authenticate + trigger migration.

---

### 🛠️ Changes Made

Added path to allowed endpoints during pending db migrations

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Manual testings

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11433
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
