### PR TITLE
[Serving] Add a basic API handler option to the graph

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -229,7 +229,12 @@ from .secret import (
     SecretTokenInfo,
     StoreSecretTokensResponse,
 )
-from .serving import ModelRunnerStepData, ModelsData, MonitoringData
+from .serving import (
+    APIHandlerAction,
+    ModelRunnerStepData,
+    ModelsData,
+    MonitoringData,
+)
 from .tag import Tag, TagObjects
 from .workflow import (
     GetWorkflowResponse,

--- a/mlrun/common/schemas/serving.py
+++ b/mlrun/common/schemas/serving.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import enum
+from enum import Enum, StrEnum
 
 from pydantic.v1 import BaseModel
-
-from mlrun.common.types import StrEnum
 
 from .background_task import BackgroundTaskList
 
@@ -44,9 +42,16 @@ class MonitoringData(StrEnum):
     MODEL_CLASS = "model_class"
 
 
-class ModelsData(enum.Enum):
+class ModelsData(Enum):
     MODEL_CLASS = 0
     MODEL_PARAMETERS = 1
 
 
 MAX_BATCH_JOB_DURATION = "1w"
+
+
+class APIHandlerAction(StrEnum):
+    """Supported API handler actions for serving endpoints"""
+
+    ALLOW = "allow"
+    FORBID = "forbid"

--- a/mlrun/common/schemas/serving.py
+++ b/mlrun/common/schemas/serving.py
@@ -55,3 +55,10 @@ class APIHandlerAction(StrEnum):
 
     ALLOW = "allow"
     FORBID = "forbid"
+
+
+class _APIEndpointKeys(StrEnum):
+    """Private enum for endpoint configuration dictionary keys"""
+
+    ACTION = "action"
+    DESCRIPTION = "description"

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -30,6 +30,7 @@ import mlrun.runtimes.kubejob as kubejob_runtime
 import mlrun.runtimes.nuclio.function as nuclio_function
 import mlrun.runtimes.pod as pod_runtime
 import mlrun.serving.utils as serving_utils
+from mlrun.common.schemas.serving import _APIEndpointKeys
 from mlrun.datastore import get_kafka_brokers_from_dict, parse_kafka_url
 from mlrun.model import ObjectList
 from mlrun.runtimes.function_reference import FunctionReference
@@ -76,8 +77,10 @@ class APIHandlerConfig(mlrun.model.ModelObj):
             self.add_endpoint_handler(
                 path=path,
                 http_method=method,
-                action=schemas.serving.APIHandlerAction(config.get("action")),
-                description=config.get("description"),
+                action=schemas.serving.APIHandlerAction(
+                    config.get(_APIEndpointKeys.ACTION)
+                ),
+                description=config.get(_APIEndpointKeys.DESCRIPTION),
             )
 
     def _parse_endpoint_key(self, endpoint_key: str) -> tuple[HTTPMethod, str]:
@@ -116,13 +119,13 @@ class APIHandlerConfig(mlrun.model.ModelObj):
                 "Overriding existing endpoint handler configuration",
                 method=http_method.value,
                 path=path,
-                old_action=self._endpoints[endpoint_key].get("action"),
+                old_action=self._endpoints[endpoint_key].get(_APIEndpointKeys.ACTION),
                 new_action=str(action),
             )
 
         self._endpoints[endpoint_key] = {
-            "action": str(action),
-            "description": description,
+            _APIEndpointKeys.ACTION: str(action),
+            _APIEndpointKeys.DESCRIPTION: description,
         }
 
     def remove_endpoint_handler(

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -15,6 +15,7 @@ import json
 import os
 from base64 import b64decode
 from copy import deepcopy
+from http import HTTPMethod
 from typing import Optional, Union
 
 import nuclio
@@ -28,6 +29,7 @@ import mlrun.datastore.datastore_profile as ds_profile
 import mlrun.runtimes.kubejob as kubejob_runtime
 import mlrun.runtimes.nuclio.function as nuclio_function
 import mlrun.runtimes.pod as pod_runtime
+import mlrun.serving.utils as serving_utils
 from mlrun.datastore import get_kafka_brokers_from_dict, parse_kafka_url
 from mlrun.model import ObjectList
 from mlrun.runtimes.function_reference import FunctionReference
@@ -49,6 +51,83 @@ from mlrun.serving.states import (
 from mlrun.utils import get_caller_globals, logger, merge_requirements, set_paths
 
 serving_subkind = "serving_v2"
+
+
+class APIHandlerConfig(mlrun.model.ModelObj):
+    """Configuration for API handler in serving graph"""
+
+    _dict_fields = ["enabled", "endpoints"]
+
+    def __init__(self, enabled: bool = True, endpoints: dict[str, dict] | None = None):
+        self.enabled = enabled
+        self._endpoints = endpoints or {}
+
+    @property
+    def endpoints(self) -> dict[str, dict]:
+        """Get the endpoints configuration as a dictionary."""
+        return self._endpoints
+
+    @endpoints.setter
+    def endpoints(self, endpoints: dict[str, dict]) -> None:
+        """Set the endpoints configuration from a dictionary."""
+        self._endpoints = {}
+        for endpoint_key, config in endpoints.items():
+            method, path = self._parse_endpoint_key(endpoint_key)
+            self.add_endpoint_handler(
+                path=path,
+                http_method=method,
+                action=schemas.serving.APIHandlerAction(config.get("action")),
+                description=config.get("description"),
+            )
+
+    def _parse_endpoint_key(self, endpoint_key: str) -> tuple[HTTPMethod, str]:
+        """Parse endpoint key 'METHOD:path' back to method and path components."""
+        try:
+            return serving_utils._split_serving_endpoint_key(endpoint_key)
+        except (ValueError, AttributeError) as e:
+            raise ValueError(
+                f"Invalid endpoint key format '{endpoint_key}'. Expected 'METHOD:path'"
+            ) from e
+
+    def get_endpoint_config(self, method: HTTPMethod, path: str) -> dict | None:
+        """Get endpoint configuration for a specific method and path."""
+        endpoint_key = serving_utils._combine_serving_endpoint_key(method, path)
+        return self._endpoints.get(endpoint_key)
+
+    def add_endpoint_handler(
+        self,
+        path: str,
+        http_method: HTTPMethod = HTTPMethod.POST,
+        action: schemas.serving.APIHandlerAction = schemas.serving.APIHandlerAction.ALLOW,
+        description: str | None = None,
+    ) -> None:
+        """Add an endpoint handler configuration.
+
+        Args:
+            path: URL path for the endpoint (e.g., '/v1/models')
+            http_method: HTTP method for the endpoint
+            action: Action to take for this endpoint
+            description: Optional description of the endpoint
+        """
+        endpoint_key = serving_utils._combine_serving_endpoint_key(http_method, path)
+        self._endpoints[endpoint_key] = {
+            "action": str(action),
+            "description": description,
+        }
+
+    def remove_endpoint_handler(
+        self,
+        path: str,
+        http_method: HTTPMethod = HTTPMethod.POST,
+    ) -> None:
+        """Remove an endpoint handler configuration.
+
+        Args:
+            path: URL path for the endpoint to remove
+            http_method: HTTP method for the endpoint to remove
+        """
+        endpoint_key = serving_utils._combine_serving_endpoint_key(http_method, path)
+        self._endpoints.pop(endpoint_key, None)
 
 
 def new_v2_model_server(
@@ -99,6 +178,7 @@ class ServingSpec(nuclio_function.NuclioSpec):
         "secret_sources",
         "track_models",
         "streaming",
+        "api_handler_config",
     ]
 
     def __init__(
@@ -157,6 +237,7 @@ class ServingSpec(nuclio_function.NuclioSpec):
         serving_spec=None,
         auth=None,
         streaming: Optional[bool] = None,
+        api_handler_config: APIHandlerConfig | None = None,
     ):
         super().__init__(
             command=command,
@@ -216,6 +297,11 @@ class ServingSpec(nuclio_function.NuclioSpec):
         self.default_content_type = default_content_type
         self.model_endpoint_creation_task_name = model_endpoint_creation_task_name
         self.streaming = streaming
+        self.api_handler_config = (
+            api_handler_config.to_dict()
+            if isinstance(api_handler_config, APIHandlerConfig)
+            else api_handler_config
+        )
 
     @property
     def graph(self) -> Union[RouterStep, RootFlowStep]:
@@ -815,6 +901,10 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
             "filename": getattr(self.spec, "filename", None),
         }
 
+        # Include API handler config if present
+        if self.spec.api_handler_config:
+            serving_spec["api_handler_config"] = self.spec.api_handler_config
+
         if self.spec.secret_sources:
             self._secrets = SecretsStore.from_list(self.spec.secret_sources)
             serving_spec["secret_sources"] = self._secrets.to_serial()
@@ -872,6 +962,7 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
             function_name=self.metadata.name,
             function_tag=self.metadata.tag,
             project=self.metadata.project,
+            api_handler_config=self.spec.api_handler_config,
             **kwargs,
         )
         server.init_states(
@@ -1063,3 +1154,34 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
                     reqs_secondary=step_requirements,
                 )
                 self.with_requirements(requirements=reqs_union, overwrite=True)
+
+    def set_api_handler_config(self, config: Union[APIHandlerConfig, dict]) -> None:
+        """Set the API handler configuration for the serving function.
+
+        Args:
+            config: APIHandlerConfig object or dictionary containing the configuration
+                   for handling different API endpoints and their actions.
+
+        Example::
+
+            # Using schemas.serving.APIHandlerConfig object
+            api_config = schemas.serving.APIHandlerConfig()
+            api_config.add_endpoint_handler(
+                "/v1/models", HTTPMethod.GET, APIHandlerAction.ALLOW
+            )
+            serving_fn.set_api_handler_config(api_config)
+
+            # Using dictionary
+            serving_fn.set_api_handler_config(
+                {"endpoints": {("GET", "/v1/models"): {"action": "allow"}}}
+            )
+        """
+        if isinstance(config, APIHandlerConfig):
+            config = config.to_dict()
+        elif not isinstance(config, dict):
+            raise ValueError(
+                f"config must be `APIHandlerConfig` or a `dict`, got {type(config)}"
+            )
+
+        # Store the configuration in the spec for serialization
+        self.spec.api_handler_config = config

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -109,6 +109,17 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         :param description: Optional description of the endpoint
         """
         endpoint_key = serving_utils._combine_serving_endpoint_key(http_method, path)
+
+        # Warn if overriding an existing endpoint
+        if endpoint_key in self._endpoints:
+            logger.warning(
+                "Overriding existing endpoint handler configuration",
+                method=http_method.value,
+                path=path,
+                old_action=self._endpoints[endpoint_key].get("action"),
+                new_action=str(action),
+            )
+
         self._endpoints[endpoint_key] = {
             "action": str(action),
             "description": description,

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -103,11 +103,10 @@ class APIHandlerConfig(mlrun.model.ModelObj):
     ) -> None:
         """Add an endpoint handler configuration.
 
-        Args:
-            path: URL path for the endpoint (e.g., '/v1/models')
-            http_method: HTTP method for the endpoint
-            action: Action to take for this endpoint
-            description: Optional description of the endpoint
+        :param path: URL path for the endpoint (e.g., '/v1/models')
+        :param http_method: HTTP method for the endpoint
+        :param action: Action to take for this endpoint (:py:class:`~mlrun.common.schemas.serving.APIHandlerAction`)
+        :param description: Optional description of the endpoint
         """
         endpoint_key = serving_utils._combine_serving_endpoint_key(http_method, path)
         self._endpoints[endpoint_key] = {
@@ -122,9 +121,8 @@ class APIHandlerConfig(mlrun.model.ModelObj):
     ) -> None:
         """Remove an endpoint handler configuration.
 
-        Args:
-            path: URL path for the endpoint to remove
-            http_method: HTTP method for the endpoint to remove
+        :param path: URL path for the endpoint to remove
+        :param http_method: HTTP method for the endpoint to remove
         """
         endpoint_key = serving_utils._combine_serving_endpoint_key(http_method, path)
         self._endpoints.pop(endpoint_key, None)
@@ -1025,12 +1023,9 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
     ) -> "kubejob_runtime.KubejobRuntime":
         """Convert this ServingRuntime to a KubejobRuntime, so that the graph can be run as a standalone job.
 
-        Args:
-            func_name: Optional custom name for the job function. If not provided, automatically
-                      appends '-batch' suffix to the serving function name to prevent database collision.
-
-        Returns:
-            KubejobRuntime configured to execute the serving graph as a batch job.
+        :param func_name: Optional custom name for the job function. If not provided, automatically
+                         appends '-batch' suffix to the serving function name to prevent database collision.
+        :return: KubejobRuntime configured to execute the serving graph as a batch job.
 
         Note:
             The job will have a different name than the serving function to prevent database collision.
@@ -1158,14 +1153,17 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
     def set_api_handler_config(self, config: Union[APIHandlerConfig, dict]) -> None:
         """Set the API handler configuration for the serving function.
 
-        Args:
-            config: APIHandlerConfig object or dictionary containing the configuration
-                   for handling different API endpoints and their actions.
+        :param config: :py:class:`~mlrun.runtimes.nuclio.serving.APIHandlerConfig` object or dictionary containing
+                      the configuration for handling different API endpoints and their actions.
 
         Example::
 
-            # Using schemas.serving.APIHandlerConfig object
-            api_config = schemas.serving.APIHandlerConfig()
+            # Using APIHandlerConfig object
+            from mlrun.runtimes.nuclio.serving import APIHandlerConfig
+            from mlrun.common.schemas.serving import APIHandlerAction
+            from http import HTTPMethod
+
+            api_config = APIHandlerConfig()
             api_config.add_endpoint_handler(
                 "/v1/models", HTTPMethod.GET, APIHandlerAction.ALLOW
             )

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -1187,7 +1187,17 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
         """
         if isinstance(config, APIHandlerConfig):
             config = config.to_dict()
-        elif not isinstance(config, dict):
+        elif isinstance(config, dict):
+            # Validate the dict by converting it to APIHandlerConfig and back
+            # This ensures it has the correct format
+            try:
+                validated_config = APIHandlerConfig.from_dict(config)
+                config = validated_config.to_dict()
+            except Exception as exc:
+                raise ValueError(
+                    f"Invalid API handler config dict format: {exc}"
+                ) from exc
+        else:
             raise ValueError(
                 f"config must be `APIHandlerConfig` or a `dict`, got {type(config)}"
             )

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -23,6 +23,7 @@ import mlrun.serving.server
 import mlrun.serving.states
 import mlrun.serving.utils as serving_utils
 import mlrun.utils
+from mlrun.common.schemas.serving import _APIEndpointKeys
 
 
 class _APIHandlerStep(mlrun.serving.states.TaskStep):
@@ -121,7 +122,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
 
             # Get endpoint definition
             endpoint_def = self.config._endpoints[matching_endpoint_key]
-            action = endpoint_def["action"]
+            action = endpoint_def[_APIEndpointKeys.ACTION]
 
             # Parse the endpoint key for logging
             matched_method, matched_path = self.config._parse_endpoint_key(

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -25,7 +25,7 @@ import mlrun.serving.utils as serving_utils
 import mlrun.utils
 
 
-class _APIHandlerStep(mlrun.serving.states.BaseStep):
+class _APIHandlerStep(mlrun.serving.states.TaskStep):
     """Private API handler step for routing and validating serving requests"""
 
     kind = "api_handler"

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""API Handler implementation for serving graphs"""
+
+from http import HTTPMethod
+
+import mlrun.common.schemas as schemas
+import mlrun.errors
+import mlrun.runtimes.nuclio.serving
+import mlrun.serving.server
+import mlrun.serving.states
+import mlrun.serving.utils as serving_utils
+import mlrun.utils
+
+
+class _APIHandlerStep(mlrun.serving.states.BaseStep):
+    """Private API handler step for routing and validating serving requests"""
+
+    kind = "api_handler"
+    default_shape = "diamond"
+
+    def __init__(
+        self,
+        config: mlrun.runtimes.nuclio.serving.APIHandlerConfig | dict | None = None,
+        name: str | None = None,
+        context: mlrun.serving.server.GraphContext | None = None,
+        **kwargs,
+    ):
+        # Filter kwargs to only pass what BaseStep expects
+        base_kwargs = {
+            k: v for k, v in kwargs.items() if k in ["after", "shape", "max_iterations"]
+        }
+        super().__init__(name=name or "api-handler", **base_kwargs)
+
+        if isinstance(config, dict):
+            self.config = mlrun.runtimes.nuclio.serving.APIHandlerConfig.from_dict(
+                config
+            )
+        elif isinstance(config, mlrun.runtimes.nuclio.serving.APIHandlerConfig):
+            self.config = config
+        else:
+            self.config = mlrun.runtimes.nuclio.serving.APIHandlerConfig()
+        self.context = context
+
+    def _init_class_object_and_handler(self, namespace, reset, **extra_kwargs):
+        """Initialize the class object and handler for the serving framework"""
+        mlrun.utils.logger.debug(
+            "_APIHandlerStep initializing",
+            name=self.name,
+            has_config=bool(self.config._endpoints),
+            context_available=bool(self.context),
+        )
+
+        # If no config was provided, try to get it from the function context
+        if not self.config._endpoints and hasattr(self, "context") and self.context:
+            mlrun.utils.logger.debug("Trying to get config from server context")
+            # Try to get API handler config from the serving server
+            if (
+                hasattr(self.context, "server")
+                and hasattr(self.context.server, "api_handler_config")
+                and self.context.server.api_handler_config
+            ):
+                mlrun.utils.logger.debug("Found API handler config in server context")
+                self.config = self.context.server.api_handler_config
+            else:
+                mlrun.utils.logger.debug(
+                    "No API handler config found in server context"
+                )
+
+        mlrun.utils.logger.debug(
+            "_APIHandlerStep initialization complete",
+            endpoints_count=len(self.config._endpoints),
+        )
+        self._object = self
+        self._handler = self.do  # Point to our do method
+
+    def do(self, event):
+        """Handler method expected by the serving framework"""
+        return self.run(event)
+
+    def _match_endpoint(self, method: HTTPMethod, path: str) -> str | None:
+        """Find matching endpoint key for the given method and path"""
+        # Only exact matches supported
+        endpoint_key = serving_utils._combine_serving_endpoint_key(method, path)
+        if endpoint_key in self.config._endpoints:
+            return endpoint_key
+
+        return None
+
+    def run(self, event, **kwargs):
+        """Handle incoming request and validate against configured endpoints"""
+        try:
+            # In MLRun serving framework, the actual event metadata is available in the context
+            # while the event parameter here is typically the body content
+            method = None
+            path = None
+
+            # Try to get event details from context if available
+            if hasattr(self, "context") and self.context:
+                # Check for current event stored in context
+                if hasattr(self.context, "current_event"):
+                    original_event = self.context.current_event
+                    method = getattr(original_event, "method", None)
+                    path = getattr(original_event, "path", None)
+                # Fallback to other context sources if needed
+                elif hasattr(self.context, "trigger") and hasattr(
+                    self.context.trigger, "headers"
+                ):
+                    headers = self.context.trigger.headers or {}
+                    method_str = headers.get("method")
+                    if method_str:
+                        method = HTTPMethod(method_str.upper())
+                    path = headers.get("path")
+
+            # Validate that we have both method and path
+            if method is None:
+                raise mlrun.errors.MLRunBadRequestError(
+                    "HTTP method not found in request context"
+                )
+            if path is None:
+                raise mlrun.errors.MLRunBadRequestError(
+                    "Request path not found in request context"
+                )
+
+            # Convert string method to HTTPMethod if needed
+            if isinstance(method, str):
+                try:
+                    method = HTTPMethod(method.upper())
+                except ValueError:
+                    raise mlrun.errors.MLRunBadRequestError(
+                        f"Unsupported HTTP method: {method}"
+                    )
+
+            mlrun.utils.logger.debug(
+                "API handler processing request",
+                method=method.value,
+                path=path,
+                endpoints_count=len(self.config._endpoints),
+            )
+
+            # Find matching endpoint
+            matching_endpoint_key = self._match_endpoint(method, path)
+
+            if not matching_endpoint_key:
+                # No matching endpoint found
+                mlrun.utils.logger.warning(
+                    "No matching endpoint found",
+                    method=method.value,
+                    path=path,
+                )
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"Endpoint not found: {method.value} {path}"
+                )
+
+            # Get endpoint definition
+            endpoint_def = self.config._endpoints[matching_endpoint_key]
+            action = endpoint_def["action"]
+
+            # Parse the endpoint key for logging
+            matched_method, matched_path = self.config._parse_endpoint_key(
+                matching_endpoint_key
+            )
+
+            mlrun.utils.logger.debug(
+                "Found matching endpoint",
+                method=method.value,
+                path=path,
+                matched_path=matched_path,
+                action=action,
+            )
+
+            # Handle the action
+            if action == schemas.APIHandlerAction.ALLOW:
+                # Pass the event to the next step in the graph
+                return event
+            elif action == schemas.APIHandlerAction.FORBID:
+                # Reject the request
+                raise mlrun.errors.MLRunBadRequestError(
+                    f"Access forbidden to {method.value} {path}"
+                )
+            else:
+                raise mlrun.errors.MLRunBadRequestError(f"Unknown action: {action}")
+
+        except Exception as exc:
+            # Log the error and re-raise
+            mlrun.utils.logger.error(
+                "API handler error",
+                error=str(exc),
+                method=getattr(event, "method", "unknown"),
+                path=getattr(event, "path", "unknown"),
+            )
+            raise

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -87,19 +87,6 @@ class _APIHandlerStep(mlrun.serving.states.BaseStep):
         self._handler = self.do  # Point to our do method
 
     def do(self, event):
-        """Handler method expected by the serving framework"""
-        return self.run(event)
-
-    def _match_endpoint(self, method: HTTPMethod, path: str) -> str | None:
-        """Find matching endpoint key for the given method and path"""
-        # Only exact matches supported
-        endpoint_key = serving_utils._combine_serving_endpoint_key(method, path)
-        if endpoint_key in self.config._endpoints:
-            return endpoint_key
-
-        return None
-
-    def run(self, event, **kwargs):
         """Handle incoming request and validate against configured endpoints"""
         try:
             # In MLRun serving framework, the actual event metadata is available in the context
@@ -202,3 +189,12 @@ class _APIHandlerStep(mlrun.serving.states.BaseStep):
                 path=getattr(event, "path", "unknown"),
             )
             raise
+
+    def _match_endpoint(self, method: HTTPMethod, path: str) -> str | None:
+        """Find matching endpoint key for the given method and path"""
+        # Only exact matches supported
+        endpoint_key = serving_utils._combine_serving_endpoint_key(method, path)
+        if endpoint_key in self.config._endpoints:
+            return endpoint_key
+
+        return None

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -54,38 +54,6 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
             self.config = mlrun.runtimes.nuclio.serving.APIHandlerConfig()
         self.context = context
 
-    def _init_class_object_and_handler(self, namespace, reset, **extra_kwargs):
-        """Initialize the class object and handler for the serving framework"""
-        mlrun.utils.logger.debug(
-            "_APIHandlerStep initializing",
-            name=self.name,
-            has_config=bool(self.config._endpoints),
-            context_available=bool(self.context),
-        )
-
-        # If no config was provided, try to get it from the function context
-        if not self.config._endpoints and hasattr(self, "context") and self.context:
-            mlrun.utils.logger.debug("Trying to get config from server context")
-            # Try to get API handler config from the serving server
-            if (
-                hasattr(self.context, "server")
-                and hasattr(self.context.server, "api_handler_config")
-                and self.context.server.api_handler_config
-            ):
-                mlrun.utils.logger.debug("Found API handler config in server context")
-                self.config = self.context.server.api_handler_config
-            else:
-                mlrun.utils.logger.debug(
-                    "No API handler config found in server context"
-                )
-
-        mlrun.utils.logger.debug(
-            "_APIHandlerStep initialization complete",
-            endpoints_count=len(self.config._endpoints),
-        )
-        self._object = self
-        self._handler = self.do  # Point to our do method
-
     def do(self, event):
         """Handle incoming request and validate against configured endpoints"""
         try:

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -26,6 +26,7 @@ import traceback
 import uuid
 from collections import defaultdict
 from datetime import UTC, datetime
+from http import HTTPMethod
 from typing import Any, Optional, Union
 
 import pandas as pd
@@ -38,7 +39,9 @@ import mlrun.common.helpers
 import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.datastore.datastore_profile as ds_profile
+import mlrun.errors
 import mlrun.model_monitoring
+import mlrun.runtimes.nuclio.serving
 import mlrun.utils
 from mlrun.config import config
 from mlrun.errors import err_to_str
@@ -128,6 +131,7 @@ class GraphServer(ModelObj):
         function_tag=None,
         project=None,
         model_endpoint_creation_task_name=None,
+        api_handler_config: "mlrun.runtimes.nuclio.serving.APIHandlerConfig | None" = None,
     ):
         self._graph = None
         self.graph: Union[RouterStep, RootFlowStep] = graph
@@ -154,6 +158,7 @@ class GraphServer(ModelObj):
         self.project = project
         self.model_endpoint_creation_task_name = model_endpoint_creation_task_name
         self.streaming = False
+        self.api_handler_config = api_handler_config
 
     def set_current_function(self, function):
         """set which child function this server is currently running on"""
@@ -278,7 +283,7 @@ class GraphServer(ModelObj):
                 "no models or steps were set, use function.set_topology() and add steps"
             )
         if not method:
-            method = "POST" if body else "GET"
+            method = HTTPMethod.POST if body else HTTPMethod.GET
         event = MockEvent(
             body=body,
             path=path,
@@ -299,6 +304,7 @@ class GraphServer(ModelObj):
         server_context = self.context
         context = context or server_context
         event.content_type = event.content_type or self.default_content_type or ""
+
         if event.headers:
             if event_id_key in event.headers:
                 event.id = event.headers.get(event_id_key)
@@ -322,6 +328,10 @@ class GraphServer(ModelObj):
                         body=message, content_type="text/plain", status_code=400
                     )
         try:
+            # Store current event in context for API handler steps to access
+            if context:
+                context.current_event = event
+
             response = self.graph.run(event, **(extra_args or {}))
         except Exception as exc:
             message = f"{exc.__class__.__name__}: {err_to_str(exc)}"
@@ -457,14 +467,76 @@ def add_monitoring_general_steps(
     return graph, monitor_flow_step
 
 
+def _add_api_handler_step_to_graph(
+    graph: RootFlowStep,
+    serving_spec: Optional["mlrun.runtimes.nuclio.serving.ServingSpec"],
+    context: "GraphContext",
+) -> RootFlowStep:
+    """Add API handler step to graph if api_handler_config is present"""
+    if isinstance(serving_spec, dict):
+        # Nuclio runtime
+        api_handler_config = serving_spec.get("api_handler_config")
+    elif isinstance(serving_spec, mlrun.runtimes.nuclio.serving.ServingSpec):
+        # Mock server
+        api_handler_config = getattr(serving_spec, "api_handler_config", None)
+    else:
+        raise mlrun.errors.MLRunValueError(
+            f"serving_spec must be dict or ServingSpec, got {type(serving_spec)}"
+        )
+    if api_handler_config:
+        context.logger.info(
+            "Adding API handler step to graph based on serving spec config"
+        )
+        # Check if _APIHandlerStep already exists to avoid duplicates
+        existing_api_handler = None
+        for step_name, step in graph.steps.items():
+            if (
+                hasattr(step, "class_name")
+                and step.class_name == "mlrun.serving.api_handler._APIHandlerStep"
+            ):
+                existing_api_handler = step
+                break
+
+        if not existing_api_handler:
+            # Find current starting steps
+            current_start_steps = []
+            for step_name, step in graph.steps.items():
+                if not step.after:  # Steps with no 'after' are starting steps
+                    current_start_steps.append(step_name)
+
+            # Add _APIHandlerStep as the first step
+            graph.add_step(
+                class_name="mlrun.serving.api_handler._APIHandlerStep",
+                name="api-handler",
+                graph_shape="diamond",
+                config=api_handler_config,
+                after=None,  # First step
+                full_event=True,
+            )
+
+            # Chain all existing starting steps to come after the API handler step
+            for step_name in current_start_steps:
+                step = graph[step_name]
+                step.after = step.after or []
+                if isinstance(step.after, str):
+                    step.after = [step.after]
+                if "api-handler" not in step.after:
+                    step.after.append("api-handler")
+
+    return graph
+
+
 def add_system_steps_to_graph(
     project: str,
     graph: RootFlowStep,
     track_models: bool,
     context,
-    serving_spec,
+    serving_spec: Optional["mlrun.runtimes.nuclio.serving.ServingSpec"],
     pause_until_background_task_completion: bool = True,
 ) -> RootFlowStep:
+    # Always add API handler step if configured
+    graph = _add_api_handler_step_to_graph(graph, serving_spec, context)
+
     if not (isinstance(graph, RootFlowStep) and graph.include_monitored_step()):
         return graph
     monitored_steps = graph.get_monitored_steps()
@@ -838,7 +910,7 @@ def execute_graph(
     batch_size: Optional[int] = None,
     read_as_lists: bool = False,
     nest_under_inputs: bool = False,
-) -> (list[Any], Any):
+) -> tuple[list[Any], Any]:
     """
     Execute graph as a job, from start to finish.
 
@@ -853,7 +925,7 @@ def execute_graph(
     :param read_as_lists: Whether to read each row as a list instead of a dictionary.
     :param nest_under_inputs: Whether to wrap each row with {"inputs": ...}.
 
-    :return: A list of responses.
+    :return: A tuple containing a list of responses and any additional data.
     """
     if _is_inside_asyncio_loop():
         _workaround_asyncio_nesting()

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -498,10 +498,19 @@ def _add_api_handler_step_to_graph(
                 break
 
         if not existing_api_handler:
-            # Find current starting steps
+            # Find current starting steps (using same logic as check_and_process_graph)
             current_start_steps = []
             for step_name, step in graph.steps.items():
-                if not step.after:  # Steps with no 'after' are starting steps
+                # A step is a starting step if:
+                # 1. It has no 'after' and no 'cycle_from' (simple starting step)
+                # 2. It has both 'after' and 'cycle_from', and they match (cyclic starting step)
+                if not step.after and not getattr(step, "cycle_from", None):
+                    current_start_steps.append(step_name)
+                elif (
+                    step.after
+                    and getattr(step, "cycle_from", None)
+                    and set(step.after) == set(step.cycle_from)
+                ):
                     current_start_steps.append(step_name)
 
             # Add _APIHandlerStep as the first step

--- a/mlrun/serving/utils.py
+++ b/mlrun/serving/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+from http import HTTPMethod
 from typing import Optional
 
 from mlrun.utils import get_in, update_in
@@ -118,3 +119,14 @@ class RouterToDict(StepToDict):
         strip: bool = False,
     ):
         return super().to_dict(exclude=["routes"], strip=strip)
+
+
+def _combine_serving_endpoint_key(method: HTTPMethod, path: str) -> str:
+    """Combine method and path to create a unique endpoint key"""
+    return f"{method.value}:{path}"
+
+
+def _split_serving_endpoint_key(endpoint_key: str) -> tuple[HTTPMethod, str]:
+    """Split the endpoint key into method and path"""
+    method_str, path = endpoint_key.split(":", 1)
+    return HTTPMethod(method_str), path

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -14,6 +14,7 @@
 
 """Unit tests for the API Handler implementation"""
 
+import logging
 from http import HTTPMethod
 from typing import cast
 from unittest.mock import MagicMock
@@ -239,6 +240,34 @@ class TestAPIHandlerConfig:
         config = APIHandlerConfig.from_dict(data)
         assert config.enabled is True
         assert config.get_endpoint_config(HTTPMethod.POST, "/predict") is not None
+
+    def test_add_endpoint_handler_override_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test that warning is logged when overriding existing endpoint"""
+        config = APIHandlerConfig()
+
+        # Add an endpoint
+        config.add_endpoint_handler(
+            "/api/test", HTTPMethod.POST, APIHandlerAction.ALLOW, "First config"
+        )
+
+        # Override the same endpoint - should trigger warning
+        with caplog.at_level(logging.WARNING):
+            config.add_endpoint_handler(
+                "/api/test", HTTPMethod.POST, APIHandlerAction.FORBID, "Second config"
+            )
+
+        # Verify warning was logged
+        assert any(
+            "Overriding existing endpoint" in record.message
+            for record in caplog.records
+        )
+
+        # Verify the endpoint was updated
+        endpoint_config = config.get_endpoint_config(HTTPMethod.POST, "/api/test")
+        assert endpoint_config["action"] == "forbid"
+        assert endpoint_config["description"] == "Second config"
 
 
 class TestEndpointKeyHelpers:

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -1,0 +1,564 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the API Handler implementation"""
+
+from http import HTTPMethod
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+import mlrun
+import mlrun.errors
+from mlrun.common.schemas.serving import APIHandlerAction
+from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
+from mlrun.serving import GraphContext
+from mlrun.serving.api_handler import _APIHandlerStep
+from mlrun.serving.server import MockEvent, RootFlowStep, _add_api_handler_step_to_graph
+from mlrun.serving.utils import (
+    _combine_serving_endpoint_key,
+    _split_serving_endpoint_key,
+)
+
+
+class EchoStep:
+    """Simple echo step for testing"""
+
+    def __init__(
+        self, context: GraphContext, name: str | None = None, prefix: str = "", **kwargs
+    ) -> None:
+        self.context = context
+        self.name = name
+        self.prefix = prefix
+
+    def do(self, event: MockEvent | str | dict):
+        """Echo the event with optional prefix"""
+        if hasattr(event, "body"):
+            body = event.body
+        else:
+            body = event
+        return f"{self.prefix}{body}" if self.prefix else body
+
+
+class TestAPIHandlerMockServer:
+    """Test API handler with mock server integration"""
+
+    def test_api_handler_minimal(self) -> None:
+        """Test minimal API handler functionality"""
+        fn = cast(
+            ServingRuntime, mlrun.new_function("test-api-minimal", kind="serving")
+        )
+
+        # Set API handler config using the set_api_handler_config method
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/some/path",  # Use a more realistic path
+            HTTPMethod.GET,
+            APIHandlerAction.ALLOW,
+            "Health check",
+        )
+
+        # Set the config on the function - this should automatically add _APIHandlerStep
+        fn.set_api_handler_config(config)
+
+        # Set topology but don't manually add _APIHandlerStep - it should be automatic
+        graph = fn.set_topology("flow", engine="sync")
+        # Add a responder step since we removed the respond() from the API handler
+        graph.to(name="echo", handler="(event)").respond()
+
+        server = fn.to_mock_server()
+        try:
+            resp = server.test(
+                "/some/path",
+                method="GET",
+                body="ping",
+            )
+            assert resp == "ping"
+        finally:
+            server.wait_for_completion()
+
+    def test_api_handler_multiple_paths(self) -> None:
+        """Test API handler with multiple different paths"""
+        fn = cast(
+            ServingRuntime, mlrun.new_function("test-api-multi-paths", kind="serving")
+        )
+
+        # Set up config with multiple endpoints
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/api/v1/health", HTTPMethod.GET, APIHandlerAction.ALLOW, "Health check"
+        )
+        config.add_endpoint_handler(
+            "/api/v1/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            "Prediction endpoint",
+        )
+        config.add_endpoint_handler(
+            "/api/v1/admin", HTTPMethod.GET, APIHandlerAction.FORBID, "Admin blocked"
+        )
+
+        # Set the config on the function - this should automatically add _APIHandlerStep
+        fn.set_api_handler_config(config)
+
+        # Set topology but don't manually add _APIHandlerStep - it should be automatic
+        graph = fn.set_topology("flow", engine="sync")
+        # Add a responder step since we removed the respond() from the API handler
+        graph.to(name="echo", handler="(event)").respond()
+
+        server = fn.to_mock_server()
+        try:
+            # Test allowed GET endpoint
+            resp = server.test("/api/v1/health", method="GET", body="ping")
+            assert resp == "ping"
+
+            # Test allowed POST endpoint
+            resp = server.test("/api/v1/predict", method="POST", body={"data": "test"})
+            assert resp == {"data": "test"}
+
+            # Test forbidden endpoint should raise an error
+            with pytest.raises(RuntimeError, match="Access forbidden"):
+                server.test("/api/v1/admin", method="GET", body="admin-request")
+
+        finally:
+            server.wait_for_completion()
+
+
+class TestAPIHandlerConfig:
+    """Direct tests for APIHandlerConfig class"""
+
+    def test_init_defaults(self) -> None:
+        """Test APIHandlerConfig initialization with defaults"""
+        config = APIHandlerConfig()
+        assert config.enabled is True
+        assert config.endpoints == {}
+
+    def test_init_with_parameters(self) -> None:
+        """Test APIHandlerConfig initialization with parameters"""
+        endpoints = {"GET:/health": {"action": "allow", "description": "Health"}}
+        config = APIHandlerConfig(enabled=False, endpoints=endpoints)
+        assert config.enabled is False
+        assert "GET:/health" in config.endpoints
+
+    def test_add_endpoint_handler(self) -> None:
+        """Test adding endpoint handlers"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/api/predict", HTTPMethod.POST, APIHandlerAction.ALLOW, "Prediction"
+        )
+
+        endpoint_config = config.get_endpoint_config(HTTPMethod.POST, "/api/predict")
+        assert endpoint_config is not None
+        assert endpoint_config["action"] == "allow"
+        assert endpoint_config["description"] == "Prediction"
+
+    def test_add_multiple_endpoints(self) -> None:
+        """Test adding multiple endpoint handlers"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/health", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        config.add_endpoint_handler("/metrics", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        config.add_endpoint_handler("/admin", HTTPMethod.POST, APIHandlerAction.FORBID)
+
+        assert len(config.endpoints) == 3
+        assert config.get_endpoint_config(HTTPMethod.GET, "/health") is not None
+        assert config.get_endpoint_config(HTTPMethod.GET, "/metrics") is not None
+        assert config.get_endpoint_config(HTTPMethod.POST, "/admin") is not None
+
+    def test_remove_endpoint_handler(self) -> None:
+        """Test removing endpoint handlers"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/api/test", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+        assert config.get_endpoint_config(HTTPMethod.POST, "/api/test") is not None
+
+        config.remove_endpoint_handler("/api/test", HTTPMethod.POST)
+        assert config.get_endpoint_config(HTTPMethod.POST, "/api/test") is None
+
+    def test_get_endpoint_config_not_found(self) -> None:
+        """Test getting non-existent endpoint config"""
+        config = APIHandlerConfig()
+        assert config.get_endpoint_config(HTTPMethod.GET, "/nonexistent") is None
+
+    def test_endpoints_property_setter(self) -> None:
+        """Test setting endpoints via property"""
+        config = APIHandlerConfig()
+        endpoints = {
+            "POST:/predict": {"action": "allow", "description": "Predict"},
+            "GET:/health": {"action": "allow", "description": "Health"},
+        }
+        config.endpoints = endpoints
+
+        assert len(config.endpoints) == 2
+        assert config.get_endpoint_config(HTTPMethod.POST, "/predict") is not None
+        assert config.get_endpoint_config(HTTPMethod.GET, "/health") is not None
+
+    def test_parse_endpoint_key(self) -> None:
+        """Test parsing endpoint keys"""
+        config = APIHandlerConfig()
+        method, path = config._parse_endpoint_key("GET:/api/test")
+        assert method == HTTPMethod.GET
+        assert path == "/api/test"
+
+    def test_parse_endpoint_key_invalid(self) -> None:
+        """Test parsing invalid endpoint key"""
+        config = APIHandlerConfig()
+        with pytest.raises(ValueError, match="Invalid endpoint key format"):
+            config._parse_endpoint_key("invalid-format")
+
+    def test_to_dict(self) -> None:
+        """Test serialization to dictionary"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.POST, APIHandlerAction.ALLOW)
+
+        config_dict = config.to_dict()
+        assert "enabled" in config_dict
+        assert "endpoints" in config_dict
+        assert config_dict["enabled"] is True
+
+    def test_from_dict(self) -> None:
+        """Test deserialization from dictionary"""
+        data = {
+            "enabled": True,
+            "endpoints": {
+                "POST:/predict": {"action": "allow", "description": "Prediction"}
+            },
+        }
+        config = APIHandlerConfig.from_dict(data)
+        assert config.enabled is True
+        assert config.get_endpoint_config(HTTPMethod.POST, "/predict") is not None
+
+
+class TestEndpointKeyHelpers:
+    """Direct tests for endpoint key helper functions"""
+
+    def test_combine_serving_endpoint_key(self) -> None:
+        """Test combining method and path into endpoint key"""
+        key = _combine_serving_endpoint_key(HTTPMethod.GET, "/api/test")
+        assert key == "GET:/api/test"
+
+        key = _combine_serving_endpoint_key(HTTPMethod.POST, "/predict")
+        assert key == "POST:/predict"
+
+    def test_split_serving_endpoint_key(self) -> None:
+        """Test splitting endpoint key into method and path"""
+        method, path = _split_serving_endpoint_key("GET:/api/test")
+        assert method == HTTPMethod.GET
+        assert path == "/api/test"
+
+        method, path = _split_serving_endpoint_key("POST:/predict")
+        assert method == HTTPMethod.POST
+        assert path == "/predict"
+
+    def test_split_serving_endpoint_key_with_colon_in_path(self) -> None:
+        """Test splitting endpoint key when path contains colon"""
+        method, path = _split_serving_endpoint_key("GET:/api/test:123")
+        assert method == HTTPMethod.GET
+        assert path == "/api/test:123"
+
+    def test_split_serving_endpoint_key_invalid(self) -> None:
+        """Test splitting invalid endpoint key"""
+        with pytest.raises(ValueError):
+            _split_serving_endpoint_key("invalid-key-without-colon")
+
+    def test_roundtrip_combine_split(self) -> None:
+        """Test roundtrip conversion"""
+        original_method = HTTPMethod.PUT
+        original_path = "/api/v1/resource/123"
+
+        key = _combine_serving_endpoint_key(original_method, original_path)
+        method, path = _split_serving_endpoint_key(key)
+
+        assert method == original_method
+        assert path == original_path
+
+
+class TestAPIHandlerStep:
+    """Direct tests for _APIHandlerStep class"""
+
+    def test_init_with_config_object(self) -> None:
+        """Test initialization with APIHandlerConfig object"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config, name="test-handler")
+        assert step.name == "test-handler"
+        assert step.config is config
+
+    def test_init_with_config_dict(self) -> None:
+        """Test initialization with config dictionary"""
+        config_dict = {
+            "enabled": True,
+            "endpoints": {
+                "POST:/predict": {"action": "allow", "description": "Predict"}
+            },
+        }
+        step = _APIHandlerStep(config=config_dict)
+        assert isinstance(step.config, APIHandlerConfig)
+        assert step.config.get_endpoint_config(HTTPMethod.POST, "/predict") is not None
+
+    def test_init_no_config(self) -> None:
+        """Test initialization without config"""
+        step = _APIHandlerStep()
+        assert isinstance(step.config, APIHandlerConfig)
+        assert step.config.endpoints == {}
+
+    def test_match_endpoint_exact(self) -> None:
+        """Test exact endpoint matching"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+        step._init_class_object_and_handler({}, False)
+
+        match = step._match_endpoint(HTTPMethod.GET, "/api/test")
+        assert match == "GET:/api/test"
+
+    def test_match_endpoint_no_match(self) -> None:
+        """Test endpoint matching when no match found"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+        step._init_class_object_and_handler({}, False)
+
+        match = step._match_endpoint(HTTPMethod.POST, "/api/test")
+        assert match is None
+
+        match = step._match_endpoint(HTTPMethod.GET, "/different/path")
+        assert match is None
+
+    def test_run_allowed_endpoint(self) -> None:
+        """Test running with allowed endpoint"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        # Create a mock context with current_event
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.GET
+        mock_event.path = "/test"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        step._init_class_object_and_handler({}, False)
+
+        result = step.run({"data": "test"})
+        assert result == {"data": "test"}
+
+    def test_run_forbidden_endpoint(self) -> None:
+        """Test running with forbidden endpoint"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/admin", HTTPMethod.POST, APIHandlerAction.FORBID)
+
+        # Create a mock context with current_event
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.POST
+        mock_event.path = "/admin"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        step._init_class_object_and_handler({}, False)
+
+        with pytest.raises(mlrun.errors.MLRunBadRequestError, match="Access forbidden"):
+            step.run({"data": "test"})
+
+    def test_run_no_matching_endpoint(self) -> None:
+        """Test running with no matching endpoint"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        # Create a mock context with current_event
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.POST
+        mock_event.path = "/nonexistent"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        step._init_class_object_and_handler({}, False)
+
+        with pytest.raises(mlrun.errors.MLRunNotFoundError, match="Endpoint not found"):
+            step.run({"data": "test"})
+
+    def test_run_no_method_in_context(self) -> None:
+        """Test running without method in context"""
+        config = APIHandlerConfig()
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = None
+        mock_event.path = "/test"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        step._init_class_object_and_handler({}, False)
+
+        with pytest.raises(
+            mlrun.errors.MLRunBadRequestError, match="HTTP method not found"
+        ):
+            step.run({"data": "test"})
+
+    def test_run_no_path_in_context(self) -> None:
+        """Test running without path in context"""
+        config = APIHandlerConfig()
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.GET
+        mock_event.path = None
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        step._init_class_object_and_handler({}, False)
+
+        with pytest.raises(
+            mlrun.errors.MLRunBadRequestError, match="Request path not found"
+        ):
+            step.run({"data": "test"})
+
+    def test_run_string_method_conversion(self) -> None:
+        """Test running with string method that gets converted to HTTPMethod"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = "get"  # lowercase string
+        mock_event.path = "/test"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        step._init_class_object_and_handler({}, False)
+
+        result = step.run({"data": "test"})
+        assert result == {"data": "test"}
+
+    def test_run_invalid_method_string(self) -> None:
+        """Test running with invalid method string"""
+        config = APIHandlerConfig()
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = "INVALID"
+        mock_event.path = "/test"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        step._init_class_object_and_handler({}, False)
+
+        with pytest.raises(
+            mlrun.errors.MLRunBadRequestError, match="Unsupported HTTP method"
+        ):
+            step.run({"data": "test"})
+
+
+class TestAddAPIHandlerStepToGraph:
+    """Direct tests for _add_api_handler_step_to_graph function"""
+
+    def test_add_api_handler_step_with_dict_spec(self) -> None:
+        """Test adding API handler step with dict serving_spec"""
+        graph = RootFlowStep()
+        graph.to(name="echo", handler="(event)")
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        serving_spec = {"api_handler_config": config.to_dict()}
+        context = MagicMock()
+
+        result_graph = _add_api_handler_step_to_graph(graph, serving_spec, context)
+
+        # Check that api-handler step was added
+        assert "api-handler" in result_graph.steps
+        api_handler_step = result_graph.steps["api-handler"]
+        assert (
+            api_handler_step.class_name == "mlrun.serving.api_handler._APIHandlerStep"
+        )
+
+        # Check that existing step now comes after api-handler
+        echo_step = result_graph.steps["echo"]
+        assert "api-handler" in echo_step.after
+
+    def test_add_api_handler_step_no_config(self) -> None:
+        """Test that no API handler step is added when config is absent"""
+        graph = RootFlowStep()
+        graph.to(name="echo", handler="(event)")
+
+        serving_spec = {}
+        context = MagicMock()
+
+        result_graph = _add_api_handler_step_to_graph(graph, serving_spec, context)
+
+        # Check that api-handler step was NOT added
+        assert "api-handler" not in result_graph.steps
+
+    def test_add_api_handler_step_prevents_duplicates(self) -> None:
+        """Test that duplicate API handler steps are not added"""
+        graph = RootFlowStep()
+        graph.add_step(
+            class_name="mlrun.serving.api_handler._APIHandlerStep",
+            name="api-handler",
+            config={},
+        )
+        graph.to(name="echo", handler="(event)")
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        serving_spec = {"api_handler_config": config.to_dict()}
+        context = MagicMock()
+
+        result_graph = _add_api_handler_step_to_graph(graph, serving_spec, context)
+
+        # Count API handler steps - should only be one
+        api_handler_steps = [
+            step
+            for step in result_graph.steps.values()
+            if hasattr(step, "class_name")
+            and step.class_name == "mlrun.serving.api_handler._APIHandlerStep"
+        ]
+        assert len(api_handler_steps) == 1
+
+    def test_add_api_handler_step_invalid_spec_type(self) -> None:
+        """Test error when serving_spec is invalid type"""
+        graph = RootFlowStep()
+        context = MagicMock()
+
+        with pytest.raises(mlrun.errors.MLRunValueError, match="serving_spec must be"):
+            _add_api_handler_step_to_graph(graph, "invalid", context)
+
+    def test_add_api_handler_step_multiple_starting_steps(self) -> None:
+        """Test adding API handler when graph has multiple starting steps"""
+        graph = RootFlowStep()
+        graph.add_step(name="step1", handler="(event)")
+        graph.add_step(name="step2", handler="(event)")
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        serving_spec = {"api_handler_config": config.to_dict()}
+        context = MagicMock()
+
+        result_graph = _add_api_handler_step_to_graph(graph, serving_spec, context)
+
+        # Both starting steps should now come after api-handler
+        assert "api-handler" in result_graph.steps["step1"].after
+        assert "api-handler" in result_graph.steps["step2"].after

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -270,6 +270,57 @@ class TestAPIHandlerConfig:
         assert endpoint_config["description"] == "Second config"
 
 
+class TestSetAPIHandlerConfig:
+    """Tests for ServingRuntime.set_api_handler_config method"""
+
+    def test_set_api_handler_config_with_valid_dict(self) -> None:
+        """Test setting API handler config with a valid dictionary"""
+        fn = cast(ServingRuntime, mlrun.new_function("test-fn", kind="serving"))
+
+        config_dict = {
+            "enabled": True,
+            "endpoints": {
+                "POST:/predict": {"action": "allow", "description": "Prediction"}
+            },
+        }
+
+        fn.set_api_handler_config(config_dict)
+        assert fn.spec.api_handler_config is not None
+        assert fn.spec.api_handler_config["enabled"] is True
+        assert "POST:/predict" in fn.spec.api_handler_config["endpoints"]
+
+    def test_set_api_handler_config_with_invalid_dict(self) -> None:
+        """Test setting API handler config with an invalid dictionary"""
+        fn = cast(ServingRuntime, mlrun.new_function("test-fn", kind="serving"))
+
+        # Invalid dict - missing required fields or invalid format
+        invalid_config = {
+            "invalid_key": "invalid_value",
+            "endpoints": "not_a_dict",  # Should be a dict
+        }
+
+        with pytest.raises(ValueError, match="Invalid API handler config dict format"):
+            fn.set_api_handler_config(invalid_config)
+
+    def test_set_api_handler_config_with_invalid_type(self) -> None:
+        """Test setting API handler config with invalid type"""
+        fn = cast(ServingRuntime, mlrun.new_function("test-fn", kind="serving"))
+
+        with pytest.raises(ValueError, match="config must be"):
+            fn.set_api_handler_config("invalid_string")
+
+    def test_set_api_handler_config_with_api_handler_config_object(self) -> None:
+        """Test setting API handler config with APIHandlerConfig object"""
+        fn = cast(ServingRuntime, mlrun.new_function("test-fn", kind="serving"))
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        fn.set_api_handler_config(config)
+        assert fn.spec.api_handler_config is not None
+        assert fn.spec.api_handler_config["enabled"] is True
+
+
 class TestEndpointKeyHelpers:
     """Direct tests for endpoint key helper functions"""
 

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -23,7 +23,7 @@ import pytest
 
 import mlrun
 import mlrun.errors
-from mlrun.common.schemas.serving import APIHandlerAction
+from mlrun.common.schemas.serving import APIHandlerAction, _APIEndpointKeys
 from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
 from mlrun.serving import GraphContext
 from mlrun.serving.api_handler import _APIHandlerStep
@@ -148,7 +148,12 @@ class TestAPIHandlerConfig:
 
     def test_init_with_parameters(self) -> None:
         """Test APIHandlerConfig initialization with parameters"""
-        endpoints = {"GET:/health": {"action": "allow", "description": "Health"}}
+        endpoints = {
+            "GET:/health": {
+                _APIEndpointKeys.ACTION: "allow",
+                _APIEndpointKeys.DESCRIPTION: "Health",
+            }
+        }
         config = APIHandlerConfig(enabled=False, endpoints=endpoints)
         assert config.enabled is False
         assert "GET:/health" in config.endpoints
@@ -162,8 +167,8 @@ class TestAPIHandlerConfig:
 
         endpoint_config = config.get_endpoint_config(HTTPMethod.POST, "/api/predict")
         assert endpoint_config is not None
-        assert endpoint_config["action"] == "allow"
-        assert endpoint_config["description"] == "Prediction"
+        assert endpoint_config[_APIEndpointKeys.ACTION] == "allow"
+        assert endpoint_config[_APIEndpointKeys.DESCRIPTION] == "Prediction"
 
     def test_add_multiple_endpoints(self) -> None:
         """Test adding multiple endpoint handlers"""
@@ -197,8 +202,14 @@ class TestAPIHandlerConfig:
         """Test setting endpoints via property"""
         config = APIHandlerConfig()
         endpoints = {
-            "POST:/predict": {"action": "allow", "description": "Predict"},
-            "GET:/health": {"action": "allow", "description": "Health"},
+            "POST:/predict": {
+                _APIEndpointKeys.ACTION: "allow",
+                _APIEndpointKeys.DESCRIPTION: "Predict",
+            },
+            "GET:/health": {
+                _APIEndpointKeys.ACTION: "allow",
+                _APIEndpointKeys.DESCRIPTION: "Health",
+            },
         }
         config.endpoints = endpoints
 
@@ -234,7 +245,10 @@ class TestAPIHandlerConfig:
         data = {
             "enabled": True,
             "endpoints": {
-                "POST:/predict": {"action": "allow", "description": "Prediction"}
+                "POST:/predict": {
+                    _APIEndpointKeys.ACTION: "allow",
+                    _APIEndpointKeys.DESCRIPTION: "Prediction",
+                }
             },
         }
         config = APIHandlerConfig.from_dict(data)
@@ -266,8 +280,8 @@ class TestAPIHandlerConfig:
 
         # Verify the endpoint was updated
         endpoint_config = config.get_endpoint_config(HTTPMethod.POST, "/api/test")
-        assert endpoint_config["action"] == "forbid"
-        assert endpoint_config["description"] == "Second config"
+        assert endpoint_config[_APIEndpointKeys.ACTION] == "forbid"
+        assert endpoint_config[_APIEndpointKeys.DESCRIPTION] == "Second config"
 
 
 class TestSetAPIHandlerConfig:
@@ -280,7 +294,10 @@ class TestSetAPIHandlerConfig:
         config_dict = {
             "enabled": True,
             "endpoints": {
-                "POST:/predict": {"action": "allow", "description": "Prediction"}
+                "POST:/predict": {
+                    _APIEndpointKeys.ACTION: "allow",
+                    _APIEndpointKeys.DESCRIPTION: "Prediction",
+                }
             },
         }
 
@@ -382,7 +399,10 @@ class TestAPIHandlerStep:
         config_dict = {
             "enabled": True,
             "endpoints": {
-                "POST:/predict": {"action": "allow", "description": "Predict"}
+                "POST:/predict": {
+                    _APIEndpointKeys.ACTION: "allow",
+                    _APIEndpointKeys.DESCRIPTION: "Predict",
+                }
             },
         }
         step = _APIHandlerStep(config=config_dict)

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -385,7 +385,7 @@ class TestAPIHandlerStep:
         step.context = context
         step._init_class_object_and_handler({}, False)
 
-        result = step.run({"data": "test"})
+        result = step.do({"data": "test"})
         assert result == {"data": "test"}
 
     def test_run_forbidden_endpoint(self) -> None:
@@ -405,7 +405,7 @@ class TestAPIHandlerStep:
         step._init_class_object_and_handler({}, False)
 
         with pytest.raises(mlrun.errors.MLRunBadRequestError, match="Access forbidden"):
-            step.run({"data": "test"})
+            step.do({"data": "test"})
 
     def test_run_no_matching_endpoint(self) -> None:
         """Test running with no matching endpoint"""
@@ -424,7 +424,7 @@ class TestAPIHandlerStep:
         step._init_class_object_and_handler({}, False)
 
         with pytest.raises(mlrun.errors.MLRunNotFoundError, match="Endpoint not found"):
-            step.run({"data": "test"})
+            step.do({"data": "test"})
 
     def test_run_no_method_in_context(self) -> None:
         """Test running without method in context"""
@@ -442,7 +442,7 @@ class TestAPIHandlerStep:
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError, match="HTTP method not found"
         ):
