### PR TITLE
[Package] Support Collection as Input

### DIFF
--- a/docs/api/mlrun.package/index.rst
+++ b/docs/api/mlrun.package/index.rst
@@ -25,7 +25,6 @@ MLRun uses packagers: classes that perform 2 tasks:
 
 .. autosummary::
    :toctree: ./generated_rsts
-   :recursive:
 
    errors
 

--- a/docs/api/mlrun.package/index.rst
+++ b/docs/api/mlrun.package/index.rst
@@ -12,21 +12,18 @@ MLRun uses packagers: classes that perform 2 tasks:
 #. **Parsing inputs** - automatically cast the runtime's inputs (user's input passed to the function via the ``inputs`` parameter of the ``run`` method) to the relevant hinted type.  (Does not require handling of data items.)
 #. **Logging outputs** - automatically save, log, and upload the function's returned objects by the provided log hints (user's input passed to the function via the ``returns`` parameter of the ``run`` method). (Does not require handling of files and artifacts.)
 
-.. currentmodule:: mlrun.package
-
 .. autosummary::
    :toctree: ./generated_rsts
    :template: class_summary.rst
 
-   packager.Packager
-   packagers.default_packager.DefaultPackager
-   packagers_manager.PackagersManager
-
+   mlrun.package.packager.Packager
+   mlrun.package.packagers.default_packager.DefaultPackager
+   mlrun.package.packagers_manager.PackagersManager
 
 .. autosummary::
    :toctree: ./generated_rsts
 
-   errors
+   mlrun.package.errors
 
 .. rubric:: Packagers
 
@@ -38,8 +35,8 @@ available by default at the start of each run.
    :toctree: ./generated_rsts
    :template: module_summary.rst
 
-   packagers.python_standard_library_packagers
-   packagers.numpy_packagers
-   packagers.pandas_packagers
+   mlrun.package.packagers.python_standard_library_packagers
+   mlrun.package.packagers.numpy_packagers
+   mlrun.package.packagers.pandas_packagers
 
 

--- a/docs/api/mlrun.package/index.rst
+++ b/docs/api/mlrun.package/index.rst
@@ -12,18 +12,21 @@ MLRun uses packagers: classes that perform 2 tasks:
 #. **Parsing inputs** - automatically cast the runtime's inputs (user's input passed to the function via the ``inputs`` parameter of the ``run`` method) to the relevant hinted type.  (Does not require handling of data items.)
 #. **Logging outputs** - automatically save, log, and upload the function's returned objects by the provided log hints (user's input passed to the function via the ``returns`` parameter of the ``run`` method). (Does not require handling of files and artifacts.)
 
+.. currentmodule:: mlrun.package
+
 .. autosummary::
    :toctree: ./generated_rsts
    :template: class_summary.rst
 
-   mlrun.package.packager.Packager
-   mlrun.package.packagers.default_packager.DefaultPackager
-   mlrun.package.packagers_manager.PackagersManager
+   packager.Packager
+   packagers.default_packager.DefaultPackager
+   packagers_manager.PackagersManager
+
 
 .. autosummary::
    :toctree: ./generated_rsts
 
-   mlrun.package.errors
+   errors
 
 .. rubric:: Packagers
 
@@ -35,8 +38,8 @@ available by default at the start of each run.
    :toctree: ./generated_rsts
    :template: module_summary.rst
 
-   mlrun.package.packagers.python_standard_library_packagers
-   mlrun.package.packagers.numpy_packagers
-   mlrun.package.packagers.pandas_packagers
+   packagers.python_standard_library_packagers
+   packagers.numpy_packagers
+   packagers.pandas_packagers
 
 

--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "sync_secret_tokens",
 ]
 
+import warnings
 from os import environ, path
 from typing import Optional
 
@@ -40,7 +41,7 @@ from .errors import MLRunInvalidArgumentError, MLRunNotFoundError
 from .execution import MLClientCtx
 from .hub import get_hub_item, get_hub_module, get_hub_step, import_module
 from .model import RunObject, RunTemplate, new_task
