### PR TITLE
[Client] Use readinessTimeoutSeconds for deploy HTTP client timeout (ML-11826)

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1986,7 +1986,11 @@ class HTTPRunDB(RunDBInterface):
             _path = (
                 f"projects/{func.metadata.project}/nuclio/{func.metadata.name}/deploy"
             )
-            resp = self.api_call("POST", _path, json=req)
+            # Use readinessTimeoutSeconds from function config if set, otherwise default to 120s
+            # Add 60s buffer for HTTP overhead beyond the Nuclio readiness timeout
+            readiness_timeout = func.spec.config.get("spec.readinessTimeoutSeconds", 60)
+            timeout = int(readiness_timeout) + 60
+            resp = self.api_call("POST", _path, json=req, timeout=timeout)
         except OSError as err:
             logger.error(f"error submitting nuclio deploy task: {err_to_str(err)}")
             raise OSError(f"error: cannot submit deploy, {err_to_str(err)}")


### PR DESCRIPTION
## Summary
When deploying Nuclio functions with many models (5000+), the deploy API call times out after the hardcoded 45-second HTTP client timeout, even though the user has set `spec.readinessTimeoutSeconds` to a higher value.

## Root Cause
The `api_call()` default timeout of 45 seconds was used regardless of the function's `readinessTimeoutSeconds` configuration. The `readinessTimeoutSeconds` only controlled the Nuclio pod startup timeout, not the HTTP client timeout.

## Changes Made
- Use the function's `readinessTimeoutSeconds` config value (plus 60s buffer) as the HTTP client timeout for the deploy POST request
- Default timeout increased from 45s to 120s (60 + 60 buffer)
- When user sets `readinessTimeoutSeconds=120`, HTTP timeout becomes 180s

## Testing
- Ran httpdb unit tests (42 passed)
- Format and lint checks passed

## Reference
- Jira: ML-11826