### PR TITLE
[Auth] Fix Service Account Configuration Validation Logic

### DIFF
--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -836,23 +836,9 @@ def resolve_project_service_account_details(
         default_service_account or mlrun.mlconf.function.spec.service_account.default
     )
 
-    # Sanity check on project configuration
-    if (
-        default_service_account
-        and (
-            allowed_service_accounts
-            and default_service_account not in allowed_service_accounts
-        )
-        or (
-            forbidden_service_accounts
-            and default_service_account in forbidden_service_accounts
-        )
-    ):
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            f"Default service account {default_service_account} is not in list of allowed "
-            + f"service accounts {allowed_service_accounts} or is in the list of forbidden service accounts "
-            + f"{forbidden_service_accounts}"
-        )
+    _validate_service_account_details(
+        default_service_account, allowed_service_accounts, forbidden_service_accounts
+    )
 
     return allowed_service_accounts, forbidden_service_accounts, default_service_account
 
@@ -1392,3 +1378,35 @@ async def _update_functions_with_deletion_info(functions, project, updates: dict
 
     tasks = [update_function(function) for function in functions]
     await asyncio.gather(*tasks)
+
+
+def _validate_service_account_details(
+    default_service_account: str,
+    allowed_service_accounts: typing.Optional[list[str]],
+    forbidden_service_accounts: typing.Optional[list[str]],
+):
+    """
+    Sanity check on project configuration.
+    Make sure the default service account is in the allowed list and not in the forbidden list if such lists exist.
+
+    :param default_service_account: The default service account name.
+    :param allowed_service_accounts: List of allowed service accounts.
+    :param forbidden_service_accounts: List of forbidden service accounts.
+
+    :raises MLRunInvalidArgumentError: In case of misconfiguration.
+    """
+    if default_service_account and (
+        (
+            allowed_service_accounts
+            and default_service_account not in allowed_service_accounts
+        )
+        or (
+            forbidden_service_accounts
+            and default_service_account in forbidden_service_accounts
+        )
+    ):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Default service account {default_service_account} is not in list of allowed "
+            + f"service accounts {allowed_service_accounts} or is in the list of forbidden service accounts "
+            + f"{forbidden_service_accounts}"
+        )

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -15,7 +15,9 @@
 import base64
 import json
 import pathlib
+import typing
 import unittest.mock
+from contextlib import nullcontext as does_not_raise
 from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2098,3 +2100,183 @@ def test_resolve_auth_secret_name(
         user_id="test-user",
         token_name=expected_token_name,
     )