-from .package import ArtifactType, DefaultPackager, Packager, handler
+from .package import ArtifactType, DefaultPackager, Packager
 from .projects import (
     MlrunProject,
     ProjectMetadata,
@@ -78,6 +79,30 @@ VolumeMount = mounts.VolumeMount
 mount_v3io = mounts.mount_v3io
 v3io_cred = mounts.v3io_cred
 auto_mount = mounts.auto_mount
+
+
+# TODO: Remove in MLRun 1.13.0.
+def __getattr__(name):
+    """handler decorator property"""
+
+    if name == "handler":
+        import warnings
+
+        warnings.warn(
+            message=(
+                "The `mlrun.handler` decorator is applied automatically if `mlrun.mlconf.packagers.enabled` is set to "
+                "True (by default its True). It should not be used manually in that case."
+                "If you still need to use it manually, please import it from `mlrun.package.handler` instead. Usage of "
+                "the decorator directly from `mlrun.handler` will be removed in MLRun 1.13.0."
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
+        from mlrun.package import handler
+
+        return handler
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 def get_version():

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -856,13 +856,23 @@ default_config = {
         # Whether to enable packagers. True will wrap each run in the `mlrun.package.handler` decorator to log and parse
         # using packagers.
         "enabled": True,
+        # Whether to automatically unpack inputs with no type hints instead of leaving them as `mlrun.DataItem` objects.
+        # If True, all inputs without type hints that were originally logged via `mlrun.package` will be unpacked
+        # automatically. Default is False.
+        "auto_unpack_inputs": False,
+        # Whether to automatically pack outputs, even if not log hints were provided by the user running the function.
+        # If True, returned objects will be packed with their default packager and their artifact key will be equal to
+        # the following name template: "<context_name>-<auto_pack_key>-<i>" where "i" is enumerated. If
+        # False, the returned objects will simply be ignored. Default is False.
+        "auto_pack_outputs": False,
+        "auto_pack_key": "artifact",
         # Whether to treat returned tuples from functions as a tuple and not as multiple returned items. If True, all
         # returned values will be packaged together as the tuple they are returned in. Default is False to enable
         # logging multiple returned items.
         "pack_tuples": False,
         # In multi-workers run, only the logging worker will pack the outputs and log the results and artifacts.
         # Otherwise, the workers will log the results and artifacts using the same keys, overriding them. It is common
-        # that only the main worker (usualy rank 0) will log, so this is the default value.
+        # that only the main worker (usually rank 0) will log, so this is the default value.
         "logging_worker": 0,
         # TODO: Consider adding support for logging from all workers (ignoring the `logging_worker`) and add the worker
         #       number to the artifact / result key (like "<key>-rank<#>". Results can have reduce operation in the

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -585,9 +585,10 @@ class MLClientCtx:
 
         def recursive_get_input(input_key: str, input_url: str | dict | list):
             if isinstance(input_url, dict):
+                inputs_dict = {}
                 for k, v in input_url.items():
-                    input_url[k] = recursive_get_input(k, v)
-                return input_url
+                    inputs_dict[k] = recursive_get_input(k, v)
+                return inputs_dict
             if isinstance(input_url, list):
                 return [
                     recursive_get_input(f"{input_key}_{i}", v)

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -562,7 +562,7 @@ class MLClientCtx:
         """
         return mlrun.get_secret_or_env(key, secret_provider=self._secrets_manager)
 
-    def get_input(self, key: str, url: str = ""):
+    def get_input(self, key: str, url: str | dict | list = ""):
         """
         Get an input :py:class:`~mlrun.DataItem` object,
         data objects have methods such as .get(), .download(), .url, .. to access the actual data.
@@ -574,7 +574,7 @@ class MLClientCtx:
 
         :param key:  The key name for the input url entry.
         :param url:  The url of the input data (file, stream, ..) - optional, saved in the inputs dictionary
-                     if the key is not already present.
+                     if the key is not already present. Can be passed as a list or dictionary of urls as well.
 
         :return:     :py:class:`~mlrun.datastore.base.DataItem` object
         """
@@ -582,12 +582,26 @@ class MLClientCtx:
             self._set_input(key, url)
 
         url = self._inputs[key]
-        return self._data_stores.object(
-            url,
-            key,
-            project=self._project,
-            allow_empty_resources=self._allow_empty_resources,
-        )
+
+        def recursive_get_input(input_key: str, input_url: str | dict | list):
+            if isinstance(input_url, dict):
+                for k, v in input_url.items():
+                    input_url[k] = recursive_get_input(k, v)
+                return input_url
+            if isinstance(input_url, list):
+                return [
+                    recursive_get_input(f"{input_key}_{i}", v)
+                    for i, v in enumerate(url)
+                ]
+            # String:
+            return self._data_stores.object(
+                input_url,
+                input_key,
+                project=self._project,
+                allow_empty_resources=self._allow_empty_resources,
+            )
+
+        return recursive_get_input(key, url)
 
     def log_result(self, key: str, value, commit=False):
         """Log a scalar result value
@@ -1470,14 +1484,26 @@ class MLClientCtx:
             self._project_object = self._rundb.get_project(self._project)
         return self._project_object
 
-    def _set_input(self, key, url=""):
+    def _set_input(self, key: str, url: str | dict | list = ""):
         if url is None:
             return
         if not url:
             url = key
-        if self.in_path and is_relative_path(url):
-            url = os.path.join(self._in_path, url)
-        self._inputs[key] = url
+
+        # In case input is a nested structure, we need to recursively set the paths:
+        def recursive_set_input(input_url: str | dict | list):
+            if isinstance(input_url, dict):
+                for k, v in input_url.items():
+                    input_url[k] = recursive_set_input(input_url=v)
+                return input_url
+            if isinstance(input_url, list):
+                return [recursive_set_input(input_url=v) for v in input_url]
+            # String
+            if self.in_path and is_relative_path(input_url):
+                input_url = os.path.join(self._in_path, input_url)
+            return input_url
+
+        self._inputs[key] = recursive_set_input(input_url=url)
 
     def _merge_tmpfile(self):
         if not self._tmpfile:
@@ -1510,6 +1536,8 @@ class MLClientCtx:
 
 
 def _cast_result(value):
+    if value is None:
+        return None
     if isinstance(value, int | str | float):
         return value
     if isinstance(value, list):

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -56,7 +56,7 @@ class BaseLauncher(abc.ABC):
         name: Optional[str] = "",
         project: Optional[str] = "",
         params: Optional[dict] = None,
-        inputs: Optional[dict[str, str]] = None,
+        inputs: Optional[dict[str, str | list | dict]] = None,
         out_path: Optional[str] = "",
         workdir: Optional[str] = "",
         artifact_path: Optional[str] = "",
@@ -143,7 +143,7 @@ class BaseLauncher(abc.ABC):
         run: "mlrun.run.RunObject",
     ):
         mlrun.utils.helpers.verify_dict_items_type(
-            "Inputs", run.spec.inputs, [str], [str]
+            "Inputs", run.spec.inputs, [str], [str, list, dict]
         )
 
         if runtime.spec.mode and runtime.spec.mode not in run_modes:

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -53,7 +53,7 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
         name: Optional[str] = "",
         project: Optional[str] = "",
         params: Optional[dict] = None,
-        inputs: Optional[dict[str, str]] = None,
+        inputs: Optional[dict[str, str | list | dict]] = None,
         out_path: Optional[str] = "",
         workdir: Optional[str] = "",
         artifact_path: Optional[str] = "",

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -41,7 +41,7 @@ class ClientRemoteLauncher(launcher.ClientBaseLauncher):
         name: Optional[str] = "",
         project: Optional[str] = "",
         params: Optional[dict] = None,
-        inputs: Optional[dict[str, str]] = None,
+        inputs: Optional[dict[str, str | list | dict]] = None,
         out_path: Optional[str] = "",
         workdir: Optional[str] = "",
         artifact_path: Optional[str] = "",

--- a/mlrun/model.py
+++ b/mlrun/model.py
@@ -1077,26 +1077,42 @@ class RunSpec(ModelObj):
         return param_file or self.hyperparams
 
     @property
-    def inputs(self) -> dict[str, str]:
+    def inputs(self) -> dict[str, str | list | dict]:
         """
-        Get the inputs dictionary. A dictionary of parameter names as keys and paths as values.
+        Get the inputs dictionary. A dictionary of parameter names as keys and paths as values. A path can also include
+        an inner collection of inputs, meaning an input can be given as a list or a dictionary of paths as well.
 
         :return: The inputs dictionary.
         """
         return self._inputs
 
     @inputs.setter
-    def inputs(self, inputs: dict[str, str]):
+    def inputs(self, inputs: dict[str, str | list | dict]):
         """
-        Set the given inputs in the spec. Inputs can include a type hint string in their keys following a colon, meaning
-        following this structure: "<input key : type hint>".
+        Set the given inputs in the spec. Inputs can include lists and dicts of inputs. For parsing with MLRun Package,
+        (in case the code doesn't have type hints) the inputs can include a type hint string in their keys following a
+        colon, meaning following this structure: "<input key : type hint>".
 
-        :exmaple:
+        For example, assuming the handler itself has no type hints, let's review all possible scenario::
 
-        >>> run_spec.inputs = {
-        ...     "my_input": "...",
-        ...     "my_hinted_input : pandas.DataFrame": "...",
-        ... }
+            run_spec.inputs = {
+                # Yield a `DataItem` (unless `auto_unpack` is True):
+                "my_input": "...",
+                # Yield a `pandas.DataFrame`:
+                "my_hinted_input : pandas.DataFrame": "...",
+                # Yield a list of `DataItem`s (unless `auto_unpack` is True):
+                "my_input_collection": ["...", "..."],
+                # Yield an `OrderedDict` of `numpy.array`s:
+                "my_hinted_input_collection : collections.OrderedDict[str, numpy.array]": {
+                    "input1": "...",
+                    "input2": "...",
+                },
+                # Yield an `OrderedDict` of `DataItem`s (unless `auto_unpack` is True):
+                "my_other_hinted_input_collection : collections.OrderedDict": {
+                    "my_dataframe": "...",
+                    "my_array": "...",
+                },
+            }
 
         :param inputs: The inputs to set.
         """

--- a/mlrun/package/__init__.py
+++ b/mlrun/package/__init__.py
@@ -18,6 +18,8 @@ from collections import OrderedDict
 from collections.abc import Callable
 from typing import Optional, Union
 
+import mlrun
+
 from ..config import config
 from .context_handler import ContextHandler
 from .errors import (
@@ -38,18 +40,13 @@ from .utils import (
 
 
 def handler(
-    labels: Optional[dict[str, str]] = None,
     outputs: Optional[list[Union[str, dict[str, str]]]] = None,
     inputs: Union[bool, dict[str, Union[str, type]]] = True,
 ):
     """
-    MLRun's handler is a decorator to wrap a function and enable setting labels, parsing inputs (`mlrun.DataItem`) using
-    type hints and log returning outputs using log hints.
+    MLRun's handler is a decorator to wrap a function and enable parsing inputs (`mlrun.DataItem`) using type hints and
+    log returning outputs using log hints.
 
-    Notice: this decorator is now appplied automatically with the release of `mlrun.package`. It should not be used
-    manually.
-
-    :param labels:  Labels to add to the run. Expecting a dictionary with the labels names as keys. Default: None.
     :param outputs: Log hints (logging configurations) for the function's returned values. Expecting a list of the
                     following values:
 
@@ -105,7 +102,6 @@ def handler(
 
     def decorator(func: Callable):
         def wrapper(*args: tuple, **kwargs: dict):
-            nonlocal labels
             nonlocal outputs
             nonlocal inputs
 
@@ -137,11 +133,18 @@ def handler(
             # Call the original function and get the returning values:
             func_outputs = func(*args, **kwargs)
 
-            # If an MLRun context is found, set the given labels and log the returning values to MLRun via the context:
+            # If 'auto_pack_outputs' is set, add auto log hints for the available outputs:
+            if mlrun.mlconf.packagers.auto_pack_outputs:
+                default_key = (
+                    f"{cxt_handler.context.name}-{mlrun.mlconf.packagers.auto_pack_key}"
+                )
+                outputs = outputs or []
+                if len(outputs) < len(func_outputs):
+                    for index in range(len(func_outputs) - len(outputs)):
+                        outputs.append(f"{default_key}-{index}")
+
+            # If an MLRun context is found, log the returning values to MLRun via the context:
             if cxt_handler.is_context_available():
-                if labels:
-                    # TODO: Should deprecate this labels
-                    cxt_handler.set_labels(labels=labels)
                 if outputs:
                     cxt_handler.log_outputs(
                         outputs=func_outputs

--- a/mlrun/package/__init__.py
+++ b/mlrun/package/__init__.py
@@ -14,6 +14,7 @@
 
 import functools
 import inspect
+import warnings
 from collections import OrderedDict
 from collections.abc import Callable
 
@@ -40,6 +41,7 @@ from mlrun.package.utils import (
 
 
 def handler(
+    labels: dict[str, str] | None = None,  # TODO: Remove in MLRun 1.13.0
     outputs: list[str | dict[str, str]] | None = None,
     inputs: bool | dict[str, str | type] = True,
 ):
@@ -47,6 +49,11 @@ def handler(
     MLRun's handler is a decorator to wrap a function and enable parsing inputs (`mlrun.DataItem`) using type hints and
     log returning outputs using log hints.
 
+    Note: This decorator is applied automatically if `mlrun.mlconf.packagers.enabled` is set to True (by default its
+    True). It should not be used manually in that case.
+
+    :param labels:  Labels to add to the run. Expecting a dictionary with the labels names as keys. Default: None.
+                    Will be deprecated in MLRun 1.13.0 - use the `context` object to set labels.
     :param outputs: Log hints (logging configurations) for the function's returned values. Expecting a list of the
                     following values:
 
@@ -99,6 +106,16 @@ def handler(
             >>> run_object.outputs
             {'my_string': 'I will be logged', 'my_array': 'store://...', 'my_multiplier': 3}
     """
+    # TODO: Remove in MLRun 1.13.0
+    if labels is not None:
+        warnings.warn(
+            message=(
+                "The 'labels' parameter of the 'mlrun.handler' decorator is deprecated and will be removed in MLRun "
+                "1.13.0. Please use the 'context' object to set labels."
+            ),
+            category=FutureWarning,
+            stacklevel=2,
+        )
 
     def decorator(func: Callable):
         def wrapper(*args: tuple, **kwargs: dict):

--- a/mlrun/package/__init__.py
+++ b/mlrun/package/__init__.py
@@ -16,7 +16,6 @@ import functools
 import inspect
 from collections import OrderedDict
 from collections.abc import Callable
-from typing import Optional, Union
 
 import mlrun
 
@@ -40,8 +39,8 @@ from .utils import (
 
 
 def handler(
-    outputs: Optional[list[Union[str, dict[str, str]]]] = None,
-    inputs: Union[bool, dict[str, Union[str, type]]] = True,
+    outputs: list[str | dict[str, str]] | None = None,
+    inputs: bool | dict[str, str | type] = True,
 ):
     """
     MLRun's handler is a decorator to wrap a function and enable parsing inputs (`mlrun.DataItem`) using type hints and

--- a/mlrun/package/__init__.py
+++ b/mlrun/package/__init__.py
@@ -21,9 +21,11 @@ import mlrun
 from mlrun.config import config
 from mlrun.package.context_handler import ContextHandler
 from mlrun.package.errors import (
+    MLRunPackageBundlingError,
     MLRunPackageCollectionError,
     MLRunPackageError,
     MLRunPackagePackingError,
+    MLRunPackageUnbundlingError,
     MLRunPackageUnpackingError,
 )
 from mlrun.package.packager import Packager

--- a/mlrun/package/__init__.py
+++ b/mlrun/package/__init__.py
@@ -18,19 +18,18 @@ from collections import OrderedDict
 from collections.abc import Callable
 
 import mlrun
-
-from ..config import config
-from .context_handler import ContextHandler
-from .errors import (
+from mlrun.config import config
+from mlrun.package.context_handler import ContextHandler
+from mlrun.package.errors import (
     MLRunPackageCollectionError,
     MLRunPackageError,
     MLRunPackagePackingError,
     MLRunPackageUnpackingError,
 )
-from .packager import Packager
-from .packagers import DefaultPackager
-from .packagers_manager import PackagersManager
-from .utils import (
+from mlrun.package.packager import Packager
+from mlrun.package.packagers import DefaultPackager
+from mlrun.package.packagers_manager import PackagersManager
+from mlrun.package.utils import (
     ArchiveSupportedFormat,
     ArtifactType,
     LogHintKey,

--- a/mlrun/package/context_handler.py
+++ b/mlrun/package/context_handler.py
@@ -15,9 +15,7 @@
 import inspect
 import os
 from collections import OrderedDict
-from typing import Union
 
-from mlrun.datastore import DataItem
 from mlrun.errors import MLRunInvalidArgumentError
 from mlrun.execution import MLClientCtx
 from mlrun.run import get_or_create_ctx
@@ -161,7 +159,7 @@ class ContextHandler:
         parsed_args = []
         type_hints_keys = list(type_hints.keys())
         for i, argument in enumerate(args):
-            if isinstance(argument, DataItem):
+            if argument in self._context.inputs:
                 parsed_args.append(
                     self._packagers_manager.unpack(
                         data_item=argument,
@@ -174,7 +172,7 @@ class ContextHandler:
 
         # Parse the keyword arguments:
         for key, value in kwargs.items():
-            if isinstance(value, DataItem):
+            if key in self._context.inputs:
                 kwargs[key] = self._packagers_manager.unpack(
                     data_item=value, type_hint=type_hints[key]
                 )
@@ -184,7 +182,7 @@ class ContextHandler:
     def log_outputs(
         self,
         outputs: list,
-        log_hints: list[Union[dict[str, str], str, None]],
+        log_hints: list[dict[str, str] | str | None],
     ):
         """
         Log the given outputs as artifacts (or results) with the stored context. Errors raised during the packing will
@@ -231,15 +229,6 @@ class ContextHandler:
 
         # Clear packagers outputs:
         self._packagers_manager.clear_packagers_outputs()
-
-    def set_labels(self, labels: dict[str, str]):
-        """
-        Set the given labels with the stored context.
-
-        :param labels: The labels to set.
-        """
-        for key, value in labels.items():
-            self._context.set_label(key=key, value=value)
 
     def _collect_packagers(
         self, packagers: list[str], is_mandatory: bool, is_custom_packagers: bool
@@ -313,7 +302,7 @@ class ContextHandler:
     def _validate_objects_to_log_hints_length(
         self,
         outputs: list,
-        log_hints: list[Union[dict[str, str], str, None]],
+        log_hints: list[dict[str, str] | str | None],
     ):
         """
         Validate the outputs and log hints are the same length. If they are not, warnings will be printed on what will

--- a/mlrun/package/context_handler.py
+++ b/mlrun/package/context_handler.py
@@ -70,6 +70,15 @@ class ContextHandler:
         # Prepare the manager (collect the MLRun builtin standard and optional packagers):
         self._collect_mlrun_packagers()
 
+    @property
+    def context(self) -> MLClientCtx:
+        """
+        Get the stored context.
+
+        :returns: The stored MLRun context.
+        """
+        return self._context
+
     def look_for_context(self, args: tuple, kwargs: dict):
         """
         Look for an MLRun context (`mlrun.MLClientCtx`). The handler will look for a context in the given order:
@@ -152,10 +161,7 @@ class ContextHandler:
         parsed_args = []
         type_hints_keys = list(type_hints.keys())
         for i, argument in enumerate(args):
-            if (
-                isinstance(argument, DataItem)
-                and type_hints[type_hints_keys[i]] is not inspect.Parameter.empty
-            ):
+            if isinstance(argument, DataItem):
                 parsed_args.append(
                     self._packagers_manager.unpack(
                         data_item=argument,
@@ -168,10 +174,7 @@ class ContextHandler:
 
         # Parse the keyword arguments:
         for key, value in kwargs.items():
-            if (
-                isinstance(value, DataItem)
-                and type_hints[key] is not inspect.Parameter.empty
-            ):
+            if isinstance(value, DataItem):
                 kwargs[key] = self._packagers_manager.unpack(
                     data_item=value, type_hint=type_hints[key]
                 )

--- a/mlrun/package/context_handler.py
+++ b/mlrun/package/context_handler.py
@@ -21,7 +21,6 @@ from mlrun.execution import MLClientCtx
 from mlrun.package.errors import MLRunPackageCollectionError, MLRunPackagePackingError
 from mlrun.package.packagers_manager import PackagersManager
 from mlrun.package.utils import LogHintUtils, TypeHintUtils
-from mlrun.run import get_or_create_ctx
 
 
 class ContextHandler:
@@ -109,6 +108,8 @@ class ContextHandler:
                     os.path.join("mlrun", "runtimes", "local")
                     in callstack_frame.filename
                 ):
+                    from mlrun.run import get_or_create_ctx
+
                     self._context = get_or_create_ctx("context")
                     break
 
@@ -223,6 +224,12 @@ class ContextHandler:
             self._context.log_results(results=self._packagers_manager.results)
             for artifact in self._packagers_manager.artifacts:
                 self._context.log_artifact(item=artifact)
+            # Update and log the bundle (if exists):
+            bundle_results = self._packagers_manager.get_bundles_results(
+                logged_outputs={**self._context.artifact_uris, **self._context.results},
+            )
+            if bundle_results:
+                self._context.log_results(results=bundle_results)
         else:
             self._context.logger.debug("Skipping logging - not the logging worker.")
 

--- a/mlrun/package/context_handler.py
+++ b/mlrun/package/context_handler.py
@@ -18,11 +18,10 @@ from collections import OrderedDict
 
 from mlrun.errors import MLRunInvalidArgumentError
 from mlrun.execution import MLClientCtx
+from mlrun.package.errors import MLRunPackageCollectionError, MLRunPackagePackingError
+from mlrun.package.packagers_manager import PackagersManager
+from mlrun.package.utils import LogHintUtils, TypeHintUtils
 from mlrun.run import get_or_create_ctx
-
-from .errors import MLRunPackageCollectionError, MLRunPackagePackingError
-from .packagers_manager import PackagersManager
-from .utils import LogHintUtils, TypeHintUtils
 
 
 class ContextHandler:

--- a/mlrun/package/errors.py
+++ b/mlrun/package/errors.py
@@ -45,3 +45,19 @@ class MLRunPackageUnpackingError(MLRunPackageError):
     """
 
     pass
+
+
+class MLRunPackageBundlingError(MLRunPackageError):
+    """
+    An error that may be raised during a `mlrun.Packager.bundle` method.
+    """
+
+    pass
+
+
+class MLRunPackageUnbundlingError(MLRunPackageError):
+    """
+    An error that may be raised during a `mlrun.Packager.unbundle` method.
+    """
+
+    pass

--- a/mlrun/package/packager.py
+++ b/mlrun/package/packager.py
@@ -18,8 +18,7 @@ from typing import Any
 
 from mlrun.artifacts import Artifact
 from mlrun.datastore import DataItem
-
-from .utils import TypeHintUtils
+from mlrun.package.utils import TypeHintUtils
 
 
 class Packager(ABC):

--- a/mlrun/package/packager.py
+++ b/mlrun/package/packager.py
@@ -85,7 +85,7 @@ class Packager(ABC):
         ...     handler="my_function",
         ...     inputs={
         ...         "data": {
-                        "a": "store://my_item1_Artifact",
+        ...             "a": "store://my_item1_Artifact",
         ...             "b": "store://my_item2_Artifact",
         ...         }
         ...     },

--- a/mlrun/package/packager.py
+++ b/mlrun/package/packager.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 from mlrun.artifacts import Artifact
 from mlrun.datastore import DataItem
@@ -52,6 +52,10 @@ class Packager(ABC):
       unpacking).
     * :py:meth:`unpack` - A class method to unpack an MLRun ``DataItem``, parsing it to its desired hinted type using
       the instructions noted while originally packing it.
+    * :py:meth:`can_bundle` - A class method to check if the packager can be used as a bundle (a collection of
+      packages) of the required type hint with the provided collection type.
+    * :py:meth:`can_unbundle` - A class method to check if the packager can be used to unbundle itself into a
+      collection of objects for packing each one of them separately.
 
     The class methods ``is_packable`` and ``is_unpackable`` are implemented with the following basic logic:
 
@@ -65,6 +69,39 @@ class Packager(ABC):
       ``get_supported_artifact_types``.
 
     Preferably, each packager should handle a single type of object.
+
+    .. rubric:: Bundles
+
+    A bundle means the type of object handled by this packager can be used to hold a collection of other objects - like
+    a ``list`` or a ``dict`` of packages. A bundle can be sent as a ``list`` or ``dict`` in a function's run input so
+    the packager manager will receive a list or dictionary of data items. A packager that support bundles means it can
+    initialize an object that will hold the unpacked data items later on - based on the type hint the user required.
+    For example::
+
+        def my_function(data: ExmapleDict[str, MyType]):
+            ...
+
+        >>> mlrun_function = mlrun.code_to_function("my_code.py", kind="job")
+        >>> run_object = mlrun_function.run(
+        ...     handler="my_function",
+        ...     inputs={
+        ...         "data": {
+                        "a": "store://my_item1_Artifact",
+        ...             "b": "store://my_item2_Artifact",
+        ...         }
+        ...     },
+        ... )
+
+    In the example above, after the packager manager used the packager of ``MyType`` to unpack all sent items, the
+    packager manager will choose the packager of ``ExmapleDict`` to initialize it on the dictionary of unpacked items to
+    create a bundle.
+
+    A packager can be a bundle if it implements the mandatory methods :py:meth:`can_bundle`, :py:meth:`can_unbundle`,
+    and the methods:
+
+    * :py:meth:`bundle` - Initialize a bundled object from a collection of objects.
+    * :py:meth:`unbundle` - Unbundle a bundled object into a simple collection of objects (either a ``list`` or a
+      ``dict``) for later packing them separately.
 
     .. rubric:: Linking Artifacts (extra data)
 
@@ -144,10 +181,10 @@ class Packager(ABC):
     def pack(
         self,
         obj: Any,
-        key: Optional[str] = None,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
-    ) -> Union[tuple[Artifact, dict], dict]:
+        key: str | None = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
+    ) -> tuple[Artifact, dict] | dict:
         """
         Pack an object as the given artifact type using the provided configurations.
 
@@ -165,8 +202,8 @@ class Packager(ABC):
     def unpack(
         self,
         data_item: DataItem,
-        artifact_type: Optional[str] = None,
-        instructions: Optional[dict] = None,
+        artifact_type: str | None = None,
+        instructions: dict | None = None,
     ) -> Any:
         """
         Unpack the data item's artifact by the provided type using the given instructions.
@@ -179,11 +216,70 @@ class Packager(ABC):
         """
         pass
 
+    def bundle(
+        self,
+        collection: dict | list,
+    ) -> Any:
+        """
+        Initialize a bundle object with the collection given using this packager.
+
+        :param collection: The collection of objects to bundle.
+
+        :return: The bundled object.
+
+        :raise NotImplementedError: In case the packager does not support bundling.
+        """
+        raise NotImplementedError(
+            f"The packager - '{self.__class__.__name__}', does not support bundling."
+        )
+
+    def unbundle(
+        self,
+        bundled_object: Any,
+    ) -> dict | list:
+        """
+        Unbundle the given object into a collection of objects (for later pack them each separately).
+
+        :return: The unbundled collection of objects - a list or dict.
+
+        :raise NotImplementedError: In case the packager does not support bundling.
+        """
+        raise NotImplementedError(
+            f"The packager - '{self.__class__.__name__}', does not support bundling."
+        )
+
+    @abstractmethod
+    def can_bundle(
+        self, bundle_hint: type, collection_type: type[dict] | type[list]
+    ) -> bool:
+        """
+        Check if the packager can be used to initialize a bundle (a collection of packages) of the required type hint
+        with the provided collection type.
+
+        :param bundle_hint:     The bundle type hint to check if the `PACKABLE_OBJECT_TYPE` matches to.
+        :param collection_type: The collection type that will be used in the type hint's constructor.
+
+        :return: True if it can be used as a bundle and False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def can_unbundle(self, bundled_object: Any) -> bool:
+        """
+        Check if the packager can unbundle a bundled object to a collection of the required type hint.
+
+        :param bundled_object: The bundled object to check if the packager can unbundle it.
+
+        :return: True if it can be unbundled and False otherwise.
+        """
+        pass
+
+    # TODO: Rename to `can_pack` for consistency with bundle, also it makes more sense...
     def is_packable(
         self,
         obj: Any,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
     ) -> bool:
         """
         Check if this packager can pack an object of the provided type as the provided artifact type.
@@ -214,8 +310,9 @@ class Packager(ABC):
 
         return True
 
+    # TODO: Rename to `can_unpack` for consistency with bundle, also it makes more sense...
     def is_unpackable(
-        self, data_item: DataItem, type_hint: type, artifact_type: Optional[str] = None
+        self, data_item: DataItem, type_hint: type, artifact_type: str | None = None
     ) -> bool:
         """
         Check if this packager can unpack an input according to the user-given type hint and the provided artifact type.
@@ -245,7 +342,7 @@ class Packager(ABC):
         # Unpackable:
         return True
 
-    def add_future_clearing_path(self, path: Union[str, Path]):
+    def add_future_clearing_path(self, path: str | Path):
         """
         Mark a path to be cleared by this packager's manager after logging the packaged artifacts.
 
@@ -318,7 +415,7 @@ class Packager(ABC):
         )
 
     def get_data_item_local_path(
-        self, data_item: DataItem, add_to_future_clearing_path: Optional[bool] = None
+        self, data_item: DataItem, add_to_future_clearing_path: bool | None = None
     ) -> str:
         """
         Get the local path to the item handled by the data item provided. The local path can be the same as the data

--- a/mlrun/package/packagers/__init__.py
+++ b/mlrun/package/packagers/__init__.py
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .default_packager import DefaultPackager
-from .numpy_packagers import NumPySupportedFormat
+from mlrun.package.packagers.default_packager import DefaultPackager

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -15,7 +15,7 @@
 import inspect
 from abc import ABCMeta
 from types import MethodType
-from typing import Any, Optional, Union
+from typing import Any
 
 import docstring_parser
 
@@ -66,7 +66,7 @@ class _DefaultPackagerMeta(ABCMeta):
 
         **Packing Sub-Classes**: True / False
 
-        * **Priority**: ...
+        **Priority**: ...
 
         **Default Artifact Types**:
 
@@ -185,7 +185,8 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     """
     A default packager that handles all types and packs them as pickle files.
 
-    The default packager implements all the required methods and has a default logic that should satisfy most
+    The default packager implements all the required methods (except for a bundle-supported packager that should still
+    implement both ``bundle`` and ``unbundle`` methods) has a default logic that should satisfy most
     use cases. To work with this class, don't override the abstract class methods, but instead follow the
     guidelines below:
 
@@ -198,6 +199,12 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     * **The class variable** :py:meth:`DEFAULT_UNPACKING_ARTIFACT_TYPE<DEFAULT_UNPACKING_ARTIFACT_TYPE>`: The default
       artifact type to unpack from. It is returned from the method
       ``get_default_unpacking_artifact_type``.
+    * **The class variable** :py:meth:`BUNDLE_FROM_LIST<BUNDLE_FROM_LIST>`: A flag that indicates whether
+      the ``PACKABLE_OBJECT_TYPE`` can be initialized from a ``list`` to be used as a collection bundle. It is used in
+      the ``can_bundle`` method. Default is False.
+    * **The class variable** :py:meth:`BUNDLE_FROM_DICT<BUNDLE_FROM_DICT>`: A flag that indicates whether
+      the ``PACKABLE_OBJECT_TYPE`` can be initialized from a ``dict`` to be used as a collection bundle. It is used in
+      the ``can_bundle`` method. Default is False.
     * **The abstract class method** :py:meth:`pack`: This method is implemented to get the object and send it to the
       relevant packing method by the given artifact type using the following naming: "pack_<artifact_type>". (If
       the artifact type was not provided, it uses the default). For example: if the artifact type is `x` then
@@ -228,12 +235,29 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     * **The abstract class method** :py:meth:`is_packable`: The method is implemented to automatically validate
         the object type and artifact type by the following rules:
 
-      * **Object type validation**: Checks if the given object type matches the variable ``PACKABLE_OBJECT_TYPE``
+      * **Object type validation**: Checks if the given object type matches the class variable ``PACKABLE_OBJECT_TYPE``
         with respect to the ``PACK_SUBCLASSES`` class variable.
       * **Artifact type validation**: Checks if the given artifact type is in the list returned from
         ``get_supported_artifact_types``.
 
     * **The abstract class method** :py:meth:`is_unpackable`: The method is left as implemented in ``Packager``.
+    * **The abstract class method** :py:meth:`can_bundle`: The method is implemented to automatically check
+        the bundle type and collection type by the following rules:
+
+      * **Bundle type validation**: Checks if the bundle type to initialize matches the class variable
+        ``PACKABLE_OBJECT_TYPE`` with respect to the ``PACK_SUBCLASSES`` class variable.
+      * **Collection type validation**: Checks if the given collection type appears as ``True`` in the matching flags:
+        ``BUNDLE_FROM_LIST`` or ``BUNDLE_FROM_DICT``.
+
+      Remember, to have a packager that supports bundles, you must also implement the methods
+      :py:meth:`bundle` and :py:meth:`unbundle`.
+    * **The abstract class method** :py:meth:`can_unbundle`: The method is implemented to automatically checks if the
+      packager can be used as a bundle (either class variables ``BUNDLE_FROM_LIST`` or ``BUNDLE_FROM_DICT`` are true)
+      and then checks that the bundle type matches the class variable ``PACKABLE_OBJECT_TYPE`` with respect to the
+      ``PACK_SUBCLASSES`` class variable.
+
+      Remember, to have a packager that supports bundles, you must also implement the methods
+      :py:meth:`bundle` and :py:meth:`unbundle`.
     * **The abstract class method** :py:meth:`get_supported_artifact_types`: The method is implemented to look for all
       pack + unpack class methods implemented to collect the supported artifact types. If ``PackagerX`` has ``pack_y``,
       ``unpack_y`` and ``pack_z``, ``unpack_z`` that means the artifact types supported are `y` and `z`.
@@ -248,34 +272,27 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
 
     From the :py:meth:`Packager<mlrun.package.packager.Packager>` docstring:
 
+    * **Bundles**: A bundle means the type of object handled by this packager can be used to hold a collection of other
+      objects - like a ``list`` or a ``dict`` of packages. A bundle can be sent as a ``list`` or ``dict`` in a
+      function's run input so the packager manager will receive a list or dictionary of data items. A packager that
+      support bundles means it can initialize an object that will hold the unpacked data items later on - based on the
+      type hint the user required.
+
+      A packager can be a bundle if it implements the mandatory methods :py:meth:`can_bundle`, :py:meth:`can_unbundle`,
+      and the methods: :py:meth:`bundle` and :py:meth:`unbundle`.
     * **Linking artifacts** ("extra data"): In order to link between packages (using the extra data or metrics spec
       attributes of an artifact), use the key as if it exists and as value ellipses (...). The manager
       links all packages once it is done packing.
 
-      For example, given extra data keys in the log hint as `extra_data`, set them to an artifact as follows::
-
-          artifact = Artifact(key="my_artifact")
-          artifact.spec.extra_data = {key: ... for key in extra_data}
-
     * **Clearing outputs**: Some packagers may produce files and temporary directories that should be deleted after
       the artifact is logged. The packager can mark paths of files and directories to delete after
       logging using the class method ``add_future_clearing_path``.
-
-      For example, in the following packager's ``pack`` method, you can write a text file, create an artifact, and then
-      mark the text file to be deleted once the artifact is logged::
-
-          with open("./some_file.txt", "w") as file:
-              file.write("Pack me")
-          artifact = Artifact(key="my_artifact")
-          self.add_future_clearing_path(path="./some_file.txt")
-          return artifact, None
-
     """
 
     #: The type of object this packager can pack and unpack.
     PACKABLE_OBJECT_TYPE: type = ...
 
-    #: A flag for indicating whether to also pack all subclasses of the `PACKABLE_OBJECT_TYPE`.
+    #: Whether to also pack all subclasses of the `PACKABLE_OBJECT_TYPE`.
     PACK_SUBCLASSES = False
 
     #: The default artifact type to pack as.
@@ -283,6 +300,12 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
 
     #: The default artifact type to unpack from.
     DEFAULT_UNPACKING_ARTIFACT_TYPE = ArtifactType.OBJECT
+
+    #: Whether the `PACKABLE_OBJECT_TYPE` can be constructed from a list to be used as a collection.
+    BUNDLE_FROM_LIST = False
+
+    #: Whether the `PACKABLE_OBJECT_TYPE` can be used as a bundle and be initialized from a dictionary.
+    BUNDLE_FROM_DICT = False
 
     def get_default_packing_artifact_type(self, obj: Any) -> str:
         """
@@ -323,10 +346,10 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     def pack(
         self,
         obj: Any,
-        key: Optional[str] = None,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
-    ) -> Union[tuple[Artifact, dict], dict]:
+        key: str | None = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
+    ) -> tuple[Artifact, dict] | dict:
         """
         Pack an object as the given artifact type using the provided configurations.
 
@@ -361,8 +384,8 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     def unpack(
         self,
         data_item: DataItem,
-        artifact_type: Optional[str] = None,
-        instructions: Optional[dict] = None,
+        artifact_type: str | None = None,
+        instructions: dict | None = None,
     ) -> Any:
         """
         Unpack the data item's artifact by the provided type using the given instructions.
@@ -401,8 +424,8 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     def is_packable(
         self,
         obj: Any,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
     ) -> bool:
         """
         Check if this packager can pack an object of the provided type as the provided artifact type.
@@ -438,6 +461,73 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
             return False
 
         # Packable:
+        return True
+
+    def can_bundle(
+        self, bundle_hint: type, collection_type: type[dict] | type[list]
+    ) -> bool:
+        """
+        Check if the packager can be used to initialize a bundle (a collection of packages) of the required type with
+        the provided collection type.
+
+        The method is implemented to validate the bundle type by checking if the given type matches the variable
+        ``PACKABLE_OBJECT_TYPE`` with respect to the ``PACK_SUBCLASSES`` class variable. If it does, it checks if the
+        given collection type's flag is set (either ``BUNDLE_FROM_LIST`` or ``BUNDLE_FROM_DICT``).
+
+        :param bundle_hint:     The bundle type hint to check if the `PACKABLE_OBJECT_TYPE` matches to.
+        :param collection_type: The available collection type that will be used in the bundle type's constructor.
+
+        :return: True if it can be used as a bundle and False otherwise.
+        """
+        # Check type (ellipses means any type):
+        if self.PACKABLE_OBJECT_TYPE is not ...:
+            if not TypeHintUtils.is_matching(
+                object_type=bundle_hint,
+                type_hint=self.PACKABLE_OBJECT_TYPE,
+                include_subclasses=self.PACK_SUBCLASSES,
+                reduce_type_hint=False,
+            ):
+                return False
+
+        # Check collection type:
+        if collection_type is list and not self.BUNDLE_FROM_LIST:
+            return False
+        if collection_type is dict and not self.BUNDLE_FROM_DICT:
+            return False
+
+        # Can bundle:
+        return True
+
+    def can_unbundle(
+        self,
+        bundled_object: Any,
+    ):
+        """
+        Check if the packager can unbundle a bundled object of the provided type.
+
+        The method is implemented to automatically checks if the packager can be used as a bundle (either class
+        variables ``BUNDLE_FROM_LIST`` or ``BUNDLE_FROM_DICT`` are true) and then checks that the bundle type matches
+        the class variable ``PACKABLE_OBJECT_TYPE`` with respect to the ``PACK_SUBCLASSES`` class variable.
+
+        :param bundled_object: The bundled object to check.
+
+        :return: True if it can unbundle and False otherwise.
+        """
+        # Check if bundling is supported:
+        if not self.BUNDLE_FROM_DICT and not self.BUNDLE_FROM_LIST:
+            return False
+
+        # Check type (ellipses means any type):
+        if self.PACKABLE_OBJECT_TYPE is not ...:
+            if not TypeHintUtils.is_matching(
+                object_type=type(bundled_object),
+                type_hint=self.PACKABLE_OBJECT_TYPE,
+                include_subclasses=self.PACK_SUBCLASSES,
+                reduce_type_hint=False,
+            ):
+                return False
+
+        # Can unbundle:
         return True
 
     def pack_object(
@@ -483,10 +573,10 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
         self,
         data_item: DataItem,
         pickle_module_name: str = DEFAULT_PICKLE_MODULE,
-        object_module_name: Optional[str] = None,
-        python_version: Optional[str] = None,
-        pickle_module_version: Optional[str] = None,
-        object_module_version: Optional[str] = None,
+        object_module_name: str | None = None,
+        python_version: str | None = None,
+        pickle_module_version: str | None = None,
+        object_module_version: str | None = None,
     ) -> Any:
         """
         Unpack the data item's object, unpickle it using the instructions, and return.

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -301,7 +301,7 @@ class DefaultPackager(Packager, metaclass=_DefaultPackagerMeta):
     #: The default artifact type to unpack from.
     DEFAULT_UNPACKING_ARTIFACT_TYPE = ArtifactType.OBJECT
 
-    #: Whether the `PACKABLE_OBJECT_TYPE` can be constructed from a list to be used as a collection.
+    #: Whether the `PACKABLE_OBJECT_TYPE` can be used as a bundle and be initialized from a list.
     BUNDLE_FROM_LIST = False
 
     #: Whether the `PACKABLE_OBJECT_TYPE` can be used as a bundle and be initialized from a dictionary.

--- a/mlrun/package/packagers/default_packager.py
+++ b/mlrun/package/packagers/default_packager.py
@@ -21,11 +21,15 @@ import docstring_parser
 
 from mlrun.artifacts import Artifact
 from mlrun.datastore import DataItem
+from mlrun.package.errors import MLRunPackagePackingError, MLRunPackageUnpackingError
+from mlrun.package.packager import Packager
+from mlrun.package.utils import (
+    DEFAULT_PICKLE_MODULE,
+    ArtifactType,
+    Pickler,
+    TypeHintUtils,
+)
 from mlrun.utils import logger
-
-from ..errors import MLRunPackagePackingError, MLRunPackageUnpackingError
-from ..packager import Packager
-from ..utils import DEFAULT_PICKLE_MODULE, ArtifactType, Pickler, TypeHintUtils
 
 
 class _DefaultPackagerMeta(ABCMeta):

--- a/mlrun/package/packagers/numpy_packagers.py
+++ b/mlrun/package/packagers/numpy_packagers.py
@@ -24,9 +24,8 @@ import pandas as pd
 from mlrun.artifacts import Artifact, DatasetArtifact
 from mlrun.datastore import DataItem
 from mlrun.errors import MLRunInvalidArgumentError
-
-from ..utils import ArtifactType, SupportedFormat
-from .default_packager import DefaultPackager
+from mlrun.package.packagers.default_packager import DefaultPackager
+from mlrun.package.utils import ArtifactType, SupportedFormat
 
 # Type for collection of numpy arrays (list / dict of arrays):
 NumPyArrayCollectionType = list[np.ndarray] | dict[str, np.ndarray]

--- a/mlrun/package/packagers/numpy_packagers.py
+++ b/mlrun/package/packagers/numpy_packagers.py
@@ -16,7 +16,7 @@ import os
 import pathlib
 import tempfile
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -29,7 +29,7 @@ from ..utils import ArtifactType, SupportedFormat
 from .default_packager import DefaultPackager
 
 # Type for collection of numpy arrays (list / dict of arrays):
-NumPyArrayCollectionType = Union[list[np.ndarray], dict[str, np.ndarray]]
+NumPyArrayCollectionType = list[np.ndarray] | dict[str, np.ndarray]
 
 
 class _Formatter(ABC):
@@ -41,7 +41,7 @@ class _Formatter(ABC):
     @abstractmethod
     def save(
         cls,
-        obj: Union[np.ndarray, NumPyArrayCollectionType],
+        obj: np.ndarray | NumPyArrayCollectionType,
         file_path: str,
         **save_kwargs: dict,
     ):
@@ -58,7 +58,7 @@ class _Formatter(ABC):
     @abstractmethod
     def load(
         cls, file_path: str, **load_kwargs: dict
-    ) -> Union[np.ndarray, NumPyArrayCollectionType]:
+    ) -> np.ndarray | NumPyArrayCollectionType:
         """
         Load the array from the given file path.
 
@@ -247,7 +247,7 @@ class NumPySupportedFormat(SupportedFormat[_Formatter]):
 
 # Default file formats for numpy arrays file artifacts:
 DEFAULT_NUMPY_ARRAY_FORMAT = NumPySupportedFormat.NPY
-DEFAULT_NUMPPY_ARRAY_COLLECTION_FORMAT = NumPySupportedFormat.NPZ
+DEFAULT_NUMPY_ARRAY_COLLECTION_FORMAT = NumPySupportedFormat.NPZ
 
 
 class NumPyNDArrayPackager(DefaultPackager):
@@ -373,7 +373,7 @@ class NumPyNDArrayPackager(DefaultPackager):
     def unpack_file(
         self,
         data_item: DataItem,
-        file_format: Optional[str] = None,
+        file_format: str | None = None,
         allow_pickle: bool = False,
     ) -> np.ndarray:
         """
@@ -443,7 +443,7 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
         self,
         obj: NumPyArrayCollectionType,
         key: str,
-        file_format: str = DEFAULT_NUMPPY_ARRAY_COLLECTION_FORMAT,
+        file_format: str = DEFAULT_NUMPY_ARRAY_COLLECTION_FORMAT,
         **save_kwargs,
     ) -> tuple[Artifact, dict]:
         """
@@ -477,7 +477,7 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
     def unpack_file(
         self,
         data_item: DataItem,
-        file_format: Optional[str] = None,
+        file_format: str | None = None,
         allow_pickle: bool = False,
     ) -> dict[str, np.ndarray]:
         """
@@ -517,7 +517,7 @@ class _NumPyNDArrayCollectionPackager(DefaultPackager):
 
     @staticmethod
     def _is_any_object_dtype(
-        array_collection: Union[np.ndarray, NumPyArrayCollectionType],
+        array_collection: np.ndarray | NumPyArrayCollectionType,
     ):
         """
         Check if any of the arrays in a collection is of type `object`.
@@ -553,8 +553,8 @@ class NumPyNDArrayDictPackager(_NumPyNDArrayCollectionPackager):
     def is_packable(
         self,
         obj: Any,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
     ) -> bool:
         """
         Check if the object provided is a dictionary of numpy arrays.
@@ -608,7 +608,7 @@ class NumPyNDArrayDictPackager(_NumPyNDArrayCollectionPackager):
     def unpack_file(
         self,
         data_item: DataItem,
-        file_format: Optional[str] = None,
+        file_format: str | None = None,
         allow_pickle: bool = False,
     ) -> dict[str, np.ndarray]:
         """
@@ -641,8 +641,8 @@ class NumPyNDArrayListPackager(_NumPyNDArrayCollectionPackager):
     def is_packable(
         self,
         obj: Any,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
     ) -> bool:
         """
         Check if the object provided is a list of numpy arrays.
@@ -688,7 +688,7 @@ class NumPyNDArrayListPackager(_NumPyNDArrayCollectionPackager):
     def unpack_file(
         self,
         data_item: DataItem,
-        file_format: Optional[str] = None,
+        file_format: str | None = None,
         allow_pickle: bool = False,
     ) -> list[np.ndarray]:
         """

--- a/mlrun/package/packagers/pandas_packagers.py
+++ b/mlrun/package/packagers/pandas_packagers.py
@@ -24,9 +24,8 @@ import pandas as pd
 from mlrun.artifacts import Artifact, DatasetArtifact
 from mlrun.datastore import DataItem
 from mlrun.errors import MLRunInvalidArgumentError
-
-from ..utils import ArtifactType, SupportedFormat
-from .default_packager import DefaultPackager
+from mlrun.package.packagers.default_packager import DefaultPackager
+from mlrun.package.utils import ArtifactType, SupportedFormat
 
 
 class _Formatter(ABC):

--- a/mlrun/package/packagers/pandas_packagers.py
+++ b/mlrun/package/packagers/pandas_packagers.py
@@ -17,7 +17,7 @@ import os
 import pathlib
 import tempfile
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import Any
 
 import pandas as pd
 
@@ -56,7 +56,7 @@ class _Formatter(ABC):
     @classmethod
     @abstractmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read the dataframe from the given file path.
@@ -173,7 +173,7 @@ class _ParquetFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read the dataframe from the given parquet file path.
@@ -221,7 +221,7 @@ class _CSVFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read the dataframe from the given csv file path.
@@ -275,7 +275,7 @@ class _H5Formatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read the dataframe from the given h5 file path.
@@ -332,7 +332,7 @@ class _XMLFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read the dataframe from the given xml file path.
@@ -391,7 +391,7 @@ class _XLSXFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read the dataframe from the given xlsx file path.
@@ -449,7 +449,7 @@ class _HTMLFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read dataframes from the given html file path.
@@ -510,7 +510,7 @@ class _JSONFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read dataframes from the given json file path.
@@ -565,7 +565,7 @@ class _FeatherFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read dataframes from the given feather file path.
@@ -620,7 +620,7 @@ class _ORCFormatter(_Formatter):
 
     @classmethod
     def read(
-        cls, file_path: str, unflatten_kwargs: Optional[dict] = None, **read_kwargs
+        cls, file_path: str, unflatten_kwargs: dict | None = None, **read_kwargs
     ) -> pd.DataFrame:
         """
         Read dataframes from the given orc file path.
@@ -730,7 +730,7 @@ class PandasDataFramePackager(DefaultPackager):
         self,
         obj: pd.DataFrame,
         key: str,
-        file_format: Optional[str] = None,
+        file_format: str | None = None,
         flatten: bool = True,
         **to_kwargs,
     ) -> tuple[Artifact, dict]:
@@ -785,8 +785,8 @@ class PandasDataFramePackager(DefaultPackager):
     def unpack_file(
         self,
         data_item: DataItem,
-        file_format: Optional[str] = None,
-        read_kwargs: Optional[dict] = None,
+        file_format: str | None = None,
+        read_kwargs: dict | None = None,
     ) -> pd.DataFrame:
         """
         Unpack a pandas dataframe from file.
@@ -827,7 +827,7 @@ class PandasDataFramePackager(DefaultPackager):
         return data_item.as_df()
 
     @staticmethod
-    def _prepare_result(obj: Union[list, dict, tuple]) -> Any:
+    def _prepare_result(obj: list | dict | tuple) -> Any:
         """
         A dataframe can be logged as a result when it being cast to a dictionary. If the dataframe has multiple indexes,
         pandas store them as a tuple, which is not json serializable, so we cast them into lists.
@@ -883,7 +883,7 @@ class PandasSeriesPackager(PandasDataFramePackager):
         self,
         obj: pd.Series,
         key: str,
-        file_format: Optional[str] = None,
+        file_format: str | None = None,
         flatten: bool = True,
         **to_kwargs,
     ) -> tuple[Artifact, dict]:
@@ -919,9 +919,9 @@ class PandasSeriesPackager(PandasDataFramePackager):
     def unpack_file(
         self,
         data_item: DataItem,
-        file_format: Optional[str] = None,
-        read_kwargs: Optional[dict] = None,
-        column_name: Optional[Union[str, int]] = None,
+        file_format: str | None = None,
+        read_kwargs: dict | None = None,
+        column_name: str | int | None = None,
     ) -> pd.Series:
         """
         Unpack a pandas series from file.

--- a/mlrun/package/packagers/python_standard_library_packagers.py
+++ b/mlrun/package/packagers/python_standard_library_packagers.py
@@ -16,7 +16,7 @@ import os
 import pathlib
 import tempfile
 import types
-from typing import Optional, Union
+from typing import Any
 
 from mlrun.artifacts import Artifact
 from mlrun.datastore import DataItem
@@ -141,7 +141,7 @@ class StrPackager(DefaultPackager):
         self,
         data_item: DataItem,
         is_directory: bool = False,
-        archive_format: Optional[str] = None,
+        archive_format: str | None = None,
     ) -> str:
         """
         Unpack a data item representing a path string. If the path is of a file, the file is downloaded to a local
@@ -194,9 +194,37 @@ class _BuiltinCollectionPackager(DefaultPackager):
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.RESULT
     DEFAULT_UNPACKING_ARTIFACT_TYPE = ArtifactType.FILE
 
+    def bundle(
+        self,
+        collection: dict | list,
+    ) -> Any:
+        """
+        Bundle a dictionary or a list into the packager's object type.
+
+        :param collection: The dictionary or list to bundle.
+
+        :return: The bundled object.
+        """
+        return self.PACKABLE_OBJECT_TYPE(collection)
+
+    def unbundle(
+        self,
+        bundled_object: Any,
+    ) -> dict | list:
+        """
+        Unbundle the packager's object type into a dictionary or a list.
+
+        :param bundled_object: The bundled object to unbundle.
+
+        :return: The unbundled dictionary or list.
+        """
+        # We can be sure the returned type is correct since the manager will only assign the correct packager for the
+        # type.
+        return bundled_object
+
     def pack_file(
         self,
-        obj: Union[dict, list],
+        obj: dict | list,
         key: str,
         file_format: str = DEFAULT_STRUCT_FILE_FORMAT,
     ) -> tuple[Artifact, dict]:
@@ -223,8 +251,8 @@ class _BuiltinCollectionPackager(DefaultPackager):
         return artifact, instructions
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
-    ) -> Union[dict, list]:
+        self, data_item: DataItem, file_format: str | None = None
+    ) -> dict | list:
         """
         Unpack a builtin collection from file.
 
@@ -259,9 +287,10 @@ class DictPackager(_BuiltinCollectionPackager):
     """
 
     PACKABLE_OBJECT_TYPE = dict
+    BUNDLE_FROM_DICT = True
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
+        self, data_item: DataItem, file_format: str | None = None
     ) -> dict:
         """
         Unpack a dictionary from file.
@@ -287,9 +316,10 @@ class ListPackager(_BuiltinCollectionPackager):
     """
 
     PACKABLE_OBJECT_TYPE = list
