### PR TITLE
[Auth] Fix incorrect argument type in translate_secret_token

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -245,38 +245,10 @@ def load_and_prepare_secret_tokens(
         authenticated_id=auth_user_id,
         filter_by_authenticated_id=True,
     )
-    secret_tokens = translate_secret_tokens(
+    secret_tokens = _translate_secret_tokens(
         validated_tokens, raise_on_error=raise_on_error
     )
     return secret_tokens
-
-
-def translate_secret_tokens(
-    tokens_list: list[dict[str, typing.Any]], raise_on_error: bool = True
-) -> list[mlrun.common.schemas.SecretToken]:
-    """
-    Translate a list of validated token dictionaries into SecretToken objects.
-
-    Each dictionary in the list must be validated and contain the required fields
-    for SecretToken creation. If an entry fails to translate, behavior depends on
-    ``raise_on_error``: raise an exception or log a warning.
-
-    :param tokens_list: List of validated token dictionaries.
-    :param raise_on_error: Whether to raise exceptions on translation errors.
-    :return: List of SecretToken objects created from the input dictionaries.
-    :rtype: list[mlrun.common.schemas.SecretToken]
-    """
-    token_file = os.path.expanduser(mlconf.auth_with_oauth_token.token_file)
-    tokens = []
-    for token in tokens_list:
-        try:
-            tokens.append(mlrun.common.schemas.SecretToken(**token))
-        except Exception as exc:
-            mlrun.utils.helpers.raise_or_log_error(
-                f"Failed to create SecretToken from entry in {token_file}: {exc}",
-                raise_on_error,
-            )
-    return tokens
 
 
 def extract_and_validate_tokens_info(
@@ -374,3 +346,36 @@ def _decode_offline_token(token: str) -> dict:
         raise mlrun.errors.MLRunInvalidArgumentError(
             "Unexpected error decoding token"
         ) from exc
+
+
+def _translate_secret_tokens(
+    tokens_dict: dict[str, dict[str, typing.Any]], raise_on_error: bool = True
+) -> list[mlrun.common.schemas.SecretToken]:
+    """
+    Translate a dictionary of validated token data into SecretToken objects.
+
+    The dictionary is keyed by token name, with values containing token data
+    (including the token string). If an entry fails to translate, behavior depends
+    on ``raise_on_error``: raise an exception or log a warning.
+
+    :param tokens_dict: Dictionary of validated token data, keyed by token name.
+    :param raise_on_error: Whether to raise exceptions on translation errors.
+    :return: List of SecretToken objects created from the input dictionary.
+    :rtype: list[mlrun.common.schemas.SecretToken]
+    """
+    token_file = os.path.expanduser(mlconf.auth_with_oauth_token.token_file)
+    tokens = []
+    for token_name, token_data in tokens_dict.items():
+        try:
+            tokens.append(
+                mlrun.common.schemas.SecretToken(
+                    name=token_name,
+                    token=token_data["token"],
+                )
+            )
+        except Exception as exc:
+            mlrun.utils.helpers.raise_or_log_error(
+                f"Failed to create SecretToken from entry in {token_file}: {exc}",
+                raise_on_error,
+            )
+    return tokens

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -239,26 +239,12 @@ def test_load_and_prepare_secret_tokens_valid(
     path = _write_file(tmp_path, "tokens.yml", content)
     monkeypatch.setattr(config.auth_with_oauth_token, "token_file", path)
 
-    # Mock translate_secret_tokens to handle the dict returned by extract_and_validate_tokens_info
-    def mock_translate_secret_tokens(tokens_dict, raise_on_error=True):
-        return [
-            mlrun.common.schemas.SecretToken(name=name, token=info["token"])
-            for name, info in tokens_dict.items()
-        ]
-
-    with patch.object(
-        mlrun.auth.utils,
-        "translate_secret_tokens",
-        side_effect=mock_translate_secret_tokens,
-    ):
-        secret_tokens = mlrun.auth.utils.load_and_prepare_secret_tokens(
-            auth_user_id=auth_user_id
-        )
-        assert isinstance(secret_tokens, list)
-        assert len(secret_tokens) == expected_count
-        assert all(
-            isinstance(t, mlrun.common.schemas.SecretToken) for t in secret_tokens
-        )
+    secret_tokens = mlrun.auth.utils.load_and_prepare_secret_tokens(
+        auth_user_id=auth_user_id
+    )
+    assert isinstance(secret_tokens, list)
+    assert len(secret_tokens) == expected_count
+    assert all(isinstance(t, mlrun.common.schemas.SecretToken) for t in secret_tokens)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Fix an issue where `translate_secret_token` expected to get a list of secret tokens, but got a dict from `extract_and_validate_tokens_info`.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Make `translate_secret_token` private function and refactor to correctly handle dict instead of list of tokens
- Removed mocking of `translate_secret_token` in test.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
- Removed mock in test
- Reproduced the issue, then saw it resolved after fix

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11920
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