+
+
+@pytest.mark.parametrize(
+    "allowed_secret, expected_allowed",
+    [
+        (None, None),
+        ("sa-allowed-1,sa-allowed-2", ["sa-allowed-1", "sa-allowed-2"]),
+    ],
+)
+@pytest.mark.parametrize(
+    "forbidden_secret, forbidden_conf, auth_info, expected_forbidden",
+    [
+        # No forbidden service accounts
+        (None, "", mlrun.common.schemas.AuthInfo(), []),
+        # Forbidden from conf only
+        (
+            [],
+            "sa-forbidden-1,sa-forbidden-2",
+            mlrun.common.schemas.AuthInfo(),
+            ["sa-forbidden-1", "sa-forbidden-2"],
+        ),
+        # Forbidden from secret only
+        (
+            "sa-forbidden-1,sa-forbidden-2",
+            "",
+            mlrun.common.schemas.AuthInfo(),
+            ["sa-forbidden-1", "sa-forbidden-2"],
+        ),
+        # Secret extends conf
+        (
+            "sa-forbidden-3,sa-forbidden-4",
+            "sa-forbidden-1,sa-forbidden-2",
+            mlrun.common.schemas.AuthInfo(),
+            ["sa-forbidden-1", "sa-forbidden-2", "sa-forbidden-3", "sa-forbidden-4"],
+        ),
+        # filter out auth info service accounts
+        (
+            "sa-forbidden-1,sa-forbidden-2",
+            "",
+            mlrun.common.schemas.AuthInfo(
+                username="sa-forbidden-1",
+                kind=mlrun.common.schemas.AuthInfoKind.service_account,
+            ),
+            ["sa-forbidden-2"],
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "default_secret, default_conf, expected_default",
+    [
+        # Default from conf
+        (
+            None,
+            "sa-default-conf",
+            "sa-default-conf",
+        ),
+        # Default from secret
+        (
+            "sa-default-secret",
+            "",
+            "sa-default-secret",
+        ),
+        # Secret overrides conf
+        (
+            "sa-default-secret",
+            "sa-default-conf",
+            "sa-default-secret",
+        ),
+        # No default
+        (
+            None,
+            "",
+            "",
+        ),
+    ],
+)
+def test_resolve_project_service_account_details(
+    allowed_secret: list[str],
+    expected_allowed: list[str],
+    forbidden_secret: list[str],
+    forbidden_conf: str,
+    auth_info: mlrun.common.schemas.AuthInfo,
+    expected_forbidden: list[str],
+    default_secret: str,
+    default_conf: str,
+    expected_default: str,
+):
+    mlrun.mlconf.function.spec.service_account.forbidden_service_accounts = (
+        forbidden_conf
+    )
+    mlrun.mlconf.function.spec.service_account.default = default_conf
+
+    def _mock_generate_client_project_secret_key(_, name):
+        return name
+
+    def _mock_get_project_secret(
+        project: str,
+        provider: mlrun.common.schemas.SecretProviderName,
+        secret_key: str,
+        token: typing.Optional[str] = None,
+        allow_secrets_from_k8s: bool = False,
+        allow_internal_secrets: bool = False,
+        key_map_secret_key: typing.Optional[str] = None,
+    ):
+        return {
+            "allowed": allowed_secret,
+            "forbidden": forbidden_secret,
+            "default": default_secret,
+        }[secret_key]
+
+    mock_secrets_crud = unittest.mock.Mock()
+    mock_secrets_crud.generate_client_project_secret_key = (
+        _mock_generate_client_project_secret_key
+    )
+    mock_secrets_crud.get_project_secret = _mock_get_project_secret
+
+    # logic from _validate_service_account_details, to determine if we expect an exception,
+    # this is tested in a separate test below: test_test_resolve_project_service_account_details_validity
+    expectation = does_not_raise()
+    if expected_default and (
+        (expected_allowed and expected_default not in expected_allowed)
+        or (expected_forbidden and expected_default in expected_forbidden)
+    ):
+        expectation = pytest.raises(mlrun.errors.MLRunInvalidArgumentError)
+
+    with patch(
+        "services.api.crud.secrets.Secrets",
+        return_value=mock_secrets_crud,
+    ):
+        with expectation:
+            (
+                resolved_allowed,
+                resolved_forbidden,
+                resolved_default,
+            ) = framework.api.utils.resolve_project_service_account_details(
+                project_name="test-project",
+                auth_info=auth_info,
+            )
+
+            assert resolved_allowed == expected_allowed
+            assert resolved_forbidden == expected_forbidden
+            assert resolved_default == expected_default
+
+
+@pytest.mark.parametrize(
+    "allowed, forbidden, default, expectation",
+    [
+        # Empty values (should pass)
+        ([], [], "", does_not_raise()),
+        # Empty lists, default set (should pass)
+        ([], [], "sa-default", does_not_raise()),
+        # Default in allowed (should pass)
+        (["sa-1", "sa-default"], [], "sa-default", does_not_raise()),
+        # Default not in forbidden (should pass)
+        ([], ["sa-2", "sa-3"], "sa-default", does_not_raise()),
+        # Default not in allowed (should raise)
+        (
+            ["sa-1", "sa-2"],
+            [],
+            "sa-default",
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+        # Default in forbidden (should raise)
+        (
+            [],
+            ["sa-default", "sa-2"],
+            "sa-default",
+            pytest.raises(mlrun.errors.MLRunInvalidArgumentError),
+        ),
+    ],
+)
+def test_test_resolve_project_service_account_details_validity(
+    allowed, forbidden, default, expectation
+):
+    with expectation:
+        framework.api.utils._validate_service_account_details(
+            allowed_service_accounts=allowed,
+            forbidden_service_accounts=forbidden,
+            default_service_account=default,
+        )

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -2249,6 +2249,7 @@ def test_resolve_project_service_account_details(
     [
         # Empty values (should pass)
         ([], [], "", does_not_raise()),
+        ([], [], None, does_not_raise()),
         # Empty lists, default set (should pass)
         ([], [], "sa-default", does_not_raise()),
         # Default in allowed (should pass)


### PR DESCRIPTION
### 📝 Description
The logic was written incorrectly, so it missed some edge cases (The parenthesis of a compound `if` statement were in the wrong place). This PR separates this check from the main method to enhance testability and maintainability while fixing the logic.

---

### 🛠️ Changes Made
- Moved the service account configuration validation logic to a separate method
- Fixed the logic in the separate method
- Added extensive unit testing for all edge cases

---

### ✅ Checklist
- [x] I have tested the changes in this PR

---

### 🧪 Testing
- Added extensive unit testing to the logic

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-1258
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

