### PR TITLE
[Authz] Fix attaching resources

### DIFF
--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -71,3 +71,4 @@ class ClientSpec(pydantic.v1.BaseModel):
     # Iguazio V4 OAuth token provider configuration
     oauth_internal_token_endpoint: typing.Optional[str]
     oauth_external_token_endpoint: typing.Optional[str]
+    authorization_namespaces_resources: typing.Optional[str]

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -643,6 +643,11 @@ class HTTPRunDB(RunDBInterface):
                 or config.httpdb.authentication.mode
             )
 
+            config.httpdb.authorization.namespaces.resources = (
+                server_cfg.get("authorization_namespaces_resources")
+                or config.httpdb.authorization.namespaces.resources
+            )
+
             # Iguazio V4 OAuth token config auto-initialization
             if (
                 config.httpdb.authentication.mode

--- a/mlrun/feature_store/common.py
+++ b/mlrun/feature_store/common.py
@@ -15,6 +15,7 @@ import typing
 from copy import copy
 
 import mlrun
+import mlrun.common.schemas
 import mlrun.errors
 from mlrun.common.schemas import AuthorizationVerificationInput
 from mlrun.runtimes import BaseRuntime

--- a/mlrun/feature_store/feature_set.py
+++ b/mlrun/feature_store/feature_set.py
@@ -19,6 +19,7 @@ from storey import EmitEveryEvent, EmitPolicy
 
 import mlrun
 import mlrun.common.schemas
+import mlrun.feature_store.api
 
 from ..config import config as mlconf
 from ..data_types import InferOptions

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -137,6 +137,9 @@ class ClientSpec(
             authentication_mode=self._get_config_value_if_not_default(
                 "httpdb.authentication.mode"
             ),
+            authorization_namespaces_resources=self._get_config_value_if_not_default(
+                "httpdb.authorization.namespaces.resources"
+            ),
             oauth_internal_token_endpoint=oauth_internal_token_endpoint,
             oauth_external_token_endpoint=oauth_external_token_endpoint,
         )


### PR DESCRIPTION
### 📝 Description

This PR fixes the SDK authorization verification issue in IG4 environments by syncing the `authorization_namespaces_resources` configuration from the server to the client.

When the SDK performs authorization checks (e.g., during `FeatureSet.ingest()` → `purge_targets()` → `verify_feature_set_permissions()`), it needs to construct the correct resource path with the proper namespace prefix. Without syncing this config from the server, the SDK uses a different resource path than the server expects, causing authorization failures.

---

### 🛠️ Changes Made

- Added `authorization_namespaces_resources` field to `ClientSpec` schema
- Server now exposes `authorization_namespaces_resources` in the client-spec endpoint
- SDK syncs this config from server during `connect()` 
- Fixed missing imports in feature store modules

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Manual testing against IG4 environment
- Verified that `FeatureSet.ingest()` authorization checks work correctly after the fix

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11986
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

This fix works in conjunction with the group type fix (PR #9242) which ensures user group IDs are properly extracted from IG4 authentication responses. Both fixes are required for proper authorization in IG4 environments.