### PR TITLE
[Tests] Make pod log collection opt-in via pytest marker (ML-11964)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ timeout = 1800  # 30 minutes per test
 log_cli = true
 log_level = "DEBUG"
 asyncio_mode = "auto"
+markers = [
+    "collect_pod_logs: collect pod logs on test failure for debugging",
+]
 
 [tool.importlinter]
 root_packages = [

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -52,7 +52,13 @@ def _collect_pod_logs_on_failure(item: Function) -> None:
 
     This helps debug test failures by showing logs from relevant pods
     (project-specific pods and system pods like mlrun-api).
+
+    Only runs for tests marked with @pytest.mark.collect_pod_logs.
     """
+    # Only collect logs for tests that opt-in via marker
+    if not item.get_closest_marker("collect_pod_logs"):
+        return
+
     try:
         test_instance = item.instance
         if test_instance is None:


### PR DESCRIPTION
### 📝 Description
Make pod log collection on test failure opt-in instead of collecting for all tests. This reduces noise from excessive log collection during system tests.

Tests that want log collection on failure now need to add the `@pytest.mark.collect_pod_logs` marker.

---

### 🛠️ Changes Made
- Add check for `collect_pod_logs` pytest marker in `_collect_pod_logs_on_failure()`
- Register the marker in `pyproject.toml` to avoid pytest warnings

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Verified linting passes
- Verified existing tests pass

---

### 🔗 References
- Ticket link: [ML-11964](https://iguazio.atlassian.net/browse/ML-11964)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Usage example:
```python
@pytest.mark.collect_pod_logs
def test_something(self):
    ...
```

[ML-11964]: https://iguazio.atlassian.net/browse/ML-11964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