### PR TITLE
[Test] Add UTs for the order fix of validation and save to DB

### DIFF
--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -17,6 +17,7 @@ import json
 import os
 import typing
 import unittest.mock
+from contextlib import nullcontext as does_not_raise
 from http import HTTPStatus
 
 import deepdiff
@@ -2247,7 +2248,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             )
 
     @pytest.mark.parametrize(
-        "sidecars,is_valid",
+        "sidecars,expectation,is_valid",
         [
             # Test case 1: Valid probes - should save to DB
             (
@@ -2264,6 +2265,7 @@ class TestNuclioRuntime(TestRuntimeBase):
                         },
                     },
                 ],
+                does_not_raise(),
                 True,
             ),
             # Test case 2: Invalid probes - should NOT save to DB
@@ -2278,12 +2280,13 @@ class TestNuclioRuntime(TestRuntimeBase):
                         },
                     },
                 ],
+                pytest.raises(HTTPException),
                 False,
             ),
         ],
     )
     def test_deploy_function_sidecar_probes_validation_and_db_save(
-        self, db: Session, sidecars, is_valid
+        self, db: Session, sidecars, expectation, is_valid
     ):
         function = self._generate_runtime(self.runtime_kind)
         function.spec.config["spec.sidecars"] = sidecars
@@ -2306,32 +2309,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             deploy_mock.return_value = function
             auth_info = mlrun.common.schemas.AuthInfo()
 
-            if not is_valid:
-                # should raise HTTPException before save
-                with pytest.raises(HTTPException) as exception_result:
-                    _deploy_function(
-                        db_session=db,
-                        auth_info=auth_info,
-                        project=self.project,
-                        name=self.name,
-                        function=function.to_dict(),
-                        builder_env=None,
-                        client_version=None,
-                        client_python_version=None,
-                    )
-
-                # Verify HTTPException was raised
-                assert (
-                    exception_result.value.status_code == HTTPStatus.BAD_REQUEST.value
-                )
-                assert "must have exactly one of" in str(
-                    exception_result.value.detail.get("reason", "")
-                )
-
-                # Verify save was NOT called (validation failed before save)
-                mock_db.assert_not_called()
-            else:
-                # Valid probes - should save to DB
+            with expectation:
                 _deploy_function(
                     db_session=db,
                     auth_info=auth_info,
@@ -2343,7 +2321,10 @@ class TestNuclioRuntime(TestRuntimeBase):
                     client_python_version=None,
                 )
 
+            if is_valid:
                 mock_db.assert_called_with(versioned=False)
+            else:
+                mock_db.assert_not_called()
 
 
 # Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -2285,9 +2285,17 @@ class TestNuclioRuntime(TestRuntimeBase):
             ),
         ],
     )
