### PR TITLE
[Auth] Ensure owner is derived from authentication object

### DIFF
--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -90,6 +90,17 @@ class DynamicTokenProvider(TokenProvider):
     def is_iguazio_session(self):
         return False
 
+    @property
+    def authenticated_username(self) -> typing.Optional[str]:
+        """
+        Extract the authenticated username from the JWT access token.
+
+        :return: The 'preferred_username' claim from the JWT, or None if not present.
+        """
+        if not self._token:
+            return None
+        return mlrun.auth.utils.resolve_jwt_username(self._token, raise_on_error=False)
+
     def fetch_token(self):
         mlrun.utils.helpers.run_with_retry(
             retry_count=self._max_retries,

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -35,6 +35,7 @@ class Claims:
 
     SUBJECT = "sub"
     EXPIRATION = "exp"
+    PREFERRED_USERNAME = "preferred_username"
 
 
 def load_offline_token(raise_on_error=True) -> typing.Optional[str]:
@@ -341,6 +342,30 @@ def resolve_jwt_subject(
         # This method is used from the client side after receiving this token from the server, there's no need or
         # ability to verify its signature here.
         return _decode_token_unverified(token).get(Claims.SUBJECT)
+    except jwt.PyJWTError as exc:
+        mlrun.utils.helpers.raise_or_log_error(
+            f"Failed to decode JWT token: {exc}", raise_on_error
+        )
+        return None
+
+
+def resolve_jwt_username(
+    token: str, raise_on_error: bool = False
+) -> typing.Optional[str]:
+    """
+    Extract the 'preferred_username' claim from a JWT token.
+
+    The token is decoded without signature verification since it has already
+    been verified earlier during the authentication process.
+
+    :param token: The JWT token string.
+    :param raise_on_error: Whether to raise an error or log a warning on failure.
+    :return: The 'preferred_username' claim value, or None if not present or extraction fails.
+    """
+    try:
+        # This method is used from the client side after receiving this token from the server, there's no need or
+        # ability to verify its signature here.
+        return _decode_token_unverified(token).get(Claims.PREFERRED_USERNAME)
     except jwt.PyJWTError as exc:
         mlrun.utils.helpers.raise_or_log_error(
             f"Failed to decode JWT token: {exc}", raise_on_error

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -366,7 +366,7 @@ def resolve_jwt_username(
         # This method is used from the client side after receiving this token from the server, there's no need or
         # ability to verify its signature here.
         return _decode_token_unverified(token).get(Claims.PREFERRED_USERNAME)
-    except jwt.PyJWTError as exc:
+    except mlrun.errors.MLRunInvalidArgumentError as exc:
         mlrun.utils.helpers.raise_or_log_error(
             f"Failed to decode JWT token: {exc}", raise_on_error
         )

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -78,11 +78,10 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
         mlrun.runtimes.utils.enrich_run_labels(
             run.metadata.labels, [mlrun_constants.MLRunInternalLabels.owner]
         )
-        if run.spec.output_path:
-            run.spec.output_path = run.spec.output_path.replace(
-                "{{run.user}}",
-                run.metadata.labels[mlrun_constants.MLRunInternalLabels.owner],
-            )
+        run.spec.output_path = mlrun.runtimes.utils.resolve_run_user_template(
+            run.spec.output_path,
+            run.metadata.labels.get(mlrun_constants.MLRunInternalLabels.owner),
+        )
         db = runtime._get_db()
         if db and runtime.kind != "handler":
             struct = runtime.to_dict()

--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -532,10 +532,10 @@ class BaseRuntime(ModelObj):
         mlrun.runtimes.utils.enrich_run_labels(
             meta.labels, [mlrun_constants.MLRunInternalLabels.owner]
         )
-        if runspec.spec.output_path:
-            runspec.spec.output_path = runspec.spec.output_path.replace(
-                "{{run.user}}", meta.labels[mlrun_constants.MLRunInternalLabels.owner]
-            )
+        runspec.spec.output_path = mlrun.runtimes.utils.resolve_run_user_template(
+            runspec.spec.output_path,
+            meta.labels.get(mlrun_constants.MLRunInternalLabels.owner),
+        )
 
         if db and self.kind != "handler":
             struct = self.to_dict()

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -453,20 +453,58 @@ def resolve_owner(
     owner_to_enrich: Optional[str] = None,
 ):
     """
-    Resolve the owner label value
+    Resolve the owner label value.
+
+    Resolution order:
+    1. For workflow runners: use owner_to_enrich if provided
+    2. V3IO_USERNAME environment variable (IG3 environments)
+    3. Authenticated username from IG4 JWT token (if available)
+    4. Local system user (getpass.getuser())
+
     :param labels: The run labels dict
-    :param auth_username: The authenticated username
+    :param owner_to_enrich: Optional owner to use for workflow runners
     :return: The resolved owner label value
     """
-
     if owner_to_enrich and (
         labels.get("job-type") == mlrun.common.constants.JOB_TYPE_WORKFLOW_RUNNER
         or labels.get("job-type")
         == mlrun.common.constants.JOB_TYPE_RERUN_WORKFLOW_RUNNER
     ):
         return owner_to_enrich
-    else:
-        return os.environ.get("V3IO_USERNAME") or getpass.getuser()
+
+    # Check V3IO_USERNAME first (IG3 environments)
+    if v3io_username := os.environ.get("V3IO_USERNAME"):
+        return v3io_username
+
+    # Try to get authenticated username from IG4 token provider
+    authenticated_username = _resolve_authenticated_username_from_token_provider()
+    if authenticated_username:
+        return authenticated_username
+
+    # Fall back to local system user
+    return getpass.getuser()
+
+
+def _resolve_authenticated_username_from_token_provider() -> Optional[str]:
+    """
+    Attempt to resolve the authenticated username from the IG4 token provider.
+
+    This is used for local runs in IG4 environments where the JWT access token
+    contains the 'preferred_username' claim.
+
+    :return: The authenticated username, or None if not available.
+    """
+    try:
+        db = mlrun.get_run_db()
+        if db and hasattr(db, "token_provider") and db.token_provider:
+            token_provider = db.token_provider
+            # Check if this is an IG4 token provider with authenticated_username
+            if hasattr(token_provider, "authenticated_username"):
+                return token_provider.authenticated_username
+    except Exception:
+        # If we can't get the DB or token provider, silently fall back
+        pass
+    return None
 
 
 def enrich_run_labels(

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -503,6 +503,19 @@ def enrich_run_labels(
     return labels
 
 
+def resolve_run_user_template(output_path: str, owner: str) -> str:
+    """
+    Replace {{run.user}} template in output path with actual owner value.
+
+    :param output_path: The output path that may contain {{run.user}} template.
+    :param owner: The owner/username to substitute.
+    :return: The resolved output path, or original if no substitution needed.
+    """
+    if not output_path or not owner:
+        return output_path
+    return output_path.replace("{{run.user}}", owner)
+
+
 def resolve_node_selectors(
     project_node_selector: dict, instance_node_selector: dict
 ) -> dict:

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -568,6 +568,16 @@ class ServerSideLauncher(launcher.BaseLauncher):
     ):
         run.metadata.labels[mlrun_constants.MLRunInternalLabels.kind] = runtime.kind
 
+        # Server-side owner enrichment: override client-provided owner with authenticated username.
+        # In authenticated environments (e.g., IG4), auth_info.username is the source of truth.
+        # This ensures the owner label reflects the authenticated user rather than the local user
+        # on the client machine (e.g., 'jovyan' in Jupyter notebooks).
+        # For CE/unauthenticated deployments, auth_info.username will be None, preserving
+        # any existing owner label from client-side enrichment.
+        if self._auth_info and self._auth_info.username:
+            run.metadata.labels[mlrun_constants.MLRunInternalLabels.owner] = (
+                self._auth_info.username
+            )
 
         # Replace {{run.user}} template in output_path with the final owner value.
         # This must happen after owner enrichment to ensure correct substitution.

--- a/server/py/services/api/launcher.py
+++ b/server/py/services/api/launcher.py
@@ -567,6 +567,15 @@ class ServerSideLauncher(launcher.BaseLauncher):
         self, runtime: mlrun.runtimes.base.BaseRuntime, run: mlrun.run.RunObject
     ):
         run.metadata.labels[mlrun_constants.MLRunInternalLabels.kind] = runtime.kind
+
+
+        # Replace {{run.user}} template in output_path with the final owner value.
+        # This must happen after owner enrichment to ensure correct substitution.
+        run.spec.output_path = mlrun.runtimes.utils.resolve_run_user_template(
+            run.spec.output_path,
+            run.metadata.labels.get(mlrun_constants.MLRunInternalLabels.owner),
+        )
+
         db = runtime._get_db()
         if db and runtime.kind != "handler":
             struct = runtime.to_dict()

--- a/server/py/services/api/tests/unit/test_launcher.py
+++ b/server/py/services/api/tests/unit/test_launcher.py
@@ -557,3 +557,113 @@ def test_enrich_and_validate_auth_token_name_iguazio_v4_token_not_found(
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError, match="No valid tokens found"):
         launcher.enrich_and_validate_auth_token_name(run)
+
+
+def test_store_function_enriches_owner_from_auth_info():
+    """Test that server-side owner enrichment overrides client-provided owner."""
+    auth_info = mlrun.common.schemas.AuthInfo(username="authenticated_user")
+    launcher = services.api.launcher.ServerSideLauncher(auth_info=auth_info)
+
+    # Simulate client-provided owner (e.g., 'jovyan' from Jupyter)
+    run = mlrun.run.RunObject(
+        metadata=mlrun.model.RunMetadata(
+            labels={mlrun.common.constants.MLRunInternalLabels.owner: "jovyan"}
+        ),
+        spec=mlrun.model.RunSpec(output_path="/data/{{run.user}}/artifacts"),
+    )
+
+    runtime = unittest.mock.MagicMock()
+    runtime.kind = "job"
+    runtime._get_db.return_value = None
+
+    launcher._store_function(runtime, run)
+
+    # Owner should be overridden with authenticated username
+    assert (
+        run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.owner]
+        == "authenticated_user"
+    )
+    # Template should be replaced with authenticated user
+    assert run.spec.output_path == "/data/authenticated_user/artifacts"
+
+
+def test_store_function_preserves_owner_when_no_auth():
+    """Test that client-provided owner is preserved when auth_info has no username (CE mode)."""
+    # No username in auth_info (CE/unauthenticated mode)
+    auth_info = mlrun.common.schemas.AuthInfo(username=None)
+    launcher = services.api.launcher.ServerSideLauncher(auth_info=auth_info)
+
+    run = mlrun.run.RunObject(
+        metadata=mlrun.model.RunMetadata(
+            labels={mlrun.common.constants.MLRunInternalLabels.owner: "local_user"}
+        ),
+        spec=mlrun.model.RunSpec(output_path="/data/{{run.user}}/artifacts"),
+    )
+
+    runtime = unittest.mock.MagicMock()
+    runtime.kind = "job"
+    runtime._get_db.return_value = None
+
+    launcher._store_function(runtime, run)
+
+    # Owner should remain as client-provided value
+    assert (
+        run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.owner]
+        == "local_user"
+    )
+    # Template should be replaced with client-provided owner
+    assert run.spec.output_path == "/data/local_user/artifacts"
+
+
+def test_store_function_preserves_owner_when_no_auth_info():
+    """Test that client-provided owner is preserved when auth_info is None."""
+    launcher = services.api.launcher.ServerSideLauncher(auth_info=None)
+
+    run = mlrun.run.RunObject(
+        metadata=mlrun.model.RunMetadata(
+            labels={mlrun.common.constants.MLRunInternalLabels.owner: "local_user"}
+        ),
+        spec=mlrun.model.RunSpec(output_path="/data/{{run.user}}/artifacts"),
+    )
+
+    runtime = unittest.mock.MagicMock()
+    runtime.kind = "job"
+    runtime._get_db.return_value = None
+
+    launcher._store_function(runtime, run)
+
+    # Owner should remain as client-provided value
+    assert (
+        run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.owner]
+        == "local_user"
+    )
+    # Template should be replaced with client-provided owner
+    assert run.spec.output_path == "/data/local_user/artifacts"
+
+
+def test_store_function_handles_no_output_path():
+    """Test that _store_function handles runs without output_path."""
+    auth_info = mlrun.common.schemas.AuthInfo(username="authenticated_user")
+    launcher = services.api.launcher.ServerSideLauncher(auth_info=auth_info)
+
+    run = mlrun.run.RunObject(
+        metadata=mlrun.model.RunMetadata(
+            labels={mlrun.common.constants.MLRunInternalLabels.owner: "jovyan"}
+        ),
+        spec=mlrun.model.RunSpec(output_path=None),
+    )
+
+    runtime = unittest.mock.MagicMock()
+    runtime.kind = "job"
+    runtime._get_db.return_value = None
+
+    # Should not raise
+    launcher._store_function(runtime, run)
+
+    # Owner should still be enriched
+    assert (
+        run.metadata.labels[mlrun.common.constants.MLRunInternalLabels.owner]
+        == "authenticated_user"
+    )
+    # output_path should remain None
+    assert run.spec.output_path is None

--- a/tests/auth/test_auth_providers.py
+++ b/tests/auth/test_auth_providers.py
@@ -224,6 +224,33 @@ def test_authenticated_user_id():
     assert provider.authenticated_user_id == "test-user"
 
 
+def test_authenticated_username():
+    """Test that authenticated_username extracts preferred_username from JWT."""
+    provider = IGTokenProvider.__new__(IGTokenProvider)
+    provider._token = jwt.encode(
+        {"sub": "test-user", "preferred_username": "admin"},
+        key="test-secret",
+        algorithm="HS256",
+    )
+    assert provider.authenticated_username == "admin"
+
+
+def test_authenticated_username_missing_claim():
+    """Test that authenticated_username returns None when claim is missing."""
+    provider = IGTokenProvider.__new__(IGTokenProvider)
+    provider._token = jwt.encode(
+        {"sub": "test-user"}, key="test-secret", algorithm="HS256"
+    )
+    assert provider.authenticated_username is None
+
+
+def test_authenticated_username_no_token():
+    """Test that authenticated_username returns None when no token is set."""
+    provider = IGTokenProvider.__new__(IGTokenProvider)
+    provider._token = None
+    assert provider.authenticated_username is None
+
+
 @pytest.mark.parametrize(
     "runtime_kind,timeout,backoff,expect_timeout_retry",
     [

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -635,3 +635,29 @@ def test_is_token_expired_missing_exp():
         mlrun.errors.MLRunInvalidArgumentError, match="Token is missing the 'exp'"
     ):
         mlrun.auth.utils.is_token_expired(token)
+
+
+@pytest.mark.parametrize(
+    "token_payload, expected_username",
+    [
+        # Token with preferred_username claim
+        ({"preferred_username": "alice"}, "alice"),
+        # Token without preferred_username claim
+        ({}, None),
+        # Token with empty preferred_username
+        ({"preferred_username": ""}, ""),
+    ],
+)
+def test_resolve_jwt_username(token_payload, expected_username):
+    """Test extracting 'preferred_username' claim from JWT token."""
+    jwt_token = _create_jwt_token(token_payload, add_defaults=True)
+    result = mlrun.auth.utils.resolve_jwt_username(jwt_token, raise_on_error=False)
+    assert result == expected_username
+
+
+def test_resolve_jwt_username_invalid_token():
+    """Test that resolve_jwt_username handles invalid tokens gracefully."""
+    result = mlrun.auth.utils.resolve_jwt_username(
+        "not-a-valid-jwt", raise_on_error=False
+    )
+    assert result is None

--- a/tests/runtimes/test_utils.py
+++ b/tests/runtimes/test_utils.py
@@ -280,3 +280,61 @@ def test_results_to_iter_status_resolution(rundb_mock):
     results = results[1:]
     mlrun.runtimes.utils.results_to_iter(results, run, execution)
     assert execution.state == mlrun.common.runtimes.constants.RunStates.completed
+
+
+@pytest.mark.parametrize(
+    "output_path, owner, expected_output_path",
+    [
+        # Basic substitution
+        (
+            "/data/{{run.user}}/artifacts",
+            "alice",
+            "/data/alice/artifacts",
+        ),
+        # Multiple occurrences
+        (
+            "/{{run.user}}/data/{{run.user}}/artifacts",
+            "bob",
+            "/bob/data/bob/artifacts",
+        ),
+        # No template in path
+        (
+            "/data/artifacts",
+            "alice",
+            "/data/artifacts",
+        ),
+        # Empty output_path returns as-is
+        (
+            "",
+            "alice",
+            "",
+        ),
+        # None output_path returns None
+        (
+            None,
+            "alice",
+            None,
+        ),
+        # Empty owner returns original path
+        (
+            "/data/{{run.user}}/artifacts",
+            "",
+            "/data/{{run.user}}/artifacts",
+        ),
+        # None owner returns original path
+        (
+            "/data/{{run.user}}/artifacts",
+            None,
+            "/data/{{run.user}}/artifacts",
+        ),
+        # Both None returns None
+        (
+            None,
+            None,
+            None,
+        ),
+    ],
+)
+def test_resolve_run_user_template(output_path, owner, expected_output_path):
+    result = mlrun.runtimes.utils.resolve_run_user_template(output_path, owner)
+    assert result == expected_output_path

--- a/tests/runtimes/test_utils.py
+++ b/tests/runtimes/test_utils.py
@@ -221,6 +221,71 @@ def test_resolve_owner(labels, env_vars, owner_to_enrich, expected_owner):
             assert owner == expected_owner
 
 
+def test_resolve_owner_uses_ig4_token_provider_username():
+    """Test that resolve_owner uses authenticated_username from IG4 token provider."""
+    # Create a mock token provider with authenticated_username
+    mock_token_provider = unittest.mock.MagicMock()
+    mock_token_provider.authenticated_username = "ig4_authenticated_user"
+
+    # Create a mock db with the token provider
+    mock_db = unittest.mock.MagicMock()
+    mock_db.token_provider = mock_token_provider
+
+    # Clear V3IO_USERNAME to trigger IG4 fallback
+    with unittest.mock.patch.dict(os.environ, {"V3IO_USERNAME": ""}, clear=True):
+        with unittest.mock.patch("mlrun.get_run_db", return_value=mock_db):
+            with unittest.mock.patch("getpass.getuser", return_value="local_user"):
+                owner = mlrun.runtimes.utils.resolve_owner({})
+                assert owner == "ig4_authenticated_user"
+
+
+def test_resolve_owner_falls_back_when_token_provider_has_no_username():
+    """Test that resolve_owner falls back to getpass when token provider has no username."""
+    # Create a mock token provider without authenticated_username
+    mock_token_provider = unittest.mock.MagicMock()
+    mock_token_provider.authenticated_username = None
+
+    # Create a mock db with the token provider
+    mock_db = unittest.mock.MagicMock()
+    mock_db.token_provider = mock_token_provider
+
+    # Clear V3IO_USERNAME to trigger fallback
+    with unittest.mock.patch.dict(os.environ, {"V3IO_USERNAME": ""}, clear=True):
+        with unittest.mock.patch("mlrun.get_run_db", return_value=mock_db):
+            with unittest.mock.patch("getpass.getuser", return_value="local_user"):
+                owner = mlrun.runtimes.utils.resolve_owner({})
+                assert owner == "local_user"
+
+
+def test_resolve_owner_falls_back_when_no_db():
+    """Test that resolve_owner falls back to getpass when no db is available."""
+    # Clear V3IO_USERNAME to trigger fallback
+    with unittest.mock.patch.dict(os.environ, {"V3IO_USERNAME": ""}, clear=True):
+        with unittest.mock.patch("mlrun.get_run_db", return_value=None):
+            with unittest.mock.patch("getpass.getuser", return_value="local_user"):
+                owner = mlrun.runtimes.utils.resolve_owner({})
+                assert owner == "local_user"
+
+
+def test_resolve_owner_v3io_username_takes_precedence_over_ig4():
+    """Test that V3IO_USERNAME takes precedence over IG4 token provider username."""
+    # Create a mock token provider with authenticated_username
+    mock_token_provider = unittest.mock.MagicMock()
+    mock_token_provider.authenticated_username = "ig4_authenticated_user"
+
+    # Create a mock db with the token provider
+    mock_db = unittest.mock.MagicMock()
+    mock_db.token_provider = mock_token_provider
+
+    # Set V3IO_USERNAME to verify it takes precedence
+    with unittest.mock.patch.dict(
+        os.environ, {"V3IO_USERNAME": "v3io_user"}, clear=True
+    ):
+        with unittest.mock.patch("mlrun.get_run_db", return_value=mock_db):
+            owner = mlrun.runtimes.utils.resolve_owner({})
+            assert owner == "v3io_user"
+
+
 def test_results_to_iter_status_resolution(rundb_mock):
     """
     Test that results_to_iter correctly updates the execution state based on the results provided.


### PR DESCRIPTION
### 📝 Description

Fix run owner resolution to use the authenticated username instead of the local system user when running jobs locally in IG4 environments.

Previously, when running a job with `local=True` against an IG4 MLRun API server, the owner label was incorrectly set to the local system user (e.g., `jovyan` in Jupyter) instead of the authenticated user. This PR ensures consistent owner resolution across both local and remote runs.

---

### 🛠️ Changes Made

**Core Changes:**
- Added `PREFERRED_USERNAME` JWT claim constant and `resolve_jwt_username()` function to extract username from JWT tokens
- Added `authenticated_username` property to `DynamicTokenProvider` class
- Enhanced `resolve_owner()` to check IG4 token provider for authenticated username before falling back to local system user
- Server-side owner enrichment now overrides client-provided owner with `auth_info.username` when available

**Resolution Order for Owner:**
1. For workflow runners: use `owner_to_enrich` if provided
2. `V3IO_USERNAME` environment variable (IG3 environments)
3. Authenticated username from IG4 JWT token (if available)
4. Local system user (`getpass.getuser()`)

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [] I confirmed whether my changes are covered by system tests
  - [] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Added unit tests
- Manual testing performed against IG4 environment with `local=True/False` runs

---

### 🔗 References
- Ticket link:  https://iguazio.atlassian.net/browse/ML-11932
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

The fix ensures that:

- For **remote runs** submitted to the server: Owner is set from `auth_info.username` (server-side)
- For **local runs** in IG4: Owner is extracted from the JWT `preferred_username` claim via the token provider
- For **IG3 environments**: `V3IO_USERNAME` takes precedence (backward compatible)
- For **CE/unauthenticated**: Falls back to local system user (backward compatible)