### PR TITLE
[Serving] Reduce default of max_iter to 100 and changed the setter to raise an error if engine is sync

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -284,7 +284,7 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
         :param engine:       - optional for flow, sync or async engine
         :param exist_ok:     - allow overriding existing topology
         :param allow_cyclic: - allow cyclic graphs (only for async flow)
-        :param max_iterations: - optional, max iterations for cyclic graphs (only for async flow)
+        :param max_iterations: - optional, max iterations for cyclic graphs (only for async flow), default 100
         :param class_args:   - optional, router/flow class init args
 
         :return: graph object (fn.spec.graph)
@@ -294,10 +294,7 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "graph topology is already set, graph was initialized, use exist_ok=True to override"
             )
-        if allow_cyclic and (
-            topology == StepKinds.router
-            or (topology == StepKinds.flow and engine == "sync")
-        ):
+        if allow_cyclic and topology == StepKinds.router:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "cyclic graphs are only supported in flow topology with async engine"
             )

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -2585,7 +2585,7 @@ class FlowStep(BaseStep):
         self._wait_for_result = False
         self._source = None
         self._start_steps = []
-        self._allow_cyclic = allow_cyclic
+        self.allow_cyclic = allow_cyclic
 
     def get_children(self):
         return self._steps.values()
@@ -3154,10 +3154,16 @@ class RootFlowStep(FlowStep):
         engine=None,
         final_step=None,
         allow_cyclic: bool = False,
-        max_iterations: Optional[int] = 10_000,
+        max_iterations: Optional[int] = None,
     ):
         super().__init__(
-            name, steps, after, engine, final_step, allow_cyclic, max_iterations
+            name,
+            steps,
+            after,
+            engine,
+            final_step,
+            allow_cyclic,
+            max_iterations or 100 if allow_cyclic else None,
         )
         self._models = set()
         self._route_models = set()
@@ -3182,7 +3188,14 @@ class RootFlowStep(FlowStep):
 
     @allow_cyclic.setter
     def allow_cyclic(self, allow_cyclic: bool):
-        self._allow_cyclic = allow_cyclic
+        if allow_cyclic and self.engine == "async":
+            self._allow_cyclic = allow_cyclic
+        elif allow_cyclic and self.engine == "sync":
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "Cyclic graphs are not supported with sync engine, please use async engine"
+            )
+        else:
+            self._allow_cyclic = allow_cyclic
 
     def add_shared_model(
         self,

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1516,6 +1516,29 @@ def test_max_iter_of_cyclic_graph(method, max_iter):
         server.wait_for_completion()
 
 
+def test_default_max_iter_of_cyclic_graph():
+    function = mlrun.new_function("tests", kind="serving", project="x")
+    graph = function.set_topology(
+        "flow",
+        engine="async",
+        allow_cyclic=True,
+    )
+    graph.to(name="start", class_name="Echo").to(class_name="Counter", name="count").to(
+        name="route",
+        class_name="Route",
+        cycle_to="count",
+    ).to(name="end", class_name="Echo").respond()
+
+    expected_error = r"Max iterations exceeded in step 'count'"
+
+    server = function.to_mock_server()
+    try:
+        with pytest.raises(RuntimeError, match=rf"{expected_error}"):
+            server.test(body={"counter": -300})
+    finally:
+        server.wait_for_completion()
+
+
 def test_mrs_with_tools_routing():
     function = mlrun.new_function("tests", kind="serving")
     graph = function.set_topology("flow", engine="async", allow_cyclic=True)
@@ -1540,3 +1563,31 @@ def test_mrs_with_tools_routing():
         assert resp["tool_b"] == 2
     finally:
         server.wait_for_completion()
+
+
+def test_invalid_cyclic_graph_defenitions():
+    function = mlrun.new_function("tests", kind="serving", project="x")
+    graph = function.set_topology("flow", engine="async", allow_cyclic=False)
+
+    with pytest.raises(
+        GraphError, match="cyclic graphs are not allowed, enable allow_cyclic"
+    ):
+        graph.to(name="start", class_name="Echo").to(
+            class_name="Counter", name="count"
+        ).to(name="route", class_name="Route", cycle_to="count").to(
+            name="end", class_name="Echo"
+        ).respond()
+
+    function_sync = mlrun.new_function("tests-sync", kind="serving", project="x")
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match=r"Cyclic graphs are not supported with sync engine, please use async engine",
+    ):
+        function_sync.set_topology("flow", engine="sync", allow_cyclic=True)
+
+    graph = function_sync.set_topology("flow", engine="sync")
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match=r"Cyclic graphs are not supported with sync engine, please use async engine",
+    ):
+        graph.allow_cyclic = True

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1565,7 +1565,7 @@ def test_mrs_with_tools_routing():
         server.wait_for_completion()
 
 
-def test_invalid_cyclic_graph_defenitions():
+def test_invalid_cyclic_graph_definitions():
     function = mlrun.new_function("tests", kind="serving", project="x")
     graph = function.set_topology("flow", engine="async", allow_cyclic=False)
 


### PR DESCRIPTION
### 📝 Description
1. set max iteration to 100
2. Edit `allow_cyclic` setter to raise error if the engine is sync

https://iguazio.atlassian.net/browse/ML-11966
https://iguazio.atlassian.net/browse/ML-11957
