### PR TITLE
[IG4] Autoset runtime igz4 oauth configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,7 +52,7 @@ kubeconfig*
 **/test-huggingface.yml
 **/tests
 **/env.yml
-**/patch[_\-]env.yml
+**/patch[_\-]env*.yml
 **/mlrun.env
 **/google-big-query-credentials.json
 

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -271,6 +271,9 @@ class MLRunPatcher:
         targets: list[str],
         image_tag: str,
     ) -> dict[str, str]:
+        mlrun_version = image_tag
+        image_tag = image_tag.replace("+", "-")
+
         for target in targets:
             logger.info(f"Building mlrun docker images: {target}:{image_tag}")
 
@@ -281,7 +284,7 @@ class MLRunPatcher:
         }
         if not self._no_build:
             env = {
-                "MLRUN_VERSION": image_tag,
+                "MLRUN_VERSION": mlrun_version,
                 "MLRUN_DOCKER_REPO": mlrun_docker_registry,
             }
 

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -17,7 +17,6 @@ import typing
 
 import yaml
 
-import mlrun.common.constants
 import mlrun.common.schemas
 import mlrun.utils.helpers
 from mlrun.config import config as mlconf
@@ -313,30 +312,3 @@ def translate_secret_tokens(
                 raise_on_error,
             )
     return tokens
-
-
-def enrich_auth_env(
-    env: dict,
-):
-    """
-    Enrich the given environment dictionary with authentication information.
-
-    This function adds authentication-related environment variables to the provided
-    environment dictionary based on the given AuthInfo object.
-
-    :param env: The environment dictionary to enrich.
-    """
-
-    if mlrun.mlconf.is_iguazio_v4_mode():
-        env["MLRUN_AUTH_WITH_OAUTH_TOKEN__ENABLED"] = "true"
-        env["MLRUN_AUTH_TOKEN_ENDPOINT"] = os.path.join(
-            mlrun.mlconf.iguazio_api_url,
-            mlrun.mlconf.httpdb.authentication.iguazio.authentication_endpoint,
-        )
-        env["MLRUN_HTTPDB__HTTP__VERIFY"] = str(
-            mlrun.mlconf.iguazio_api_ssl_verify
-        ).lower()
-        env["MLRUN_AUTH_WITH_OAUTH_TOKEN__TOKEN_FILE"] = os.path.join(
-            mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
-            mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
-        )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import enum
 import http
+import os
 import re
 import time
 import traceback
@@ -642,8 +643,7 @@ class HTTPRunDB(RunDBInterface):
 
             # Iguazio V4 OAuth token config auto-initialization
             if (
-                not config.auth_token_endpoint
-                and config.httpdb.authentication.mode
+                config.httpdb.authentication.mode
                 == mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value
             ):
                 # if running inside kubernetes, use the internal endpoint, otherwise use the external endpoint
@@ -657,6 +657,14 @@ class HTTPRunDB(RunDBInterface):
                     )
 
                 config.auth_with_oauth_token.enabled = True
