### PR TITLE
[Bug] Fix package test reliability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,24 +246,34 @@ jobs:
         include:
           - python-version: "3.11"
             pipeline-adapter: "kfp-v1-8"
+    env:
+      MLRUN_PYTHON_PACKAGE_INSTALLER: uv
     steps:
     - uses: actions/checkout@v6
+
     - name: Set up python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+
+    - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # 7.2.0
+      with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
     - name: Install automation scripts dependencies and add mlrun to dev packages
-      run: make install-automation-requirements && pip install -e .
-      # Install KFP v2 only when the adapter is kfp-v2
-    - name: Install KFP Adapter if required
       run: |
-        if [[ "${{ matrix.pipeline-adapter }}" == "kfp-v2" ]]; then
-          pip install mlrun-pipelines-kfp-v2
-        fi
+        uv venv venv --seed
+        source venv/bin/activate
+        make install-automation-requirements
+        uv pip install -e .
 
     - name: Test package
-      run: MLRUN_PYTHON_VERSION=${{ matrix.python-version }} make test-package
+      run: |
+        source venv/bin/activate
+        make test-package
+      env:
+        MLRUN_PYTHON_VERSION: ${{ matrix.python-version }}
 
   docs:
     name: Build Project Documentation

--- a/Makefile
+++ b/Makefile
@@ -810,7 +810,7 @@ test-system-open-source: update-version-file ## Run mlrun system tests with open
 
 .PHONY: test-package compile-schemas
 test-package: ## Run mlrun package tests
-	python ./automation/package_test/test.py run
+	MLRUN_PYTHON_PACKAGE_INSTALLER=$(MLRUN_PYTHON_PACKAGE_INSTALLER) python ./automation/package_test/test.py run
 
 .PHONY: test-go
 test-go-unit: ## Run mlrun go unit tests

--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -13,19 +13,240 @@
 # limitations under the License.
 
 import json
+import os
 import re
+import shlex
 import subprocess
+from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import click
 
 import mlrun.utils
 