-            step.run({"data": "test"})
+            step.do({"data": "test"})
 
     def test_run_no_path_in_context(self) -> None:
         """Test running without path in context"""
@@ -460,7 +460,7 @@ class TestAPIHandlerStep:
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError, match="Request path not found"
         ):
-            step.run({"data": "test"})
+            step.do({"data": "test"})
 
     def test_run_string_method_conversion(self) -> None:
         """Test running with string method that gets converted to HTTPMethod"""
@@ -477,7 +477,7 @@ class TestAPIHandlerStep:
         step.context = context
         step._init_class_object_and_handler({}, False)
 
-        result = step.run({"data": "test"})
+        result = step.do({"data": "test"})
         assert result == {"data": "test"}
 
     def test_run_invalid_method_string(self) -> None:
@@ -496,7 +496,7 @@ class TestAPIHandlerStep:
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError, match="Unsupported HTTP method"
         ):
-            step.run({"data": "test"})
+            step.do({"data": "test"})
 
 
 class TestAddAPIHandlerStepToGraph:

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -633,3 +633,39 @@ class TestAddAPIHandlerStepToGraph:
         # Both starting steps should now come after api-handler
         assert "api-handler" in result_graph.steps["step1"].after
         assert "api-handler" in result_graph.steps["step2"].after
