### PR TITLE
[Authentication] Change user secret token from username to userid

### DIFF
--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -103,7 +103,7 @@ class MLRunInternalLabels:
     workflow = "workflow"
     feature_vector = "feature-vector"
 
-    auth_username = f"{MLRUN_LABEL_PREFIX}user"
+    auth_userid = f"{MLRUN_LABEL_PREFIX}user-id"
     auth_token_name = f"{MLRUN_LABEL_PREFIX}token"
 
     @classmethod
@@ -130,3 +130,7 @@ class DeployStatusTextKind(mlrun.common.types.StrEnum):
 class WorkflowSubmitMode(mlrun.common.types.StrEnum):
     direct = "direct"  # call KFP retry API directly
     rerun = "rerun"  # launch a RerunRunner function
+
+
+class InternalAnnotations:
+    auth_username = f"{MLRUN_LABEL_PREFIX}user"

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -79,7 +79,7 @@ class SecretProviderInterface(ABC):
     @abstractmethod
     def store_user_token_secret(
         self,
-        username: str,
+        auth_info: mlrun.common.schemas.AuthInfo,
         token_name: str,
         token: str,
         expiration: int,
@@ -91,7 +91,7 @@ class SecretProviderInterface(ABC):
     @abstractmethod
     def get_user_token_secret_value(
         self,
-        username: str,
+        user_id: str,
         token_name: str,
         namespace: typing.Optional[str] = None,
     ) -> str:
@@ -100,7 +100,7 @@ class SecretProviderInterface(ABC):
     @abstractmethod
     def list_user_token_secrets(
         self,
-        username: str,
+        user_id: str,
         namespace: typing.Optional[str] = None,
     ) -> list[mlrun.common.schemas.SecretTokenInfo]:
         pass
@@ -108,7 +108,7 @@ class SecretProviderInterface(ABC):
     @abstractmethod
     def delete_user_token_secret(
         self,
-        username: str,
+        user_id: str,
         token_name: str,
         namespace: typing.Optional[str] = None,
     ) -> None:
@@ -192,37 +192,54 @@ class InMemorySecretProvider(SecretProviderInterface):
 
     def store_user_token_secret(
         self,
-        username: str,
+        auth_info: mlrun.common.schemas.AuthInfo,
         token_name: str,
         token: str,
         expiration: int,
         force: bool = False,
         namespace: typing.Optional[str] = None,
     ) -> typing.Optional[mlrun.common.schemas.SecretEventActions]:
-        raise NotImplementedError()
+        secret_name = self.resolve_auth_secret_name(auth_info.user_id, token_name)
+        self.secrets_map[secret_name] = {
+            "token": token,
+            "expiration": expiration,
+            "user_id": auth_info.user_id,
+            "token_name": token_name,
+        }
+        return mlrun.common.schemas.SecretEventActions.created
 
     def get_user_token_secret_value(
         self,
-        username: str,
+        user_id: str,
         token_name: str,
         namespace: typing.Optional[str] = None,
     ) -> str:
-        raise NotImplementedError()
+        secret_name = self.resolve_auth_secret_name(user_id, token_name)
+        return self.secrets_map[secret_name]["token"]
 
     def list_user_token_secrets(
         self,
-        username: str,
+        user_id: str,
         namespace: typing.Optional[str] = None,
     ) -> list[mlrun.common.schemas.SecretTokenInfo]:
-        raise NotImplementedError()
+        secret_names = list(self.secrets_map.keys())
+        return [
+            mlrun.common.schemas.SecretTokenInfo(
+                name=self.secrets_map[secret_name]["token_name"],
+                expiration=self.secrets_map[secret_name]["expiration"],
+            )
+            for secret_name in secret_names
+            if self.secrets_map[secret_name]["user_id"] == user_id
+        ]
 
     def delete_user_token_secret(
         self,
-        username: str,
+        user_id: str,
         token_name: str,
         namespace: typing.Optional[str] = None,
     ) -> None:
-        raise NotImplementedError()
+        secret_name = self.resolve_auth_secret_name(user_id, token_name)
+        del self.secrets_map[secret_name]
 
     @staticmethod
     def _generate_auth_secret_data(username: str, access_key: str):

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -32,6 +32,7 @@ import mlrun.common.schemas
 import mlrun.common.secrets
 import mlrun.common.secrets as mlsecrets
 import mlrun.errors
+import mlrun.k8s_utils
 import mlrun.platforms.iguazio
 import mlrun.runtimes
 import mlrun.runtimes.pod
@@ -714,6 +715,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         namespace: str = "",
         type_: str = SecretTypes.opaque,
         labels: typing.Optional[dict] = None,
+        annotations: typing.Optional[dict] = None,
         encoded: bool = False,
     ):
         """
@@ -730,6 +732,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
          if empty.
         :param type_: Kubernetes secret type (default: Opaque).
         :param labels: Optional dictionary of labels to attach to the secret.
+        :param annotations: Optional dictionary of annotations to attach to the secret.
         :param encoded: Whether the secret values are already base64-encoded. Defaults to False.
         """
         logger.debug("Creating secret", secret_name=secret_name)
@@ -746,6 +749,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 name=secret_name,
                 namespace=namespace,
                 labels=labels,
