### PR TITLE
[SDK] Get IG4 Auth info from api

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -330,7 +330,8 @@ def enrich_auth_env(
     if mlrun.mlconf.is_iguazio_v4_mode():
         env["MLRUN_AUTH_WITH_OAUTH_TOKEN__ENABLED"] = "true"
         env["MLRUN_AUTH_TOKEN_ENDPOINT"] = os.path.join(
-            mlrun.mlconf.iguazio_api_url, "api/v1/authentication/refresh-access-token"
+            mlrun.mlconf.iguazio_api_url,
+            mlrun.mlconf.httpdb.authentication.iguazio.authentication_endpoint,
         )
         env["MLRUN_HTTPDB__HTTP__VERIFY"] = str(
             mlrun.mlconf.iguazio_api_ssl_verify

--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -68,3 +68,6 @@ class ClientSpec(pydantic.v1.BaseModel):
     system_id: typing.Optional[str]
     model_endpoint_monitoring_store_prefixes: typing.Optional[dict[str, str]]
     authentication_mode: typing.Optional[str]
+    # Iguazio V4 OAuth token provider configuration
+    oauth_internal_token_endpoint: typing.Optional[str]
+    oauth_external_token_endpoint: typing.Optional[str]

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -85,7 +85,8 @@ default_config = {
     "kfp_image": "mlrun/mlrun-kfp",  # image to use for KFP runner
     "dask_kfp_image": "mlrun/mlrun",  # image to use for dask KFP runner
     "igz_version": "",  # the version of the iguazio system the API is running on
-    "iguazio_api_url": "",  # the url to iguazio api
+    "iguazio_api_url": "",  # the url to iguazio api (internal / external access with priority to internal)
+    "iguazio_api_url_ingress": "",  # the url to iguazio api ingress (for external access)
     "iguazio_api_ssl_verify": True,  # verify ssl certificate of iguazio api
     "spark_app_image": "",  # image to use for spark operator app runtime
     "spark_app_image_tag": "",  # image tag to use for spark operator app runtime
@@ -428,6 +429,7 @@ default_config = {
             "bearer": {"token": ""},
             "iguazio": {
                 "session_verification_endpoint": "data_sessions/verifications/app_service",
+                "authentication_endpoint": "api/v1/authentication/refresh-access-token",
             },
         },
         "nuclio": {
@@ -888,6 +890,7 @@ default_config = {
         # for a token named "default", if "default" does not exist, it will use the first token in the file
         "token_name": "",
     },
+    # a runtime computed value. Do not set it manually.
     "auth_token_endpoint": "",
     "services": {
         # The running service name. One of: "api", "alerts"

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -183,16 +183,13 @@ class HTTPRunDB(RunDBInterface):
         else:
             _, _, token = mlrun.platforms.add_or_refresh_credentials(
                 self._parsed_url.hostname,
-                self._parsed_url.username,
-                self._parsed_url.password,
+                self.user,
+                self.password,
                 config.httpdb.token,
             )
 
             if token:
                 self.token_provider = mlrun.auth.StaticTokenProvider(token)
-
-        self.user = username
-        self.password = password
 
     def __repr__(self):
         cls = self.__class__.__name__

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -643,7 +643,7 @@ class HTTPRunDB(RunDBInterface):
             # Iguazio V4 OAuth token config auto-initialization
             if (
                 not config.auth_token_endpoint
-                and config.httpdb.authentication.mode
+                and server_cfg.get("authentication_mode")
                 == mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value
             ):
                 # if running inside kubernetes, use the internal endpoint, otherwise use the external endpoint
@@ -655,6 +655,8 @@ class HTTPRunDB(RunDBInterface):
                     config.auth_token_endpoint = server_cfg.get(
                         "oauth_external_token_endpoint"
                     )
+
+                config.auth_with_oauth_token.enabled = True
 
         except Exception as exc:
             logger.warning(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -643,7 +643,7 @@ class HTTPRunDB(RunDBInterface):
             # Iguazio V4 OAuth token config auto-initialization
             if (
                 not config.auth_token_endpoint
-                and server_cfg.get("authentication_mode")
+                and config.httpdb.authentication.mode
                 == mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value
             ):
                 # if running inside kubernetes, use the internal endpoint, otherwise use the external endpoint

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -39,6 +39,7 @@ import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
 import mlrun.common.types
+import mlrun.k8s_utils
 import mlrun.platforms
 import mlrun.projects
 import mlrun.runtimes.nuclio.api_gateway
@@ -141,24 +142,30 @@ class HTTPRunDB(RunDBInterface):
             version.Version().get_python_version()
         )
 
+        self.user = None
+        self.password = None
+        self.token_provider = None
+        self.base_url = None
+        self._parsed_url = None
+
         self._enrich_and_validate(url)
 
     def _enrich_and_validate(self, url):
-        parsed_url = urlparse(url)
-        scheme = parsed_url.scheme.lower()
-        if scheme not in ("http", "https"):
-            raise ValueError(
-                f"Invalid URL scheme {scheme} for HTTPRunDB, only http(s) is supported"
-            )
-
-        endpoint = parsed_url.hostname
-        if parsed_url.port:
-            endpoint += f":{parsed_url.port}"
-        base_url = f"{parsed_url.scheme}://{endpoint}{parsed_url.path}"
+        base_url, parsed_url = self._resolve_api_urls(url)
 
         self.base_url = base_url
-        username = parsed_url.username or config.httpdb.user
-        password = parsed_url.password or config.httpdb.password
+        self._parsed_url = parsed_url
+        self.user = parsed_url.username or config.httpdb.user
+        self.password = parsed_url.password or config.httpdb.password
+        self._init_token_provider()
+
+    def _init_token_provider(self):
+        """
+        Initialize token provider according to current config.
+
+        Must be called after `connect()` synced config from server (client-spec), since
+        some auth flows (e.g. Iguazio V4 OAuth token) require values fetched from the API.
+        """
         self.token_provider = None
 
         if config.auth_with_client_id.enabled:
@@ -171,10 +178,14 @@ class HTTPRunDB(RunDBInterface):
         elif config.auth_with_oauth_token.enabled:
             self.token_provider = mlrun.auth.IGTokenProvider(
                 token_endpoint=config.auth_token_endpoint,
+                timeout=config.auth_with_oauth_token.request_timeout,
             )
         else:
-            username, password, token = mlrun.platforms.add_or_refresh_credentials(
-                parsed_url.hostname, username, password, config.httpdb.token
+            _, _, token = mlrun.platforms.add_or_refresh_credentials(
+                self._parsed_url.hostname,
+                self._parsed_url.username,
+                self._parsed_url.password,
+                config.httpdb.token,
             )
 
             if token:
@@ -463,7 +474,7 @@ class HTTPRunDB(RunDBInterface):
 
         return True
 
-    def connect(self, secrets=None):
+    def connect(self, secrets=None) -> typing.Self:
         """Connect to the MLRun API server. Must be called prior to executing any other method.
         The code utilizes the URL for the API server from the configuration - ``config.dbpath``.
 
@@ -474,7 +485,8 @@ class HTTPRunDB(RunDBInterface):
         """
         # hack to allow unit tests to instantiate HTTPRunDB without a real server behind
         if "mock-server" in self.base_url:
-            return
+            return self
+
         resp = self.api_call("GET", "client-spec", timeout=5)
         try:
             server_cfg = resp.json()
@@ -631,12 +643,31 @@ class HTTPRunDB(RunDBInterface):
                 or config.httpdb.authentication.mode
             )
 
+            # Iguazio V4 OAuth token config auto-initialization
+            if (
+                not config.auth_token_endpoint
+                and config.httpdb.authentication.mode
+                == mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value
+            ):
+                # if running inside kubernetes, use the internal endpoint, otherwise use the external endpoint
+                if mlrun.k8s_utils.is_running_inside_kubernetes_cluster():
+                    config.auth_token_endpoint = server_cfg.get(
+                        "oauth_internal_token_endpoint"
+                    )
+                else:
+                    config.auth_token_endpoint = server_cfg.get(
+                        "oauth_external_token_endpoint"
+                    )
+
         except Exception as exc:
             logger.warning(
                 "Failed syncing config from server",
                 exc=err_to_str(exc),
                 traceback=traceback.format_exc(),
             )
+
+        # Initialize token provider after syncing config from server
+        self._init_token_provider()
 
         if config.is_iguazio_v4_mode() and config.auth_with_oauth_token.enabled:
             mlrun.secrets.sync_secret_tokens()
@@ -5741,6 +5772,24 @@ class HTTPRunDB(RunDBInterface):
             )
             page_params.pop("limit")
         return page_params
+
+    def _resolve_api_urls(self, url: str) -> tuple[str, str]:
+        """
+        Resolves the base url and parsed url from the given url.
+        """
+        parsed_url = urlparse(url)
+        scheme = parsed_url.scheme.lower()
+        if scheme not in ("http", "https"):
+            raise ValueError(
+                f"Invalid URL scheme {scheme} for HTTPRunDB, only http(s) is supported"
+            )
+
+        endpoint = parsed_url.hostname
+        if parsed_url.port:
+            endpoint += f":{parsed_url.port}"
+        base_url = f"{parsed_url.scheme}://{endpoint}{parsed_url.path}"
+
+        return base_url, parsed_url
 
 
 def _as_json(obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ generate-hashes = true
 universal = true
 
 [tool.pytest.ini_options]
-addopts = "-v -rf --disable-warnings"
+addopts = "-v -rf --disable-warnings --import-mode=importlib"
 pythonpath = "./server/py" # This allows running server side tests from the project root directory
 python_files = [
     "tests/*/test_*.py",

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -34,6 +34,18 @@ class ClientSpec(
             framework.utils.runtimes.mpijob.resolve_mpijob_crd_version()
         )
 
+        oauth_internal_token_endpoint = None
+        oauth_external_token_endpoint = None
+        if config.is_iguazio_v4_mode():
+            oauth_external_token_endpoint = self._join_url(
+                config.iguazio_api_url_ingress,
+                config.httpdb.authentication.iguazio.authentication_endpoint,
+            )
+            oauth_internal_token_endpoint = self._join_url(
+                config.iguazio_api_url,
+                config.httpdb.authentication.iguazio.authentication_endpoint,
+            )
+
         return mlrun.common.schemas.ClientSpec(
             version=config.version,
             namespace=config.namespace,
@@ -124,6 +136,8 @@ class ClientSpec(
             authentication_mode=self._get_config_value_if_not_default(
                 "httpdb.authentication.mode"
             ),
+            oauth_internal_token_endpoint=oauth_internal_token_endpoint,
+            oauth_external_token_endpoint=oauth_external_token_endpoint,
         )
 
     @staticmethod

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Optional
 
 import mlrun.common.schemas
@@ -37,11 +38,11 @@ class ClientSpec(
         oauth_internal_token_endpoint = None
         oauth_external_token_endpoint = None
         if config.is_iguazio_v4_mode():
-            oauth_external_token_endpoint = self._join_url(
+            oauth_external_token_endpoint = os.path.join(
                 config.iguazio_api_url_ingress,
                 config.httpdb.authentication.iguazio.authentication_endpoint,
             )
-            oauth_internal_token_endpoint = self._join_url(
+            oauth_internal_token_endpoint = os.path.join(
                 config.iguazio_api_url,
                 config.httpdb.authentication.iguazio.authentication_endpoint,
             )

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -274,36 +274,36 @@ def test_get_client_spec_cached(
 def test_client_spec_includes_oauth_config_in_iguazio_v4_mode(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
-    mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.IGUAZIO_V4
-    mlrun.mlconf.iguazio_api_url = "https://dashboard.default-tenant.app.example.com"
+    mlrun.mlconf.httpdb.authentication.mode = (
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4
+    )
+    mlrun.mlconf.iguazio_api_url = "http://x.local"
+    mlrun.mlconf.iguazio_api_url_ingress = "https://x.com"
     services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
 
     response = client.get("client-spec")
     assert response.status_code == http.HTTPStatus.OK.value
     response_body = response.json()
 
-    assert response_body["oauth_enabled"] is True
     assert (
         response_body["oauth_external_token_endpoint"]
-        == "https://dashboard.default-tenant.app.example.com/api/v1/authentication/refresh-access-token"
+        == "https://x.com/api/v1/authentication/refresh-access-token"
     )
     assert (
         response_body["oauth_internal_token_endpoint"]
-        == "https://dashboard.default-tenant.svc.cluster.local/api/v1/authentication/refresh-access-token"
+        == "http://x.local/api/v1/authentication/refresh-access-token"
     )
 
 
 def test_client_spec_does_not_include_oauth_config_when_not_iguazio_v4_mode(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
-    mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.NONE
-    mlrun.mlconf.iguazio_api_url = "https://dashboard.default-tenant.app.example.com"
+    mlrun.mlconf.httpdb.authentication.mode = mlrun.common.types.AuthenticationMode.NONE
     services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
 
     response = client.get("client-spec")
     assert response.status_code == http.HTTPStatus.OK.value
     response_body = response.json()
 
-    assert response_body.get("oauth_enabled") in (None, False)
     assert response_body.get("oauth_external_token_endpoint") is None
     assert response_body.get("oauth_internal_token_endpoint") is None

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -269,3 +269,41 @@ def test_get_client_spec_cached(
             cached_response = client.get("client-spec")
             assert cached_response.status_code == http.HTTPStatus.OK.value
             assert mocked_get_client.call_count == 3
+
+
+def test_client_spec_includes_oauth_config_in_iguazio_v4_mode(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.IGUAZIO_V4
+    mlrun.mlconf.iguazio_api_url = "https://dashboard.default-tenant.app.example.com"
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    response_body = response.json()
+
+    assert response_body["oauth_enabled"] is True
+    assert (
+        response_body["oauth_external_token_endpoint"]
+        == "https://dashboard.default-tenant.app.example.com/api/v1/authentication/refresh-access-token"
+    )
+    assert (
+        response_body["oauth_internal_token_endpoint"]
+        == "https://dashboard.default-tenant.svc.cluster.local/api/v1/authentication/refresh-access-token"
+    )
+
+
+def test_client_spec_does_not_include_oauth_config_when_not_iguazio_v4_mode(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.NONE
+    mlrun.mlconf.iguazio_api_url = "https://dashboard.default-tenant.app.example.com"
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    response_body = response.json()
+
+    assert response_body.get("oauth_enabled") in (None, False)
+    assert response_body.get("oauth_external_token_endpoint") is None
+    assert response_body.get("oauth_internal_token_endpoint") is None

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -27,7 +27,6 @@ from socket import socket
 from subprocess import DEVNULL, PIPE, Popen, run
 from sys import executable
 from tempfile import mkdtemp
-from typing import Optional
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -485,6 +484,11 @@ def test_iguazio_v4_oauth_config_is_applied_before_token_provider_init(
         "oauth_external_token_endpoint": external_token_endpoint,
         "oauth_internal_token_endpoint": internal_token_endpoint,
     }
+
+    # Ensure deterministic endpoint selection (external) regardless of env/CI kubernetes detection
+    monkeypatch.setattr(
+        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: False
+    )
 
     with patch.object(mlrun.auth.utils, "load_offline_token", return_value="offline"):
         with patch.object(HTTPRunDB, "api_call") as api_call:
@@ -1418,7 +1422,7 @@ def _retrieve_all_items_with_pagination(
     return items
 
 
-def _generate_project_and_artifact(project: str = "newproj", tag: Optional[str] = None):
+def _generate_project_and_artifact(project: str = "newproj", tag: str | None = None):
     proj_obj = mlrun.new_project(project)
 
     logged_artifact = proj_obj.log_artifact(

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import codecs
 import datetime
+import json
 import sys
 import time
 import typing

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -26,6 +26,7 @@ from subprocess import DEVNULL, PIPE, Popen, run
 from sys import executable
 from tempfile import mkdtemp
 from typing import Optional
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import deepdiff
@@ -42,7 +43,7 @@ import mlrun.common.types
 import mlrun.errors
 import mlrun.projects.project
 from mlrun import RunObject
-from mlrun.auth.providers import StaticTokenProvider
+from mlrun.auth.providers import IGTokenProvider, StaticTokenProvider
 from mlrun.db.httpdb import HTTPRunDB
 from tests.conftest import tests_root_directory, wait_for_server
 
@@ -448,6 +449,97 @@ def test_client_id_auth(requests_mock: requests_mock_package.Mocker, monkeypatch
 
     with pytest.raises(mlrun.errors.MLRunRuntimeError):
         db.trigger_migrations()
+
+
+def _encode_jwt(payload: dict) -> str:
+    def _b64(obj: dict) -> str:
+        raw = json.dumps(obj, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("utf-8")
+
+    header = {"alg": "none", "typ": "JWT"}
+    return f"{_b64(header)}.{_b64(payload)}."
+
+
+def test_iguazio_v4_oauth_config_is_applied_before_token_provider_init(
+    requests_mock: requests_mock_package.Mocker, monkeypatch
+):
+    mlrun.mlconf.auth_with_client_id.enabled = False
+    mlrun.mlconf.auth_with_oauth_token.enabled = False
+    mlrun.mlconf.auth_token_endpoint = ""
+    external_token_endpoint = "https://dashboard.default-tenant.app.example.com/api/v1/authentication/refresh-access-token"
+    internal_token_endpoint = "https://dashboard.default-tenant.svc.cluster.local/api/v1/authentication/refresh-access-token"
+
+    iat = int(time.time())
+    exp = iat + 3600
+    jwt_token = _encode_jwt({"iat": iat, "exp": exp})
+    requests_mock.post(
+        external_token_endpoint, json={"spec": {"accessToken": jwt_token}}
+    )
+
+    server_cfg = {
+        "version": mlrun.mlconf.version,
+        "authentication_mode": mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value,
+        "oauth_enabled": True,
+        "oauth_external_token_endpoint": external_token_endpoint,
+        "oauth_internal_token_endpoint": internal_token_endpoint,
+    }
+
+    with patch.object(mlrun.auth.utils, "load_offline_token", return_value="offline"):
+        with patch.object(HTTPRunDB, "api_call") as api_call:
+            api_response = MagicMock()
+            api_response.json.return_value = server_cfg
+            api_call.return_value = api_response
+
+            db = HTTPRunDB("http://some-server:1919")
+            assert db.token_provider is None
+
+            db.connect()
+            assert mlrun.mlconf.auth_with_oauth_token.enabled is True
+            assert mlrun.mlconf.auth_token_endpoint == external_token_endpoint
+            assert isinstance(db.token_provider, IGTokenProvider)
+            assert db.token_provider.get_token() == jwt_token
+
+
+def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
+    requests_mock: requests_mock_package.Mocker, monkeypatch
+):
+    mlrun.mlconf.auth_with_client_id.enabled = False
+    mlrun.mlconf.auth_with_oauth_token.enabled = False
+    mlrun.mlconf.auth_token_endpoint = ""
+
+    external_token_endpoint = "https://dashboard.default-tenant.app.example.com/api/v1/authentication/refresh-access-token"
+    internal_token_endpoint = "https://dashboard.default-tenant.svc.cluster.local/api/v1/authentication/refresh-access-token"
+
+    iat = int(time.time())
+    exp = iat + 3600
+    jwt_token = _encode_jwt({"iat": iat, "exp": exp})
+    requests_mock.post(
+        internal_token_endpoint, json={"spec": {"accessToken": jwt_token}}
+    )
+
+    server_cfg = {
+        "version": mlrun.mlconf.version,
+        "authentication_mode": mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value,
+        "oauth_enabled": True,
+        "oauth_external_token_endpoint": external_token_endpoint,
+        "oauth_internal_token_endpoint": internal_token_endpoint,
+    }
+
+    monkeypatch.setattr(
+        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: True
+    )
+
+    with patch.object(mlrun.auth.utils, "load_offline_token", return_value="offline"):
+        with patch.object(HTTPRunDB, "api_call") as api_call:
+            api_response = MagicMock()
+            api_response.json.return_value = server_cfg
+            api_call.return_value = api_response
+
+            db = HTTPRunDB("http://some-server:1919")
+            db.connect()
+            assert mlrun.mlconf.auth_token_endpoint == internal_token_endpoint
+            assert isinstance(db.token_provider, IGTokenProvider)
+            assert db.token_provider.get_token() == jwt_token
 
 
 def _generate_runtime(name) -> mlrun.runtimes.KubejobRuntime:

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -199,6 +199,16 @@ def create_server(request):
         cleanup()
 
 
+@pytest.fixture
+def token_file(tmp_path):
+    token_file = tmp_path / "token.yaml"
+    token_file.write_text(
+        json.dumps({"secretTokens": [{"name": "default", "token": "jwt_token"}]})
+    )
+    mlrun.mlconf.auth_with_oauth_token.token_file = token_file
+    return token_file
+
+
 def test_log(create_server):
     server: Server = create_server()
     db = server.conn
@@ -462,7 +472,7 @@ def _encode_jwt(payload: dict) -> str:
 
 
 def test_iguazio_v4_oauth_config_is_applied_before_token_provider_init(
-    requests_mock: requests_mock_package.Mocker, monkeypatch
+    requests_mock: requests_mock_package.Mocker, monkeypatch, token_file
 ):
     mlrun.mlconf.auth_with_client_id.enabled = False
     mlrun.mlconf.auth_with_oauth_token.enabled = False
@@ -507,7 +517,7 @@ def test_iguazio_v4_oauth_config_is_applied_before_token_provider_init(
 
 
 def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
-    requests_mock: requests_mock_package.Mocker, monkeypatch
+    requests_mock: requests_mock_package.Mocker, monkeypatch, token_file
 ):
     mlrun.mlconf.auth_with_client_id.enabled = False
     mlrun.mlconf.auth_with_oauth_token.enabled = False


### PR DESCRIPTION
### 📝 Description

Initialize Iguazio v4 OAuth token configuration automatically from `/client-spec`, so users no longer need to manually set OAuth env vars before importing MLRun.

---

### 🛠️ Changes Made

- Extended `/client-spec` response with IG4 OAuth token config (internal svc + external ingress endpoints).
- Updated SDK `HTTPRunDB.connect()` to apply OAuth config **before** token provider initialization (IG token flow).
- Fixed pytest configuration to use importlib (best practice and avoids test issues on cursor/vscode)

---

### ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Unit tests:
  - `server/py/services/api/tests/unit/api/test_client_spec.py`
  - `tests/rundb/test_httpdb.py` (IG4 OAuth auto-config)

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11449
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

N/A