+    BUNDLE_FROM_LIST = True
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
+        self, data_item: DataItem, file_format: str | None = None
     ) -> list:
         """
         Unpack a list from file.
@@ -361,7 +391,7 @@ class TuplePackager(ListPackager):
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
+        self, data_item: DataItem, file_format: str | None = None
     ) -> tuple:
         """
         Unpack a tuple from file.
@@ -408,7 +438,7 @@ class SetPackager(ListPackager):
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
+        self, data_item: DataItem, file_format: str | None = None
     ) -> set:
         """
         Unpack a set from file.
@@ -444,7 +474,7 @@ class FrozensetPackager(SetPackager):
         return super().pack_file(obj=set(obj), key=key, file_format=file_format)
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
+        self, data_item: DataItem, file_format: str | None = None
     ) -> frozenset:
         """
         Unpack a frozenset from file.
@@ -466,6 +496,9 @@ class BytesPackager(ListPackager):
     """
 
     PACKABLE_OBJECT_TYPE = bytes
+    # Disable bundling since bytes items must be integers (0-255), and IntPackager doesn't support
+    # file unpacking, making bundling from files impractical.
+    BUNDLE_FROM_LIST = False
 
     def pack_result(self, obj: bytes, key: str) -> dict:
         """
@@ -493,7 +526,7 @@ class BytesPackager(ListPackager):
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
+        self, data_item: DataItem, file_format: str | None = None
     ) -> bytes:
         """
         Unpack a bytes from file.
@@ -540,7 +573,7 @@ class BytearrayPackager(BytesPackager):
         return super().pack_file(obj=bytes(obj), key=key, file_format=file_format)
 
     def unpack_file(
-        self, data_item: DataItem, file_format: Optional[str] = None
+        self, data_item: DataItem, file_format: str | None = None
     ) -> bytearray:
         """
         Unpack a bytearray from file.
@@ -600,7 +633,7 @@ class PathPackager(StrPackager):
         self,
         data_item: DataItem,
         is_directory: bool = False,
-        archive_format: Optional[str] = None,
+        archive_format: str | None = None,
     ) -> pathlib.Path:
         """
         Unpack a data item representing a `Path`. If the path is of a file, the file is downloaded to a local

--- a/mlrun/package/packagers/python_standard_library_packagers.py
+++ b/mlrun/package/packagers/python_standard_library_packagers.py
@@ -289,9 +289,7 @@ class DictPackager(_BuiltinCollectionPackager):
     PACKABLE_OBJECT_TYPE = dict
     BUNDLE_FROM_DICT = True
 
-    def unpack_file(
-        self, data_item: DataItem, file_format: str | None = None
-    ) -> dict:
+    def unpack_file(self, data_item: DataItem, file_format: str | None = None) -> dict:
         """
         Unpack a dictionary from file.
 
@@ -318,9 +316,7 @@ class ListPackager(_BuiltinCollectionPackager):
     PACKABLE_OBJECT_TYPE = list
     BUNDLE_FROM_LIST = True
 
-    def unpack_file(
-        self, data_item: DataItem, file_format: str | None = None
-    ) -> list:
+    def unpack_file(self, data_item: DataItem, file_format: str | None = None) -> list:
         """
         Unpack a list from file.
 
@@ -390,9 +386,7 @@ class TuplePackager(ListPackager):
         """
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
-    def unpack_file(
-        self, data_item: DataItem, file_format: str | None = None
-    ) -> tuple:
+    def unpack_file(self, data_item: DataItem, file_format: str | None = None) -> tuple:
         """
         Unpack a tuple from file.
 
@@ -437,9 +431,7 @@ class SetPackager(ListPackager):
         """
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
-    def unpack_file(
-        self, data_item: DataItem, file_format: str | None = None
-    ) -> set:
+    def unpack_file(self, data_item: DataItem, file_format: str | None = None) -> set:
         """
         Unpack a set from file.
 
@@ -525,9 +517,7 @@ class BytesPackager(ListPackager):
         """
         return super().pack_file(obj=list(obj), key=key, file_format=file_format)
 
-    def unpack_file(
-        self, data_item: DataItem, file_format: str | None = None
-    ) -> bytes:
+    def unpack_file(self, data_item: DataItem, file_format: str | None = None) -> bytes:
         """
         Unpack a bytes from file.
 

--- a/mlrun/package/packagers/python_standard_library_packagers.py
+++ b/mlrun/package/packagers/python_standard_library_packagers.py
@@ -21,15 +21,14 @@ from typing import Any
 from mlrun.artifacts import Artifact
 from mlrun.datastore import DataItem
 from mlrun.errors import MLRunInvalidArgumentError
-
-from ..utils import (
+from mlrun.package.packagers.default_packager import DefaultPackager
+from mlrun.package.utils import (
     DEFAULT_ARCHIVE_FORMAT,
     DEFAULT_STRUCT_FILE_FORMAT,
     ArchiveSupportedFormat,
     ArtifactType,
     StructFileSupportedFormat,
 )
-from .default_packager import DefaultPackager
 
 # ----------------------------------------------------------------------------------------------------------------------
 # builtins packagers:

--- a/mlrun/package/packagers/python_standard_library_packagers.py
+++ b/mlrun/package/packagers/python_standard_library_packagers.py
@@ -15,6 +15,7 @@
 import os
 import pathlib
 import tempfile
+import types
 from typing import Optional, Union
 
 from mlrun.artifacts import Artifact
@@ -40,11 +41,11 @@ class NonePackager(DefaultPackager):
     ``None`` packager.
     """
 
-    # TODO: From python 3.10 the `PACKABLE_OBJECT_TYPE` should be changed to `types.NoneType`
-    PACKABLE_OBJECT_TYPE = type(None)
+    PACKABLE_OBJECT_TYPE = types.NoneType
     DEFAULT_PACKING_ARTIFACT_TYPE = ArtifactType.RESULT
 
-    # TODO: `None` as pickle will be available from Python 3.10, so this method can be removed once we move to 3.10.
+    # `None` as pickle is possible since Python 3.10, but it cannot be imported from `builtins`, hence we have this
+    # method to keep it unpickle-able by design.
     def get_supported_artifact_types(self) -> list[str]:
         """
         Get all the supported artifact types on this packager. It will be the same as `DefaultPackager` but without the

--- a/mlrun/package/packagers/python_standard_library_packagers.py
+++ b/mlrun/package/packagers/python_standard_library_packagers.py
@@ -488,8 +488,7 @@ class BytesPackager(ListPackager):
     """
 
     PACKABLE_OBJECT_TYPE = bytes
-    # Disable bundling since bytes items must be integers (0-255), and IntPackager doesn't support
-    # file unpacking, making bundling from files impractical.
+    # Disable bundling since bytes bundling seem impractical.
     BUNDLE_FROM_LIST = False
 
     def pack_result(self, obj: bytes, key: str) -> dict:

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -177,7 +177,7 @@ class PackagersManager:
         self,
         obj: Any,
         log_hint: dict[str, str],
-        _unbundle_level: int = None,
+        _unbundle_level: int | None = None,
     ) -> Artifact | dict | None | list[Artifact | dict | None]:
         """
         Pack an object using one of the manager's packagers.
@@ -514,7 +514,7 @@ class PackagersManager:
     def _get_packager_for_bundling(
         self,
         bundle_hint: type,
-        collection_type: type[dict] | type[list] = None,
+        collection_type: type[dict] | type[list] | None = None,
     ) -> Packager | None:
         """
         Look for a packager that can bundle the given type hint on the provided collection type (list or dict).

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -23,6 +23,9 @@ import mlrun.errors
 from mlrun.artifacts import Artifact
 from mlrun.artifacts.base import verify_target_path
 from mlrun.datastore import DataItem, get_store_resource, store_manager
+from mlrun.package.packager import Packager
+from mlrun.package.packagers.default_packager import DefaultPackager
+from mlrun.package.utils import LogHintKey, LogHintUtils, TypeHintUtils
 from mlrun.utils import logger
 
 from .errors import (
@@ -32,9 +35,6 @@ from .errors import (
     MLRunPackageUnbundlingError,
     MLRunPackageUnpackingError,
 )
-from .packager import Packager
-from .packagers.default_packager import DefaultPackager
-from .utils import LogHintKey, LogHintUtils, TypeHintUtils
 
 
 class PackagersManager:

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -23,18 +23,17 @@ import mlrun.errors
 from mlrun.artifacts import Artifact
 from mlrun.artifacts.base import verify_target_path
 from mlrun.datastore import DataItem, get_store_resource, store_manager
-from mlrun.package.packager import Packager
-from mlrun.package.packagers.default_packager import DefaultPackager
-from mlrun.package.utils import LogHintKey, LogHintUtils, TypeHintUtils
-from mlrun.utils import logger
-
-from .errors import (
+from mlrun.package.errors import (
     MLRunPackageBundlingError,
     MLRunPackageCollectionError,
     MLRunPackagePackingError,
     MLRunPackageUnbundlingError,
     MLRunPackageUnpackingError,
 )
+from mlrun.package.packager import Packager
+from mlrun.package.packagers.default_packager import DefaultPackager
+from mlrun.package.utils import LogHintKey, LogHintUtils, TypeHintUtils
+from mlrun.utils import logger
 
 
 class PackagersManager:

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -265,6 +265,13 @@ class PackagersManager:
 
         :return: The unpacked object parsed as type hinted.
         """
+        # Check if a type hint was provided - if not, continue only if user set auto unpacking:
+        if (
+            type_hint is inspect.Parameter.empty
+            and not mlrun.mlconf.packagers.auto_unpack_inputs
+        ):
+            return data_item
+
         # Check if `DataItem` is hinted - meaning the user can expect a data item and do not want to unpack it:
         if TypeHintUtils.is_matching(object_type=DataItem, type_hint=type_hint):
             return data_item
@@ -285,15 +292,15 @@ class PackagersManager:
         # Unpack:
         try:
             if packaging_instructions:
-                # The data item is a package and the object type is equal or part of the type hint (part of is in case
-                # of a `typing.Union` for example):
+                # The data item is a package (if the object type is equal or part of the type hint (part of means in
+                # case of a `typing.Union` for example) it will be unpacked as a package, otherwise as a data item):
                 return self._unpack_package(
                     data_item=data_item,
                     artifact_key=artifact_key,
                     packaging_instructions=packaging_instructions,
                     type_hint=type_hint,
                 )
-            # The data item is not a package or the object type is not equal or part of the type hint:
+            # The data item is not a package (will continue only if a type hint was provided):
             return self._unpack_data_item(
                 data_item=data_item,
                 type_hint=type_hint,
@@ -600,7 +607,7 @@ class PackagersManager:
                 f"with the attribute 'with_repo=True`.\n"
                 f"MLRun will try to unpack according to the provided type hint in code."
             )
-        elif type_hint is None:
+        elif type_hint is inspect.Parameter.empty:
             # User count on the type noted in the package, so we unpack it as is:
             unpack_as_package = True
         else:
@@ -642,13 +649,25 @@ class PackagersManager:
         `typing.Union`), the manager goes over the types, and reduces them while looking for the first packager that
         can successfully unpack the data item.
 
+        If the type hint is empty (meaning it was not provided), a warning is printed and the data item is returned as
+        is.
+
         :param data_item: The data item to unpack.
         :param type_hint: The type hint to unpack it to.
 
-        :return: The unpacked object.
+        :return: The unpacked object if a type hint was provided or the data item itself if type hint was empty.
 
         :raise MLRunPackageUnpackingError: If there is no packager that supports the provided type hint.
         """
+        # Check if a type hint is available:
+        if type_hint is inspect.Parameter.empty:
+            logger.warn(
+                f"Although 'auto_unpack_inputs' is set, the input of '{data_item.key}' could not be "
+                f"unpacked as it was not originally packaged. To unpack it, please provide a type hint in the handler "
+                f"code or the inputs key in the MLRun's function `run` method call."
+            )
+            return data_item
+
         # Prepare a list of a packager and exception string for all the failures in case there was no fitting packager:
         found_packagers: list[tuple[Packager, str]] = []
 

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -17,23 +17,24 @@ import inspect
 import os
 import shutil
 import traceback
-from typing import Any, Optional, Union
+from typing import Any
 
 import mlrun.errors
 from mlrun.artifacts import Artifact
 from mlrun.artifacts.base import verify_target_path
 from mlrun.datastore import DataItem, get_store_resource, store_manager
-from mlrun.errors import MLRunInvalidArgumentError
 from mlrun.utils import logger
 
 from .errors import (
+    MLRunPackageBundlingError,
     MLRunPackageCollectionError,
     MLRunPackagePackingError,
+    MLRunPackageUnbundlingError,
     MLRunPackageUnpackingError,
 )
 from .packager import Packager
 from .packagers.default_packager import DefaultPackager
-from .utils import LogHintKey, TypeHintUtils
+from .utils import LogHintKey, LogHintUtils, TypeHintUtils
 
 
 class PackagersManager:
@@ -43,7 +44,7 @@ class PackagersManager:
     It prepares the instructions / log hint configurations and then looks for the first packager that fits the task.
     """
 
-    def __init__(self, default_packager: Optional[type[Packager]] = None):
+    def __init__(self, default_packager: type[Packager] | None = None):
         """
         Initialize a packagers manager.
 
@@ -81,7 +82,7 @@ class PackagersManager:
         return self._results
 
     def collect_packagers(
-        self, packagers: list[Union[type[Packager], str]], default_priority: int = 5
+        self, packagers: list[type[Packager] | str], default_priority: int = 5
     ):
         """
         Collect the provided packagers. Packagers passed as module paths are imported and validated to be of type
@@ -173,80 +174,99 @@ class PackagersManager:
         self._packagers.sort()
 
     def pack(
-        self, obj: Any, log_hint: dict[str, str]
-    ) -> Union[Artifact, dict, None, list[Union[Artifact, dict, None]]]:
+        self,
+        obj: Any,
+        log_hint: dict[str, str],
+        _unbundle_level: int = None,
+    ) -> Artifact | dict | None | list[Artifact | dict | None]:
         """
-        Pack an object using one of the manager's packagers. A `dict` ("**") or `list` ("*") unpacking syntax in the
-        log hint key packs the objects within them in separate packages.
+        Pack an object using one of the manager's packagers.
 
-        :param obj:      The object to pack as an artifact.
-        :param log_hint: The log hint to use.
+        A `list` unpacking syntax ("*") in the log hint key unbundle the given object to pack each of its item
+        separately. If a number is added before the asterisk ("X*"), it represent the level of unbundling.
+
+        For example, if the object is a nested list `[[1, 2], [3, 4]]` and the log hint key is "1*", the object will be
+        unbundled once to `[1, 2]` and `[3, 4]`, and each of these items will be packed separately. If the log hint key
+        is "2*", the object will be unbundled twice to `1`, `2`, `3`, and `4`, and each of these items will be packed
+        separately.
+
+        By default, an asterisk without a number will unbundle all the levels possible.
+
+        :param obj:             The object to pack as an artifact.
+        :param log_hint:        The log hint to use.
+        :param _unbundle_level: Inner argument. Mention the level of unbundling to perform. If provided, the method will
+                                unbundle the object only if the level is > 0, and will decrease the level by 1 for every
+                                unbundling. If None is provided (default behavior), the unbundling will be performed
+                                according to the log hint key.
 
         :return: The packaged artifact or result. None is returned if there was a problem while packing the object. If
-                 a prefix of dict or list unpacking was provided in the log hint key, a list of all the arbitrary number
-                 of packaged objects is returned.
+                 unbundling is performed, a list of all the unbundled packaged objects is returned.
 
-        :raise MLRunInvalidArgumentError: If the key in the log hint instructs to log an arbitrary number of artifacts
-                                          but the object type does not match the "*" or "**" used in the key.
-        :raise MLRunPackagePackingError:  If there was an error during the packing.
+        :raise MLRunInvalidArgumentError:   If the key in the log hint instructs do not follow the unbundling syntax.
+        :raise MLRunPackagePackingError:    If there was an error during the packing.
+        :raise MLRunPackageUnbundlingError: If there was an error during the unbundling.
         """
-        # Get the key to see if needed to pack arbitrary number of objects via list or dict prefixes:
-        log_hint_key = log_hint[LogHintKey.KEY]
-        if log_hint_key.startswith("**"):
-            # A dictionary unpacking prefix was given, validate the object is a dictionary and prepare the objects to
-            # pack with their keys:
-            if not isinstance(obj, dict):
-                raise MLRunInvalidArgumentError(
-                    f"The log hint key '{log_hint_key}' has a dictionary unpacking prefix ('**') to log arbitrary "
-                    f"number of objects within the dictionary, but a dictionary was not provided, the given object is "
-                    f"of type '{self._get_type_name(type(obj))}'. The object is ignored, to log it, please remove the "
-                    f"'**' prefix from the key."
-                )
-            objects_to_pack = {
-                f"{log_hint_key[len('**'):]}{dict_key}": dict_obj
-                for dict_key, dict_obj in obj.items()
-            }
-        elif log_hint_key.startswith("*"):
-            # An iterable unpacking prefix was given, validate the object is iterable and prepare the objects to pack
-            # with their keys:
-            is_iterable = True
-            try:
-                for _ in obj:
-                    break
-            except TypeError:
-                is_iterable = False
-            if not is_iterable:
-                raise MLRunInvalidArgumentError(
-                    f"The log hint key '{log_hint_key}' has an iterable unpacking prefix ('*') to log arbitrary number "
-                    f"of objects within it (like a `list` or `set`), but an iterable object was not provided, the "
-                    f"given object is of type '{self._get_type_name(type(obj))}'. The object is ignored, to log it, "
-                    f"please remove the '*' prefix from the key."
-                )
-            objects_to_pack = {
-                f"{log_hint_key[len('*'):]}{i}": obj_i for i, obj_i in enumerate(obj)
-            }
-        else:
-            # A single object is required to be packaged:
-            objects_to_pack = {log_hint_key: obj}
+        # Check if needed to unbundle:
+        log_hint_key, unbundle_level = LogHintUtils.extract_unbundling_from_key(
+            log_hint=log_hint[LogHintKey.KEY]
+        )
+        if _unbundle_level is not None:
+            # Inner call with unbundle level provided - override the extracted level:
+            unbundle_level = _unbundle_level
 
-        # Go over the collected keys and objects and pack them:
-        packages = []
-        for key, per_key_obj in objects_to_pack.items():
-            # Edit the key in the log hint:
-            per_key_log_hint = log_hint.copy()
-            per_key_log_hint[LogHintKey.KEY] = key
-            # Pack and collect the package:
-            try:
-                packages.append(self._pack(obj=per_key_obj, log_hint=per_key_log_hint))
-            except Exception as exception:
-                raise MLRunPackagePackingError(
-                    f"An exception was raised during the packing of '{per_key_log_hint}': {exception}"
-                ) from exception
+        # Check if unbundling is required:
+        if unbundle_level:
+            objects_to_pack = self._unbundle(bundled_object=obj)
+            if isinstance(objects_to_pack, dict):
+                objects_to_pack = {
+                    f"{log_hint_key}_{dict_key}": dict_obj
+                    for dict_key, dict_obj in obj.items()
+                }
+            else:
+                objects_to_pack = {
+                    f"{log_hint_key}_{i}": obj_i for i, obj_i in enumerate(obj)
+                }
+            # Go over the collected keys and objects and pack them (with decreased unbundle level):
+            unbundle_level = (
+                unbundle_level - 1
+                if isinstance(unbundle_level, int)
+                else unbundle_level
+            )
+            packages = []
+            for key, per_key_obj in objects_to_pack.items():
+                # Edit the key in the log hint:
+                per_key_log_hint = log_hint.copy()
+                per_key_log_hint[LogHintKey.KEY] = key
+                # Pack and collect the package:
+                try:
+                    currently_packaged = self.pack(
+                        obj=per_key_obj,
+                        log_hint=per_key_log_hint,
+                        _unbundle_level=unbundle_level,
+                    )
+                    if isinstance(currently_packaged, list):
+                        packages.extend(currently_packaged)
+                    else:
+                        packages.append(currently_packaged)
+                except Exception as exception:
+                    raise MLRunPackagePackingError(
+                        f"An exception was raised during the packing of '{per_key_log_hint}': {exception}"
+                    ) from exception
+            return packages
 
-        # If multiple packages were packed, return a list, otherwise return the single package:
-        return packages if len(packages) > 1 else packages[0]
+        # A single object is required to be packaged:
+        try:
+            package = self._pack(
+                obj=obj, log_hint=log_hint.copy()
+            )  # Log hint is copied to preserve key for error.
+        except Exception as exception:
+            raise MLRunPackagePackingError(
+                f"An exception was raised during the packing of '{log_hint[LogHintKey.KEY]}': {exception}"
+            ) from exception
 
-    def unpack(self, data_item: DataItem, type_hint: type) -> Any:
+        return package
+
+    def unpack(self, data_item: DataItem | dict | list, type_hint: type) -> Any:
         """
         Unpack an object using one of the manager's packagers. The data item can be unpacked in two ways:
 
@@ -255,12 +275,16 @@ class PackagersManager:
         * As a data item: If the data item is not a package or the type hint provided is not equal to the one noted in
           the package.
 
+        If the `data_item` received is a collection (a `dict` or `list`), each item in the collection will be unpacked
+        according to the type hint provided.
+
         If the type hint is a `mlrun.DataItem` then it won't be unpacked.
 
         Notice: It is not recommended to use a different packager than the one that originally packed the object to
         unpack it. A warning displays in that case.
 
-        :param data_item: The data item holding the package.
+        :param data_item: The data item holding the package. Can be a collection of data items (the type hint must
+                          match a packager that supports initializing a collection).
         :param type_hint: The type hint to parse the data item as.
 
         :return: The unpacked object parsed as type hinted.
@@ -275,6 +299,16 @@ class PackagersManager:
         # Check if `DataItem` is hinted - meaning the user can expect a data item and do not want to unpack it:
         if TypeHintUtils.is_matching(object_type=DataItem, type_hint=type_hint):
             return data_item
+
+        # Check if the data item is a collection (a `dict` or `list`):
+        if isinstance(data_item, dict | list):
+            # Bundle it:
+            try:
+                return self._bundle(collection=data_item, type_hint=type_hint)
+            except Exception as exception:
+                raise MLRunPackageBundlingError(
+                    f"An exception was raised during the bundling of '{type(data_item)}': {exception}"
+                ) from exception
 
         # Set variables to hold the manager notes and packager instructions:
         artifact_key = None
@@ -388,7 +422,7 @@ class PackagersManager:
         """
         return [*self._packagers, self._default_packager]
 
-    def _get_packager_by_name(self, name: str) -> Union[Packager, None]:
+    def _get_packager_by_name(self, name: str) -> Packager | None:
         """
         Look for a packager with the given name and return it.
 
@@ -410,9 +444,9 @@ class PackagersManager:
     def _get_packager_for_packing(
         self,
         obj: Any,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
-    ) -> Union[Packager, None]:
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
+    ) -> Packager | None:
         """
         Look for a packager that can pack the provided object as the provided artifact type.
 
@@ -424,7 +458,7 @@ class PackagersManager:
 
         :return: The found packager or None if it wasn't found.
         """
-        # Look for a packager for the combination of object nad artifact type:
+        # Look for a packager for the combination of object and artifact type:
         for packager in self._packagers:
             if packager.is_packable(
                 obj=obj, artifact_type=artifact_type, configurations=configurations
@@ -438,8 +472,8 @@ class PackagersManager:
         self,
         data_item: Any,
         type_hint: type,
-        artifact_type: Optional[str] = None,
-    ) -> Union[Packager, None]:
+        artifact_type: str | None = None,
+    ) -> Packager | None:
         """
         Look for a packager that can unpack the data item of the given type hint as the provided artifact type.
 
@@ -451,7 +485,7 @@ class PackagersManager:
 
         :return: The found packager or None if it wasn't found.
         """
