### PR TITLE
[SDK] Fix setting token file name

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -885,7 +885,9 @@ default_config = {
         "enabled": False,
         "request_timeout": 5,
         "refresh_threshold": 0.75,
-        "token_file": "~/.igz.yml",
+        # Default is empty. automatically set based on configuration (end client vs jupyter vs runtime, etc)
+        # can be set manually set using envvars
+        "token_file": "",
         # Default is empty because if set, searches for the specific token name in the file, if empty, it will look
         # for a token named "default", if "default" does not exist, it will use the first token in the file
         "token_name": "",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -648,6 +648,23 @@ class HTTPRunDB(RunDBInterface):
                 config.httpdb.authentication.mode
                 == mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value
             ):
+                if not config.auth_with_oauth_token.token_file:
+                    user_token_file = os.path.expanduser("~/.igz.yml")
+
+                    # runtimes
+                    # TODO: change to os.getenv("MLRUN_RUNTIME_KIND")
+                    # when https://github.com/mlrun/mlrun/pull/9121 is done.
+                    if (
+                        mlrun.k8s_utils.is_running_inside_kubernetes_cluster()
+                        and not os.environ.get("JPY_SESSION_NAME")
+                    ):
+                        user_token_file = os.path.join(
+                            mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
+                            mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
+                        )
+
+                    config.auth_with_oauth_token.token_file = user_token_file
+
                 # if running inside kubernetes, use the internal endpoint, otherwise use the external endpoint
                 if mlrun.k8s_utils.is_running_inside_kubernetes_cluster():
                     config.auth_token_endpoint = server_cfg.get(
@@ -659,14 +676,6 @@ class HTTPRunDB(RunDBInterface):
                     )
 
                 config.auth_with_oauth_token.enabled = True
