### PR TITLE
[Model Monitoring] Fix event loop blocking during model endpoint creation (ML-11826)

### DIFF
--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -1985,7 +1985,10 @@ class MonitoringDeployment:
         delete_background_task: fastapi.BackgroundTasks,
     ):
         async with semaphore:
-            result = framework.db.session.run_function_with_new_db_session(
+            # Use run_in_threadpool to avoid blocking the event loop
+            # while performing synchronous DB operations
+            result = await run_in_threadpool(
+                framework.db.session.run_function_with_new_db_session,
                 func=services.api.crud.ModelEndpoints().create_model_endpoints,
                 model_endpoints_instructions=model_endpoints_instructions,
                 project=project,


### PR DESCRIPTION
## Summary
Fixed a critical issue where deploying serving functions with many models (e.g., 5000) would cause:
- Deploy API requests to timeout (nginx 180s proxy-read-timeout)
- UI to become unresponsive during deployment
- Server appeared to complete processing but response never reached client

## Root Cause
The `_create_model_endpoint_limited` async function was calling `run_function_with_new_db_session()` synchronously, which blocked the event loop while creating model endpoints in the background task.

## Changes Made
- Wrapped the sync DB operation with `run_in_threadpool` to execute it in a thread pool worker without blocking the event loop

## Testing
- Verified with 5000 model deployment test
- Deploy API now responds in ~7s instead of timing out
- UI remains responsive during background model endpoint creation

## Reference
- Jira: ML-11826