-        # Look for a packager for the combination of object type nad artifact type:
+        # Look for a packager for the combination of object type and artifact type:
         for packager in self._packagers:
             if packager.is_unpackable(
                 data_item=data_item, type_hint=type_hint, artifact_type=artifact_type
@@ -461,7 +495,53 @@ class PackagersManager:
         # No packager was found:
         return None
 
-    def _pack(self, obj: Any, log_hint: dict) -> Union[Artifact, dict, None]:
+    def _get_packager_for_bundling(
+        self,
+        bundle_hint: type,
+        collection_type: type[dict] | type[list] = None,
+    ) -> Packager | None:
+        """
+        Look for a packager that can bundle the given type hint on the provided collection type (list or dict).
+
+        If a packager was not found None will be returned.
+
+        :param bundle_hint:       The bundle type hint the packager to get should handle.
+        :param collection_type: The collection type the packager to get should construct from.
+
+        :return: The found packager or None if it wasn't found.
+        """
+        # Look for a packager for the combination of type hint and collection type:
+        for packager in self._packagers:
+            if packager.can_bundle(
+                bundle_hint=bundle_hint, collection_type=collection_type
+            ):
+                return packager
+
+        # No packager was found:
+        return None
+
+    def _get_packager_for_unbundling(
+        self,
+        bundled_object: Any,
+    ) -> Packager | None:
+        """
+        Look for a packager that can unbundle the given object into a collection (list or dict).
+
+        If a packager was not found None will be returned.
+
+        :param bundled_object:  The bundle object the packager to get should handle.
+
+        :return: The found packager or None if it wasn't found.
+        """
+        # Look for a packager for the combination of type hint and collection type:
+        for packager in self._packagers:
+            if packager.can_unbundle(bundled_object=bundled_object):
+                return packager
+
+        # No packager was found:
+        return None
+
+    def _pack(self, obj: Any, log_hint: dict) -> Artifact | dict | None:
         """
         Pack an object using one of the manager's packagers.
 
@@ -721,13 +801,142 @@ class PackagersManager:
             )
         )
 
+    def _bundle(self, collection: dict | list, type_hint: type) -> Any:
+        """
+        Bundle a collection of data items according to the type hint provided.
+
+        :param collection: The collection of data items to unpack.
+        :param type_hint:  The user's type hint.
+
+        :return: The bundled collection.
+
+        :raise MLRunPackageBundlingError: If there is no packager to bundle the collection type.
+        :raise MLRunPackageUnpackingError: If there is no packager to initialize the collection type.
+        """
+        # Prepare a set to hold possible type hints to try to bundle as:
+        possible_type_hints = set()
+
+        # Check if there is no type hint (auto unpacking must be on - it was verified already in `unpack`):
+        if type_hint is inspect.Parameter.empty:
+            possible_type_hints.add(type(collection))
+        else:
+            # Reduce pure hints (like `typing.Any`, `typing.Union`, etc.) to possible real types:
+            possible_type_hints_test = {type_hint}
+            while possible_type_hints_test:
+                for hint in possible_type_hints_test:
+                    if not TypeHintUtils.is_pure_hint(type_hint=hint):
+                        possible_type_hints.add(hint)
+                # Remove the found types from the test set and continue reducing:
+                possible_type_hints_test = (
+                    possible_type_hints_test - possible_type_hints
+                )
+                possible_type_hints_test = TypeHintUtils.reduce_type_hint(
+                    type_hint=possible_type_hints_test
+                )
+            if len(possible_type_hints) == 0:
+                # No real type was found, set the bundle type hint to the collection type:
+                possible_type_hints.add(type(collection))
+
+        # Go over the hints and try to bundle as one of them:
+        found_packagers = []
+        for hint in possible_type_hints:
+            # Get the origin (bundle object type) and args (bundle items type) of the type hint:
+            bundle_type_hint, items_type_hint = TypeHintUtils.deconstruct_type_hint(
+                type_hint=hint
+            )
+            if items_type_hint is not inspect.Parameter.empty:
+                # TODO: We are going to take the last `Generic` variable registered. Usually this is the item type in
+                #       collections like `list`, `set` (which has only one variable: list[V]) and `dict` (which has two,
+                #       one for the keys and the last one is the value: `dict[_KT, _VT]`).
+                #       To improve this, we can try to go over some of the popular `Generic` variable naming conventions
+                #       like `T`, `V`, `VT`, etc. to identify the item type better:
+                #       `[p.__name__ for p in bundle_type.__parameters__]`.
+                #       Another option is to try each of them until one works in unpacking.
+                items_type_hint = (
+                    items_type_hint[-1]
+                    if isinstance(items_type_hint, tuple)
+                    else items_type_hint
+                )
+            # Get a packager that can bundle as the given type hint on the given collection type:
+            packager = self._get_packager_for_bundling(
+                bundle_hint=bundle_type_hint, collection_type=type(collection)
+            )
+            if packager is None:
+                # No packager was found that supports this hinted type:
+                continue
+            # Unpack items in the collection according to the items type hint:
+            try:
+                if isinstance(collection, dict):
+                    unpacked_collection = {
+                        key: self.unpack(data_item=data_item, type_hint=items_type_hint)
+                        for key, data_item in collection.items()
+                    }
+                else:  # It's a list.
+                    unpacked_collection = [
+                        self.unpack(data_item=data_item, type_hint=items_type_hint)
+                        for data_item in collection
+                    ]
+            except Exception:
+                # Could not bundle as the type hint, collect the exception and go to the next one:
+                found_packagers.append((packager, traceback.format_exc()))
+                continue
+            # Bundle:
+            try:
+                return packager.bundle(collection=unpacked_collection)
+            except Exception:
+                # Could not bundle as the type hint, collect the exception and go to the next one:
+                found_packagers.append((packager, traceback.format_exc()))
+                continue
+
+        # The method did not return until this point, raise an error:
+        if found_packagers:
+            raise MLRunPackageBundlingError(
+                f"Could not bundle the input with the hinted type '{type_hint}'. The following packagers were tried to "
+                f"be used to bundle it but raised the exceptions joined:\n\n"
+                + "\n".join(
+                    [
+                        f"Found packager: '{packager}'\nException: {exception}\n"
+                        for packager, exception in found_packagers
+                    ]
+                )
+            )
+        raise MLRunPackageBundlingError(
+            f"No packager was found that can bundle a '{type(collection).__name__}' into '{type_hint}'."
+        )
+
+    def _unbundle(self, bundled_object: Any) -> dict | list:
+        """
+        Unbundle a bundled object into a collection of data items.
+
+        :param bundled_object: The bundled object to unbundle.
+
+        :return: The unbundled collection of data items.
+
+        :raise MLRunPackageUnbundlingError: If there is no packager to unbundle the given object.
+        """
+        # Get a packager that can unbundle the given object:
+        packager = self._get_packager_for_unbundling(bundled_object=bundled_object)
+        if packager is None:
+            raise MLRunPackageUnbundlingError(
+                f"No packager was found to unbundle the object of type '{type(bundled_object)}'."
+            )
+
+        # Unbundle:
+        try:
+            return packager.unbundle(bundled_object=bundled_object)
+        except Exception as exception:
+            raise MLRunPackageUnbundlingError(
+                f"An exception was raised during the unbundling of an object of type "
+                f"'{type(bundled_object)}': {exception}"
+            ) from exception
+
     @staticmethod
     def _look_for_extra_data(
         key: str,
         artifacts: list[Artifact],
         artifact_uris: dict,
         results: dict,
-    ) -> Union[Artifact, str, int, float, None]:
+    ) -> Artifact | str | int | float | None:
         """
         Look for an extra data item (artifact or result) by given key. If not found, None is returned.
 

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -214,9 +214,25 @@ class PackagersManager:
             # Inner call with unbundle level provided - override the extracted level:
             unbundle_level = _unbundle_level
 
-        # Check if unbundling is required:
+        # If unbundling is required, check the object can be unbundled (we don't want to fail on non-unbundle-able
+        # object as it is common that a user function might return a list[object] | object, so the expected log hint
+        # would be with *):
+        objects_to_pack = None
         if unbundle_level:
-            objects_to_pack = self._unbundle(bundled_object=obj)
+            try:
+                objects_to_pack = self._unbundle(bundled_object=obj)
+            except MLRunPackageUnbundlingError as unbundling_error:
+                if "No packager was found to unbundle the object" not in str(
+                    unbundling_error
+                ):
+                    raise unbundling_error
+                logger.debug(
+                    f"Unbundle level was not reached for '{log_hint_key}', but it cannot be unbundled (there is no "
+                    f"packager that can unbundle it) so we continue to pack it as a single object."
+                )
+
+        # If unbundling was performed, pack each of the unbundled objects separately:
+        if objects_to_pack is not None:
             if isinstance(objects_to_pack, dict):
                 objects_to_pack = {
                     f"{log_hint_key}_{dict_key}": dict_obj
@@ -228,9 +244,9 @@ class PackagersManager:
                 }
             # Go over the collected keys and objects and pack them (with decreased unbundle level):
             unbundle_level = (
-                unbundle_level - 1
-                if isinstance(unbundle_level, int)
-                else unbundle_level
+                unbundle_level
+                if isinstance(unbundle_level, bool)
+                else unbundle_level - 1
             )
             packages = []
             for key, per_key_obj in objects_to_pack.items():

--- a/mlrun/package/packagers_manager.py
+++ b/mlrun/package/packagers_manager.py
@@ -17,6 +17,7 @@ import inspect
 import os
 import shutil
 import traceback
+import warnings
 from typing import Any
 
 import mlrun.errors
@@ -62,6 +63,9 @@ class PackagersManager:
         self._artifacts: list[Artifact] = []
         self._results = {}
 
+        # Temporary holder for bundle structures results to update the store paths before logging them as results:
+        self._bundles = {}
+
     @property
     def artifacts(self) -> list[Artifact]:
         """
@@ -79,6 +83,22 @@ class PackagersManager:
         :return: A results dictionary.
         """
         return self._results
+
+    def get_bundles_results(self, logged_outputs: dict) -> dict:
+        """
+        Get the bundles results with updated store paths according to the logged outputs.
+
+        :param logged_outputs: The logged outputs dictionary from the MLRun context.
+
+        :return: A results dictionary with the bundles updated store paths.
+        """
+        updated_bundles = {}
+        for key, bundle_structure in self._bundles.items():
+            updated_bundles[key] = self._update_bundle_results(
+                bundle_structure=bundle_structure,
+                logged_outputs=logged_outputs,
+            )
+        return updated_bundles
 
     def collect_packagers(
         self, packagers: list[type[Packager] | str], default_priority: int = 5
@@ -176,7 +196,6 @@ class PackagersManager:
         self,
         obj: Any,
         log_hint: dict[str, str],
-        _unbundle_level: int | None = None,
     ) -> Artifact | dict | None | list[Artifact | dict | None]:
         """
         Pack an object using one of the manager's packagers.
@@ -193,10 +212,6 @@ class PackagersManager:
 
         :param obj:             The object to pack as an artifact.
         :param log_hint:        The log hint to use.
-        :param _unbundle_level: Inner argument. Mention the level of unbundling to perform. If provided, the method will
-                                unbundle the object only if the level is > 0, and will decrease the level by 1 for every
-                                unbundling. If None is provided (default behavior), the unbundling will be performed
-                                according to the log hint key.
 
         :return: The packaged artifact or result. None is returned if there was a problem while packing the object. If
                  unbundling is performed, a list of all the unbundled packaged objects is returned.
@@ -205,75 +220,40 @@ class PackagersManager:
         :raise MLRunPackagePackingError:    If there was an error during the packing.
         :raise MLRunPackageUnbundlingError: If there was an error during the unbundling.
         """
+        # TODO: Remove in MLRun 1.13.0
+        if "**" in log_hint[LogHintKey.KEY]:
+            warnings.warn(
+                message=(
+                    "The '**' for packing dictionary items separately is replaced by a single '*', same as list. "
+                    "Please read the documentation on the new bundling and unbundling feature. Using '**' will be "
+                    "removed in MLRun 1.13.0. Currently replacing '**' with '*' automatically."
+                ),
+                category=FutureWarning,
+                stacklevel=2,
+            )
+            log_hint[LogHintKey.KEY] = log_hint[LogHintKey.KEY].replace("**", "*")
+
         # Check if needed to unbundle:
         log_hint_key, unbundle_level = LogHintUtils.extract_unbundling_from_key(
             log_hint=log_hint[LogHintKey.KEY]
         )
-        if _unbundle_level is not None:
-            # Inner call with unbundle level provided - override the extracted level:
-            unbundle_level = _unbundle_level
 
-        # If unbundling is required, check the object can be unbundled (we don't want to fail on non-unbundle-able
-        # object as it is common that a user function might return a list[object] | object, so the expected log hint
-        # would be with *):
-        objects_to_pack = None
-        if unbundle_level:
-            try:
-                objects_to_pack = self._unbundle(bundled_object=obj)
-            except MLRunPackageUnbundlingError as unbundling_error:
-                if "No packager was found to unbundle the object" not in str(
-                    unbundling_error
-                ):
-                    raise unbundling_error
-                logger.debug(
-                    f"Unbundle level was not reached for '{log_hint_key}', but it cannot be unbundled (there is no "
-                    f"packager that can unbundle it) so we continue to pack it as a single object."
-                )
-
-        # If unbundling was performed, pack each of the unbundled objects separately:
-        if objects_to_pack is not None:
-            if isinstance(objects_to_pack, dict):
-                objects_to_pack = {
-                    f"{log_hint_key}_{dict_key}": dict_obj
-                    for dict_key, dict_obj in obj.items()
-                }
-            else:
-                objects_to_pack = {
-                    f"{log_hint_key}_{i}": obj_i for i, obj_i in enumerate(obj)
-                }
-            # Go over the collected keys and objects and pack them (with decreased unbundle level):
-            unbundle_level = (
-                unbundle_level
-                if isinstance(unbundle_level, bool)
-                else unbundle_level - 1
-            )
-            packages = []
-            for key, per_key_obj in objects_to_pack.items():
-                # Edit the key in the log hint:
-                per_key_log_hint = log_hint.copy()
-                per_key_log_hint[LogHintKey.KEY] = key
-                # Pack and collect the package:
-                try:
-                    currently_packaged = self.pack(
-                        obj=per_key_obj,
-                        log_hint=per_key_log_hint,
-                        _unbundle_level=unbundle_level,
-                    )
-                    if isinstance(currently_packaged, list):
-                        packages.extend(currently_packaged)
-                    else:
-                        packages.append(currently_packaged)
-                except Exception as exception:
-                    raise MLRunPackagePackingError(
-                        f"An exception was raised during the packing of '{per_key_log_hint}': {exception}"
-                    ) from exception
-            return packages
+        # Update the log hint key:
+        log_hint[LogHintKey.KEY] = log_hint_key
 
         # A single object is required to be packaged:
         try:
-            package = self._pack(
-                obj=obj, log_hint=log_hint.copy()
-            )  # Log hint is copied to preserve key for error.
+            if unbundle_level:
+                package, bundle_result = self._pack_bundle(
+                    obj=obj,
+                    log_hint=log_hint,
+                    unbundle_level=unbundle_level,
+                )
+                self._bundles[log_hint_key] = bundle_result
+            else:
+                package = self._pack(
+                    obj=obj, log_hint=log_hint.copy()
+                )  # Log hint is copied to preserve key for error.
         except Exception as exception:
             raise MLRunPackagePackingError(
                 f"An exception was raised during the packing of '{log_hint[LogHintKey.KEY]}': {exception}"
@@ -428,6 +408,43 @@ class PackagersManager:
         ARTIFACT_TYPE = "artifact_type"
         INSTRUCTIONS = "instructions"
 
+    def _update_bundle_results(
+        self, bundle_structure: Any, logged_outputs: dict
+    ) -> Any:
+        """
+        Update the bundle results according to the logged outputs. This method goes over the bundle structure
+        recursively and look for the log hint keys to update them with the logged outputs paths.
+
+        :param bundle_structure: The bundle structure to update.
+        :param logged_outputs:   The logged outputs dictionary from the MLRun context.
+
+        :return: The updated bundle structure.
+        """
+        # Dict case:
+        if isinstance(bundle_structure, dict):
+            return {
+                bundle_key: (
+                    logged_outputs[package_key]
+                    if not isinstance(package_key, list | dict)
+                    else self._update_bundle_results(
+                        bundle_structure=bundle_structure[bundle_key],
+                        logged_outputs=logged_outputs,
+                    )
+                )
+                for bundle_key, package_key in bundle_structure.items()
+            }
+
+        # List case:
+        return [
+            logged_outputs[package_key]
+            if not isinstance(package_key, list | dict)
+            else self._update_bundle_results(
+                bundle_structure=bundle_structure[index],
+                logged_outputs=logged_outputs,
+            )
+            for index, package_key in enumerate(bundle_structure)
+        ]
+
     def _get_packagers_with_default_packager(self) -> list[Packager]:
         """
         Get the full list of packagers - the collected packagers and the default packager (located at last place in the
@@ -555,6 +572,96 @@ class PackagersManager:
 
         # No packager was found:
         return None
+
+    def _pack_bundle(
+        self, obj: object, log_hint: dict, unbundle_level: bool | int
+    ) -> tuple[list[Artifact | dict | None], dict]:
+        """
+        Pack a bundle of objects using one of the manager's packagers.
+
+        :param obj:            The objects bundle to pack as artifacts.
+        :param log_hint:       The log hint to use.
+        :param unbundle_level: Mention the level of unbundling to perform. If provided, the method will unbundle the
+                               object only if the level is > 0, and will decrease the level by 1 for every unbundling.
+
+        :return: A list of all packaged artifacts or results along the bundle structure as result. None is returned if
+                 there was a problem while packing the objects.
+
+        :raise MLRunPackagePackingError:    If there was an error during the packing.
+        :raise MLRunPackageUnbundlingError: If there was an error during the unbundling.
+        """
+        # Check the object can be unbundled (we don't want to fail on non-unbundle-able object, as it is very common
+        # to return a list[object] | object from a function. In this case, the user may run with a log hint that would
+        # start with * but only a single object will return - we don't want to fail on this, but rather pack it as a
+        # single object):
+        log_hint_key = log_hint[LogHintKey.KEY]
+        unbundled_object = None
+        if unbundle_level:
+            try:
+                unbundled_object = self._unbundle(bundled_object=obj)
+            except MLRunPackageUnbundlingError as unbundling_error:
+                if "No packager was found to unbundle the object" not in str(
+                    unbundling_error
+                ):
+                    raise unbundling_error
+                logger.debug(
+                    f"Unbundle level was not reached for '{log_hint_key}', but it cannot be unbundled (there is no "
+                    f"packager that can unbundle it) so we continue to pack it as a single object."
+                )
+
+        # If the object cannot be unbundled, pack it as a single object:
+        if unbundled_object is None:
+            return [self._pack(obj=obj, log_hint=log_hint)], log_hint_key
+
+        # Unbundling was performed, create a log hint for each of the unbundled items:
+        if isinstance(unbundled_object, dict):
+            objects_to_pack = {
+                f"{log_hint_key}_{dict_key}": dict_obj
+                for dict_key, dict_obj in unbundled_object.items()
+            }
+            bundle_structure = {
+                dict_key: package_key
+                for dict_key, package_key in zip(
+                    unbundled_object.keys(), objects_to_pack.keys()
+                )
+            }
+        else:
+            objects_to_pack = {
+                f"{log_hint_key}_{i}": obj_i for i, obj_i in enumerate(unbundled_object)
+            }
+            bundle_structure = list(objects_to_pack.keys())
+
+        # Go over the collected keys and objects and pack them (with decreased unbundle level):
+        unbundle_level = (
+            unbundle_level if isinstance(unbundle_level, bool) else unbundle_level - 1
+        )
+        packages = []
+        for (key, per_key_obj), i in zip(
+            objects_to_pack.items(),
+            unbundled_object.keys()
+            if isinstance(unbundled_object, dict)
+            else range(len(unbundled_object)),
+        ):
+            # Edit the key in the log hint:
+            per_key_log_hint = log_hint.copy()
+            per_key_log_hint[LogHintKey.KEY] = key
+            # Pack and collect the package:
+            try:
+                currently_packaged, bundle_structure[i] = self._pack_bundle(
+                    obj=per_key_obj,
+                    log_hint=per_key_log_hint,
+                    unbundle_level=unbundle_level,
+                )
+                if isinstance(currently_packaged, list):
+                    packages.extend(currently_packaged)
+                else:
+                    packages.append(currently_packaged)
+            except Exception as exception:
+                raise MLRunPackagePackingError(
+                    f"An exception was raised during the packing of '{per_key_log_hint}': {exception}"
+                ) from exception
+
+        return packages, bundle_structure
 
     def _pack(self, obj: Any, log_hint: dict) -> Artifact | dict | None:
         """

--- a/mlrun/package/utils/__init__.py
+++ b/mlrun/package/utils/__init__.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ._archiver import ArchiveSupportedFormat
-from ._formatter import StructFileSupportedFormat
-from ._pickler import Pickler
-from ._supported_format import SupportedFormat
-from .log_hint_utils import LogHintKey, LogHintUtils
-from .type_hint_utils import TypeHintUtils
+from mlrun.package.utils._archiver import ArchiveSupportedFormat
+from mlrun.package.utils._formatter import StructFileSupportedFormat
+from mlrun.package.utils._pickler import Pickler
+from mlrun.package.utils._supported_format import SupportedFormat
+from mlrun.package.utils.log_hint_utils import LogHintKey, LogHintUtils
+from mlrun.package.utils.type_hint_utils import TypeHintUtils
 
 # The default pickle module to use for pickling objects:
 DEFAULT_PICKLE_MODULE = "cloudpickle"

--- a/mlrun/package/utils/_archiver.py
+++ b/mlrun/package/utils/_archiver.py
@@ -19,8 +19,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 import mlrun.utils
-
-from ._supported_format import SupportedFormat
+from mlrun.package.utils._supported_format import SupportedFormat
 
 
 class _Archiver(ABC):

--- a/mlrun/package/utils/_formatter.py
+++ b/mlrun/package/utils/_formatter.py
@@ -15,7 +15,7 @@
 import ast
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Union
+from typing import Any
 
 import yaml
 
@@ -61,7 +61,7 @@ class _JSONFormatter(_Formatter):
     DEFAULT_DUMP_KWARGS = {"indent": 4}
 
     @classmethod
-    def write(cls, obj: Union[list, dict], file_path: str, **dump_kwargs: dict):
+    def write(cls, obj: list | dict, file_path: str, **dump_kwargs: dict):
         """
         Write the object to a json file. The object must be serializable according to the json format.
 
@@ -74,7 +74,7 @@ class _JSONFormatter(_Formatter):
             json.dump(obj, file, **dump_kwargs)
 
     @classmethod
-    def read(cls, file_path: str) -> Union[list, dict]:
+    def read(cls, file_path: str) -> list | dict:
         """
         Read an object from the json file given.
 
@@ -93,7 +93,7 @@ class _JSONLFormatter(_Formatter):
     """
 
     @classmethod
-    def write(cls, obj: Union[list, dict], file_path: str, **dump_kwargs: dict):
+    def write(cls, obj: list | dict, file_path: str, **dump_kwargs: dict):
         """
         Write the object to a jsonl file. The object must be serializable according to the json format.
 
@@ -109,7 +109,7 @@ class _JSONLFormatter(_Formatter):
                 file.write(json.dumps(obj=line, **dump_kwargs) + "\n")
 
     @classmethod
-    def read(cls, file_path: str) -> Union[list, dict]:
+    def read(cls, file_path: str) -> list | dict:
         """
         Read an object from the jsonl file given.
 
@@ -136,7 +136,7 @@ class _YAMLFormatter(_Formatter):
     DEFAULT_DUMP_KWARGS = {"default_flow_style": False, "indent": 4}
 
     @classmethod
-    def write(cls, obj: Union[list, dict], file_path: str, **dump_kwargs: dict):
+    def write(cls, obj: list | dict, file_path: str, **dump_kwargs: dict):
         """
         Write the object to a yaml file. The object must be serializable according to the yaml format.
 
@@ -149,7 +149,7 @@ class _YAMLFormatter(_Formatter):
             yaml.safe_dump(obj, file, **dump_kwargs)
 
     @classmethod
-    def read(cls, file_path: str) -> Union[list, dict]:
+    def read(cls, file_path: str) -> list | dict:
         """
         Read an object from the yaml file given.
 

--- a/mlrun/package/utils/_formatter.py
+++ b/mlrun/package/utils/_formatter.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import yaml
 
-from ._supported_format import SupportedFormat
+from mlrun.package.utils._supported_format import SupportedFormat
 
 
 class _Formatter(ABC):

--- a/mlrun/package/utils/_pickler.py
+++ b/mlrun/package/utils/_pickler.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 import warnings
 from types import ModuleType
-from typing import Any, Optional, Union
+from typing import Any
 
 from mlrun.errors import MLRunInvalidArgumentError
 from mlrun.utils import logger
@@ -34,8 +34,8 @@ class Pickler:
 
     @staticmethod
     def pickle(
-        obj: Any, pickle_module_name: str, output_path: Optional[str] = None
-    ) -> tuple[str, dict[str, Union[str, None]]]:
+        obj: Any, pickle_module_name: str, output_path: str | None = None
+    ) -> tuple[str, dict[str, str | None]]:
         """
         Pickle an object using the given module. The pickled object will be saved to file to the given output path.
 
@@ -91,10 +91,10 @@ class Pickler:
     def unpickle(
         pickle_path: str,
         pickle_module_name: str,
-        object_module_name: Optional[str] = None,
-        python_version: Optional[str] = None,
-        pickle_module_version: Optional[str] = None,
-        object_module_version: Optional[str] = None,
+        object_module_name: str | None = None,
+        python_version: str | None = None,
+        pickle_module_version: str | None = None,
+        object_module_version: str | None = None,
     ) -> Any:
         """
         Unpickle an object using the given instructions. Warnings may be raised in case any of the versions are
@@ -178,7 +178,7 @@ class Pickler:
                 )
 
     @staticmethod
-    def _get_module_version(module_name: str) -> Union[str, None]:
+    def _get_module_version(module_name: str) -> str | None:
         """
         Get a module's version. Most updated modules have versions but some don't. In case the version could not be
         read, None is returned.

--- a/mlrun/package/utils/_supported_format.py
+++ b/mlrun/package/utils/_supported_format.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC
-from typing import Generic, TypeVar, Union
+from typing import Generic, TypeVar
 
 # A generic type for a supported format handler class type:
 FileHandlerType = TypeVar("FileHandlerType")
@@ -56,7 +56,7 @@ class SupportedFormat(ABC, Generic[FileHandlerType]):
         return cls._FORMAT_HANDLERS_MAP[fmt]
 
     @classmethod
-    def match_format(cls, path: str) -> Union[str, None]:
+    def match_format(cls, path: str) -> str | None:
         """
         Try to match one of the available formats this class holds to a given path.
 

--- a/mlrun/package/utils/log_hint_utils.py
+++ b/mlrun/package/utils/log_hint_utils.py
@@ -107,10 +107,19 @@ class LogHintUtils:
             return log_hint, False
 
         # Extract unbundle level and key:
-        unbundle_level, key = log_hint.split("*")
+        unbundle_level, key = log_hint.split("*", 1)
+
+        # Make sure a key is given:
+        if not key.strip():
+            raise MLRunInvalidArgumentError(
+                f"Invalid log hint key '{log_hint}'. Key is missing after the '*' indicating unbundling. A log hint "
+                f"key with unbundling should be in the format of "
+                f"'<unbundle_level>*<key>' or '*<key>' for full "
+                f"unbundling."
+            )
 
         # If unbundle level is given, convert to int:
-        if unbundle_level:
+        if unbundle_level.strip():
             try:
                 unbundle_level = int(unbundle_level.strip())
             except ValueError:

--- a/mlrun/package/utils/log_hint_utils.py
+++ b/mlrun/package/utils/log_hint_utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typing
-
 from mlrun.errors import MLRunInvalidArgumentError
 
 
@@ -35,8 +33,8 @@ class LogHintUtils:
 
     @staticmethod
     def parse_log_hint(
-        log_hint: typing.Union[dict[str, str], str, None],
-    ) -> typing.Union[dict[str, str], None]:
+        log_hint: dict[str, str] | str | None,
+    ) -> dict[str, str] | None:
         """
         Parse a given log hint from string to a logging configuration dictionary. The string will be read as the
         artifact key ('key' in the dictionary) and if the string have a single colon, the following structure is
@@ -91,3 +89,37 @@ class LogHintUtils:
             )
 
         return log_hint
+
+    @staticmethod
+    def extract_unbundling_from_key(log_hint: str) -> tuple[str, bool | int]:
+        """
+        Extract unbundling information from a log hint key if exists. If the log hint key contains an asterisk '*', it
+        indicates that unbundling is required. The part before the asterisk represents the unbundle level (an integer or
+        empty for full unbundling), and the part after the asterisk is the actual artifact key.
+
+        :param log_hint: The log hint key to extract unbundling information from.
+
+        :return: A tuple containing the actual artifact key and the unbundle level (True for full unbundling, False for
+                 no unbundling, or an integer for specific unbundle level).
+        """
+        # Check if unbundling is required:
+        if "*" not in log_hint:
+            return log_hint, False
+
+        # Extract unbundle level and key:
+        unbundle_level, key = log_hint.split("*")
+
+        # If unbundle level is given, convert to int:
+        if unbundle_level:
+            try:
+                unbundle_level = int(unbundle_level.strip())
+            except ValueError:
+                raise MLRunInvalidArgumentError(
+                    f"Invalid unbundle level '{unbundle_level}' in log hint '{log_hint}'. "
+                    f"Unbundle level must be an integer."
+                )
+        else:
+            # If no level is given, set to True for full unbundling:
+            unbundle_level = True
+
+        return key.strip(), unbundle_level

--- a/mlrun/package/utils/type_hint_utils.py
+++ b/mlrun/package/utils/type_hint_utils.py
@@ -15,6 +15,7 @@
 import builtins
 import collections
 import importlib
+import inspect
 import itertools
 import re
 import types
@@ -40,6 +41,9 @@ class TypeHintUtils:
 
         :return: True if the type hint from `typing` / `types` and False otherwise.
         """
+        # Handle ellipsis (...) which is used in tuple type hints like tuple[int, ...]
+        if type_hint is ...:
+            return False
         # A type hint should be one of the based typing classes, meaning it will have "typing" as its module. Some
         # typing classes are considered a type (like `TypeVar`) so we check their type as well. The only case "types"
         # will be a module for the type of the type hint is for `GenericAlias` like `list[int]`.
@@ -48,7 +52,35 @@ class TypeHintUtils:
         )
 
     @staticmethod
-    def parse_type_hint(type_hint: typing.Union[type, str]) -> type:
+    def is_pure_hint(type_hint: type) -> bool:
+        """
+        Check whether a given type hint is a pure type hint, meaning it cannot be instantiated as an object (like
+        `list` from `list[int]` can) or refer to one (like `List[int]` can refer to `list[int]`). For example:
+        `typing.Union` and `typing.TypeVar` are pure type hints.
+
+        :param type_hint: The type hint to check.
+
+        :return: True if the type hint is a pure type hint and False otherwise.
+        """
+        # A pure type hint should be first and for all a typing type:
+        if not TypeHintUtils.is_typing_type(type_hint=type_hint):
+            return False
+
+        # Check for generic aliases (like `list[int]` or `List[int]`), which are not pure type hints
+        # (`typing._GenericAlias` is tested via `type(typing.List[int])`):
+        if (
+            type(type_hint)
+            is types.GenericAlias  # Python objects as type hints: list[int], dict[str, int], etc.
+            or type(type_hint)
+            is type(
+                list[int]
+            )  # Typing module type hints: List[int], Dict[str, int], etc.
+        ):
+            return False
+        return True
+
+    @staticmethod
+    def parse_type_hint(type_hint: type | str) -> type:
         """
         Parse a given type hint from string to its actual hinted type class object. The string must be one of the
         following:
@@ -72,87 +104,120 @@ class TypeHintUtils:
         if not isinstance(type_hint, str):
             return type_hint
 
-        # Validate the type hint is a valid module path:
-        if not bool(
-            re.fullmatch(
-                r"([a-zA-Z_][a-zA-Z0-9_]*\.)*[a-zA-Z_][a-zA-Z0-9_]*", type_hint
-            )
-        ):
-            raise MLRunInvalidArgumentError(
-                f"Invalid type hint. An input type hint must be a valid python class name or its module import path. "
-                f"For example: 'list', 'pandas.DataFrame', 'numpy.ndarray', 'sklearn.linear_model.LinearRegression'. "
-                f"Type hint given: '{type_hint}'."
-            )
-
-        # Look for a builtin type (rest of the builtin types like `int`, `str`, `float` should be treated as results,
-        # hence not given as an input to an MLRun function, but as a parameter):
+        # Prepare a set of builtin types for quick lookup:
         builtin_types = {
             builtin_name: builtin_type
             for builtin_name, builtin_type in builtins.__dict__.items()
-            if isinstance(builtin_type, type)
+            if isinstance(builtin_type, type) or builtin_name == "None"
         }
-        if type_hint in builtin_types:
-            return builtin_types[type_hint]
 
-        # If it's not a builtin, its should have a full module path, meaning at least one '.' to separate the module and
-        # the class. If it doesn't, we will try to get the class from the main module:
-        if "." not in type_hint:
-            logger.warn(
-                f"The type hint string given '{type_hint}' is not a `builtins` python type. MLRun will try to look for "
-                f"it in the `__main__` module instead."
-            )
-            try:
-                return TypeHintUtils.parse_type_hint(type_hint=f"__main__.{type_hint}")
-            except MLRunInvalidArgumentError:
-                raise MLRunInvalidArgumentError(
-                    f"MLRun tried to get the type hint '{type_hint}' but it can't as it is not a valid builtin Python "
-                    f"type (one of `list`, `dict`, `str`, `int`, etc.) nor a locally declared type (from the "
-                    f"`__main__` module). Pay attention using only the type as string is not allowed as the handler's "
-                    f"scope is different than MLRun's. To properly give a type hint as string, please specify the full "
-                    f"module path without aliases. For example: do not use `DataFrame` or `pd.DataFrame`, use "
-                    f"`pandas.DataFrame`."
+        # Prepare custom scope for eval:
+        scope = dict(globals())
+
+        # Look for inner arguments inside square brackets (e.g. `List[int]`, `Dict[str, float]`, etc.) to extract types
+        # for importing them before validating the main type hint (notice we ignore literals and values, so
+        # for `typing.Literal["A"]` we'll not try to import `"A"`):
+        raw_matches = re.finditer(
+            r"""
+             (?P<type>[a-zA-Z_][\w.]*) | # Identifiers (Types)
+             (?P<value>"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|-?\d+(?:\.\d+)?) # Literals (Values)
+             """,
+            type_hint,
+            re.VERBOSE,
+        )
+        extracted_types = set([m.group("type") for m in raw_matches if m.group("type")])
+
+        # Iterate over the extracted types to import them first for validation (as they are needed for the main hint):
+        for extracted_type in extracted_types:
+            # Validate the type hint is a valid module path:
+            if not bool(
+                re.fullmatch(
+                    r"([a-zA-Z_][a-zA-Z0-9_]*\.)*[a-zA-Z_][a-zA-Z0-9_]*", extracted_type
                 )
-
-        # Import the module to receive the hinted type:
-        try:
-            # Get the module path and the type class (If we'll wish to support inner classes, the `rsplit` won't work):
-            module_path, type_hint = type_hint.rsplit(".", 1)
+            ):
+                raise MLRunInvalidArgumentError(
+                    f"Invalid type hint. An input type hint must be a valid python class name or its module import "
+                    f"path. For example: 'list', 'pandas.DataFrame', 'numpy.ndarray', "
+                    f"'sklearn.linear_model.LinearRegression'. Type hint given: '{extracted_type}'."
+                )
+            # Look for a builtin type:
+            if extracted_type in builtin_types:
+                continue
+            # If it's not a builtin, its should have a full module path, meaning at least one '.' to separate the module and
+            # the class. If it doesn't, we will try to get the class from the main module:
+            if "." not in extracted_type:
+                logger.warn(
+                    f"The type hint string given '{extracted_type}' is not a `builtins` python type. MLRun will try to "
+                    f"look for it in the `__main__` module instead."
+                )
+                try:
+                    return TypeHintUtils.parse_type_hint(
+                        type_hint=f"__main__.{extracted_type}"
+                    )
+                except MLRunInvalidArgumentError:
+                    raise MLRunInvalidArgumentError(
+                        f"MLRun tried to get the type hint '{extracted_type}' but it can't as it is not a valid builtin "
+                        f"Python type (one of `list`, `dict`, `str`, `int`, etc.) nor a locally declared type (from "
+                        f"the `__main__` module). Pay attention using only the type as string is not allowed as the "
+                        f"handler's scope is different than MLRun's. To properly give a type hint as string, please "
+                        f"specify the full module path without aliases. For example: do not use `DataFrame` or "
+                        f"`pd.DataFrame`, use `pandas.DataFrame`."
+                    )
+            # Get the module path and the type class (If we'll wish to support inner classes, the `rsplit` won't
+            # work):
+            module_path, extracted_type = extracted_type.rsplit(".", 1)
             # Replace alias if needed (alias assumed to be imported already, hence we look in globals):
             # For example:
             # If in handler scope there was `import A.B.C as abc` and user gave a type hint "abc.Something" then:
-            # `module_path[0]` will be equal to "abc". Then, because it is an alias, it will appear in the globals, so
-            # we'll replace the alias with the full module name in order to import the module.
-            module_path = module_path.split(".")
-            if module_path[0] in globals():
-                module_path[0] = globals()[module_path[0]].__name__
-            module_path = ".".join(module_path)
+            # `module_path[0]` will be equal to "abc". Then, because it is an alias, it will appear in the globals,
+            # so we'll replace the alias with the full module name in order to import the module.
+            module_path_with_alias = module_path.split(".")
+            if module_path_with_alias[0] in globals():
+                module_path_with_alias[0] = globals()[
+                    module_path_with_alias[0]
+                ].__name__
+            module_path_with_alias = ".".join(module_path_with_alias)
             # Import the module:
-            module = importlib.import_module(module_path)
-            # Get the class type from the module:
-            type_hint = getattr(module, type_hint)
-        except ModuleNotFoundError as module_not_found_error:
-            # May be raised from `importlib.import_module` in case the module does not exist.
+            try:
+                module = importlib.import_module(module_path_with_alias)
+            except ModuleNotFoundError as module_not_found_error:
+                # May be raised from `importlib.import_module` in case the module does not exist.
+                raise MLRunInvalidArgumentError(
+                    f"MLRun tried to get the type hint '{extracted_type}' but the module '{module_path}' cannot be "
+                    f"imported. Keep in mind that using alias in the module path (meaning: import module as alias) is "
+                    f"not allowed. If the module path is correct, please make sure the module package is installed in "
+                    f"the python interpreter."
+                ) from module_not_found_error
+            # Check the type exists in the module:
+            if not hasattr(module, extracted_type):
+                # Class type cannot be imported directly from the imported module.
+                raise MLRunInvalidArgumentError(
+                    f"MLRun tried to get the type hint '{extracted_type}' from the module '{module.__name__}' but it "
+                    f"seems it doesn't exist. Make sure the class can be imported from the module with the exact "
+                    f"module path you passed. Notice inner classes (a class inside of a class) are not supported."
+                )
+            # Add the type to the scope for eval:
+            scope[extracted_type] = getattr(module, extracted_type)
+            type_hint = type_hint.replace(
+                f"{module_path}.{extracted_type}", extracted_type
+            )
+
+        # Lastly, we validate the main type hint structure:
+        try:
+            # Evaluate the type hint string to get the actual type hint:
+            type_hint = eval(type_hint, scope)
+        except Exception as eval_exception:
             raise MLRunInvalidArgumentError(
-                f"MLRun tried to get the type hint '{type_hint}' but the module '{module_path}' cannot be imported. "
-                f"Keep in mind that using alias in the module path (meaning: import module as alias) is not allowed. "
-                f"If the module path is correct, please make sure the module package is installed in the python "
-                f"interpreter."
-            ) from module_not_found_error
-        except AttributeError as attribute_error:
-            # May be raised from `getattr(module, type_hint)` in case the class type cannot be imported directly from
-            # the imported module.
-            raise MLRunInvalidArgumentError(
-                f"MLRun tried to get the type hint '{type_hint}' from the module '{module.__name__}' but it seems it "
-                f"doesn't exist. Make sure the class can be imported from the module with the exact module path you "
-                f"passed. Notice inner classes (a class inside of a class) are not supported."
-            ) from attribute_error
+                f"MLRun tried to parse the type hint string '{type_hint}' but failed evaluating it to an actual type "
+                f"hint. Make sure the type hint is a valid python type hint structure. Error: {eval_exception}"
+            ) from eval_exception
 
         return type_hint
 
     @staticmethod
     def is_matching(
         object_type: type,
-        type_hint: typing.Union[type, set[type]],
+        type_hint: type | set[type],
         include_subclasses: bool = True,
         reduce_type_hint: bool = True,
     ) -> bool:
@@ -189,8 +254,44 @@ class TypeHintUtils:
         return False
 
     @staticmethod
+    def deconstruct_type_hint(
+        type_hint: type,
+    ) -> tuple[type, tuple[type, ...] | type[inspect.Parameter.empty]]:
+        """
+        Deconstruct a type hint to its origin and argument types. For example: `typing.List[int]` will return
+        `(list, (int,))`.
+
+        Note: Ellipsis (`...`) in type hints like `tuple[int, ...]` are filtered out from the arguments,
+        since they indicate variable length rather than an actual type. In this case, `tuple[int, ...]`
+        will return `(tuple, (int,))`.
+
+        :param type_hint: The type hint to deconstruct.
+
+        :return: A tuple of the origin type and a tuple of argument types, or `inspect.Parameter.empty`
+                 if there are no arguments (or only ellipsis arguments).
+        """
+        # Get the origin of the type hint:
+        origin = typing.get_origin(type_hint)
+        if origin is None:
+            # Not a typing type, return as is with no args:
+            return type_hint, inspect.Parameter.empty
+
+        # Get the type hint's subscriptions - arguments:
+        args = typing.get_args(type_hint)
+
+        # Filter out ellipsis (...) from the args, as it indicates variable length, not a type.
+        # This is common in tuple type hints like `tuple[int, ...]` which means a tuple of any number of ints.
+        args = tuple(arg for arg in args if arg is not ...)
+
+        # Return inspect.Parameter.empty if no args remain after filtering:
+        if len(args) == 0:
+            return origin, inspect.Parameter.empty
+
+        return origin, args
+
+    @staticmethod
     def reduce_type_hint(
-        type_hint: typing.Union[type, set[type]],
+        type_hint: type | set[type],
     ) -> set[type]:
         """
         Reduce a type hint (or a set of type hints) using the `_reduce_type_hint` function.

--- a/mlrun/package/utils/type_hint_utils.py
+++ b/mlrun/package/utils/type_hint_utils.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import builtins
+import collections
 import importlib
 import itertools
 import re
+import types
 import typing
 
 from mlrun.errors import MLRunInvalidArgumentError
@@ -40,8 +42,8 @@ class TypeHintUtils:
         """
         # A type hint should be one of the based typing classes, meaning it will have "typing" as its module. Some
         # typing classes are considered a type (like `TypeVar`) so we check their type as well. The only case "types"
-        # will be a module is for generic aliases like `list[int]`.
-        return (type_hint.__module__ == "typing") or (
+        # will be a module for the type of the type hint is for `GenericAlias` like `list[int]`.
+        return (type_hint.__module__ in ["typing", "types"]) or (
             type(type_hint).__module__ in ["typing", "types"]
         )
 
@@ -195,7 +197,7 @@ class TypeHintUtils:
 
         :param type_hint: The type hint to reduce.
 
-        :return: The reduced type hints set or an empty set if the type hint could not be reduced.
+        :return: The reduced type hints set or an empty set if the type hints could not be reduced.
         """
         # Wrap in a set if provided a single type hint:
         type_hints = {type_hint} if not isinstance(type_hint, set) else type_hint
@@ -260,27 +262,23 @@ class TypeHintUtils:
         # type alias (e.g. origin of List[int] is list):
         origin = typing.get_origin(type_hint)
 
-        # If the typing type has no origin (e.g. None is returned), we cannot reduce it, so we return an empty list:
-        if origin is None:
-            return []
-
-        # If the origin is a type of one of `builtins`, `contextlib` or `collections` (for example: List's origin is
-        # list) then we can be sure there is nothing to reduce as it's a regular type:
-        if not TypeHintUtils.is_typing_type(type_hint=origin):
-            return [origin]
-
         # Get the type's subscriptions - arguments, in order to reduce it to them (we know for sure there are arguments,
         # otherwise origin would have been None):
         args = typing.get_args(type_hint)
 
-        # Return the reduced type as its arguments according to the origin:
-        if origin is typing.Callable:
+        # If the typing type has no origin (e.g. None is returned) and it has no args (meaning it is a type without
+        # subscriptions), we cannot reduce it, so we return an empty list:
+        if origin is None:
+            return []
+
+        # Check for a special typing type and return the reduced type accordingly:
+        if origin is typing.Callable or origin is collections.abc.Callable:
             # A callable cannot be reduced to its arguments, so we'll return the origin - Callable:
-            return [typing.Callable]
+            return [collections.abc.Callable]
         if origin is typing.Literal:
             # Literal arguments are not types, but values. So we'll take the types of the values as the reduced type:
             return [type(arg) for arg in args]
-        if origin is typing.Union:
+        if origin is typing.Union or origin is types.UnionType:
             # A union is reduced to its arguments:
             return list(args)
         if origin is typing.Annotated:
@@ -290,6 +288,20 @@ class TypeHintUtils:
         if origin is typing.Final or origin is typing.ClassVar:
             # Both Final and ClassVar takes only one argument - the type:
             return [args[0]]
+        # For `typing.Generic` we return `[]` as it cannot be reduced further.
 
-        # For Generic types we return an empty list:
-        return []
+        # It is not a special typing type, it is most likely a `types.GenericAlias` or `typing._GenericAlias` so we
+        # return the origin:
+        # TODO: Technically we should reduce a generic alias from its args by one level at a time.
+        #       For example:
+        #       * `Dict[str, list[int]]` will be reduced to `dict[str, list]` and on another call to `dict`.
+        #       * `List[int | str | dict[str, int | float]]` will be reduced to `List[int | str | dict[str, int]]` and
+        #         `List[int | str | dict[str, float]]`, which then both will yield `List[int | str | dict]`, and finally
+        #         `list`.
+        #       The algorithm should find the deepest typing type possible (like union) and reduce it. Once there are no
+        #       more typing types to reduce, the deepest args should be reduced until we reach the core origin we now
+        #       return by default. If there are two or more args to reduce, all combinations (permutations) should be
+        #       returned.
+        #       For now, we reduce only to the origin type itself regardless of its args, as it seems to be sufficient
+        #       for our users.
+        return [origin]

--- a/mlrun/package/utils/type_hint_utils.py
+++ b/mlrun/package/utils/type_hint_utils.py
@@ -73,7 +73,7 @@ class TypeHintUtils:
             is types.GenericAlias  # Python objects as type hints: list[int], dict[str, int], etc.
             or type(type_hint)
             is type(
-                list[int]
+                typing.List[int]  # noqa: UP006
             )  # Typing module type hints: List[int], Dict[str, int], etc.
         ):
             return False

--- a/mlrun/package/utils/type_hint_utils.py
+++ b/mlrun/package/utils/type_hint_utils.py
@@ -143,8 +143,8 @@ class TypeHintUtils:
             # Look for a builtin type:
             if extracted_type in builtin_types:
                 continue
-            # If it's not a builtin, its should have a full module path, meaning at least one '.' to separate the module and
-            # the class. If it doesn't, we will try to get the class from the main module:
+            # If it's not a builtin, its should have a full module path, meaning at least one '.' to separate the module
+            # and the class. If it doesn't, we will try to get the class from the main module:
             if "." not in extracted_type:
                 logger.warn(
                     f"The type hint string given '{extracted_type}' is not a `builtins` python type. MLRun will try to "
@@ -156,11 +156,11 @@ class TypeHintUtils:
                     )
                 except MLRunInvalidArgumentError:
                     raise MLRunInvalidArgumentError(
-                        f"MLRun tried to get the type hint '{extracted_type}' but it can't as it is not a valid builtin "
-                        f"Python type (one of `list`, `dict`, `str`, `int`, etc.) nor a locally declared type (from "
-                        f"the `__main__` module). Pay attention using only the type as string is not allowed as the "
-                        f"handler's scope is different than MLRun's. To properly give a type hint as string, please "
-                        f"specify the full module path without aliases. For example: do not use `DataFrame` or "
+                        f"MLRun tried to get the type hint '{extracted_type}' but it can't as it is not a valid "
+                        f"builtin Python type (one of `list`, `dict`, `str`, `int`, etc.) nor a locally declared type "
+                        f"(from the `__main__` module). Pay attention using only the type as string is not allowed as "
+                        f"the handler's scope is different than MLRun's. To properly give a type hint as string, "
+                        f"please specify the full module path without aliases. For example: do not use `DataFrame` or "
                         f"`pd.DataFrame`, use `pandas.DataFrame`."
                     )
             # Get the module path and the type class (If we'll wish to support inner classes, the `rsplit` won't

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -293,7 +293,7 @@ class BaseRuntime(ModelObj):
         name: Optional[str] = "",
         project: Optional[str] = "",
         params: Optional[dict] = None,
-        inputs: Optional[dict[str, str]] = None,
+        inputs: Optional[dict[str, str | list | dict]] = None,
         out_path: Optional[str] = "",
         workdir: Optional[str] = "",
         artifact_path: Optional[str] = "",
@@ -325,7 +325,8 @@ class BaseRuntime(ModelObj):
         :param params:         Input parameters (dict).
         :param inputs:         Input objects to pass to the handler. Type hints can be given so the input will be parsed
                                during runtime from `mlrun.DataItem` to the given type hint. The type hint can be given
-                               in the key field of the dictionary after a colon, e.g: "<key> : <type_hint>".
+                               in the key field of the dictionary after a colon, e.g: "<key> : <type_hint>". An input
+                               can include a collection of inputs in a dict or list.
         :param out_path:       (deprecated) Default artifact output path.
         :param artifact_path:  (deprecated) Default artifact output path (will replace out_path).
         :param workdir:        Working directory of the executed job and the default path for artifact inputs
@@ -738,7 +739,7 @@ class BaseRuntime(ModelObj):
         hyperparams=None,
         selector="",
         hyper_param_options: HyperParamOptions = None,
-        inputs: Optional[dict] = None,
+        inputs: Optional[dict[str, str | list | dict]] = None,
         outputs: Optional[list] = None,
         workdir: str = "",
         artifact_path: str = "",
@@ -763,7 +764,8 @@ class BaseRuntime(ModelObj):
                             see: :py:class:`~mlrun.model.HyperParamOptions`
         :param inputs:          Input objects to pass to the handler. Type hints can be given so the input will be
                                 parsed during runtime from `mlrun.DataItem` to the given type hint. The type hint can be
-                                given in the key field of the dictionary after a colon, e.g: "<key> : <type_hint>".
+                                given in the key field of the dictionary after a colon, e.g: "<key> : <type_hint>". An
+                                input can include a collection of inputs in a dict or list.
         :param outputs:         list of outputs which can pass in the workflow
         :param artifact_path:   default artifact output path (replace out_path)
         :param workdir:         working directory of the executed job and the default path for artifact inputs

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -552,10 +552,13 @@ def get_func_arg(handler, runobj: RunObject, context: MLClientCtx, is_nuclio=Fal
 
     def _get_input_value(input_key: str):
         input_obj = context.get_input(input_key, inputs[input_key])
-        # If there is no type hint annotation but there is a default value and its type is string, point the data
-        # item to local downloaded file path (`local()` returns the downloaded temp path string):
-        if args[input_key].annotation is inspect.Parameter.empty and isinstance(
-            args[input_key].default, str
+        # If it's a single data item (not a dictionary or list of data items) and there is no type hint annotation but
+        # there is a default value and its type is string, point the data item to local downloaded file path (`local()`
+        # returns the downloaded temp path string):
+        if (
+            not isinstance(input_obj, dict | list)
+            and args[input_key].annotation is inspect.Parameter.empty
+            and isinstance(args[input_key].default, str)
         ):
             return input_obj.local()
         else:

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -36,6 +36,7 @@ from nuclio import Event
 import mlrun
 import mlrun.common.constants as mlrun_constants
 from mlrun.lists import RunList
+from mlrun.package import handler as mlrun_handler_decorator
 
 from ..errors import err_to_str
 from ..execution import MLClientCtx
@@ -501,7 +502,7 @@ def exec_from_params(handler, runobj: RunObject, context: MLClientCtx, cwd=None)
                 # log hints (Expected behavior: inputs are being parsed when they have type hints in code or given
                 # by user. Outputs are logged only if log hints are provided by the user):
                 if mlrun.mlconf.packagers.enabled:
-                    val = mlrun.handler(
+                    val = mlrun_handler_decorator(
                         inputs=(
                             runobj.spec.inputs_type_hints
                             if runobj.spec.inputs_type_hints

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -74,7 +74,7 @@ class ServerSideLauncher(launcher.BaseLauncher):
         name: Optional[str] = "",
         project: Optional[str] = "",
         params: Optional[dict] = None,
-        inputs: Optional[dict[str, str]] = None,
+        inputs: Optional[dict[str, str | dict | list]] = None,
         out_path: Optional[str] = "",
         workdir: Optional[str] = "",
         artifact_path: Optional[str] = "",

--- a/tests/launcher/test_local.py
+++ b/tests/launcher/test_local.py
@@ -112,7 +112,9 @@ def test_validate_inputs():
     run = mlrun.run.RunObject(spec=mlrun.model.RunSpec(inputs={"input1": 1}))
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentTypeError) as exc:
         launcher._validate_run(runtime, run)
-    assert "'Inputs' should be of type Dict[str, str]" in str(exc.value)
+    assert "'Inputs' should be of type Dict[str, Union[str,list,dict]]." in str(
+        exc.value
+    )
 
 
 def test_validate_run_success():

--- a/tests/launcher/test_remote.py
+++ b/tests/launcher/test_remote.py
@@ -68,7 +68,9 @@ def test_validate_inputs():
     run = mlrun.run.RunObject(spec=mlrun.model.RunSpec(inputs={"input1": 1}))
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentTypeError) as exc:
         launcher._validate_run(runtime, run)
-    assert "'Inputs' should be of type Dict[str, str]" in str(exc.value)
+    assert "'Inputs' should be of type Dict[str, Union[str,list,dict]]." in str(
+        exc.value
+    )
 
 
 def test_validate_run_success():

--- a/tests/package/packager_tester.py
+++ b/tests/package/packager_tester.py
@@ -15,7 +15,7 @@
 import sys
 from abc import ABC
 from collections.abc import Callable
-from typing import Any, NamedTuple, Union
+from typing import Any, NamedTuple
 
 import cloudpickle
 
@@ -47,7 +47,7 @@ class PackTest(NamedTuple):
     """
 
     pack_handler: str
-    log_hint: Union[str, dict]
+    log_hint: str | dict
     validation_function: Callable[..., bool]
     pack_parameters: dict = {}
     validation_parameters: dict = {}
@@ -70,7 +70,7 @@ class UnpackTest(NamedTuple):
                                    exception message. Default is None (the test should succeed).
     """
 
-    prepare_input_function: Callable[..., tuple[str, str]]
+    prepare_input_function: Callable[..., tuple[str | dict[str, str] | list[str], str]]
     unpack_handler: str
     prepare_parameters: dict = {}
     unpack_parameters: dict = {}
@@ -98,7 +98,7 @@ class PackToUnpackTest(NamedTuple):
     """
 
     pack_handler: str
-    log_hint: Union[str, dict]
+    log_hint: str | dict
     pack_parameters: dict = {}
     expected_instructions: dict = {}
     unpack_handler: str = None
@@ -117,7 +117,7 @@ class PackagerTester(ABC):
     PACKAGER_IN_TEST: Packager = None
 
     # The list of tests tuples to include from this tester in the tests of "test_packagers.py":
-    TESTS: list[Union[PackTest, UnpackTest, PackToUnpackTest]] = []
+    TESTS: list[PackTest | UnpackTest | PackToUnpackTest] = []
 
 
 class NewClass:

--- a/tests/package/packagers_testers/python_standard_library_packagers_testers.py
+++ b/tests/package/packagers_testers/python_standard_library_packagers_testers.py
@@ -398,7 +398,7 @@ class DictPackagerTester(PackagerTester):
         ),
         PackTest(
             pack_handler="pack_dict_for_bundling",
-            log_hint="*items",
+            log_hint="1*items",
             validation_function=validate_bundled_dict,
         ),
         *[
@@ -443,7 +443,7 @@ class DictPackagerTester(PackagerTester):
         ],
         PackToUnpackTest(
             pack_handler="pack_dict_for_bundling",
-            log_hint="*items: object",
+            log_hint="1*items: object",
             unpack_handler="unpack_bundled_dict",
         ),
     ]
