### PR TITLE
Update token to use GitHub token instead of PAT

### DIFF
--- a/.github/workflows/upgrade-lock.yaml
+++ b/.github/workflows/upgrade-lock.yaml
@@ -57,4 +57,4 @@ jobs:
         # See:
         # https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#token
         # Fine-grained Personal Access Token (PAT) with contents: write and pull-requests: write scopes.
-        token: ${{ secrets.MLRUN_PR_PAT }}
+        token: ${{ github.token }}

--- a/.github/workflows/upgrade-lock.yaml
+++ b/.github/workflows/upgrade-lock.yaml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/create-github-app-token@v2
       id: app-token
       with:
-        app-id: ${{ vars.GH_APP_ID }}
+        app-id: ${{ secrets.GH_APP_ID }}
         private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
         
     - uses: actions/checkout@v6

--- a/.github/workflows/upgrade-lock.yaml
+++ b/.github/workflows/upgrade-lock.yaml
@@ -30,6 +30,9 @@ jobs:
     if: github.repository_owner == 'mlrun'
     steps:
     - uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.MLRUN_PR_PAT }}
+        persist-credentials: false
 
     - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # 7.2.1
 

--- a/.github/workflows/upgrade-lock.yaml
+++ b/.github/workflows/upgrade-lock.yaml
@@ -29,10 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'mlrun'
     steps:
+    - uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ vars.GH_APP_ID }}
+        private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        
     - uses: actions/checkout@v6
       with:
-        token: ${{ secrets.MLRUN_PR_PAT }}
-        persist-credentials: false
+        token: ${{ steps.app-token.outputs.token }}
 
     - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # 7.2.1
 
@@ -47,6 +52,7 @@ jobs:
         else
           echo "title=[Requirements-automated] Upgrade lock files" >> "$GITHUB_OUTPUT"
         fi
+        
     - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # 8.1.0
       with:
         title: ${{ steps.format-title.outputs.title }}
@@ -57,7 +63,3 @@ jobs:
         commit-message: Upgrade uv lock files
         branch: "automated/uv-lock-upgrade-${{ github.ref_name }}"
         delete-branch: true
-        # See:
-        # https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#token
-        # Fine-grained Personal Access Token (PAT) with contents: write and pull-requests: write scopes.
-        token: ${{ github.token }}

--- a/.github/workflows/upgrade-lock.yaml
+++ b/.github/workflows/upgrade-lock.yaml
@@ -38,6 +38,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         token: ${{ steps.app-token.outputs.token }}
+        persist-credentials: false
 
     - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # 7.2.1
 
@@ -63,3 +64,4 @@ jobs:
         commit-message: Upgrade uv lock files
         branch: "automated/uv-lock-upgrade-${{ github.ref_name }}"
         delete-branch: true
+        token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration, changing the authentication token used for creating pull requests in the `upgrade-lock.yaml` GitHub Actions workflow.

- Updated the workflow to use the built-in `github.token` instead of the custom secret `MLRUN_PR_PAT` for authentication when creating pull requests.