### PR TITLE
[Auth] Align invoking APIGW with iguazio4 conventions

### DIFF
--- a/mlrun/auth/nuclio.py
+++ b/mlrun/auth/nuclio.py
@@ -1,0 +1,89 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+
+import requests.auth
+from nuclio.auth import AuthInfo as _NuclioAuthInfo
+from nuclio.auth import AuthKinds as NuclioAuthKinds
+
+import mlrun.auth.providers
+import mlrun.common.schemas.auth
+
+
+class NuclioAuthInfo(_NuclioAuthInfo):
+    def __init__(self, token=None, **kwargs):
+        super().__init__(**kwargs)
+        self._token = token
+
+    @classmethod
+    def from_auth_info(cls, auth_info: "mlrun.common.schemas.auth.AuthInfo"):
+        if not auth_info:
+            return None
+        if mlrun.mlconf.is_iguazio_v4_mode():
+            return cls.from_request_headers(auth_info.request_headers)
+        if auth_info.session != "":
+            return NuclioAuthInfo(
+                password=auth_info.session, mode=NuclioAuthKinds.iguazio
+            )
+        return None
+
+    @classmethod
+    def from_request_headers(cls, headers: dict[str, str]):
+        if not headers:
+            return cls()
+        for key, value in headers.items():
+            if key.lower() == "authorization":
+                if value.lower().startswith("bearer "):
+                    return cls(
+                        token=value[len("bearer ") :],
+                        mode=NuclioAuthKinds.iguazio,
+                    )
+                if value.lower().startswith("basic "):
+                    token = value[len("basic ") :]
+                    decoded_token = base64.b64decode(token).decode("utf-8")
+                    username, password = decoded_token.split(":", 1)
+                    return cls(
+                        username=username,
+                        password=password,
+                        mode=NuclioAuthKinds.iguazio,
+                    )
+        return cls()
+
+    @classmethod
+    def from_envvar(cls):
+        if mlrun.mlconf.is_iguazio_v4_mode():
+            token_provider = mlrun.auth.providers.IGTokenProvider(
+                token_endpoint=mlrun.mlconf.auth_token_endpoint,
+            )
+            return cls(
+                token=token_provider.get_token(),
+                mode=NuclioAuthKinds.iguazio,
+            )
+        return super().from_envvar()
+
+    def to_requests_auth(self) -> "requests.auth":
+        if self._token:
+            # in iguazio v4 mode we use bearer token auth
+            return _RequestAuthBearerToken(self._token)
+        return super().to_requests_auth()
+
+
+class _RequestAuthBearerToken(requests.auth.AuthBase):
+    def __init__(self, token: str):
+        self._token = token
+
+    def __call__(self, r):
+        r.headers["Authorization"] = f"Bearer {self._token}"
+        return r

--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -12,13 +12,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import typing
 
 import pydantic.v1
-from nuclio.auth import AuthInfo as NuclioAuthInfo
+import requests.auth
+from nuclio.auth import AuthInfo as _NuclioAuthInfo
 from nuclio.auth import AuthKinds as NuclioAuthKinds
 
 import mlrun.common.types
+
+
+class NuclioAuthInfo(_NuclioAuthInfo):
+    def __init__(self, token=None, **kwargs):
+        super().__init__(**kwargs)
+        self._token = token
+
+    @classmethod
+    def from_request_headers(cls, headers: dict[str, str]):
+        if not headers:
+            return cls()
+        for key, value in headers.items():
+            if key.lower() == "authorization":
+                if value.lower().startswith("bearer "):
+                    return cls(
+                        token=value[len("bearer ") :],
+                        mode=NuclioAuthKinds.iguazio,
+                    )
+                if value.lower().startswith("basic "):
+                    token = value[len("basic ") :]
+                    decoded_token = base64.b64decode(token).decode("utf-8")
+                    username, password = decoded_token.split(":", 1)
+                    return cls(
+                        username=username,
+                        password=password,
+                        mode=NuclioAuthKinds.iguazio,
+                    )
+        return cls()
+
+    @classmethod
+    def from_envvar(cls):
+        import mlrun.auth.utils
+
+        if mlrun.mlconf.is_iguazio_v4_mode():
+            return _NuclioAuthInfo(
+                password=mlrun.auth.utils.load_offline_token(),
+                mode=NuclioAuthKinds.iguazio,
+            )
+        return super().from_envvar()
+
+    def to_requests_auth(self) -> "requests.auth":
+        if mlrun.mlconf.is_iguazio_v4_mode():
+            # in iguazio v4 mode we use bearer token auth
+            auth = requests.auth.AuthBase()
+            auth.__call__ = lambda r: r.headers.update(
+                {"Authorization": f"Bearer {self._token}"}
+            )
+            return auth
+        return super().to_requests_auth()
 
 
 class ProjectsRole(mlrun.common.types.StrEnum):