@@ -523,7 +523,7 @@ class ListPackagerTester(PackagerTester):
         ),
         PackTest(
             pack_handler="pack_list_for_bundling",
-            log_hint="*items",
+            log_hint="1*items",
             validation_function=validate_bundled_list,
         ),
         *[
@@ -568,7 +568,7 @@ class ListPackagerTester(PackagerTester):
         ],
         PackToUnpackTest(
             pack_handler="pack_list_for_bundling",
-            log_hint="*items: object",
+            log_hint="1*items: object",
             unpack_handler="unpack_bundled_list",
         ),
     ]
@@ -650,7 +650,7 @@ class TuplePackagerTester(PackagerTester):
         ),
         PackTest(
             pack_handler="pack_tuple_for_bundling",
-            log_hint="*items",
+            log_hint="1*items",
             validation_function=validate_bundled_tuple,
         ),
         *[
@@ -695,7 +695,7 @@ class TuplePackagerTester(PackagerTester):
         ],
         PackToUnpackTest(
             pack_handler="pack_tuple_for_bundling",
-            log_hint="*items: object",
+            log_hint="1*items: object",
             unpack_handler="unpack_bundled_tuple",
         ),
     ]
@@ -779,7 +779,7 @@ class SetPackagerTester(PackagerTester):
         ),
         PackTest(
             pack_handler="pack_set_for_bundling",
-            log_hint="*items",
+            log_hint="1*items",
             validation_function=validate_bundled_set,
         ),
         *[
@@ -824,7 +824,7 @@ class SetPackagerTester(PackagerTester):
         ],
         PackToUnpackTest(
             pack_handler="pack_set_for_bundling",
-            log_hint="*items: object",
+            log_hint="1*items: object",
             unpack_handler="unpack_bundled_set",
         ),
     ]
@@ -910,7 +910,7 @@ class FrozensetPackagerTester(PackagerTester):
         ),
         PackTest(
             pack_handler="pack_frozenset_for_bundling",
-            log_hint="*items",
+            log_hint="1*items",
             validation_function=validate_bundled_frozenset,
         ),
         *[
@@ -955,7 +955,7 @@ class FrozensetPackagerTester(PackagerTester):
         ],
         PackToUnpackTest(
             pack_handler="pack_frozenset_for_bundling",
-            log_hint="*items: object",
+            log_hint="1*items: object",
             unpack_handler="unpack_bundled_frozenset",
         ),
     ]

--- a/tests/package/packagers_testers/python_standard_library_packagers_testers.py
+++ b/tests/package/packagers_testers/python_standard_library_packagers_testers.py
@@ -361,15 +361,8 @@ def unpack_bundled_dict(obj: dict[str, dict]):
     assert obj == _BUNDLE_DICT_SAMPLE
 
 
-def validate_bundled_dict(results: dict) -> bool:
-    # Each key should be packed separately with the prefix "items_"
-    for key in _BUNDLE_DICT_SAMPLE.keys():
-        expected_key = f"items_{key}"
-        if expected_key not in results:
-            return False
-        if results[expected_key] != _BUNDLE_DICT_SAMPLE[key]:
-            return False
-    return True
+def validate_bundled_dict(result: dict) -> bool:
+    return result == _BUNDLE_DICT_SAMPLE
 
 
 def prepare_bundled_dict() -> tuple[dict[str, str], str]:
@@ -486,15 +479,8 @@ def unpack_bundled_list(obj: list[list]):
     assert obj == _BUNDLE_LIST_SAMPLE
 
 
-def validate_bundled_list(results: dict) -> bool:
-    # Each index should be packed separately with the prefix "items_"
-    for i, value in enumerate(_BUNDLE_LIST_SAMPLE):
-        expected_key = f"items_{i}"
-        if expected_key not in results:
-            return False
-        if results[expected_key] != value:
-            return False
-    return True
+def validate_bundled_list(result: list) -> bool:
+    return result == _BUNDLE_LIST_SAMPLE
 
 
 def prepare_bundled_list() -> tuple[list[str], str]:
@@ -612,16 +598,8 @@ def unpack_bundled_tuple(obj: tuple[tuple]):
     assert obj == _BUNDLE_TUPLE_SAMPLE
 
 
-def validate_bundled_tuple(results: dict) -> bool:
-    # Each index should be packed separately with the prefix "items_"
-    for i, value in enumerate(_BUNDLE_TUPLE_SAMPLE):
-        expected_key = f"items_{i}"
-        if expected_key not in results:
-            return False
-        # Tuples are serialized as lists
-        if tuple(results[expected_key]) != value:
-            return False
-    return True
+def validate_bundled_tuple(result: list) -> bool:
+    return tuple(tuple(r) for r in result) == _BUNDLE_TUPLE_SAMPLE
 
 
 def prepare_bundled_tuple() -> tuple[list[str], str]:
@@ -739,17 +717,8 @@ def unpack_bundled_set(obj: set[frozenset]):
     assert obj == _BUNDLE_SET_SAMPLE
 
 
-def validate_bundled_set(results: dict) -> bool:
-    # Each index should be packed separately with the prefix "items_"
-    # Sets are unordered, so we compare collected values as sets
-    collected_values = set()
-    for i in range(len(_BUNDLE_SET_SAMPLE)):
-        expected_key = f"items_{i}"
-        if expected_key not in results:
-            return False
-        # Frozensets are serialized as lists
-        collected_values.add(frozenset(results[expected_key]))
-    return collected_values == _BUNDLE_SET_SAMPLE
+def validate_bundled_set(result: list) -> bool:
+    return set(frozenset(r) for r in result) == _BUNDLE_SET_SAMPLE
 
 
 def prepare_bundled_set() -> tuple[list[str], str]:
