### PR TITLE
[SDK] Fix project enrichment after save

### DIFF
--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -325,7 +325,7 @@ class NopDB(RunDBInterface):
         self, project: mlrun.common.schemas.Project | dict
     ) -> mlrun.common.schemas.Project:
         if isinstance(project, dict):
-            project = mlrun.common.schemas.Project(**project)
+            project = mlrun.projects.MlrunProject.from_dict(project)
         return project
 
     def store_project(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3765,11 +3765,14 @@ class MlrunProject(ModelObj):
         :store: if True, allow updating in case project already exists
         """
         self.export(filepath)
-        project = self.save_to_db(store)
+        project: MlrunProject = self.save_to_db(store)
+
+        # Update this object with the enriched project returned by the API,
+        # without losing runtime-only fields that aren't serialized (e.g. `spec.context`).
         self._enrich(project)
         return self
 
-    def save_to_db(self, store=True):
+    def save_to_db(self, store=True) -> "MlrunProject":
         """save project to database
 
         :store: if True, allow updating in case project already exists

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3766,7 +3766,7 @@ class MlrunProject(ModelObj):
         """
         self.export(filepath)
         project = self.save_to_db(store)
-        self.__dict__.update(project.__dict__)
+        self._enrich(project)
         return self
 
     def save_to_db(self, store=True):
@@ -5834,6 +5834,51 @@ class MlrunProject(ModelObj):
 
     def _resolve_artifact_owner(self):
         return os.getenv("V3IO_USERNAME") or self.spec.owner
+
+    def _enrich(self, other: "MlrunProject"):
+        """
+        Enrich this project in-place using values from another project object.
+
+        The enrichment is performed for the fields listed in `self._dict_fields`:
+        `kind`, `metadata`, `spec`, and `status`.
+
+        - For string fields (currently `kind`), the value is overwritten from `other`.
+        - For object fields (e.g. `metadata`, `spec`, `status`), this performs a shallow
+          merge between the dict representations of both objects (using dict union),
+          preferring values from `other` on key collisions.
+
+        Note that this method mutates the underlying private objects (`self._metadata`,
+        `self._spec`, `self._status`) by setting attributes per merged key.
+
+        :param other: Project object providing the desired values to merge into `self`.
+        """
+        for field in self._dict_fields:
+            current_value = getattr(self, field, None)
+            other_value = getattr(other, field, None)
+
+            # Enrichment is additive: if `other` doesn't provide a value, keep the current one as-is.
+            if other_value is None:
+                continue
+
+            if isinstance(current_value, str):
+                setattr(self, field, other_value)
+                continue
+
+            # If current value is missing, we can safely take the other value as-is (there is nothing to preserve).
+            if current_value is None:
+                setattr(self, field, other_value)
+                continue
+
+            # We intentionally do NOT replace the whole object (e.g. `self.spec = other.spec`) because
+            # some values are not serialized and can be lost during assignment (e.g. `spec.context`).
+            # A shallow merge of the known fields preserves existing runtime-only values on `self`.
+            current_dict = current_value.to_dict()
+            other_dict = other_value.to_dict()
+            merged_dict = current_dict | other_dict
+
+            target_object = getattr(self, f"_{field}")
+            for key, value in merged_dict.items():
+                setattr(target_object, key, value)
 
 
 def _set_as_current_active_project(project: MlrunProject):

--- a/tests/artifacts/conftest.py
+++ b/tests/artifacts/conftest.py
@@ -1,0 +1,43 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+import typing
+
+import pytest
+
+import mlrun
+
+
+@pytest.fixture
+def new_project_factory(
+    tmp_path: pathlib.Path,
+) -> typing.Callable[..., mlrun.projects.project.MlrunProject]:
+    """
+    Create MLRun projects with an isolated filesystem context.
+
+    This prevents test contamination from using the default project context ("./"),
+    which depends on the current working directory and may leak state between tests.
+    """
+
+    def _new_project(name: str, **kwargs) -> mlrun.projects.project.MlrunProject:
+        # only set context if it is not already set
+        context = kwargs.pop("context", None)
+        if context is None:
+            context_path = tmp_path / "projects" / name
+            context_path.mkdir(parents=True, exist_ok=True)
+            context = context_path.as_posix()
+        return mlrun.new_project(name, context=context, **kwargs)
+
+    return _new_project

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -88,7 +88,7 @@ def test_extend_artifact_path():
         assert extend_artifact_path(test, "yz") == expected[i]
 
 
-def test_model_artifact_validators():
+def test_model_artifact_validators(new_project_factory):
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
         match="Arguments 'model_file' and 'model_url' cannot be"
@@ -108,7 +108,7 @@ def test_model_artifact_validators():
             body=b"dummy_model_content",
             model_url="http://localhost:8080/v2/models/mymodel/infer",
         )
-    project = mlrun.new_project("test-project", save=False)
+    project = new_project_factory("test-project", save=False)
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
         match="log_artifact of ModelArtifact does not accept arguments for both upload and model_url parameters",
@@ -432,8 +432,8 @@ def test_log_artifact_with_target_path_and_upload_options(
         ("artifact.key", does_not_raise()),
     ],
 )
-def test_log_artifact_with_invalid_key(artifact_key, expected):
-    project = mlrun.new_project("test-project")
+def test_log_artifact_with_invalid_key(artifact_key, expected, new_project_factory):
+    project = new_project_factory("test-project")
     target_path = "s3://some/path"
     artifact = mlrun.artifacts.Artifact(
         key=artifact_key, body="123", target_path=target_path
@@ -662,8 +662,8 @@ def test_resolve_body_hash_path(
         assert expected_target_path == target_path
 
 
-def test_inline_body():
-    project = mlrun.new_project("inline", save=False)
+def test_inline_body(new_project_factory):
+    project = new_project_factory("inline", save=False)
 
     # log an artifact and save the content/body in the object (inline)
     artifact = project.log_artifact(
@@ -680,9 +680,9 @@ def test_inline_body():
     assert artifact.metadata.key == "y"
 
 
-def test_register_artifacts(rundb_mock):
+def test_register_artifacts(rundb_mock, new_project_factory):
     project_name = "my-projects"
-    project = mlrun.new_project(project_name)
+    project = new_project_factory(project_name)
     artifact_key = "my-art"
     artifact_tag = "v1"
     project.set_artifact(
@@ -699,9 +699,9 @@ def test_register_artifacts(rundb_mock):
     assert artifact.tree == expected_tree
 
 
-def test_producer_in_exported_artifact():
+def test_producer_in_exported_artifact(new_project_factory):
     project_name = "my-project"
-    project = mlrun.new_project(project_name, save=False)
+    project = new_project_factory(project_name, save=False)
 
     artifact = project.log_artifact(
         "x", body="123", is_inline=True, artifact_path=results_dir

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -246,8 +246,8 @@ def test_log_dataset_with_column_overflow(monkeypatch, ensure_project):
     assert artifact.status.header_original_length == 6
 
 
-def test_create_dataset_non_existing_label():
-    project = mlrun.new_project("artifact-experiment", save=False)
+def test_create_dataset_non_existing_label(new_project_factory):
+    project = new_project_factory("artifact-experiment", save=False)
     df = pandas.DataFrame(
         {
             "column_1": [0, 1, 2, 3, 4],

--- a/tests/artifacts/test_model.py
+++ b/tests/artifacts/test_model.py
@@ -51,14 +51,14 @@ def test_model_target_paths(
     assert model.model_target_file == expected_model_target_file
 
 
-def test_tag_not_in_model_spec():
+def test_tag_not_in_model_spec(new_project_factory):
     model_name = "my-model"
     tag = "some-tag"
     project_name = "model-spec-test"
     artifact_path = results_dir / project_name
 
     # create a project and log a model
-    project = mlrun.new_project(project_name, save=False)
+    project = new_project_factory(project_name, save=False)
     project.log_model(
         model_name,
         body="model body",
@@ -100,8 +100,8 @@ def test_sanitize_model_spec():
     assert future_extra_data not in sanitized_model_spec["spec"]["extra_data"]
 
 
-def test_get_model_without_suffix():
-    project = mlrun.new_project("get-model-without-suffix")
+def test_get_model_without_suffix(new_project_factory):
+    project = new_project_factory("get-model-without-suffix")
     model_name = f"custom_suffix_model_{uuid.uuid4()}"
     for suffix in mlrun.artifacts.model.MODEL_OPTIONAL_SUFFIXES:
         file_name = f"model.{suffix}"
@@ -120,25 +120,24 @@ def test_get_model_without_suffix():
         assert data == b"123"
 
 
-def test_get_model_with_dataitem(rundb_mock, tmpdir: pathlib.Path):
+def test_get_model_with_dataitem(rundb_mock, new_project_factory):
     model_name = "my-model"
     tag = "some-tag"
     project_name = "get-model-with-data-item"
-    artifact_path = tmpdir / project_name
     body = "model body"
     file_name = "trained_model.pkl"
 
     # create a project and log a model
-    project = mlrun.new_project(project_name, save=False)
+    project = new_project_factory(project_name, save=False)
     model_artifact = project.log_model(
         model_name,
         body=body,
         model_file=file_name,
         tag=tag,
-        artifact_path=artifact_path,
+        artifact_path=project.context,
         upload=True,
     )
 
     model_dataitem = model_artifact.to_dataitem()
-    model_path, model_spec, _ = mlrun.artifacts.get_model(model_dataitem)
-    assert f"{artifact_path}/{model_name}/{file_name}" == model_path
+    model_path, _, _ = mlrun.artifacts.get_model(model_dataitem)
+    assert f"{project.context}/{model_name}/{file_name}" == model_path

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -528,7 +528,7 @@ class RunDBMock:
 
     def create_project(self, project):
         if isinstance(project, dict):
-            project = mlrun.common.schemas.Project(**project)
+            project = mlrun.projects.MlrunProject.from_dict(project)
         self._project = project
         self._project_name = project.metadata.name
         return self._project

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2661,3 +2661,54 @@ def test_with_secrets_azure_vault_allows_non_auth_secret(tmp_path, monkeypatch):
             "secrets": [],  # minimal valid payload for add_source
         },
     )
+
+
+def test_project_enrich():
+    base = mlrun.projects.project.MlrunProject(
+        metadata=mlrun.projects.project.ProjectMetadata(
+            name="p1",
+        ),
+        spec=mlrun.projects.project.ProjectSpec(
+            source="repo1",
+            params={"a": "1", "b": "2"},
+        ),
+    )
+    base.status = mlrun.projects.project.ProjectStatus(state="offline")
+    base.spec.context = "/somewhere"
+
+    other = mlrun.projects.project.MlrunProject(
+        metadata=mlrun.projects.project.ProjectMetadata(
+            name="p1",
+            labels={"b": "3"},
+            annotations={"y": "2"},
+        ),
+        spec=mlrun.projects.project.ProjectSpec(
+            source="repo1",
+            owner="bob",
+        ),
+    )
+    other.status = mlrun.projects.project.ProjectStatus(state="online")
+
+    base_metadata_id = id(base.metadata)
+    base_spec_id = id(base.spec)
+    base_status_id = id(base.status)
+
+    base._enrich(other)
+
+    # string overwrite
+    assert base.kind == "project"
+
+    # objects are mutated in-place (not replaced)
+    assert id(base.metadata) == base_metadata_id
+    assert id(base.spec) == base_spec_id
+    assert id(base.status) == base_status_id
+
+    # shallow merge semantics: dict-valued fields are replaced (not deep-merged)
+    assert base.metadata.labels == {"b": "3"}
+    assert base.metadata.annotations == {"y": "2"}
+    assert base.spec.params == {"a": "1", "b": "2"}
+    assert base.spec.context == "/somewhere"
+
+    # override precedence: other wins on collisions
+    assert base.spec.owner == "bob"
+    assert base.status.state == "online"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2712,3 +2712,42 @@ def test_project_enrich():
     # override precedence: other wins on collisions
     assert base.spec.owner == "bob"
     assert base.status.state == "online"
+
+
+def test_project_enrich_skips_none_fields():
+    """
+    Cover the additive enrichment behavior: if the incoming project doesn't provide a value
+    for a field (e.g. status=None), enrichment must not override the current value.
+
+    This specifically covers `MlrunProject._enrich()`:
+    `if other_value is None: continue`
+    """
+    base = mlrun.projects.project.MlrunProject(
+        metadata=mlrun.projects.project.ProjectMetadata(
+            name="p1",
+        ),
+        spec=mlrun.projects.project.ProjectSpec(
+            source="repo1",
+        ),
+    )
+    base.status = mlrun.projects.project.ProjectStatus(state="offline")
+    base_status_id = id(base.status)
+
+    other = mlrun.projects.project.MlrunProject(
+        metadata=mlrun.projects.project.ProjectMetadata(
+            name="p1",
+        ),
+        spec=mlrun.projects.project.ProjectSpec(
+            source="repo1",
+        ),
+    )
+    # `status=None` is normalized by the public setter into an empty ProjectStatus(),
+    # so to cover the exact "other_value is None" branch we set the private field directly.
+    other._status = None
+    assert other.status is None
+
+    base._enrich(other)
+
+    # `other` didn't provide status, so base.status should be preserved (same object, same state)
+    assert id(base.status) == base_status_id
+    assert base.status.state == "offline"

--- a/tests/system/projects/test_project.py
+++ b/tests/system/projects/test_project.py
@@ -512,7 +512,6 @@ class TestProject(TestMLRunSystem):
             "gen-iris",
             image="mlrun/mlrun",
             handler="iris_generator",
-            requirements=["requests"],
         )
         self._logger.debug("Set project function", project=project.to_yaml())
         run = project.run(
@@ -528,7 +527,7 @@ class TestProject(TestMLRunSystem):
         assert fn.status.state == "ready"
         assert fn.spec.image, "image path got cleared"
         for env in fn.spec.env:
-            if env["name"] in ["V3IO_ACCESS_KEY", "MLRUN_ATH_SESSION"]:
+            if env["name"] in ["V3IO_ACCESS_KEY", "MLRUN_AUTH_SESSION"]:
                 assert "valueFrom" in env, "content must be taken from secret"
                 # TODO: uncomment when we have system tests with full k8s access
                 # secret_name = env["valueFrom"]["secretKeyRef"]["name"]


### PR DESCRIPTION
### 📝 Description

This PR fixes project state handling after saving a project to the DB by replacing a raw `__dict__` update with a controlled in-place enrichment. The enrichment preserves runtime-only fields (e.g. `spec.context`) while still updating persisted fields returned from the DB.

---

### 🛠️ Changes Made

- Replace `self.__dict__.update(project.__dict__)` with `self._enrich(project)` after `save_to_db(...)`
- Add unit test for `_enrich` behavior (`tests/projects/test_project.py`)
- Minor system test alignment (`tests/system/projects/test_project.py`)

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- UT + failing system tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12014
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- `_enrich` is intentionally additive and avoids replacing `spec/metadata/status` objects to prevent losing runtime-only fields.