### PR TITLE
[Developer] Add support for optional local agent configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -68,3 +68,4 @@ kubeconfig*
 # AI markdown files
 CLAUDE.md
 AGENTS.md
+AGENTS.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ tests/coverage_reports/*.html
 mlrun.env
 **/mlrun.env
 tests/system/mlrun.env
+AGENTS.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,2 @@
 @AGENTS.md
+@?AGENTS.local.md


### PR DESCRIPTION
## Summary
Add AGENTS.local.md as an optional include in CLAUDE.md for local/personal agent configuration that won't be committed to the repository.

## Changes Made
- Add @?AGENTS.local.md optional include syntax to CLAUDE.md
- Add AGENTS.local.md to .gitignore

## Testing
N/A - configuration only

## Breaking Changes
- No