+
+    def test_add_api_handler_step_with_cyclic_graph(self) -> None:
+        """Test adding API handler to a graph with cyclic steps"""
+        graph = RootFlowStep()
+
+        # Create a cyclic graph: step1 -> step2 -> step3 -> step1
+        # First create steps without the cyclic dependency
+        graph.add_step(name="step1", handler="(event)")
+        graph.add_step(name="step2", handler="(event)", after=["step1"])
+        graph.add_step(name="step3", handler="(event)", after=["step2"])
+
+        # Now add the cycle: step1 comes after step3
+        graph.steps["step1"].after = ["step3"]
+        # Mark step1 as cyclic (it has 'after' but is also a starting point)
+        graph.steps["step1"].cycle_from = ["step3"]
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        serving_spec = {"api_handler_config": config.to_dict()}
+        context = MagicMock()
+
+        result_graph = _add_api_handler_step_to_graph(graph, serving_spec, context)
+
+        # API handler should be added
+        assert "api-handler" in result_graph.steps
+
+        # step1 (the cyclic starting step) should now come after api-handler
+        assert "api-handler" in result_graph.steps["step1"].after
+        # step1 should still maintain its cycle_from
+        assert result_graph.steps["step1"].cycle_from == ["step3"]
+
+        # step2 and step3 should not have api-handler in their after lists
+        # (they are not starting steps)
+        assert "api-handler" not in result_graph.steps["step2"].after
+        assert "api-handler" not in result_graph.steps["step3"].after

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -350,7 +350,6 @@ class TestAPIHandlerStep:
         config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
 
         step = _APIHandlerStep(config=config)
