### PR TITLE
[CI] Better Go Test Summary

### DIFF
--- a/server/go/Makefile
+++ b/server/go/Makefile
@@ -31,6 +31,9 @@ GOLANGCI_LINT_VERSION := 2.4.0
 GOLANGCI_LINT_BIN := $(CI_BIN_DIR)/golangci-lint
 GOLANGCI_LINT_INSTALL_COMMAND := GOBIN=$(CI_BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
 
+GOTESTSUM_VERSION = v1.13.0
+GOTESTSUM_BIN := $(CI_BIN_DIR)/gotestsum-$(GOTESTSUM_VERSION)
+
 #
 # Build
 #
@@ -89,13 +92,19 @@ compile-schemas-go:
 #
 # Test
 #
+
+$(GOTESTSUM_BIN):
+	@echo "$(YELLOW)Installing gotestsum $(GOTESTSUM_VERSION)...$(NC)"
+	GOBIN=$(CI_BIN_DIR) go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION) && \
+    mv $(CI_BIN_DIR)/gotestsum $(GOTESTSUM_BIN)
+
 .PHONY: test-unit-local
-test-unit-local: compile-schemas-local
-	go test -v -race -tags=test_unit -short ./...
+test-unit-local: compile-schemas-local $(GOTESTSUM_BIN)
+	$(GOTESTSUM_BIN) --format testname -- -v -race -tags=test_unit -short ./...
 
 .PHONY: test-integration-local
-test-integration-local: compile-schemas-local
-	go test -v -p 1 -race -tags=test_integration ./...
+test-integration-local: compile-schemas-local $(GOTESTSUM_BIN)
+	$(GOTESTSUM_BIN) --format testname -- -v -p 1 -race -tags=test_integration ./...
 
 .PHONY: test-unit-dockerized
 test-unit-dockerized: schemas-compiler


### PR DESCRIPTION
### 📝 Description
The test output is not ideal to read and find the issues.
We are now using https://github.com/gotestyourself/gotestsum which creates a nicer test summary when running the tests (see example below from orca).

---

### 🛠️ Changes Made
- The go Makefile ensures the gotestsum binary exists in the required version
- The go Makefile

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### Summary Example

(from orca)

```
=== Failed
=== FAIL: frameworks/clients/clients/cache/inmemory TestCacheClientTestSuite/TestDelete (0.00s)
26.01.06 09:58:20.584 (D)                test.cache Setting cache item {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey", "ttl": "5s"}
26.01.06 09:58:20.584 (D)                test.cache Starting cache invalidation loop {"ctx": "d1ad6493-906a-4f56-a0c4-537a7061b068"}
26.01.06 09:58:20.585 (D)                test.cache Deleting cache key {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
26.01.06 09:58:20.585 (D)                test.cache Deleting cache key {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
26.01.06 09:58:20.585 (D)                test.cache Setting cache item {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey", "ttl": "5s"}
26.01.06 09:58:20.585 (D)                test.cache Getting cache item {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
26.01.06 09:58:20.585 (D)                test.cache Deleting cache key {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f", "key": "TestKey"}
    client_test.go:125: 
                Error Trace:    /Users/Adam_Melnick/iguazio/misc_workspace/orca/backend/go/frameworks/clients/clients/cache/inmemory/client_test.go:125
                                                        /Users/Adam_Melnick/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.darwin-arm64/src/runtime/asm_arm64.s:1268
                Error:          Not equal: 
                                expected: "TestValuebla"
                                actual  : "TestValue"
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -TestValuebla
                                +TestValue
                Test:           TestCacheClientTestSuite/TestDelete
                Messages:       Expected the popped value to match the inserted value
26.01.06 09:58:20.585 (D)                test.cache Stopping cache client {"ctx": "952c869a-bdc7-48ea-8ae9-ce0286aed51f"}
26.01.06 09:58:20.585 (D)                test.cache Stopping cache invalidation loop {"ctx": "d1ad6493-906a-4f56-a0c4-537a7061b068"}
    --- FAIL: TestCacheClientTestSuite/TestDelete (0.00s)

=== FAIL: frameworks/clients/clients/cache/inmemory TestCacheClientTestSuite (6.01s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)
    cookie_test.go:224: 
                Error Trace:    /Users/Adam_Melnick/iguazio/misc_workspace/orca/backend/go/subdomains/authentication/transport/mappers/cookie_test.go:224
                                                        /Users/Adam_Melnick/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:115
                Error:          Not equal: 
                                expected: "asd"
                                actual  : ""
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -asd
                                +
                Test:           TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name
        --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)
    --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite (0.10s)

DONE 1027 tests, 5 failures in 7.019s
make[1]: *** [test-unit] Error 1
make: *** [test-unit] Error 2
estGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)
    cookie_test.go:224: 
                Error Trace:    /Users/Adam_Melnick/iguazio/misc_workspace/orca/backend/go/subdomains/authentication/transport/mappers/cookie_test.go:224
                                                        /Users/Adam_Melnick/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:115
                Error:          Not equal: 
                                expected: "asd"
                                actual  : ""
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -asd
                                +
                Test:           TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name
        --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies/Cookie_present_but_wrong_name (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)
    --- FAIL: TestCookieMapperTestSuite/TestGetRefreshTokenFromRequestCookies (0.00s)

=== FAIL: subdomains/authentication/transport/mappers TestCookieMapperTestSuite (0.05s)

DONE 1027 tests, 5 failures in 6.984s
make[1]: *** [test-unit] Error 1
make: *** [test-unit] Error 2
```