### PR TITLE
[Application runtime] Fix order of validation and save to DB

### DIFF
--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -481,16 +481,16 @@ def _deploy_function(
         # TODO in ML-11600/ML-11599 need to handle redeployment with different auth token name
         launcher.enrich_and_validate_auth_token_name(fn)
 
+        # Validate sidecar probe configurations before deployment
+        sidecars = fn.spec.config.get("spec.sidecars") or []
+        if sidecars:
+            _validate_sidecar_probes(sidecars)
+
         # save the function to DB
         fn.save(versioned=False)
 
         # after saving function to DB, we need to restore the original config so that the sensitive data won't be stored
         fn.spec.config = raw_config
-
-        # Validate sidecar probe configurations before deployment
-        sidecars = fn.spec.config.get("spec.sidecars") or []
-        if sidecars:
-            _validate_sidecar_probes(sidecars)
 
         fn = _deploy_nuclio_runtime(
             auth_info,


### PR DESCRIPTION
### 📝 Description
Move validation before saving the spec to DB

---

### 🛠️ Changes Made
- `Nuclio.py`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Dev test

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11970
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
- Logs before:
```
> 2026-01-12 08:29:10,422 [debug] Received request: ...
> 2026-01-12 08:29:10,433 [info] Deploying function: ...
> 2026-01-12 08:29:10,521 [debug] Reading secret: ...
> 2026-01-12 08:29:10,527 [debug] Updating secret: ...
> 2026-01-12 08:29:10,540 [debug] Reading secret: ...
> 2026-01-12 08:29:10,543 [debug] Updating secret: ...
> 2026-01-12 08:29:10,561 [debug] Saving function: ...
> 2026-01-12 08:29:10,576 [error] {'reason': 'Sidecar livenessProbe must have exactly one of the following configuration sections: httpGet, exec, tcpSocket, grpc'}: ...
> 2026-01-12 08:29:10,577 [error] Traceback (most recent call last):
  File "/mlrun/server/py/services/api/api/endpoints/nuclio.py", line 493, in _deploy_function
    _validate_sidecar_probes(sidecars)
  File "/mlrun/server/py/services/api/api/endpoints/nuclio.py", line 802, in _validate_sidecar_probes
    framework.api.utils.log_and_raise(
  File "/mlrun/server/py/framework/api/utils.py", line 69, in log_and_raise
    raise HTTPException(status_code=status, detail=kw)
fastapi.exceptions.HTTPException: 400: {'reason': 'Sidecar livenessProbe must have exactly one of the following configuration sections: httpGet, exec, tcpSocket, grpc'}: {"ctx":"11861e9c599ff2d1247a32cc10247347"}
> 2026-01-12 08:29:10,577 [error] {'reason': "Runtime error: 400: {'reason': 'Sidecar livenessProbe must have exactly one of the following configuration sections: httpGet, exec, tcpSocket, grpc'}"}: ...
> 2026-01-12 08:29:10,578 [debug] Sending response: ...
```
- Logs after:
```
> 2026-01-12 09:01:04,534 [debug] Received request: ...
> 2026-01-12 09:01:04,544 [info] Deploying function: ...
> 2026-01-12 09:01:04,665 [debug] Reading secret: ...
> 2026-01-12 09:01:04,670 [debug] Updating secret: ...
> 2026-01-12 09:01:04,683 [debug] Reading secret: ...
> 2026-01-12 09:01:04,686 [debug] Updating secret: ...
> 2026-01-12 09:01:04,702 [error] {'reason': 'Sidecar livenessProbe must have exactly one of the following configuration sections: httpGet, exec, tcpSocket, grpc'}: {"ctx":"c6d1cfd791c93fac844d4f96b1f969b6"}
> 2026-01-12 09:01:04,703 [error] Traceback (most recent call last):
  File "/mlrun/server/py/services/api/api/endpoints/nuclio.py", line 487, in _deploy_function
    _validate_sidecar_probes(sidecars)
  File "/mlrun/server/py/services/api/api/endpoints/nuclio.py", line 805, in _validate_sidecar_probes
    framework.api.utils.log_and_raise(
  File "/mlrun/server/py/framework/api/utils.py", line 69, in log_and_raise
    raise HTTPException(status_code=status, detail=kw)
fastapi.exceptions.HTTPException: 400: {'reason': 'Sidecar livenessProbe must have exactly one of the following configuration sections: httpGet, exec, tcpSocket, grpc'}: {"ctx":"c6d1cfd791c93fac844d4f96b1f969b6"}
> 2026-01-12 09:01:04,704 [error] {'reason': "Runtime error: 400: {'reason': 'Sidecar livenessProbe must have exactly one of the following configuration sections: httpGet, exec, tcpSocket, grpc'}"}: ...
> 2026-01-12 09:01:04,705 [debug] Sending response: ...
```