-    def test_deploy_function_sidecar_probes_validation_and_db_save(
+    def test_sidecar_probe_validation_db_save(
         self, db: Session, sidecars, expectation, is_valid
     ):
+        """Test that sidecar probe validation happens before DB save.
+
+        Validates that:
+        - Valid sidecar probes allow the function to be saved to DB
+        - Invalid sidecar probes:
+          1. Raise specific HTTPException from _validate_sidecar_probes
+          2. No DB changes (save is not called)
+        """
         function = self._generate_runtime(self.runtime_kind)
         function.spec.config["spec.sidecars"] = sidecars
 
@@ -2309,7 +2317,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             deploy_mock.return_value = function
             auth_info = mlrun.common.schemas.AuthInfo()
 
-            with expectation:
+            with expectation as exception_result:
                 _deploy_function(
                     db_session=db,
                     auth_info=auth_info,
@@ -2322,8 +2330,16 @@ class TestNuclioRuntime(TestRuntimeBase):
                 )
 
             if is_valid:
+                assert exception_result is None
                 mock_db.assert_called_with(versioned=False)
             else:
+                # Verify HTTPException was raised by _validate_sidecar_probes
+                assert (
+                    exception_result.value.status_code == HTTPStatus.BAD_REQUEST.value
+                )
+                assert "must have exactly one of" in str(
+                    exception_result.value.detail.get("reason", "")
+                )
                 mock_db.assert_not_called()
 
 

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -43,7 +43,7 @@ from mlrun.utils import logger
 
 import services.api.crud.runtimes.nuclio.function
 import services.api.crud.runtimes.nuclio.helpers
-from services.api.api.endpoints.nuclio import _validate_sidecar_probes
+from services.api.api.endpoints.nuclio import _deploy_function, _validate_sidecar_probes
 from services.api.tests.unit.conftest import APIK8sSecretsMock
 from services.api.tests.unit.runtimes.base import TestRuntimeBase
 from services.api.utils.functions import build_function
@@ -2245,6 +2245,105 @@ class TestNuclioRuntime(TestRuntimeBase):
             assert "must have exactly one of" in str(
                 exception_result.value.detail.get("reason", "")
             )
+
+    @pytest.mark.parametrize(
+        "sidecars,is_valid",
+        [
+            # Test case 1: Valid probes - should save to DB
+            (
+                [
+                    {
+                        "name": "sidecar-http",
+                        "readinessProbe": {
+                            "httpGet": {
+                                "path": "/healthy",
+                                "port": 8080,
+                            },
+                            "initialDelaySeconds": 17,
+                            "periodSeconds": 13,
+                        },
+                    },
+                ],
+                True,
+            ),
+            # Test case 2: Invalid probes - should NOT save to DB
+            (
+                [
+                    {
+                        "name": "sidecar-invalid",
+                        "readinessProbe": {
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 3,
+                            # Missing httpGet, exec, tcpSocket, or grpc
+                        },
+                    },
+                ],
+                False,
+            ),
+        ],
+    )
+    def test_deploy_function_sidecar_probes_validation_and_db_save(
+        self, db: Session, sidecars, is_valid
+    ):
+        function = self._generate_runtime(self.runtime_kind)
+        function.spec.config["spec.sidecars"] = sidecars
+
+        # Mock fn.save()
+        mock_db = unittest.mock.Mock()
+
+        # Mock _deploy_nuclio_runtime to avoid actual deployment
+        with (
+            unittest.mock.patch(
+                "services.api.api.endpoints.nuclio._deploy_nuclio_runtime"
+            ) as deploy_mock,
+            unittest.mock.patch.object(mlrun.runtimes.RemoteRuntime, "save", mock_db),
+            unittest.mock.patch.object(
+                mlrun.runtimes.RemoteRuntime,
+                "mask_sensitive_data_in_config",
+                return_value={},
+            ),
+        ):
+            deploy_mock.return_value = function
+            auth_info = mlrun.common.schemas.AuthInfo()
+
+            if not is_valid:
+                # should raise HTTPException before save
+                with pytest.raises(HTTPException) as exception_result:
+                    _deploy_function(
+                        db_session=db,
+                        auth_info=auth_info,
+                        project=self.project,
+                        name=self.name,
+                        function=function.to_dict(),
+                        builder_env=None,
+                        client_version=None,
+                        client_python_version=None,
+                    )
+
+                # Verify HTTPException was raised
+                assert (
+                    exception_result.value.status_code == HTTPStatus.BAD_REQUEST.value
+                )
+                assert "must have exactly one of" in str(
+                    exception_result.value.detail.get("reason", "")
+                )
+
+                # Verify save was NOT called (validation failed before save)
+                mock_db.assert_not_called()
+            else:
+                # Valid probes - should save to DB
+                _deploy_function(
+                    db_session=db,
+                    auth_info=auth_info,
+                    project=self.project,
+                    name=self.name,
+                    function=function.to_dict(),
+                    builder_env=None,
+                    client_version=None,
+                    client_python_version=None,
+                )
+
+                mock_db.assert_called_with(versioned=False)
 
 
 # Kind of "nuclio:mlrun" is a special case of nuclio functions. Run the same suite of tests here as well


### PR DESCRIPTION
### 📝 Description
Add unit test coverage to ensure Nuclio sidecar probe validation is enforced before function persistence, and that invalid configurations are rejected without saving to the DB.

---

### 🛠️ Changes Made
- Added relevant Unit tests to `api/test/unit/runtimes/test_nuclio.py`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Added UTs 

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11970
- Covers: https://github.com/mlrun/mlrun/pull/9197

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