@@ -141,7 +192,7 @@ class AuthInfo(pydantic.v1.BaseModel):
 
     def to_nuclio_auth_info(self):
         if mlrun.mlconf.is_iguazio_v4_mode():
-            return NuclioAuthInfoWithHeaders(headers=self.request_headers)
+            return NuclioAuthInfo.from_request_headers(self.request_headers)
         if self.session != "":
             return NuclioAuthInfo(password=self.session, mode=NuclioAuthKinds.iguazio)
         return None
@@ -162,37 +213,3 @@ class AuthInfo(pydantic.v1.BaseModel):
 
 class Credentials(pydantic.v1.BaseModel):
     access_key: typing.Optional[str]
-
-
-class NuclioAuthInfoWithHeaders(NuclioAuthInfo):
-    """ "
-    Nuclio AuthInfo subclass that supports custom headers.
-    This is needed because Nuclio Jupyter is using `to_requests_auth` method, but in Iguazio V4 we need to inject
-    the Auth headers instead of using basic auth
-    """
-
-    def __init__(self, headers=None, **kwargs):
-        super().__init__(**kwargs)
-        self._headers = headers or {}
-
-    def to_requests_auth(self):
-        # Return custom auth handler that applies headers
-        base_auth = super().to_requests_auth()
-        return _CustomAuthWithHeaders(base_auth, self._headers)
-
-
-class _CustomAuthWithHeaders:
-    """
-    Custom requests auth handler that applies additional headers to the request
-    """
-
-    def __init__(self, base_auth, headers):
-        self.base_auth = base_auth
-        self.headers = headers
-
-    def __call__(self, request):
-        if self.base_auth:
-            request = self.base_auth(request)
-        for key, value in self.headers.items():
-            request.headers[key] = value
-        return request

--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -55,14 +55,14 @@ class NuclioAuthInfo(_NuclioAuthInfo):
         import mlrun.auth.utils
 
         if mlrun.mlconf.is_iguazio_v4_mode():