+                annotations=annotations,
             ),
             data=secret_data,
         )

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1178,7 +1178,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
     def store_user_token_secret(
         self,
-        username: str,
+        auth_info: mlrun.common.schemas.AuthInfo,
         token_name: str,
         token: str,
         expiration: int,
@@ -1196,7 +1196,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         - `tokensFile`: Base64-encoded YAML containing the token and its name.
         - `tokenExpiration`: Token expiration as a string.
 
-        :param username: The user who owns the token.
+        :param auth_info: Authentication information containing user_id and username.
         :param token_name: The logical name for the token.
         :param token: The offline token string (JWT).
         :param expiration: The token's expiration timestamp (int UNIX epoch).
@@ -1206,12 +1206,19 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :return: SecretEventActions.{created, updated, skipped}
         """
         labels = {
-            mlrun_constants.MLRunInternalLabels.auth_username: username,
+            mlrun_constants.MLRunInternalLabels.auth_userid: auth_info.user_id,
             mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
+        }
+        annotations = {
+            mlrun_constants.InternalAnnotations.auth_username: mlrun.k8s_utils.sanitize_label_value(
+                auth_info.username
+            ),
         }
 
         create = False
-        k8s_secret = self._get_user_token_secret(username, token_name, namespace)
+        k8s_secret = self._get_user_token_secret(
+            auth_info.user_id, token_name, namespace
+        )
         if not k8s_secret:
             create = True
 
@@ -1219,8 +1226,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             # Secret does not exist (or labels mismatch) → create it
             self._create_secret(
                 labels=labels,
+                annotations=annotations,
                 namespace=namespace,
-                secret_name=self._resolve_auth_secret_name(username, token_name),
+                secret_name=self._resolve_auth_secret_name(
+                    auth_info.user_id, token_name
+                ),
                 secrets=self._encode_user_token(token_name, token, expiration),
                 encoded=True,
             )
@@ -1231,7 +1241,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self._update_secret(
                 k8s_secret=k8s_secret,
                 namespace=namespace,
-                secret_name=self._resolve_auth_secret_name(username, token_name),
+                secret_name=self._resolve_auth_secret_name(
+                    auth_info.user_id, token_name
+                ),
                 secrets=self._encode_user_token(token_name, token, expiration),
                 encoded=True,
             )
@@ -1239,9 +1251,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         return None
 
-    def _resolve_auth_secret_name(self, username: str, token: str) -> str:
+    def _resolve_auth_secret_name(self, user_id: str, token_name: str) -> str:
         return mlrun.mlconf.secret_stores.kubernetes.auth_secret_name.format(
-            hashed_access_key=hashlib.sha224((username + token).encode()).hexdigest()
+            hashed_access_key=hashlib.sha224(
+                (user_id + token_name).encode()
+            ).hexdigest()
         )
 
     def _encode_user_token(
@@ -1281,18 +1295,18 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
     def list_user_token_secrets(
         self,
-        username: str,
+        user_id: str,
         namespace: typing.Optional[str] = None,
     ) -> list[mlrun.common.schemas.SecretTokenInfo]:
         """
         List all offline token secrets for a given user.
 
-        :param username: The user whose tokens should be listed.
+        :param user_id: The user ID whose tokens should be listed.
         :param namespace: Kubernetes namespace where the secrets are stored.
         :return: List of SecretTokenInfo objects, each containing the token name and expiration.
         """
         namespace = self.resolve_namespace(namespace)
-        labels = {mlrun_constants.MLRunInternalLabels.auth_username: username}
+        labels = {mlrun_constants.MLRunInternalLabels.auth_userid: user_id}
 
         k8s_secrets = self.list_secrets(namespace=namespace, labels=labels)
 
@@ -1397,18 +1411,18 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
     def get_user_token_secret_value(
         self,
-        username: str,
+        user_id: str,
         token_name: str,
         namespace: typing.Optional[str] = None,
     ) -> str:
         """
         Retrieve the offline token string for a specific user and token name.
 
-        This method locates the Kubernetes secret associated with the given user
+        This method locates the Kubernetes secret associated with the given user ID
         and token name, decodes the base64-encoded YAML in the `tokensFile` field,
         and extracts the requested offline token string.
 
-        :param username: The owner of the token.
+        :param user_id: The user ID of the token owner.
         :param token_name: The logical name of the token to retrieve.
         :param namespace: Kubernetes namespace where the secret is stored.
                           If empty, the default namespace will be used.
@@ -1419,10 +1433,10 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             data fails.
         """
 
-        k8s_secret = self._get_user_token_secret(username, token_name, namespace)
+        k8s_secret = self._get_user_token_secret(user_id, token_name, namespace)
         if not k8s_secret:
             raise mlrun.errors.MLRunNotFoundError(
-                f"Token '{token_name}' not found for user '{username}'"
+                f"Token '{token_name}' not found for user_id '{user_id}'"
             )
         return self._extract_token_from_secret(k8s_secret)
 
@@ -1439,21 +1453,21 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :raises mlrun.errors.MLRunRuntimeError: If decoding/parsing fails.
         """
         try:
-            username = k8s_secret.metadata.labels[
-                mlrun_constants.MLRunInternalLabels.auth_username
+            user_id = k8s_secret.metadata.labels[
+                mlrun_constants.MLRunInternalLabels.auth_userid
             ]
             token_name = k8s_secret.metadata.labels[
                 mlrun_constants.MLRunInternalLabels.auth_token_name
             ]
         except KeyError as exc:
             raise mlrun.errors.MLRunRuntimeError(
-                f"Secret {k8s_secret.metadata.name} is missing required labels for username or token name"
+                f"Secret {k8s_secret.metadata.name} is missing required labels for user_id or token name"
             ) from exc
         try:
             encoded_tokens_file = k8s_secret.data.get("tokensFile")
             if not encoded_tokens_file:
                 raise mlrun.errors.MLRunNotFoundError(
-                    f"Token '{token_name}' not found in secret for user '{username}'"
+                    f"Token '{token_name}' not found in secret for user_id '{user_id}'"
                 )
 
             decoded_yaml = base64.b64decode(encoded_tokens_file).decode("utf-8")
@@ -1463,12 +1477,12 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
             if not token_entry or not token_entry.get("token"):
                 raise mlrun.errors.MLRunNotFoundError(
-                    f"Token '{token_name}' not found in secret for user '{username}'"
+                    f"Token '{token_name}' not found in secret for user_id '{user_id}'"
                 )
 
             logger.debug(
                 "Successfully extracted offline token from secret",
-                username=username,
+                user_id=user_id,
                 token_name=token_name,
             )
             return token_entry["token"]
@@ -1478,7 +1492,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         except Exception as exc:
             logger.error(
                 "Failed decoding token from secret",
-                username=username,
+                user_id=user_id,
                 token_name=token_name,
                 exc=mlrun.errors.err_to_str(exc),
             )
@@ -1488,25 +1502,25 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
     def delete_user_token_secret(
         self,
-        username: str,
+        user_id: str,
         token_name: str,
         namespace: typing.Optional[str] = None,
     ) -> None:
         """
         Delete a Kubernetes secret corresponding to a user's offline token.
 
-        :param username: Owner of the token.
+        :param user_id: User ID of the token owner.
         :param token_name: Logical name of the token.
         :param namespace: Kubernetes namespace where the secret is stored.
         :raises mlrun.errors.MLRunNotFoundError: If the secret does not exist.
         :raises mlrun.errors.MLRunRuntimeError: If deletion fails for any reason.
         """
         namespace = self.resolve_namespace(namespace)
-        secret_name = self._resolve_auth_secret_name(username, token_name)
+        secret_name = self._resolve_auth_secret_name(user_id, token_name)
 
         logger.debug(
             "Deleting user token secret from Kubernetes",
-            username=username,
+            user_id=user_id,
             token_name=token_name,
             secret_name=secret_name,
             namespace=namespace,
@@ -1520,31 +1534,31 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             logger.debug(
                 "Successfully deleted user token secret",
                 secret_name=secret_name,
-                username=username,
+                user_id=user_id,
                 namespace=namespace,
             )
         except k8s_client_rest.ApiException as exc:
             if exc.status == 404:
                 raise mlrun.errors.MLRunNotFoundError(
-                    f"Secret for token '{token_name}' not found for user '{username}'"
+                    f"Secret for token '{token_name}' not found for user_id '{user_id}'"
                 ) from exc
             raise mlrun.errors.MLRunRuntimeError(
-                f"Failed to delete secret for token '{token_name}' for user '{username}'"
+                f"Failed to delete secret for token '{token_name}' for user_id '{user_id}'"
             ) from exc
         except Exception as exc:
             raise mlrun.errors.MLRunRuntimeError(
-                f"Unexpected error deleting secret for token '{token_name}' for user '{username}'"
+                f"Unexpected error deleting secret for token '{token_name}' for user_id '{user_id}'"
             ) from exc
 
     def _get_user_token_secret(
         self,
-        username: str,
+        user_id: str,
         token_name: str,
         namespace: typing.Optional[str] = None,
     ):
         namespace = self.resolve_namespace(namespace)
         labels = {
-            mlrun_constants.MLRunInternalLabels.auth_username: username,
+            mlrun_constants.MLRunInternalLabels.auth_userid: user_id,
             mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
         }
 

--- a/server/py/services/api/api/endpoints/user_secrets.py
+++ b/server/py/services/api/api/endpoints/user_secrets.py
@@ -60,7 +60,7 @@ async def list_secret_tokens(
 
     return await run_in_threadpool(
         services.api.crud.Secrets().list_secret_tokens,
-        auth_info.username,
+        auth_info,
     )
 
 
@@ -77,6 +77,5 @@ async def revoke_secret_token(
     return await run_in_threadpool(
         services.api.crud.Secrets().revoke_secret_token,
         name,
-        auth_info.username,
-        auth_info.request_headers,
+        auth_info,
     )

--- a/server/py/services/api/crud/pipelines.py
+++ b/server/py/services/api/crud/pipelines.py
@@ -625,7 +625,7 @@ class Pipelines(
         # Workflows do not go through launcher/runtime handler
         # So enrichment, validation and secret retrieval need to be done here
         auth_secret_name = services.api.utils.helpers.resolve_auth_token_secret_name(
-            provided_token_name=provided_token_name, username=auth_info.username
+            provided_token_name=provided_token_name, user_id=auth_info.user_id
         )
 
         data = mlrun_pipelines.common.ops.process_kfp_workflow_secret_references(

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -466,7 +466,7 @@ class Secrets(
             expiration = token_info["token_exp"]
 
             action = self.secrets_provider.store_user_token_secret(
-                username=auth_info.username,
+                auth_info=auth_info,
                 token_name=token_name,
                 token=token,
                 expiration=expiration,
@@ -497,27 +497,17 @@ class Secrets(
 
     def list_secret_tokens(
         self,
-        authenticated_username: str,
+        auth_info: mlrun.common.schemas.AuthInfo,
     ) -> mlrun.common.schemas.ListSecretTokensResponse:
         """
         List all offline tokens stored for the authenticated user.
 
-        :param authenticated_username: Username whose tokens will be listed.
+        :param auth_info: Authentication information of the user.
         :return: ListSecretTokensResponse containing token names and expirations.
         """
-        logger.debug(
-            "Listing secret tokens for user",
-            username=authenticated_username,
-        )
 
         secret_tokens = self.secrets_provider.list_user_token_secrets(
-            username=authenticated_username,
-        )
-
-        logger.debug(
-            "Finished listing secret tokens",
-            username=authenticated_username,
-            token_count=len(secret_tokens),
+            user_id=auth_info.user_id,
         )
 
         return mlrun.common.schemas.ListSecretTokensResponse(
@@ -527,41 +517,38 @@ class Secrets(
     def revoke_secret_token(
         self,
         token_name: str,
-        authenticated_username: str,
-        request_headers: typing.Optional[dict[str, str]] = None,
+        auth_info: mlrun.common.schemas.AuthInfo,
     ):
         """
         Revoke a stored offline token for a user and delete its corresponding Kubernetes secret.
 
         This method performs two actions:
         1. Calls the Iguazio management service to revoke the offline token.
-        2. Removes the Kubernetes secret named `mlrun-auth-<username>-<token_name>`
-           associated with the token.
+        2. Removes the Kubernetes secret associated with the token.
 
         :param token_name:
             Logical name of the token to revoke (used in the Kubernetes secret name).
-        :param authenticated_username:
-            The username of the authenticated user who owns the token.
-        :param request_headers:
-            Optional request headers (e.g., containing the user's access token)
-            to authenticate with the Iguazio management service.
+        :param auth_info:
+            Authentication information of the user who owns the token.
         """
         logger.debug(
             "Revoking secret token for user",
-            username=authenticated_username,
+            user_id=auth_info.user_id,
+            username=auth_info.username,
             token_name=token_name,
         )
 
         try:
             # Get the offline token string
             token = self.secrets_provider.get_user_token_secret_value(
-                username=authenticated_username,
+                user_id=auth_info.user_id,
                 token_name=token_name,
             )
         except mlrun.errors.MLRunNotFoundError:
             logger.warning(
                 "Token not found, nothing to revoke",
-                username=authenticated_username,
+                user_id=auth_info.user_id,
+                username=auth_info.username,
                 token_name=token_name,
             )
             return
@@ -569,18 +556,19 @@ class Secrets(
         # Revoke via Iguazio
         # TODO: move init iguazio_client (ML-11077)
         iguazio_client = framework.utils.clients.iguazio.v4.Client()
-        iguazio_client.revoke_offline_token(token, request_headers)
+        iguazio_client.revoke_offline_token(token, auth_info.request_headers)
 
         # Delete the Kubernetes secret
         try:
             self.secrets_provider.delete_user_token_secret(
-                username=authenticated_username,
+                user_id=auth_info.user_id,
                 token_name=token_name,
             )
         except Exception as exc:
             logger.error(
                 "Token revoked but failed to delete associated secret",
-                username=authenticated_username,
+                user_id=auth_info.user_id,
+                username=auth_info.username,
                 token_name=token_name,
                 exc=mlrun.errors.err_to_str(exc),
             )
@@ -590,27 +578,28 @@ class Secrets(
 
         logger.debug(
             "Finished revoking secret token for user",
-            username=authenticated_username,
+            user_id=auth_info.user_id,
+            username=auth_info.username,
             token_name=token_name,
         )
 
     def get_secret_token(
         self,
         token_name: str,
-        authenticated_username: str,
+        auth_info: mlrun.common.schemas.AuthInfo,
     ) -> mlrun.common.schemas.SecretToken:
         """
         Get a specific offline token stored for the authenticated user by token name.
 
         :param token_name: Name of the token to retrieve.
-        :param authenticated_username: Username whose token will be retrieved.
+        :param auth_info: Authentication information of the user.
         :return: SecretToken object containing the token name and token value.
         :raises mlrun.errors.MLRunNotFoundError: If the token does not exist for the user.
         :raises mlrun.errors.MLRunRuntimeError: If reading or decoding the token fails.
         """
 
         token_value = self.secrets_provider.get_user_token_secret_value(
-            username=authenticated_username,
+            user_id=auth_info.user_id,
             token_name=token_name,
         )
 

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -491,11 +491,11 @@ class BaseRuntimeHandler(ABC):
         if not mlrun.mlconf.is_iguazio_v4_mode():
             return
 
-        username = auth_info.username if auth_info else None
+        user_id = auth_info.user_id if auth_info else None
 
         # Validation that the secret exists is done in the ServerSideLauncher
         secret = framework.utils.singletons.k8s.get_k8s_helper()._get_user_token_secret(
-            username=username, token_name=token_name
+            user_id=user_id, token_name=token_name
         )
 
         # In case the secret was not found (such as in IG3), we do not mount it

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -2088,13 +2088,13 @@ def test_resolve_auth_secret_name(
     )
 
     result = services.api.utils.helpers.resolve_auth_token_secret_name(
-        provided_token, "test-user"
+        provided_token, user_id="test-user"
     )
 
     assert result == expected_secret_name
 
     # Verify the function uses the correct token name (default or provided)
     k8s_helper._get_user_token_secret.assert_called_once_with(
-        username="test-user",
+        user_id="test-user",
         token_name=expected_token_name,
     )

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -914,14 +914,14 @@ def test_list_secret_tokens_returns_tokens():
 
 
 def test_revoke_secret_token_success(mock_iguazio_client):
-    auth_info = mlrun.common.schemas.AuthInfo(
-        username="dummy-user", user_id="user-id-123"
-    )
-    token_name = "my-token"
-    fake_token = "jwt-token-123"
     request_headers = {
         mlrun.common.schemas.HeaderNames.authorization: f"{mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer}123",
     }
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123", request_headers=request_headers
+    )
+    token_name = "my-token"
+    fake_token = "jwt-token-123"
 
     mock_secrets_provider = unittest.mock.Mock()
     services.api.crud.Secrets().secrets_provider = mock_secrets_provider

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -885,7 +885,9 @@ def test_store_secret_tokens_refresh_access_tokens_failure(mock_iguazio_client):
 
 
 def test_list_secret_tokens_returns_tokens():
-    username = "dummy-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
     expected_tokens = [
         mlrun.common.schemas.SecretTokenInfo(name="jupyter", expiration=1750979191),
         mlrun.common.schemas.SecretTokenInfo(name="my-token", expiration=1754966400),
@@ -897,9 +899,7 @@ def test_list_secret_tokens_returns_tokens():
         unittest.mock.Mock(return_value=expected_tokens)
     )
 
-    response = services.api.crud.Secrets().list_secret_tokens(
-        authenticated_username=username
-    )
+    response = services.api.crud.Secrets().list_secret_tokens(auth_info=auth_info)
 
     assert isinstance(response, mlrun.common.schemas.ListSecretTokensResponse)
     assert len(response.secret_tokens) == 2
@@ -909,12 +909,14 @@ def test_list_secret_tokens_returns_tokens():
     assert response.secret_tokens[1].expiration == 1754966400
 
     mock_secrets_provider.list_user_token_secrets.assert_called_once_with(
-        username=username
+        user_id=auth_info.user_id
     )
 
 
 def test_revoke_secret_token_success(mock_iguazio_client):
-    username = "dummy-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
     token_name = "my-token"
     fake_token = "jwt-token-123"
     request_headers = {
@@ -929,23 +931,24 @@ def test_revoke_secret_token_success(mock_iguazio_client):
 
     services.api.crud.Secrets().revoke_secret_token(
         token_name=token_name,
-        authenticated_username=username,
-        request_headers=request_headers,
+        auth_info=auth_info,
     )
 
     mock_secrets_provider.get_user_token_secret_value.assert_called_once_with(
-        username=username, token_name=token_name
+        user_id=auth_info.user_id, token_name=token_name
     )
     mock_iguazio_client.revoke_offline_token.assert_called_once_with(
         fake_token, request_headers
     )
     mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
-        username=username, token_name=token_name
+        user_id=auth_info.user_id, token_name=token_name
     )
 
 
 def test_revoke_secret_token_secret_not_found(mock_iguazio_client):
-    username = "dummy-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
     token_name = "missing"
 
     mock_secrets_provider = unittest.mock.Mock()
@@ -956,12 +959,14 @@ def test_revoke_secret_token_secret_not_found(mock_iguazio_client):
     )
 
     services.api.crud.Secrets().revoke_secret_token(
-        token_name=token_name, authenticated_username=username
+        token_name=token_name, auth_info=auth_info
     )
 
 
 def test_revoke_secret_token_iguazio_failure(mock_iguazio_client):
-    username = "dummy-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
     token_name = "badtoken"
     fake_token = "jwt-token-456"
 
@@ -973,12 +978,14 @@ def test_revoke_secret_token_iguazio_failure(mock_iguazio_client):
 
     with pytest.raises(RuntimeError, match="Iguazio error"):
         services.api.crud.Secrets().revoke_secret_token(
-            token_name=token_name, authenticated_username=username
+            token_name=token_name, auth_info=auth_info
         )
 
 
 def test_revoke_secret_token_delete_failure(mock_iguazio_client):
-    username = "dummy-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
     token_name = "fail-delete"
     fake_token = "jwt-token-789"
 
@@ -994,12 +1001,14 @@ def test_revoke_secret_token_delete_failure(mock_iguazio_client):
         match="revoked, but failed to delete associated secret",
     ):
         services.api.crud.Secrets().revoke_secret_token(
-            token_name=token_name, authenticated_username=username
+            token_name=token_name, auth_info=auth_info
         )
 
 
 def test_get_secret_token_success():
-    username = "dummy-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
     token_name = "my-token"
     fake_token_value = "jwt-fake-token"
 
@@ -1009,11 +1018,11 @@ def test_get_secret_token_success():
 
     result = services.api.crud.Secrets().get_secret_token(
         token_name=token_name,
-        authenticated_username=username,
+        auth_info=auth_info,
     )
 
     mock_secrets_provider.get_user_token_secret_value.assert_called_once_with(
-        username=username,
+        user_id=auth_info.user_id,
         token_name=token_name,
     )
 
@@ -1023,7 +1032,9 @@ def test_get_secret_token_success():
 
 
 def test_get_secret_token_not_found():
-    username = "dummy-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
     token_name = "missing-token"
 
     mock_secrets_provider = unittest.mock.Mock()
@@ -1035,7 +1046,7 @@ def test_get_secret_token_not_found():
     with pytest.raises(mlrun.errors.MLRunNotFoundError, match="Token not found"):
         services.api.crud.Secrets().get_secret_token(
             token_name=token_name,
-            authenticated_username=username,
+            auth_info=auth_info,
         )
 
 

--- a/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_kubejob.py
@@ -1055,7 +1055,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
         expected_secret_count,
     ):
         token_name = "test-token"
-        auth_info = mlrun.common.schemas.AuthInfo(username="test-user")
+        auth_info = mlrun.common.schemas.AuthInfo(user_id="test-user")
 
         runtime = mlrun.runtimes.kubejob.KubejobRuntime()
         runtime.spec.volume_mounts = initial_volume_mounts.copy()
@@ -1110,7 +1110,7 @@ class TestKubejobRuntimeHandler(TestRuntimeHandlerBase):
 
     def test_mount_secret_token_to_runtime_non_existing_secret(self):
         token_name = "test-token"
-        auth_info = mlrun.common.schemas.AuthInfo(username="test-user")
+        auth_info = mlrun.common.schemas.AuthInfo(user_id="test-user")
 
         runtime = mlrun.runtimes.kubejob.KubejobRuntime()
 

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -484,13 +484,16 @@ def test_list_pod_events(k8s_helper):
 def test_store_user_token_secret_created(k8s_helper):
     k8s_helper.list_secrets = mock.MagicMock(return_value=[])
 
-    username = "test-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        user_id="test-user-id",
+        username="test-user",
+    )
     token_name = "my-token"
     token_value = "abc123"
     expiration = 9999
 
     result = k8s_helper.store_user_token_secret(
-        username=username,
+        auth_info=auth_info,
         token_name=token_name,
         token=token_value,
         expiration=expiration,
@@ -519,21 +522,142 @@ def test_store_user_token_secret_created(k8s_helper):
     assert decoded_expiration == expiration
 
 
+@pytest.mark.parametrize(
+    "username, expected_sanitized_username",
+    [
+        # Normal username
+        ("test-user", "test-user"),
+        # Username with @ symbol (common in email-style usernames)
+        ("user@example.com", "user-example.com"),
+        # Username with spaces
+        ("user name", "user-name"),
+        # Username with special characters
+        ("user!@#$%^&*()", "user----------"),
+        # Username starting with number (valid in labels)
+        ("123user", "123user"),
+        # Username ending with hyphen (valid in labels)
+        ("user-", "user-"),
+        # Username with consecutive dots (valid in labels)
+        ("user..name", "user..name"),
+        # Very long username (exceeds 63 char limit, gets truncated)
+        (
+            "a" * 100,
+            "a" * 63,
+        ),
+        # Long username with invalid characters at truncation point
+        (
+            "user@example.com" + "x" * 60,
+            "user-example.com" + "x" * 47,
+        ),
+    ],
+)
+def test_store_user_token_secret_sanitizes_username(
+    k8s_helper, username, expected_sanitized_username
+):
+    """Test that username is properly sanitized when stored as annotation."""
+    import uuid
+
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[])
+
+    # Use a proper UUID for user_id
+    user_id = str(uuid.uuid4())
+    auth_info = mlrun.common.schemas.AuthInfo(
+        user_id=user_id,
+        username=username,
+    )
+    token_name = "my-token"
+    token_value = "abc123"
+    expiration = 9999
+
+    result = k8s_helper.store_user_token_secret(
+        auth_info=auth_info,
+        token_name=token_name,
+        token=token_value,
+        expiration=expiration,
+        namespace="default",
+    )
+
+    # Verify creation succeeded
+    assert result == mlrun.common.schemas.SecretEventActions.created
+    k8s_helper._create_secret.assert_called_once()
+
+    # Verify labels contain user_id (UUID) and token_name
+    labels = k8s_helper._create_secret.call_args.kwargs["labels"]
+    assert labels[mlrun_constants.MLRunInternalLabels.auth_userid] == user_id
+    assert labels[mlrun_constants.MLRunInternalLabels.auth_token_name] == token_name
+
+    # Verify annotations contain sanitized username
+    annotations = k8s_helper._create_secret.call_args.kwargs["annotations"]
+    assert (
+        annotations[mlrun_constants.InternalAnnotations.auth_username]
+        == expected_sanitized_username
+    )
+
+
+def test_store_user_token_secret_with_uuid_user_id(k8s_helper):
+    """Test that user_id as UUID is properly handled in labels and secret naming."""
+    import uuid
+
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[])
+
+    # Use proper UUID format for user_id
+    user_id = str(uuid.uuid4())
+    auth_info = mlrun.common.schemas.AuthInfo(
+        user_id=user_id,
+        username="test-user@example.com",
+    )
+    token_name = "my-token"
+    token_value = "abc123"
+    expiration = 9999
+
+    result = k8s_helper.store_user_token_secret(
+        auth_info=auth_info,
+        token_name=token_name,
+        token=token_value,
+        expiration=expiration,
+        namespace="default",
+    )
+
+    # Verify creation succeeded
+    assert result == mlrun.common.schemas.SecretEventActions.created
+    k8s_helper._create_secret.assert_called_once()
+
+    # Verify labels contain the UUID user_id
+    labels = k8s_helper._create_secret.call_args.kwargs["labels"]
+    assert labels[mlrun_constants.MLRunInternalLabels.auth_userid] == user_id
+
+    # Verify the UUID is valid
+    parsed_uuid = uuid.UUID(labels[mlrun_constants.MLRunInternalLabels.auth_userid])
+    assert str(parsed_uuid) == user_id
+
+    # Verify the secret name is derived from user_id + token_name hash
+    secret_name = k8s_helper._create_secret.call_args.kwargs["secret_name"]
+    expected_secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
+    assert secret_name == expected_secret_name
+
+
 def test_store_user_token_secret_updated(k8s_helper):
-    username = "test-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        user_id="test-user-id",
+        username="test-user",
+    )
     token_name = "my-token"
     token_value = "abc123"
     new_expiration = 2000
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(auth_info.user_id, token_name)
 
     # Existing secret with older expiration
     existing_secret = _make_user_token_secret(
-        secret_name, token_name=token_name, token_value=token_value, expiration=1000
+        secret_name,
+        token_name=token_name,
+        token_value=token_value,
+        expiration=1000,
+        user_id=auth_info.user_id,
     )
     k8s_helper.read_secret = mock.MagicMock(return_value=existing_secret)
 
     result = k8s_helper.store_user_token_secret(
-        username=username,
+        auth_info=auth_info,
         token_name=token_name,
         token=token_value,
         expiration=new_expiration,
@@ -578,21 +702,25 @@ def test_store_user_token_secret_updated(k8s_helper):
 def test_store_user_token_secret_skipped_and_force_update(
     k8s_helper, expiration, force, expected_result, update_called, create_called
 ):
-    username = "test-user"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        user_id="test-user-id",
+        username="test-user",
+    )
     token_name = "my-token"
     token_value = "abc123"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(auth_info.user_id, token_name)
 
     existing_secret = _make_user_token_secret(
         secret_name,
         token_name=token_name,
         token_value=token_value,
         expiration=5000,
+        user_id=auth_info.user_id,
     )
     k8s_helper.list_secrets = mock.MagicMock(return_value=[existing_secret])
 
     result = k8s_helper.store_user_token_secret(
-        username=username,
+        auth_info=auth_info,
         token_name=token_name,
         token=token_value,
         expiration=expiration,
@@ -617,13 +745,13 @@ def test_list_secrets_with_labels(k8s_helper):
     secret1 = _make_k8s_secret(
         "secret1",
         labels={
-            mlrun_constants.MLRunInternalLabels.auth_username: "test-user",
+            mlrun_constants.MLRunInternalLabels.auth_userid: "test-user-id",
         },
     )
     secret2 = _make_k8s_secret(
         "secret2",
         labels={
-            mlrun_constants.MLRunInternalLabels.auth_username: "test-user",
+            mlrun_constants.MLRunInternalLabels.auth_userid: "test-user-id",
         },
     )
 
@@ -636,12 +764,12 @@ def test_list_secrets_with_labels(k8s_helper):
 
     result = k8s_helper.list_secrets(
         namespace="default",
-        labels={mlrun_constants.MLRunInternalLabels.auth_username: "test-user"},
+        labels={mlrun_constants.MLRunInternalLabels.auth_userid: "test-user-id"},
     )
 
     assert result == [secret1, secret2]
     k8s_helper.v1api.list_namespaced_secret.assert_called_once_with(
-        namespace="default", label_selector="mlrun/user=test-user"
+        namespace="default", label_selector="mlrun/user-id=test-user-id"
     )
 
 
@@ -680,20 +808,20 @@ def test_list_secrets_empty(k8s_helper):
 def test_list_user_token_secrets_valid(k8s_helper):
     token1_name = "token1"
     token2_name = "token2"
-    username = "test-user"
-    secret1_name = k8s_helper._resolve_auth_secret_name(username, token1_name)
-    secret2_name = k8s_helper._resolve_auth_secret_name(username, token2_name)
+    user_id = "test-user-id"
+    secret1_name = k8s_helper._resolve_auth_secret_name(user_id, token1_name)
+    secret2_name = k8s_helper._resolve_auth_secret_name(user_id, token2_name)
     secret1 = _make_user_token_secret(
-        secret1_name, token_name=token1_name, expiration=1111
+        secret1_name, token_name=token1_name, expiration=1111, user_id=user_id
     )
     secret2 = _make_user_token_secret(
-        secret2_name, token_name=token2_name, expiration=2222
+        secret2_name, token_name=token2_name, expiration=2222, user_id=user_id
     )
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.list_secrets = mock.MagicMock(return_value=[secret1, secret2])
 
-    result = k8s_helper.list_user_token_secrets(username=username, namespace="default")
+    result = k8s_helper.list_user_token_secrets(user_id=user_id, namespace="default")
 
     assert len(result) == 2
     assert result[0].name == token1_name
@@ -703,28 +831,28 @@ def test_list_user_token_secrets_valid(k8s_helper):
 
     k8s_helper.list_secrets.assert_called_once_with(
         namespace="default",
-        labels={mlrun_constants.MLRunInternalLabels.auth_username: "test-user"},
+        labels={mlrun_constants.MLRunInternalLabels.auth_userid: "test-user-id"},
     )
 
 
 def test_list_user_token_secrets_invalid_expiration(k8s_helper):
-    username = "test-user"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, "token1")
+    user_id = "test-user-id"
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, "token1")
     bad_secret = _make_user_token_secret(
-        secret_name=secret_name, expiration=b"not-a-number"
+        secret_name=secret_name, expiration=b"not-a-number", user_id=user_id
     )
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.list_secrets = mock.MagicMock(return_value=[bad_secret])
 
-    result = k8s_helper.list_user_token_secrets(username=username, namespace="default")
+    result = k8s_helper.list_user_token_secrets(user_id=user_id, namespace="default")
     assert len(result) == 0
 
 
 def test_get_user_token_secret_value_valid(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "my-token"
     token_value = "abc123"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     # Create a Kubernetes secret with properly encoded tokensFile
     existing_secret = _make_user_token_secret(
@@ -732,13 +860,14 @@ def test_get_user_token_secret_value_valid(k8s_helper):
         token_name=token_name,
         token_value=token_value,
         expiration=9999,
+        user_id=user_id,
     )
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.list_secrets = mock.MagicMock(return_value=[existing_secret])
 
     token_value_from_k8s = k8s_helper.get_user_token_secret_value(
-        username=username,
+        user_id=user_id,
         token_name=token_name,
         namespace="default",
     )
@@ -748,67 +877,75 @@ def test_get_user_token_secret_value_valid(k8s_helper):
 
 
 def test_get_user_token_secret_value_not_found(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "my-token"
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.list_secrets = mock.MagicMock(return_value=None)
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        k8s_helper.get_user_token_secret_value(
-            username, token_name, namespace="default"
-        )
+        k8s_helper.get_user_token_secret_value(user_id, token_name, namespace="default")
 
 
 def test_get_user_token_secret_value_invalid_base64(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "my-token"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     # Create a secret with an invalid base64 tokensFile
-    bad_secret = _make_k8s_secret(secret_name)
+    bad_secret = _make_k8s_secret(
+        secret_name,
+        labels={
+            mlrun_constants.MLRunInternalLabels.auth_userid: user_id,
+            mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
+        },
+    )
     bad_secret.data["tokensFile"] = "!!!invalidbase64!!!"  # invalid base64 content
     bad_secret.data["tokenExpiration"] = base64.b64encode(b"9999").decode()
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
-    k8s_helper.read_secret = mock.MagicMock(return_value=bad_secret)
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[bad_secret])
 
     with pytest.raises(mlrun.errors.MLRunRuntimeError):
         k8s_helper.get_user_token_secret_value(
-            username=username,
+            user_id=user_id,
             token_name=token_name,
             namespace="default",
         )
 
 
 def test_get_user_token_secret_value_invalid_yaml(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "my-token"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     # Base64 encoded string but invalid YAML
     bad_yaml = base64.b64encode(b"{invalid_yaml: ]").decode()
-    bad_secret = _make_k8s_secret(secret_name)
+    bad_secret = _make_k8s_secret(
+        secret_name,
+        labels={
+            mlrun_constants.MLRunInternalLabels.auth_userid: user_id,
+            mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
+        },
+    )
     bad_secret.data["tokensFile"] = bad_yaml
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
-    k8s_helper.read_secret = mock.MagicMock(return_value=bad_secret)
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[bad_secret])
 
     with pytest.raises(mlrun.errors.MLRunRuntimeError):
-        k8s_helper.get_user_token_secret_value(
-            username, token_name, namespace="default"
-        )
+        k8s_helper.get_user_token_secret_value(user_id, token_name, namespace="default")
 
 
 def test_delete_user_token_secret_success(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "token1"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock()
 
     k8s_helper.delete_user_token_secret(
-        username=username, token_name=token_name, namespace="default"
+        user_id=user_id, token_name=token_name, namespace="default"
     )
 
     k8s_helper.v1api.delete_namespaced_secret.assert_called_once_with(
@@ -818,9 +955,9 @@ def test_delete_user_token_secret_success(k8s_helper):
 
 
 def test_delete_user_token_secret_not_found(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "missing"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock(
@@ -829,7 +966,7 @@ def test_delete_user_token_secret_not_found(k8s_helper):
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError) as exc:
         k8s_helper.delete_user_token_secret(
-            username=username, token_name=token_name, namespace="default"
+            user_id=user_id, token_name=token_name, namespace="default"
         )
 
     assert f"Secret for token '{token_name}' not found" in str(exc.value)
@@ -841,9 +978,9 @@ def test_delete_user_token_secret_not_found(k8s_helper):
 
 
 def test_delete_user_token_secret_api_error(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "badtoken"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock(
@@ -852,7 +989,7 @@ def test_delete_user_token_secret_api_error(k8s_helper):
 
     with pytest.raises(mlrun.errors.MLRunRuntimeError) as exc:
         k8s_helper.delete_user_token_secret(
-            username=username, token_name=token_name, namespace="default"
+            user_id=user_id, token_name=token_name, namespace="default"
         )
 
     assert "Failed to delete secret" in str(exc.value)
@@ -864,9 +1001,9 @@ def test_delete_user_token_secret_api_error(k8s_helper):
 
 
 def test_delete_user_token_secret_unexpected_error(k8s_helper):
-    username = "test-user"
+    user_id = "test-user-id"
     token_name = "oops"
-    secret_name = k8s_helper._resolve_auth_secret_name(username, token_name)
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.v1api.delete_namespaced_secret = mock.MagicMock(
@@ -875,7 +1012,7 @@ def test_delete_user_token_secret_unexpected_error(k8s_helper):
 
     with pytest.raises(mlrun.errors.MLRunRuntimeError) as exc:
         k8s_helper.delete_user_token_secret(
-            username=username, token_name=token_name, namespace="default"
+            user_id=user_id, token_name=token_name, namespace="default"
         )
 
     assert "Unexpected error deleting secret" in str(exc.value)
@@ -892,9 +1029,10 @@ def _make_user_token_secret(
     token_value="abc123",
     expiration=None,
     labels=None,
+    user_id="test-user-id",
 ):
     labels = labels or {
-        mlrun_constants.MLRunInternalLabels.auth_username: "test-user",
+        mlrun_constants.MLRunInternalLabels.auth_userid: user_id,
         mlrun_constants.MLRunInternalLabels.auth_token_name: token_name,
     }
     secret = _make_k8s_secret(secret_name, labels)

--- a/server/py/services/api/utils/helpers.py
+++ b/server/py/services/api/utils/helpers.py
@@ -76,13 +76,13 @@ def resolve_client_default_kfp_image(
 
 
 def resolve_auth_token_secret_name(
-    provided_token_name: typing.Optional[str], username: typing.Optional[str]
+    provided_token_name: typing.Optional[str], user_id: typing.Optional[str]
 ) -> typing.Optional[str]:
     """
     Resolve the name of the secret that holds the user's auth token. Performs enrichment and validation of the
     token name.
     :param provided_token_name: The name of the token provided by the user, if any.
-    :param username: The username for which the token is being resolved.
+    :param user_id: The user ID for which the token is being resolved.
 
     :return: The name of the secret that holds the user's auth token.
     """
@@ -95,6 +95,6 @@ def resolve_auth_token_secret_name(
             or mlrun.common.constants.MLRUN_RUNTIME_AUTH_DEFAULT_TOKEN_NAME
         )
         secret = framework.utils.singletons.k8s.get_k8s_helper()._get_user_token_secret(
-            username=username, token_name=token_name
+            user_id=user_id, token_name=token_name
         )
         return secret.metadata.name if secret else None


### PR DESCRIPTION
### 📝 Description



### 📝 Description

Change user token secret naming convention to use `auth_info.user_id` instead of `auth_info.username`. This change ensures that user token secrets are stored using a stable identifier (`user_id` which is a UUID) rather than usernames which may contain characters invalid for Kubernetes resource names.

---

### 🛠️ Changes Made

- Changed `store_user_token_secret` to accept `auth_info` directly instead of `username`
- Added `auth_userid` label from `auth_info.user_id` for secret identification
- Updated `resolve_auth_token_secret_name` to use `user_id` parameter
- Added `InternalAnnotations` class in constants for annotation keys

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Unit tests + ig4 running KFP / Kubejob

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11976
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

