### PR TITLE
[Datastore] Fix boto3 and botocore import errors

### DIFF
--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -59,7 +59,6 @@ from ..utils import logger
 from .base import DataItem
 from .datastore import StoreManager, in_memory_store, uri_to_ipython
 from .dbfs_store import DatabricksFileBugFixed, DatabricksFileSystemDisableCache
-from .s3 import parse_s3_bucket_and_key
 from .sources import (
     BigQuerySource,
     CSVSource,
@@ -75,7 +74,7 @@ from .store_resources import (
     parse_store_uri,
 )
 from .targets import CSVTarget, NoSqlTarget, ParquetTarget, StreamTarget
-from .utils import get_kafka_brokers_from_dict, parse_kafka_url
+from .utils import get_kafka_brokers_from_dict, parse_kafka_url, parse_s3_bucket_and_key
 
 store_manager = StoreManager()
 

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -18,6 +18,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import boto3
+import botocore.exceptions
 from boto3.s3.transfer import TransferConfig
 from fsspec.registry import get_filesystem_class
 
@@ -228,9 +229,17 @@ class S3Store(DataStore):
     def get(self, key, size=None, offset=0):
         bucket, key = self.get_bucket_and_key(key)
         obj = self.s3.Object(bucket, key)
-        if size or offset:
-            return obj.get(Range=S3Store.get_range(size, offset))["Body"].read()
-        return obj.get()["Body"].read()
+        try:
+            if size or offset:
+                return obj.get(Range=S3Store.get_range(size, offset))["Body"].read()
+            return obj.get()["Body"].read()
+
+        except botocore.exceptions.ClientError as exc:
+            if exc.response["Error"]["Code"] == "NoSuchKey":
+                # "NoSuchKey" errors codes - equivalent to `FileNotFoundError`
+                raise FileNotFoundError(f"s3://{bucket}/{key}") from exc
+            # Other errors are raised as-is
+            raise
 
     def put(self, key, data, append=False):
         data, _ = self._prepare_put_data(data, append)

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -24,6 +24,9 @@ from fsspec.registry import get_filesystem_class
 import mlrun.errors
 
 from .base import DataStore, FileStats, make_datastore_schema_sanitizer
+from .utils import parse_s3_bucket_and_key
+
+__all__ = ["parse_s3_bucket_and_key"]
 
 
 class S3Store(DataStore):
@@ -259,16 +262,3 @@ class S3Store(DataStore):
         #  In order to raise an error if there is connection error, ML-7056.
         self.filesystem.exists(path=path)
         self.filesystem.rm(path=path, recursive=recursive, maxdepth=maxdepth)
-
-
-def parse_s3_bucket_and_key(s3_path):
-    try:
-        path_parts = s3_path.replace("s3://", "").split("/")
-        bucket = path_parts.pop(0)
-        key = "/".join(path_parts)
-    except Exception as exc:
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            "failed to parse s3 bucket and key"
-        ) from exc
-
-    return bucket, key

--- a/mlrun/datastore/utils.py
+++ b/mlrun/datastore/utils.py
@@ -345,3 +345,16 @@ def parse_url(url):
 def accepts_param(func: callable, param_name):
     sig = inspect.signature(func)
     return param_name in sig.parameters
+
+
+def parse_s3_bucket_and_key(s3_path: str) -> tuple[str, str]:
+    try:
+        path_parts = s3_path.replace("s3://", "").split("/")
+        bucket = path_parts.pop(0)
+        key = "/".join(path_parts)
+    except Exception as exc:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "failed to parse s3 bucket and key"
+        ) from exc
+
+    return bucket, key

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -23,6 +23,7 @@ import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
+import mlrun.model_monitoring
 
 
 class RunDBError(Exception):

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -23,7 +23,6 @@ import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
-import mlrun.model_monitoring
 
 
 class RunDBError(Exception):

--- a/mlrun/model_monitoring/__init__.py
+++ b/mlrun/model_monitoring/__init__.py
@@ -15,5 +15,4 @@
 from mlrun.common.schemas import ModelEndpoint, ModelEndpointList
 
 from .db import get_tsdb_connector
-from .db._schedules import delete_model_monitoring_schedules_user_folder
 from .helpers import get_stream_path

