### PR TITLE
[Projects] Fix leader project creation flow

### DIFF
--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -20,8 +20,10 @@ import fastapi
 
 import mlrun
 import mlrun.common.schemas as schemas
+import mlrun.utils.helpers
 import mlrun.utils.singleton
 from mlrun.common.types import AuthenticationMode
+from mlrun.utils import logger
 
 import framework.utils.auth.providers.nop
 import framework.utils.auth.providers.opa
@@ -299,6 +301,30 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
                 project_name, ""
             ),
             resource_namespace,
+        )
+
+    async def ensure_project_permissions(
+        self,
+        project_name: str,
+        auth_info: mlrun.common.schemas.AuthInfo,
+    ):
+        """
+        Ensures project permissions are populated in the AuthVerifier
+        """
+
+        async def _check_project_read_permissions():
+            await self.query_project_permissions(
+                project_name,
+                mlrun.common.schemas.AuthorizationAction.read,
+                auth_info,
+            )
+
+        await mlrun.utils.helpers.retry_until_successful_async(
+            backoff=1,
+            timeout=10,
+            logger=logger,
+            verbose=False,
+            _function=_check_project_read_permissions,
         )
 
     def _generate_resource_string_from_project_resource(

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -187,10 +187,22 @@ class Client(BaseClient, project_follower.Member):
 
         def _update_owner_or_create_policies():
             self._client.set_override_auth_headers(auth_info.request_headers)
-            if self._project_policies_exist(project.metadata.name, auth_info):
-                self.patch_project(session, name, project.dict(), auth_info=auth_info)
-            else:
+            try:
+                # Try to create policies first
                 self.create_project(session, project, auth_info=auth_info)
+            except httpx.HTTPStatusError as exc:
+                # If policies already exist (409 Conflict), update instead
+                if exc.response.status_code == httpx.codes.CONFLICT:
+                    self._logger.debug(
+                        "Project policies already exist, updating owner instead",
+                        project=project.metadata.name,
+                    )
+                    self.patch_project(
+                        session, name, project.dict(), auth_info=auth_info
+                    )
+                else:
+                    # Unexpected error, re-raise
+                    raise
 
         self._try_callback_with_httpx_exceptions(
             _update_owner_or_create_policies,

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -189,9 +189,14 @@ class Client(BaseClient, project_follower.Member):
             self._client.set_override_auth_headers(auth_info.request_headers)
             try:
                 # Try to create policies first
-                self.create_project(session, project, auth_info=auth_info)
+                self._client.create_default_project_policies(
+                    project=project.metadata.name
+                )
+                self._logger.info(
+                    "Successfully created default project policies in Iguazio"
+                )
             except httpx.HTTPStatusError as exc:
-                # If policies already exist (409 Conflict), update instead
+                # If policies already exist (409 Conflict), update owner instead
                 if exc.response.status_code == httpx.codes.CONFLICT:
                     self._logger.debug(
                         "Project policies already exist, updating owner instead",

--- a/server/py/framework/utils/projects/leader.py
+++ b/server/py/framework/utils/projects/leader.py
@@ -397,7 +397,7 @@ class Member(
         # TODO: do it concurrently
         follower_responses = {
             follower_name: getattr(follower, method)(*args, **kwargs)
-            for follower_name, follower in self._followers.items()
+            for follower_name, follower in sorted(self._followers.items())
         }
         if not leader_first:
             leader_response = getattr(self._leader_follower, method)(*args, **kwargs)

--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -73,6 +73,12 @@ async def create_project(
     )
     if is_running_in_background:
         return fastapi.Response(status_code=http.HTTPStatus.ACCEPTED.value)
+
+    await framework.utils.auth.verifier.AuthVerifier().ensure_project_permissions(
+        project.metadata.name,
+        auth_info,
+    )
+
     response.status_code = http.HTTPStatus.CREATED.value
     return project
 
@@ -107,6 +113,12 @@ async def store_project(
     )
     if is_running_in_background:
         return fastapi.Response(status_code=http.HTTPStatus.ACCEPTED.value)
+
+    await framework.utils.auth.verifier.AuthVerifier().ensure_project_permissions(
+        project.metadata.name,
+        auth_info,
+    )
+
     return project
 
 

--- a/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
@@ -486,11 +486,12 @@ def test_store_project(
 ):
     project = _generate_igv4_project(owner=owner)
 
-    if not project_exists:
-        iguazio_client._client.get_project_policy_assignments.side_effect = (
+    if project_exists:
+        # Simulate 409 Conflict when trying to create project policies that already exist
+        iguazio_client._client.create_default_project_policies.side_effect = (
             _generate_igv4_httpx_exception(
-                "Project not found",
-                httpx.codes.NOT_FOUND,
+                "Project policies already exist",
+                httpx.codes.CONFLICT,
             )
         )
 
@@ -501,16 +502,16 @@ def test_store_project(
         igv4_auth_info.request_headers
     )
 
-    iguazio_client._client.get_project_policy_assignments.assert_called_once_with(
+    # create_project is always called first (which calls create_default_project_policies)
+    iguazio_client._client.create_default_project_policies.assert_called_once_with(
         project=TEST_PROJECT_NAME
     )
 
     if not project_exists:
-        iguazio_client._client.create_default_project_policies.assert_called_once_with(
-            project=TEST_PROJECT_NAME
-        )
+        # New project: create succeeded, no need to update owner
         iguazio_client._client.update_project_owner.assert_not_called()
     else:
+        # Existing project: 409 Conflict triggered patch_project
         if not owner:
             iguazio_client._client.update_project_owner.assert_not_called()
         else:


### PR DESCRIPTION
### 📝 Description

This PR addresses a few issues that were found in the project creation flow when MLRun is the project Leader:
1. Ensures that project permissions are properly established after project creation and storage operations, by adding a retry mechanism to wait for permission propagation before returning from the API endpoints, preventing race conditions where clients may immediately try to access the newly created project before permissions are fully available.
    1. Note that this doesn't ensure both chief and worker have the updated copies, but it is a best effort and the delay margins between the two should be small enough.
2. When running operations on all followers (such as create/store project), run them on the `sorted` list of followers. When the followers are defined `['igz', 'nuclio']` this ensures the project policies are created before the project is created on Nuclio.
    1. This is quite hacky, I agree, but until we provide a more robust project leader mechanism it will have to do.
3. Refactor iguazio v4's `store_project` to decide if it a "create" or "update" based on if `create_project` raises a 409 Conflict error. If conflict - it is an "update", if not - it is a "create".
    1. This was needed because in the old implementation which used `get_project_policy_assignments`, we would get a 403 and not a 404, so we couldn't really tell if that 403 is because the project doesn't exist or we really don't have permissions.

---

### 🛠️ Changes Made
- **Added `ensure_project_permissions()` method to `AuthVerifier`** (`server/py/framework/utils/auth/verifier.py`):
  - New async method that retries project read permission checks with a 1-second backoff and 10-second timeout
  - Handles race conditions where the auth provider may not immediately have permissions available after project creation

- **Updated project endpoints** (`server/py/services/api/api/endpoints/projects.py`):
  - Added `ensure_project_permissions()` call after `create_project` completes (before returning 201)
  - Added `ensure_project_permissions()` call after `store_project` completes

- **Refactored iguazio's `store_project`** (`server/py/framework/utils/clients/iguazio/v4.py`):
  - Resolving create or updated according to a 409 Conflict status

- **Sorted followers list when running all on all followers** (`server/py/framework/utils/projects/leader.py`):
  - Minimal effort to ensure `igz` follower operations run before `nuclio` follwer.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Manual testing to verify permissions are available immediately after project creation
- Verified retry mechanism properly waits for permission propagation
- Tested both in IG3 and IG4

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1002, https://iguazio.atlassian.net/browse/IG4-1044
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
