### PR TITLE
[CLI] Add load-source command for single-file artifact loading

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1328,12 +1328,7 @@ def show_or_set_config(
     default=None,
     help="project name (extracted from URI if not provided)",
 )
-@click.option(
-    "--source-uri",
-    "-s",
-    required=True,
-    help="URI of the artifact",
-)
+@click.argument("source_uri", type=str)
 @click.option(
     "--target",
     "-t",
@@ -1341,13 +1336,13 @@ def show_or_set_config(
     help="target directory to write the source file",
 )
 def load_source(project, source_uri, target):
-    """Load source code artifact into a target directory for use by the sidecar.
+    """Load source code artifact into target directory.
 
     This is an internal CLI command used by init containers to prepare
     application source code before the sidecar container starts.
 
     Example:
-        mlrun load-source -p my-project -s store://artifacts/my-project/app.py
+        mlrun load-source store://artifacts/my-project/app.py
     """
 
     try:

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1342,7 +1342,7 @@ def load_source(source_uri, project, target):
     application source code before the sidecar container starts.
 
     Example:
-        mlrun load-source store://artifacts/my-project/app.py
+        mlrun load-source store://artifacts/my-project/app.py -t /tmp/mlrun_code
     """
 
     try:

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1322,20 +1322,20 @@ def show_or_set_config(
 
 
 @main.command(name="load-source")
+@click.argument("source_uri", type=str)
 @click.option(
     "--project",
     "-p",
     default=None,
     help="project name (extracted from URI if not provided)",
 )
-@click.argument("source_uri", type=str)
 @click.option(
     "--target",
     "-t",
     default="/home/mlrun_code",
     help="target directory to write the source file",
 )
-def load_source(project, source_uri, target):
+def load_source(source_uri, project, target):
     """Load source code artifact into target directory.
 
     This is an internal CLI command used by init containers to prepare

--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -39,6 +39,7 @@ import mlrun.platforms
 import mlrun.utils.helpers
 from mlrun.common.helpers import parse_versioned_object_uri
 from mlrun.runtimes.mounts import auto_mount as auto_mount_modifier
+from mlrun.utils.clones import load_source_code
 
 from .config import config as mlconf
 from .db import get_run_db
@@ -1318,6 +1319,47 @@ def show_or_set_config(
 
     else:
         print(f"Error: Unsupported config option {op}")
+
+
+@main.command(name="load-source")
+@click.option(
+    "--project",
+    "-p",
+    default=None,
+    help="project name (extracted from URI if not provided)",
+)
+@click.option(
+    "--source-uri",
+    "-s",
+    required=True,
+    help="URI of the artifact",
+)
+@click.option(
+    "--target",
+    "-t",
+    default="/home/mlrun_code",
+    help="target directory to write the source file",
+)
+def load_source(project, source_uri, target):
+    """Load source code artifact into a target directory for use by the sidecar.
+
+    This is an internal CLI command used by init containers to prepare
+    application source code before the sidecar container starts.
+
+    Example:
+        mlrun load-source -p my-project -s store://artifacts/my-project/app.py
+    """
+
+    try:
+        result_path = load_source_code(
+            source_uri=source_uri,
+            target_dir=target,
+            project=project,
+        )
+        print(f"Successfully loaded source to: {result_path}")
+    except Exception as err:
+        print(f"Error loading source: {err_to_str(err)}")
+        exit(1)
 
 
 def fill_params(params, params_dict=None):

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -230,12 +230,12 @@ def load_source_code(
     :returns: Path to the loaded file
     """
     if not source_uri:
-        raise ValueError("source_uri is required")
+        raise mlrun.errors.MLRunInvalidArgumentError("source_uri is required")
     if not target_dir:
-        raise ValueError("target_dir is required")
+        raise mlrun.errors.MLRunInvalidArgumentError("target_dir is required")
     # Validate that source_uri is a store artifact URI
     if not mlrun.datastore.is_store_uri(source_uri):
-        raise ValueError(
+        raise mlrun.errors.MLRunInvalidArgumentError(
             f"source_uri must be a store artifact URI (store://...), got: {source_uri}"
         )
 
@@ -255,6 +255,11 @@ def load_source_code(
     local_file_path = os.path.join(target_dir, filename)
 
     # Download the artifact content to the target directory
-    mlrun.get_dataitem(artifact_target_path).download(local_file_path)
+    try:
+        mlrun.get_dataitem(artifact_target_path).download(local_file_path)
+    except Exception as exc:
+        raise mlrun.errors.MLRunRuntimeError(
+            f"Failed to download artifact from {artifact_target_path} to {local_file_path}"
+        ) from exc
 
     return local_file_path

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -231,10 +231,8 @@ def load_source_code(
     """
     if not source_uri:
         raise ValueError("source_uri is required")
-
     if not target_dir:
         raise ValueError("target_dir is required")
-
     # Validate that source_uri is a store artifact URI
     if not mlrun.datastore.is_store_uri(source_uri):
         raise ValueError(
@@ -259,5 +257,4 @@ def load_source_code(
     # Download the artifact content to the target directory
     mlrun.get_dataitem(artifact_target_path).download(local_file_path)
 
-    logger.info(f"Successfully loaded source from {source_uri} to {local_file_path}")
     return local_file_path

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -211,3 +211,53 @@ def extract_source(source: str, workdir=None, secrets=None, clone=True):
 
     logger.info(f"extracting source from {source} to {target_dir}")
     return target_dir
+
+
+def load_source_code(
+    source_uri: str,
+    target_dir: str,
+    project: str | None = None,
+) -> str:
+    """
+    Load a single-file artifact from the artifact store into a target directory.
+    This function is used by the Application Runtime init container to prepare
+    source code on a shared volume before the sidecar container starts.
+
+    :param source_uri: URI of the artifact (store://artifacts/project/key)
+    :param target_dir: Target directory where the file will be placed
+    :param project:    Optional project name (extracted from URI if not provided)
+
+    :returns: Path to the loaded file
+    """
+    if not source_uri:
+        raise ValueError("source_uri is required")
+
+    if not target_dir:
+        raise ValueError("target_dir is required")
+
+    # Validate that source_uri is a store artifact URI
+    if not mlrun.datastore.is_store_uri(source_uri):
+        raise ValueError(
+            f"source_uri must be a store artifact URI (store://...), got: {source_uri}"
+        )
+
+    # Resolve the artifact from the store
+    artifact = mlrun.datastore.get_store_resource(source_uri, project=project)
+
+    # Get the target path where the artifact content is stored
+    artifact_target_path = artifact.get_target_path()
+    if not artifact_target_path:
+        raise ValueError(f"Artifact {source_uri} does not have a valid target path")
+
+    # Create target directory if it doesn't exist
+    os.makedirs(target_dir, exist_ok=True)
+
+    # Determine the filename from the artifact target path
+    filename = os.path.basename(artifact_target_path)
+    local_file_path = os.path.join(target_dir, filename)
+
+    # Download the artifact content to the target directory
+    mlrun.get_dataitem(artifact_target_path).download(local_file_path)
+
+    logger.info(f"Successfully loaded source from {source_uri} to {local_file_path}")
+    return local_file_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ def test_cli_load_source_success(project):
     runner = CliRunner()
     source_uri = "store://artifacts/my-project/handler.py"
 
-    cli_args = ["load-source", "--source-uri", source_uri]
+    cli_args = ["load-source", source_uri]
     if project:
         cli_args.extend(["--project", project])
 
@@ -120,7 +120,7 @@ def test_cli_load_source_failure():
     ):
         result = runner.invoke(
             main,
-            ["load-source", "--source-uri", "store://artifacts/project/file.py"],
+            ["load-source", "store://artifacts/project/file.py"],
         )
 
     assert result.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pathlib
+import unittest.mock
+
+import pytest
+from click.testing import CliRunner
 
 import mlrun.projects
-from mlrun.__main__ import load_notification
+from mlrun.__main__ import load_notification, main
 from mlrun.artifacts.plots import PlotArtifact
 from mlrun.lists import ArtifactList
 
@@ -76,3 +80,48 @@ def generate_artifact(name, uid=None, kind=None):
         artifact["metadata"]["uid"] = uid
 
     return artifact
+
+
+@pytest.mark.parametrize(
+    "project",
+    [None, "my-project"],
+)
+def test_cli_load_source_success(project):
+    # Test load-source CLI with and without an explicit project
+    runner = CliRunner()
+    source_uri = "store://artifacts/my-project/handler.py"
+
+    cli_args = ["load-source", "--source-uri", source_uri]
+    if project:
+        cli_args.extend(["--project", project])
+
+    with unittest.mock.patch(
+        "mlrun.__main__.load_source_code",
+        return_value="/home/mlrun_code/handler.py",
+    ) as mock_load:
+        result = runner.invoke(main, cli_args)
+
+    assert result.exit_code == 0
+    assert "Successfully loaded source to:" in result.output
+    mock_load.assert_called_once_with(
+        source_uri=source_uri,
+        target_dir="/home/mlrun_code",
+        project=project,
+    )
+
+
+def test_cli_load_source_failure():
+    # Test that CLI properly reports errors and exits with code 1
+    runner = CliRunner()
+
+    with unittest.mock.patch(
+        "mlrun.__main__.load_source_code",
+        side_effect=ValueError("Artifact not found"),
+    ):
+        result = runner.invoke(
+            main,
+            ["load-source", "--source-uri", "store://artifacts/project/file.py"],
+        )
+
+    assert result.exit_code == 1
+    assert "Error loading source:" in result.output

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest.mock
 
 import pytest
 
+import mlrun.datastore
 import mlrun.utils.clones
 
 
@@ -63,3 +65,99 @@ def test_add_credentials_git_remote_url(url, secrets, enriched):
         assert url == resolved_url
     assert secrets.get("GIT_TOKEN", "") in resolved_url
     assert enriched is url_enriched
+
+
+@pytest.mark.parametrize("project", [None, "my-project"])
+def test_load_source_code_success(tmp_path, project):
+    source_uri = "store://artifacts/my-project/handler.py"
+    target_dir = str(tmp_path / "target")
+    artifact_target_path = "s3://bucket/artifacts/handler.py"
+
+    mock_artifact = unittest.mock.MagicMock()
+    mock_artifact.get_target_path.return_value = artifact_target_path
+    mock_dataitem = unittest.mock.MagicMock()
+
+    with (
+        unittest.mock.patch.object(mlrun.datastore, "is_store_uri", return_value=True),
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=mock_artifact
+        ) as mock_get_resource,
+        unittest.mock.patch(
+            "mlrun.get_dataitem", return_value=mock_dataitem
+        ) as mock_get_dataitem,
+    ):
+        result = mlrun.utils.clones.load_source_code(
+            source_uri=source_uri,
+            target_dir=target_dir,
+            project=project,
+        )
+
+    expected_path = os.path.join(target_dir, "handler.py")
+
+    # Assert returned path is under target_dir
+    assert result == expected_path
+    assert result.startswith(target_dir)
+
+    # Assert directory was actually created
+    assert os.path.isdir(target_dir)
+
+    mock_get_resource.assert_called_once_with(source_uri, project=project)
+
+    # Assert get_dataitem is called with the artifact's target path
+    mock_get_dataitem.assert_called_once_with(artifact_target_path)
+
+    # Assert download is called with the local destination path
+    mock_dataitem.download.assert_called_once_with(expected_path)
+
+
+@pytest.mark.parametrize(
+    "source_uri,target_dir,is_store_uri_return,artifact_target_path,error_match",
+    [
+        # Missing source_uri
+        ("", "/tmp/target", True, "s3://path", "source_uri is required"),
+        # Missing target_dir
+        (
+            "store://artifacts/project/file.py",
+            "",
+            True,
+            "s3://path",
+            "target_dir is required",
+        ),
+        # Invalid store URI
+        (
+            "http://not-a-store/file.py",
+            "/tmp/target",
+            False,
+            "s3://path",
+            "must be a store artifact URI",
+        ),
+        # Artifact without target path
+        (
+            "store://artifacts/project/file.py",
+            "/tmp/target",
+            True,
+            None,
+            "does not have a valid target path",
+        ),
+    ],
+)
+def test_load_source_code_failures(
+    source_uri, target_dir, is_store_uri_return, artifact_target_path, error_match
+):
+    # Test various failure scenarios for load_source_code
+    mock_artifact = unittest.mock.MagicMock()
+    mock_artifact.get_target_path.return_value = artifact_target_path
+
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "is_store_uri", return_value=is_store_uri_return
+        ),
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=mock_artifact
+        ),
+    ):
+        with pytest.raises(ValueError, match=error_match):
+            mlrun.utils.clones.load_source_code(
+                source_uri=source_uri,
+                target_dir=target_dir,
+            )

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -69,7 +69,8 @@ def test_add_credentials_git_remote_url(url, secrets, enriched):
 
 @pytest.mark.parametrize("project", [None, "my-project"])
 def test_load_source_code_success(tmp_path, project):
-    source_uri = "store://artifacts/my-project/handler.py"
+    project_name = project or "my-project"
+    source_uri = f"store://artifacts/{project_name}/handler.py"
     target_dir = str(tmp_path / "target")
     artifact_target_path = "s3://bucket/artifacts/handler.py"
 


### PR DESCRIPTION
### 📝 Description
This PR introduces support for loading single-file artifacts, forming the first part of the Application Runtime’s single-file support and pull-at-runtime feature. 

It enables the MLRun CLI to download a single artifact from the artifact store into a specified target directory. 
This ensures that single-file artifacts are correctly materialized on a shared volume, allowing application runtimes and sidecars to initialize with the required source code.

---

### 🛠️ Changes Made
Added `mlrun load-source` CLI command with options for --project, --source-uri, and --target.

Example Usage:
`mlrun load-source store://artifacts/my-project/handler.py -t /tmp/my_code`

Implemented `load_source_code` function to:

- Validate the store URI and required parameters.
- Download a single-file artifact from the MLRun artifact store.
- Ensure the target directory exists.
- Return the full path to the downloaded file.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
Unit tests covering :

- Successful loading of artifacts with and without a project.
- Validation errors for missing or invalid parameters.
- Assertions for correct artifact resolution, directory creation, and file download.

Tested on vmdev:
1) After logging an artifact :

```
$ mlrun load-source 'store://artifacts/my-proj/my_artifact#0@4be5629d-a115-4d78-a6d9-7738ab909ffd^702fe0fa5c0e0e1acff5f839978db6fe1d06d67a' --target /tmp/mlrun_code

Successfully loaded source to: /tmp/mlrun_code/my_artifact.txt
```

2) Invalid artifact store :
```
$ mlrun load-source 'https://example/file.py' --target /tmp/mlrun_code

Error loading source: source_uri must be a store artifact URI (store://...), got: https://example/file.py
```

3) Artifact uri does not exist :
```
$ mlrun load-source 'store://artifacts/my-proj/wrong_uri' --target /tmp/mlrun_code

Error loading source: read artifact my-proj/wrong_uri details: MLRunNotFoundError('Artifact my-proj/wrong_uri#0:latest not found'), caused by: 404 Client Error: Not Found for url: http://mlrun-api:8080/api/v2/projects/my-proj/artifacts/wrong_uri?format=full&tag=latest&iter=0
```


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11952
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
