### PR TITLE
[AuthN] Support Using Service Account Tokens For Internal System Requests

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 import time
 import typing

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
+import time
 import typing
 
 import jwt
@@ -25,6 +25,15 @@ from mlrun.config import config as mlconf
 
 if typing.TYPE_CHECKING:
     import mlrun.db
+
+
+class Claims:
+    """
+    JWT Claims constants.
+    """
+
+    SUBJECT = "sub"
+    EXPIRATION = "exp"
 
 
 def load_offline_token(raise_on_error=True) -> typing.Optional[str]:
@@ -269,21 +278,24 @@ def extract_and_validate_tokens_info(
 
         # Validate name is provided and not duplicate
         if secret_token.name and secret_token.name not in token_values:
-            decoded_token = _decode_offline_token(secret_token.token)
+            # The token is expected to be a refresh token which we cannot verify ourselves, we verify it separately
+            # via orca when exchanging it for an access token. We decode it here without verification to extract its
+            # claims.
+            decoded_token = _decode_token_unverified(secret_token.token)
 
             # Validate token expiration existence
-            if not decoded_token.get("exp"):
+            if not decoded_token.get(Claims.EXPIRATION):
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"Offline token '{token_name}' is missing the 'exp' (expiration) claim"
                 )
             # Validate token subject existence
-            if not decoded_token.get("sub"):
+            if not decoded_token.get(Claims.SUBJECT):
                 raise mlrun.errors.MLRunInvalidArgumentError(
                     f"Offline token '{token_name}' is missing the 'sub' (subject) claim"
                 )
 
             # Validate token belongs to the authenticated user
-            token_sub = decoded_token.get("sub")
+            token_sub = decoded_token.get(Claims.SUBJECT)
             if token_sub != authenticated_id:
                 # just ignore the token as it doesn't belong to the authenticated user
                 if filter_by_authenticated_id:
