### PR TITLE
[Serving] Validate that `BaseStep`'s `after` parameter is a list

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -148,9 +148,7 @@ class BaseStep(ModelObj):
         self._parent = None
         self.comment = None
         self.context = None
-        if after and not isinstance(after, list):
-            raise mlrun.errors.MLRunInvalidArgumentError("after must be a list")
-        self.after = after or []
+        self.after = after
         self._next = None
         self.shape = shape
         self.on_error = None
@@ -185,6 +183,19 @@ class BaseStep(ModelObj):
         elif key not in self.next:
             self._next.append(key)
         return self
+
+    @property
+    def after(self):
+        return self._after
+
+    @after.setter
+    def after(self, value):
+        if value is None:
+            value = []
+        elif not isinstance(value, list):
+            value = [value]
+
+        self._after = value
 
     def after_step(self, *after, append=True):
         """specify the previous step names"""

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -148,6 +148,8 @@ class BaseStep(ModelObj):
         self._parent = None
         self.comment = None
         self.context = None
+        if after and not isinstance(after, list):
+            raise mlrun.errors.MLRunInvalidArgumentError("after must be a list")
         self.after = after or []
         self._next = None
         self.shape = shape

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -491,4 +491,4 @@ def test_sync_flow_with_branches():
 # ML-11985
 def test_mrs_rejects_bad_after_param():
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-        ModelRunnerStep(name="my_model_runner", after="I-shouldn't-be-passed-directly"),
+        ModelRunnerStep(name="my_model_runner", after="I-shouldn't-be-passed-directly")

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -486,3 +486,9 @@ def test_sync_flow_with_branches():
     graph.add_step(name="gather", class_name="Gather", after=["s1", "s2"])
     with pytest.raises(mlrun.serving.states.GraphError):
         fn.to_mock_server()
+
+
+# ML-11985
+def test_mrs_rejects_bad_after_param():
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        ModelRunnerStep(name="my_model_runner", after="I-shouldn't-be-passed-directly"),

--- a/tests/serving/test_flow.py
+++ b/tests/serving/test_flow.py
@@ -489,6 +489,6 @@ def test_sync_flow_with_branches():
 
 
 # ML-11985
-def test_mrs_rejects_bad_after_param():
-    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-        ModelRunnerStep(name="my_model_runner", after="I-shouldn't-be-passed-directly")
+def test_mrs_wraps_after():
+    after = "other-step"
+    assert ModelRunnerStep(name="my_model_runner", after=after).after == [after]


### PR DESCRIPTION
to prevent it being iterated over character by character, resulting in confusing errors to the user.

Added regression test.

[ML-11985](https://iguazio.atlassian.net/browse/ML-11985)

[ML-11985]: https://iguazio.atlassian.net/browse/ML-11985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