-logger = mlrun.utils.create_logger(level="debug", name="automation")
+
+def _test_extra_worker(logger, extra, extra_tests_data, package_installer):
+    """
+    Worker function for parallel execution.
+    This is a module-level function so it can be pickled for ProcessPoolExecutor.
+    """
+    pid = os.getpid()
+    worker_logger = logger.get_child(f"pid-{pid}.{extra or 'base'}")
+    normalized_extra = extra.replace("[", "").replace("]", "")
+    venv_name = f"extra-{normalized_extra}"
+    venv_name = f"test-venvs/{venv_name}".rstrip("-")
+
+    result = {"extra": extra, "tests": {}}
+
+    try:
+        with Venv(worker_logger, package_installer, venv_name) as venv:
+            venv.install_extra(extra)
+
+            # Test imports
+            try:
+                _run_import_test(venv, extra, extra_tests_data, worker_logger)
+                result["tests"]["import_test"] = {"passed": True}
+            except Exception as e:
+                worker_logger.warning(f"Import test failed for {extra}", error=str(e))
+                result["tests"]["import_test"] = {"passed": False}
+
+            # Test requirements conflicts
+            try:
+                _run_conflicts_test(venv, extra, worker_logger)
+                result["tests"]["requirements_conflicts_test"] = {"passed": True}
+            except Exception as e:
+                worker_logger.warning(
+                    f"Conflicts test failed for {extra}", error=str(e)
+                )
+                result["tests"]["requirements_conflicts_test"] = {"passed": False}
+
+            # Test vulnerabilities (if needed)
+            if extra_tests_data.get("perform_vulnerability_check"):
+                try:
+                    _run_vulnerability_test(venv, extra, worker_logger)
+                    result["tests"]["requirements_vulnerabilities_test"] = {
+                        "passed": True
+                    }
+                except Exception as e:
+                    worker_logger.warning(
+                        f"Vulnerability test failed for {extra}", error=str(e)
+                    )
+                    result["tests"]["requirements_vulnerabilities_test"] = {
+                        "passed": False
+                    }
+    except Exception as e:
+        worker_logger.error(f"Failed to test extra {extra}", error=str(e))
+        result["tests"]["import_test"] = {"passed": False}
+        result["tests"]["requirements_conflicts_test"] = {"passed": False}
+
+    return result
+
+
+def _run_import_test(venv, extra, extra_tests_data, worker_logger):
+    worker_logger.debug("Testing extra imports", extra=extra)
+    env = {"MLRUN_LOG_LEVEL": "DEBUG"}
+    test_command = f"python -c '{extra_tests_data['import_test_command']}'"
+    venv.run_command(test_command, env=env)
+    if "api" not in extra:
+        venv.run_command(test_command, env=env | {"MLRUN_DBPATH": "http://mock-server"})
+
+
+def _run_conflicts_test(venv, extra, worker_logger):
+    worker_logger.debug("Testing requirements conflicts", extra=extra)
+    venv.install_package("pipdeptree<2.29.0")
+    venv.run_command("pipdeptree --warn fail")
+
+
+def _run_vulnerability_test(venv, extra, worker_logger):
+    worker_logger.debug("Testing requirements vulnerabilities", extra=extra)
+    venv.install_package("safety")
+    code, stdout, _ = venv.run_command("safety check --json", raise_on_error=False)
+    if code != 0:
+        full_report = json.loads(stdout)
+        vulnerabilities = full_report["vulnerabilities"]
+        if vulnerabilities:
+            worker_logger.debug(
+                "Found requirements vulnerabilities", vulnerabilities=vulnerabilities
+            )
+
+        ignored_vulnerabilities = {
+            "kubernetes": [
+                {
+                    "pattern": r"^Kubernetes(.*)unfixed vulnerability, CVE-2021-29923(.*)",
+                    "reason": "Vulnerability not fixed, nothing we can do",
+                }
+            ],
+            "mlrun": [
+                {
+                    "pattern": r"^Mlrun(.*)TensorFlow' \(2.4.1\)(.*)$",
+                    "reason": "Newer tensorflow versions are not compatible with our CUDA and rapids versions",
+                },
+                {
+                    "pattern": (
+                        r"(.*)(https://github\.com/mlrun/mlrun/pull/1997/commits/"
+                        r"de4c87f478f8d76dd8e46942588c81ef0d0b481e|1\.0\.3rc1 adds "
+                        r"\"notebook~=6\.4|1\.0\.3rc1 adds \"pillow~=9\.0)(.*)"
+                    ),
+                    "reason": "Already fixed, we're getting them only because in CI our version is 0.0.0+unstable",
+                },
+            ],
+        }
+
+        filtered_vulnerabilities = []
+        for vulnerability in vulnerabilities:
+            if vulnerability["package_name"] in ignored_vulnerabilities:
+                ignored_vulnerability = ignored_vulnerabilities[
+                    vulnerability["package_name"]
+                ]
+                ignore_vulnerability = False
+                for ignored_pattern in ignored_vulnerability:
+                    if re.search(ignored_pattern["pattern"], vulnerability["advisory"]):
+                        worker_logger.debug(
+                            "Ignoring vulnerability",
+                            vulnerability=vulnerability,
+                            reason=ignored_pattern["reason"],
+                        )
+                        ignore_vulnerability = True
+                        break
+                if ignore_vulnerability:
+                    continue
+            filtered_vulnerabilities.append(vulnerability)
+
+        if filtered_vulnerabilities:
+            message = "Found vulnerable requirements that can not be ignored"
+            worker_logger.warning(
+                message,
+                filtered_vulnerabilities=filtered_vulnerabilities,
+                ignored_vulnerabilities=ignored_vulnerabilities,
+            )
+            raise AssertionError(message)
+
+
+class Venv:
+    def __init__(self, logger, package_manager="pip", venv_name="test-venv"):
+        self._venv_name = venv_name
+        self._package_manager = package_manager
+        self._package_installer_command = (
+            "uv pip install"
+            if self._package_manager == "uv"
+            else "python -m pip install"
+        )
+        self._logger = logger
+
+    def __enter__(self):
+        self._create_venv()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._clean_venv()
+
+    def install_extra(self, extra):
+        self._logger.debug(
+            "Installing extra",
+            extra=extra,
+        )
+        self.install_package("pip~=25.0.0", upgrade=True)
+        self.install_package(f".{extra}")
+
+    def install_package(self, package, upgrade=False):
+        return self.run_command(
+            f"{self._package_installer_command} {'--upgrade' if upgrade else ''} {shlex.quote(package)}"
+        )
+
+    def run_command(self, command, env=None, raise_on_error=True):
+        venv_command = f". {self._venv_name}/bin/activate"
+        command = f"{venv_command} && {command}"
+        return self._run_command(command, env=env, raise_on_error=raise_on_error)
+
+    def _create_venv(self):
+        self._logger.debug(
+            "Creating venv",
+            venv_name=self._venv_name,
+        )
+        self._run_command(f"python -m venv {self._venv_name}")
+
+    def _clean_venv(self):
+        self._logger.debug(
+            "Cleaning venv",
+            venv_name=self._venv_name,
+        )
+        self._run_command(f"rm -rf {self._venv_name}")
+
+    def _run_command(
+        self,
+        command,
+        env=None,
+        raise_on_error=True,
+    ):
+        process = subprocess.Popen(
+            command,
+            env=env,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,  # Merge stderr into stdout for streaming
+            text=True,
+        )
+        output_lines = []
+        for line in process.stdout:
+            line = line.rstrip("\n")
+            output_lines.append(line)
+            self._logger.debug(f"> {line}")
+        process.wait()
+        output = "\n".join(output_lines)
+        if process.returncode != 0 and raise_on_error:
+            self._logger.warning(
+                "Command failed",
+                output=output,
+                return_code=process.returncode,
+                cmd=command,
+            )
+            raise subprocess.CalledProcessError(process.returncode, command, output, "")
+        return process.returncode, output, ""
 
 
 class PackageTester:
