### PR TITLE
[Nuclio] Add RabbitMQ trigger support (ML-7879)

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -60,6 +60,7 @@ def extra_requirements() -> dict[str, list[str]]:
             # because confluent kafka supports avro format by default
             "avro~=1.11",
         ],
+        "rabbitmq": ["pika~=1.3"],
         "redis": ["redis~=4.3"],
         "databricks-sdk": ["databricks-sdk~=0.20.0"],
         "sqlalchemy": ["sqlalchemy~=2.0"],

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -36,6 +36,7 @@ google-cloud-bigquery-storage~=2.17
 google-cloud==0.34
 kafka-python~=2.1.0
 avro~=1.11
+pika~=1.3
 redis~=4.3
 graphviz~=0.20.0
 # any newer version then 0.13 should be tested with adlfs,gcsfs and s3fs installation.

--- a/mlrun/datastore/__init__.py
+++ b/mlrun/datastore/__init__.py
@@ -45,6 +45,7 @@ import mlrun.datastore.wasbfs
 from mlrun.datastore.datastore_profile import (
     DatastoreProfileKafkaStream,
     DatastoreProfileKafkaTarget,
+    DatastoreProfileRabbitMQ,
     DatastoreProfileV3io,
 )
 from mlrun.datastore.model_provider.model_provider import ModelProvider

--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -221,6 +221,72 @@ class DatastoreProfileKafkaSource(DatastoreProfileKafkaStream):
     type: str = pydantic.v1.Field("kafka_source")
 
 
+class DatastoreProfileRabbitMQ(DatastoreProfile):
+    """
+    Datastore profile for RabbitMQ connections.
+
+    Used to configure RabbitMQ triggers for Nuclio functions.
+
+    Example::
+
+        profile = DatastoreProfileRabbitMQ(
+            name="my-rabbitmq",
+            broker_url="amqp://rabbitmq-host:5672",
+            exchange_name="my-exchange",
+            queue_name="my-queue",
+            username="user",
+            password="secret",
+        )
+        project.register_datastore_profile(profile)
+
+        # Then use in trigger:
+        function.add_rabbitmq_trigger(url="ds://my-rabbitmq")
+    """
+
+    type: str = "rabbitmq"
+    _private_attributes = ("password", "username")
+
+    broker_url: str
+    exchange_name: str
+    queue_name: typing.Optional[str] = None
+    topics: typing.Optional[typing.Union[str, list[str]]] = None
+    username: typing.Optional[str] = None
+    password: typing.Optional[str] = None
+    prefetch_count: int = 0
+    durable_exchange: bool = False
+    durable_queue: bool = False
+    on_error: str = "nack"
+    requeue_on_error: bool = False
+    reconnect_duration: str = "5m"
+    reconnect_interval: str = "15s"
+    num_workers: int = 1
+    worker_termination_timeout: str = "10s"
+
+    def attributes(self) -> dict[str, typing.Any]:
+        """Return trigger attributes dictionary."""
+        topics = self.topics
+        if isinstance(topics, str):
+            topics = [topics]
+
+        return {
+            "url": self.broker_url,
+            "exchange_name": self.exchange_name,
+            "queue_name": self.queue_name,
+            "topics": topics,
+            "username": self.username,
+            "password": self.password,
+            "prefetch_count": self.prefetch_count,
+            "durable_exchange": self.durable_exchange,
+            "durable_queue": self.durable_queue,
+            "on_error": self.on_error,
+            "requeue_on_error": self.requeue_on_error,
+            "reconnect_duration": self.reconnect_duration,
+            "reconnect_interval": self.reconnect_interval,
+            "num_workers": self.num_workers,
+            "worker_termination_timeout": self.worker_termination_timeout,
+        }
+
+
 class DatastoreProfileV3io(DatastoreProfile):
     type: str = pydantic.v1.Field("v3io")
     v3io_access_key: typing.Optional[str] = None
@@ -592,6 +658,7 @@ _DATASTORE_TYPE_TO_PROFILE_CLASS: dict[str, type[DatastoreProfile]] = {
     "config": ConfigProfile,
     "openai": OpenAIProfile,
     "huggingface": HuggingFaceProfile,
+    "rabbitmq": DatastoreProfileRabbitMQ,
 }
 
 

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -20,7 +20,6 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from time import sleep
-from urllib.parse import urlparse, urlunparse
 
 import inflection
 import nuclio
@@ -50,7 +49,7 @@ from mlrun.platforms.iguazio import (
 )
 from mlrun.runtimes.base import FunctionStatus, RunError
 from mlrun.runtimes.mounts import VolumeMount, mount_v3io, v3io_cred
-from mlrun.runtimes.nuclio.triggers import RabbitMQTrigger
+from mlrun.runtimes.nuclio.triggers import RabbitMQTrigger, extract_credentials_from_url
 from mlrun.runtimes.pod import KubeResource, KubeResourceSpec
 from mlrun.runtimes.utils import get_item_name, log_std
 from mlrun.utils import get_in, logger, update_in
@@ -1254,37 +1253,20 @@ class RemoteRuntime(KubeResource):
         if not url or not isinstance(url, str):
             return
 
-        try:
-            parsed = urlparse(url)
-        except Exception:
-            raise mlrun.errors.MLRunValueError("invalid URL format")
+        creds = extract_credentials_from_url(url)
 
         # Only process if credentials are present in the URL
-        if not (parsed.username or parsed.password):
+        if not creds.username and not creds.password:
             return
 
-        # Extract credentials
-        username = parsed.username or ""
-        password = parsed.password or ""
-
-        # Reconstruct clean URL
-        hostname = parsed.hostname or ""
-        netloc = f"{hostname}:{parsed.port}" if parsed.port else hostname
-
-        clean_url = urlunparse(
-            (
-                parsed.scheme,
-                netloc,
-                parsed.path,
-                parsed.params,
-                parsed.query,
-                parsed.fragment,
-            )
-        )
-
         # Update trigger safely
-        trigger["url"] = clean_url
-        trigger.update({"username": username, "password": password})
+        trigger["url"] = creds.url
+        trigger.update(
+            {
+                "username": creds.username or "",
+                "password": creds.password or "",
+            }
+        )
 
     def _trigger_of_kind_exists(self, kind: str) -> bool:
         if not self.spec.config:

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -50,6 +50,7 @@ from mlrun.platforms.iguazio import (
 )
 from mlrun.runtimes.base import FunctionStatus, RunError
 from mlrun.runtimes.mounts import VolumeMount, mount_v3io, v3io_cred
+from mlrun.runtimes.nuclio.triggers import RabbitMQTrigger
 from mlrun.runtimes.pod import KubeResource, KubeResourceSpec
 from mlrun.runtimes.utils import get_item_name, log_std
 from mlrun.utils import get_in, logger, update_in
@@ -657,6 +658,106 @@ class RemoteRuntime(KubeResource):
             logger.warning(f"Setting function replicas to {shards}")
             self.spec.min_replicas = shards
             self.spec.max_replicas = shards
