### PR TITLE
[Nuclio] Fix patch project auth info propagation

### DIFF
--- a/server/py/framework/utils/clients/nuclio.py
+++ b/server/py/framework/utils/clients/nuclio.py
@@ -83,7 +83,7 @@ class Client(
             project=project,
             patch_mode=patch_mode,
         )
-        response = self._get_project_from_nuclio(name)
+        response = self._get_project_from_nuclio(name, auth_info=auth_info)
         response_body = response.json()
         if project.get("metadata", {}).get("labels") is not None:
             response_body.setdefault("metadata", {}).setdefault("labels", {}).update(


### PR DESCRIPTION
### 📝 Description

Fix Nuclio client's `patch_project` function by propagating the `auth_info` project to the initial get project request.

---

### 🛠️ Changes Made

- **`server/py/framework/utils/clients/nuclio.py`** - pass `auth_info` properly in `patch_project` function.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Verified by running the following in an IG4 system where mlrun is the project leader, and verified it works:
```python
project_name = "t2"
project = mlrun.get_or_create_project(project_name,f"./{project_name}")
mlrun.get_run_db().patch_project(name=project_name, project={"spec": {"description": 'rrr'}})
```

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1174

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