-            return _NuclioAuthInfo(
-                password=mlrun.auth.utils.load_offline_token(),
+            return cls(
+                token=mlrun.auth.utils.load_offline_token(),
                 mode=NuclioAuthKinds.iguazio,
             )
         return super().from_envvar()
 
     def to_requests_auth(self) -> "requests.auth":
-        if mlrun.mlconf.is_iguazio_v4_mode():
+        if self._token:
             # in iguazio v4 mode we use bearer token auth
             auth = requests.auth.AuthBase()
             auth.__call__ = lambda r: r.headers.update(

--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -12,73 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import base64
 import typing
 
 import pydantic.v1
-import requests.auth
-from nuclio.auth import AuthInfo as _NuclioAuthInfo
-from nuclio.auth import AuthKinds as NuclioAuthKinds
 
 import mlrun.common.types
-
-
-class NuclioAuthInfo(_NuclioAuthInfo):
-    def __init__(self, token=None, **kwargs):
-        super().__init__(**kwargs)
-        self._token = token
-
-    @classmethod
-    def from_request_headers(cls, headers: dict[str, str]):
-        if not headers:
-            return cls()
-        for key, value in headers.items():
-            if key.lower() == "authorization":
-                if value.lower().startswith("bearer "):
-                    return cls(
-                        token=value[len("bearer ") :],
-                        mode=NuclioAuthKinds.iguazio,
-                    )
-                if value.lower().startswith("basic "):
-                    token = value[len("basic ") :]
-                    decoded_token = base64.b64decode(token).decode("utf-8")
-                    username, password = decoded_token.split(":", 1)
-                    return cls(
-                        username=username,
-                        password=password,
-                        mode=NuclioAuthKinds.iguazio,
-                    )
-        return cls()
-
-    @classmethod
-    def from_envvar(cls):
-        import os
-
-        import mlrun.auth.providers
-
-        if mlrun.mlconf.is_iguazio_v4_mode():
-            token_endpoint = mlrun.mlconf.auth_token_endpoint or os.path.join(
-                mlrun.mlconf.iguazio_api_url,
-                "api/v1/authentication/refresh-access-token",
-            )
-            token_provider = mlrun.auth.providers.IGTokenProvider(
-                token_endpoint=token_endpoint
-            )
-            return cls(
-                token=token_provider.get_token(),
-                mode=NuclioAuthKinds.iguazio,
-            )
-        return super().from_envvar()
-
-    def to_requests_auth(self) -> "requests.auth":
-        if self._token:
-            # in iguazio v4 mode we use bearer token auth
-            auth = requests.auth.AuthBase()
-            auth.__call__ = lambda r: r.headers.update(
-                {"Authorization": f"Bearer {self._token}"}
-            )
-            return auth
-        return super().to_requests_auth()
 
 
 class ProjectsRole(mlrun.common.types.StrEnum):
@@ -198,13 +136,6 @@ class AuthInfo(pydantic.v1.BaseModel):
     user_unix_id: typing.Optional[int] = None
     projects_role: typing.Optional[ProjectsRole] = None
     planes: list[str] = []
-
-    def to_nuclio_auth_info(self):
-        if mlrun.mlconf.is_iguazio_v4_mode():
-            return NuclioAuthInfo.from_request_headers(self.request_headers)
-        if self.session != "":
-            return NuclioAuthInfo(password=self.session, mode=NuclioAuthKinds.iguazio)
-        return None
 
     def get_member_ids(self) -> list[str]:
         member_ids = []

--- a/mlrun/common/schemas/auth.py
+++ b/mlrun/common/schemas/auth.py
@@ -52,11 +52,20 @@ class NuclioAuthInfo(_NuclioAuthInfo):
 
     @classmethod
     def from_envvar(cls):
-        import mlrun.auth.utils
+        import os
+
+        import mlrun.auth.providers
 
         if mlrun.mlconf.is_iguazio_v4_mode():
+            token_endpoint = mlrun.mlconf.auth_token_endpoint or os.path.join(
+                mlrun.mlconf.iguazio_api_url,
+                "api/v1/authentication/refresh-access-token",
+            )
+            token_provider = mlrun.auth.providers.IGTokenProvider(
+                token_endpoint=token_endpoint
+            )
             return cls(
-                token=mlrun.auth.utils.load_offline_token(),
+                token=token_provider.get_token(),
                 mode=NuclioAuthKinds.iguazio,
             )
         return super().from_envvar()

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -20,6 +20,7 @@ import requests
 from nuclio.auth import AuthKinds as NuclioAuthKinds
 
 import mlrun
+import mlrun.auth.nuclio
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.helpers
 import mlrun.common.schemas as schemas
@@ -445,7 +446,7 @@ class APIGateway(ModelObj):
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     "API Gateway invocation requires authentication. Please pass credentials"
                 )
-            auth = mlrun.common.schemas.auth.NuclioAuthInfo(
+            auth = mlrun.auth.nuclio.NuclioAuthInfo(
                 username=credentials[0], password=credentials[1]
             ).to_requests_auth()
 
@@ -455,16 +456,14 @@ class APIGateway(ModelObj):
         ):
             # inject access key from env
             if credentials:
-                auth = mlrun.common.schemas.auth.NuclioAuthInfo(
+                auth = mlrun.auth.nuclio.NuclioAuthInfo(
                     username=credentials[0],
                     password=credentials[1],
                     mode=NuclioAuthKinds.iguazio,
                 ).to_requests_auth()
             else:
                 auth = (
-                    mlrun.common.schemas.auth.NuclioAuthInfo()
-                    .from_envvar()
-                    .to_requests_auth()
+                    mlrun.auth.nuclio.NuclioAuthInfo().from_envvar().to_requests_auth()
                 )
             if not auth:
                 raise mlrun.errors.MLRunInvalidArgumentError(
@@ -474,7 +473,7 @@ class APIGateway(ModelObj):
             self.spec.authentication.authentication_mode
             == schemas.APIGatewayAuthenticationMode.iguazio.value
         ):
-            auth = mlrun.common.schemas.auth.NuclioAuthInfo.from_envvar().to_requests_auth()
+            auth = mlrun.auth.nuclio.NuclioAuthInfo.from_envvar().to_requests_auth()
         url = urljoin(self.invoke_url, path or "")
 
         # Determine the correct keyword argument for the body

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -550,6 +550,7 @@ class APIGateway(ModelObj):
         """
         self.spec.authentication = AccessKeyAuth()
 
+    @min_nuclio_versions("1.15.10")
     def with_iguazio_auth(self):
         """
         Set iguazio authentication for the API gateway.

--- a/mlrun/runtimes/nuclio/api_gateway.py
+++ b/mlrun/runtimes/nuclio/api_gateway.py
@@ -17,13 +17,13 @@ from typing import Optional, Union
 from urllib.parse import urljoin
 
 import requests
-from nuclio.auth import AuthInfo as NuclioAuthInfo
 from nuclio.auth import AuthKinds as NuclioAuthKinds
 
 import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.helpers
 import mlrun.common.schemas as schemas
+import mlrun.common.schemas.auth
 import mlrun.common.types
 from mlrun.model import ModelObj
 from mlrun.platforms.iguazio import min_iguazio_versions
@@ -445,7 +445,7 @@ class APIGateway(ModelObj):
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     "API Gateway invocation requires authentication. Please pass credentials"
                 )
-            auth = NuclioAuthInfo(
+            auth = mlrun.common.schemas.auth.NuclioAuthInfo(
                 username=credentials[0], password=credentials[1]
             ).to_requests_auth()
 
@@ -455,13 +455,17 @@ class APIGateway(ModelObj):
         ):
             # inject access key from env
             if credentials:
-                auth = NuclioAuthInfo(
+                auth = mlrun.common.schemas.auth.NuclioAuthInfo(
                     username=credentials[0],
                     password=credentials[1],
                     mode=NuclioAuthKinds.iguazio,
                 ).to_requests_auth()
             else:
-                auth = NuclioAuthInfo().from_envvar().to_requests_auth()
+                auth = (
+                    mlrun.common.schemas.auth.NuclioAuthInfo()
+                    .from_envvar()
+                    .to_requests_auth()
+                )
             if not auth:
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     "API Gateway invocation requires authentication. Please set V3IO_ACCESS_KEY env var"
@@ -470,7 +474,7 @@ class APIGateway(ModelObj):
             self.spec.authentication.authentication_mode
             == schemas.APIGatewayAuthenticationMode.iguazio.value
         ):
-            auth = NuclioAuthInfo().from_envvar().to_requests_auth()
+            auth = mlrun.common.schemas.auth.NuclioAuthInfo.from_envvar().to_requests_auth()
         url = urljoin(self.invoke_url, path or "")
 
         # Determine the correct keyword argument for the body

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -31,6 +31,7 @@ from kubernetes import client
 from nuclio.deploy import find_dashboard_url, get_deploy_status
 from nuclio.triggers import V3IOStreamTrigger
 
+import mlrun.auth.nuclio
 import mlrun.common.constants
 import mlrun.db
 import mlrun.errors
@@ -1547,7 +1548,7 @@ def get_nuclio_deploy_status(
             verbose,
             resolve_address,
             return_function_status=True,
-            auth_info=auth_info.to_nuclio_auth_info() if auth_info else None,
+            auth_info=mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(auth_info),
         )
     except requests.exceptions.ConnectionError as exc:
         mlrun.errors.raise_for_status(

--- a/server/py/framework/utils/clients/nuclio.py
+++ b/server/py/framework/utils/clients/nuclio.py
@@ -21,6 +21,7 @@ import requests.adapters
 import requests.auth
 import sqlalchemy.orm
 
+import mlrun.auth.nuclio
 import mlrun.common.formatters
 import mlrun.common.schemas
 import mlrun.errors
@@ -253,7 +254,9 @@ class Client(
 
         auth = None
         if auth_info:
-            auth = auth_info.to_nuclio_auth_info().to_requests_auth()
+            auth = mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(
+                auth_info
+            ).to_requests_auth()
 
         response = self._session.request(
             method,

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -23,6 +23,7 @@ import nuclio.utils
 import requests
 
 import mlrun
+import mlrun.auth.nuclio
 import mlrun.auth.utils
 import mlrun.common.constants
 import mlrun.common.constants as mlrun_constants
@@ -91,7 +92,7 @@ def deploy_nuclio_function(
             create_new=mlrun.mlconf.httpdb.projects.leader == "mlrun",
             watch=False,
             return_address_mode=nuclio.deploy.ReturnAddressModes.all,
-            auth_info=auth_info.to_nuclio_auth_info() if auth_info else None,
+            auth_info=mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(auth_info),
         )
     except nuclio.utils.DeployError as exc:
         if exc.err:
@@ -161,7 +162,7 @@ def get_nuclio_deploy_status(
             verbose,
             resolve_address,
             return_function_status=True,
-            auth_info=auth_info.to_nuclio_auth_info() if auth_info else None,
+            auth_info=mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(auth_info),
         )
     except requests.exceptions.ConnectionError as exc:
         mlrun.errors.raise_for_status(

--- a/tests/runtimes/test_api_gateway.py
+++ b/tests/runtimes/test_api_gateway.py
@@ -130,9 +130,23 @@ def test_from_envvar_iguazio_v4_mode(monkeypatch):
         "mode",
         mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
     )
-    with patch("mlrun.auth.utils.load_offline_token", return_value="offline-v4-token"):
+    monkeypatch.setattr(mlrun.mlconf, "auth_token_endpoint", "")
+    monkeypatch.setattr(mlrun.mlconf, "iguazio_api_url", "https://iguazio.example")
+
+    with patch(
+        "mlrun.auth.providers.IGTokenProvider",
+    ) as mock_token_provider_cls:
+        mock_token_provider = MagicMock()
+        mock_token_provider.get_token.return_value = "access-v4-token"
+        mock_token_provider_cls.return_value = mock_token_provider
+
         auth_info = mlrun.common.schemas.auth.NuclioAuthInfo.from_envvar()
-        assert auth_info._token == "offline-v4-token"
+
+        mock_token_provider_cls.assert_called_once_with(
+            token_endpoint="https://iguazio.example/api/v1/authentication/refresh-access-token"
+        )
+        mock_token_provider.get_token.assert_called_once()
+        assert auth_info._token == "access-v4-token"
 
 
 def test_from_envvar_non_iguazio_v4_mode(monkeypatch):

--- a/tests/runtimes/test_api_gateway.py
+++ b/tests/runtimes/test_api_gateway.py
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+import mlrun
 import mlrun.common.schemas
+import mlrun.common.schemas.auth
+import mlrun.common.types
 import mlrun.runtimes.nuclio
 
 
@@ -65,3 +71,309 @@ def test_with_annotations():
 
     api_gateway.with_annotations(annotations)
     assert api_gateway.metadata.annotations == annotations
+
+
+@pytest.mark.parametrize(
+    "headers, expected_token, expected_username, expected_password",
+    [
+        # Bearer token auth
+        (
+            {"Authorization": "Bearer my-bearer-token"},
+            "my-bearer-token",
+            None,
+            None,
+        ),
+        # Basic auth
+        (
+            {"Authorization": f"Basic {base64.b64encode(b'user:pass').decode()}"},
+            None,
+            "user",
+            "pass",
+        ),
+        # Basic auth with colon in password
+        (
+            {
+                "Authorization": f"Basic {base64.b64encode(b'user:pass:with:colons').decode()}"
+            },
+            None,
+            "user",
+            "pass:with:colons",
+        ),
+        # Empty headers
+        ({}, None, None, None),
+        # None headers
+        (None, None, None, None),
+        # Headers without Authorization
+        ({"Content-Type": "application/json"}, None, None, None),
+    ],
+)
+def test_from_request_headers(
+    headers, expected_token, expected_username, expected_password
+):
+    """Test NuclioAuthInfo.from_request_headers with various header formats"""
+    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo.from_request_headers(headers)
+
+    if expected_token:
+        assert auth_info._token == expected_token
+    else:
+        assert auth_info._token is None
+
+    if expected_username:
+        assert auth_info._username == expected_username
+        assert auth_info._password == expected_password
+
+
+def test_from_envvar_iguazio_v4_mode(monkeypatch):
+    """Test NuclioAuthInfo.from_envvar in iguazio v4 mode"""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+    )
+    with patch("mlrun.auth.utils.load_offline_token", return_value="offline-v4-token"):
+        auth_info = mlrun.common.schemas.auth.NuclioAuthInfo.from_envvar()
+        assert auth_info._token == "offline-v4-token"
+
+
+def test_from_envvar_non_iguazio_v4_mode(monkeypatch):
+    """Test NuclioAuthInfo.from_envvar in non-iguazio v4 mode"""
+    monkeypatch.setenv("V3IO_ACCESS_KEY", "test-access-key")
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        "none",  # Any non-IGUAZIO_V4 value
+    )
+    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo.from_envvar()
+    # Should call parent's from_envvar which uses V3IO_ACCESS_KEY
+    assert auth_info._token is None
+    # Parent class stores access_key as password
+    assert auth_info._password == "test-access-key"
+
+
+def test_to_requests_auth_with_token():
+    """Test NuclioAuthInfo.to_requests_auth returns bearer auth when token is set"""
+    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo(token="my-bearer-token")
+    auth = auth_info.to_requests_auth()
+
+    # Verify it's a valid auth object
+    assert auth is not None
+
+    # Verify it adds Bearer token to request headers
+    mock_request = MagicMock()
+    mock_request.headers = {}
+    auth.__call__(mock_request)
+
+    assert "Authorization" in mock_request.headers
+    assert mock_request.headers["Authorization"] == "Bearer my-bearer-token"
+
+
+def test_to_requests_auth_without_token():
+    """Test NuclioAuthInfo.to_requests_auth falls back to parent when no token"""
+    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo(
+        username="user", password="pass"
+    )
+    auth = auth_info.to_requests_auth()
+
+    # Parent class should return basic auth
+    assert auth is not None
+
+
+def test_to_nuclio_auth_info_iguazio_v4_mode_with_bearer(monkeypatch):
+    """Test AuthInfo.to_nuclio_auth_info in iguazio v4 mode with bearer token"""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+    )
+    auth_info = mlrun.common.schemas.auth.AuthInfo(
+        request_headers={"Authorization": "Bearer my-v4-token"}
+    )
+    nuclio_auth = auth_info.to_nuclio_auth_info()
+
+    assert nuclio_auth is not None
+    assert nuclio_auth._token == "my-v4-token"
+
+
+def test_to_nuclio_auth_info_iguazio_v4_mode_with_basic(monkeypatch):
+    """Test AuthInfo.to_nuclio_auth_info in iguazio v4 mode with basic auth"""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+    )
+    encoded_creds = base64.b64encode(b"admin:password123").decode()
+    auth_info = mlrun.common.schemas.auth.AuthInfo(
+        request_headers={"Authorization": f"Basic {encoded_creds}"}
+    )
+    nuclio_auth = auth_info.to_nuclio_auth_info()
+
+    assert nuclio_auth is not None
+    assert nuclio_auth._username == "admin"
+    assert nuclio_auth._password == "password123"
+
+
+def test_to_nuclio_auth_info_non_v4_mode_with_session(monkeypatch):
+    """Test AuthInfo.to_nuclio_auth_info in non-v4 mode with session"""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        "none",  # Any non-IGUAZIO_V4 value
+    )
+    auth_info = mlrun.common.schemas.auth.AuthInfo(session="my-session-token")
+    nuclio_auth = auth_info.to_nuclio_auth_info()
+
+    assert nuclio_auth is not None
+    assert nuclio_auth._password == "my-session-token"
+
+
+def test_to_nuclio_auth_info_non_v4_mode_no_session(monkeypatch):
+    """Test AuthInfo.to_nuclio_auth_info returns None when no auth in non-v4 mode"""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        "none",  # Any non-IGUAZIO_V4 value
+    )
+    auth_info = mlrun.common.schemas.auth.AuthInfo(session="")
+    nuclio_auth = auth_info.to_nuclio_auth_info()
+
+    assert nuclio_auth is None
+
+
+def test_invoke_basic_auth_creates_nuclio_auth_info(monkeypatch):
+    """Test that invoke with basic auth uses NuclioAuthInfo correctly"""
+    api_gateway = _create_api_gateway("basic")
+
+    # Mock the requests.request
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("requests.request", return_value=mock_response) as mock_request:
+        api_gateway.invoke(
+            method="GET", credentials=("test-user", "test-pass"), path="/test"
+        )
+
+        # Verify request was made with auth
+        mock_request.assert_called_once()
+        call_kwargs = mock_request.call_args[1]
+        assert call_kwargs["auth"] is not None
+
+
+def test_invoke_access_key_auth_with_credentials(monkeypatch):
+    """Test invoke with access_key auth and explicit credentials"""
+    api_gateway = _create_api_gateway("access_key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("requests.request", return_value=mock_response) as mock_request:
+        api_gateway.invoke(
+            method="GET", credentials=("user", "access-key"), path="/test"
+        )
+
+        mock_request.assert_called_once()
+        call_kwargs = mock_request.call_args[1]
+        assert call_kwargs["auth"] is not None
+
+
+def test_invoke_access_key_auth_from_envvar(monkeypatch):
+    """Test invoke with access_key auth using environment variable"""
+    api_gateway = _create_api_gateway("access_key")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    # Mock from_envvar to return auth with token
+    with patch.object(
+        mlrun.common.schemas.auth.NuclioAuthInfo,
+        "from_envvar",
+        return_value=mlrun.common.schemas.auth.NuclioAuthInfo(token="env-access-token"),
+    ):
+        with patch("requests.request", return_value=mock_response) as mock_request:
+            api_gateway.invoke(method="GET", path="/test")
+
+            mock_request.assert_called_once()
+            call_kwargs = mock_request.call_args[1]
+            assert call_kwargs["auth"] is not None
+
+
+def test_invoke_access_key_auth_no_credentials_raises(monkeypatch):
+    """Test invoke with access_key auth raises when no credentials available"""
+    api_gateway = _create_api_gateway("access_key")
+
+    # Mock from_envvar to return None (no auth available)
+    with patch.object(
+        mlrun.common.schemas.auth.NuclioAuthInfo,
+        "from_envvar",
+        return_value=mlrun.common.schemas.auth.NuclioAuthInfo(),
+    ):
+        with patch.object(
+            mlrun.common.schemas.auth.NuclioAuthInfo,
+            "to_requests_auth",
+            return_value=None,
+        ):
+            with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+                api_gateway.invoke(method="GET", path="/test")
+
+            assert "V3IO_ACCESS_KEY" in str(exc_info.value)
+
+
+def test_invoke_iguazio_auth_uses_from_envvar(monkeypatch):
+    """Test invoke with iguazio auth uses from_envvar directly"""
+    api_gateway = _create_api_gateway("iguazio")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    mock_auth_result = MagicMock()
+    with patch.object(
+        mlrun.common.schemas.auth.NuclioAuthInfo, "from_envvar"
+    ) as mock_from_envvar:
+        mock_nuclio_auth = MagicMock()
+        mock_nuclio_auth.to_requests_auth.return_value = mock_auth_result
+        mock_from_envvar.return_value = mock_nuclio_auth
+
+        with patch("requests.request", return_value=mock_response) as mock_request:
+            api_gateway.invoke(method="GET", path="/test")
+
+            # Verify from_envvar was called as a classmethod (no instance)
+            mock_from_envvar.assert_called_once()
+            mock_request.assert_called_once()
+            call_kwargs = mock_request.call_args[1]
+            assert call_kwargs["auth"] == mock_auth_result
+
+
+def test_invoke_basic_auth_requires_credentials():
+    """Test that basic auth invoke requires credentials"""
+    api_gateway = _create_api_gateway("basic")
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+        api_gateway.invoke(method="GET", path="/test")
+
+    assert "authentication" in str(exc_info.value).lower()
+    assert "credentials" in str(exc_info.value).lower()
+
+
+def _create_api_gateway(authentication_mode="none"):
+    """Helper to create an API gateway with specified auth mode"""
+    auth_map = {
+        "none": mlrun.runtimes.nuclio.api_gateway.NoneAuth(),
+        "basic": mlrun.runtimes.nuclio.api_gateway.BasicAuth(
+            username="user", password="pass"
+        ),
+        "access_key": mlrun.runtimes.nuclio.api_gateway.AccessKeyAuth(),
+        "iguazio": mlrun.runtimes.nuclio.api_gateway.IguazioAuth(),
+    }
+
+    return mlrun.runtimes.nuclio.api_gateway.APIGateway(
+        metadata=mlrun.runtimes.nuclio.api_gateway.APIGatewayMetadata(name="test"),
+        spec=mlrun.runtimes.nuclio.api_gateway.APIGatewaySpec(
+            project="test",
+            host="https://example.com",
+            path="/api",
+            functions=["test-func"],
+            authentication=auth_map[authentication_mode],
+        ),
+        status=mlrun.runtimes.nuclio.api_gateway.APIGatewayStatus(
+            state=mlrun.common.schemas.APIGatewayState.ready
+        ),
+    )

--- a/tests/runtimes/test_api_gateway.py
+++ b/tests/runtimes/test_api_gateway.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import mlrun
+import mlrun.auth.nuclio
 import mlrun.common.schemas
 import mlrun.common.schemas.auth
 import mlrun.common.types
@@ -111,7 +112,7 @@ def test_from_request_headers(
     headers, expected_token, expected_username, expected_password
 ):
     """Test NuclioAuthInfo.from_request_headers with various header formats"""
-    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo.from_request_headers(headers)
+    auth_info = mlrun.auth.nuclio.NuclioAuthInfo.from_request_headers(headers)
 
     if expected_token:
         assert auth_info._token == expected_token
@@ -140,7 +141,7 @@ def test_from_envvar_iguazio_v4_mode(monkeypatch):
         mock_token_provider.get_token.return_value = "access-v4-token"
         mock_token_provider_cls.return_value = mock_token_provider
 
-        auth_info = mlrun.common.schemas.auth.NuclioAuthInfo.from_envvar()
+        auth_info = mlrun.auth.nuclio.NuclioAuthInfo.from_envvar()
 
         mock_token_provider_cls.assert_called_once_with(
             token_endpoint="https://iguazio.example/api/v1/authentication/refresh-access-token"
@@ -157,7 +158,7 @@ def test_from_envvar_non_iguazio_v4_mode(monkeypatch):
         "mode",
         "none",  # Any non-IGUAZIO_V4 value
     )
-    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo.from_envvar()
+    auth_info = mlrun.auth.nuclio.NuclioAuthInfo.from_envvar()
     # Should call parent's from_envvar which uses V3IO_ACCESS_KEY
     assert auth_info._token is None
     # Parent class stores access_key as password
@@ -166,7 +167,7 @@ def test_from_envvar_non_iguazio_v4_mode(monkeypatch):
 
 def test_to_requests_auth_with_token():
     """Test NuclioAuthInfo.to_requests_auth returns bearer auth when token is set"""
-    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo(token="my-bearer-token")
+    auth_info = mlrun.auth.nuclio.NuclioAuthInfo(token="my-bearer-token")
     auth = auth_info.to_requests_auth()
 
     # Verify it's a valid auth object
@@ -183,9 +184,7 @@ def test_to_requests_auth_with_token():
 
 def test_to_requests_auth_without_token():
     """Test NuclioAuthInfo.to_requests_auth falls back to parent when no token"""
-    auth_info = mlrun.common.schemas.auth.NuclioAuthInfo(
-        username="user", password="pass"
-    )
+    auth_info = mlrun.auth.nuclio.NuclioAuthInfo(username="user", password="pass")
     auth = auth_info.to_requests_auth()
 
     # Parent class should return basic auth
@@ -202,7 +201,7 @@ def test_to_nuclio_auth_info_iguazio_v4_mode_with_bearer(monkeypatch):
     auth_info = mlrun.common.schemas.auth.AuthInfo(
         request_headers={"Authorization": "Bearer my-v4-token"}
     )
-    nuclio_auth = auth_info.to_nuclio_auth_info()
+    nuclio_auth = mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(auth_info)
 
     assert nuclio_auth is not None
     assert nuclio_auth._token == "my-v4-token"
@@ -219,7 +218,7 @@ def test_to_nuclio_auth_info_iguazio_v4_mode_with_basic(monkeypatch):
     auth_info = mlrun.common.schemas.auth.AuthInfo(
         request_headers={"Authorization": f"Basic {encoded_creds}"}
     )
-    nuclio_auth = auth_info.to_nuclio_auth_info()
+    nuclio_auth = mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(auth_info)
 
     assert nuclio_auth is not None
     assert nuclio_auth._username == "admin"
@@ -234,7 +233,7 @@ def test_to_nuclio_auth_info_non_v4_mode_with_session(monkeypatch):
         "none",  # Any non-IGUAZIO_V4 value
     )
     auth_info = mlrun.common.schemas.auth.AuthInfo(session="my-session-token")