-
-                # TODO: change to os.getenv("MLRUN_RUNTIME_KIND") when https://github.com/mlrun/mlrun/pull/9121
-                # is merged. The reason we can't do it for all k8s pods is dev-envs like jupyter.
-                if mlrun.k8s_utils.is_running_inside_kubernetes_cluster():
-                    config.auth_with_oauth_token.token_file = os.path.join(
-                        mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
-                        mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
-                    )
 
         except Exception as exc:
             logger.warning(

--- a/mlrun/secrets.py
+++ b/mlrun/secrets.py
@@ -262,8 +262,7 @@ def sync_secret_tokens() -> None:
     Synchronize local secret tokens with the backend.
 
     This function:
-      1. Reads the local token file (default: ~/.igz.yml, configurable via
-         `mlrun.mlconf.auth_with_oauth_token.token_file`).
+      1. Reads the local token file (defaults to `mlrun.mlconf.auth_with_oauth_token.token_file` value).
       2. Validates its content and converts validated tokens into `SecretToken` objects.
       3. Uploads the tokens to the backend.
       4. Logs a warning if any tokens were updated on the backend due to newer

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -579,6 +579,96 @@ def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
             assert mlrun.mlconf.auth_with_oauth_token.token_file == expected_token_file
 
 
+@pytest.mark.parametrize(
+    "is_k8s,has_jupyter_env,preconfigured_token_file,expected_token_file_suffix",
+    [
+        # Running in k8s (not Jupyter) - should use k8s secret path
+        (True, False, None, "/var/mlrun-secrets/auth/.igz.yml"),
+        # Running in k8s under Jupyter - should use user home token file
+        (True, True, None, "~/.igz.yml"),
+        # Running locally (not k8s) - should use user home token file
+        (False, False, None, "~/.igz.yml"),
+        # Token file already configured - should not change it
+        (True, False, "/custom/path/token.yml", "/custom/path/token.yml"),
+    ],
+)
+def test_iguazio_v4_oauth_token_file_auto_initialization(
+    requests_mock: requests_mock_package.Mocker,
+    monkeypatch,
+    is_k8s,
+    has_jupyter_env,
+    preconfigured_token_file,
+    expected_token_file_suffix,
+):
+    """
+    Test that token_file is correctly auto-initialized based on environment:
+    - In k8s (not Jupyter): uses /var/mlrun-secrets/auth/.igz.yml
+    - In k8s under Jupyter: uses ~/.igz.yml
+    - Locally: uses ~/.igz.yml
+    - Pre-configured: preserves the existing value
+    """
+
+    mlrun.mlconf.auth_with_oauth_token.token_file = preconfigured_token_file
+
+    external_token_endpoint = "https://dashboard.default-tenant.app.example.com/api/v1/authentication/refresh-access-token"
+    internal_token_endpoint = "https://dashboard.default-tenant.svc.cluster.local/api/v1/authentication/refresh-access-token"
+
+    iat = int(time.time())
+    exp = iat + 3600
+    jwt_token = _encode_jwt({"iat": iat, "exp": exp})
+
+    # Mock token endpoint - use internal if k8s, external otherwise
+    token_endpoint = internal_token_endpoint if is_k8s else external_token_endpoint
+    requests_mock.post(token_endpoint, json={"spec": {"accessToken": jwt_token}})
+
+    server_cfg = {
+        "version": mlrun.mlconf.version,
+        "authentication_mode": mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value,
+        "oauth_enabled": True,
+        "oauth_external_token_endpoint": external_token_endpoint,
+        "oauth_internal_token_endpoint": internal_token_endpoint,
+    }
+
+    # Mock kubernetes detection
+    monkeypatch.setattr(
+        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: is_k8s
+    )
+
+    # Set or clear Jupyter environment variable
+    if has_jupyter_env:
+        monkeypatch.setenv("JPY_SESSION_NAME", "jupyter-session")
+    else:
+        monkeypatch.delenv("JPY_SESSION_NAME", raising=False)
+
+    # Mock secret tokens reading for k8s environments
+    monkeypatch.setattr(
+        mlrun.auth.utils,
+        "read_secret_tokens_file",
+        lambda raise_on_error: {
+            "secretTokens": [{"name": "default", "token": "offline"}]
+        },
+    )
+
+    # Determine the expected token file path
+    if preconfigured_token_file:
+        expected_token_file = preconfigured_token_file
+    elif expected_token_file_suffix == "~/.igz.yml":
+        expected_token_file = os.path.expanduser("~/.igz.yml")
+    else:
+        expected_token_file = expected_token_file_suffix
+
+    with patch.object(mlrun.auth.utils, "load_offline_token", return_value="offline"):
+        with patch.object(HTTPRunDB, "api_call") as api_call:
+            api_response = MagicMock()
+            api_response.json.return_value = server_cfg
+            api_call.return_value = api_response
+            db = HTTPRunDB("http://some-server:1919")
+            db.connect()
+            assert (
+                mlrun.mlconf.auth_with_oauth_token.token_file == expected_token_file
+            ), f"Expected token_file to be {expected_token_file}, got {mlrun.mlconf.auth_with_oauth_token.token_file}"
+
+
 def test_init_token_provider_stores_username_and_password_from_add_or_refresh_credentials(
     monkeypatch,
 ):


### PR DESCRIPTION
### 📝 Description

To ensure token file names can be explicitly set and (correctly) auto set for runtimes / local development it was required to remove the ~/.igz.yml from config.py and set it according to running env (k8s, jupyter, local).

This fixes Iguazio v4 OAuth token file auto-initialization to correctly distinguish between Kubernetes runtime environments and Jupyter environments. Previously, the token file was always overwritten to the k8s secret path when running inside Kubernetes, which broke authentication for Jupyter environments.


---

### 🛠️ Changes Made

- Modified the token file initialization logic to check for Jupyter environment (`JPY_SESSION_NAME`) before overriding to k8s secret path
- Changed default `token_file` config from `~/.igz.yml` to empty string, allowing dynamic initialization based on runtime context
- Updated docstring in `sync_secret_tokens` to reflect the new behavior


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- UT
- igz4 envs

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
