### PR TITLE
[Requirements] Bump storey to 1.11.6

### DIFF
--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -3619,8 +3619,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.5 \
-    --hash=sha256:92df75ebd9c26114f398e5efedf42eec1ad838b9547705ccf606f7e694f3113a
+storey==1.11.6 \
+    --hash=sha256:52285fff5f247de257265d44b75d91ebf6d6d7433bc7044afd4a6006f8916e62
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -3412,8 +3412,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.5 \
-    --hash=sha256:92df75ebd9c26114f398e5efedf42eec1ad838b9547705ccf606f7e694f3113a
+storey==1.11.6 \
+    --hash=sha256:52285fff5f247de257265d44b75d91ebf6d6d7433bc7044afd4a6006f8916e62
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -3047,8 +3047,8 @@ starlette==0.49.3 \
     --hash=sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284 \
     --hash=sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f
     # via fastapi
-storey==1.11.5 \
-    --hash=sha256:92df75ebd9c26114f398e5efedf42eec1ad838b9547705ccf606f7e694f3113a
+storey==1.11.6 \
+    --hash=sha256:52285fff5f247de257265d44b75d91ebf6d6d7433bc7044afd4a6006f8916e62
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -2864,8 +2864,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.5 \
-    --hash=sha256:92df75ebd9c26114f398e5efedf42eec1ad838b9547705ccf606f7e694f3113a
+storey==1.11.6 \
+    --hash=sha256:52285fff5f247de257265d44b75d91ebf6d6d7433bc7044afd4a6006f8916e62
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -3619,8 +3619,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.5 \
-    --hash=sha256:92df75ebd9c26114f398e5efedf42eec1ad838b9547705ccf606f7e694f3113a
+storey==1.11.6 \
+    --hash=sha256:52285fff5f247de257265d44b75d91ebf6d6d7433bc7044afd4a6006f8916e62
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -4581,8 +4581,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.11.5 \
-    --hash=sha256:92df75ebd9c26114f398e5efedf42eec1ad838b9547705ccf606f7e694f3113a
+storey==1.11.6 \
+    --hash=sha256:52285fff5f247de257265d44b75d91ebf6d6d7433bc7044afd4a6006f8916e62
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -4695,8 +4695,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.11.5 \
-    --hash=sha256:92df75ebd9c26114f398e5efedf42eec1ad838b9547705ccf606f7e694f3113a
+storey==1.11.6 \
+    --hash=sha256:52285fff5f247de257265d44b75d91ebf6d6d7433bc7044afd4a6006f8916e62
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2025.5.1, <=2025.7.0
 v3iofs~=0.1.17
-storey~=1.11.5
+storey~=1.11.6
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,7 +128,7 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"~=1.11.5"},
+        "storey": {"~=1.11.6"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "scipy": {"~=1.16.3"},


### PR DESCRIPTION
## Summary
Update storey dependency from 1.11.5 to 1.11.6.

## Changes Made
- Update storey version in requirements.txt
- Update storey version and hash in all locked requirements files
- Update test_requirements.py to match new version

## Checklist
- [x] I have tested the changes in this PR
- [x] I updated the documentation (if applicable)

## Testing
- Verified version and hash updates are correct
- Requirements test should pass with updated version

## Breaking Changes?
- [ ] Yes
- [x] No