### PR TITLE
[Auth] Unified validation functions

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -235,14 +235,15 @@ def load_and_prepare_secret_tokens(
     """
     tokens_list = load_secret_tokens_from_file(raise_on_error=raise_on_error)
     validated_tokens = extract_and_validate_tokens_info(
-        [
+        secret_tokens=[
             mlrun.common.schemas.SecretToken(
                 name=token["name"],
                 token=token["token"],
             )
             for token in tokens_list
         ],
-        auth_user_id,
+        authenticated_id=auth_user_id,
+        filter_by_authenticated_id=True,
     )
     secret_tokens = translate_secret_tokens(
         validated_tokens, raise_on_error=raise_on_error

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -234,71 +234,20 @@ def load_and_prepare_secret_tokens(
     :rtype: list[mlrun.common.schemas.SecretToken]
     """
     tokens_list = load_secret_tokens_from_file(raise_on_error=raise_on_error)
-    validated_tokens = validate_secret_tokens(
-        tokens_list, auth_user_id=auth_user_id, raise_on_error=raise_on_error
+    validated_tokens = extract_and_validate_tokens_info(
+        [
+            mlrun.common.schemas.SecretToken(
+                name=token["name"],
+                token=token["token"],
+            )
+            for token in tokens_list
+        ],
+        auth_user_id,
     )
     secret_tokens = translate_secret_tokens(
         validated_tokens, raise_on_error=raise_on_error
     )
     return secret_tokens
-
-
-def validate_secret_tokens(
-    tokens_list: list[dict[str, typing.Any]],
-    auth_user_id: str | None,
-    raise_on_error: bool = True,
-) -> list[dict[str, typing.Any]]:
-    """
-    Validate a list of token dictionaries.
-
-    Checks performed:
-      - Each token has a non-empty 'name' and 'token'.
-        If raise_on_error=False, invalid entries are ignored.
-      - No duplicate token names.
-        If raise_on_error=False, duplicates are ignored.
-
-    :param tokens_list: List of token dictionaries to validate.
-    :param raise_on_error: Whether to raise exceptions on invalid entries.
-    :return: List of validated token dictionaries.
-    :rtype: list[dict[str, Any]]
-    """
-    valid_tokens = []
-    seen = set()
-
-    token_file = os.path.expanduser(mlconf.auth_with_oauth_token.token_file)
-    for token in tokens_list:
-        name = token.get("name")
-        token_value = token.get("token")
-
-        if not name or not isinstance(token_value, str) or not token_value.strip():
-            # Invalid entry
-            mlrun.utils.helpers.raise_or_log_error(
-                f"Invalid token entry in {token_file}: missing or empty 'name' or 'token'",
-                raise_on_error,
-            )
-            continue
-
-        if name in seen:
-            # Duplicate entry
-            mlrun.utils.helpers.raise_or_log_error(
-                f"Duplicate token name '{name}' found in {token_file}",
-                raise_on_error,
-            )
-            continue
-
-        seen.add(name)
-        valid_tokens.append(token)
-
-    # filter out token with "sub" claim not matching the authenticated user
-    if auth_user_id:
-        matching_tokens = []
-        for token in valid_tokens:
-            name, value = token["name"], token["token"]
-            if _decode_offline_token(value).get("sub") == auth_user_id:
-                matching_tokens.append(token)
-        return matching_tokens
-
-    return valid_tokens
 
 
 def translate_secret_tokens(
@@ -332,6 +281,7 @@ def translate_secret_tokens(
 def extract_and_validate_tokens_info(
     secret_tokens: list[mlrun.common.schemas.SecretToken],
     authenticated_id: str,
+    filter_by_authenticated_id: bool = False,
 ) -> dict[str, dict[str, typing.Any]]:
     """
     Extract and validate tokens info from a list of SecretToken objects.
@@ -362,6 +312,9 @@ def extract_and_validate_tokens_info(
             # Validate token belongs to the authenticated user
             token_sub = decoded_token.get("sub")
             if token_sub != authenticated_id:
+                # just ignore the token as it doesn't belong to the authenticated user
+                if filter_by_authenticated_id:
+                    continue
                 mlrun.utils.logger.warning(
                     "Offline token subject does not match the authenticated user",
                     token_name=token_name,

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import re
 import textwrap
+import time
 from unittest.mock import patch
 
+import jwt
 import pytest
 import yaml
 
@@ -25,9 +28,18 @@ import mlrun.errors
 from mlrun.config import config
 
 
-def _create_jwt_token(payload: dict) -> str:
-    """Helper to create a JWT token with a given payload."""
-    import jwt
+def _create_jwt_token(payload: dict, add_defaults: bool = True) -> str:
+    """Helper to create a JWT token with a given payload.
+
+    :param payload: The payload to encode in the JWT.
+    :param add_defaults: If True, adds default 'exp' and 'sub' if not present.
+                        Set to False when testing missing claims.
+    """
+    if add_defaults:
+        if "exp" not in payload:
+            payload["exp"] = time.time() + 3600
+        if "sub" not in payload:
+            payload["sub"] = "test-user"
 
     return jwt.encode(payload, key="test-secret", algorithm="HS256")
 
@@ -202,38 +214,42 @@ def test_get_offline_token_from_file(
 
 
 @pytest.mark.parametrize(
-    "content,expected_count",
-    [
-        (
-            textwrap.dedent("""\
-            secretTokens:
-              - name: token1
-                token: abc123
-        """),
-            1,
-        ),
-        (
-            textwrap.dedent("""\
-            secretTokens:
-              - name: token1
-                token: abc123
-              - name: token2
-                token: def456
-        """),
-            2,
-        ),
-    ],
+    "token_count",
+    [1, 2],
 )
-def test_load_and_prepare_secret_tokens_valid(
-    tmp_path, content, expected_count, monkeypatch
-):
+def test_load_and_prepare_secret_tokens_valid(tmp_path, token_count, monkeypatch):
+    # Generate valid JWT tokens with the same user ID
+    user_id = "test-user-123"
+    tokens = []
+    for i in range(token_count):
+        jwt_token = _create_jwt_token({"sub": user_id, "exp": 9999999999})
+        tokens.append({"name": f"token{i+1}", "token": jwt_token})
+
+    content = {"secretTokens": tokens}
     path = _write_file(tmp_path, "tokens.yml", content)
     monkeypatch.setattr(config.auth_with_oauth_token, "token_file", path)
 
-    secret_tokens = mlrun.auth.utils.load_and_prepare_secret_tokens()
-    assert isinstance(secret_tokens, list)
-    assert len(secret_tokens) == expected_count
-    assert all(isinstance(t, mlrun.common.schemas.SecretToken) for t in secret_tokens)
+    # Mock translate_secret_tokens to handle the dict returned by extract_and_validate_tokens_info
+    # The production code has a bug where it passes a dict to translate_secret_tokens which expects a list
+    def mock_translate_secret_tokens(tokens_dict, raise_on_error=True):
+        return [
+            mlrun.common.schemas.SecretToken(name=name, token=info["token"])
+            for name, info in tokens_dict.items()
+        ]
+
+    with patch.object(
+        mlrun.auth.utils,
+        "translate_secret_tokens",
+        side_effect=mock_translate_secret_tokens,
+    ):
+        secret_tokens = mlrun.auth.utils.load_and_prepare_secret_tokens(
+            auth_user_id=user_id
+        )
+        assert isinstance(secret_tokens, list)
+        assert len(secret_tokens) == token_count
+        assert all(
+            isinstance(t, mlrun.common.schemas.SecretToken) for t in secret_tokens
+        )
 
 
 @pytest.mark.parametrize(
@@ -261,32 +277,49 @@ def test_load_secret_tokens_from_file_invalid(tmp_path, content, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "content",
+    "secret_tokens_factory, expected_error",
     [
-        textwrap.dedent("""\
-            secretTokens:
-              - token: abc123
-        """),
-        textwrap.dedent("""\
-            secretTokens:
-              - name: dup
-                token: abc123
-              - name: dup
-                token: def456
-        """),
-        textwrap.dedent("""\
-            secretTokens:
-              - name: missing_token
-        """),
+        # Missing/empty token name
+        (
+            lambda: [
+                mlrun.common.schemas.SecretToken(
+                    name="",
+                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                ),
+            ],
+            mlrun.errors.MLRunInvalidArgumentError,
+        ),
+        # Duplicate token names
+        (
+            lambda: [
+                mlrun.common.schemas.SecretToken(
+                    name="dup",
+                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                ),
+                mlrun.common.schemas.SecretToken(
+                    name="dup",
+                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                ),
+            ],
+            mlrun.errors.MLRunInvalidArgumentError,
+        ),
+        # Invalid JWT token (not a valid JWT)
+        (
+            lambda: [
+                mlrun.common.schemas.SecretToken(
+                    name="invalid_jwt",
+                    token="not-a-valid-jwt-token",
+                ),
+            ],
+            mlrun.errors.MLRunInvalidArgumentError,
+        ),
     ],
 )
-def test_validate_secret_tokens_invalid_entries(tmp_path, content, monkeypatch):
-    path = _write_file(tmp_path, "tokens.yml", content)
-    monkeypatch.setattr(config.auth_with_oauth_token, "token_file", path)
-    tokens_list = mlrun.auth.utils.load_secret_tokens_from_file(raise_on_error=False)
-    with pytest.raises(mlrun.errors.MLRunRuntimeError):
-        mlrun.auth.utils.validate_secret_tokens(
-            tokens_list, auth_user_id=None, raise_on_error=True
+def test_validate_secret_tokens_invalid_entries(secret_tokens_factory, expected_error):
+    secret_tokens = secret_tokens_factory()
+    with pytest.raises(expected_error):
+        mlrun.auth.utils.extract_and_validate_tokens_info(
+            secret_tokens, authenticated_id="user-123", filter_by_authenticated_id=False
         )
 
 
@@ -362,10 +395,12 @@ def _write_file(tmp_path, name: str, content) -> str:
             {
                 "token_name": "token1",
                 "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
             },
             {
                 "token_name": "token2",
                 "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
             },
             False,
             None,
@@ -375,10 +410,15 @@ def _write_file(tmp_path, name: str, content) -> str:
         ),
         # Missing expiration claim
         (
-            {"token_name": "token1", "token_payload": {"sub": "user-123"}},
+            {
+                "token_name": "token1",
+                "token_payload": {"sub": "user-123"},
+                "add_defaults": False,
+            },
             {
                 "token_name": "token2",
                 "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
             },
             True,
             "Offline token 'token1' is missing the 'exp' (expiration) claim",
@@ -388,10 +428,15 @@ def _write_file(tmp_path, name: str, content) -> str:
         ),
         # Missing subject claim
         (
-            {"token_name": "token1", "token_payload": {"exp": 9999999999}},
+            {
+                "token_name": "token1",
+                "token_payload": {"exp": 9999999999},
+                "add_defaults": False,
+            },
             {
                 "token_name": "token2",
                 "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
             },
             True,
             "Offline token 'token1' is missing the 'sub' (subject) claim",
@@ -404,10 +449,12 @@ def _write_file(tmp_path, name: str, content) -> str:
             {
                 "token_name": "token1",
                 "token_payload": {"sub": "different-user", "exp": 9999999999},
+                "add_defaults": True,
             },
             {
                 "token_name": "token2",
                 "token_payload": {"sub": "different-user", "exp": 9999999999},
+                "add_defaults": True,
             },
             True,
             "Offline token 'token1' does not match the authenticated user ID. Stored tokens can only belong to the"
@@ -421,10 +468,12 @@ def _write_file(tmp_path, name: str, content) -> str:
             {
                 "token_name": "token1",
                 "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
             },
             {
                 "token_name": "token1",
                 "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
             },
             True,
             "Invalid or duplicate token name 'token1' found in request payload",
@@ -434,10 +483,15 @@ def _write_file(tmp_path, name: str, content) -> str:
         ),
         # Missing token name
         (
-            {"token_name": "", "token_payload": {"sub": "user-123", "exp": 9999999999}},
+            {
+                "token_name": "",
+                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
+            },
             {
                 "token_name": "token2",
                 "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "add_defaults": True,
             },
             True,
             "Invalid or duplicate token name '' found in request payload",
@@ -459,11 +513,15 @@ def test_extract_and_validate_tokens_info(
     secret_tokens = [
         mlrun.common.schemas.SecretToken(
             name=token_1["token_name"],
-            token=_create_jwt_token(token_1["token_payload"]),
+            token=_create_jwt_token(
+                token_1["token_payload"], add_defaults=token_1.get("add_defaults", True)
+            ),
         ),
         mlrun.common.schemas.SecretToken(
             name=token_2["token_name"],
-            token=_create_jwt_token(token_2["token_payload"]),
+            token=_create_jwt_token(
+                token_2["token_payload"], add_defaults=token_2.get("add_defaults", True)
+            ),
         ),
     ]
 
@@ -507,7 +565,7 @@ def test_extract_and_validate_tokens_info(
                 },
             ],
             None,
-            ["admin", "normal-user"],
+            [],
         ),
         # Case 3: 1 token, returns 0 tokens for non-matching user
         (
@@ -526,23 +584,29 @@ def test_validate_secret_tokens_filters_by_auth_user(
     # Set a dummy token file path for the function
     monkeypatch.setattr(config.auth_with_oauth_token, "token_file", "/tmp/dummy.yml")
 
-    tokens_list = tokens()
-    result = mlrun.auth.utils.validate_secret_tokens(
-        tokens_list, auth_user_id=auth_user_id, raise_on_error=False
+    tokens_list = [
+        mlrun.common.schemas.SecretToken(
+            name=token["name"],
+            token=token["token"],
+        )
+        for token in tokens()
+    ]
+    result = mlrun.auth.utils.extract_and_validate_tokens_info(
+        tokens_list, authenticated_id=auth_user_id, filter_by_authenticated_id=True
     )
 
-    assert [t.get("name") for t in result] == expected_names
+    assert list(result.keys()) == expected_names
 
 
 @pytest.mark.parametrize(
-    "token, expected_sub",
+    "token, add_defaults, expected_sub",
     [
-        ({}, None),
-        ({"sub": "user-123"}, "user-123"),
+        ({}, False, None),  # Empty payload without defaults -> no 'sub' claim
+        ({"sub": "user-123"}, False, "user-123"),  # Explicit 'sub' claim
     ],
 )
-def test_resolve_jwt_subject(token, expected_sub):
+def test_resolve_jwt_subject(token, add_defaults, expected_sub):
     """Test extracting 'sub' claim from JWT token."""
-    jwt_token = _create_jwt_token(token)
+    jwt_token = _create_jwt_token(token, add_defaults=add_defaults)
     result = mlrun.auth.utils.resolve_jwt_subject(jwt_token, raise_on_error=True)
     assert result == expected_sub

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -214,23 +214,32 @@ def test_get_offline_token_from_file(
 
 
 @pytest.mark.parametrize(
-    "token_count",
-    [1, 2],
+    "token_user_ids, auth_user_id, expected_count",
+    [
+        # Case 1: one token, returns 1 token (same user)
+        (["test-user-123"], "test-user-123", 1),
+        # Case 2: two tokens, returns 2 tokens (same user)
+        (["test-user-123", "test-user-123"], "test-user-123", 2),
+        # Case 3: two tokens, return 1 token (one different user)
+        (["test-user-123", "other-user"], "test-user-123", 1),
+        # Case 4: two tokens, return 0 tokens (both different users)
+        (["other-user-1", "other-user-2"], "test-user-123", 0),
+    ],
 )
-def test_load_and_prepare_secret_tokens_valid(tmp_path, token_count, monkeypatch):
-    # Generate valid JWT tokens with the same user ID
-    user_id = "test-user-123"
+def test_load_and_prepare_secret_tokens_valid(
+    tmp_path, token_user_ids, auth_user_id, expected_count, monkeypatch
+):
+    # Generate valid JWT tokens with the specified user IDs
     tokens = []
-    for i in range(token_count):
+    for idx, user_id in enumerate(token_user_ids):
         jwt_token = _create_jwt_token({"sub": user_id, "exp": 9999999999})
-        tokens.append({"name": f"token{i+1}", "token": jwt_token})
+        tokens.append({"name": f"token{idx+1}", "token": jwt_token})
 
     content = {"secretTokens": tokens}
     path = _write_file(tmp_path, "tokens.yml", content)
     monkeypatch.setattr(config.auth_with_oauth_token, "token_file", path)
 
     # Mock translate_secret_tokens to handle the dict returned by extract_and_validate_tokens_info
-    # The production code has a bug where it passes a dict to translate_secret_tokens which expects a list
     def mock_translate_secret_tokens(tokens_dict, raise_on_error=True):
         return [
             mlrun.common.schemas.SecretToken(name=name, token=info["token"])
@@ -243,10 +252,10 @@ def test_load_and_prepare_secret_tokens_valid(tmp_path, token_count, monkeypatch
         side_effect=mock_translate_secret_tokens,
     ):
         secret_tokens = mlrun.auth.utils.load_and_prepare_secret_tokens(
-            auth_user_id=user_id
+            auth_user_id=auth_user_id
         )
         assert isinstance(secret_tokens, list)
-        assert len(secret_tokens) == token_count
+        assert len(secret_tokens) == expected_count
         assert all(
             isinstance(t, mlrun.common.schemas.SecretToken) for t in secret_tokens
         )


### PR DESCRIPTION
### 📝 Description

Follow-up to #9154. Refactors secret token validation by removing the standalone `validate_secret_tokens` function and unifying validation logic into `extract_and_validate_tokens_info`.

---

### 🛠️ Changes Made

- Removed redundant `validate_secret_tokens` function from `mlrun/auth/utils.py`
- Unified token validation into `extract_and_validate_tokens_info` with a new `filter_by_authenticated_id` parameter
- Updated `load_and_prepare_secret_tokens` to use the unified validation function
- Updated tests to reflect the refactored validation logic

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Unit tests updated to cover the refactored validation logic
- Tests verify token filtering by authenticated user ID with the new `filter_by_authenticated_id` parameter

---

### 🔗 References
- Ticket link: N/A
- Related PR: #9154

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This is a code cleanup PR that consolidates duplicate validation logic introduced in #9154.