@@ -870,17 +839,8 @@ def unpack_bundled_frozenset(obj: frozenset[frozenset]):
     assert obj == _BUNDLE_FROZENSET_SAMPLE
 
 
-def validate_bundled_frozenset(results: dict) -> bool:
-    # Each index should be packed separately with the prefix "items_"
-    # Frozensets are unordered, so we compare collected values as sets
-    collected_values = set()
-    for i in range(len(_BUNDLE_FROZENSET_SAMPLE)):
-        expected_key = f"items_{i}"
-        if expected_key not in results:
-            return False
-        # Frozensets are serialized as lists
-        collected_values.add(frozenset(results[expected_key]))
-    return collected_values == _BUNDLE_FROZENSET_SAMPLE
+def validate_bundled_frozenset(result: list) -> bool:
+    return frozenset(frozenset(r) for r in result) == _BUNDLE_FROZENSET_SAMPLE
 
 
 def prepare_bundled_frozenset() -> tuple[list[str], str]:

--- a/tests/package/packagers_testers/python_standard_library_packagers_testers.py
+++ b/tests/package/packagers_testers/python_standard_library_packagers_testers.py
@@ -348,6 +348,41 @@ def prepare_dict_file(file_format: str) -> tuple[str, str]:
     return file_path, temp_directory
 
 
+# Unbundling test samples and handlers for dict:
+_BUNDLE_DICT_SAMPLE = {"a": {"x": 1}, "b": {"y": 2}, "c": {"z": 3}}
+
+
+def pack_dict_for_bundling() -> dict:
+    return _BUNDLE_DICT_SAMPLE
+
+
+def unpack_bundled_dict(obj: dict[str, dict]):
+    assert isinstance(obj, dict)
+    assert obj == _BUNDLE_DICT_SAMPLE
+
+
+def validate_bundled_dict(results: dict) -> bool:
+    # Each key should be packed separately with the prefix "items_"
+    for key in _BUNDLE_DICT_SAMPLE.keys():
+        expected_key = f"items_{key}"
+        if expected_key not in results:
+            return False
+        if results[expected_key] != _BUNDLE_DICT_SAMPLE[key]:
+            return False
+    return True
+
+
+def prepare_bundled_dict() -> tuple[dict[str, str], str]:
+    temp_directory = tempfile.mkdtemp()
+    formatter = StructFileSupportedFormat.get_format_handler(fmt="json")
+    paths = {}
+    for key, value in _BUNDLE_DICT_SAMPLE.items():
+        file_path = os.path.join(temp_directory, f"{key}.json")
+        formatter.write(obj=value, file_path=file_path)
+        paths[key] = file_path
+    return paths, temp_directory
+
+
 class DictPackagerTester(PackagerTester):
     """
     A tester for the `DictPackager`.
@@ -361,6 +396,11 @@ class DictPackagerTester(PackagerTester):
             log_hint="my_dict",
             validation_function=validate_dict_result,
         ),
+        PackTest(
+            pack_handler="pack_dict_for_bundling",
+            log_hint="*items",
+            validation_function=validate_bundled_dict,
+        ),
         *[
             UnpackTest(
                 prepare_input_function=prepare_dict_file,
@@ -369,6 +409,10 @@ class DictPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        UnpackTest(
+            prepare_input_function=prepare_bundled_dict,
+            unpack_handler="unpack_bundled_dict",
+        ),
         PackToUnpackTest(
             pack_handler="pack_dict",
             log_hint="my_dict",
@@ -397,6 +441,11 @@ class DictPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_dict_for_bundling",
+            log_hint="*items: object",
+            unpack_handler="unpack_bundled_dict",
+        ),
     ]
 
 
@@ -424,6 +473,41 @@ def prepare_list_file(file_format: str) -> tuple[str, str]:
     return file_path, temp_directory
 
 
+# Bundling/unbundling test samples and handlers for list:
+_BUNDLE_LIST_SAMPLE = [[1, 2], [3, 4], [5, 6]]
+
+
+def pack_list_for_bundling() -> list:
+    return _BUNDLE_LIST_SAMPLE
+
+
+def unpack_bundled_list(obj: list[list]):
+    assert isinstance(obj, list)
+    assert obj == _BUNDLE_LIST_SAMPLE
+
+
+def validate_bundled_list(results: dict) -> bool:
+    # Each index should be packed separately with the prefix "items_"
+    for i, value in enumerate(_BUNDLE_LIST_SAMPLE):
+        expected_key = f"items_{i}"
+        if expected_key not in results:
+            return False
+        if results[expected_key] != value:
+            return False
+    return True
+
+
+def prepare_bundled_list() -> tuple[list[str], str]:
+    temp_directory = tempfile.mkdtemp()
+    formatter = StructFileSupportedFormat.get_format_handler(fmt="json")
+    paths = []
+    for i, value in enumerate(_BUNDLE_LIST_SAMPLE):
+        file_path = os.path.join(temp_directory, f"{i}.json")
+        formatter.write(obj=value, file_path=file_path)
+        paths.append(file_path)
+    return paths, temp_directory
+
+
 class ListPackagerTester(PackagerTester):
     """
     A tester for the `ListPackager`.
@@ -437,6 +521,11 @@ class ListPackagerTester(PackagerTester):
             log_hint="my_list",
             validation_function=validate_list_result,
         ),
+        PackTest(
+            pack_handler="pack_list_for_bundling",
+            log_hint="*items",
+            validation_function=validate_bundled_list,
+        ),
         *[
             UnpackTest(
                 prepare_input_function=prepare_list_file,
@@ -445,6 +534,10 @@ class ListPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        UnpackTest(
+            prepare_input_function=prepare_bundled_list,
+            unpack_handler="unpack_bundled_list",
+        ),
         PackToUnpackTest(
             pack_handler="pack_list",
             log_hint="my_list",
@@ -473,6 +566,11 @@ class ListPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_list_for_bundling",
+            log_hint="*items: object",
+            unpack_handler="unpack_bundled_list",
+        ),
     ]
 
 
@@ -501,6 +599,42 @@ def prepare_tuple_file(file_format: str) -> tuple[str, str]:
     return file_path, temp_directory
 
 
+# Bundling/unbundling test samples and handlers for tuple:
+_BUNDLE_TUPLE_SAMPLE = ((1, 2), (3, 4), (5, 6))
+
+
+def pack_tuple_for_bundling() -> tuple:
+    return _BUNDLE_TUPLE_SAMPLE
+
+
+def unpack_bundled_tuple(obj: tuple[tuple]):
+    assert isinstance(obj, tuple)
+    assert obj == _BUNDLE_TUPLE_SAMPLE
+
+
+def validate_bundled_tuple(results: dict) -> bool:
+    # Each index should be packed separately with the prefix "items_"
+    for i, value in enumerate(_BUNDLE_TUPLE_SAMPLE):
+        expected_key = f"items_{i}"
+        if expected_key not in results:
+            return False
+        # Tuples are serialized as lists
+        if tuple(results[expected_key]) != value:
+            return False
+    return True
+
+
+def prepare_bundled_tuple() -> tuple[list[str], str]:
+    temp_directory = tempfile.mkdtemp()
+    formatter = StructFileSupportedFormat.get_format_handler(fmt="json")
+    paths = []
+    for i, value in enumerate(_BUNDLE_TUPLE_SAMPLE):
+        file_path = os.path.join(temp_directory, f"{i}.json")
+        formatter.write(obj=list(value), file_path=file_path)
+        paths.append(file_path)
+    return paths, temp_directory
+
+
 class TuplePackagerTester(PackagerTester):
     """
     A tester for the `TuplePackager`.
@@ -514,6 +648,11 @@ class TuplePackagerTester(PackagerTester):
             log_hint="my_tuple",
             validation_function=validate_tuple_result,
         ),
+        PackTest(
+            pack_handler="pack_tuple_for_bundling",
+            log_hint="*items",
+            validation_function=validate_bundled_tuple,
+        ),
         *[
             UnpackTest(
                 prepare_input_function=prepare_tuple_file,
@@ -522,6 +661,10 @@ class TuplePackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        UnpackTest(
+            prepare_input_function=prepare_bundled_tuple,
+            unpack_handler="unpack_bundled_tuple",
+        ),
         PackToUnpackTest(
             pack_handler="pack_tuple",
             log_hint="my_tuple",
@@ -550,6 +693,11 @@ class TuplePackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_tuple_for_bundling",
+            log_hint="*items: object",
+            unpack_handler="unpack_bundled_tuple",
+        ),
     ]
 
 
@@ -578,6 +726,44 @@ def prepare_set_file(file_format: str) -> tuple[str, str]:
     return file_path, temp_directory
 
 
+# Bundling/unbundling test samples and handlers for set:
+_BUNDLE_SET_SAMPLE = {frozenset([1, 2]), frozenset([3, 4]), frozenset([5, 6])}
+
+
+def pack_set_for_bundling() -> set:
+    return _BUNDLE_SET_SAMPLE
+
+
+def unpack_bundled_set(obj: set[frozenset]):
+    assert isinstance(obj, set)
+    assert obj == _BUNDLE_SET_SAMPLE
+
+
+def validate_bundled_set(results: dict) -> bool:
+    # Each index should be packed separately with the prefix "items_"
+    # Sets are unordered, so we compare collected values as sets
+    collected_values = set()
+    for i in range(len(_BUNDLE_SET_SAMPLE)):
+        expected_key = f"items_{i}"
+        if expected_key not in results:
+            return False
+        # Frozensets are serialized as lists
+        collected_values.add(frozenset(results[expected_key]))
+    return collected_values == _BUNDLE_SET_SAMPLE
+
+
+def prepare_bundled_set() -> tuple[list[str], str]:
+    temp_directory = tempfile.mkdtemp()
+    formatter = StructFileSupportedFormat.get_format_handler(fmt="json")
+    paths = []
+    bundle_list = sorted(_BUNDLE_SET_SAMPLE, key=lambda x: sorted(x))
+    for i, value in enumerate(bundle_list):
+        file_path = os.path.join(temp_directory, f"{i}.json")
+        formatter.write(obj=list(value), file_path=file_path)
+        paths.append(file_path)
+    return paths, temp_directory
+
+
 class SetPackagerTester(PackagerTester):
     """
     A tester for the `SetPackager`.
@@ -591,6 +777,11 @@ class SetPackagerTester(PackagerTester):
             log_hint="my_set",
             validation_function=validate_set_result,
         ),
+        PackTest(
+            pack_handler="pack_set_for_bundling",
+            log_hint="*items",
+            validation_function=validate_bundled_set,
+        ),
         *[
             UnpackTest(
                 prepare_input_function=prepare_set_file,
@@ -599,6 +790,10 @@ class SetPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        UnpackTest(
+            prepare_input_function=prepare_bundled_set,
+            unpack_handler="unpack_bundled_set",
+        ),
         PackToUnpackTest(
             pack_handler="pack_set",
             log_hint="my_set",
@@ -627,6 +822,11 @@ class SetPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_set_for_bundling",
+            log_hint="*items: object",
+            unpack_handler="unpack_bundled_set",
+        ),
     ]
 
 
@@ -655,6 +855,46 @@ def prepare_frozenset_file(file_format: str) -> tuple[str, str]:
     return file_path, temp_directory
 
 
+# Bundling/unbundling test samples and handlers for frozenset:
+_BUNDLE_FROZENSET_SAMPLE = frozenset(
+    [frozenset([1, 2]), frozenset([3, 4]), frozenset([5, 6])]
+)
+
+
+def pack_frozenset_for_bundling() -> frozenset:
+    return _BUNDLE_FROZENSET_SAMPLE
+
+
+def unpack_bundled_frozenset(obj: frozenset[frozenset]):
+    assert isinstance(obj, frozenset)
+    assert obj == _BUNDLE_FROZENSET_SAMPLE
+
+
+def validate_bundled_frozenset(results: dict) -> bool:
+    # Each index should be packed separately with the prefix "items_"
+    # Frozensets are unordered, so we compare collected values as sets
+    collected_values = set()
+    for i in range(len(_BUNDLE_FROZENSET_SAMPLE)):
+        expected_key = f"items_{i}"
+        if expected_key not in results:
+            return False
+        # Frozensets are serialized as lists
+        collected_values.add(frozenset(results[expected_key]))
+    return collected_values == _BUNDLE_FROZENSET_SAMPLE
+
+
+def prepare_bundled_frozenset() -> tuple[list[str], str]:
+    temp_directory = tempfile.mkdtemp()
+    formatter = StructFileSupportedFormat.get_format_handler(fmt="json")
+    paths = []
+    bundle_list = sorted(_BUNDLE_FROZENSET_SAMPLE, key=lambda x: sorted(x))
+    for i, value in enumerate(bundle_list):
+        file_path = os.path.join(temp_directory, f"{i}.json")
+        formatter.write(obj=list(value), file_path=file_path)
+        paths.append(file_path)
+    return paths, temp_directory
+
+
 class FrozensetPackagerTester(PackagerTester):
     """
     A tester for the `FrozensetPackager`.
@@ -668,6 +908,11 @@ class FrozensetPackagerTester(PackagerTester):
             log_hint="my_frozenset",
             validation_function=validate_frozenset_result,
         ),
+        PackTest(
+            pack_handler="pack_frozenset_for_bundling",
+            log_hint="*items",
+            validation_function=validate_bundled_frozenset,
+        ),
         *[
             UnpackTest(
                 prepare_input_function=prepare_frozenset_file,
@@ -676,6 +921,10 @@ class FrozensetPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        UnpackTest(
+            prepare_input_function=prepare_bundled_frozenset,
+            unpack_handler="unpack_bundled_frozenset",
+        ),
         PackToUnpackTest(
             pack_handler="pack_frozenset",
             log_hint="my_frozenset",
@@ -704,6 +953,11 @@ class FrozensetPackagerTester(PackagerTester):
             )
             for file_format in StructFileSupportedFormat.get_all_formats()
         ],
+        PackToUnpackTest(
+            pack_handler="pack_frozenset_for_bundling",
+            log_hint="*items: object",
+            unpack_handler="unpack_bundled_frozenset",
+        ),
     ]
 
 

--- a/tests/package/packagers_testers/python_standard_library_packagers_testers.py
+++ b/tests/package/packagers_testers/python_standard_library_packagers_testers.py
@@ -16,6 +16,7 @@ import ast
 import os
 import pathlib
 import tempfile
+import types
 
 from mlrun import MLClientCtx
 from mlrun.package.packagers.python_standard_library_packagers import (
@@ -47,17 +48,12 @@ from tests.package.packager_tester import (
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-NoneType = type(None)  # TODO: Replace with types.NoneType from python 3.10
-
-
-def pack_none() -> NoneType:
+def pack_none() -> types.NoneType:
     return None
 
 
-def validate_none(result: NoneType) -> bool:
-    # TODO: None values should not be casted to strings when casted to results, once it is implemented in
-    #       'execution._cast_result`, change this validation to `return result is None`.
-    return result == "None"
+def validate_none(result: types.NoneType) -> bool:
+    return result is None
 
 
 class NonePackagerTester(PackagerTester):

--- a/tests/package/test_packagers.py
+++ b/tests/package/test_packagers.py
@@ -170,38 +170,23 @@ def test_packager_pack(rundb_mock, tester: type[PackagerTester], test: PackTest)
         )
         is_unbundling = unbundle_level is not False
 
-        if artifact_type == ArtifactType.RESULT:
-            if is_unbundling:
-                # For unbundling, filter results to only include keys that start with the unbundle prefix
-                unbundled_results = {
-                    k: v
-                    for k, v in pack_run.status.results.items()
-                    if k.startswith(unbundle_key)
-                }
-                assert test.validation_function(
-                    unbundled_results, **test.validation_parameters
-                )
-            else:
-                assert key in pack_run.status.results
-                assert test.validation_function(
-                    pack_run.status.results[key], **test.validation_parameters
-                )
-        else:
-            if is_unbundling:
-                # For unbundling, filter outputs to only include keys that start with the unbundle prefix
-                unbundled_artifacts = {
-                    k: pack_run.outputs[k]
-                    for k in pack_run.outputs
-                    if k.startswith(unbundle_key)
-                }
-                assert test.validation_function(
-                    unbundled_artifacts, **test.validation_parameters
-                )
-            else:
-                assert key in pack_run.outputs
-                assert test.validation_function(
-                    pack_run._artifact(key=key), **test.validation_parameters
-                )
+        # If bundling was performed, check each element from the bundle accordingly (they will be sent to the validation
+        # function as well):
+        unbundled_artifacts = {}
+        if is_unbundling:
+            key = unbundle_key
+            unbundled_artifacts = {
+                k: pack_run.outputs[k]
+                for k in pack_run.outputs
+                if k.startswith(unbundle_key) and k != unbundle_key
+            }
+            assert unbundled_artifacts
+
+        # Verify the output:
+        assert key in pack_run.outputs
+        assert test.validation_function(
+            pack_run.outputs[key], **test.validation_parameters
+        )
     except Exception as exception:
         # An error was raised, check if the test failed or should have failed:
         if test.exception is None:
@@ -320,29 +305,14 @@ def test_packager_pack_to_unpack(
                 for k in pack_run.outputs
                 if k.startswith(unbundle_key)
             }
-            assert len(unbundled_outputs) > 0
-            # Determine if bundle was dict or list based on key suffixes (enumerating happens with "_" for lists):
-            suffixes = [
-                key[len(unbundle_key) + 1 :] for key in unbundled_outputs.keys()
-            ]
-            is_list_like = all(suffix.isdigit() for suffix in suffixes)
-            if is_list_like:
-                # Reconstruct list from indexed outputs for bundling
-                bundled_input = [
-                    unbundled_outputs[f"{unbundle_key}_{i}"]
-                    for i in range(len(unbundled_outputs))
-                ]
-            else:
-                # Reconstruct dict from keyed outputs for bundling
-                bundled_input = {
-                    suffix: unbundled_outputs[f"{unbundle_key}_{suffix}"]
-                    for suffix in suffixes
-                }
+            assert (
+                len(unbundled_outputs) > 2
+            )  # The bundle result + at least one artifact from the bundle.
             # Run unpack handler with bundled input
             mlrun_function.run(
                 name="unpack",
                 handler=test.unpack_handler,
-                inputs={"obj": bundled_input},
+                inputs={"obj": pack_run.outputs[unbundle_key]},
                 params=test.unpack_parameters,
                 artifact_path=test_directory.name,
                 local=True,

--- a/tests/package/test_packagers.py
+++ b/tests/package/test_packagers.py
@@ -16,7 +16,6 @@ import inspect
 import shutil
 import tempfile
 import typing
-from typing import Union
 
 import pytest
 
@@ -79,7 +78,7 @@ _PACKAGERS_TESTERS = [
 
 
 def _get_tests_tuples(
-    test_type: Union[type[PackTest], type[UnpackTest], type[PackToUnpackTest]],
+    test_type: type[PackTest] | type[UnpackTest] | type[PackToUnpackTest],
 ) -> list[tuple[type[PackagerTester], PackTest]]:
     return [
         (tester, test)
@@ -91,7 +90,7 @@ def _get_tests_tuples(
 
 def _setup_test(
     tester: type[PackagerTester],
-    test: Union[PackTest, UnpackTest, PackToUnpackTest],
+    test: PackTest | UnpackTest | PackToUnpackTest,
     test_directory: str,
 ) -> KubejobRuntime:
     # Enabled logging tuples only if the tuple test is about to be setup:
@@ -113,7 +112,7 @@ def _setup_test(
 
 
 def _get_key_and_artifact_type(
-    tester: type[PackagerTester], test: Union[PackTest, PackToUnpackTest]
+    tester: type[PackagerTester], test: PackTest | PackToUnpackTest
 ) -> tuple[str, str]:
     # Parse the log hint (in case it is a string):
     log_hint = LogHintUtils.parse_log_hint(log_hint=test.log_hint)
@@ -164,16 +163,45 @@ def test_packager_pack(rundb_mock, tester: type[PackagerTester], test: PackTest)
 
         # Verify the packaged output:
         key, artifact_type = _get_key_and_artifact_type(tester=tester, test=test)
+
+        # Check if unbundling was performed (key starts with "*" or contains "*"):
+        unbundle_key, unbundle_level = LogHintUtils.extract_unbundling_from_key(
+            log_hint=key
+        )
+        is_unbundling = unbundle_level is not False
+
         if artifact_type == ArtifactType.RESULT:
-            assert key in pack_run.status.results
-            assert test.validation_function(
-                pack_run.status.results[key], **test.validation_parameters
-            )
+            if is_unbundling:
+                # For unbundling, filter results to only include keys that start with the unbundle prefix
+                unbundled_results = {
+                    k: v
+                    for k, v in pack_run.status.results.items()
+                    if k.startswith(unbundle_key)
+                }
+                assert test.validation_function(
+                    unbundled_results, **test.validation_parameters
+                )
+            else:
+                assert key in pack_run.status.results
+                assert test.validation_function(
+                    pack_run.status.results[key], **test.validation_parameters
+                )
         else:
-            assert key in pack_run.outputs
-            assert test.validation_function(
-                pack_run._artifact(key=key), **test.validation_parameters
-            )
+            if is_unbundling:
+                # For unbundling, filter outputs to only include keys that start with the unbundle prefix
+                unbundled_artifacts = {
+                    k: pack_run.outputs[k]
+                    for k in pack_run.outputs
+                    if k.startswith(unbundle_key)
+                }
+                assert test.validation_function(
+                    unbundled_artifacts, **test.validation_parameters
+                )
+            else:
+                assert key in pack_run.outputs
+                assert test.validation_function(
+                    pack_run._artifact(key=key), **test.validation_parameters
+                )
     except Exception as exception:
         # An error was raised, check if the test failed or should have failed:
         if test.exception is None:
@@ -262,46 +290,103 @@ def test_packager_pack_to_unpack(
 
         # Verify the outputs are logged (artifact type as "result" will stop the test here as it cannot be unpacked):
         key, artifact_type = _get_key_and_artifact_type(tester=tester, test=test)
+
+        # Check if unbundling was performed (key starts with "*" or contains "*"):
+        unbundle_key, unbundle_level = LogHintUtils.extract_unbundling_from_key(
+            log_hint=key
+        )
+        is_unbundling = unbundle_level is not False
+
+        # Verify result:
         if artifact_type == ArtifactType.RESULT:
-            assert key in pack_run.status.results
+            if is_unbundling:
+                # For unbundling results, just verify results exist with the prefix
+                unbundled_results = {
+                    k: v
+                    for k, v in pack_run.status.results.items()
+                    if k.startswith(unbundle_key)
+                }
+                assert len(unbundled_results) > 0
+            else:
+                assert key in pack_run.status.results
             return
-        assert key in pack_run.outputs
 
-        # Validate the packager manager notes and packager instructions:
-        unpackaging_instructions = pack_run._artifact(key=key)["spec"][
-            "unpackaging_instructions"
-        ]
-        assert (
-            unpackaging_instructions["packager_name"]
-            == tester.PACKAGER_IN_TEST.__class__.__name__
-        )
-        if tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE is not ...:
-            # Check the object name noted match the packager handled type (at least subclass of it):
-            packable_object_type_name = PackagersManager._get_type_name(
-                typ=tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE
-                if tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE.__module__ != "typing"
-                else typing.get_origin(tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE)
+        # Verify artifact (Notice: for bundles we do not check the instructions as the packager in test did only the
+        # bundling and unbundling, not the packing - so there are no instructions):
+        if is_unbundling:
+            # For unbundling artifacts, collect all outputs that start with the unbundle prefix:
+            unbundled_outputs = {
+                k: pack_run.outputs[k]
+                for k in pack_run.outputs
+                if k.startswith(unbundle_key)
+            }
+            assert len(unbundled_outputs) > 0
+            # Determine if bundle was dict or list based on key suffixes (enumerating happens with "_" for lists):
+            suffixes = [
+                key[len(unbundle_key) + 1 :] for key in unbundled_outputs.keys()
+            ]
+            is_list_like = all(suffix.isdigit() for suffix in suffixes)
+            if is_list_like:
+                # Reconstruct list from indexed outputs for bundling
+                bundled_input = [
+                    unbundled_outputs[f"{unbundle_key}_{i}"]
+                    for i in range(len(unbundled_outputs))
+                ]
+            else:
+                # Reconstruct dict from keyed outputs for bundling
+                bundled_input = {
+                    suffix: unbundled_outputs[f"{unbundle_key}_{suffix}"]
+                    for suffix in suffixes
+                }
+            # Run unpack handler with bundled input
+            mlrun_function.run(
+                name="unpack",
+                handler=test.unpack_handler,
+                inputs={"obj": bundled_input},
+                params=test.unpack_parameters,
+                artifact_path=test_directory.name,
+                local=True,
             )
-            assert unpackaging_instructions[
-                "object_type"
-            ] == packable_object_type_name or issubclass(
-                PackagersManager._get_type_from_name(
-                    type_name=unpackaging_instructions["object_type"]
-                ),
-                tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE,
+        else:
+            # Regular single artifact unpacking:
+            assert key in pack_run.outputs
+            # Validate the packager manager notes and packager instructions:
+            unpackaging_instructions = pack_run._artifact(key=key)["spec"][
+                "unpackaging_instructions"
+            ]
+            assert (
+                unpackaging_instructions["packager_name"]
+                == tester.PACKAGER_IN_TEST.__class__.__name__
             )
-        assert unpackaging_instructions["artifact_type"] == artifact_type
-        assert unpackaging_instructions["instructions"] == test.expected_instructions
-
-        # Run the unpacking handler:
-        mlrun_function.run(
-            name="unpack",
-            handler=test.unpack_handler,
-            inputs={"obj": pack_run.outputs[key]},
-            params=test.unpack_parameters,
-            artifact_path=test_directory.name,
-            local=True,
-        )
+            if tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE is not ...:
+                # Check the object name noted match the packager handled type (at least subclass of it):
+                packable_object_type_name = PackagersManager._get_type_name(
+                    typ=tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE
+                    if tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE.__module__
+                    != "typing"
+                    else typing.get_origin(tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE)
+                )
+                assert unpackaging_instructions[
+                    "object_type"
+                ] == packable_object_type_name or issubclass(
+                    PackagersManager._get_type_from_name(
+                        type_name=unpackaging_instructions["object_type"]
+                    ),
+                    tester.PACKAGER_IN_TEST.PACKABLE_OBJECT_TYPE,
+                )
+            assert unpackaging_instructions["artifact_type"] == artifact_type
+            assert (
+                unpackaging_instructions["instructions"] == test.expected_instructions
+            )
+            # Run the unpacking handler:
+            mlrun_function.run(
+                name="unpack",
+                handler=test.unpack_handler,
+                inputs={"obj": pack_run.outputs[key]},
+                params=test.unpack_parameters,
+                artifact_path=test_directory.name,
+                local=True,
+            )
     except Exception as exception:
         # An error was raised, check if the test failed or should have failed:
         if test.exception is None:

--- a/tests/package/test_packagers_manager.py
+++ b/tests/package/test_packagers_manager.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import tempfile
 import zipfile
-from typing import Any, Optional, Union
+from typing import Any
 
 import pytest
 
@@ -51,27 +51,35 @@ class PackagerA(Packager):
     def is_packable(
         self,
         obj: Any,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
     ) -> bool:
         return type(obj) is self.PACKABLE_OBJECT_TYPE and artifact_type == "result"
 
     def pack(
         self,
         obj: str,
-        key: Optional[str] = None,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
+        key: str | None = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
     ) -> dict:
         return {f"{key}_from_PackagerA": obj}
 
     def unpack(
         self,
         data_item: DataItem,
-        artifact_type: Optional[str] = None,
-        instructions: Optional[dict] = None,
+        artifact_type: str | None = None,
+        instructions: dict | None = None,
     ) -> str:
         pass
+
+    def can_bundle(
+        self, bundle_hint: type, collection_type: type[dict] | type[list]
+    ) -> bool:
+        return False
+
+    def can_unbundle(self, bundled_object: Any) -> bool:
+        return False
 
 
 class PackagerB(DefaultPackager):
@@ -154,17 +162,17 @@ class PackagerC(PackagerA):
     def pack(
         self,
         obj: float,
-        key: Optional[str] = None,
-        artifact_type: Optional[str] = None,
-        configurations: Optional[dict] = None,
+        key: str | None = None,
+        artifact_type: str | None = None,
+        configurations: dict | None = None,
     ) -> dict:
         return {key: round(obj, configurations["n_round"])}
 
     def unpack(
         self,
         data_item: DataItem,
-        artifact_type: Optional[str] = None,
-        instructions: Optional[dict] = None,
+        artifact_type: str | None = None,
+        instructions: dict | None = None,
     ) -> float:
         return data_item.key * 2
 
@@ -207,7 +215,7 @@ class NotAPackager:
     ],
 )
 def test_collect_packagers(
-    packagers_to_collect: list[str], validation: Union[list[type[Packager]], str]
+    packagers_to_collect: list[str], validation: list[type[Packager]] | str
 ):
     """
     Test the manager's `collect_packagers` method.
@@ -333,53 +341,50 @@ def test_clear_packagers_outputs():
     "key, obj, expected_results",
     [
         (
-            "*list_",
+            "*list",
             [0.12111, 0.56111],
             {"list_0": 0.12, "list_1": 0.56},
         ),
         (
-            "*set_",
+            "*set",
             {0.12111, 0.56111},
             {"set_0": 0.12, "set_1": 0.56},
         ),
         (
             "*",
             (0.12111, 0.56111),
-            {"0": 0.12, "1": 0.56},
+            {"_0": 0.12, "_1": 0.56},
         ),
         (
-            "*error",
-            0.12111,
-            "The log hint key '*error' has an iterable unpacking prefix ('*')",
-        ),
-        (
-            "**dict_",
+            "*dict",
             {"a": 0.12111, "b": 0.56111},
             {"dict_a": 0.12, "dict_b": 0.56},
-        ),
-        ("**", {"a": 0.12111, "b": 0.56111}, {"a": 0.12, "b": 0.56}),
-        (
-            "**error",
-            0.12111,
-            "The log hint key '**error' has a dictionary unpacking prefix ('**')",
         ),
     ],
 )
 def test_arbitrary_log_hint(
     key: str,
-    obj: Union[list, dict, tuple, set],
-    expected_results: Union[dict[str, float], str],
+    obj: list | dict | tuple | set,
+    expected_results: dict[str, float] | str,
 ):
     """
-    Test the arbitrary log hint key prefixes "*" and "**".
+    Test the arbitrary log hint key prefix "*" for unbundling.
 
     :param key:              The key to use in the log hint
     :param obj:              The object to pack
     :param expected_results: The expected results that should be packed. A string means an error should be raised.
     """