-    def __init__(self):
-        self._logger = logger
+    def __init__(self, logger):
+        self._logger = logger.get_child("package_tester")
+        self._package_installer = os.getenv("MLRUN_PYTHON_PACKAGE_INSTALLER", "pip")
 
         basic_import = "import mlrun"
         s3_import = "import mlrun.datastore.s3"
@@ -56,15 +277,10 @@ class PackageTester:
                 "import_test_command": f"{basic_import}; {azure_key_vault_import}"
             },
             "[alibaba-oss]": {"import_test_command": f"{basic_import}; {oss_import}"},
-            # TODO: this won't actually fail if the requirement is missing
-            "[google-cloud-bigquery]": {
-                "import_test_command": f"{basic_import}; {google_cloud_bigquery_import}"
-            },
             "[google-cloud]": {
-                "import_test_command": f"{basic_import}; {google_cloud_storage_import}"
+                "import_test_command": f"{basic_import}; {google_cloud_storage_import}; {google_cloud_bigquery_import}"
             },
             "[redis]": {"import_test_command": f"{basic_import}; {redis_import}"},
-            # TODO: this won't actually fail if the requirement is missing
             "[kafka]": {"import_test_command": f"{basic_import}; {targets_import}"},
             "[complete]": {
                 "import_test_command": f"{basic_import}; {s3_import}; {azure_blob_storage_import}; "
@@ -76,36 +292,48 @@ class PackageTester:
         }
 
     def run(self):
-        self._logger.info(
-            "Running package tests",
-        )
+        self._logger.info("Running package tests in parallel")
 
         results = {}
-        for extra, extra_tests_data in self._extras_tests_data.items():
-            self._create_venv()
-            self._install_extra(extra)
-            results[extra] = {}
-            self._run_test(self._test_extra_imports, extra, results, "import_test")
-            self._run_test(
-                self._test_requirements_conflicts,
-                extra,
-                results,
-                "requirements_conflicts_test",
-            )
-            if extra_tests_data.get("perform_vulnerability_check"):
-                self._run_test(
-                    self._test_requirements_vulnerabilities,
+        max_workers = min(len(self._extras_tests_data), os.cpu_count() or 4)
+        self._logger.info(f"Using {max_workers} parallel workers")
+
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(
+                    _test_extra_worker,
+                    self._logger,
                     extra,
-                    results,
-                    "requirements_vulnerabilities_test",
-                )
-            self._clean_venv()
+                    extra_tests_data,
+                    self._package_installer,
+                ): extra
+                for extra, extra_tests_data in self._extras_tests_data.items()
+            }
+
+            for future in as_completed(futures):
+                extra = futures[future]
+                try:
+                    result = future.result()
+                    results[result["extra"]] = result["tests"]
+                    self._logger.info(
+                        f"Completed testing extra: {extra or 'base'}",
+                        results=result["tests"],
+                    )
+                except Exception as exc:
+                    self._logger.error(
+                        f"Test for {extra} generated an exception", exc=exc
+                    )
+                    results[extra] = {
+                        "import_test": {"passed": False},
+                        "requirements_conflicts_test": {"passed": False},
+                    }
 
         failed = False