+
+    def add_rabbitmq_trigger(
+        self,
+        url: str,
+        exchange_name: typing.Optional[str] = None,
+        name: str = "rabbitmq",
+        queue_name: typing.Optional[str] = None,
+        topics: typing.Optional[list[str]] = None,
+        username: typing.Optional[str] = None,
+        password: typing.Optional[str] = None,
+        prefetch_count: typing.Optional[int] = None,
+        durable_exchange: typing.Optional[bool] = None,
+        durable_queue: typing.Optional[bool] = None,
+        on_error: typing.Optional[str] = None,
+        requeue_on_error: typing.Optional[bool] = None,
+        reconnect_duration: typing.Optional[str] = None,
+        reconnect_interval: typing.Optional[str] = None,
+        num_workers: typing.Optional[int] = None,
+        worker_termination_timeout: typing.Optional[str] = None,
+    ):
+        """Add a RabbitMQ trigger to the function.
+
+        Allows consuming messages from RabbitMQ queues or topic-based routing.
+        See https://docs.nuclio.io/en/latest/reference/triggers/rabbitmq.html for more details.
+
+        :param url:                       RabbitMQ connection URL in AMQP format
+                                          (e.g., 'amqp://host:port' or 'amqp://user:pass@host:port')
+                                          or a datastore profile URL (e.g., 'ds://profile-name')
+        :param exchange_name:             The exchange that contains the queue (required unless
+                                          using a datastore profile that provides it)
+        :param name:                      Trigger name (default: 'rabbitmq')
+        :param queue_name:                Specific queue to consume from. Either queue_name or
+                                          topics must be specified, but not both.
+        :param topics:                    List of topics (routing keys) to subscribe to. Creates
+                                          a unique queue and binds it to these routing keys. Either
+                                          queue_name or topics must be specified, but not both.
+        :param username:                  RabbitMQ username (can also be embedded in URL)
+        :param password:                  RabbitMQ password (can also be embedded in URL)
+        :param prefetch_count:            Broker channel prefetch limit (0 = unlimited)
+        :param durable_exchange:          Whether the exchange should survive broker restart
+        :param durable_queue:             Whether the queue should survive broker restart
+        :param on_error:                  Error handling strategy: 'ack' or 'nack'
+        :param requeue_on_error:          Whether to requeue failed messages (when on_error='nack')
+        :param reconnect_duration:        Total time to attempt reconnection (e.g., '5m')
+        :param reconnect_interval:        Time between reconnection attempts (e.g., '15s')
+        :param num_workers:               Number of workers processing messages concurrently
+        :param worker_termination_timeout: Timeout for worker termination (e.g., '10s')
+
+        Example usage::
+
+            function.add_rabbitmq_trigger(
+                url="amqp://rabbitmq-host:5672",
+                exchange_name="my-exchange",
+                queue_name="my-queue",
+                username="user",
+                password="pass",
+            )
+
+        Or with topics (routing keys)::
+
+            function.add_rabbitmq_trigger(
+                url="amqp://rabbitmq-host:5672",
+                exchange_name="my-exchange",
+                topics=["key1", "key2"],
+            )
+
+        Or using a datastore profile::
+
+            function.add_rabbitmq_trigger(url="ds://my-rabbitmq-profile")
+
+        When using a datastore profile (ds:// URL), all parameters from the profile
+        are used as defaults. Any parameter explicitly passed to this method will
+        override the corresponding profile value, including falsy values like 0 or False::
+
+            # Profile has prefetch_count=10, but explicit 0 overrides it
+            function.add_rabbitmq_trigger(
+                url="ds://my-rabbitmq-profile",
+                prefetch_count=0,  # Overrides profile's prefetch_count=10
+            )
+        """
+        self.add_trigger(
+            name,
+            RabbitMQTrigger(
+                url=url,
+                exchange_name=exchange_name,
+                queue_name=queue_name,
+                topics=topics,
+                username=username,
+                password=password,
+                prefetch_count=prefetch_count,
+                durable_exchange=durable_exchange,
+                durable_queue=durable_queue,
+                on_error=on_error,
+                requeue_on_error=requeue_on_error,
+                reconnect_duration=reconnect_duration,
+                reconnect_interval=reconnect_interval,
+                num_workers=num_workers,
+                worker_termination_timeout=worker_termination_timeout,
+            ),
+        )
 
     def deploy(
         self,

--- a/mlrun/runtimes/nuclio/triggers.py
+++ b/mlrun/runtimes/nuclio/triggers.py
@@ -86,13 +86,12 @@ class RabbitMQTrigger(NuclioTrigger):
         :param url:                       RabbitMQ connection URL in AMQP format
                                           (e.g., 'amqp://host:port' or 'amqp://user:pass@host:port')
                                           or a datastore profile URL (e.g., 'ds://profile-name')
-        :param exchange_name:             The exchange that contains the queue (required unless
-                                          using a datastore profile)
-        :param queue_name:                Specific queue to consume from. Either queue_name or
-                                          topics must be specified, but not both.
+        :param exchange_name:             The exchange that contains the queue
+        :param queue_name:                Specific queue to consume from. Mutually exclusive
+                                          with topics.
         :param topics:                    List of topics (routing keys) to subscribe to. Creates
-                                          a unique queue and binds it to these routing keys. Either
-                                          queue_name or topics must be specified, but not both.
+                                          a unique queue and binds it to these routing keys.
+                                          Mutually exclusive with queue_name.
         :param username:                  RabbitMQ username (can also be embedded in URL)
         :param password:                  RabbitMQ password (can also be embedded in URL)
         :param prefetch_count:            Broker channel prefetch limit (0 = unlimited)
@@ -152,38 +151,12 @@ class RabbitMQTrigger(NuclioTrigger):
             if worker_termination_timeout is None:
                 worker_termination_timeout = attrs.get("worker_termination_timeout")
 
-        # Apply defaults for parameters still None after profile merge
-        if prefetch_count is None:
-            prefetch_count = 0
-        if durable_exchange is None:
-            durable_exchange = False
-        if durable_queue is None:
-            durable_queue = False
-        if on_error is None:
-            on_error = "nack"
-        if requeue_on_error is None:
-            requeue_on_error = False
-        if reconnect_duration is None:
-            reconnect_duration = "5m"
-        if reconnect_interval is None:
-            reconnect_interval = "15s"
-        if num_workers is None:
-            num_workers = 1
-        if worker_termination_timeout is None:
-            worker_termination_timeout = "10s"
-
-        # Validate exchange_name is provided
-        if not exchange_name:
-            raise ValueError("exchange_name is required")
-
-        # Validate that exactly one of queue_name or topics is specified
+        # Validate that queue_name and topics are mutually exclusive
         if queue_name and topics:
             raise ValueError("Cannot specify both queue_name and topics. Choose one.")
-        if not queue_name and not topics:
-            raise ValueError("Must specify either queue_name or topics.")
 
-        # Validate on_error value
-        if on_error not in ("ack", "nack"):
+        # Validate on_error value if provided
+        if on_error is not None and on_error not in ("ack", "nack"):
             raise ValueError(f"on_error must be 'ack' or 'nack', got '{on_error}'")
 
         # Extract credentials from URL if not provided explicitly
@@ -203,32 +176,40 @@ class RabbitMQTrigger(NuclioTrigger):
                 clean_url += parsed_url.path
             url = clean_url
 
-        # Build the trigger structure
+        # Build the trigger structure with only non-None values
+        # Let Nuclio handle defaults for unspecified parameters
         struct = {
             "kind": self.kind,
             "url": url,
-            "numWorkers": num_workers,
-            "workerTerminationTimeout": worker_termination_timeout,
-            "attributes": {
-                "exchangeName": exchange_name,
-                "reconnectDuration": reconnect_duration,
-                "reconnectInterval": reconnect_interval,
-                "prefetchCount": prefetch_count,
-                "durableExchange": durable_exchange,
-                "durableQueue": durable_queue,
-            },
+            "attributes": {},
         }
 
-        # Add queue_name or topics
-        if queue_name:
-            struct["attributes"]["queueName"] = queue_name
-        if topics:
-            struct["attributes"]["topics"] = topics
+        # Add optional top-level parameters
+        if num_workers is not None:
+            struct["numWorkers"] = num_workers
+        if worker_termination_timeout is not None:
+            struct["workerTerminationTimeout"] = worker_termination_timeout
 
-        # Add error handling configuration
-        if on_error:
+        # Add optional attributes
+        if exchange_name is not None:
+            struct["attributes"]["exchangeName"] = exchange_name
+        if queue_name is not None:
+            struct["attributes"]["queueName"] = queue_name
+        if topics is not None:
+            struct["attributes"]["topics"] = topics
+        if reconnect_duration is not None:
+            struct["attributes"]["reconnectDuration"] = reconnect_duration
+        if reconnect_interval is not None:
+            struct["attributes"]["reconnectInterval"] = reconnect_interval
+        if prefetch_count is not None:
+            struct["attributes"]["prefetchCount"] = prefetch_count
+        if durable_exchange is not None:
+            struct["attributes"]["durableExchange"] = durable_exchange
+        if durable_queue is not None:
+            struct["attributes"]["durableQueue"] = durable_queue
+        if on_error is not None:
             struct["attributes"]["onError"] = on_error
-        if requeue_on_error:
+        if requeue_on_error is not None:
             struct["attributes"]["requeueOnError"] = requeue_on_error
 
         # Add credentials if provided

--- a/mlrun/runtimes/nuclio/triggers.py
+++ b/mlrun/runtimes/nuclio/triggers.py
@@ -1,0 +1,240 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+from urllib.parse import urlparse
+
+from nuclio.triggers import NuclioTrigger
+
+
+class RabbitMQTrigger(NuclioTrigger):
+    """
+    RabbitMQ trigger for Nuclio functions.
+
+    Allows consuming messages from RabbitMQ queues or topic-based routing.
+
+    See https://docs.nuclio.io/en/latest/reference/triggers/rabbitmq.html for more details.
+
+    Example usage::
+
+        trigger = RabbitMQTrigger(
+            url="amqp://rabbitmq-host:5672",
+            exchange_name="my-exchange",
+            queue_name="my-queue",
+            username="user",
+            password="pass",
+        )
+        function.add_trigger("my-rabbitmq-trigger", trigger)
+
+    Or with topics (routing keys)::
+
+        trigger = RabbitMQTrigger(
+            url="amqp://rabbitmq-host:5672",
+            exchange_name="my-exchange",
+            topics=["key1", "key2"],
+        )
+
+    Or using a datastore profile::
+
+        trigger = RabbitMQTrigger(url="ds://my-rabbitmq-profile")
+
+    When using a datastore profile (ds:// URL), all parameters from the profile
+    are used as defaults. Any parameter explicitly passed will override the
+    corresponding profile value, including falsy values like 0 or False::
+
+        # Profile has prefetch_count=10, but explicit 0 overrides it
+        trigger = RabbitMQTrigger(
+            url="ds://my-rabbitmq-profile",
+            prefetch_count=0,  # Overrides profile's prefetch_count=10
+        )
+    """
+
+    kind = "rabbit-mq"
+
+    def __init__(
+        self,
+        url: str,
+        exchange_name: Optional[str] = None,
+        queue_name: Optional[str] = None,
+        topics: Optional[list[str]] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        prefetch_count: Optional[int] = None,
+        durable_exchange: Optional[bool] = None,
+        durable_queue: Optional[bool] = None,
+        on_error: Optional[str] = None,
+        requeue_on_error: Optional[bool] = None,
+        reconnect_duration: Optional[str] = None,
+        reconnect_interval: Optional[str] = None,
+        num_workers: Optional[int] = None,
+        worker_termination_timeout: Optional[str] = None,
+    ):
+        """
+        Initialize a RabbitMQ trigger.
+
+        :param url:                       RabbitMQ connection URL in AMQP format
+                                          (e.g., 'amqp://host:port' or 'amqp://user:pass@host:port')
+                                          or a datastore profile URL (e.g., 'ds://profile-name')
+        :param exchange_name:             The exchange that contains the queue (required unless
+                                          using a datastore profile)
+        :param queue_name:                Specific queue to consume from. Either queue_name or
+                                          topics must be specified, but not both.
+        :param topics:                    List of topics (routing keys) to subscribe to. Creates
+                                          a unique queue and binds it to these routing keys. Either
+                                          queue_name or topics must be specified, but not both.
+        :param username:                  RabbitMQ username (can also be embedded in URL)
+        :param password:                  RabbitMQ password (can also be embedded in URL)
+        :param prefetch_count:            Broker channel prefetch limit (0 = unlimited)
+        :param durable_exchange:          Whether the exchange should survive broker restart
+        :param durable_queue:             Whether the queue should survive broker restart
+        :param on_error:                  Error handling strategy: 'ack' or 'nack'
+        :param requeue_on_error:          Whether to requeue failed messages (when on_error='nack')
+        :param reconnect_duration:        Total time to attempt reconnection (e.g., '5m')
+        :param reconnect_interval:        Time between reconnection attempts (e.g., '15s')
+        :param num_workers:               Number of workers processing messages concurrently
+        :param worker_termination_timeout: Timeout for worker termination (e.g., '10s')
+        """
+        # Handle datastore profile URL
+        if url.startswith("ds://"):
+            from mlrun.datastore.datastore_profile import (
+                DatastoreProfileRabbitMQ,
+                datastore_profile_read,
+            )
+
+            datastore_profile = datastore_profile_read(url)
+            if not isinstance(datastore_profile, DatastoreProfileRabbitMQ):
+                raise ValueError(
+                    f"Unexpected datastore profile type: {datastore_profile.type}. "
+                    "Only DatastoreProfileRabbitMQ is supported."
+                )
+
+            # Get attributes from profile, explicit params override profile values
+            # Use 'is None' checks to properly handle falsy values like 0 and False
+            attrs = datastore_profile.attributes()
+            url = attrs["url"]
+            if exchange_name is None:
+                exchange_name = attrs.get("exchange_name")
+            if queue_name is None:
+                queue_name = attrs.get("queue_name")
+            if topics is None:
+                topics = attrs.get("topics")
+            if username is None:
+                username = attrs.get("username")
+            if password is None:
+                password = attrs.get("password")
+            if prefetch_count is None:
+                prefetch_count = attrs.get("prefetch_count")
+            if durable_exchange is None:
+                durable_exchange = attrs.get("durable_exchange")
+            if durable_queue is None:
+                durable_queue = attrs.get("durable_queue")
+            if on_error is None:
+                on_error = attrs.get("on_error")
+            if requeue_on_error is None:
+                requeue_on_error = attrs.get("requeue_on_error")
+            if reconnect_duration is None:
+                reconnect_duration = attrs.get("reconnect_duration")
+            if reconnect_interval is None:
+                reconnect_interval = attrs.get("reconnect_interval")
+            if num_workers is None:
+                num_workers = attrs.get("num_workers")
+            if worker_termination_timeout is None:
+                worker_termination_timeout = attrs.get("worker_termination_timeout")
+
+        # Apply defaults for parameters still None after profile merge
+        if prefetch_count is None:
+            prefetch_count = 0
+        if durable_exchange is None:
+            durable_exchange = False
+        if durable_queue is None:
+            durable_queue = False
+        if on_error is None:
+            on_error = "nack"
+        if requeue_on_error is None:
+            requeue_on_error = False
+        if reconnect_duration is None:
+            reconnect_duration = "5m"
+        if reconnect_interval is None:
+            reconnect_interval = "15s"
+        if num_workers is None:
+            num_workers = 1
+        if worker_termination_timeout is None:
+            worker_termination_timeout = "10s"
+
+        # Validate exchange_name is provided
+        if not exchange_name:
+            raise ValueError("exchange_name is required")
+
+        # Validate that exactly one of queue_name or topics is specified
+        if queue_name and topics:
+            raise ValueError("Cannot specify both queue_name and topics. Choose one.")
+        if not queue_name and not topics:
+            raise ValueError("Must specify either queue_name or topics.")
+
+        # Validate on_error value
+        if on_error not in ("ack", "nack"):
+            raise ValueError(f"on_error must be 'ack' or 'nack', got '{on_error}'")
+
+        # Extract credentials from URL if not provided explicitly
+        parsed_url = urlparse(url)
+        if parsed_url.username and not username:
+            username = parsed_url.username
+        if parsed_url.password and not password:
+            password = parsed_url.password
+
+        # Build clean URL without credentials if they were embedded
+        if parsed_url.username or parsed_url.password:
+            # Reconstruct URL without credentials
+            clean_url = f"{parsed_url.scheme}://{parsed_url.hostname}"
+            if parsed_url.port:
+                clean_url += f":{parsed_url.port}"
+            if parsed_url.path:
+                clean_url += parsed_url.path
+            url = clean_url
+
+        # Build the trigger structure
+        struct = {
+            "kind": self.kind,
+            "url": url,
+            "numWorkers": num_workers,
+            "workerTerminationTimeout": worker_termination_timeout,
+            "attributes": {
+                "exchangeName": exchange_name,
+                "reconnectDuration": reconnect_duration,
+                "reconnectInterval": reconnect_interval,
+                "prefetchCount": prefetch_count,
+                "durableExchange": durable_exchange,
+                "durableQueue": durable_queue,
+            },
+        }
+
+        # Add queue_name or topics
+        if queue_name:
+            struct["attributes"]["queueName"] = queue_name
+        if topics:
+            struct["attributes"]["topics"] = topics
+
+        # Add error handling configuration
+        if on_error:
+            struct["attributes"]["onError"] = on_error
+        if requeue_on_error:
+            struct["attributes"]["requeueOnError"] = requeue_on_error
+
+        # Add credentials if provided
+        if username:
+            struct["username"] = username
+        if password:
+            struct["password"] = password
+
+        super().__init__(struct)

--- a/mlrun/runtimes/nuclio/triggers.py
+++ b/mlrun/runtimes/nuclio/triggers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import NamedTuple, Optional
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 from nuclio.triggers import NuclioTrigger
 
@@ -36,7 +36,7 @@ def _first_not_none(*values):
     return None
 
 
-def _extract_credentials_from_url(url: str) -> UrlCredentials:
+def extract_credentials_from_url(url: str) -> UrlCredentials:
     """
     Extract credentials from URL and return clean URL without embedded credentials.
 
@@ -51,11 +51,18 @@ def _extract_credentials_from_url(url: str) -> UrlCredentials:
         return UrlCredentials(url, None, None)
 
     # Reconstruct URL without credentials
-    clean_url = f"{parsed.scheme}://{parsed.hostname}"
-    if parsed.port:
-        clean_url += f":{parsed.port}"
-    if parsed.path:
-        clean_url += parsed.path
+    hostname = parsed.hostname or ""
+    netloc = f"{hostname}:{parsed.port}" if parsed.port else hostname
+    clean_url = urlunparse(
+        (
+            parsed.scheme,
+            netloc,
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
 
     # Decode URL-encoded characters (e.g., %40 -> @, %20 -> space)
     username = unquote(parsed.username) if parsed.username else None
@@ -190,7 +197,7 @@ class RabbitMQTrigger(NuclioTrigger):
             )
 
         # Extract credentials from URL if not provided explicitly
-        creds = _extract_credentials_from_url(url)
+        creds = extract_credentials_from_url(url)
         url = creds.url
         username = _first_not_none(username, creds.username)
         password = _first_not_none(password, creds.password)

--- a/mlrun/runtimes/nuclio/triggers.py
+++ b/mlrun/runtimes/nuclio/triggers.py
@@ -12,10 +12,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-from urllib.parse import urlparse
+from typing import NamedTuple, Optional
+from urllib.parse import unquote, urlparse
 
 from nuclio.triggers import NuclioTrigger
+
+import mlrun.datastore.datastore_profile
+
+
+class UrlCredentials(NamedTuple):
+    """Parsed URL with extracted and decoded credentials."""
+
+    url: str
+    username: Optional[str]
+    password: Optional[str]
+
+
+def _first_not_none(*values):
+    """Return the first non-None value, or None if all are None."""
+    for v in values:
+        if v is not None:
+            return v
+    return None
+
+
+def _extract_credentials_from_url(url: str) -> UrlCredentials:
+    """
+    Extract credentials from URL and return clean URL without embedded credentials.
+
+    Credentials are URL-decoded to handle special characters (e.g., %40 -> @).
+
+    :param url: URL that may contain embedded credentials (e.g., 'amqp://user:pass@host:port')
+    :return: UrlCredentials with clean_url, decoded username, and decoded password
+    """
+    parsed = urlparse(url)
+
+    if not parsed.username and not parsed.password:
+        return UrlCredentials(url, None, None)
+
+    # Reconstruct URL without credentials
+    clean_url = f"{parsed.scheme}://{parsed.hostname}"
+    if parsed.port:
+        clean_url += f":{parsed.port}"
+    if parsed.path:
+        clean_url += parsed.path
+
+    # Decode URL-encoded characters (e.g., %40 -> @, %20 -> space)
+    username = unquote(parsed.username) if parsed.username else None
+    password = unquote(parsed.password) if parsed.password else None
+
+    return UrlCredentials(clean_url, username, password)
 
 
 class RabbitMQTrigger(NuclioTrigger):
@@ -104,118 +150,88 @@ class RabbitMQTrigger(NuclioTrigger):
         :param num_workers:               Number of workers processing messages concurrently
         :param worker_termination_timeout: Timeout for worker termination (e.g., '10s')
         """
-        # Handle datastore profile URL
+        # Handle datastore profile URL - merge profile values with explicit params
         if url.startswith("ds://"):
-            from mlrun.datastore.datastore_profile import (
-                DatastoreProfileRabbitMQ,
-                datastore_profile_read,
-            )
-
-            datastore_profile = datastore_profile_read(url)
-            if not isinstance(datastore_profile, DatastoreProfileRabbitMQ):
+            profile = mlrun.datastore.datastore_profile.datastore_profile_read(url)
+            if not isinstance(
+                profile, mlrun.datastore.datastore_profile.DatastoreProfileRabbitMQ
+            ):
                 raise ValueError(
-                    f"Unexpected datastore profile type: {datastore_profile.type}. "
+                    f"Unexpected datastore profile type: {profile.type}. "
                     "Only DatastoreProfileRabbitMQ is supported."
                 )
-
-            # Get attributes from profile, explicit params override profile values
-            # Use 'is None' checks to properly handle falsy values like 0 and False
-            attrs = datastore_profile.attributes()
+            attrs = profile.attributes()
             url = attrs["url"]
-            if exchange_name is None:
-                exchange_name = attrs.get("exchange_name")
-            if queue_name is None:
-                queue_name = attrs.get("queue_name")
-            if topics is None:
-                topics = attrs.get("topics")
-            if username is None:
-                username = attrs.get("username")
-            if password is None:
-                password = attrs.get("password")
-            if prefetch_count is None:
-                prefetch_count = attrs.get("prefetch_count")
-            if durable_exchange is None:
-                durable_exchange = attrs.get("durable_exchange")
-            if durable_queue is None:
-                durable_queue = attrs.get("durable_queue")
-            if on_error is None:
-                on_error = attrs.get("on_error")
-            if requeue_on_error is None:
-                requeue_on_error = attrs.get("requeue_on_error")
-            if reconnect_duration is None:
-                reconnect_duration = attrs.get("reconnect_duration")
-            if reconnect_interval is None:
-                reconnect_interval = attrs.get("reconnect_interval")
-            if num_workers is None:
-                num_workers = attrs.get("num_workers")
-            if worker_termination_timeout is None:
-                worker_termination_timeout = attrs.get("worker_termination_timeout")
+            exchange_name = _first_not_none(exchange_name, attrs.get("exchange_name"))
+            queue_name = _first_not_none(queue_name, attrs.get("queue_name"))
+            topics = _first_not_none(topics, attrs.get("topics"))
+            username = _first_not_none(username, attrs.get("username"))
+            password = _first_not_none(password, attrs.get("password"))
+            prefetch_count = _first_not_none(
+                prefetch_count, attrs.get("prefetch_count")
+            )
+            durable_exchange = _first_not_none(
+                durable_exchange, attrs.get("durable_exchange")
+            )
+            durable_queue = _first_not_none(durable_queue, attrs.get("durable_queue"))
+            on_error = _first_not_none(on_error, attrs.get("on_error"))
+            requeue_on_error = _first_not_none(
+                requeue_on_error, attrs.get("requeue_on_error")
+            )
+            reconnect_duration = _first_not_none(
+                reconnect_duration, attrs.get("reconnect_duration")
+            )
+            reconnect_interval = _first_not_none(
+                reconnect_interval, attrs.get("reconnect_interval")
+            )
+            num_workers = _first_not_none(num_workers, attrs.get("num_workers"))
+            worker_termination_timeout = _first_not_none(
+                worker_termination_timeout, attrs.get("worker_termination_timeout")
+            )
 
-        # Validate that queue_name and topics are mutually exclusive
+        # Extract credentials from URL if not provided explicitly
+        creds = _extract_credentials_from_url(url)
+        url = creds.url
+        username = _first_not_none(username, creds.username)
+        password = _first_not_none(password, creds.password)
+
+        # Validate
         if queue_name and topics:
             raise ValueError("Cannot specify both queue_name and topics. Choose one.")
-
-        # Validate on_error value if provided
         if on_error is not None and on_error not in ("ack", "nack"):
             raise ValueError(f"on_error must be 'ack' or 'nack', got '{on_error}'")
 
-        # Extract credentials from URL if not provided explicitly
-        parsed_url = urlparse(url)
-        if parsed_url.username and not username:
-            username = parsed_url.username
-        if parsed_url.password and not password:
-            password = parsed_url.password
+        # Build the trigger structure
+        struct = {"kind": self.kind, "url": url, "attributes": {}}
+        attrs = struct["attributes"]
 
-        # Build clean URL without credentials if they were embedded
-        if parsed_url.username or parsed_url.password:
-            # Reconstruct URL without credentials
-            clean_url = f"{parsed_url.scheme}://{parsed_url.hostname}"
-            if parsed_url.port:
-                clean_url += f":{parsed_url.port}"
-            if parsed_url.path:
-                clean_url += parsed_url.path
-            url = clean_url
-
-        # Build the trigger structure with only non-None values
-        # Let Nuclio handle defaults for unspecified parameters
-        struct = {
-            "kind": self.kind,
-            "url": url,
-            "attributes": {},
-        }
-
-        # Add optional top-level parameters
+        if username is not None:
+            struct["username"] = username
+        if password is not None:
+            struct["password"] = password
         if num_workers is not None:
             struct["numWorkers"] = num_workers
         if worker_termination_timeout is not None:
             struct["workerTerminationTimeout"] = worker_termination_timeout
-
-        # Add optional attributes
         if exchange_name is not None:
-            struct["attributes"]["exchangeName"] = exchange_name
+            attrs["exchangeName"] = exchange_name
         if queue_name is not None:
-            struct["attributes"]["queueName"] = queue_name
+            attrs["queueName"] = queue_name
         if topics is not None:
-            struct["attributes"]["topics"] = topics
+            attrs["topics"] = topics
         if reconnect_duration is not None:
-            struct["attributes"]["reconnectDuration"] = reconnect_duration
+            attrs["reconnectDuration"] = reconnect_duration
         if reconnect_interval is not None:
-            struct["attributes"]["reconnectInterval"] = reconnect_interval
+            attrs["reconnectInterval"] = reconnect_interval
         if prefetch_count is not None:
-            struct["attributes"]["prefetchCount"] = prefetch_count
+            attrs["prefetchCount"] = prefetch_count
         if durable_exchange is not None:
-            struct["attributes"]["durableExchange"] = durable_exchange
+            attrs["durableExchange"] = durable_exchange
         if durable_queue is not None:
-            struct["attributes"]["durableQueue"] = durable_queue
+            attrs["durableQueue"] = durable_queue
         if on_error is not None:
-            struct["attributes"]["onError"] = on_error
+            attrs["onError"] = on_error
         if requeue_on_error is not None:
-            struct["attributes"]["requeueOnError"] = requeue_on_error
-
-        # Add credentials if provided
-        if username:
-            struct["username"] = username
-        if password:
-            struct["password"] = password
+            attrs["requeueOnError"] = requeue_on_error
 
         super().__init__(struct)

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -15,6 +15,7 @@
 import pathlib
 import sys
 from contextlib import nullcontext as does_not_raise
+from unittest.mock import patch
 
 import pytest
 from deepdiff import DeepDiff
@@ -22,6 +23,7 @@ from deepdiff import DeepDiff
 import mlrun
 import mlrun.errors
 from mlrun import code_to_function
+from mlrun.datastore.datastore_profile import DatastoreProfileRabbitMQ
 from mlrun.utils.helpers import resolve_git_reference_from_source
 from tests.runtimes.test_base import TestAutoMount
 
@@ -166,6 +168,184 @@ def test_v3io_stream_trigger_validate_consumer_group(consumer_group, expected):
         )
         trigger = function.spec.config["spec.triggers.mystream"]
         assert trigger["attributes"]["consumerGroup"] == consumer_group
