### PR TITLE
[Projects] Ensure project spec owner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ install-dev-requirements: ## Install dev-requirements relevant for pytest and co
 		$(MLRUN_PIP_NO_CACHE_FLAG) \
 		-r dev-requirements.txt
 
-.PHONY: install-dev-requirements
+.PHONY: install-automation-requirements
 install-automation-requirements: ## Install automation-requirements relevant for CI and automation scripts
 	# relevant for pip package installer only
 	@if [ "$(MLRUN_PYTHON_PACKAGE_INSTALLER)" = "pip" ]; then \

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -322,9 +322,11 @@ class NopDB(RunDBInterface):
         pass
 
     def store_project(
-        self, name: str, project: mlrun.common.schemas.Project
+        self, name: str, project: mlrun.common.schemas.Project | dict
     ) -> mlrun.common.schemas.Project:
-        pass
+        if isinstance(project, dict):
+            project = mlrun.common.schemas.Project(**project)
+        return project
 
     def patch_project(
         self,
@@ -335,9 +337,11 @@ class NopDB(RunDBInterface):
         pass
 
     def create_project(
-        self, project: mlrun.common.schemas.Project
+        self, project: mlrun.common.schemas.Project | dict
     ) -> mlrun.common.schemas.Project:
-        pass
+        if isinstance(project, dict):
+            project = mlrun.common.schemas.Project(**project)
+        return project
 
     def list_projects(
         self,

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -321,12 +321,17 @@ class NopDB(RunDBInterface):
     ):
         pass
 
-    def store_project(
-        self, name: str, project: mlrun.common.schemas.Project | dict
+    def create_project(
+        self, project: mlrun.common.schemas.Project | dict
     ) -> mlrun.common.schemas.Project:
         if isinstance(project, dict):
             project = mlrun.common.schemas.Project(**project)
         return project
+
+    def store_project(
+        self, name: str, project: mlrun.common.schemas.Project | dict
+    ) -> mlrun.common.schemas.Project:
+        return self.create_project(project)
 
     def patch_project(
         self,
@@ -335,13 +340,6 @@ class NopDB(RunDBInterface):
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
     ) -> mlrun.common.schemas.Project:
         pass
-
-    def create_project(
-        self, project: mlrun.common.schemas.Project | dict
-    ) -> mlrun.common.schemas.Project:
-        if isinstance(project, dict):
-            project = mlrun.common.schemas.Project(**project)
-        return project
 
     def list_projects(
         self,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3756,7 +3756,8 @@ class MlrunProject(ModelObj):
         :store: if True, allow updating in case project already exists
         """
         self.export(filepath)
-        self.save_to_db(store)
+        project = self.save_to_db(store)
+        self.__dict__.update(project.__dict__)
         return self
 
     def save_to_db(self, store=True):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3373,7 +3373,16 @@ class MlrunProject(ModelObj):
                         function_definition, self, name
                     )
                 except FileNotFoundError as exc:
-                    message = f"File {exc.filename} not found while syncing project functions."
+                    filename = getattr(exc, "filename", None) or getattr(
+                        exc, "filename2", None
+                    )
+                    if not filename:
+                        filename = getattr(exc, "args", ["unknown"])[0]
+                        # "not found" is a common error message, remove it
+                        filename = filename.replace("not found", "").strip()
+                    message = (
+                        f"File {filename} not found while syncing project functions."
+                    )
                     if silent:
                         message += " Skipping function reload"
                         logger.warn(message, name=name)

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3515,9 +3515,7 @@ class SQLDB(DBInterface):
             else:
                 projects.append(
                     mlrun.common.formatters.ProjectFormat.format_obj(
-                        self._transform_project_record_to_schema(
-                            project_record
-                        ),
+                        self._transform_project_record_to_schema(project_record),
                         format_,
                     )
                 )

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3383,7 +3383,7 @@ class SQLDB(DBInterface):
     # ---- Projects ----
     def create_project(self, session: Session, project: mlrun.common.schemas.Project):
         logger.debug("Creating project in DB", project_name=project.metadata.name)
-        created = datetime.utcnow()
+        created = datetime.now(UTC)
         project.metadata.created = created
         # TODO: handle taking out the functions/workflows/artifacts out of the project and save them separately
         project_record = Project(
@@ -3468,7 +3468,7 @@ class SQLDB(DBInterface):
     ) -> mlrun.common.schemas.ProjectOut:
         project_record = self._get_project_record(session, name, project_id)
 
-        return self._transform_project_record_to_schema(session, project_record)
+        return self._transform_project_record_to_schema(project_record)
 
     def delete_project(
         self,
@@ -3516,7 +3516,7 @@ class SQLDB(DBInterface):
                 projects.append(
                     mlrun.common.formatters.ProjectFormat.format_obj(
                         self._transform_project_record_to_schema(
-                            session, project_record
+                            project_record
                         ),
                         format_,
                     )
@@ -6255,27 +6255,8 @@ class SQLDB(DBInterface):
         return model_endpoint_full_dict
 
     def _transform_project_record_to_schema(
-        self, session: Session, project_record: Project
+        self, project_record: Project
     ) -> mlrun.common.schemas.ProjectOut:
-        # in projects that was created before 0.6.0 the full object wasn't created properly - fix that, and return
-        if not project_record.full_object:
-            project = mlrun.common.schemas.Project(
-                metadata=mlrun.common.schemas.ProjectMetadata(
-                    name=project_record.name,
-                    created=project_record.created,
-                ),
-                spec=mlrun.common.schemas.ProjectSpec(
-                    description=project_record.description,
-                    source=project_record.source,
-                    default_function_node_selector=project_record.default_function_node_selector,
-                ),
-                status=mlrun.common.schemas.ObjectStatus(
-                    state=project_record.state,
-                ),
-            )
-            self.store_project(session, project_record.name, project)
-            return mlrun.common.schemas.ProjectOut(**project.dict())
-        # TODO: handle transforming the functions/workflows/artifacts references to real objects
         return mlrun.common.schemas.ProjectOut(**project_record.full_object)
 
     def _transform_notification_record_to_spec_and_status(

--- a/server/py/framework/utils/projects/leader.py
+++ b/server/py/framework/utils/projects/leader.py
@@ -71,8 +71,7 @@ class Member(
         wait_for_completion: bool = True,
         commit_before_get: bool = False,
     ) -> tuple[typing.Optional[mlrun.common.schemas.ProjectOut], bool]:
-        self._enrich_project_create(project, auth_info)
-        self._enrich_and_validate(project)
+        self._enrich_and_validate(project, auth_info)
         self._run_on_all_followers(
             True, "create_project", db_session, project, auth_info
         )
@@ -87,7 +86,7 @@ class Member(
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
         wait_for_completion: bool = True,
     ) -> tuple[typing.Optional[mlrun.common.schemas.ProjectOut], bool]:
-        self._enrich_and_validate(project)
+        self._enrich_and_validate(project, auth_info)
         self._validate_body_and_path_names_matches(name, project)
         self._run_on_all_followers(
             True, "store_project", db_session, name, project, auth_info
@@ -439,19 +438,22 @@ class Member(
             raise ValueError(f"Unknown follower name: {name}")
         return followers_classes_map[name]()
 
-    def _enrich_and_validate(self, project: mlrun.common.schemas.Project):
-        self._enrich_project(project)
+    def _enrich_and_validate(
+        self,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo | None = None,
+    ):
+        self._enrich_project(project, auth_info)
         self._validate_project(project)
 
     @staticmethod
-    def _enrich_project(project: mlrun.common.schemas.Project):
-        project.status.state = project.spec.desired_state
-
-    @staticmethod
-    def _enrich_project_create(
-        project: mlrun.common.schemas.Project, auth_info: mlrun.common.schemas.AuthInfo
+    def _enrich_project(
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo | None = None,
     ):
-        project.spec.owner = auth_info.username
+        if auth_info and project.spec.owner is None:
+            project.spec.owner = auth_info.username
+        project.status.state = project.spec.desired_state
 
     @staticmethod
     def _enrich_project_patch(project_patch: dict):

--- a/server/py/framework/utils/projects/leader.py
+++ b/server/py/framework/utils/projects/leader.py
@@ -71,11 +71,13 @@ class Member(
         wait_for_completion: bool = True,
         commit_before_get: bool = False,
     ) -> tuple[typing.Optional[mlrun.common.schemas.ProjectOut], bool]:
+        self._enrich_project_create(project, auth_info)
         self._enrich_and_validate(project)
         self._run_on_all_followers(
             True, "create_project", db_session, project, auth_info
         )
-        return self.get_project(db_session, project.metadata.name), False
+        project = self.get_project(db_session, project.metadata.name)
+        return project, False
 
     def store_project(
         self,
@@ -444,6 +446,12 @@ class Member(
     @staticmethod
     def _enrich_project(project: mlrun.common.schemas.Project):
         project.status.state = project.spec.desired_state
+
+    @staticmethod
+    def _enrich_project_create(
+        project: mlrun.common.schemas.Project, auth_info: mlrun.common.schemas.AuthInfo
+    ):
+        project.spec.owner = auth_info.username
 
     @staticmethod
     def _enrich_project_patch(project_patch: dict):

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -813,11 +813,7 @@ def test_build_function_masks_access_key(
     mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.IGUAZIO
     # set auto mount to ensure it doesn't override the access key
     mlrun.mlconf.storage.auto_mount_type = "v3io_credentials"
-    monkeypatch.setattr(
-        framework.utils.clients.iguazio.v3,
-        "AsyncClient",
-        lambda *args, **kwargs: unittest.mock.AsyncMock(),
-    )
+    services.api.tests.unit.api.utils.setup_iguazio_v3_async_client_mock(monkeypatch)
     services.api.tests.unit.api.utils.create_project(client, PROJECT)
     function_dict = {
         "kind": "job",
@@ -882,11 +878,7 @@ def test_build_no_access_key(
     expected_reason,
 ):
     mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.IGUAZIO
-    monkeypatch.setattr(
-        framework.utils.clients.iguazio.v3,
-        "AsyncClient",
-        lambda *args, **kwargs: unittest.mock.AsyncMock(),
-    )
+    services.api.tests.unit.api.utils.setup_iguazio_v3_async_client_mock(monkeypatch)
 
     services.api.tests.unit.api.utils.create_project(client, PROJECT)
     function_dict = {

--- a/server/py/services/api/tests/unit/api/utils.py
+++ b/server/py/services/api/tests/unit/api/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest.mock
 import uuid
 from http import HTTPStatus
 from typing import Optional
@@ -19,12 +20,45 @@ from typing import Optional
 import httpx
 from fastapi.testclient import TestClient
 
-import mlrun.artifacts.dataset
-import mlrun.artifacts.model
 import mlrun.common.schemas
-import mlrun.errors
+
+import framework.utils.clients.iguazio.v3
 
 PROJECT = "project-name"
+
+
+def setup_iguazio_v3_async_client_mock(
+    monkeypatch, username="username", session="session", data_session="data_session"
+):
+    """
+    Set up a properly configured mock for Iguazio v3 AsyncClient
+
+    The mock's verify_request_session method returns a proper AuthInfo object instead of
+    a mock, which prevents pickling errors when the project object is serialized.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture
+        username: Username to return in AuthInfo (default: "username")
+        session: Session to return in AuthInfo (default: "session")
+        data_session: Data session to return in AuthInfo (default: "data_session")
+
+    Returns:
+        The configured mock client
+    """
+    mock_client = unittest.mock.AsyncMock()
+    mock_client.verify_request_session = unittest.mock.AsyncMock(
+        return_value=mlrun.common.schemas.auth.AuthInfo(
+            username=username,
+            session=session,
+            data_session=data_session,
+        )
+    )
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v3,
+        "AsyncClient",
+        lambda *args, **kwargs: mock_client,
+    )
+    return mock_client
 
 
 def create_project(

--- a/server/py/services/api/tests/unit/db/test_projects.py
+++ b/server/py/services/api/tests/unit/db/test_projects.py
@@ -68,25 +68,6 @@ class TestProjects(TestDatabaseBase):
             == {}
         )
 
-    def test_get_project_with_pre_060_record(self):
-        project_name = "project_name"
-        self._generate_and_insert_pre_060_record(project_name)
-        pre_060_record = (
-            self._db_session.query(Project).filter(Project.name == project_name).one()
-        )
-        assert pre_060_record.full_object is None
-        project = self._db.get_project(
-            self._db_session,
-            project_name,
-        )
-        assert project.metadata.name == project_name
-        updated_record = (
-            self._db_session.query(Project).filter(Project.name == project_name).one()
-        )
-        # when GET performed on a project of the old format - we're upgrading it to the new format - ensuring it
-        # happened
-        assert updated_record.full_object is not None
-
     def test_list_project(self):
         expected_projects = [
             {"name": "project-name-1"},

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -14,6 +14,7 @@
 import pathlib
 import re
 import unittest.mock
+import uuid
 from contextlib import nullcontext as does_not_raise
 
 import pytest
@@ -28,13 +29,17 @@ import mlrun.launcher.factory
 from mlrun.common.types import AuthenticationMode
 from mlrun.config import Config
 
-import framework.utils.clients.iguazio.v3
 import services.api.launcher
 import services.api.tests.unit.api.utils
 
 assets_path = pathlib.Path(__file__).parent / "assets"
 func_path = assets_path / "sample_function.py"
 handler = "hello_word"
+
+
+@pytest.fixture
+def random_project_name():
+    return f"some-project-{uuid.uuid4().hex[:8]}"
 
 
 @pytest.mark.parametrize(
@@ -58,20 +63,17 @@ def test_create_server_side_launcher(is_remote, local, expectation):
 
 
 def test_enrich_runtime_with_auth_info(
-    monkeypatch, k8s_secrets_mock, client: TestClient
+    monkeypatch, k8s_secrets_mock, client: TestClient, random_project_name: str
 ):
-    project = "some-project"
+    project = random_project_name
     mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.IGUAZIO
-    monkeypatch.setattr(
-        framework.utils.clients.iguazio.v3,
-        "AsyncClient",
-        lambda *args, **kwargs: unittest.mock.AsyncMock(),
-    )
+
+    services.api.tests.unit.api.utils.setup_iguazio_v3_async_client_mock(monkeypatch)
     auth_info = mlrun.common.schemas.auth.AuthInfo(
         access_key="access_key",
         username="username",
     )
-    services.api.tests.unit.api.utils.create_project(client, project)
+    services.api.tests.unit.api.utils.create_project(client, project_name=project)
 
     launcher_kwargs = {"auth_info": auth_info}
     launcher = mlrun.launcher.factory.LauncherFactory().create_launcher(
@@ -149,10 +151,10 @@ def test_validate_state_thresholds_failure(state_thresholds, expected_error):
 
 
 def test_new_function_args_with_default_image_pull_secret(
-    db: sqlalchemy.orm.Session, client: TestClient
+    db: sqlalchemy.orm.Session, client: TestClient, random_project_name: str
 ):
-    project = "some-project"
-    services.api.tests.unit.api.utils.create_project(client, project)
+    project = random_project_name
+    services.api.tests.unit.api.utils.create_project(client, project_name=project)
 
     mlrun.mlconf.function.spec.image_pull_secret = Config(
         {"default": "adam-docker-registry-auth"}

--- a/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
+++ b/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
@@ -62,6 +62,58 @@ def leader_follower(
     return projects_leader._leader_follower
 
 
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "create_project",
+        "store_project",
+    ],
+)
+@pytest.mark.parametrize(
+    "explicit_owner, auth_user, expected_owner",
+    [
+        (None, "auth-user", "auth-user"),
+        ("explicit-owner", "auth-user", "explicit-owner"),
+        ("explicit-owner", "explicit-owner", "explicit-owner"),
+    ],
+)
+def test_project_owner_from_auth_info_only_when_missing(
+    projects_leader: framework.utils.projects.leader.Member,
+    method_name: str,
+    explicit_owner: str | None,
+    auth_user: str,
+    expected_owner: str,
+):
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+        spec=mlrun.common.schemas.ProjectSpec(
+            description="some description",
+            owner=explicit_owner,
+        ),
+    )
+    auth_info = mlrun.common.schemas.AuthInfo(username=auth_user)
+
+    if method_name == "create_project":
+        created_project, _ = projects_leader.create_project(
+            None,
+            project,
+            auth_info=auth_info,
+        )
+        project_out = created_project
+    elif method_name == "store_project":
+        stored_project, _ = projects_leader.store_project(
+            None,
+            project.metadata.name,
+            project,
+            auth_info=auth_info,
+        )
+        project_out = stored_project
+    else:
+        raise ValueError(f"Unexpected method name: {method_name}")
+
+    assert project_out.spec.owner == expected_owner
+
+
 def test_projects_sync_follower_project_adoption(
     db: sqlalchemy.orm.Session,
     projects_leader: framework.utils.projects.leader.Member,

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -528,9 +528,9 @@ class RunDBMock:
 
     def create_project(self, project):
         if isinstance(project, dict):
-            project = mlrun.projects.MlrunProject.from_dict(project)
+            project = mlrun.common.schemas.Project(**project)
         self._project = project
-        self._project_name = project.name
+        self._project_name = project.metadata.name
         return self._project
 
     def get_project(self, name):


### PR DESCRIPTION
### 📝 Description

This PR ensures that the project owner is automatically set from the authenticated user's information when a project is created or stored without an explicit owner. Previously, projects could be created without an owner field being populated.

---

### 🛠️ Changes Made

- **Set project owner from auth info**: Added logic in `_enrich_project` to populate `project.spec.owner` from `auth_info.username` when the owner is not already set
- **Consolidated enrichment logic**: Merged `_enrich_project_create` into `_enrich_project` for a single enrichment path
- **Update local project object**: After `save_to_db`, the local project object is now updated with server-side changes (e.g., generated metadata)
- **Removed unused `session` parameter**: Cleaned up `_transform_project_record_to_schema` by removing the unused `session` argument
- **Removed legacy migration code**: Removed pre-0.6.0 project migration code that auto-fixed incomplete project records on read
- **Minor fixes**: Fixed Makefile `.PHONY` target typo, replaced deprecated `datetime.utcnow()` with `datetime.now(UTC)`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Manually tested project creation via SDK to verify owner is populated

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11868
- Design docs links: 
- External links: 

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The legacy migration code for pre-0.6.0 projects was removed as it's no longer needed (MLRun 0.6.0 was released years ago)
- Owner is only set if `project.spec.owner` is `None`, preserving explicitly provided owners