### PR TITLE
[Tests] Add writer flush time to several tests sleep functionality 

### DIFF
--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -2124,7 +2124,7 @@ class TestModelEndpointGetMetrics(TestMLRunSystemModelMonitoring):
     """Test get_model_endpoint_monitoring_metrics functionality."""
 
     project_name = "model-endpoint-get-metrics"
-    image: Optional[str] = "artifactory.iguazeng.com:10557/davids/mlrun:1.11.0"
+    image: Optional[str] = None
 
     @staticmethod
     def _generate_event(

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -2061,7 +2061,7 @@ class TestModelInferenceTSDBRecord(TestMLRunSystemModelMonitoring):
             # TODO: activate ad-hoc mode when ML-5792 is done
         )
 
-        sleep(180)
+        sleep(210)
 
         self._test_v3io_tsdb_record()
 
@@ -2124,7 +2124,7 @@ class TestModelEndpointGetMetrics(TestMLRunSystemModelMonitoring):
     """Test get_model_endpoint_monitoring_metrics functionality."""
 
     project_name = "model-endpoint-get-metrics"
-    image: Optional[str] = None
+    image: Optional[str] = "artifactory.iguazeng.com:10557/davids/mlrun:1.11.0"
 
     @staticmethod
     def _generate_event(
@@ -2233,7 +2233,7 @@ class TestModelEndpointGetMetrics(TestMLRunSystemModelMonitoring):
             ),
         )
         # wait for the nuclio function to check for the stream inputs
-        sleep(15)
+        sleep(45)
         expected_for_mep1 = [
             "invocations",
             "metric1",


### PR DESCRIPTION
📝 Description

As part of the transition to an asynchronous writer, a flush interval of 30 seconds was introduced.
Accordingly, this flush time was added to the sleep duration in the `test_get_model_endpoint_metrics` and `test_record` tests before validating the correctness of the TSDB data.

---

### 🛠️ Changes Made
Fix sys tests : 
1. `TestModelInferenceTSDBRecord::test_record`
2. `TestModelEndpointGetMetrics::test_get_model_endpoint_metrics`
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
