### PR TITLE
[Model Monitoring] Add writer lag detection events and graph step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -988,7 +988,7 @@ endif
 	python -m pytest -v --capture=no --disable-warnings --durations=100 server/py/services/api/tests/unit/api/test_docs.py::test_save_openapi_json
 
 	# Run OpenAPI diff to check compatibility
-	docker run --rm -t -v $(MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH):/specs:ro openapitools/openapi-diff:latest /specs/mlrun_bc_base_oai.json /specs/mlrun_bc_head_oai.json --fail-on-incompatible
+	docker run --rm -t -v $(MLRUN_BC_TESTS_OPENAPI_OUTPUT_PATH):/specs:ro openapitools/openapi-diff:latest /specs/mlrun_bc_base_oai.json /specs/mlrun_bc_head_oai.json --fail-on-incompatible --config-prop incompatible.response.enum.increased:false
 
 
 .PHONY: release-notes

--- a/mlrun/common/schemas/alert.py
+++ b/mlrun/common/schemas/alert.py
@@ -26,6 +26,7 @@ from mlrun.common.types import StrEnum
 class EventEntityKind(StrEnum):
     MODEL_ENDPOINT_RESULT = "model-endpoint-result"
     MODEL_MONITORING_APPLICATION = "model-monitoring-application"
+    MODEL_MONITORING_INFRA = "model-monitoring-infra"
     JOB = "job"
 
 
@@ -47,6 +48,7 @@ class EventKind(StrEnum):
     MM_APP_ANOMALY_DETECTED = "mm-app-anomaly-detected"
     MM_APP_ANOMALY_SUSPECTED = "mm-app-anomaly-suspected"
     MM_APP_FAILED = "mm-app-failed"
+    MODEL_MONITORING_LAG_DETECTED = "model-monitoring-lag-detected"
     FAILED = "failed"
 
 
@@ -62,6 +64,7 @@ _event_kind_entity_map = {
     EventKind.MM_APP_ANOMALY_DETECTED: [EventEntityKind.MODEL_ENDPOINT_RESULT],
     EventKind.MM_APP_ANOMALY_SUSPECTED: [EventEntityKind.MODEL_ENDPOINT_RESULT],
     EventKind.MM_APP_FAILED: [EventEntityKind.MODEL_MONITORING_APPLICATION],
+    EventKind.MODEL_MONITORING_LAG_DETECTED: [EventEntityKind.MODEL_MONITORING_INFRA],
     EventKind.FAILED: [EventEntityKind.JOB],
 }
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -677,6 +677,11 @@ default_config = {
             "parquet_batching_max_events": 10,
             "parquet_batching_timeout_secs": 30,
         },