-        step._init_class_object_and_handler({}, False)
 
         match = step._match_endpoint(HTTPMethod.GET, "/api/test")
         assert match == "GET:/api/test"
@@ -361,7 +360,6 @@ class TestAPIHandlerStep:
         config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
 
         step = _APIHandlerStep(config=config)
-        step._init_class_object_and_handler({}, False)
 
         match = step._match_endpoint(HTTPMethod.POST, "/api/test")
         assert match is None
@@ -383,7 +381,6 @@ class TestAPIHandlerStep:
 
         step = _APIHandlerStep(config=config)
         step.context = context
-        step._init_class_object_and_handler({}, False)
 
         result = step.do({"data": "test"})
         assert result == {"data": "test"}
@@ -402,7 +399,6 @@ class TestAPIHandlerStep:
 
         step = _APIHandlerStep(config=config)
         step.context = context
-        step._init_class_object_and_handler({}, False)
 
         with pytest.raises(mlrun.errors.MLRunBadRequestError, match="Access forbidden"):
             step.do({"data": "test"})
@@ -421,7 +417,6 @@ class TestAPIHandlerStep:
 
         step = _APIHandlerStep(config=config)
         step.context = context
-        step._init_class_object_and_handler({}, False)
 
         with pytest.raises(mlrun.errors.MLRunNotFoundError, match="Endpoint not found"):
             step.do({"data": "test"})