+
+
+def test_rabbitmq_trigger_with_queue_name():
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    function.add_rabbitmq_trigger(
+        url="amqp://rabbitmq-host:5672",
+        exchange_name="my-exchange",
+        queue_name="my-queue",
+        username="user",
+        password="pass",
+        prefetch_count=10,
+        durable_exchange=True,
+        durable_queue=True,
+        num_workers=4,
+    )
+    trigger = function.spec.config["spec.triggers.rabbitmq"]
+    assert trigger["kind"] == "rabbit-mq"
+    assert trigger["url"] == "amqp://rabbitmq-host:5672"
+    assert trigger["numWorkers"] == 4
+    assert trigger["username"] == "user"
+    assert trigger["password"] == "pass"
+    assert trigger["attributes"]["exchangeName"] == "my-exchange"
+    assert trigger["attributes"]["queueName"] == "my-queue"
+    assert trigger["attributes"]["prefetchCount"] == 10
+    assert trigger["attributes"]["durableExchange"] is True
+    assert trigger["attributes"]["durableQueue"] is True
+
+
+def test_rabbitmq_trigger_with_topics():
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    function.add_rabbitmq_trigger(
+        url="amqp://rabbitmq-host:5672",
+        exchange_name="my-exchange",
+        topics=["key1", "key2"],
+        name="my-rabbitmq",
+    )
+    trigger = function.spec.config["spec.triggers.my-rabbitmq"]
+    assert trigger["kind"] == "rabbit-mq"
+    assert trigger["attributes"]["exchangeName"] == "my-exchange"
+    assert trigger["attributes"]["topics"] == ["key1", "key2"]
+    assert "queueName" not in trigger["attributes"]
+
+
+def test_rabbitmq_trigger_extracts_credentials_from_url():
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    function.add_rabbitmq_trigger(
+        url="amqp://myuser:mypass@rabbitmq-host:5672",
+        exchange_name="my-exchange",
+        queue_name="my-queue",
+    )
+    trigger = function.spec.config["spec.triggers.rabbitmq"]
+    assert trigger["url"] == "amqp://rabbitmq-host:5672"
+    assert trigger["username"] == "myuser"
+    assert trigger["password"] == "mypass"
+
+
+def test_rabbitmq_trigger_error_handling_config():
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    function.add_rabbitmq_trigger(
+        url="amqp://rabbitmq-host:5672",
+        exchange_name="my-exchange",
+        queue_name="my-queue",
+        on_error="ack",
+        requeue_on_error=True,
+    )
+    trigger = function.spec.config["spec.triggers.rabbitmq"]
+    assert trigger["attributes"]["onError"] == "ack"
+    assert trigger["attributes"]["requeueOnError"] is True
+
+
+@pytest.mark.parametrize(
+    "queue_name,topics,expected",
+    [
+        (None, None, pytest.raises(ValueError)),
+        ("queue", ["key"], pytest.raises(ValueError)),
+        ("queue", None, does_not_raise()),
+        (None, ["key"], does_not_raise()),
+    ],
+)
+def test_rabbitmq_trigger_queue_or_topics_validation(queue_name, topics, expected):
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    with expected:
+        function.add_rabbitmq_trigger(
+            url="amqp://rabbitmq-host:5672",
+            exchange_name="my-exchange",
+            queue_name=queue_name,
+            topics=topics,
+        )
+
+
+@pytest.mark.parametrize(
+    "on_error,expected",
+    [
+        ("ack", does_not_raise()),
+        ("nack", does_not_raise()),
+        ("invalid", pytest.raises(ValueError)),
+    ],
+)
+def test_rabbitmq_trigger_on_error_validation(on_error, expected):
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    with expected:
+        function.add_rabbitmq_trigger(
+            url="amqp://rabbitmq-host:5672",
+            exchange_name="my-exchange",
+            queue_name="my-queue",
+            on_error=on_error,
+        )
+
+
+def test_rabbitmq_trigger_with_datastore_profile():
+    # Create a mock profile
+    mock_profile = DatastoreProfileRabbitMQ(
+        name="test-rabbitmq",
+        broker_url="amqp://profile-host:5672",
+        exchange_name="profile-exchange",
+        queue_name="profile-queue",
+        username="profile-user",
+        password="profile-pass",
+        prefetch_count=5,
+        durable_exchange=True,
+    )
+
+    with patch(
+        "mlrun.datastore.datastore_profile.datastore_profile_read",
+        return_value=mock_profile,
+    ):
+        function: mlrun.runtimes.RemoteRuntime = mlrun.new_function(
+            "tst", kind="nuclio"
+        )
+        function.add_rabbitmq_trigger(url="ds://test-rabbitmq")
+
+        trigger = function.spec.config["spec.triggers.rabbitmq"]
+        assert trigger["kind"] == "rabbit-mq"
+        assert trigger["url"] == "amqp://profile-host:5672"
+        assert trigger["username"] == "profile-user"
+        assert trigger["password"] == "profile-pass"
+        assert trigger["attributes"]["exchangeName"] == "profile-exchange"
+        assert trigger["attributes"]["queueName"] == "profile-queue"
+        assert trigger["attributes"]["prefetchCount"] == 5
+        assert trigger["attributes"]["durableExchange"] is True
+
+
+def test_rabbitmq_trigger_explicit_falsy_values_override_profile():
+    """Test that explicitly passed falsy values (0, False) override profile defaults."""
+    # Create a profile with non-default values
+    mock_profile = DatastoreProfileRabbitMQ(
+        name="test-rabbitmq",
+        broker_url="amqp://profile-host:5672",
+        exchange_name="profile-exchange",
+        queue_name="profile-queue",
+        prefetch_count=10,  # Profile has 10
+        durable_exchange=True,  # Profile has True
+        durable_queue=True,  # Profile has True
+        num_workers=5,  # Profile has 5
+    )
+
+    with patch(
+        "mlrun.datastore.datastore_profile.datastore_profile_read",
+        return_value=mock_profile,
+    ):
+        function: mlrun.runtimes.RemoteRuntime = mlrun.new_function(
+            "tst", kind="nuclio"
+        )
+        # Explicitly pass falsy values that should override profile
+        function.add_rabbitmq_trigger(
+            url="ds://test-rabbitmq",
+            prefetch_count=0,  # Explicit 0 should override profile's 10
+            durable_exchange=False,  # Explicit False should override profile's True
+            durable_queue=False,  # Explicit False should override profile's True
+            num_workers=1,  # Explicit 1 should override profile's 5
+        )
+
+        trigger = function.spec.config["spec.triggers.rabbitmq"]
+        # Verify explicit falsy values were used, not profile values
+        assert trigger["attributes"]["prefetchCount"] == 0
+        assert trigger["attributes"]["durableExchange"] is False
+        assert trigger["attributes"]["durableQueue"] is False
+        assert trigger["numWorkers"] == 1
 
 
 def test_resolve_git_reference_from_source():

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -241,10 +241,14 @@ def test_rabbitmq_trigger_error_handling_config():
 @pytest.mark.parametrize(
     "queue_name,topics,expected",
     [
-        (None, None, pytest.raises(ValueError)),
+        # Both specified - error (mutually exclusive)
         ("queue", ["key"], pytest.raises(ValueError)),
+        # Only queue_name - OK
         ("queue", None, does_not_raise()),
+        # Only topics - OK
         (None, ["key"], does_not_raise()),
+        # Neither specified - OK (let Nuclio handle validation)
+        (None, None, does_not_raise()),
     ],
 )
 def test_rabbitmq_trigger_queue_or_topics_validation(queue_name, topics, expected):
