### PR TITLE
[Auth] Remove IG4 Default Forbidden Service Accounts To Be Configured Specifically

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -284,11 +284,7 @@ default_config = {
             },
             "service_account": {
                 "default": None,
-                "forbidden_service_accounts": [
-                    "mlrun-api",
-                    "iguazio",
-                    "nuclio",
-                ],
+                "forbidden_service_accounts": "",
             },
             "state_thresholds": {
                 "default": {
@@ -1464,6 +1460,14 @@ class Config:
             or semver.VersionInfo.parse(self.nuclio_version)
             >= semver.VersionInfo.parse("1.12.10")
         )
+
+    def forbidden_service_accounts(self):
+        if self.function.spec.service_account.forbidden_service_accounts:
+            return self.function.spec.service_account.forbidden_service_accounts.split(
+                ","
+            )
+
+        return []
 
 
 # Global configuration

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1461,11 +1461,15 @@ class Config:
             >= semver.VersionInfo.parse("1.12.10")
         )
 
-    def forbidden_service_accounts(self):
-        if self.function.spec.service_account.forbidden_service_accounts:
-            return self.function.spec.service_account.forbidden_service_accounts.split(
-                ","
-            )
+    def default_forbidden_service_accounts(self):
+        forbidden_service_accounts_str = (
+            self.function.spec.service_account.forbidden_service_accounts
+        )
+        if forbidden_service_accounts_str:
+            return [
+                service_account.strip()
+                for service_account in forbidden_service_accounts_str.split(",")
+            ]
 
         return []
 

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -790,9 +790,7 @@ def resolve_project_service_account_details(
             for service_account in allowed_service_accounts.split(",")
         ]
 
-    forbidden_service_accounts = (
-        mlrun.mlconf.function.spec.service_account.forbidden_service_accounts[:]
-    )
+    forbidden_service_accounts = mlrun.mlconf.forbidden_service_accounts()
     forbidden_service_accounts_secret = (
         services.api.crud.secrets.Secrets().get_project_secret(
             project_name,

--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -790,7 +790,7 @@ def resolve_project_service_account_details(
             for service_account in allowed_service_accounts.split(",")
         ]
 
-    forbidden_service_accounts = mlrun.mlconf.forbidden_service_accounts()
+    forbidden_service_accounts = mlrun.mlconf.default_forbidden_service_accounts()
     forbidden_service_accounts_secret = (
         services.api.crud.secrets.Secrets().get_project_secret(
             project_name,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -736,6 +736,28 @@ def test_set_and_load_default_config():
         del os.environ["MLRUN_KFP_TTL"]
 
 
+@pytest.mark.parametrize(
+    "service_account_str, expected_service_accounts",
+    [
+        ("", []),
+        ("service-account-1", ["service-account-1"]),
+        (
+            "service-account-1,service-account-2, service-account-3 ",
+            ["service-account-1", "service-account-2", "service-account-3"],
+        ),
+    ],
+)
+def test_default_forbidden_service_account_config(
+    service_account_str, expected_service_accounts
+):
+    mlrun.mlconf.function.spec.service_account.forbidden_service_accounts = (
+        service_account_str
+    )
+    assert (
+        mlrun.mlconf.default_forbidden_service_accounts() == expected_service_accounts
+    )
+
+
 def _exec_mlrun(cmd, cwd=None):
     cmd = [sys.executable, "-m", "mlrun"] + cmd.split()
     out = subprocess.run(cmd, capture_output=True, cwd=cwd)


### PR DESCRIPTION
### 📝 Description
The Forbidden Service Accounts is mainly relevant for IG4 systems, not IG3 nor CE systems. Moreover there are some CE systems that use `mlrun-api` as the default function service account.
This PR removes the default forbidden list and makes the list readable from an env var as a comma delimited list

---

### 🛠️ Changes Made
- Removed default `forbidden_service_accounts`
- Converted `forbidden_service_accounts` to `str` instead of `list` and made a helper to return a split and stripped list

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- UTs
- Manual testing

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12047
- igzctl Config PR link: https://github.com/iguazio/mlefi/pull/329

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