@@ -437,7 +432,6 @@ class TestAPIHandlerStep:
 
         step = _APIHandlerStep(config=config)
         step.context = context
-        step._init_class_object_and_handler({}, False)
 
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError, match="HTTP method not found"
@@ -455,7 +449,6 @@ class TestAPIHandlerStep:
 
         step = _APIHandlerStep(config=config)
         step.context = context
-        step._init_class_object_and_handler({}, False)
 
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError, match="Request path not found"
@@ -475,7 +468,6 @@ class TestAPIHandlerStep:
 
         step = _APIHandlerStep(config=config)
         step.context = context
-        step._init_class_object_and_handler({}, False)
 
         result = step.do({"data": "test"})
         assert result == {"data": "test"}
@@ -491,7 +483,6 @@ class TestAPIHandlerStep:
 
         step = _APIHandlerStep(config=config)
         step.context = context
-        step._init_class_object_and_handler({}, False)
 
         with pytest.raises(
             mlrun.errors.MLRunBadRequestError, match="Unsupported HTTP method"

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Iguazio
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPMethod
+
+import mlrun
+import tests.system.base
+from mlrun.common.schemas.serving import APIHandlerAction
+from mlrun.runtimes.nuclio.serving import APIHandlerConfig
+
+
+@tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
+class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
+    """System tests for serving function API handler functionality."""
+
+    project_name = "serving-api-handler-5"
+    image: str = "dev-snapshot.artifactory.iguazeng.com/jond/mlrun:ml-11670-8"
+
+    def _create_serving_function(
+        self,
+        name: str,
+        api_config: APIHandlerConfig | None = None,
+    ) -> mlrun.runtimes.ServingRuntime:
+        """Create a basic serving function for testing."""
+        # Create serving function using project (no external file needed)
+        function = self.project.set_function(
+            name=name,
+            kind="serving",
+            image=self.image,
+        )
+
+        # Set API handler config if provided
+        if api_config:
+            function.set_api_handler_config(api_config)
+
+        # Set up basic serving topology with inline handler like unit test
+        graph = function.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler="(event)").respond()
+
+        return function
+
+    def test_api_handler_allowed(self) -> None:
+        """Test that allowed API handlers work correctly (allow case)."""
+        self._logger.info("Testing allowed API handler functionality")
+
+        # Create API handler config that allows specific endpoint
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/api/v1/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            "Prediction endpoint",
+        )
+
+        # Create and deploy serving function with allowed handler
+        function = self._create_serving_function(
+            name="allowed-api-handler", api_config=config
+        )
+
+        # Check that the API handler config is set correctly in the function spec
+        assert (
+            function.spec.api_handler_config is not None
+        ), "API handler config should be set in function spec"
+        # Convert back to APIHandlerConfig for comparison
+        spec_config = APIHandlerConfig.from_dict(function.spec.api_handler_config)
+        assert (
+            spec_config.endpoints == config.endpoints
+        ), "API handler endpoints should match the config set"
+        self._logger.debug(
+            "API handler config correctly set in function spec",
+            endpoints=spec_config.endpoints,
+        )
+
+        # Deploy the function
+        self._logger.debug("Deploying serving function with allowed handler")
+        function.deploy()
+
+        # Test the allowed API endpoint using function.invoke
+        self._logger.debug("Testing allowed API handler endpoint")
+        response = function.invoke(path="/api/v1/predict", body={"test": "data"})
+
+        # Verify response - inline handler just echoes the event
+        assert response is not None, "Handler should return a response"
+        self._logger.info("Allowed API handler test passed")
+
+    def test_api_handler_forbidden(self) -> None:
+        """Test that forbidden API handlers are properly restricted (forbid case)."""
+        self._logger.info("Testing forbidden API handler functionality")
+
+        # Create API handler config that forbids specific endpoint
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/api/v1/admin",
+            HTTPMethod.GET,
+            APIHandlerAction.FORBID,
+            "Admin endpoint blocked",
+        )
+
+        # Create serving function with restricted handler
+        function = self._create_serving_function(
+            name="forbidden-api-handler", api_config=config
+        )
+
+        # Deploy the function
+        self._logger.debug(
+            "Deploying serving function with forbidden API handler config"
+        )
+        function.deploy()
+
+        # Test the forbidden API endpoint - this should raise an error
+        self._logger.debug("Testing forbidden API handler endpoint")
+        try:
+            response = function.invoke(
+                path="/api/v1/admin", body={"test": "restricted"}
+            )
+            # If we get here without an exception, check if the response indicates forbidden
+            assert (
+                "forbidden" in str(response).lower()
+                or "access denied" in str(response).lower()
+                or "not allowed" in str(response).lower()
+            ), f"Expected forbidden response, got: {response}"
+        except Exception as e:
+            # This is expected - the API handler should block the request
+            self._logger.debug(f"API handler correctly blocked request: {e}")
+            assert (
+                "forbidden" in str(e).lower()
+                or "access denied" in str(e).lower()
+                or "not allowed" in str(e).lower()
+            ), f"Exception should indicate forbidden access: {e}"
+
+        self._logger.info("Forbidden API handler test passed")

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -23,8 +23,8 @@ from mlrun.runtimes.nuclio.serving import APIHandlerConfig
 class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
     """System tests for serving function API handler functionality."""
 