-    nuclio_auth = auth_info.to_nuclio_auth_info()
+    nuclio_auth = mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(auth_info)
 
     assert nuclio_auth is not None
     assert nuclio_auth._password == "my-session-token"
@@ -248,7 +247,7 @@ def test_to_nuclio_auth_info_non_v4_mode_no_session(monkeypatch):
         "none",  # Any non-IGUAZIO_V4 value
     )
     auth_info = mlrun.common.schemas.auth.AuthInfo(session="")
-    nuclio_auth = auth_info.to_nuclio_auth_info()
+    nuclio_auth = mlrun.auth.nuclio.NuclioAuthInfo.from_auth_info(auth_info)
 
     assert nuclio_auth is None
 
@@ -298,9 +297,9 @@ def test_invoke_access_key_auth_from_envvar(monkeypatch):
 
     # Mock from_envvar to return auth with token
     with patch.object(
-        mlrun.common.schemas.auth.NuclioAuthInfo,
+        mlrun.auth.nuclio.NuclioAuthInfo,
         "from_envvar",
-        return_value=mlrun.common.schemas.auth.NuclioAuthInfo(token="env-access-token"),
+        return_value=mlrun.auth.nuclio.NuclioAuthInfo(token="env-access-token"),
     ):
         with patch("requests.request", return_value=mock_response) as mock_request:
             api_gateway.invoke(method="GET", path="/test")