-    # Prepare the test:
+    # Prepare the test - include packagers that support unbundling (dict, list, set, tuple):
     packagers_manager = PackagersManager()
-    packagers_manager.collect_packagers(packagers=[PackagerC])
+    packagers_manager.collect_packagers(
+        packagers=[
+            PackagerC,  # For packing the float items
+            "mlrun.package.packagers.python_standard_library_packagers.DictPackager",
+            "mlrun.package.packagers.python_standard_library_packagers.ListPackager",
+            "mlrun.package.packagers.python_standard_library_packagers.SetPackager",
+            "mlrun.package.packagers.python_standard_library_packagers.TuplePackager",
+        ]
+    )
 
     # Pack an arbitrary amount of objects:
     try:
@@ -412,12 +417,12 @@ class _DummyDataItem:
     [
         (
             0.5,
-            Union[int, bytes, float, int],
+            int | bytes | float | int,
             1.0,
         ),
         (
             0.5,
-            Union[int, bytes, int],
+            int | bytes | int,
             "Could not unpack data item with the hinted type",
         ),
     ],
@@ -425,7 +430,7 @@ class _DummyDataItem:
 def test_plural_type_hint_unpacking(
     data: Any,
     type_hint: Any,
-    expected_results: Union[Any, str],
+    expected_results: Any | str,
 ):
     """
     Test unpacking when plural type hint is given (for example: a union of types).

--- a/tests/package/test_packagers_manager.py
+++ b/tests/package/test_packagers_manager.py
@@ -346,14 +346,9 @@ def test_clear_packagers_outputs():
             {"list_0": 0.12111, "list_1": 0.56111},
         ),
         (
-            "*set",
-            {0.12111, 0.56111},
-            {"set_0": 0.12111, "set_1": 0.56111},
-        ),
-        (
             "*",
             (0.12111, 0.56111),
-            {"_0": 0.12111, "_1": 0.56111},
+            "Key is missing after the '*'",
         ),
         (
             "*dict",
@@ -441,6 +436,16 @@ def test_unbundling_log_hint(
 
     # Validate multiple packages were packed:
     assert packagers_manager.results == expected_results
+
+    # Validate the bundle structure key:
+    assert (
+        list(
+            packagers_manager.get_bundles_results(
+                logged_outputs=packagers_manager.results
+            ).values()
+        )[0]
+        == obj
+    )
 
 
 class _DummyDataItem:

--- a/tests/package/test_packagers_manager.py
+++ b/tests/package/test_packagers_manager.py
@@ -343,26 +343,68 @@ def test_clear_packagers_outputs():
         (
             "*list",
             [0.12111, 0.56111],
-            {"list_0": 0.12, "list_1": 0.56},
+            {"list_0": 0.12111, "list_1": 0.56111},
         ),
         (
             "*set",
             {0.12111, 0.56111},
-            {"set_0": 0.12, "set_1": 0.56},
+            {"set_0": 0.12111, "set_1": 0.56111},
         ),
         (
             "*",
             (0.12111, 0.56111),
-            {"_0": 0.12, "_1": 0.56},
+            {"_0": 0.12111, "_1": 0.56111},
         ),
         (
             "*dict",
             {"a": 0.12111, "b": 0.56111},
-            {"dict_a": 0.12, "dict_b": 0.56},
+            {"dict_a": 0.12111, "dict_b": 0.56111},
+        ),
+        (
+            "*dict",
+            {
+                "a": [1.11, [2.22, 3.333, 4.4444], 5.55555],
+                "b": {"c": 6.23, "d": [7.77, 8.8888]},
+            },
+            {
+                "dict_a_0": 1.11,
+                "dict_a_1_0": 2.22,
+                "dict_a_1_1": 3.333,
+                "dict_a_1_2": 4.4444,
+                "dict_a_2": 5.55555,
+                "dict_b_c": 6.23,
+                "dict_b_d_0": 7.77,
+                "dict_b_d_1": 8.8888,
+            },
+        ),
+        (
+            "2*dict",
+            {
+                "a": [1.11, [2.22, 3.333, 4.4444], 5.55555],
+                "b": {"c": 6.23, "d": [7.77, 8.8888]},
+            },
+            {
+                "dict_a_0": 1.11,
+                "dict_a_1": [2.22, 3.333, 4.4444],
+                "dict_a_2": 5.55555,
+                "dict_b_c": 6.23,
+                "dict_b_d": [7.77, 8.8888],
+            },
+        ),
+        (
+            "1*dict",
+            {
+                "a": [1.11, [2.22, 3.333, 4.4444], 5.55555],
+                "b": {"c": 6.23, "d": [7.77, 8.8888]},
+            },
+            {
+                "dict_a": [1.11, [2.22, 3.333, 4.4444], 5.55555],
+                "dict_b": {"c": 6.23, "d": [7.77, 8.8888]},
+            },
         ),
     ],
 )
-def test_arbitrary_log_hint(
+def test_unbundling_log_hint(
     key: str,
     obj: list | dict | tuple | set,
     expected_results: dict[str, float] | str,
@@ -378,7 +420,6 @@ def test_arbitrary_log_hint(
     packagers_manager = PackagersManager()
     packagers_manager.collect_packagers(
         packagers=[
-            PackagerC,  # For packing the float items
             "mlrun.package.packagers.python_standard_library_packagers.DictPackager",
             "mlrun.package.packagers.python_standard_library_packagers.ListPackager",
             "mlrun.package.packagers.python_standard_library_packagers.SetPackager",
@@ -389,7 +430,7 @@ def test_arbitrary_log_hint(
     # Pack an arbitrary amount of objects:
     try:
         packagers_manager.pack(
-            obj=obj, log_hint={"key": key, "artifact_type": "result", "n_round": 2}
+            obj=obj, log_hint={"key": key, "artifact_type": "result"}
         )
     except MLRunInvalidArgumentError as error:
         # Catch only if the expected results is a string, otherwise it is a legitimate exception:

--- a/tests/package/test_usage.py
+++ b/tests/package/test_usage.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import copy
 import json
 import os
 import pathlib
@@ -39,11 +39,24 @@ RETURNS_LOG_HINTS = [
     "my_int",
     "my_str : result",
     "my_object: object",
+    "**my_df_dict_",
+    "*my_array_list_",
 ]
 
 
 def log_artifacts_and_results() -> (
-    tuple[np.ndarray, pd.DataFrame, str, dict, list, int, str, Pipeline]
+    tuple[
+        np.ndarray,
+        pd.DataFrame,
+        str,
+        dict,
+        list,
+        int,
+        str,
+        Pipeline,
+        dict[str, pd.DataFrame],
+        list[np.ndarray],
+    ]
 ):
     encoder_to_imputer = Pipeline(
         steps=[
@@ -63,6 +76,13 @@ def log_artifacts_and_results() -> (
     with open(file_path, "w") as file:
         file.write("123")
 
+    dataframes = {
+        "abc": pd.DataFrame(np.random.rand(5, 5)),
+        "def": pd.DataFrame(np.random.rand(10, 3)),
+        "ghi": pd.DataFrame(np.random.rand(7, 8)),
+    }
+    arrays = [np.random.rand(10) for _ in range(10)]
+
     return (
         np.ones((10, 20)),
         pd.DataFrame(np.zeros((20, 10))),
@@ -72,6 +92,8 @@ def log_artifacts_and_results() -> (
         3,
         "hello",
         encoder_to_imputer,
+        dataframes,
+        arrays,
     )
 
 
@@ -84,7 +106,10 @@ def _assert_parsing(
     my_object: Pipeline,
     my_int: int,
     my_str: str,
+    my_df_dict: dict[str, pd.DataFrame],
+    my_array_list: list[np.ndarray],
 ):
+    # TODO: Uncomment the inner assertions once the packagers collection unpacking is added to the PR.
     assert isinstance(my_array, np.ndarray)
     assert np.all(my_array == np.ones((10, 20)))
 
@@ -108,6 +133,15 @@ def _assert_parsing(
     assert isinstance(my_object, Pipeline)
     assert my_object.transform(my_list).tolist() == [[0], [1], [2]]
 
+    assert isinstance(my_df_dict, dict)
+    assert list(my_df_dict.keys()) == ["abc", "def", "ghi"]
+    # for v in my_df_dict.values():
+    #     assert isinstance(v, pd.DataFrame)
+
+    assert isinstance(my_array_list, list)
+    # for v in my_array_list:
+    #     assert isinstance(v, np.ndarray)
+
     return [my_str] * my_int
 
 
@@ -120,6 +154,8 @@ def parse_inputs_from_type_annotations(
     my_object: Pipeline,
     my_int: int,
     my_str: str,
+    my_df_dict: dict[str, pd.DataFrame],
+    my_array_list: list[np.ndarray],
 ):
     _assert_parsing(
         my_array=my_array,
@@ -130,22 +166,48 @@ def parse_inputs_from_type_annotations(
         my_object=my_object,
         my_int=my_int,
         my_str=my_str,
+        my_df_dict=my_df_dict,
+        my_array_list=my_array_list,
     )
 
 
 def parse_inputs_from_mlrun_function(
-    my_array, my_df, my_file, my_dict, my_list, my_object, my_int, my_str
+    my_array,
+    my_df,
+    my_file,
+    my_dict,
+    my_list,
+    my_object,
+    my_int,
+    my_str,
+    my_df_dict,
+    my_array_list,
+    is_conf_test: bool,
 ):
-    _assert_parsing(
-        my_array=my_array,
-        my_df=my_df,
-        my_file=my_file,
-        my_dict=my_dict,
-        my_list=my_list,
-        my_object=my_object,
-        my_int=my_int,
-        my_str=my_str,
-    )
+    if is_conf_test:
+        _assert_auto_unpacking(
+            my_array=my_array,
+            my_df=my_df,
+            my_file=my_file,
+            my_dict=my_dict,
+            my_list=my_list,
+            my_object=my_object,
+            my_df_dict=my_df_dict,
+            my_array_list=my_array_list,
+        )
+    else:
+        _assert_parsing(
+            my_array=my_array,
+            my_df=my_df,
+            my_file=my_file,
+            my_dict=my_dict,
+            my_list=my_list,
+            my_object=my_object,
+            my_int=my_int,
+            my_str=my_str,
+            my_df_dict=my_df_dict,
+            my_array_list=my_array_list,
+        )
 
 
 @pytest.mark.parametrize("is_enabled", [True, False])
@@ -176,8 +238,12 @@ def test_mlconf_packagers_enabled(rundb_mock, is_enabled: bool, returns: list):
 
     # There should always be at least one output - the manually logged result:
     if is_enabled and returns:
-        # Plus all configured returning values:
-        assert len(log_artifacts_and_results_run.outputs) == 1 + len(RETURNS_LOG_HINTS)
+        # Plus all configured returning values ("**my_df_dict_" yields 3 outputs + "*my_array_list_" yields 10
+        # outputs - 2, the keys):
+        assert (
+            len(log_artifacts_and_results_run.outputs)
+            == 1 + len(RETURNS_LOG_HINTS) + 3 + 10 - 2
+        )
     else:
         # Plus the default logged output as string MLRun did before packagers and log hints:
         assert len(log_artifacts_and_results_run.outputs) == 1 + 1
@@ -212,6 +278,23 @@ def test_parse_inputs_from_type_annotations(rundb_mock):
             "my_file": log_artifacts_and_results_run.outputs["my_file"],
             "my_object": log_artifacts_and_results_run.outputs["my_object"],
             "my_dict": log_artifacts_and_results_run.outputs["my_dict"],
+            "my_df_dict": {
+                "abc": log_artifacts_and_results_run.outputs["my_df_dict_abc"],
+                "def": log_artifacts_and_results_run.outputs["my_df_dict_def"],
+                "ghi": log_artifacts_and_results_run.outputs["my_df_dict_ghi"],
+            },
+            "my_array_list": [
+                log_artifacts_and_results_run.outputs["my_array_list_0"],
+                log_artifacts_and_results_run.outputs["my_array_list_1"],
+                log_artifacts_and_results_run.outputs["my_array_list_2"],
+                log_artifacts_and_results_run.outputs["my_array_list_3"],
+                log_artifacts_and_results_run.outputs["my_array_list_4"],
+                log_artifacts_and_results_run.outputs["my_array_list_5"],
+                log_artifacts_and_results_run.outputs["my_array_list_6"],
+                log_artifacts_and_results_run.outputs["my_array_list_7"],
+                log_artifacts_and_results_run.outputs["my_array_list_8"],
+                log_artifacts_and_results_run.outputs["my_array_list_9"],
+            ],
         },
         params={
             "my_int": log_artifacts_and_results_run.outputs["my_int"],
@@ -258,10 +341,28 @@ def test_parse_inputs_from_mlrun_function(rundb_mock):
                 "my_object"
             ],
             "my_dict: dict": log_artifacts_and_results_run.outputs["my_dict"],
+            "my_df_dict": {
+                "abc": log_artifacts_and_results_run.outputs["my_df_dict_abc"],
+                "def": log_artifacts_and_results_run.outputs["my_df_dict_def"],
+                "ghi": log_artifacts_and_results_run.outputs["my_df_dict_ghi"],
+            },
+            "my_array_list": [
+                log_artifacts_and_results_run.outputs["my_array_list_0"],
+                log_artifacts_and_results_run.outputs["my_array_list_1"],
+                log_artifacts_and_results_run.outputs["my_array_list_2"],
+                log_artifacts_and_results_run.outputs["my_array_list_3"],
+                log_artifacts_and_results_run.outputs["my_array_list_4"],
+                log_artifacts_and_results_run.outputs["my_array_list_5"],
+                log_artifacts_and_results_run.outputs["my_array_list_6"],
+                log_artifacts_and_results_run.outputs["my_array_list_7"],
+                log_artifacts_and_results_run.outputs["my_array_list_8"],
+                log_artifacts_and_results_run.outputs["my_array_list_9"],
+            ],
         },
         params={
             "my_int": log_artifacts_and_results_run.outputs["my_int"],
             "my_str": log_artifacts_and_results_run.outputs["my_str"],
+            "is_conf_test": False,
         },
         artifact_path=artifact_path.name,
         local=True,
@@ -269,6 +370,246 @@ def test_parse_inputs_from_mlrun_function(rundb_mock):
 
     # Clean the test outputs:
     artifact_path.cleanup()
+
+
+def _assert_auto_unpacking(
+    my_array, my_df, my_file, my_dict, my_list, my_object, my_df_dict, my_array_list
+):
+    if not mlrun.mlconf.packagers.auto_unpack_inputs:
+        # Make sure all inputs are DataItems (were not unpacked):
+        for obj in [my_array, my_df, my_file, my_dict, my_list, my_object]:
+            assert isinstance(obj, mlrun.DataItem)
+
+        for v in my_df_dict.values():
+            assert isinstance(v, mlrun.DataItem)
+
+        for v in my_array_list:
+            assert isinstance(v, mlrun.DataItem)
+    else:
+        assert isinstance(my_array, np.ndarray)
+        assert isinstance(my_df, pd.DataFrame)
+        assert isinstance(my_file, str)
+        assert isinstance(my_dict, dict)
+        assert isinstance(my_list, list)
+        assert isinstance(my_object, Pipeline)
+        # TODO: Uncomment the inner assertions once the packagers collection unpacking is added to the PR.
+        # for v in my_df_dict.values():
+        #     assert isinstance(v, pd.DataFrame)
+        # for v in my_array_list:
+        #     assert isinstance(v, np.ndarray)
+
+
+@pytest.mark.parametrize("auto_unpack_inputs", [True, False])
+def test_parse_inputs_with_mlconf_packagers_auto_unpack_inputs(
+    rundb_mock, auto_unpack_inputs: bool
+):
+    """
+    Run the `parse_inputs_from_mlrun_function` function with MLRun to see the packagers are being auto-unpacked by their
+    original packager or not if auto_unpack_inputs is not set - which means all will remain `DataItem`s.
+
+    :param rundb_mock:         A runDB mock fixture.
+    :param auto_unpack_inputs: The `mlconf.packagers.auto_unpack_inputs` configuration value.
+    """
+    # Set the configuration:
+    mlrun.mlconf.packagers.auto_unpack_inputs = auto_unpack_inputs
+
+    # Create the function:
+    mlrun_function = mlrun.code_to_function(filename=__file__, kind="job")
+    artifact_path = tempfile.TemporaryDirectory()
+
+    # Run the logging functions:
+    log_artifacts_and_results_run = mlrun_function.run(
+        handler="log_artifacts_and_results",
+        returns=RETURNS_LOG_HINTS,
+        artifact_path=artifact_path.name,
+        local=True,
+    )
+
+    # Run the function that will parse the data items:
+    mlrun_function.run(
+        handler="parse_inputs_from_mlrun_function",
+        inputs={
+            "my_list": log_artifacts_and_results_run.outputs["my_list"],
+            "my_array": log_artifacts_and_results_run.outputs["my_array"],
+            "my_df": log_artifacts_and_results_run.outputs["my_df"],
+            "my_file": log_artifacts_and_results_run.outputs["my_file"],
+            "my_object": log_artifacts_and_results_run.outputs["my_object"],
+            "my_dict": log_artifacts_and_results_run.outputs["my_dict"],
+            "my_df_dict": {
+                "abc": log_artifacts_and_results_run.outputs["my_df_dict_abc"],
+                "def": log_artifacts_and_results_run.outputs["my_df_dict_def"],
+                "ghi": log_artifacts_and_results_run.outputs["my_df_dict_ghi"],
+            },
+            "my_array_list": [
+                log_artifacts_and_results_run.outputs["my_array_list_0"],
+                log_artifacts_and_results_run.outputs["my_array_list_1"],
+                log_artifacts_and_results_run.outputs["my_array_list_2"],
+                log_artifacts_and_results_run.outputs["my_array_list_3"],
+                log_artifacts_and_results_run.outputs["my_array_list_4"],
+                log_artifacts_and_results_run.outputs["my_array_list_5"],
+                log_artifacts_and_results_run.outputs["my_array_list_6"],
+                log_artifacts_and_results_run.outputs["my_array_list_7"],
+                log_artifacts_and_results_run.outputs["my_array_list_8"],
+                log_artifacts_and_results_run.outputs["my_array_list_9"],
+            ],
+        },
+        params={
+            "my_int": log_artifacts_and_results_run.outputs["my_int"],
+            "my_str": log_artifacts_and_results_run.outputs["my_str"],
+            "is_conf_test": True,
+        },
+        artifact_path=artifact_path.name,
+        local=True,
+    )
+
+    # Clean the test outputs:
+    artifact_path.cleanup()
+
+
+def log_with_and_without_packagers():
+    context = mlrun.get_or_create_ctx(name="ctx")
+
+    context_df = pd.DataFrame({"x": [10, 20, 30], "y": [40, 50, 60]})
+    package_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    context.log_dataset("context_df", context_df)
+
+    return package_df
+
+
+def parse_from_package_and_context(context_df, package_df):
+    if mlrun.mlconf.packagers.auto_unpack_inputs:
+        assert isinstance(context_df, mlrun.DataItem)
+        assert context_df.as_df().equals(
+            pd.DataFrame({"x": [10, 20, 30], "y": [40, 50, 60]})
+        )
+        assert isinstance(package_df, pd.DataFrame)
+        assert package_df.equals(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+    else:
+        assert isinstance(context_df, mlrun.DataItem)
+        assert context_df.as_df().equals(
+            pd.DataFrame({"x": [10, 20, 30], "y": [40, 50, 60]})
+        )
+        assert isinstance(package_df, mlrun.DataItem)
+        assert package_df.as_df().equals(pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}))
+
+
+@pytest.mark.parametrize("auto_unpack_inputs", [True, False])
+def test_log_with_and_without_packagers(rundb_mock, auto_unpack_inputs: bool):
+    """
+    Run the `log_with_and_without_packagers` function with MLRun to see the packagers are being auto-unpacked by their
+    original packager or not if auto_unpack_inputs is not set or the input is not a package (logged via context).
+
+    :param rundb_mock:         A runDB mock fixture.
+    :param auto_unpack_inputs: The `mlconf.packagers.auto_unpack_inputs` configuration value.
+    """
+    # Set the configuration:
+    mlrun.mlconf.packagers.auto_unpack_inputs = auto_unpack_inputs
+
+    # Create the function:
+    mlrun_function = mlrun.code_to_function(filename=__file__, kind="job")
+    artifact_path = tempfile.TemporaryDirectory()
+
+    # Run the logging functions:
+    log_with_and_without_packagers_run = mlrun_function.run(
+        handler="log_with_and_without_packagers",
+        returns=["package_df"],
+        artifact_path=artifact_path.name,
+        local=True,
+    )
+
+    # Run the function that will parse the data items:
+    mlrun_function.run(
+        handler="parse_from_package_and_context",
+        inputs={
+            "context_df": log_with_and_without_packagers_run.outputs["context_df"],
+            "package_df": log_with_and_without_packagers_run.outputs["package_df"],
+        },
+        artifact_path=artifact_path.name,
+        local=True,
+    )
+
+    # Clean the test outputs:
+    artifact_path.cleanup()
+
+
+@pytest.mark.parametrize("auto_pack_outputs", [True, False])
+@pytest.mark.parametrize("auto_pack_key", [None, "test"])
+@pytest.mark.parametrize(
+    "returns",
+    [
+        [
+            "my_array",
+            "my_df",
+            "my_file: path",
+            {"key": "my_dict", "artifact_type": "object"},
+        ],
+        None,
+    ],
+)
+def test_log_outputs_with_mlconf_packagers_auto_pack_outputs(
+    rundb_mock,
+    auto_pack_outputs: bool,
+    auto_pack_key: str,
+    returns: list[str],
+):
+    """
+    Run the `log_artifacts_and_results` function with MLRun to see the packagers are packing the outputs automatically
+    given the `mlconf.packagers.auto_pack_outputs` configuration in different scenarios.
+
+    :param rundb_mock:        A runDB mock fixture.
+    :param auto_pack_outputs: The `mlconf.packagers.auto_pack_outputs` configuration value.
+    :param auto_pack_key:     The `mlconf.packagers.auto_pack_key` configuration value.
+    :param returns:           Log hints to pass in the 'returns' parameter.
+    """
+    # Set the configuration:
+    mlrun.mlconf.packagers.auto_pack_outputs = auto_pack_outputs
+    if auto_pack_key:
+        mlrun.mlconf.packagers.auto_pack_key = auto_pack_key
+
+    # Create the function:
+    mlrun_function = mlrun.code_to_function(filename=__file__, kind="job")
+    artifact_path = tempfile.TemporaryDirectory()
+
+    # Run the logging function:
+    log_artifacts_and_results_run = mlrun_function.run(
+        name="test-run",
+        handler="log_artifacts_and_results",
+        artifact_path=artifact_path.name,
+        returns=copy.deepcopy(
+            returns
+        ),  # We copy as in local the outputs are being appended to the list.
+        local=True,
+    )
+
+    # There should always be at least one output - the manually logged result:
+    if auto_pack_outputs:
+        # 'auto_pack_outputs' is set, assert all returning values (notice there are no '**' and '*' in "my_df_dict_" and
+        # "my_array_list_" now):
+        assert len(log_artifacts_and_results_run.outputs) == 1 + len(RETURNS_LOG_HINTS)
+        # Check for the manually logged result:
+        assert "manually_logged_result" in log_artifacts_and_results_run.outputs
+        # Check the auto-logged outputs:
+        key = "test-run-test" if auto_pack_key else "test-run-artifact"
+        for i in range(
+            len(log_artifacts_and_results_run.outputs)
+            - (1 + (len(returns) if returns else 0))
+        ):
+            assert f"{key}-{i}" in log_artifacts_and_results_run.outputs
+        # Check the outputs from the 'returns' parameter:
+        if returns:
+            for i in returns:
+                if isinstance(i, str):
+                    assert (
+                        i.split(":")[0].strip() in log_artifacts_and_results_run.outputs
+                    )
+                elif isinstance(i, dict):
+                    assert i["key"] in log_artifacts_and_results_run.outputs
+    else:
+        # Plus the default logged output as string MLRun did before packagers and log hints if returns is not set:
+        assert len(log_artifacts_and_results_run.outputs) == 1 + (
+            len(returns) if returns else 1
+        )
 
 
 class BaseClassPackager(DefaultPackager):

--- a/tests/package/test_usage.py
+++ b/tests/package/test_usage.py
@@ -16,7 +16,7 @@ import json
 import os
 import pathlib
 import tempfile
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -33,14 +33,13 @@ from tests.package.usage_assets import BaseClass, InheritingClass
 RETURNS_LOG_HINTS = [
     "my_array",
     "my_df",
-    "my_file: path",
     {"key": "my_dict", "artifact_type": "object"},
     "my_list:  file",
     "my_int",
     "my_str : result",
     "my_object: object",
-    "**my_df_dict_",
-    "*my_array_list_",
+    "*my_df_dict",
+    "*my_array_list",
 ]
 
 
@@ -48,7 +47,6 @@ def log_artifacts_and_results() -> (
     tuple[
         np.ndarray,
         pd.DataFrame,
-        str,
         dict,
         list,
         int,
@@ -75,6 +73,7 @@ def log_artifacts_and_results() -> (
     file_path = os.path.join(context.artifact_path, "my_file.txt")
     with open(file_path, "w") as file:
         file.write("123")
+    context.log_artifact(item="manually_logged_file", local_path=file_path)
 
     dataframes = {
         "abc": pd.DataFrame(np.random.rand(5, 5)),
@@ -86,7 +85,6 @@ def log_artifacts_and_results() -> (
     return (
         np.ones((10, 20)),
         pd.DataFrame(np.zeros((20, 10))),
-        file_path,
         {"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]},
         [["A"], ["B"], [""]],
         3,
@@ -100,7 +98,7 @@ def log_artifacts_and_results() -> (
 def _assert_parsing(
     my_array: np.ndarray,
     my_df: mlrun.DataItem,
-    my_file: Union[int, mlrun.DataItem],
+    manually_logged_file: str | mlrun.DataItem,
     my_dict: dict,
     my_list: list,
     my_object: Pipeline,
@@ -109,7 +107,6 @@ def _assert_parsing(
     my_df_dict: dict[str, pd.DataFrame],
     my_array_list: list[np.ndarray],
 ):
-    # TODO: Uncomment the inner assertions once the packagers collection unpacking is added to the PR.
     assert isinstance(my_array, np.ndarray)
     assert np.all(my_array == np.ones((10, 20)))
 
@@ -118,9 +115,9 @@ def _assert_parsing(
     assert my_df.shape == (20, 10)
     assert my_df.sum().sum() == 0
 
-    assert isinstance(my_file, mlrun.DataItem)
-    my_file = my_file.local()
-    with open(my_file) as file:
+    assert isinstance(manually_logged_file, mlrun.DataItem)
+    manually_logged_file = manually_logged_file.local()
+    with open(manually_logged_file) as file:
         file_content = file.read()
     assert file_content == "123"
 
@@ -135,12 +132,15 @@ def _assert_parsing(
 
     assert isinstance(my_df_dict, dict)
     assert list(my_df_dict.keys()) == ["abc", "def", "ghi"]
-    # for v in my_df_dict.values():
-    #     assert isinstance(v, pd.DataFrame)
+    for v in my_df_dict.values():
+        assert isinstance(v, pd.DataFrame)
 
     assert isinstance(my_array_list, list)
-    # for v in my_array_list:
-    #     assert isinstance(v, np.ndarray)
+    for v in my_array_list:
+        assert isinstance(
+            v,
+            np.ndarray if mlrun.mlconf.packagers.auto_unpack_inputs else mlrun.DataItem,
+        )
 
     return [my_str] * my_int
 
@@ -148,19 +148,19 @@ def _assert_parsing(
 def parse_inputs_from_type_annotations(
     my_array: np.ndarray,
     my_df: mlrun.DataItem,
-    my_file: Union[int, mlrun.DataItem],
+    manually_logged_file: str | mlrun.DataItem,
     my_dict: dict,
     my_list: list,
     my_object: Pipeline,
     my_int: int,
     my_str: str,
     my_df_dict: dict[str, pd.DataFrame],
-    my_array_list: list[np.ndarray],
+    my_array_list: list,
 ):
     _assert_parsing(
         my_array=my_array,
         my_df=my_df,
-        my_file=my_file,
+        manually_logged_file=manually_logged_file,
         my_dict=my_dict,
         my_list=my_list,
         my_object=my_object,
@@ -174,7 +174,7 @@ def parse_inputs_from_type_annotations(
 def parse_inputs_from_mlrun_function(
     my_array,
     my_df,
-    my_file,
+    manually_logged_file,
     my_dict,
     my_list,
     my_object,
@@ -188,7 +188,7 @@ def parse_inputs_from_mlrun_function(
         _assert_auto_unpacking(
             my_array=my_array,
             my_df=my_df,
-            my_file=my_file,
+            manually_logged_file=manually_logged_file,
             my_dict=my_dict,
             my_list=my_list,
             my_object=my_object,
@@ -199,7 +199,7 @@ def parse_inputs_from_mlrun_function(
         _assert_parsing(
             my_array=my_array,
             my_df=my_df,
-            my_file=my_file,
+            manually_logged_file=manually_logged_file,
             my_dict=my_dict,
             my_list=my_list,
             my_object=my_object,
@@ -236,17 +236,17 @@ def test_mlconf_packagers_enabled(rundb_mock, is_enabled: bool, returns: list):
         local=True,
     )
 
-    # There should always be at least one output - the manually logged result:
+    # There should always be at least two outputs - the manually logged result and artifact:
     if is_enabled and returns:
-        # Plus all configured returning values ("**my_df_dict_" yields 3 outputs + "*my_array_list_" yields 10
+        # Plus all configured returning values ("*my_df_dict_" yields 3 outputs + "*my_array_list_" yields 10
         # outputs - 2, the keys):
         assert (
             len(log_artifacts_and_results_run.outputs)
-            == 1 + len(RETURNS_LOG_HINTS) + 3 + 10 - 2
+            == 2 + len(RETURNS_LOG_HINTS) + 3 + 10 - 2
         )
     else:
         # Plus the default logged output as string MLRun did before packagers and log hints:
-        assert len(log_artifacts_and_results_run.outputs) == 1 + 1
+        assert len(log_artifacts_and_results_run.outputs) == 2 + 1
 
 
 def test_parse_inputs_from_type_annotations(rundb_mock):
@@ -275,7 +275,9 @@ def test_parse_inputs_from_type_annotations(rundb_mock):
             "my_list": log_artifacts_and_results_run.outputs["my_list"],
             "my_array": log_artifacts_and_results_run.outputs["my_array"],
             "my_df": log_artifacts_and_results_run.outputs["my_df"],
-            "my_file": log_artifacts_and_results_run.outputs["my_file"],
+            "manually_logged_file": log_artifacts_and_results_run.outputs[
+                "manually_logged_file"
+            ],
             "my_object": log_artifacts_and_results_run.outputs["my_object"],
             "my_dict": log_artifacts_and_results_run.outputs["my_dict"],
             "my_df_dict": {
@@ -335,18 +337,20 @@ def test_parse_inputs_from_mlrun_function(rundb_mock):
             "my_array : numpy.ndarray": log_artifacts_and_results_run.outputs[
                 "my_array"
             ],
-            "my_df": log_artifacts_and_results_run.outputs["my_df"],
-            "my_file": log_artifacts_and_results_run.outputs["my_file"],
+            "my_df : mlrun.DataItem": log_artifacts_and_results_run.outputs["my_df"],
+            "manually_logged_file": log_artifacts_and_results_run.outputs[
+                "manually_logged_file"
+            ],
             "my_object: sklearn.pipeline.Pipeline": log_artifacts_and_results_run.outputs[
                 "my_object"
             ],
             "my_dict: dict": log_artifacts_and_results_run.outputs["my_dict"],
-            "my_df_dict": {
+            "my_df_dict: dict[pandas.DataFrame]": {
                 "abc": log_artifacts_and_results_run.outputs["my_df_dict_abc"],
                 "def": log_artifacts_and_results_run.outputs["my_df_dict_def"],
                 "ghi": log_artifacts_and_results_run.outputs["my_df_dict_ghi"],
             },
-            "my_array_list": [
+            "my_array_list: list": [
                 log_artifacts_and_results_run.outputs["my_array_list_0"],
                 log_artifacts_and_results_run.outputs["my_array_list_1"],
                 log_artifacts_and_results_run.outputs["my_array_list_2"],
@@ -373,11 +377,18 @@ def test_parse_inputs_from_mlrun_function(rundb_mock):
 
 
 def _assert_auto_unpacking(
-    my_array, my_df, my_file, my_dict, my_list, my_object, my_df_dict, my_array_list
+    my_array,
+    my_df,
+    manually_logged_file,
+    my_dict,
+    my_list,
+    my_object,
+    my_df_dict,
+    my_array_list,
 ):
     if not mlrun.mlconf.packagers.auto_unpack_inputs:
         # Make sure all inputs are DataItems (were not unpacked):
-        for obj in [my_array, my_df, my_file, my_dict, my_list, my_object]:
+        for obj in [my_array, my_df, manually_logged_file, my_dict, my_list, my_object]:
             assert isinstance(obj, mlrun.DataItem)
 
         for v in my_df_dict.values():
@@ -388,15 +399,16 @@ def _assert_auto_unpacking(
     else:
         assert isinstance(my_array, np.ndarray)
         assert isinstance(my_df, pd.DataFrame)
-        assert isinstance(my_file, str)
+        assert isinstance(
+            manually_logged_file, mlrun.DataItem
+        )  # Not logged via packager.
         assert isinstance(my_dict, dict)
         assert isinstance(my_list, list)
         assert isinstance(my_object, Pipeline)
-        # TODO: Uncomment the inner assertions once the packagers collection unpacking is added to the PR.
-        # for v in my_df_dict.values():
-        #     assert isinstance(v, pd.DataFrame)
-        # for v in my_array_list:
-        #     assert isinstance(v, np.ndarray)
+        for v in my_df_dict.values():
+            assert isinstance(v, pd.DataFrame)
+        for v in my_array_list:
+            assert isinstance(v, np.ndarray)
 
 
 @pytest.mark.parametrize("auto_unpack_inputs", [True, False])
@@ -432,7 +444,9 @@ def test_parse_inputs_with_mlconf_packagers_auto_unpack_inputs(
             "my_list": log_artifacts_and_results_run.outputs["my_list"],
             "my_array": log_artifacts_and_results_run.outputs["my_array"],
             "my_df": log_artifacts_and_results_run.outputs["my_df"],
-            "my_file": log_artifacts_and_results_run.outputs["my_file"],
+            "manually_logged_file": log_artifacts_and_results_run.outputs[
+                "manually_logged_file"
+            ],
             "my_object": log_artifacts_and_results_run.outputs["my_object"],
             "my_dict": log_artifacts_and_results_run.outputs["my_dict"],
             "my_df_dict": {
@@ -541,7 +555,6 @@ def test_log_with_and_without_packagers(rundb_mock, auto_unpack_inputs: bool):
         [
             "my_array",
             "my_df",
-            "my_file: path",
             {"key": "my_dict", "artifact_type": "object"},
         ],
         None,
@@ -582,32 +595,34 @@ def test_log_outputs_with_mlconf_packagers_auto_pack_outputs(
         local=True,
     )
 
-    # There should always be at least one output - the manually logged result:
+    # There should always be at least two outputs - the manually logged result and artifact:
     if auto_pack_outputs:
-        # 'auto_pack_outputs' is set, assert all returning values (notice there are no '**' and '*' in "my_df_dict_" and
+        # 'auto_pack_outputs' is set, assert all returning values (notice there are no '*' in "my_df_dict_" and
         # "my_array_list_" now):
-        assert len(log_artifacts_and_results_run.outputs) == 1 + len(RETURNS_LOG_HINTS)
-        # Check for the manually logged result:
+        assert len(log_artifacts_and_results_run.outputs) == 2 + len(RETURNS_LOG_HINTS)
+        # Check for the manually logged result and artifact:
         assert "manually_logged_result" in log_artifacts_and_results_run.outputs
+        assert "manually_logged_file" in log_artifacts_and_results_run.outputs
         # Check the auto-logged outputs:
         key = "test-run-test" if auto_pack_key else "test-run-artifact"
         for i in range(
             len(log_artifacts_and_results_run.outputs)
-            - (1 + (len(returns) if returns else 0))
+            - (2 + (len(returns) if returns else 0))
         ):
             assert f"{key}-{i}" in log_artifacts_and_results_run.outputs
         # Check the outputs from the 'returns' parameter:
         if returns:
-            for i in returns:
-                if isinstance(i, str):
+            for log_hint in returns:
+                if isinstance(log_hint, str):
                     assert (
-                        i.split(":")[0].strip() in log_artifacts_and_results_run.outputs
+                        log_hint.split(":")[0].strip()
+                        in log_artifacts_and_results_run.outputs
                     )
-                elif isinstance(i, dict):
-                    assert i["key"] in log_artifacts_and_results_run.outputs
+                elif isinstance(log_hint, dict):
+                    assert log_hint["key"] in log_artifacts_and_results_run.outputs
     else:
         # Plus the default logged output as string MLRun did before packagers and log hints if returns is not set:
-        assert len(log_artifacts_and_results_run.outputs) == 1 + (
+        assert len(log_artifacts_and_results_run.outputs) == 2 + (
             len(returns) if returns else 1
         )
 
@@ -620,10 +635,10 @@ class BaseClassPackager(DefaultPackager):
         self,
         data_item: DataItem,
         pickle_module_name: str = "cloudpickle",
-        object_module_name: Optional[str] = None,
-        python_version: Optional[str] = None,
-        pickle_module_version: Optional[str] = None,
-        object_module_version: Optional[str] = None,
+        object_module_name: str | None = None,
+        python_version: str | None = None,
+        pickle_module_version: str | None = None,
+        object_module_version: str | None = None,
     ) -> Any:
         base_class = super().unpack_object(
             data_item=data_item,
@@ -641,19 +656,19 @@ class BaseClassPackager(DefaultPackager):
         return base_class
 
 
-def func_to_pack_base_class(a: int, b: Optional[str] = None) -> BaseClass:
+def func_to_pack_base_class(a: int, b: str | None = None) -> BaseClass:
     if b:
         return InheritingClass(a=a, b=b)
     return BaseClass(a=a)
 
 
-def func_to_unpack_base_class(base_class: BaseClass, a: int, b: Optional[str] = None):
+def func_to_unpack_base_class(base_class: BaseClass, a: int, b: str | None = None):
     assert isinstance(base_class, BaseClass)
     assert base_class.a == a - 1
 
 
 def func_to_unpack_inheriting_class(
-    base_class: InheritingClass, a: int, b: Optional[str] = None
+    base_class: InheritingClass, a: int, b: str | None = None
 ):
     assert isinstance(base_class, InheritingClass)
     assert base_class.b == b

--- a/tests/package/test_usage.py
+++ b/tests/package/test_usage.py
@@ -238,11 +238,11 @@ def test_mlconf_packagers_enabled(rundb_mock, is_enabled: bool, returns: list):
 
     # There should always be at least two outputs - the manually logged result and artifact:
     if is_enabled and returns:
-        # Plus all configured returning values ("*my_df_dict_" yields 3 outputs + "*my_array_list_" yields 10
+        # Plus all configured returning values ("*my_df_dict_" yields 4 outputs + "*my_array_list_" yields 11
         # outputs - 2, the keys):
         assert (
             len(log_artifacts_and_results_run.outputs)
-            == 2 + len(RETURNS_LOG_HINTS) + 3 + 10 - 2
+            == 2 + len(RETURNS_LOG_HINTS) + 4 + 11 - 2
         )
     else:
         # Plus the default logged output as string MLRun did before packagers and log hints:
@@ -449,23 +449,8 @@ def test_parse_inputs_with_mlconf_packagers_auto_unpack_inputs(
             ],
             "my_object": log_artifacts_and_results_run.outputs["my_object"],
             "my_dict": log_artifacts_and_results_run.outputs["my_dict"],
-            "my_df_dict": {
-                "abc": log_artifacts_and_results_run.outputs["my_df_dict_abc"],
-                "def": log_artifacts_and_results_run.outputs["my_df_dict_def"],
-                "ghi": log_artifacts_and_results_run.outputs["my_df_dict_ghi"],
-            },
-            "my_array_list": [
-                log_artifacts_and_results_run.outputs["my_array_list_0"],
-                log_artifacts_and_results_run.outputs["my_array_list_1"],
-                log_artifacts_and_results_run.outputs["my_array_list_2"],
-                log_artifacts_and_results_run.outputs["my_array_list_3"],
-                log_artifacts_and_results_run.outputs["my_array_list_4"],
-                log_artifacts_and_results_run.outputs["my_array_list_5"],
-                log_artifacts_and_results_run.outputs["my_array_list_6"],
-                log_artifacts_and_results_run.outputs["my_array_list_7"],
-                log_artifacts_and_results_run.outputs["my_array_list_8"],
-                log_artifacts_and_results_run.outputs["my_array_list_9"],
-            ],
+            "my_df_dict": log_artifacts_and_results_run.outputs["my_df_dict"],
+            "my_array_list": log_artifacts_and_results_run.outputs["my_array_list"],
         },
         params={
             "my_int": log_artifacts_and_results_run.outputs["my_int"],

--- a/tests/package/utils/test_formatter.py
+++ b/tests/package/utils/test_formatter.py
@@ -14,6 +14,7 @@
 
 import tempfile
 from pathlib import Path
+
 import pytest
 
 from mlrun.package.utils import StructFileSupportedFormat

--- a/tests/package/utils/test_formatter.py
+++ b/tests/package/utils/test_formatter.py
@@ -14,8 +14,6 @@
 
 import tempfile
 from pathlib import Path
-from typing import Union
-
 import pytest
 
 from mlrun.package.utils import StructFileSupportedFormat
@@ -33,7 +31,7 @@ from mlrun.package.utils import StructFileSupportedFormat
     "file_format",
     StructFileSupportedFormat.get_all_formats(),
 )
-def test_formatter(obj: Union[list, dict], file_format: str):
+def test_formatter(obj: list | dict, file_format: str):
     """
     Test the formatters for writing and reading python objects.
 