-    project_name = "serving-api-handler-5"
-    image: str = "dev-snapshot.artifactory.iguazeng.com/jond/mlrun:ml-11670-8"
+    project_name = "serving-api-handler"
+    image: str | None = None
 
     def _create_serving_function(
         self,


### PR DESCRIPTION
### 📝 Description

This PR adds an API handler feature to MLRun serving graphs, enabling fine-grained control over which HTTP endpoints are accessible.

### Key Changes

**Core Implementation:**
- Added `_APIHandlerStep` class for routing and validating serving requests based on configured endpoints
- Added `APIHandlerConfig` class to manage endpoint configurations (path, HTTP method, action)
- Introduced `APIHandlerAction` enum with `ALLOW` and `FORBID` actions
- Implemented `_add_api_handler_step_to_graph()` to automatically inject the API handler as the first step in serving graphs

**API Enhancements:**
- Added `set_api_handler_config()` method to `ServingRuntime` for configuring endpoint access control
- Helper functions `_combine_serving_endpoint_key()` and `_split_serving_endpoint_key()` for endpoint key management

**Testing:**
- Comprehensive unit tests covering `APIHandlerConfig`, `_APIHandlerStep`, endpoint key helpers, and graph integration
- System tests for end-to-end validation
- Mock server integration tests for various HTTP methods and paths

### Usage Example

```python
from mlrun.runtimes.nuclio.serving import APIHandlerConfig
from mlrun.common.schemas.serving import APIHandlerAction
from http import HTTPMethod

config = APIHandlerConfig()
config.add_endpoint_handler("/predict", HTTPMethod.POST, APIHandlerAction.ALLOW)
config.add_endpoint_handler("/admin", HTTPMethod.POST, APIHandlerAction.FORBID)

serving_fn.set_api_handler_config(config)
```

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR

---

### 🔗 References

- Ticket link: [ML-11670](https://iguazio.atlassian.net/browse/ML-11670)
- Design docs links: linked in the feature.

---

### 🚨 Breaking Changes?

- [x] No

[ML-11670]: https://iguazio.atlassian.net/browse/ML-11670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