@@ -316,12 +315,12 @@ def test_invoke_access_key_auth_no_credentials_raises(monkeypatch):
 
     # Mock from_envvar to return None (no auth available)
     with patch.object(
-        mlrun.common.schemas.auth.NuclioAuthInfo,
+        mlrun.auth.nuclio.NuclioAuthInfo,
         "from_envvar",
-        return_value=mlrun.common.schemas.auth.NuclioAuthInfo(),
+        return_value=mlrun.auth.nuclio.NuclioAuthInfo(),
     ):
         with patch.object(
-            mlrun.common.schemas.auth.NuclioAuthInfo,
+            mlrun.auth.nuclio.NuclioAuthInfo,
             "to_requests_auth",
             return_value=None,
         ):
@@ -340,7 +339,7 @@ def test_invoke_iguazio_auth_uses_from_envvar(monkeypatch):
 
     mock_auth_result = MagicMock()
     with patch.object(
-        mlrun.common.schemas.auth.NuclioAuthInfo, "from_envvar"
+        mlrun.auth.nuclio.NuclioAuthInfo, "from_envvar"
     ) as mock_from_envvar:
         mock_nuclio_auth = MagicMock()
         mock_nuclio_auth.to_requests_auth.return_value = mock_auth_result

--- a/tests/runtimes/test_api_gateway.py
+++ b/tests/runtimes/test_api_gateway.py
@@ -131,8 +131,11 @@ def test_from_envvar_iguazio_v4_mode(monkeypatch):
         "mode",
         mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
     )