@@ -301,7 +313,7 @@ def extract_and_validate_tokens_info(
 
             # Store token info
             token_values[secret_token.name] = {
-                "token_exp": decoded_token.get("exp"),
+                "token_exp": decoded_token.get(Claims.EXPIRATION),
                 "token": secret_token.token,
             }
         else:
@@ -325,7 +337,9 @@ def resolve_jwt_subject(
     :return: The 'sub' claim value, or None if extraction fails.
     """
     try:
-        return _decode_offline_token(token).get("sub")
+        # This method is used from the client side after receiving this token from the server, there's no need or
+        # ability to verify its signature here.
+        return _decode_token_unverified(token).get(Claims.SUBJECT)
     except jwt.PyJWTError as exc:
         mlrun.utils.helpers.raise_or_log_error(
             f"Failed to decode JWT token: {exc}", raise_on_error
@@ -333,10 +347,29 @@ def resolve_jwt_subject(
         return None
 
 
-def _decode_offline_token(token: str) -> dict:
+def is_token_expired(token: str, buffer_seconds: int = 0) -> bool:
+    """
+    Check if a JWT token is expired based on its 'exp' claim.
+
+    :param token: The JWT token string.
+    :param buffer_seconds: Number of seconds to subtract from the expiration time
+    :return: True if the token is expired, False otherwise.
+    """
+
+    # This method is used for caching and/or extra validation purposes in addition to the main verification flow,
+    # so we decode without signature verification here.
+    decoded_token = _decode_token_unverified(token)
+    expiration = decoded_token.get(Claims.EXPIRATION)
+    if not expiration:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Token is missing the 'exp' (expiration) claim"
+        )
+    now = time.time()
+    return now >= expiration - buffer_seconds
+
+
+def _decode_token_unverified(token: str) -> dict:
     try:
-        # The token is expected to be a JWT. We don't verify its signature here, because it has already been
-        # verified earlier during the refresh_access_token call.
         return jwt.decode(token, options={"verify_signature": False})
     except jwt.DecodeError as exc:
         raise mlrun.errors.MLRunInvalidArgumentError(

--- a/mlrun/common/schemas/constants.py
+++ b/mlrun/common/schemas/constants.py
@@ -106,6 +106,7 @@ class HeaderNames:
     v3io_user_id = "x-v3io-user-id"
     v3io_session_planes = "x-v3io-session-planes"
     authorization = "authorization"
+    igz_authenticator_kind = "x-igz-authenticator-kind"
     cookies = "cookies"
     cookie = "cookie"
     x_request_id = "x-request-id"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -431,6 +431,11 @@ default_config = {
                 "session_verification_endpoint": "data_sessions/verifications/app_service",
                 "authentication_endpoint": "api/v1/authentication/refresh-access-token",
             },
+            "service_account": {
+                # the following are the default values for k8s service accounts, but may be changed per deployment
+                "token_expiration_seconds": 600,
+                "token_path": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+            },
         },
         "nuclio": {
             # One of ClusterIP | NodePort

--- a/server/py/framework/utils/clients/iguazio/base.py
+++ b/server/py/framework/utils/clients/iguazio/base.py
@@ -188,6 +188,9 @@ class BaseAsyncClient(BaseClient):
             mlrun.common.schemas.HeaderNames.x_request_id: getattr(
                 request.state, "request_id", ""
             ),
+            mlrun.common.schemas.HeaderNames.igz_authenticator_kind: request.headers.get(
+                mlrun.common.schemas.HeaderNames.igz_authenticator_kind, ""
+            ),
         }
         async with (
             self._send_request_to_api_async(

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -31,6 +31,7 @@ import mlrun.common.types
 import mlrun.errors
 from mlrun.utils import get_in
 
+import framework.utils.clients.service_account_token as service_account_token
 import framework.utils.projects.remotes.follower as project_follower
 from framework.utils.clients.iguazio.base import BaseAsyncClient, BaseClient
 
@@ -41,6 +42,7 @@ _GROUP_TYPE_VALUE = "type.googleapis.com/group.Group"
 class Client(BaseClient, project_follower.Member):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self._service_account_token_client = service_account_token.Client()
         self._client = iguazio.Client(
             api_url=self._api_url,
             auto_login=False,
@@ -162,6 +164,10 @@ class Client(BaseClient, project_follower.Member):
         self._logger.debug("Creating default project policies in Iguazio")
 
         def _create_default_project_policies():
+            # TODO: Currently, create_default_project_policies relies on the auth info of the incoming request to
+            #       determine the owner of the project. The iguazio api needs to be updated to accept an explicit owner
+            #       parameter so we can use the service account token here.
+            #       This isn't required now, but will be for the project sync functionality.
             self._client.set_override_auth_headers(auth_info.request_headers)
             self._client.create_default_project_policies(project=project.metadata.name)
             self._logger.info(
@@ -252,7 +258,9 @@ class Client(BaseClient, project_follower.Member):
         self._logger.debug("Deleting project policies in Iguazio")
 
         def _delete_project_policies():
-            self._client.set_override_auth_headers(auth_info.request_headers)
+            self._client.set_override_auth_headers(
+                self._service_account_token_client.auth_headers
+            )
             self._client.delete_project_policies(project=name)
             self._logger.info("Successfully deleted project policies in Iguazio")
 
@@ -306,7 +314,9 @@ class Client(BaseClient, project_follower.Member):
     def _project_policies_exist(
         self, project: str, auth_info: mlrun.common.schemas.AuthInfo
     ) -> bool:
-        self._client.set_override_auth_headers(auth_info.request_headers)
+        self._client.set_override_auth_headers(
+            self._service_account_token_client.auth_headers
+        )
         try:
             self._client.get_project_policy_assignments(project=project)
         except httpx.HTTPStatusError as exc:

--- a/server/py/framework/utils/clients/service_account_token.py
+++ b/server/py/framework/utils/clients/service_account_token.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mlrun
+import mlrun.auth.utils
+import mlrun.utils.singleton
+
+
+class Client(
+    metaclass=mlrun.utils.singleton.AbstractSingleton,
+):
+    """
+    A client for Iguazio service account authentication.
+
+    This client reads the service account token from a specified file path (mounted by kubernetes)
+    and provides methods to add authentication headers to HTTP requests.
+    """
+
+    _SERVICE_ACCOUNT_AUTHENTICATION_HEADER = {
+        "X-IGZ-Authenticator-Kind": "sa",
+    }
+
+    _TOKEN_PATH = mlrun.mlconf.httpdb.authentication.service_account.token_path
+    _TOKEN_EXPIRATION_SECONDS = (
+        mlrun.mlconf.httpdb.authentication.service_account.token_expiration_seconds
+    )
+    _TOKEN_EXPIRATION_BUFFER_SECONDS = _TOKEN_EXPIRATION_SECONDS * (
+        1 - mlrun.mlconf.auth_with_oauth_token.refresh_threshold
+    )
+
+    def __init__(self) -> None:
+        self._token_cache = None
+
+    def escalate_request_headers(self, headers: dict[str, str]) -> dict[str, str]:
+        """
+        Add service account authentication headers to the given headers.
+
+        :param headers: Original request headers.
+        :return: Headers with added service account authentication.
+        """
+        auth_headers = self.auth_headers
+        combined_headers = headers.copy()
+        combined_headers.update(auth_headers)
+        return combined_headers
+
+    @property
+    def auth_headers(self) -> dict[str, str]:
+        """
+        Get the service account authentication headers.
+        """
+        headers = self._SERVICE_ACCOUNT_AUTHENTICATION_HEADER.copy()
+        headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    @property
+    def token(self) -> str:
+        """
+        Get the service account token, using a cached value if it's still valid.
+        """
+        if self._token_cache and not mlrun.auth.utils.is_token_expired(
+            self._token_cache, self._TOKEN_EXPIRATION_BUFFER_SECONDS
+        ):
+            return self._token_cache
+
+        with open(self._TOKEN_PATH) as token_file:
+            self._token_cache = token_file.read().strip()
+
+        return self._token_cache

--- a/server/py/framework/utils/clients/service_account_token.py
+++ b/server/py/framework/utils/clients/service_account_token.py
@@ -14,6 +14,7 @@
 
 import mlrun
 import mlrun.auth.utils
+import mlrun.common.schemas
 import mlrun.utils.singleton
 
 
@@ -28,7 +29,7 @@ class Client(
     """
 
     _SERVICE_ACCOUNT_AUTHENTICATION_HEADER = {
-        "X-IGZ-Authenticator-Kind": "sa",
+        mlrun.common.schemas.HeaderNames.igz_authenticator_kind: "sa",
     }
 
     _TOKEN_PATH = mlrun.mlconf.httpdb.authentication.service_account.token_path

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -34,6 +34,7 @@ import framework.utils.auth.verifier
 import framework.utils.background_tasks
 import framework.utils.clients.messaging
 import framework.utils.clients.nuclio
+import framework.utils.clients.service_account_token as service_account_token
 import framework.utils.projects.remotes.follower as project_follower
 import framework.utils.singletons.db
 import services.alerts.crud
@@ -49,6 +50,10 @@ class Projects(
     project_follower.Member,
     metaclass=mlrun.utils.singleton.AbstractSingleton,
 ):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._service_account_token_client = service_account_token.Client()
+
     def create_project(
         self,
         session: sqlalchemy.orm.Session,
@@ -218,9 +223,17 @@ class Projects(
             services.alerts.crud.Alerts().delete_alerts(session=session, project=name)
         else:
             messaging_client = framework.utils.clients.messaging.Client()
+
+            # as the project has already been deleted, it will no longer exist in the permission manifest at all,
+            # so we must escalate the request to have permissions to delete all project resources
+            request_headers = (
+                self._service_account_token_client.escalate_request_headers(
+                    auth_info.request_headers
+                )
+            )
             messaging_client.delete(
                 path=f"projects/{name}/alerts",
-                headers=auth_info.request_headers,
+                headers=request_headers,
                 raise_on_failure=True,
             )
 

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -223,14 +223,17 @@ class Projects(
             services.alerts.crud.Alerts().delete_alerts(session=session, project=name)
         else:
             messaging_client = framework.utils.clients.messaging.Client()
+            request_headers = auth_info.request_headers
 
-            # as the project has already been deleted, it will no longer exist in the permission manifest at all,
-            # so we must escalate the request to have permissions to delete all project resources
-            request_headers = (
-                self._service_account_token_client.escalate_request_headers(
-                    auth_info.request_headers
+            if mlrun.mlconf.is_iguazio_v4_mode():
+                # In IG4 as the project has already been deleted, it will no longer exist in the permission manifest at
+                # all, so we must escalate the request to have permissions to delete all project resources
+                request_headers = (
+                    self._service_account_token_client.escalate_request_headers(
+                        auth_info.request_headers
+                    )
                 )
-            )
+
             messaging_client.delete(
                 path=f"projects/{name}/alerts",
                 headers=request_headers,

--- a/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
@@ -523,11 +523,17 @@ def test_store_project(
 
 @pytest.mark.parametrize("iguazio_client", [("v4", "sync")], indirect=True)
 def test_delete_project(mock_session, iguazio_client, igv4_auth_info):
-    iguazio_client.delete_project(
-        mock_session, TEST_PROJECT_NAME, auth_info=igv4_auth_info
-    )
+    auth_headers = {"test": "test"}
+    with unittest.mock.patch(
+        "framework.utils.clients.service_account_token.Client.auth_headers",
+        auth_headers,
+    ):
+        iguazio_client.delete_project(
+            mock_session, TEST_PROJECT_NAME, auth_info=igv4_auth_info
+        )
+
     iguazio_client._client.set_override_auth_headers.assert_called_once_with(
-        igv4_auth_info.request_headers
+        auth_headers
     )
     iguazio_client._client.delete_project_policies.assert_called_once_with(
         project=TEST_PROJECT_NAME

--- a/server/py/services/api/tests/unit/utils/clients/test_service_account_token.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_service_account_token.py
@@ -16,6 +16,8 @@ from unittest import mock
 
 import pytest
 
+import mlrun.common.schemas
+
 import framework.utils.clients.service_account_token as service_account_token
 
 TEST_TOKEN = "test-token"
@@ -86,7 +88,7 @@ def test_auth_headers(patch_config, patch_is_token_expired):
     patch_is_token_expired.return_value = False
     client = service_account_token.Client()
     expected = {
-        "X-IGZ-Authenticator-Kind": "sa",
+        mlrun.common.schemas.HeaderNames.igz_authenticator_kind: "sa",
         "Authorization": f"Bearer {TEST_TOKEN}",
     }
     assert client.auth_headers == expected
@@ -98,7 +100,7 @@ def test_escalate_request_headers(patch_config, patch_is_token_expired):
     original = {"foo": "bar"}
     result = client.escalate_request_headers(original)
     assert result["foo"] == "bar"
-    assert result["X-IGZ-Authenticator-Kind"] == "sa"
+    assert result[mlrun.common.schemas.HeaderNames.igz_authenticator_kind] == "sa"
     assert result["Authorization"] == f"Bearer {TEST_TOKEN}"
 
 

--- a/server/py/services/api/tests/unit/utils/clients/test_service_account_token.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_service_account_token.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+import framework.utils.clients.service_account_token as service_account_token
+
+TEST_TOKEN = "test-token"
+TEST_NEW_TOKEN = "new-token"
+TEST_TOKEN_EXPIRATION_SECONDS = 3600
+TEST_TOKEN_EXPIRATION_BUFFER_SECONDS = TEST_TOKEN_EXPIRATION_SECONDS * 0.1
+
+
+@pytest.fixture
+def token_path(tmp_path):
+    token_file = tmp_path / "token"
+    token_file.write_text(TEST_TOKEN)
+    return str(token_file)
+
+
+@pytest.fixture
+def patch_config(token_path):
+    service_account_token_client = service_account_token.Client()
+    with (
+        mock.patch.object(
+            service_account_token_client,
+            "_TOKEN_PATH",
+            token_path,
+        ),
+        mock.patch.object(
+            service_account_token_client,
+            "_TOKEN_EXPIRATION_SECONDS",
+            TEST_TOKEN_EXPIRATION_SECONDS,
+        ),
+        mock.patch.object(
+            service_account_token_client,
+            "_TOKEN_EXPIRATION_BUFFER_SECONDS",
+            TEST_TOKEN_EXPIRATION_BUFFER_SECONDS,
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def patch_is_token_expired():
+    with mock.patch("mlrun.auth.utils.is_token_expired") as is_token_expired_mock:
+        yield is_token_expired_mock
+
+
+def test_token_read_and_cache(patch_config, patch_is_token_expired):
+    patch_is_token_expired.return_value = False
+    client = service_account_token.Client()
+    # First call should read from file and won't check expiration
+    token1 = client.token
+    assert token1 == TEST_TOKEN
+    # Second call should use cache and check expiration
+    token2 = client.token
+    assert token2 == TEST_TOKEN
+    # is_token_expired should be called only once
+    assert patch_is_token_expired.call_count == 1
+
+
+def test_token_expired_forces_reload(patch_config, patch_is_token_expired):
+    patch_is_token_expired.side_effect = [True, False]
+    client = service_account_token.Client()
+    with mock.patch("builtins.open", mock.mock_open(read_data=TEST_NEW_TOKEN)) as m:
+        token = client.token
+        assert token == TEST_NEW_TOKEN
+        m.assert_called_once_with(client._TOKEN_PATH)
+
+
+def test_auth_headers(patch_config, patch_is_token_expired):
+    patch_is_token_expired.return_value = False
+    client = service_account_token.Client()
+    expected = {
+        "X-IGZ-Authenticator-Kind": "sa",
+        "Authorization": f"Bearer {TEST_TOKEN}",
+    }
+    assert client.auth_headers == expected
+
+
+def test_escalate_request_headers(patch_config, patch_is_token_expired):
+    patch_is_token_expired.return_value = False
+    client = service_account_token.Client()
+    original = {"foo": "bar"}
+    result = client.escalate_request_headers(original)
+    assert result["foo"] == "bar"
+    assert result["X-IGZ-Authenticator-Kind"] == "sa"
+    assert result["Authorization"] == f"Bearer {TEST_TOKEN}"
+
+
+def test_token_file_missing(patch_config, patch_is_token_expired):
+    patch_is_token_expired.return_value = True
+    client = service_account_token.Client()
+    with mock.patch("builtins.open", side_effect=FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
+            _ = client.token
+
+
+def test_token_strip_whitespace(patch_config, patch_is_token_expired):
+    patch_is_token_expired.return_value = True
+    client = service_account_token.Client()
+    with mock.patch(
+        "builtins.open", mock.mock_open(read_data="  token-with-space  \n")
+    ):
+        token = client.token
+        assert token == "token-with-space"
+
+
+def test_singleton_behavior(patch_config, patch_is_token_expired):
+    patch_is_token_expired.return_value = False
+    client1 = service_account_token.Client()
+    client2 = service_account_token.Client()
+    assert client1 is client2

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -605,3 +605,33 @@ def test_resolve_jwt_subject(token, add_defaults, expected_sub):
     jwt_token = _create_jwt_token(token, add_defaults=add_defaults)
     result = mlrun.auth.utils.resolve_jwt_subject(jwt_token, raise_on_error=True)
     assert result == expected_sub
+
+
+@pytest.mark.parametrize(
+    "exp_offset, buffer_seconds, should_expire",
+    [
+        # Token expired 10 seconds ago, no buffer
+        (-10, 0, True),
+        # Token expires in 10 seconds, no buffer
+        (10, 0, False),
+        # Token expires in 10 seconds, buffer 15 seconds (should be expired)
+        (10, 15, True),
+        # Token expires in 10 seconds, buffer 5 seconds (should not be expired)
+        (10, 5, False),
+        # Token expires now, no buffer
+        (0, 0, True),
+    ],
+)
+def test_is_token_expired(exp_offset, buffer_seconds, should_expire):
+    exp = int(time.time()) + exp_offset
+    token = _create_jwt_token({"exp": exp, "sub": "user-1"}, add_defaults=False)
+    result = mlrun.auth.utils.is_token_expired(token, buffer_seconds=buffer_seconds)
+    assert result is should_expire
+
+
+def test_is_token_expired_missing_exp():
+    token = _create_jwt_token({"sub": "user-1"}, add_defaults=False)
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="Token is missing the 'exp'"
+    ):
+        mlrun.auth.utils.is_token_expired(token)


### PR DESCRIPTION
### 📝 Description
This pull request introduces enhancements and fixes related to authentication and service account token handling in the MLRun framework.

---

### 🛠️ Changes Made
- Introduced a `Claims` class for JWT claims constants in `mlrun/auth/utils.py`.
- Added `is_token_expired` and `_decode_token_unverified` utility functions for JWT token handling.
- Added a new `igz_authenticator_kind` header constant in `mlrun/common/schemas/constants.py`.
- Introduced a `service_account` configuration section in `mlrun/config.py` for Kubernetes service account tokens.
- Created a new `service_account_token.py` client for managing service account tokens.
- Updated Iguazio client logic to use the service account token for escalated requests.
- Added unit tests for the `service_account_token.py` client.
- Enhanced existing tests in `test_auth_utils.py` to cover token expiration scenarios.
- Made the delete project alerts functionality escalate to the service account token in case the project permissions are already removed

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added unit tests for the `service_account_token.py` client to validate token caching, expiration handling, and header escalation.
- Added unit tests in `test_auth_utils.py` to cover token expiration and missing claims scenarios.
- Verified changes manually in a Kubernetes environment to ensure proper handling of service account tokens.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11618

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Known issue: The `create_default_project_policies` method currently relies on incoming request auth info. Future updates to the Iguazio API are required to support explicit owner parameters.

