### PR TITLE
[Project] Fix Project Role Header Enrichment

### DIFF
--- a/server/py/framework/utils/clients/helpers.py
+++ b/server/py/framework/utils/clients/helpers.py
@@ -24,8 +24,7 @@ def enrich_headers(headers: dict | None = None, path: str | None = None) -> dict
     inject_context_id_header(headers)
 
     if (
-        mlrun.mlconf.httpdb.projects.leader == "mlrun"
-        and path is not None
+        path is not None
         and "projects" in path
         and mlrun.common.schemas.HeaderNames.projects_role not in headers
     ):

--- a/server/py/services/api/tests/unit/utils/clients/test_client_helpers.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_client_helpers.py
@@ -110,34 +110,15 @@ def test_enrich_headers_injects_context_id(set_context_id):
     assert result[mlrun.common.schemas.HeaderNames.igz_ctx] == context_id
 
 
-def test_enrich_headers_adds_projects_role_when_leader_is_mlrun(set_context_id):
+def test_enrich_headers_adds_projects_role(set_context_id):
+    """
+    Test that the projects role header is always added when the path contains "projects"
+    """
     set_context_id(None)
-    original_leader = mlrun.mlconf.httpdb.projects.leader
-    mlrun.mlconf.httpdb.projects.leader = "mlrun"
-
-    try:
-        result = clients_helpers.enrich_headers(
-            headers={}, path="/api/v1/projects/my-project"
-        )
-        assert result[mlrun.common.schemas.HeaderNames.projects_role] == "mlrun"
-    finally:
-        mlrun.mlconf.httpdb.projects.leader = original_leader
-
-
-def test_enrich_headers_does_not_add_projects_role_when_leader_is_not_mlrun(
-    set_context_id,
-):
-    set_context_id(None)
-    original_leader = mlrun.mlconf.httpdb.projects.leader
-    mlrun.mlconf.httpdb.projects.leader = "iguazio"
-
-    try:
-        result = clients_helpers.enrich_headers(
-            headers={}, path="/api/v1/projects/my-project"
-        )
-        assert mlrun.common.schemas.HeaderNames.projects_role not in result
-    finally:
-        mlrun.mlconf.httpdb.projects.leader = original_leader
+    result = clients_helpers.enrich_headers(
+        headers={}, path="/api/v1/projects/my-project"
+    )
+    assert result[mlrun.common.schemas.HeaderNames.projects_role] == "mlrun"
 
 
 def test_enrich_headers_does_not_add_projects_role_when_path_is_none(set_context_id):

--- a/server/py/services/api/tests/unit/utils/clients/test_client_helpers.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_client_helpers.py
@@ -118,74 +118,58 @@ def test_enrich_headers_adds_projects_role(set_context_id):
     result = clients_helpers.enrich_headers(
         headers={}, path="/api/v1/projects/my-project"
     )
-    assert result[mlrun.common.schemas.HeaderNames.projects_role] == "mlrun"
+    assert (
+        result[mlrun.common.schemas.HeaderNames.projects_role]
+        == mlrun.mlconf.httpdb.projects.leader
+    )
 
 
 def test_enrich_headers_does_not_add_projects_role_when_path_is_none(set_context_id):
     set_context_id(None)
-    original_leader = mlrun.mlconf.httpdb.projects.leader
-    mlrun.mlconf.httpdb.projects.leader = "mlrun"
-
-    try:
-        result = clients_helpers.enrich_headers(headers={}, path=None)
-        assert mlrun.common.schemas.HeaderNames.projects_role not in result
-    finally:
-        mlrun.mlconf.httpdb.projects.leader = original_leader
+    result = clients_helpers.enrich_headers(headers={}, path=None)
+    assert mlrun.common.schemas.HeaderNames.projects_role not in result
 
 
 def test_enrich_headers_does_not_add_projects_role_when_path_has_no_projects(
     set_context_id,
 ):
     set_context_id(None)
