### PR TITLE
[Tests] Update test by adding mock model provider artifact to the graph

### DIFF
--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -44,7 +44,7 @@ from tests.system.runtimes.assets.function_with_model import DummyModel, MyModel
 class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
     project_name = "test-nuclio-runtime"
 
-    image: str = "mlrun/mlrun"
+    image: str = "artifactory.iguazeng.com:10557/davids/mlrun:1.11.0"
 
     def test_deploy_function_with_error_handler(self):
         code_path = str(self.assets_path / "function-with-catcher.py")
@@ -176,9 +176,21 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
             image=self.image,
             kind="serving",
         )
+
+        model_artifact = self.project.log_model(
+            "my_model",
+            model_url="mock://my-model-url",
+            default_config={"model_version": "4"},
+        )
+
         graph = function.set_topology("flow")
         model_runner = ModelRunnerStep(name="model-runner")
-        model_runner.add_model("my_llm", "mlrun.serving.states.LLModel", "naive")
+        model_runner.add_model(
+            "my_llm",
+            "mlrun.serving.states.LLModel",
+            "naive",
+            model_artifact=model_artifact,
+        )
         graph.to(model_runner).respond()
         deployment = function.deploy()
         assert deployment == function.get_url()  # check function url

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -44,7 +44,7 @@ from tests.system.runtimes.assets.function_with_model import DummyModel, MyModel
 class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
     project_name = "test-nuclio-runtime"
 
-    image: str = "artifactory.iguazeng.com:10557/davids/mlrun:1.11.0"
+    image: str = "mlrun/mlrun"
 
     def test_deploy_function_with_error_handler(self):
         code_path = str(self.assets_path / "function-with-catcher.py")


### PR DESCRIPTION
As defined in https://github.com/mlrun/mlrun/pull/9090, LLModel requires a valid model provider. Therefore, any usage of this class in a graph must include a corresponding model artifact.

This change is covered by the test test_set_function_llmodel_without_py, where a model artifact is added to the relevant endpoint that uses the LLModel class. The model artifact points to a mock provider.