+
+                # TODO: change to os.getenv("MLRUN_RUNTIME_KIND") when https://github.com/mlrun/mlrun/pull/9121
+                # is merged. The reason we can't do it for all k8s pods is dev-envs like jupyter.
+                if mlrun.k8s_utils.is_running_inside_kubernetes_cluster():
+                    config.auth_with_oauth_token.token_file = os.path.join(
+                        mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
+                        mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
+                    )
 
         except Exception as exc:
             logger.warning(

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -735,7 +735,6 @@ def code_to_function(
         )
 
     """
-    filebase, _ = path.splitext(path.basename(filename))
     ignored_tags = ignored_tags or mlconf.ignored_notebook_tags
 
     def add_name(origin, name=""):

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -23,7 +23,6 @@ from typing import Optional, Union
 import requests.exceptions
 from nuclio.build import mlrun_footer
 
-import mlrun.auth.utils
 import mlrun.common.constants
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.formatters
@@ -460,8 +459,6 @@ class BaseRuntime(ModelObj):
             # TODO: Remove this in 1.12.0 as MLRUN_DEFAULT_PROJECT is deprecated and should not be injected anymore
             "MLRUN_DEFAULT_PROJECT": active_project,
         }
-
-        mlrun.auth.utils.enrich_auth_env(runtime_env)
 
         if runobj:
             runtime_env["MLRUN_EXEC_CONFIG"] = runobj.to_json(

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -24,7 +24,6 @@ import requests
 
 import mlrun
 import mlrun.auth.nuclio
-import mlrun.auth.utils
 import mlrun.common.constants
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
@@ -379,8 +378,6 @@ def _enrich_config_spec(
 
 def _resolve_env_vars(function):
     env_dict, external_source_env_dict = function._get_nuclio_config_spec_env()
-    mlrun.auth.utils.enrich_auth_env(env_dict)
-
     return env_dict, external_source_env_dict
 
 

--- a/server/py/services/api/tests/unit/runtimes/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtimes/test_kubejob.py
@@ -28,7 +28,6 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.k8s_utils
 from mlrun.common.schemas import SecurityContextEnrichmentModes
-from mlrun.common.types import AuthenticationMode
 from mlrun.config import config as mlconf
 from mlrun.runtimes.mounts import auto_mount
 from mlrun.runtimes.utils import generate_resources
@@ -1465,34 +1464,6 @@ def my_func(context):
 
         # validate that the default project env var is also set for backward compatibility
         assert env["MLRUN_DEFAULT_PROJECT"] == self.project
-
-    def test_generate_runtime_env_injects_iguazio4_envs(self):
-        runtime = self._generate_runtime()
-        iguazio_api_url = "https://api.example.com"
-        runobj = mlrun.model.RunObject.from_dict(
-            {
-                "metadata": {
-                    "name": "job",
-                    "project": self.project,
-                },
-            }
-        )
-        mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.IGUAZIO_V4
-        mlrun.mlconf.iguazio_api_url = iguazio_api_url
-        mlrun.mlconf.iguazio_api_ssl_verify = False
-
-        env = runtime._generate_runtime_env(runobj)
-
-        # Iguazio v4 auth envs are injected
-        assert env["MLRUN_AUTH_WITH_OAUTH_TOKEN__ENABLED"] == "true"
-        assert env["MLRUN_AUTH_TOKEN_ENDPOINT"] == os.path.join(
-            iguazio_api_url, "api/v1/authentication/refresh-access-token"
-        )
-        assert env["MLRUN_HTTPDB__HTTP__VERIFY"] == "false"
-        assert env["MLRUN_AUTH_WITH_OAUTH_TOKEN__TOKEN_FILE"] == os.path.join(
-            mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
-            mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
-        )
 
     @staticmethod
     def _assert_build_commands(expected_commands, runtime):

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -16,6 +16,7 @@ import base64
 import codecs
 import datetime
 import json
+import os
 import sys
 import time
 import typing
@@ -37,6 +38,7 @@ import requests_mock as requests_mock_package
 import mlrun.alerts
 import mlrun.artifacts
 import mlrun.artifacts.base
+import mlrun.common.constants
 import mlrun.common.formatters
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
@@ -568,6 +570,13 @@ def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
             assert mlrun.mlconf.auth_token_endpoint == internal_token_endpoint
             assert isinstance(db.token_provider, IGTokenProvider)
             assert db.token_provider.get_token() == jwt_token
+
+            # Verify token_file is set to the expected path when running inside k8s
+            expected_token_file = os.path.join(
+                mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
+                mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
+            )
+            assert mlrun.mlconf.auth_with_oauth_token.token_file == expected_token_file
 
 
 def _generate_runtime(name) -> mlrun.runtimes.KubejobRuntime:

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -517,7 +517,7 @@ def test_iguazio_v4_oauth_config_is_applied_before_token_provider_init(
 
 
 def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
-    requests_mock: requests_mock_package.Mocker, monkeypatch, token_file
+    requests_mock: requests_mock_package.Mocker, monkeypatch
 ):
     mlrun.mlconf.auth_with_client_id.enabled = False
     mlrun.mlconf.auth_with_oauth_token.enabled = False
@@ -543,6 +543,18 @@ def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
 
     monkeypatch.setattr(
         mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: True
+    )
+    monkeypatch.setattr(
+        mlrun.auth.utils,
+        "read_secret_tokens_file",
+        lambda raise_on_error: {
+            "secretTokens": [
+                {
+                    "name": "default",
+                    "token": "offline",
+                }
+            ]
+        },
     )
 
     with patch.object(mlrun.auth.utils, "load_offline_token", return_value="offline"):


### PR DESCRIPTION
### 📝 Description

Remove runtime-level auth env var injection (`enrich_auth_env`) and centralize auth configuration through the client-spec mechanism upon import mlrun. Auth token file path is *currently* set directly during httpdb config sync when running inside k8s cluster.

---

### 🛠️ Changes Made

- Removed `enrich_auth_env` function from `mlrun/auth/utils.py`
- Set `token_file` path directly in `httpdb.py` during config sync when running inside k8s
- Removed `enrich_auth_env` calls from `base.py` and `nuclio/function.py`
- Removed related test that validated the old env injection behavior
- Fixed patch_remote.py to handle tags with `+` in its mlrun version.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Unit tests: `test_client_spec.py`, `test_kubejob.py`, `test_httpdb.py` OAuth tests
- Manual testing required on IG4 environment

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11898
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

Part of the IG4 AuthN initiative. OAuth token config (enabled flag, endpoint) continues to be set via client-spec sync. Token file path is now set directly when running inside k8s cluster instead of being injected per-runtime.