@@ -252,7 +256,6 @@ def test_rabbitmq_trigger_queue_or_topics_validation(queue_name, topics, expecte
     with expected:
         function.add_rabbitmq_trigger(
             url="amqp://rabbitmq-host:5672",
-            exchange_name="my-exchange",
             queue_name=queue_name,
             topics=topics,
         )
@@ -271,7 +274,6 @@ def test_rabbitmq_trigger_on_error_validation(on_error, expected):
     with expected:
         function.add_rabbitmq_trigger(
             url="amqp://rabbitmq-host:5672",
-            exchange_name="my-exchange",
             queue_name="my-queue",
             on_error=on_error,
         )

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -224,6 +224,20 @@ def test_rabbitmq_trigger_extracts_credentials_from_url():
     assert trigger["password"] == "mypass"
 
 
+def test_rabbitmq_trigger_decodes_url_encoded_credentials():
+    """Test that URL-encoded special characters in credentials are decoded."""
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    # Password contains special characters: p@ss word (encoded as p%40ss%20word)
+    function.add_rabbitmq_trigger(
+        url="amqp://my%40user:p%40ss%20word@rabbitmq-host:5672",
+        queue_name="my-queue",
+    )
+    trigger = function.spec.config["spec.triggers.rabbitmq"]
+    assert trigger["url"] == "amqp://rabbitmq-host:5672"
+    assert trigger["username"] == "my@user"
+    assert trigger["password"] == "p@ss word"
+
+
 def test_rabbitmq_trigger_error_handling_config():
     function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
     function.add_rabbitmq_trigger(

--- a/tests/system/env-template.yml
+++ b/tests/system/env-template.yml
@@ -42,6 +42,9 @@ MLRUN_SYSTEM_TESTS_GOOGLE_BIG_QUERY_CREDENTIALS_JSON:
 # kafka brokers string for kafka tests
 MLRUN_SYSTEM_TESTS_KAFKA_BROKERS:
 
+# RabbitMQ AMQP URL for RabbitMQ trigger tests - e.g. amqp://guest:guest@localhost:5672
+MLRUN_SYSTEM_TESTS_RABBITMQ_URL:
+
 # slack webhook for sending system test reports
 MLRUN_SYSTEM_TESTS_SLACK_WEBHOOK_URL:
 

--- a/tests/system/runtimes/assets/rabbitmq_handler.py
+++ b/tests/system/runtimes/assets/rabbitmq_handler.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from storey import MapClass
+
+
+class ProcessMessage(MapClass):
+    """Simple step that processes RabbitMQ messages and adds a marker."""
+
+    def do(self, event):
+        self.context.logger.info(f"Processing message: {event}")
+
+        if isinstance(event, bytes):
+            import json
+
+            event = json.loads(event.decode("utf-8"))
+
+        # Add processing marker
+        event["_processed"] = True
+
+        return event

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -1304,3 +1304,269 @@ class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
         fn.with_http(workers=1)
         fn.deploy()
         return fn
+
+
+@tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+class TestNuclioRuntimeWithRabbitMQ(tests.system.base.TestMLRunSystem):
+    """System tests for RabbitMQ trigger support in Nuclio functions.
+
+    Requires:
+        - MLRUN_SYSTEM_TESTS_RABBITMQ_URL: RabbitMQ AMQP URL (e.g., amqp://user:pass@host:5672)
+    """
+
+    project_name = "rabbitmq-project"
+    exchange_uuid_part = uuid.uuid4()
+    exchange_name = f"test-exchange-{exchange_uuid_part}"
+    queue_name = f"test-queue-{exchange_uuid_part}"
+    rabbitmq_url = os.getenv("MLRUN_SYSTEM_TESTS_RABBITMQ_URL")
+
+    image: str = "mlrun/mlrun"
+
+    def _create_rabbitmq_connection(self):
+        """Create a fresh RabbitMQ connection."""
+        import pika
+
+        params = pika.URLParameters(self.rabbitmq_url)
+        # Increase heartbeat to handle longer operations
+        params.heartbeat = 600
+        connection = pika.BlockingConnection(params)
+        return connection, connection.channel()
+
+    @pytest.fixture()
+    def rabbitmq_fixture(self):
+        import tempfile
+
+        # Create temp directory for parquet output
+        tmp_dir = tempfile.mkdtemp(prefix="rabbitmq_test_")
+
+        # Setup: Create exchange and queue, then close connection
+        # This avoids heartbeat timeouts during long deployments
+        connection, channel = self._create_rabbitmq_connection()
+        channel.exchange_declare(
+            exchange=self.exchange_name, exchange_type="topic", durable=False
+        )
+        channel.queue_declare(queue=self.queue_name, durable=False)
+        channel.queue_bind(
+            exchange=self.exchange_name, queue=self.queue_name, routing_key="test.#"
+        )
+        connection.close()
+
+        try:
+            # Yield a helper to create fresh connections for publishing
+            yield self._create_rabbitmq_connection, tmp_dir
+        finally:
+            # Cleanup: delete queue, exchange, and temp directory
+            try:
+                connection, channel = self._create_rabbitmq_connection()
+                channel.queue_delete(queue=self.queue_name)
+                channel.exchange_delete(exchange=self.exchange_name)
+                connection.close()
+            except Exception:
+                pass
+            try:
+                import shutil
+
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+            except Exception:
+                pass
+
+    @pytest.mark.skipif(
+        not rabbitmq_url, reason="MLRUN_SYSTEM_TESTS_RABBITMQ_URL not defined"
+    )
+    def test_rabbitmq_trigger_end_to_end(self, rabbitmq_fixture):
+        """Test end-to-end message processing with RabbitMQ trigger.
+
+        Verifies:
+        1. Function deploys successfully with RabbitMQ trigger
+        2. Messages published to RabbitMQ are received and processed
+        3. Processed messages are written to v3io Parquet output
+        """
+        create_connection, _ = rabbitmq_fixture
+
+        # Use v3io path accessible from Kubernetes
+        v3io_username = os.getenv("V3IO_USERNAME", "iguazio")
+        output_path = (
+            f"v3io:///users/{v3io_username}/rabbitmq_test_{self.exchange_uuid_part}"
+        )
+
+        code_path = str(self.assets_path / "rabbitmq_handler.py")
+
+        self._logger.debug("Creating serving function with RabbitMQ trigger")
+        function = mlrun.code_to_function(
+            name="rabbitmq-e2e-test",
+            kind="serving",
+            project=self.project_name,
+            filename=code_path,
+            image=self.image,
+        )
+
+        # Set up graph: ProcessMessage -> ParquetTarget (v3io)
+        graph = function.set_topology("flow", engine="async")
+        graph.to(name="process", class_name="ProcessMessage").to(
+            name="parquet",
+            class_name="storey.ParquetTarget",
+            path=output_path,
+            flush_after_seconds=5,
+        )
+
+        # Add RabbitMQ trigger
+        function.add_rabbitmq_trigger(
+            url=self.rabbitmq_url,
+            exchange_name=self.exchange_name,
+            queue_name=self.queue_name,
+            prefetch_count=1,
+        )
+
+        self._logger.debug("Deploying serving function")
+        function.deploy()
+
+        # Verify function is deployed and running
+        db_function = self.project.get_function(function.metadata.name)
+        assert db_function.status.state == "ready"
+
+        # Create fresh connection after deployment to publish messages
+        connection, channel = create_connection()
+        try:
+            # Publish test messages
+            test_messages = [
+                {"message_id": "msg1", "test": "hello_rabbitmq", "value": 42},
+                {"message_id": "msg2", "test": "second_message", "value": 100},
+            ]
+
+            for msg in test_messages:
+                channel.basic_publish(
+                    exchange=self.exchange_name,
+                    routing_key="test.message",
+                    body=json.dumps(msg),
+                )
+                self._logger.debug(f"Published message: {msg['message_id']}")
+        finally:
+            connection.close()
+
+        # Wait for processing and parquet flush
+        self._logger.debug("Waiting for message processing and parquet write...")
+        time.sleep(15)
+
+        try:
+            # Read parquet output from v3io and verify
+            df = pd.read_parquet(output_path)
+            self._logger.debug(f"Read {len(df)} records from parquet")
+
+            assert len(df) >= 2, f"Expected at least 2 records, got {len(df)}"
+            assert "_processed" in df.columns, "Missing _processed marker column"
+            assert df["_processed"].all(), "Not all messages have _processed=True"
+
+            # Verify message content
+            message_ids = set(df["message_id"].tolist())
+            assert "msg1" in message_ids, "msg1 not found in output"
+            assert "msg2" in message_ids, "msg2 not found in output"
+        finally:
+            # Cleanup v3io output
+            try:
+                import fsspec
+
+                fs = fsspec.filesystem("v3io")
+                fs.rm(output_path.replace("v3io://", ""), recursive=True)
+            except Exception as e:
+                self._logger.warning(f"Failed to cleanup v3io output: {e}")
+
+    @pytest.mark.skipif(
+        not rabbitmq_url, reason="MLRUN_SYSTEM_TESTS_RABBITMQ_URL not defined"
+    )
+    def test_rabbitmq_trigger_with_topics(self, rabbitmq_fixture):
+        """Test deploying a function with RabbitMQ trigger using topics."""
+        create_connection, _ = rabbitmq_fixture
+
+        code_path = str(self.assets_path / "rabbitmq_handler.py")
+
+        self._logger.debug("Creating serving function with RabbitMQ trigger (topics)")
+        function = mlrun.code_to_function(
+            name="rabbitmq-binding-test",
+            kind="serving",
+            project=self.project_name,
+            filename=code_path,
+            image=self.image,
+        )
+
+        # Set up simple graph
+        graph = function.set_topology("flow", engine="async")
+        graph.to(name="process", class_name="ProcessMessage").respond()
+
+        # Add RabbitMQ trigger with topics (creates a unique queue)
+        function.add_rabbitmq_trigger(
+            url=self.rabbitmq_url,
+            exchange_name=self.exchange_name,
+            topics=["events.#", "notifications.*"],
+            prefetch_count=1,
+        )
+
+        self._logger.debug("Deploying serving function")
+        function.deploy()
+
+        # Verify function is deployed and running
+        db_function = self.project.get_function(function.metadata.name)
+        assert db_function.status.state == "ready"
+
+        # Create fresh connection after deployment to publish messages
+        connection, channel = create_connection()
+        try:
+            # Publish test messages to different routing keys
+            for routing_key in ["events.user.created", "notifications.alert"]:
+                test_message = json.dumps({"routing_key": routing_key, "data": "test"})
+                channel.basic_publish(
+                    exchange=self.exchange_name,
+                    routing_key=routing_key,
+                    body=test_message,
+                )
+                self._logger.debug(f"Published message with routing key: {routing_key}")
+        finally:
+            connection.close()
+
+        # Allow time for message processing
+        time.sleep(5)
+
+    @pytest.mark.skipif(
+        not rabbitmq_url, reason="MLRUN_SYSTEM_TESTS_RABBITMQ_URL not defined"
+    )
+    def test_rabbitmq_trigger_config_in_nuclio_spec(self, rabbitmq_fixture):
+        """Test that RabbitMQ trigger configuration is correctly passed to Nuclio."""
+        code_path = str(self.assets_path / "rabbitmq_handler.py")
+
+        function = mlrun.code_to_function(
+            name="rabbitmq-config-test",
+            kind="serving",
+            project=self.project_name,
+            filename=code_path,
+            image=self.image,
+        )
+
+        # Set up simple graph (required for serving function)
+        graph = function.set_topology("flow", engine="async")
+        graph.to(name="process", class_name="ProcessMessage").respond()
+
+        # Add RabbitMQ trigger with various configurations
+        function.add_rabbitmq_trigger(
+            url=self.rabbitmq_url,
+            exchange_name=self.exchange_name,
+            queue_name=self.queue_name,
+            prefetch_count=10,
+            durable_exchange=True,
+            durable_queue=True,
+            on_error="nack",
+            requeue_on_error=True,
+            num_workers=2,
+        )
+
+        # Verify trigger configuration before deployment
+        trigger_config = function.spec.config.get("spec.triggers.rabbitmq")
+        assert trigger_config is not None
+        assert trigger_config["kind"] == "rabbit-mq"
+        assert trigger_config["attributes"]["exchangeName"] == self.exchange_name
+        assert trigger_config["attributes"]["queueName"] == self.queue_name
+        assert trigger_config["attributes"]["prefetchCount"] == 10
+        assert trigger_config["attributes"]["durableExchange"] is True
+        assert trigger_config["attributes"]["durableQueue"] is True
+        assert trigger_config["attributes"]["onError"] == "nack"
+        assert trigger_config["attributes"]["requeueOnError"] is True
+        assert trigger_config["numWorkers"] == 2


### PR DESCRIPTION
## Summary

Add support for RabbitMQ triggers in Nuclio functions, enabling MLRun users to consume messages from RabbitMQ queues or topic-based routing.

## Changes Made

- **New `RabbitMQTrigger` class** (`mlrun/runtimes/nuclio/triggers.py`)
  - Supports queue-based and topic-based (routing keys) consumption
  - Handles credential extraction from URL or explicit parameters
  - Integrates with datastore profiles for credential management
  - Explicit parameters override profile defaults (including falsy values like 0)

- **New `add_rabbitmq_trigger()` method** on `RemoteRuntime` (`mlrun/runtimes/nuclio/function.py`)
  - Convenience method for adding RabbitMQ triggers
  - Full parameter support matching Nuclio's RabbitMQ trigger spec

- **New `DatastoreProfileRabbitMQ`** (`mlrun/datastore/datastore_profile.py`)
  - Secure credential management via datastore profiles
  - Supports all RabbitMQ trigger configuration options

- **Dependencies**
  - Added `pika~=1.3` for RabbitMQ client support

## Testing

- 13 unit tests covering:
  - Queue-based triggers
  - Topic-based triggers (routing keys)
  - Credential extraction from URL
  - Error handling configuration
  - Validation (queue_name vs topics mutual exclusivity)
  - Datastore profile integration
  - Explicit falsy value override

- 3 system tests covering:
  - End-to-end message flow (RabbitMQ → Nuclio → MLRun graph → Parquet output)
  - Topic-based routing with wildcards
  - Nuclio spec configuration verification

## Example Usage

```python
# Direct configuration
function.add_rabbitmq_trigger(
    url="amqp://rabbitmq-host:5672",
    exchange_name="my-exchange",
    queue_name="my-queue",
    username="user",
    password="pass",
)

# With topics (routing keys)
function.add_rabbitmq_trigger(
    url="amqp://rabbitmq-host:5672",
    exchange_name="my-exchange",
    topics=["events.#", "notifications.*"],
)

# Using datastore profile
function.add_rabbitmq_trigger(url="ds://my-rabbitmq-profile")
```

## Reference

- Jira: [ML-7879](https://iguazio.atlassian.net/browse/ML-7879)
- Design: [Confluence - RabbitMQ Trigger Support](https://iguazio.atlassian.net/wiki/spaces/Dataflows/pages/621805571/ML-7879+-+RabbitMQ+Trigger+Support+for+MLRun)
- Nuclio docs: https://docs.nuclio.io/en/latest/reference/triggers/rabbitmq.html

## Breaking Changes

None - this is a new feature addition.

[ML-7879]: https://iguazio.atlassian.net/browse/ML-7879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