-        for extra_tests_results in results.values():
-            if (
-                not extra_tests_results["import_test"]["passed"]
-                or not extra_tests_results["requirements_conflicts_test"]["passed"]
+        for extra, extra_tests_results in results.items():
+            if not extra_tests_results.get("import_test", {}).get(
+                "passed", False
+            ) or not extra_tests_results.get("requirements_conflicts_test", {}).get(
+                "passed", False
             ):
                 failed = True
                 break
@@ -116,202 +344,6 @@ class PackageTester:
         if failed:
             raise RuntimeError("Package tests failed")
 
-    def _run_test(self, test_function, extra, results, test_key):
-        try:
-            test_function(extra)
-        except Exception:
-            results[extra].setdefault(test_key, {})["passed"] = False
-        else:
-            results[extra].setdefault(test_key, {})["passed"] = True
-
-    def _test_extra_imports(self, extra):
-        self._logger.debug(
-            "Testing extra imports",
-            extra=extra,
-        )
-        test_command = (
-            f"python -c '{self._extras_tests_data[extra]['import_test_command']}'"
-        )
-        self._run_command(
-            test_command,
-            run_in_venv=True,
-        )
-        if "api" not in extra:
-            # When api is not in the extra it's an extra purposed for the client usage
-            # Usually it will be used with a remote server - meaning httpdb as the run db, to test that (will cause
-            # different imports to be done) we're setting the DB path
-            self._run_command(
-                test_command,
-                run_in_venv=True,
-                env={"MLRUN_DBPATH": "http://mock-server"},
-            )
-
-    def _test_requirements_vulnerabilities(self, extra):
-        """
-        When additional vulnerabilities are being discovered, we expect this test to fail; our objective is to fix them
-        all ASAP. There are several circumstances when this cannot be handled simply by using a newer version, such as
-        when another library requires an older version, a vulnerability that has not been fixed, or an environment
-        requirement. If this is the case, we will add the library with a thorough description of the issue and suggested
-        action items for future readers to the ignored_vulnerabilities.
-        When a vulnerability is fixed, we should remove it from the ignored_vulnerabilities list.
-        """
-        self._logger.debug(
-            "Testing requirements vulnerabilities",
-            extra=extra,
-        )
-        self._run_command(
-            "pip install safety",
-            run_in_venv=True,
-        )
-        code, stdout, stderr = self._run_command(
-            "safety check --json",
-            run_in_venv=True,
-            raise_on_error=False,
-        )
-        if code != 0:
-            full_report = json.loads(stdout)
-            vulnerabilities = full_report["vulnerabilities"]
-            if vulnerabilities:
-                self._logger.debug(
-                    "Found requirements vulnerabilities",
-                    vulnerabilities=vulnerabilities,
-                )
-            ignored_vulnerabilities = {
-                "kubernetes": [
-                    {
-                        "pattern": r"^Kubernetes(.*)unfixed vulnerability, CVE-2021-29923(.*)",
-                        "reason": "Vulnerability not fixed, nothing we can do",
-                    }
-                ],
-                "mlrun": [
-                    {
-                        "pattern": r"^Mlrun(.*)TensorFlow' \(2.4.1\)(.*)$",
-                        "reason": "Newer tensorflow versions are not compatible with our CUDA and rapids versions so we"
-                        " can't upgrade it",
-                    },
-                    {
-                        "pattern": r"(.*)"
-                        r"("
-                        r"https://github\.com/mlrun/mlrun/pull/1997/commits/de4c87f478f8d76dd8e46942588c81e"
-                        r"f0d0b481e"
-                        r"|"
-                        r"1\.0\.3rc1 adds \"notebook~=6\.4"
-                        r"|"
-                        r"1\.0\.3rc1 adds \"pillow~=9\.0"
-                        r")"
-                        r"(.*)",
-                        "reason": "Those already fixed, we're getting them only because in our CI our version is "
-                        "0.0.0+unstable",
-                    },
-                ],
-            }
-
-            filtered_vulnerabilities = []
-            for vulnerability in vulnerabilities:
-                if vulnerability["package_name"] in ignored_vulnerabilities:
-                    ignored_vulnerability = ignored_vulnerabilities[
-                        vulnerability["package_name"]
-                    ]
-                    ignore_vulnerability = False
-                    for ignored_pattern in ignored_vulnerability:
-                        if re.search(
-                            ignored_pattern["pattern"], vulnerability["advisory"]
-                        ):
-                            self._logger.debug(
-                                "Ignoring vulnerability",
-                                vulnerability=vulnerability,
-                                reason=ignored_pattern["reason"],
-                            )
-                            ignore_vulnerability = True
-                            break
-                    if ignore_vulnerability:
-                        continue
-                filtered_vulnerabilities.append(vulnerability)
-            if filtered_vulnerabilities:
-                message = "Found vulnerable requirements that can not be ignored"
-                logger.warning(
-                    message,
-                    filtered_vulnerabilities=filtered_vulnerabilities,
-                    ignored_vulnerabilities=ignored_vulnerabilities,
-                )
-                raise AssertionError(message)
-
-    def _test_requirements_conflicts(self, extra):
-        self._logger.debug(
-            "Testing requirements conflicts",
-            extra=extra,
-        )
-        self._run_command(
-            # pin pipdeptree below 2.29.0 until mlflow upgrade:
-            # pipdeptree ver 2.29 requires packaging >= 25.0 while mlflow-skinny (mlflow dep) requires packaging < 25.0
-            "pip install 'pipdeptree<2.29.0'",
-            run_in_venv=True,
-        )
-        self._run_command(
-            "pipdeptree --warn fail",
-            run_in_venv=True,
-        )
-
-    def _create_venv(self):
-        self._logger.debug(
-            "Creating venv",
-        )
-        self._run_command(
-            "python -m venv test-venv",
-        )
-        self._run_command(
-            "python -m pip install -r automation/requirements.txt", run_in_venv=True
-        )
-
-    def _clean_venv(self):
-        self._logger.debug(
-            "Cleaning venv",
-        )
-        self._run_command(
-            "rm -rf test-venv",
-        )
-
-    def _install_extra(self, extra):
-        self._logger.debug(
-            "Installing extra",
-            extra=extra,
-        )
-        self._run_command(
-            "python -m pip install --upgrade pip~=25.0.0",
-            run_in_venv=True,
-        )
-
-        self._run_command(
-            f"pip install '.{extra}'",
-            run_in_venv=True,
-        )
-
-    def _run_command(self, command, run_in_venv=False, env=None, raise_on_error=True):
-        if run_in_venv:
-            command = f". test-venv/bin/activate && {command}"
-        try:
-            process = subprocess.run(
-                command,
-                env=env,
-                shell=True,
-                check=True,
-                capture_output=True,
-                encoding="utf-8",
-            )
-        except subprocess.CalledProcessError as exc:
-            if raise_on_error:
-                logger.warning(
-                    "Command failed",
-                    stdout=exc.stdout,
-                    stderr=exc.stderr,
-                    return_code=exc.returncode,
-                    cmd=exc.cmd,
-                    args=exc.args,
-                )
-                raise
-            return exc.returncode, exc.stdout, exc.stderr
-        return process.returncode, process.stdout, process.stderr
-
 
 @click.group()
 def main():
@@ -320,7 +352,12 @@ def main():
 
 @main.command(context_settings=dict(ignore_unknown_options=True))
 def run():
-    package_tester = PackageTester()
+    logger = mlrun.utils.create_logger(
+        level="debug",
+        name="automation",
+        formatter_kind=mlrun.utils.FormatterKinds.HUMAN_EXTENDED.name,
+    )
+    package_tester = PackageTester(logger)
     try:
         package_tester.run()
     except Exception as exc:

--- a/automation/package_test/test.py
+++ b/automation/package_test/test.py
@@ -188,9 +188,11 @@ class Venv:
         self.install_package(f".{extra}")
 
     def install_package(self, package, upgrade=False):
-        return self.run_command(
-            f"{self._package_installer_command} {'--upgrade' if upgrade else ''} {shlex.quote(package)}"
-        )
+        cmd = self._package_installer_command
+        if upgrade:
+            cmd += " --upgrade"
+        cmd += f" {shlex.quote(package)}"
+        return self.run_command(cmd)
 
     def run_command(self, command, env=None, raise_on_error=True):
         venv_command = f". {self._venv_name}/bin/activate"
@@ -343,6 +345,11 @@ class PackageTester:
         )
         if failed:
             raise RuntimeError("Package tests failed")
