### PR TITLE
[Feature Store] Fix ingest failing on IG4 due to missing V3IO_ACCESS_KEY

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -98,7 +98,10 @@ def write_spark_dataframe_with_options(spark_options, df, mode, write_format=Non
 
 def default_target_names():
     targets = mlrun.mlconf.feature_store.default_targets
-    return [target.strip() for target in targets.split(",")]
+    names = [target.strip() for target in targets.split(",")]
+    if not mlrun.mlconf.is_using_v3io():
+        names = [t for t in names if t != "nosql"]
+    return names
 
 
 def get_default_targets(offline_only=False):

--- a/tests/feature-store/test_ingest.py
+++ b/tests/feature-store/test_ingest.py
@@ -94,6 +94,23 @@ def test_set_targets_with_string():
     assert not nosql_target.partitioned
 
 
+def test_get_default_targets_excludes_nosql_when_v3io_unavailable(monkeypatch):
+    """ML-12070: nosql (V3IO-backed) should be excluded from defaults when V3IO is unavailable."""
+    from mlrun.datastore.targets import get_default_targets
+
+    monkeypatch.setattr(mlrun.mlconf.httpdb.authentication, "mode", "iguazio-v4")
+    targets = get_default_targets()
+    assert [t.name for t in targets] == ["parquet"]
+
+
+def test_get_default_targets_includes_nosql_when_v3io_available():
+    """ML-12070: nosql should be included in defaults when V3IO is available."""
+    from mlrun.datastore.targets import get_default_targets
+
+    targets = get_default_targets()
+    assert [t.name for t in targets] == ["parquet", "nosql"]
+
+
 def test_return_df(rundb_mock):
     fset = fstore.FeatureSet(
         "myset",


### PR DESCRIPTION
### 📝 Description
On IG4 (Iguazio Gen 4), V3IO is not used, but the default feature store targets config still includes `nosql` (V3IO-backed). During ingest, `NoSqlTarget` tries to instantiate a `V3ioStore`, which fails because `V3IO_ACCESS_KEY` is not available.

This fix excludes `nosql` from `default_target_names()` when `is_using_v3io()` returns `False` (IG4 or CE mode).

---

### 🛠️ Changes Made
- Modified `default_target_names()` in `mlrun/datastore/targets.py` to filter out `nosql` when V3IO is unavailable
- Added two unit tests verifying default target behavior with and without V3IO

---

### ✅ Checklist
- [x] I have tested the changes in this PR
- [ ] I updated the documentation (if applicable)

---

### 🧪 Testing
- Added `test_get_default_targets_excludes_nosql_when_v3io_unavailable` — sets auth mode to `iguazio-v4` and verifies nosql is excluded
- Added `test_get_default_targets_includes_nosql_when_v3io_available` — verifies default config still includes nosql
- All 6 tests in `tests/feature-store/test_ingest.py` pass
- `make lint` passes

---

### 🔗 References
- Ticket link: [ML-12070](https://iguazio.atlassian.net/browse/ML-12070)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
On IG4, the default feature store target is now `parquet` only (no online target). This matches the platform capability since V3IO is not available on IG4.

[ML-12070]: https://iguazio.atlassian.net/browse/ML-12070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