--- a/tests/package/utils/test_log_hint_utils.py
+++ b/tests/package/utils/test_log_hint_utils.py
@@ -85,7 +85,6 @@ def test_parse_log_hint(log_hint: str | dict, expected_log_hint: str | dict):
         # Full unbundling (no level specified)
         ("*results", "results", True),
         ("*my_data", "my_data", True),
-        ("*", "", True),
         # Level-specific unbundling
         ("1*results", "results", 1),
         ("2*nested", "nested", 2),
@@ -96,6 +95,12 @@ def test_parse_log_hint(log_hint: str | dict, expected_log_hint: str | dict):
         # Error case - invalid level
         ("abc*results", "Invalid unbundle level", None),
         ("1.5*results", "Invalid unbundle level", None),
+        # TODO: Error case - multiple asterisks (will be validated by the LogHint class in next PR
+        # ("1*2*results", "Invalid log hint key", None),
+        # Error case - empty key after asterisk
+        ("*", "Key is missing after the '*'", None),
+        ("  * ", "Key is missing after the '*'", None),
+        ("1*", "Key is missing after the '*'", None),
     ],
 )
 def test_extract_unbundling_from_key(

--- a/tests/package/utils/test_log_hint_utils.py
+++ b/tests/package/utils/test_log_hint_utils.py
@@ -57,9 +57,7 @@ from mlrun.package.utils.log_hint_utils import LogHintKey, LogHintUtils
         ),
     ],
 )
-def test_parse_log_hint(
-    log_hint: str | dict, expected_log_hint: str | dict
-):
+def test_parse_log_hint(log_hint: str | dict, expected_log_hint: str | dict):
     """
     Test the `LogHintUtils.parse_log_hint` function with multiple types.
 

--- a/tests/package/utils/test_log_hint_utils.py
+++ b/tests/package/utils/test_log_hint_utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
-
 import pytest
 
 from mlrun.errors import MLRunInvalidArgumentError
@@ -60,7 +58,7 @@ from mlrun.package.utils.log_hint_utils import LogHintKey, LogHintUtils
     ],
 )
 def test_parse_log_hint(
-    log_hint: Union[str, dict], expected_log_hint: Union[str, dict]
+    log_hint: str | dict, expected_log_hint: str | dict
 ):
     """
     Test the `LogHintUtils.parse_log_hint` function with multiple types.
@@ -75,5 +73,51 @@ def test_parse_log_hint(
     except MLRunInvalidArgumentError as error:
         if isinstance(expected_log_hint, str):
             assert expected_log_hint in str(error)
+        else:
+            raise error
+
+
+@pytest.mark.parametrize(
+    "log_hint, expected_key, expected_level",
+    [
+        # No unbundling
+        ("results", "results", False),
+        ("my_data", "my_data", False),
+        ("some_key_with_underscore", "some_key_with_underscore", False),
+        # Full unbundling (no level specified)
+        ("*results", "results", True),
+        ("*my_data", "my_data", True),
+        ("*", "", True),
+        # Level-specific unbundling
+        ("1*results", "results", 1),
+        ("2*nested", "nested", 2),
+        ("3*deep", "deep", 3),
+        ("10*multi", "multi", 10),
+        # Whitespace handling
+        ("1 *results", "results", 1),  # Space before * is stripped from level
+        # Error case - invalid level
+        ("abc*results", "Invalid unbundle level", None),
+        ("1.5*results", "Invalid unbundle level", None),
+    ],
+)
+def test_extract_unbundling_from_key(
+    log_hint: str, expected_key: str, expected_level: bool | int | None
+):
+    """
+    Test the `LogHintUtils.extract_unbundling_from_key` function.
+
+    :param log_hint:       The log hint key to extract unbundling information from.
+    :param expected_key:   The expected artifact key after extraction. A string starting with "Invalid" indicates
+                           an error should be raised.
+    :param expected_level: The expected unbundle level (True for full unbundling, False for no unbundling,
+                           or an integer for specific unbundle level). None indicates an error case.
+    """
+    try:
+        key, level = LogHintUtils.extract_unbundling_from_key(log_hint=log_hint)
+        assert key == expected_key
+        assert level == expected_level
+    except MLRunInvalidArgumentError as error:
+        if expected_level is None:
+            assert expected_key in str(error)
         else:
             raise error

--- a/tests/package/utils/test_pickler.py
+++ b/tests/package/utils/test_pickler.py
@@ -14,8 +14,6 @@
 
 import tempfile
 from pathlib import Path
-from typing import Union
-
 import cloudpickle
 import numpy as np
 import pytest
@@ -49,7 +47,7 @@ from mlrun.package.utils import Pickler
         ("numpy", "A pickle module is expected to have a"),
     ],
 )
-def test_pickler(pickle_module_name: str, expected_notes: Union[dict, str]):
+def test_pickler(pickle_module_name: str, expected_notes: dict | str):
     """
     Test the `Pickler` with multiple pickling modules.
 

--- a/tests/package/utils/test_pickler.py
+++ b/tests/package/utils/test_pickler.py
@@ -14,6 +14,7 @@
 
 import tempfile
 from pathlib import Path
+
 import cloudpickle
 import numpy as np
 import pytest

--- a/tests/package/utils/test_type_hint_utils.py
+++ b/tests/package/utils/test_type_hint_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import inspect
 import typing
 
 import pytest
@@ -62,11 +63,80 @@ def test_is_typing_type(type_hint: type, expected_result: bool):
 
 
 @pytest.mark.parametrize(
+    "type_hint, expected_result",
+    [
+        # Pure type hints (cannot be instantiated, return True):
+        (typing.Union, True),
+        (typing.TypeVar("A", int, str), True),
+        (typing.ForwardRef("pandas.DataFrame"), True),
+        (typing.Callable, True),
+        (typing.Literal, True),
+        (typing.Optional, True),
+        (typing.Annotated, True),
+        (typing.Final, True),
+        (typing.ClassVar, True),
+        # Generic aliases (not pure, return False):
+        (list[int], False),
+        (tuple[int, str], False),
+        (dict[str, int], False),
+        (typing.List[int], False),  # noqa: UP006
+        (typing.Dict[str, int], False),  # noqa: UP006
+        (typing.Tuple[int, str], False),  # noqa: UP006
+        # Regular types (not typing types, return False):
+        (list, False),
+        (int, False),
+        (str, False),
+        (SomeClass, False),
+    ],
+)
+def test_is_pure_hint(type_hint: type, expected_result: bool):
+    """
+    Test the `TypeHintUtils.is_pure_hint` function with multiple types.
+
+    :param type_hint:       The type to check.
+    :param expected_result: The expected result.
+    """
+    assert TypeHintUtils.is_pure_hint(type_hint=type_hint) == expected_result
+
+
+@pytest.mark.parametrize(
+    "type_hint, expected_result",
+    [
+        # Generic aliases (have origin and args):
+        (list[int], (list, (int,))),
+        (dict[str, int], (dict, (str, int))),
+        (tuple[int, str], (tuple, (int, str))),
+        (typing.List[int], (list, (int,))),  # noqa: UP006
+        (typing.Dict[str, int], (dict, (str, int))),  # noqa: UP006
+        (typing.Tuple[int, str], (tuple, (int, str))),  # noqa: UP006
+        # Typing special forms with args:
+        (typing.Optional[int], (typing.Union, (int, type(None)))),
+        (typing.Union[int, str], (typing.Union, (int, str))),
+        # Ellipsis in tuple (should be filtered out):
+        (tuple[int, ...], (tuple, (int,))),
+        # Non-generic types (no origin, return empty):
+        (list, (list, inspect.Parameter.empty)),
+        (int, (int, inspect.Parameter.empty)),
+        (str, (str, inspect.Parameter.empty)),
+        (SomeClass, (SomeClass, inspect.Parameter.empty)),
+    ],
+)
+def test_deconstruct_type_hint(type_hint: type, expected_result: tuple):
+    """
+    Test the `TypeHintUtils.deconstruct_type_hint` function with multiple types.
+
+    :param type_hint:       The type hint to deconstruct.
+    :param expected_result: The expected (origin, args) tuple.
+    """
+    assert TypeHintUtils.deconstruct_type_hint(type_hint=type_hint) == expected_result
+
+
+@pytest.mark.parametrize(
     "type_string, expected_type",
     [
         ("int", int),
         ("list", list),
-        ("typing.Tuple[int, str]", tuple[int, str]),
+        ("typing.Tuple[int, str]", typing.Tuple[int, str]),  # noqa: UP006
         ("tuple[int, str]", tuple[int, str]),
         ("dict[str, int]", dict[str, int]),
         ("typing.Optional[float]", typing.Optional[float]),

--- a/tests/package/utils/test_type_hint_utils.py
+++ b/tests/package/utils/test_type_hint_utils.py
@@ -66,7 +66,7 @@ def test_is_typing_type(type_hint: type, expected_result: bool):
     [
         ("int", int),
         ("list", list),
-        ("typing.Tuple[int, str]", typing.Tuple[int, str]),
+        ("typing.Tuple[int, str]", tuple[int, str]),
         ("tuple[int, str]", tuple[int, str]),
         ("dict[str, int]", dict[str, int]),
         ("typing.Optional[float]", typing.Optional[float]),

--- a/tests/package/utils/test_type_hint_utils.py
+++ b/tests/package/utils/test_type_hint_utils.py
@@ -217,8 +217,7 @@ def test_is_matching(
         # Multiple types to reduce:
         ({int, str, list[int]}, {list}),
         (list[str], {list}),
-        # TODO: Uncomment once we support Python >= 3.10:
-        # (str | int, {str, int}),
+        (str | int, {str, int}),
     ],
 )
 def test_reduce_type_hint(type_hint: type, expected_result: set[type]):

--- a/tests/package/utils/test_type_hint_utils.py
+++ b/tests/package/utils/test_type_hint_utils.py
@@ -48,8 +48,7 @@ class AnotherClass(SomeClass):
         (SomeClass, False),
         (list[int], True),
         (tuple[int, str], True),
-        # TODO: Uncomment once we support Python >= 3.10:
-        # (str | int, True),
+        (str | int, True),
     ],
 )
 def test_is_typing_type(type_hint: type, expected_result: bool):
@@ -67,7 +66,17 @@ def test_is_typing_type(type_hint: type, expected_result: bool):
     [
         ("int", int),
         ("list", list),
+        ("typing.Tuple[int, str]", typing.Tuple[int, str]),
+        ("tuple[int, str]", tuple[int, str]),
+        ("dict[str, int]", dict[str, int]),
+        ("typing.Optional[float]", typing.Optional[float]),
+        ("typing.Union[str, int]", typing.Union[str, int]),
+        ("str | int", str | int),
         ("tests.package.utils.test_type_hint_utils.SomeClass", SomeClass),
+        (
+            'dict[str, set[tests.package.utils.test_type_hint_utils.SomeClass]] | None | typing.Literal["A", "B"]',
+            dict[str, set[SomeClass]] | None | typing.Literal["A", "B"],
+        ),
         (
             "fail",
             "MLRun tried to get the type hint 'fail' but it can't as it is not a valid builtin Python type (one of "
@@ -82,9 +91,18 @@ def test_is_typing_type(type_hint: type, expected_result: bool):
             "module_not_exist.Fail",
             "MLRun tried to get the type hint 'Fail' but the module 'module_not_exist' cannot be imported.",
         ),
+        ("list[int", "Make sure the type hint is a valid python type hint structure"),
+        (
+            "int | str |",
+            "Make sure the type hint is a valid python type hint structure",
+        ),
+        (
+            "typing.List[]",
+            "Make sure the type hint is a valid python type hint structure",
+        ),
     ],
 )
-def test_parse_type_hint(type_string: str, expected_type: typing.Union[str, type]):
+def test_parse_type_hint(type_string: str, expected_type: str | type):
     """
     Test the `TypeHintUtils.parse_type_hint` function with multiple types.
 
@@ -94,7 +112,7 @@ def test_parse_type_hint(type_string: str, expected_type: typing.Union[str, type
     """
     try:
         parsed_type = TypeHintUtils.parse_type_hint(type_hint=type_string)
-        assert parsed_type is expected_type
+        assert parsed_type == expected_type
     except MLRunInvalidArgumentError as error:
         if isinstance(expected_type, str):
             assert expected_type in str(error)


### PR DESCRIPTION
### 📝 Description

Allowing users to pass a `dict` or a `list` as elements in the `inputs` dictionary of an MLRun function's `run` method - basically passing an input of inputs. 

https://iguazio.atlassian.net/browse/ML-11892

---

### 🛠️ Changes Made

- [x] Updated `mlrun.package` type hints for Python 3.11.
- [x] `inputs` for an MLRun function `run` method can now be passed as collections (lists and dictionaries) of inputs.
- [x] Added new configurations to `mlconf`:
  - [x] `auto_unpack_inputs=False`: Whether to automatically unpack inputs with no type hints instead of leaving them as 
    `mlrun.DataItem` objects. If True, all inputs without type hints that were originally logged via `mlrun.package` 
    will be unpacked automatically. If False, the inputs will remain `DataItem`s. Default is False.
  - [x] `auto_pack_outputs=False` and `auto_pack_key="artifact"`: Whether to automatically pack outputs, even if no log hints were provided by the user running the function. If True, returned objects will be packed with their default 
    packager and their artifact key will be equal to the following name template: 
    `"<function_name>-<handler>-<auto_pack_key>-<i>"` where `"i"` is enumerated. If False, the returned objects will 
    simply be ignored. Default is False.
- [x] Bundle and unbundle feature:
  - [x] Made packagers support unpacking a collection of inputs via inner arguments of type hints (or default behavior of the new available configurations). 
  - [x] Any bundle-able type can be returned as a collection now and its inner items will be packaged separately. 
- [x] Type hinting changed for Python 3.10+ format. 

**IMPORTANT**: Change docs for `mlrun_op` in `mlrun_pipelines` to reflect the new functionality. In addition in line 278 in `ops.py` change:
```python
for input_param, val in inputs.items():
   cmd += ["-i", f"{input_param}={val}"]
```
to:
```python
for input_param, val in inputs.items():
   cmd += ["-i", f"{input_param}={json.dumps(val) if isinstance(val, dict | list) else val}"]
```

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
Multiple tessts were added to check any new feature / function / method.
---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