+
+    # Exposed funcaionlity for external test cases
+    def test_requirements_vulnerabilities(self, extra):
+        with Venv(self._logger, self._package_installer) as venv:
+            _run_vulnerability_test(venv, extra, self._logger)
 
 
 @click.group()

--- a/tests/automation/package_test/test_package_test.py
+++ b/tests/automation/package_test/test_package_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest.mock
 
 import pytest
 
@@ -21,9 +20,9 @@ import tests.conftest
 from mlrun.utils import logger
 
 
-def test_test_requirements_vulnerabilities():
-    package_tester = automation.package_test.test.PackageTester()
-    cases = [
+@pytest.mark.parametrize(
+    "case",
+    [
         {
             "output": """
     {
@@ -43,8 +42,7 @@ def test_test_requirements_vulnerabilities():
                 "more_info_url": "https://pyup.io/v/44716/f17"
             }
         ]
-    }
-""",
+    }""",
             "expected_to_fail": True,
         },
         {
@@ -57,31 +55,42 @@ def test_test_requirements_vulnerabilities():
         {
             "output": "",
         },
-    ]
-    for case in cases:
-        logger.info("Testing case", case=case)
+    ],
+)
+def test_requirements_vulnerabilities(case, monkeypatch):
+    package_tester = automation.package_test.test.PackageTester(logger)
 
-        def _run_command_mock(command, *args, **kwargs):
-            # _test_requirements_vulnerabilities flow is running two commands:
-            # 1. pip install safety - we don't care about it, so simply return success
-            # 2. safety check --json - this is the actual one we want to mock the output for
-            if command == "pip install safety":
-                return 0, "", ""
-            elif command == "safety check --json":
-                if case.get("output_file"):
-                    with open(case["output_file"]) as file:
-                        output = file.readlines()
-                        output = "".join(output)
-                else:
-                    output = case.get("output")
-                code = 255 if output else 0
-                return code, output, ""
+    logger.info("Testing case", case=case)
+
+    def _run_command_mock(_, command, *args, **kwargs):
+        # _test_requirements_vulnerabilities flow is running two commands:
+        # 1. pip install safety - we don't care about it, so simply return success
+        # 2. safety check --json - this is the actual one we want to mock the output for
+        if "pip install safety" in command:
+            return 0, "", ""
+        elif "safety check --json" in command:
+            if case.get("output_file"):
+                with open(case["output_file"]) as file:
+                    output = file.readlines()
+                    output = "".join(output)
             else:
-                raise NotImplementedError(f"Got unexpected command: {command}")
-
-        package_tester._run_command = unittest.mock.Mock(side_effect=_run_command_mock)
-        if case.get("expected_to_fail"):
-            with pytest.raises(AssertionError, match="Found vulnerable requirements"):
-                package_tester._test_requirements_vulnerabilities("some-extra")
+                output = case.get("output")
+            code = 255 if output else 0
+            return code, output, ""
         else:
-            package_tester._test_requirements_vulnerabilities("some-extra")
+            raise NotImplementedError(f"Got unexpected command: {command}")
+
+    monkeypatch.setattr(
+        automation.package_test.test.Venv, "_run_command", _run_command_mock
+    )
+    monkeypatch.setattr(
+        automation.package_test.test.Venv, "_create_venv", lambda _: None
+    )
+    monkeypatch.setattr(
+        automation.package_test.test.Venv, "_clean_venv", lambda _: None
+    )
+    if case.get("expected_to_fail"):
+        with pytest.raises(AssertionError, match="Found vulnerable requirements"):
+            package_tester.test_requirements_vulnerabilities("some-extra")
+    else:
+        package_tester.test_requirements_vulnerabilities("some-extra")


### PR DESCRIPTION
### 📝 Description

Fix the package test (`make test-package`) reliability by removing the `automation/requirements.txt` installation that polluted the test venv environment.

Using `uv` + process pool - reducing execution time from `Successful in 12m` to `Successful in 1m`

---

### 🛠️ Changes Made

- Removed `pip install -r automation/requirements.txt` from test venv creation which polluted the environment with `boto3` and other packages
- Refactored test.py to use a `Venv` context manager class for cleaner venv lifecycle management
- Added `ProcessPoolExecutor` for parallel test execution across all extras (faster CI)
- Added streaming output for pip install commands
- Added process ID to worker logger for better debugging in parallel execution
- Use `uv` as python package manager

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Ran `make test-package` locally to verify the fix
- The first test (base mlrun without extras) now correctly validates that optional dependencies like `boto3` are not present

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11948
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

**Root cause:** PR #7694 added `pip install -r automation/requirements.txt` to the test venv's `_create_venv()` method. This installed `boto3` (among other packages), polluting the clean test environment and causing the package test to incorrectly pass when it should have failed (as discovered by ML-11946).