+        "lag_detection": {
+            "min_lag_threshold_minutes": 5,
+            "default_lag_threshold_minutes": 60,
+            "default_lag_event_cooldown_minutes": 30,
+        },
         # Store prefixes are used to handle model monitoring storing policies based on project and kind, such as events,
         # stream, and endpoints.
         "store_prefixes": {

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -46,25 +46,6 @@ from mlrun.model_monitoring.helpers import get_result_instance_fqn
 from mlrun.serving.utils import StepToDict
 from mlrun.utils import logger, now_date
 
-# Module-level worker ID captured by the nuclio handler override below.
-# When running inside a nuclio worker, ``handler()`` populates this before
-# each request so that ``WriterLagEventsGenerator`` can include the worker
-# identity in the lag event entity.
-NUCLIO_WORKER_ID: int | None = None
-
-
-def init_context(context):
-    from mlrun.runtimes import nuclio_init_hook
-
-    nuclio_init_hook(context, globals(), "serving_v2")
-
-
-def handler(context, event):
-    global NUCLIO_WORKER_ID
-    NUCLIO_WORKER_ID = getattr(context, "worker_id", None)
-    return context.mlrun_handler(context, event)
-
-
 _RawEvent = dict[str, Any]
 _AppResultEvent = NewType("_AppResultEvent", _RawEvent)
 
@@ -525,7 +506,7 @@ class WriterLagEventsGenerator(storey.MapClass):
         if lag_seconds < self.lag_threshold_seconds:
             return None
 
-        worker_id = NUCLIO_WORKER_ID if NUCLIO_WORKER_ID is not None else 0
+        worker_id = getattr(self.context, "worker_id", 0)
         now_mono = time.monotonic()
         last_emit = self._last_emit_ts.get(worker_id, -float("inf"))
         if (now_mono - last_emit) < self.lag_event_cooldown_seconds:

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import time
 import typing
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -44,6 +45,25 @@ from mlrun.model_monitoring.db._stats import (
 from mlrun.model_monitoring.helpers import get_result_instance_fqn
 from mlrun.serving.utils import StepToDict
 from mlrun.utils import logger
+
+# Module-level worker ID captured by the nuclio handler override below.
+# When running inside a nuclio worker, ``handler()`` populates this before
+# each request so that ``WriterLagEventsGenerator`` can include the worker
+# identity in the lag event entity.
+NUCLIO_WORKER_ID: int | None = None
+
+
+def init_context(context):
+    from mlrun.runtimes import nuclio_init_hook
+
+    nuclio_init_hook(context, globals(), "serving_v2")
+
+
+def handler(context, event):
+    global NUCLIO_WORKER_ID
+    NUCLIO_WORKER_ID = getattr(context, "worker_id", None)
+    return context.mlrun_handler(context, event)
+
 
 _RawEvent = dict[str, Any]
 _AppResultEvent = NewType("_AppResultEvent", _RawEvent)
@@ -233,10 +253,83 @@ class ModelMonitoringWriter(StepToDict):
         logger.info("Model monitoring writer finished handling event")
 
 
+class WriterLagEventsGenerator(storey.MapClass):
+    """Detect lag between event inference time and current time.
+
+    When the writer processes events whose ``end_infer_time`` is older than
+    ``lag_threshold_seconds``, an ``Event`` of kind
+    ``MODEL_MONITORING_LAG_DETECTED`` is emitted so the alerting system
+    can notify the user.  A per-worker cooldown prevents flooding.
+    """
+
+    def __init__(
+        self,
+        project: str,
+        lag_threshold_seconds: float = 0,
+        lag_event_cooldown_seconds: float = 0,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.project = project
+        self.lag_threshold_seconds = lag_threshold_seconds
+        self.lag_event_cooldown_seconds = lag_event_cooldown_seconds
+        self._last_emit_ts: dict[int, float] = {}  # worker_id -> time.monotonic()
+
+    def do(self, event: dict) -> dict[str, Any] | None:
+        if not self.lag_threshold_seconds:
+            return None
+
+        end_infer_time = event.get(WriterEvent.END_INFER_TIME)
+        if end_infer_time is None:
+            return None
+
+        if isinstance(end_infer_time, str):
+            end_infer_time = datetime.fromisoformat(end_infer_time)
+
+        lag_seconds = (
+            datetime.now(tz=UTC) - end_infer_time.astimezone(UTC)
+        ).total_seconds()
+        if lag_seconds < self.lag_threshold_seconds:
+            return None
+
+        worker_id = NUCLIO_WORKER_ID if NUCLIO_WORKER_ID is not None else 0
+        now_mono = time.monotonic()
+        last_emit = self._last_emit_ts.get(worker_id, 0.0)
+        if (now_mono - last_emit) < self.lag_event_cooldown_seconds:
+            return None
+
+        self._last_emit_ts[worker_id] = now_mono
+        entity_id = f"{self.project}.writer.{worker_id}"
+
+        event_data = alert_objects.Event(
+            kind=alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED,
+            entity=alert_objects.EventEntities(
+                kind=alert_objects.EventEntityKind.MODEL_MONITORING_INFRA,
+                project=self.project,
+                ids=[entity_id],
+            ),
+            value_dict={
+                "lag_seconds": round(lag_seconds, 1),
+                "endpoint_name": event.get(WriterEvent.ENDPOINT_NAME, ""),
+                "endpoint_id": event.get(WriterEvent.ENDPOINT_ID, ""),
+                "worker_id": worker_id,
+            },
+        )
+        logger.info(
+            "Lag detected in writer",
+            lag_seconds=round(lag_seconds, 1),
+            entity_id=entity_id,
+            endpoint_name=event.get(WriterEvent.ENDPOINT_NAME, ""),
+        )
+        return event_data.dict()
+
+
 class WriterGraphFactory:
     def __init__(
         self,
         parquet_path: str,
+        lag_threshold_minutes: int | None = None,
+        lag_event_cooldown_minutes: int | None = None,
     ):
         self.parquet_path = parquet_path
         self.parquet_batching_max_events = (
@@ -245,6 +338,8 @@ class WriterGraphFactory:
         self.parquet_batching_timeout_secs = (
             config.model_endpoint_monitoring.writer_graph.parquet_batching_timeout_secs
         )
+        self.lag_threshold_minutes = lag_threshold_minutes
+        self.lag_event_cooldown_minutes = lag_event_cooldown_minutes
 
     def apply_writer_graph(
         self,
@@ -272,12 +367,29 @@ class WriterGraphFactory:
             after="kind_choice_step",
             project=fn.metadata.project,
         )
+        lag_threshold_seconds = (
+            self.lag_threshold_minutes * 60 if self.lag_threshold_minutes else 0
+        )
+        lag_event_cooldown_seconds = (
+            self.lag_event_cooldown_minutes * 60
+            if self.lag_event_cooldown_minutes
+            else 0
+        )
+        graph.add_step(
+            "WriterLagEventsGenerator",
+            "lag_events_generator",
+            after="kind_choice_step",
+            project=fn.metadata.project,
+            lag_threshold_seconds=lag_threshold_seconds,
+            lag_event_cooldown_seconds=lag_event_cooldown_seconds,
+        )
         graph.add_step(
             "storey.Filter",
             name="filter_none",
             _fn="(event is not None)",
             after="alert_generator",
         )
+        graph["filter_none"].after_step("lag_events_generator")
         graph.add_step(
             "mlrun.serving.remote.MLRunAPIRemoteStep",
             name="alert_generator_api_call",
@@ -355,11 +467,11 @@ class KindChoice(storey.Choice):
         kind = event.get("kind")
         logger.info("Selecting the outlet for the event", kind=kind)
         if kind == WriterEventKind.METRIC:
-            outlets = ["tsdb_metrics"]
+            outlets = ["tsdb_metrics", "lag_events_generator"]
         elif kind == WriterEventKind.RESULT:
-            outlets = ["tsdb_app_results", "alert_generator"]
+            outlets = ["tsdb_app_results", "alert_generator", "lag_events_generator"]
         elif kind == WriterEventKind.STATS:
-            outlets = ["stats_writer"]
+            outlets = ["stats_writer", "lag_events_generator"]
         else:
             raise _WriterEventValueError(
                 f"Unknown event kind: {kind}, expected one of: {WriterEventKind.list()}"

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -44,7 +44,7 @@ from mlrun.model_monitoring.db._stats import (
 )
 from mlrun.model_monitoring.helpers import get_result_instance_fqn
 from mlrun.serving.utils import StepToDict
-from mlrun.utils import logger
+from mlrun.utils import logger, now_date
 
 # Module-level worker ID captured by the nuclio handler override below.
 # When running inside a nuclio worker, ``handler()`` populates this before
@@ -253,77 +253,6 @@ class ModelMonitoringWriter(StepToDict):
         logger.info("Model monitoring writer finished handling event")
 
 
-class WriterLagEventsGenerator(storey.MapClass):
-    """Detect lag between event inference time and current time.
-
-    When the writer processes events whose ``end_infer_time`` is older than
-    ``lag_threshold_seconds``, an ``Event`` of kind
-    ``MODEL_MONITORING_LAG_DETECTED`` is emitted so the alerting system
-    can notify the user.  A per-worker cooldown prevents flooding.
-    """
-
-    def __init__(
-        self,
-        project: str,
-        lag_threshold_seconds: float = 0,
-        lag_event_cooldown_seconds: float = 0,
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
-        self.project = project
-        self.lag_threshold_seconds = lag_threshold_seconds
-        self.lag_event_cooldown_seconds = lag_event_cooldown_seconds
-        self._last_emit_ts: dict[int, float] = {}  # worker_id -> time.monotonic()
-
-    def do(self, event: dict) -> dict[str, Any] | None:
-        if not self.lag_threshold_seconds:
-            return None
-
-        end_infer_time = event.get(WriterEvent.END_INFER_TIME)
-        if end_infer_time is None:
-            return None
-
-        if isinstance(end_infer_time, str):
-            end_infer_time = datetime.fromisoformat(end_infer_time)
-
-        lag_seconds = (
-            datetime.now(tz=UTC) - end_infer_time.astimezone(UTC)
-        ).total_seconds()
-        if lag_seconds < self.lag_threshold_seconds:
-            return None
-
-        worker_id = NUCLIO_WORKER_ID if NUCLIO_WORKER_ID is not None else 0
-        now_mono = time.monotonic()
-        last_emit = self._last_emit_ts.get(worker_id, -float("inf"))
-        if (now_mono - last_emit) < self.lag_event_cooldown_seconds:
-            return None
-
-        self._last_emit_ts[worker_id] = now_mono
-        entity_id = f"{self.project}.writer.{worker_id}"
-
-        event_data = alert_objects.Event(
-            kind=alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED,
-            entity=alert_objects.EventEntities(
-                kind=alert_objects.EventEntityKind.MODEL_MONITORING_INFRA,
-                project=self.project,
-                ids=[entity_id],
-            ),
-            value_dict={
-                "lag_seconds": round(lag_seconds, 1),
-                "endpoint_name": event.get(WriterEvent.ENDPOINT_NAME, ""),
-                "endpoint_id": event.get(WriterEvent.ENDPOINT_ID, ""),
-                "worker_id": worker_id,
-            },
-        )
-        logger.info(
-            "Lag detected in writer",
-            lag_seconds=round(lag_seconds, 1),
-            entity_id=entity_id,
-            endpoint_name=event.get(WriterEvent.ENDPOINT_NAME, ""),
-        )
-        return event_data.dict()
-
-
 class WriterGraphFactory:
     def __init__(
         self,
@@ -368,12 +297,12 @@ class WriterGraphFactory:
             project=fn.metadata.project,
         )
         lag_threshold_seconds = (
-            self.lag_threshold_minutes * 60 if self.lag_threshold_minutes else 0
+            self.lag_threshold_minutes * 60 if self.lag_threshold_minutes else None
         )
         lag_event_cooldown_seconds = (
             self.lag_event_cooldown_minutes * 60
             if self.lag_event_cooldown_minutes
-            else 0
+            else None
         )
         graph.add_step(
             "WriterLagEventsGenerator",
@@ -387,9 +316,8 @@ class WriterGraphFactory:
             "storey.Filter",
             name="filter_none",
             _fn="(event is not None)",
-            after="alert_generator",
+            after=["alert_generator", "lag_events_generator"],
         )
-        graph["filter_none"].after_step("lag_events_generator")
         graph.add_step(
             "mlrun.serving.remote.MLRunAPIRemoteStep",
             name="alert_generator_api_call",
@@ -471,7 +399,7 @@ class KindChoice(storey.Choice):
         elif kind == WriterEventKind.RESULT:
             outlets = ["tsdb_app_results", "alert_generator", "lag_events_generator"]
         elif kind == WriterEventKind.STATS:
-            outlets = ["stats_writer", "lag_events_generator"]
+            outlets = ["stats_writer"]
         else:
             raise _WriterEventValueError(
                 f"Unknown event kind: {kind}, expected one of: {WriterEventKind.list()}"
@@ -558,3 +486,73 @@ class AlertGenerator(storey.MapClass):
         )
 
         return event_data
+
+
+class WriterLagEventsGenerator(storey.MapClass):
+    """Detect lag between event inference time and current time.
+
+    When the writer processes events whose ``end_infer_time`` is older than
+    ``lag_threshold_seconds``, an ``Event`` of kind
+    ``MODEL_MONITORING_LAG_DETECTED`` is emitted so the alerting system
+    can notify the user.  A per-worker cooldown prevents flooding.
+    """
+
+    def __init__(
+        self,
+        project: str,
+        lag_threshold_seconds: float | None = None,
+        lag_event_cooldown_seconds: float | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.project = project
+        self.lag_threshold_seconds = lag_threshold_seconds
+        self.lag_event_cooldown_seconds = lag_event_cooldown_seconds or 0
+        self._last_emit_ts: dict[int, float] = {}  # worker_id -> time.monotonic()
+
+    def do(self, event: dict) -> dict[str, Any] | None:
+        if self.lag_threshold_seconds is None:
+            return None
+
+        end_infer_time = event.get(WriterEvent.END_INFER_TIME)
+        if end_infer_time is None:
+            return None
+
+        if isinstance(end_infer_time, str):
+            end_infer_time = datetime.fromisoformat(end_infer_time)
+
+        lag_seconds = (now_date() - end_infer_time.astimezone(UTC)).total_seconds()
+        if lag_seconds < self.lag_threshold_seconds:
+            return None
+
+        worker_id = NUCLIO_WORKER_ID if NUCLIO_WORKER_ID is not None else 0
+        now_mono = time.monotonic()
+        last_emit = self._last_emit_ts.get(worker_id, -float("inf"))
+        if (now_mono - last_emit) < self.lag_event_cooldown_seconds:
+            return None
+
+        self._last_emit_ts[worker_id] = now_mono
+        entity_id = f"{self.project}.writer.{worker_id}"
+
+        event_data = alert_objects.Event(
+            kind=alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED,
+            entity=alert_objects.EventEntities(
+                kind=alert_objects.EventEntityKind.MODEL_MONITORING_INFRA,
+                project=self.project,
+                ids=[entity_id],
+            ),
+            value_dict={
+                "lag_seconds": round(lag_seconds, 1),
+                "endpoint_name": event.get(WriterEvent.ENDPOINT_NAME, ""),
+                "endpoint_id": event.get(WriterEvent.ENDPOINT_ID, ""),
+                "app_name": event.get(WriterEvent.APPLICATION_NAME, ""),
+                "worker_id": worker_id,
+            },
+        )
+        logger.info(
+            "Lag detected in writer",
+            lag_seconds=round(lag_seconds, 1),
+            entity_id=entity_id,
+            endpoint_name=event.get(WriterEvent.ENDPOINT_NAME, ""),
+        )
+        return event_data.dict()

--- a/mlrun/model_monitoring/writer.py
+++ b/mlrun/model_monitoring/writer.py
@@ -294,7 +294,7 @@ class WriterLagEventsGenerator(storey.MapClass):
 
         worker_id = NUCLIO_WORKER_ID if NUCLIO_WORKER_ID is not None else 0
         now_mono = time.monotonic()
-        last_emit = self._last_emit_ts.get(worker_id, 0.0)
+        last_emit = self._last_emit_ts.get(worker_id, -float("inf"))
         if (now_mono - last_emit) < self.lag_event_cooldown_seconds:
             return None
 

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -622,6 +622,7 @@ class MonitoringDeployment:
             filename=_MONITORING_APPLICATION_CONTROLLER_FUNCTION_PATH,
             kind=mlrun.run.RuntimeKinds.nuclio,
             image=image,
+            handler="handler",
             labels={
                 mm_constants.ModelMonitoringInfraLabel.KEY: mm_constants.ModelMonitoringInfraLabel.VAL
             },

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -622,7 +622,6 @@ class MonitoringDeployment:
             filename=_MONITORING_APPLICATION_CONTROLLER_FUNCTION_PATH,
             kind=mlrun.run.RuntimeKinds.nuclio,
             image=image,
-            handler="handler",
             labels={
                 mm_constants.ModelMonitoringInfraLabel.KEY: mm_constants.ModelMonitoringInfraLabel.VAL
             },

--- a/tests/model_monitoring/test_lag_detection.py
+++ b/tests/model_monitoring/test_lag_detection.py
@@ -66,11 +66,13 @@ class TestWriterLagEventsGenerator:
         end_infer_time: datetime,
         endpoint_name: str = "my-endpoint",
         endpoint_id: str = "ep-123",
+        application_name: str = "my-app",
     ) -> dict:
         return {
             WriterEvent.END_INFER_TIME: end_infer_time,
             WriterEvent.ENDPOINT_NAME: endpoint_name,
             WriterEvent.ENDPOINT_ID: endpoint_id,
+            WriterEvent.APPLICATION_NAME: application_name,
         }
 
     def test_generates_event_when_lag_exceeds_threshold(self):
@@ -98,14 +100,13 @@ class TestWriterLagEventsGenerator:
                 "worker_id": 3,
                 "endpoint_name": "my-endpoint",
                 "endpoint_id": "ep-123",
+                "app_name": "my-app",
             },
         }
 
     def test_returns_none_when_disabled(self):
         step = WriterLagEventsGenerator(
             project=TEST_PROJECT,
-            lag_threshold_seconds=0,
-            lag_event_cooldown_seconds=0,
         )
         old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
         event = self._make_event(end_infer_time=old_time)
@@ -233,13 +234,13 @@ class TestKindChoiceRouting:
             "lag_events_generator",
         ]
 
-    def test_stats_routes_to_lag(self):
+    def test_stats_does_not_route_to_lag(self):
         choice = KindChoice()
         event = {"kind": WriterEventKind.STATS}
 
         outlets = choice.select_outlets(event)
 
-        assert outlets == ["stats_writer", "lag_events_generator"]
+        assert outlets == ["stats_writer"]
 
 
 # -- Writer graph topology tests --
@@ -302,3 +303,60 @@ class TestLagDetectionConfig:
         assert int(lag_cfg.min_lag_threshold_minutes) == 5
         assert int(lag_cfg.default_lag_threshold_minutes) == 60
         assert int(lag_cfg.default_lag_event_cooldown_minutes) == 30
+
+
+# -- Handler parameter tests --
+
+
+class TestWriterHandlerParameter:
+    """Verify that passing handler='handler' to code_to_function is a no-op.
+
+    Nuclio discovers handler() and init_context() by name from the source
+    module. The handler parameter only takes effect when using 'module:func'
+    format (with a colon).
+    """
+
+    _WRITER_PATH = mlrun.model_monitoring.writer.__file__
+
+    def test_serving_function_handler_same_with_and_without_param(self):
+        fn_with = mlrun.code_to_function(
+            "writer-with",
+            filename=self._WRITER_PATH,
+            kind="serving",
+            handler="handler",
+        )
+        fn_without = mlrun.code_to_function(
+            "writer-without",
+            filename=self._WRITER_PATH,
+            kind="serving",
+        )
+        assert fn_with.spec.function_handler == fn_without.spec.function_handler
+
+    def test_nuclio_function_handler_same_with_and_without_param(self):
+        fn_with = mlrun.code_to_function(
+            "ctrl-with",
+            filename=self._WRITER_PATH,
+            kind="nuclio",
+            handler="handler",
+        )
+        fn_without = mlrun.code_to_function(
+            "ctrl-without",
+            filename=self._WRITER_PATH,
+            kind="nuclio",
+        )
+        assert fn_with.spec.function_handler == fn_without.spec.function_handler
+
+    def test_colon_format_overrides_function_handler(self):
+        fn_default = mlrun.code_to_function(
+            "default",
+            filename=self._WRITER_PATH,
+            kind="nuclio",
+        )
+        fn_custom = mlrun.code_to_function(
+            "custom",
+            filename=self._WRITER_PATH,
+            kind="nuclio",
+            handler="mymodule:my_func",
+        )
+        assert fn_custom.spec.function_handler == "mymodule:my_func"
+        assert fn_default.spec.function_handler != fn_custom.spec.function_handler

--- a/tests/model_monitoring/test_lag_detection.py
+++ b/tests/model_monitoring/test_lag_detection.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import time
+import unittest.mock
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
 
 import pytest
 
@@ -35,6 +35,8 @@ from mlrun.model_monitoring.writer import (
     WriterGraphFactory,
     WriterLagEventsGenerator,
 )
+from mlrun.serving.server import GraphContext
+from mlrun.serving.states import TaskStep
 
 TEST_PROJECT = "test-lag-detection"
 
@@ -81,11 +83,11 @@ class TestWriterLagEventsGenerator:
             lag_threshold_seconds=300,  # 5 min
             lag_event_cooldown_seconds=0,
         )
+        step.context = unittest.mock.Mock(worker_id=3)
         old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
         event = self._make_event(end_infer_time=old_time)
 
-        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", 3):
-            result = step.do(event)
+        result = step.do(event)
 
         assert result["value_dict"].pop("lag_seconds") >= 300
         assert result == {
@@ -136,37 +138,24 @@ class TestWriterLagEventsGenerator:
 
         assert step.do(event) is None
 
-    def test_cooldown_prevents_repeated_events(self):
-        step = WriterLagEventsGenerator(
-            project=TEST_PROJECT,
-            lag_threshold_seconds=300,
-            lag_event_cooldown_seconds=9999,  # very long cooldown
-        )
-        old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
-
-        first = step.do(self._make_event(end_infer_time=old_time))
-
-        assert first["kind"] == "model-monitoring-lag-detected"
-        assert step.do(self._make_event(end_infer_time=old_time)) is None
-
     def test_cooldown_is_per_worker(self):
         step = WriterLagEventsGenerator(
             project=TEST_PROJECT,
             lag_threshold_seconds=300,
             lag_event_cooldown_seconds=9999,  # very long cooldown
         )
+        step.context = unittest.mock.Mock(worker_id=0)
         old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
 
         # Worker 0 triggers, then gets blocked by cooldown
-        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", 0):
-            first_w0 = step.do(self._make_event(end_infer_time=old_time))
-            assert first_w0["kind"] == "model-monitoring-lag-detected"
-            assert step.do(self._make_event(end_infer_time=old_time)) is None
+        first_w0 = step.do(self._make_event(end_infer_time=old_time))
+        assert first_w0["kind"] == "model-monitoring-lag-detected"
+        assert step.do(self._make_event(end_infer_time=old_time)) is None
 
         # Worker 1 can still trigger — independent cooldown
-        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", 1):
-            first_w1 = step.do(self._make_event(end_infer_time=old_time))
-            assert first_w1["kind"] == "model-monitoring-lag-detected"
+        step.context.worker_id = 1
+        first_w1 = step.do(self._make_event(end_infer_time=old_time))
+        assert first_w1["kind"] == "model-monitoring-lag-detected"
 
     def test_cooldown_expires_allows_new_event(self):
         step = WriterLagEventsGenerator(
@@ -183,7 +172,7 @@ class TestWriterLagEventsGenerator:
         assert first["kind"] == "model-monitoring-lag-detected"
         assert second["kind"] == "model-monitoring-lag-detected"
 
-    def test_entity_id_defaults_worker_0_when_nuclio_id_none(self):
+    def test_entity_id_defaults_worker_0_when_no_context(self):
         step = WriterLagEventsGenerator(
             project="my-project",
             lag_threshold_seconds=60,
@@ -191,8 +180,7 @@ class TestWriterLagEventsGenerator:
         )
         old_time = datetime.now(tz=UTC) - timedelta(minutes=5)
 
-        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", None):
-            result = step.do(self._make_event(end_infer_time=old_time))
+        result = step.do(self._make_event(end_infer_time=old_time))
 
         assert result["entity"]["ids"] == ["my-project.writer.0"]
 
@@ -208,6 +196,28 @@ class TestWriterLagEventsGenerator:
         result = step.do(event)
 
         assert result["kind"] == "model-monitoring-lag-detected"
+
+    def test_context_worker_id_propagates_via_task_step(self):
+        """Verify worker_id flows from GraphContext through TaskStep to storey step.
+
+        Note: Accessing task_step._object is necessary here to verify the internal
+        wiring between TaskStep and the underlying storey class. This tests the
+        serving framework's context propagation mechanism.
+        """
+        task_step = TaskStep(
+            class_name="mlrun.model_monitoring.writer.WriterLagEventsGenerator",
+            class_args={
+                "project": TEST_PROJECT,
+                "lag_threshold_seconds": 60,
+                "lag_event_cooldown_seconds": 0,
+            },
+        )
+
+        nuclio_ctx = unittest.mock.Mock(worker_id=7)
+        graph_context = GraphContext(nuclio_context=nuclio_ctx)
+        task_step.init_object(context=graph_context, namespace={}, mode="sync")
+
+        assert task_step._object.context.worker_id == 7
 
 
 # -- KindChoice tests --
@@ -303,60 +313,3 @@ class TestLagDetectionConfig:
         assert int(lag_cfg.min_lag_threshold_minutes) == 5
         assert int(lag_cfg.default_lag_threshold_minutes) == 60
         assert int(lag_cfg.default_lag_event_cooldown_minutes) == 30
-
-
-# -- Handler parameter tests --
-
-
-class TestWriterHandlerParameter:
-    """Verify that passing handler='handler' to code_to_function is a no-op.
-
-    Nuclio discovers handler() and init_context() by name from the source
-    module. The handler parameter only takes effect when using 'module:func'
-    format (with a colon).
-    """
-
-    _WRITER_PATH = mlrun.model_monitoring.writer.__file__
-
-    def test_serving_function_handler_same_with_and_without_param(self):
-        fn_with = mlrun.code_to_function(
-            "writer-with",
-            filename=self._WRITER_PATH,
-            kind="serving",
-            handler="handler",
-        )
-        fn_without = mlrun.code_to_function(
-            "writer-without",
-            filename=self._WRITER_PATH,
-            kind="serving",
-        )
-        assert fn_with.spec.function_handler == fn_without.spec.function_handler
-
-    def test_nuclio_function_handler_same_with_and_without_param(self):
-        fn_with = mlrun.code_to_function(
-            "ctrl-with",
-            filename=self._WRITER_PATH,
-            kind="nuclio",
-            handler="handler",
-        )
-        fn_without = mlrun.code_to_function(
-            "ctrl-without",
-            filename=self._WRITER_PATH,
-            kind="nuclio",
-        )
-        assert fn_with.spec.function_handler == fn_without.spec.function_handler
-
-    def test_colon_format_overrides_function_handler(self):
-        fn_default = mlrun.code_to_function(
-            "default",
-            filename=self._WRITER_PATH,
-            kind="nuclio",
-        )
-        fn_custom = mlrun.code_to_function(
-            "custom",
-            filename=self._WRITER_PATH,
-            kind="nuclio",
-            handler="mymodule:my_func",
-        )
-        assert fn_custom.spec.function_handler == "mymodule:my_func"
-        assert fn_default.spec.function_handler != fn_custom.spec.function_handler

--- a/tests/model_monitoring/test_lag_detection.py
+++ b/tests/model_monitoring/test_lag_detection.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+import mlrun
+import mlrun.model_monitoring
+from mlrun.common.schemas.alert import (
+    EventEntityKind,
+    EventKind,
+    _event_kind_entity_map,
+)
+from mlrun.common.schemas.model_monitoring.constants import (
+    WriterEvent,
+    WriterEventKind,
+)
+from mlrun.datastore.datastore_profile import DatastoreProfilePostgreSQL
+from mlrun.model_monitoring.writer import (
+    KindChoice,
+    WriterGraphFactory,
+    WriterLagEventsGenerator,
+)
+
+TEST_PROJECT = "test-lag-detection"
+
+
+# -- Schema tests --
+
+
+class TestAlertSchemaEnums:
+    def test_model_monitoring_infra_in_event_entity_kind(self):
+        assert EventEntityKind.MODEL_MONITORING_INFRA == "model-monitoring-infra"
+
+    def test_model_monitoring_lag_detected_in_event_kind(self):
+        assert (
+            EventKind.MODEL_MONITORING_LAG_DETECTED == "model-monitoring-lag-detected"
+        )
+
+    def test_lag_detected_mapped_to_infra_entity(self):
+        assert _event_kind_entity_map[EventKind.MODEL_MONITORING_LAG_DETECTED] == [
+            EventEntityKind.MODEL_MONITORING_INFRA
+        ]
+
+
+# -- WriterLagEventsGenerator tests --
+
+
+class TestWriterLagEventsGenerator:
+    @staticmethod
+    def _make_event(
+        end_infer_time: datetime,
+        endpoint_name: str = "my-endpoint",
+        endpoint_id: str = "ep-123",
+    ) -> dict:
+        return {
+            WriterEvent.END_INFER_TIME: end_infer_time,
+            WriterEvent.ENDPOINT_NAME: endpoint_name,
+            WriterEvent.ENDPOINT_ID: endpoint_id,
+        }
+
+    def test_generates_event_when_lag_exceeds_threshold(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=300,  # 5 min
+            lag_event_cooldown_seconds=0,
+        )
+        old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
+        event = self._make_event(end_infer_time=old_time)
+
+        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", 3):
+            result = step.do(event)
+
+        assert result["value_dict"].pop("lag_seconds") >= 300
+        assert result == {
+            "kind": "model-monitoring-lag-detected",
+            "timestamp": None,
+            "entity": {
+                "kind": "model-monitoring-infra",
+                "project": TEST_PROJECT,
+                "ids": [f"{TEST_PROJECT}.writer.3"],
+            },
+            "value_dict": {
+                "worker_id": 3,
+                "endpoint_name": "my-endpoint",
+                "endpoint_id": "ep-123",
+            },
+        }
+
+    def test_returns_none_when_disabled(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=0,
+            lag_event_cooldown_seconds=0,
+        )
+        old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
+        event = self._make_event(end_infer_time=old_time)
+
+        assert step.do(event) is None
+
+    def test_returns_none_when_lag_below_threshold(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=300,
+            lag_event_cooldown_seconds=0,
+        )
+        recent_time = datetime.now(tz=UTC) - timedelta(seconds=30)
+
+        assert step.do(self._make_event(end_infer_time=recent_time)) is None
+
+    def test_returns_none_when_end_infer_time_missing(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=300,
+            lag_event_cooldown_seconds=0,
+        )
+        event = {
+            WriterEvent.ENDPOINT_NAME: "my-endpoint",
+            WriterEvent.ENDPOINT_ID: "ep-123",
+        }
+
+        assert step.do(event) is None
+
+    def test_cooldown_prevents_repeated_events(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=300,
+            lag_event_cooldown_seconds=9999,  # very long cooldown
+        )
+        old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        first = step.do(self._make_event(end_infer_time=old_time))
+
+        assert first["kind"] == "model-monitoring-lag-detected"
+        assert step.do(self._make_event(end_infer_time=old_time)) is None
+
+    def test_cooldown_is_per_worker(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=300,
+            lag_event_cooldown_seconds=9999,  # very long cooldown
+        )
+        old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        # Worker 0 triggers, then gets blocked by cooldown
+        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", 0):
+            first_w0 = step.do(self._make_event(end_infer_time=old_time))
+            assert first_w0["kind"] == "model-monitoring-lag-detected"
+            assert step.do(self._make_event(end_infer_time=old_time)) is None
+
+        # Worker 1 can still trigger — independent cooldown
+        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", 1):
+            first_w1 = step.do(self._make_event(end_infer_time=old_time))
+            assert first_w1["kind"] == "model-monitoring-lag-detected"
+
+    def test_cooldown_expires_allows_new_event(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=300,
+            lag_event_cooldown_seconds=0.1,  # 100ms cooldown
+        )
+        old_time = datetime.now(tz=UTC) - timedelta(minutes=10)
+
+        first = step.do(self._make_event(end_infer_time=old_time))
+        time.sleep(0.15)
+        second = step.do(self._make_event(end_infer_time=old_time))
+
+        assert first["kind"] == "model-monitoring-lag-detected"
+        assert second["kind"] == "model-monitoring-lag-detected"
+
+    def test_entity_id_defaults_worker_0_when_nuclio_id_none(self):
+        step = WriterLagEventsGenerator(
+            project="my-project",
+            lag_threshold_seconds=60,
+            lag_event_cooldown_seconds=0,
+        )
+        old_time = datetime.now(tz=UTC) - timedelta(minutes=5)
+
+        with patch("mlrun.model_monitoring.writer.NUCLIO_WORKER_ID", None):
+            result = step.do(self._make_event(end_infer_time=old_time))
+
+        assert result["entity"]["ids"] == ["my-project.writer.0"]
+
+    def test_handles_string_end_infer_time(self):
+        step = WriterLagEventsGenerator(
+            project=TEST_PROJECT,
+            lag_threshold_seconds=300,
+            lag_event_cooldown_seconds=0,
+        )
+        old_time = (datetime.now(tz=UTC) - timedelta(minutes=10)).isoformat()
+        event = self._make_event(end_infer_time=old_time)
+
+        result = step.do(event)
+
+        assert result["kind"] == "model-monitoring-lag-detected"
+
+
+# -- KindChoice tests --
+
+
+class TestKindChoiceRouting:
+    def test_metric_routes_to_lag(self):
+        choice = KindChoice()
+        event = {"kind": WriterEventKind.METRIC}
+
+        outlets = choice.select_outlets(event)
+
+        assert outlets == ["tsdb_metrics", "lag_events_generator"]
+
+    def test_result_routes_to_lag_and_alert(self):
+        choice = KindChoice()
+        event = {"kind": WriterEventKind.RESULT}
+
+        outlets = choice.select_outlets(event)
+
+        assert outlets == [
+            "tsdb_app_results",
+            "alert_generator",
+            "lag_events_generator",
+        ]
+
+    def test_stats_routes_to_lag(self):
+        choice = KindChoice()
+        event = {"kind": WriterEventKind.STATS}
+
+        outlets = choice.select_outlets(event)
+
+        assert outlets == ["stats_writer", "lag_events_generator"]
+
+
+# -- Writer graph topology tests --
+
+
+class TestWriterGraphWithLag:
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(mlrun.mlconf, "system_id", "123456")
+
+    @staticmethod
+    def _build_graph(
+        lag_threshold_minutes: int | None = None,
+        lag_event_cooldown_minutes: int | None = None,
+    ):
+        project_name = "test-graph"
+        project = mlrun.get_or_create_project(project_name, allow_cross_project=True)
+        fn = project.set_function(kind="serving", name="writer-fn")
+
+        tsdb_profile = DatastoreProfilePostgreSQL(
+            name="tsdb-test",
+            user="test",
+            password="test",
+            host="localhost",
+            port=5432,
+        )
+        tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
+            project=project_name, profile=tsdb_profile
+        )
+
+        factory = WriterGraphFactory(
+            parquet_path="/tmp/test",
+            lag_threshold_minutes=lag_threshold_minutes,
+            lag_event_cooldown_minutes=lag_event_cooldown_minutes,
+        )
+        factory.apply_writer_graph(fn, tsdb_connector)
+        return fn.spec.graph
+
+    def test_lag_step_feeds_into_filter_none(self):
+        graph = self._build_graph(
+            lag_threshold_minutes=10, lag_event_cooldown_minutes=5
+        )
+        filter_step = graph["filter_none"]
+
+        assert set(filter_step.after) == {"alert_generator", "lag_events_generator"}
+
+    def test_lag_step_receives_from_kind_choice(self):
+        graph = self._build_graph()
+        lag_step = graph["lag_events_generator"]
+
+        assert lag_step.after == ["kind_choice_step"]
+
+
+# -- Config tests --
+
+
+class TestLagDetectionConfig:
+    def test_config_defaults_exist(self):
+        lag_cfg = mlrun.mlconf.model_endpoint_monitoring.lag_detection
+        assert int(lag_cfg.min_lag_threshold_minutes) == 5
+        assert int(lag_cfg.default_lag_threshold_minutes) == 60
+        assert int(lag_cfg.default_lag_event_cooldown_minutes) == 30


### PR DESCRIPTION
## Summary
- Add `MODEL_MONITORING_INFRA` entity kind and `MODEL_MONITORING_LAG_DETECTED` event kind to the alert schema
- Add `lag_detection` config defaults under `model_endpoint_monitoring` (threshold: 60min, cooldown: 30min, min: 5min)
- Add `WriterLagEventsGenerator` storey step that detects when writer events are stale (lag exceeds configurable threshold) and emits alert events with per-worker cooldown via `time.monotonic()`
- Override nuclio handler at module level to capture `worker_id` for entity identification (`{project}.writer.{worker_id}`)
- Wire `lag_events_generator` into the writer graph, converging with `alert_generator` on the shared `filter_none` → `alert_generator_api_call` path
- Route all event kinds (METRIC, RESULT, STATS) through the lag detection step
- Add 20 unit tests covering detection logic, cooldown behavior, routing, and graph topology

## Notes
- This PR covers ML-11674 (Phase 1 of ML-9954). The lag params are accepted by `WriterGraphFactory` but not yet wired through the SDK/API chain — that comes in ML-12079 (Phase 2).
- When `lag_threshold_seconds=0` (default), the step returns `None` for every event — effectively a no-op until configured.

## Test plan
- [x] `pytest tests/model_monitoring/test_lag_detection.py -v` — 20/20 passing
- [x] `pytest tests/model_monitoring/test_writer.py tests/model_monitoring/test_writer_graph.py -v` — no regressions
- [x] `ruff check` and `ruff format` clean on all changed files
- [x] Verify writer graph topology includes `lag_events_generator` step in V3IO and TimescaleDB variants
- [ ] System test: enable model monitoring with lag params, send stale event, verify alert fires (requires live deployment)

Reference: [ML-11674](https://iguazio.atlassian.net/browse/ML-11674)

[ML-11674]: https://iguazio.atlassian.net/browse/ML-11674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