-    monkeypatch.setattr(mlrun.mlconf, "auth_token_endpoint", "")
-    monkeypatch.setattr(mlrun.mlconf, "iguazio_api_url", "https://iguazio.example")
+    monkeypatch.setattr(
+        mlrun.mlconf,
+        "auth_token_endpoint",
+        "https://iguazio.example/api/v1/authentication/refresh-access-token",
+    )
 
     with patch(
         "mlrun.auth.providers.IGTokenProvider",


### PR DESCRIPTION
### 📝 Description

Add Iguazio V4 authentication support for API Gateway by introducing a new `NuclioAuthInfo` class that handles bearer token authentication.

---

### 🛠️ Changes Made
- Added new `mlrun/auth/nuclio.py` module with `NuclioAuthInfo` class supporting:
  - Bearer token authentication for Iguazio V4 mode
  - Basic auth and session-based auth for non-V4 modes
  - `from_auth_info()`, `from_request_headers()`, and `from_envvar()` factory methods
- Removed deprecated `to_nuclio_auth_info()` method and helper classes from `mlrun/common/schemas/auth.py`
- Updated API Gateway, Nuclio function deployments, and server-side clients to use the new `NuclioAuthInfo` class
- Added `@min_nuclio_versions("1.15.10")` requirement for `with_iguazio_auth()` method

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Tests over igz3 for regression ✔️ 
- Tests over igz4 for progression ✔️ 

---

### 🔗 References
- Ticket link:  https://iguazio.atlassian.net/browse/ML-11562
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Refactors Nuclio authentication to properly support Iguazio V4's bearer token-based authentication while maintaining backward compatibility with V3 session-based auth.