--- a/mlrun/model_monitoring/db/_schedules.py
+++ b/mlrun/model_monitoring/db/_schedules.py
@@ -19,8 +19,6 @@ from datetime import datetime
 from types import TracebackType
 from typing import TYPE_CHECKING, Final, Optional
 
-import botocore.exceptions
-
 import mlrun
 import mlrun.common.schemas as schemas
 import mlrun.errors
@@ -84,16 +82,8 @@ class ModelMonitoringSchedulesFileBase(AbstractContextManager, ABC):
         except (
             mlrun.errors.MLRunNotFoundError,
             # Different errors are raised for S3 or local storage, see ML-8042
-            botocore.exceptions.ClientError,
             FileNotFoundError,
-        ) as err:
-            if (
-                isinstance(err, botocore.exceptions.ClientError)
-                # Add a log only to "NoSuchKey" errors codes - equivalent to `FileNotFoundError`
-                and err.response["Error"]["Code"] != "NoSuchKey"
-            ):
-                raise
-
+        ):
             logger.exception(
                 "The schedules file was not found. It should have been created "
                 "as a part of the model endpoint's creation",

--- a/mlrun/model_monitoring/db/_stats.py
+++ b/mlrun/model_monitoring/db/_stats.py
@@ -18,7 +18,6 @@ from abc import abstractmethod
 from datetime import UTC, datetime
 from typing import cast
 
-import botocore.exceptions
 import fsspec
 
 import mlrun.datastore.base
@@ -88,16 +87,8 @@ class ModelMonitoringStatsFile(abc.ABC):
         except (
             mlrun.errors.MLRunNotFoundError,
             # Different errors are raised for S3 or local storage, see ML-8042
-            botocore.exceptions.ClientError,
             FileNotFoundError,
         ) as err:
-            if (
-                isinstance(err, botocore.exceptions.ClientError)
-                # Add a log only to "NoSuchKey" errors codes - equivalent to `FileNotFoundError`
-                and err.response["Error"]["Code"] != "NoSuchKey"
-            ):
-                raise
-
             logger.warning(
                 "The Stats file was not found. It should have been created "
                 "as a part of the model endpoint's creation",

--- a/tests/datastore/test_s3.py
+++ b/tests/datastore/test_s3.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import botocore.exceptions
+import pytest
+
+from mlrun.datastore.s3 import S3Store
+
+
+class TestS3StoreExceptionHandling:
+    """Unit tests for S3Store exception handling logic.
+
+    Tests specifically cover the exception handling in the S3Store.get() method,
+    focusing on the conversion of NoSuchKey errors to FileNotFoundError.
+    """
+
+    @pytest.fixture
+    @patch("boto3.resource")
+    @patch("mlrun.datastore.s3.DataStore.__init__")
+    @patch("mlrun.datastore.s3.S3Store._get_secret_or_env")
+    def s3_store(
+        self,
+        mock_get_secret_or_env: Mock,
+        mock_datastore_init: Mock,
+        mock_boto3_resource: Mock,
+    ) -> S3Store:
+        """Create a real S3Store instance with mocked boto3 dependencies."""
+        mock_datastore_init.return_value = None
+        mock_get_secret_or_env.return_value = None  # No environment secrets
+
+        # Create real S3Store instance
+        s3_store = S3Store(
+            parent=None, schema="s3", name="test", endpoint="test-bucket", secrets=None
+        )
+
+        # Manually set up required attributes that DataStore.__init__ would normally set
+        s3_store._secrets = {}
+        s3_store._parent = None
+        s3_store.kind = "s3"
+        s3_store.name = "test"
+        s3_store.endpoint = "test-bucket"
+        s3_store._filesystem = None
+
+        # Mock required methods that might be called
+        s3_store._get_parent_secret = Mock(return_value=None)
+        s3_store._join = Mock(side_effect=lambda key: f"/{key}")
+        s3_store._prepare_put_data = Mock(return_value=(b"data", None))
+        s3_store._sanitize_options = Mock(side_effect=lambda x: x)
+
+        # Mock the boto3 resource
+        s3_store.s3 = mock_boto3_resource.return_value
+
+        return s3_store
+
+    @pytest.fixture
+    def mock_s3_obj(self, s3_store: S3Store) -> Mock:
+        """Create a mock S3 object for testing."""
+        mock_obj = Mock()
+        s3_store.s3.Object.return_value = mock_obj
+        return mock_obj
+
+    def test_get_handles_nosuchkey_error_raises_filenotfound(
+        self, s3_store: S3Store, mock_s3_obj: Mock
+    ) -> None:
+        """Test that NoSuchKey error is converted to FileNotFoundError.
+
+        Verifies that when AWS S3 returns a NoSuchKey error, the S3Store.get() method
+        correctly converts it to a FileNotFoundError with proper S3 URI format and
+        preserves the original exception as the cause.
+        """
+        # Create a mock ClientError with NoSuchKey error code
+        error_response = {
+            "Error": {
+                "Code": "NoSuchKey",
+                "Message": "The specified key does not exist.",
+            }
+        }
+        client_error = botocore.exceptions.ClientError(
+            error_response=error_response, operation_name="GetObject"
+        )
+
+        # Mock the object.get() method to raise the ClientError
+        mock_s3_obj.get.side_effect = client_error
+
+        # Test that FileNotFoundError is raised with correct message
+        with pytest.raises(FileNotFoundError) as exc_info:
+            s3_store.get("test-key")
+
+        assert str(exc_info.value) == "s3://test-bucket/test-key"
+        assert exc_info.value.__cause__ is client_error
+
+    def test_get_handles_nosuchkey_error_with_size_and_offset_raises_filenotfound(
+        self, s3_store: S3Store, mock_s3_obj: Mock
+    ) -> None:
+        """Test that NoSuchKey error is converted to FileNotFoundError when using range requests.
+
+        Verifies that partial read requests (with size and offset) also properly handle
+        NoSuchKey errors and that the Range header is correctly set.
+        """
+        # Create a mock ClientError with NoSuchKey error code
+        error_response = {
+            "Error": {
+                "Code": "NoSuchKey",
+                "Message": "The specified key does not exist.",
+            }
+        }
+        client_error = botocore.exceptions.ClientError(
+            error_response=error_response, operation_name="GetObject"
+        )
+
+        # Mock the object.get() method to raise the ClientError
+        mock_s3_obj.get.side_effect = client_error
+
+        # Test that FileNotFoundError is raised with size and offset parameters
+        with pytest.raises(FileNotFoundError) as exc_info:
+            s3_store.get("test-key", size=100, offset=50)
+
+        assert str(exc_info.value) == "s3://test-bucket/test-key"
+        assert exc_info.value.__cause__ is client_error
+
+        # Verify that get() was called with Range parameter
+        mock_s3_obj.get.assert_called_once_with(Range="bytes=50-149")
+
+    def test_get_reraises_other_client_errors(
+        self, s3_store: S3Store, mock_s3_obj: Mock
+    ) -> None:
+        """Test that non-NoSuchKey ClientErrors are re-raised as-is.
+
+        Ensures that other AWS errors (like AccessDenied) are not converted to
+        FileNotFoundError but are passed through unchanged.
+        """
+        # Create a mock ClientError with a different error code
+        error_response = {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}}
+        client_error = botocore.exceptions.ClientError(
+            error_response=error_response, operation_name="GetObject"
+        )
+
+        # Mock the object.get() method to raise the ClientError
+        mock_s3_obj.get.side_effect = client_error
+
+        # Test that the original ClientError is re-raised
+        with pytest.raises(botocore.exceptions.ClientError) as exc_info:
+            s3_store.get("test-key")
+
+        assert exc_info.value is client_error
+
+    def test_get_success_without_size_offset(
+        self, s3_store: S3Store, mock_s3_obj: Mock
+    ) -> None:
+        """Test successful get operation without size and offset.
+
+        Verifies the happy path where S3 returns data successfully for a full object read.
+        """
+        # Mock successful response
+        mock_body = Mock()
+        mock_body.read.return_value = b"test data"
+        mock_s3_obj.get.return_value = {"Body": mock_body}
+
+        result = s3_store.get("test-key")
+
+        assert result == b"test data"
+        mock_s3_obj.get.assert_called_once_with()
+
+    def test_get_success_with_size_and_offset(
+        self, s3_store: S3Store, mock_s3_obj: Mock
+    ) -> None:
+        """Test successful get operation with size and offset.
+
+        Verifies that partial read requests work correctly and generate proper Range headers.
+        """
+        # Mock successful response
+        mock_body = Mock()
+        mock_body.read.return_value = b"partial data"
+        mock_s3_obj.get.return_value = {"Body": mock_body}
+
+        result = s3_store.get("test-key", size=100, offset=50)
+
+        assert result == b"partial data"
+        mock_s3_obj.get.assert_called_once_with(Range="bytes=50-149")
+
+    def test_get_success_with_offset_only(
+        self, s3_store: S3Store, mock_s3_obj: Mock
+    ) -> None:
+        """Test successful get operation with offset only.
+
+        Verifies that reads from a specific offset to end-of-file work correctly.
+        """
+        # Mock successful response
+        mock_body = Mock()
+        mock_body.read.return_value = b"data from offset"
+        mock_s3_obj.get.return_value = {"Body": mock_body}
+
+        result = s3_store.get("test-key", offset=100)
+
+        assert result == b"data from offset"
+        mock_s3_obj.get.assert_called_once_with(Range="bytes=100-")
+
+    def test_get_range_static_method(self) -> None:
+        """Test the static get_range method used by get().
+
+        Verifies that the Range header generation logic works correctly for various
+        combinations of size and offset parameters.
+        """
+        # Test with size and offset
+        range_header = S3Store.get_range(100, 50)
+        assert range_header == "bytes=50-149"
+
+        # Test with offset only (size=None)
+        range_header = S3Store.get_range(None, 100)
+        assert range_header == "bytes=100-"
+
+        # Test with size=0 (should be treated as no size)
+        range_header = S3Store.get_range(0, 50)
+        assert range_header == "bytes=50-"

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -62,6 +62,9 @@ from mlrun.model_monitoring.applications import (
     histogram_data_drift,
 )
 from mlrun.model_monitoring.applications.evidently import SUPPORTED_EVIDENTLY_VERSION
+from mlrun.model_monitoring.db._schedules import (
+    delete_model_monitoring_schedules_user_folder,
+)
 from mlrun.utils.logger import Logger
 from mlrun.utils.v3io_clients import get_v3io_client
 from tests.system.base import TestMLRunSystem
@@ -2137,9 +2140,7 @@ class TestAppJobModelEndpointData(TestMLRunSystemModelMonitoring):
             executor.submit(self._deploy_model_serving)
 
     def custom_teardown(self) -> None:
-        mlrun.model_monitoring.delete_model_monitoring_schedules_user_folder(
-            self.project_name
-        )
+        delete_model_monitoring_schedules_user_folder(self.project_name)
         return super().custom_teardown()
 
     @pytest.mark.parametrize("run_local", [False, True])


### PR DESCRIPTION
### 📝 Description

This PR fixes the `import mlrun` errors introduced from `1.11.0-rc14`.
A new `nuclio-jupyter` version removed the `boto3` (https://github.com/nuclio/nuclio-jupyter/pull/194):

> 3. Remove boto3 from required deps - Moved to optional [boto3] extra for backward compatibility

And it revealed two bugs:

1. `import mlrun` boils down to `import boto3` and `import botocore` in other imported mlrun modules.
2. The package test is faulty. This is a separate issue, to be handled in [ML-11948](https://iguazio.atlassian.net/browse/ML-11948).

This PR moved the boto3/botocore imports to the `mlrun.datastore.s3` module, where they should be (and only there).
It also adds unit tests, removed unneeded imports, and moves some code the the proper module.

---

### ✅ Checklist

- [x] I have tested the changes in this PR

---

### 🧪 Testing

I packaged mlrun locally with

```sh
make package-wheel
```

Created a clean Python 3.11 venv, installed the mlrun wheel in it, and ran

```sh
python -c "import mlrun"
```

---

### 🔗 References
- Ticket link: [ML-11946](https://iguazio.atlassian.net/browse/ML-11946)

---

### 🚨 Breaking Changes?

There is a small breaking change in the error returned from `S3Store.get`. When the object does not exist, a `FileNotFound` error will be raised.

[ML-11946]: https://iguazio.atlassian.net/browse/ML-11946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ML-11948]: https://iguazio.atlassian.net/browse/ML-11948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