### PR TITLE
[Feature Store] Attach authorization namespace when verifying permissions

### DIFF
--- a/mlrun/feature_store/common.py
+++ b/mlrun/feature_store/common.py
@@ -20,7 +20,7 @@ from mlrun.common.schemas import AuthorizationVerificationInput
 from mlrun.runtimes import BaseRuntime
 from mlrun.runtimes.function_reference import FunctionReference
 from mlrun.runtimes.utils import enrich_function_from_dict
-from mlrun.utils import StorePrefix, logger
+from mlrun.utils import StorePrefix, helpers, logger
 
 from ..common.helpers import parse_versioned_object_uri
 from ..config import config
@@ -134,8 +134,8 @@ def verify_feature_set_permissions(
 ):
     project, _, _, _ = parse_feature_set_uri(feature_set.uri)
 
-    resource = (
-        mlrun.common.schemas.AuthorizationResourceTypes.feature_set.to_resource_string(
+    resource = helpers.attach_authorization_namespace_prefix(
+        resource=mlrun.common.schemas.AuthorizationResourceTypes.feature_set.to_resource_string(
             project, "feature-set"
         )
     )

--- a/mlrun/feature_store/common.py
+++ b/mlrun/feature_store/common.py
@@ -81,10 +81,8 @@ def get_feature_set_by_uri(uri, project=None):
     """get feature set object from db by uri"""
     db = mlrun.get_run_db()
     project, name, tag, uid = parse_feature_set_uri(uri, project)
-    resource = (
-        mlrun.common.schemas.AuthorizationResourceTypes.feature_set.to_resource_string(
-            project, "feature-set"
-        )
+    resource = _generate_project_feature_store_resource_string(
+        project=project, resource="feature-set"
     )
 
     auth_input = AuthorizationVerificationInput(
@@ -111,8 +109,8 @@ def get_feature_vector_by_uri(uri, project=None, update=True):
 
     project, name, tag, uid = parse_versioned_object_uri(uri, active_project)
 
-    resource = mlrun.common.schemas.AuthorizationResourceTypes.feature_vector.to_resource_string(
-        project, "feature-vector"
+    resource = _generate_project_feature_store_resource_string(
+        project=project, resource="feature-vector"
     )
 
     if update:
@@ -134,10 +132,8 @@ def verify_feature_set_permissions(
 ):
     project, _, _, _ = parse_feature_set_uri(feature_set.uri)
 
-    resource = helpers.attach_authorization_namespace_prefix(
-        resource=mlrun.common.schemas.AuthorizationResourceTypes.feature_set.to_resource_string(
-            project, "feature-set"
-        )
+    resource = _generate_project_feature_store_resource_string(
+        project=project, resource="feature-set"
     )
     db = feature_set._get_run_db()
 
@@ -163,13 +159,34 @@ def verify_feature_vector_permissions(
 ):
     project = feature_vector._metadata.project or config.active_project
 
-    resource = mlrun.common.schemas.AuthorizationResourceTypes.feature_vector.to_resource_string(
-        project, "feature-vector"
+    resource = _generate_project_feature_store_resource_string(
+        project=project, resource="feature-vector"
     )
 
     db = mlrun.get_run_db()
     auth_input = AuthorizationVerificationInput(resource=resource, action=action)
     db.verify_authorization(auth_input)
+
+
+def _generate_project_feature_store_resource_string(
+    project: str,
+    resource: str,
+) -> str:
+    """
+    Generate the project feature set resource string to use in permissions verification
+    """
+    if resource == "feature-set":
+        return helpers.attach_authorization_namespace_prefix(
+            resource=mlrun.common.schemas.AuthorizationResourceTypes.feature_set.to_resource_string(
+                project, resource
+            )
+        )
+
+    return helpers.attach_authorization_namespace_prefix(
+        resource=mlrun.common.schemas.AuthorizationResourceTypes.feature_vector.to_resource_string(
+            project, resource
+        )
+    )
 
 
 class RunConfig:

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2645,3 +2645,27 @@ def is_async_serving_graph(function_spec) -> bool:
         return True
 
     return False
+
+
+def attach_authorization_namespace_prefix(
+    resource: str,
+    namespace: mlrun.common.schemas.AuthorizationResourceNamespace = (
+        mlrun.common.schemas.AuthorizationResourceNamespace.resources
+    ),
+) -> str:
+    """
+    Attach the authorization namespace prefix to the resource.
+
+    :param resource: The resource string to attach the namespace prefix to.
+    :param namespace: The namespace to attach the prefix to.
+        Defaults to `mlrun.common.schemas.AuthorizationResourceNamespace.resources`.
+    :returns: The resource string with the namespace prefix attached.
+    """
+    if namespace == mlrun.common.schemas.AuthorizationResourceNamespace.resources:
+        namespace_prefix = config.httpdb.authorization.namespaces.resources
+    else:
+        namespace_prefix = config.httpdb.authorization.namespaces.mgmt
+
+    if namespace_prefix:
+        resource = f"/{namespace_prefix}{resource}"
+    return resource


### PR DESCRIPTION
### 📝 Description
This PR fixes authorization verification for feature sets by ensuring the authorization namespace prefix is properly attached to resource strings when verifying permissions. 
This ensures that authorization checks work correctly in namespaced environments where resources need to be prefixed with namespaces like `/resources` or `/mgmt`.

---

### 🛠️ Changes Made
- **Added authorization namespace prefix support in `mlrun/feature_store/common.py`**:
  - Updated `verify_feature_set_permissions()` to attach the authorization namespace prefix to resource strings before authorization verification
  - This ensures the authorization namespace prefix (e.g., `/resources` or `/mgmt`) is properly attached to the feature set resource string

- **Refactored feature store authorization logic**:
  - Created a new helper function `_generate_project_feature_store_resource_string()` that centralizes the logic for generating resource strings with namespace prefixes
  - Refactored the following functions to use the new helper:
    - `get_feature_set_by_uri()`
    - `get_feature_vector_by_uri()`
    - `verify_feature_set_permissions()`
    - `verify_feature_vector_permissions()`
  - This refactoring improves code maintainability and ensures consistent namespace prefix handling across all feature store authorization checks

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Tested manually against an IG4 system that has a namespace prefix configured.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1150

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This change aligns the feature store permission verification with the authorization namespace prefix pattern used elsewhere in the codebase. The `attach_authorization_namespace_prefix()` helper function from `mlrun/utils/helpers.py` is now consistently used across all feature store authorization checks through the new `_generate_project_feature_store_resource_string()` helper function, ensuring proper namespace prefix handling for both feature sets and feature vectors.