-    original_leader = mlrun.mlconf.httpdb.projects.leader
-    mlrun.mlconf.httpdb.projects.leader = "mlrun"
-
-    try:
-        result = clients_helpers.enrich_headers(
-            headers={}, path="/api/v1/functions/my-function"
-        )
-        assert mlrun.common.schemas.HeaderNames.projects_role not in result
-    finally:
-        mlrun.mlconf.httpdb.projects.leader = original_leader
+    result = clients_helpers.enrich_headers(
+        headers={}, path="/api/v1/functions/my-function"
+    )
+    assert mlrun.common.schemas.HeaderNames.projects_role not in result
 
 
 def test_enrich_headers_does_not_override_existing_projects_role(set_context_id):
     set_context_id(None)
-    original_leader = mlrun.mlconf.httpdb.projects.leader
-    mlrun.mlconf.httpdb.projects.leader = "mlrun"
     existing_role = "custom-role"
 
-    try:
-        result = clients_helpers.enrich_headers(
-            headers={mlrun.common.schemas.HeaderNames.projects_role: existing_role},
-            path="/api/v1/projects/my-project",
-        )
-        assert result[mlrun.common.schemas.HeaderNames.projects_role] == existing_role
-    finally:
-        mlrun.mlconf.httpdb.projects.leader = original_leader
+    result = clients_helpers.enrich_headers(
+        headers={mlrun.common.schemas.HeaderNames.projects_role: existing_role},
+        path="/api/v1/projects/my-project",
+    )
+    assert result[mlrun.common.schemas.HeaderNames.projects_role] == existing_role
 
 
 def test_enrich_headers_preserves_existing_headers(set_context_id):
     context_id = "test-context"
     set_context_id(context_id)
-    original_leader = mlrun.mlconf.httpdb.projects.leader
-    mlrun.mlconf.httpdb.projects.leader = "mlrun"
 
-    try:
-        headers = {
-            "Authorization": "Bearer token",
-            "X-Custom-Header": "custom-value",
-        }
-        result = clients_helpers.enrich_headers(
-            headers=headers, path="/api/v1/projects/my-project"
-        )
+    headers = {
+        "Authorization": "Bearer token",
+        "X-Custom-Header": "custom-value",
+    }
+    result = clients_helpers.enrich_headers(
+        headers=headers, path="/api/v1/projects/my-project"
+    )
 
-        # Should preserve existing headers
-        assert result["Authorization"] == "Bearer token"
-        assert result["X-Custom-Header"] == "custom-value"
-        # Should add context id
-        assert result[mlrun.common.schemas.HeaderNames.igz_ctx] == context_id
-        # Should add projects role
-        assert result[mlrun.common.schemas.HeaderNames.projects_role] == "mlrun"
-    finally:
-        mlrun.mlconf.httpdb.projects.leader = original_leader
+    # Should preserve existing headers
+    assert result["Authorization"] == "Bearer token"
+    assert result["X-Custom-Header"] == "custom-value"
+    # Should add context id
+    assert result[mlrun.common.schemas.HeaderNames.igz_ctx] == context_id
+    # Should add projects role
+    assert (
+        result[mlrun.common.schemas.HeaderNames.projects_role]
+        == mlrun.mlconf.httpdb.projects.leader
+    )


### PR DESCRIPTION
### 📝 Description
In https://github.com/mlrun/mlrun/pull/9233 the logic for enriching the project role header slightly changed accidentally. It was assumed the header was only relevant when MLRun is the leader, however also when IG3 is the leader, MLRun attaches this header to send requests to IG3 as the project leader. IG3 stopped getting this header and started returning responses in a malformed state. This PR simply returns the logic to how it was previously.

---

### 🛠️ Changes Made
- Remove the check of whether the project leader is MLRun from the project role header enrichment method

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Modified existing UTs of the project role header enrichment method
- Manual testing by patching a system and running the `tutorials/05-model-monitoring.ipynb` notebook

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12026

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

