### PR TITLE
[Serving] Fix `OnlineVectorService` following changes in #9248

### DIFF
--- a/mlrun/feature_store/feature_vector_utils.py
+++ b/mlrun/feature_store/feature_vector_utils.py
@@ -394,33 +394,31 @@ class OnlineVectorService:
             futures.append(self._controller.emit(row, return_awaitable_result=True))
 
         for future in futures:
-            result = future.await_result()
-            data = result.body
-            if data:
-                actual_columns = data.keys()
-                if all([col in self._index_columns for col in actual_columns]):
-                    # didn't get any data from the graph
-                    results.append(None)
-                    continue
-                for column in self._requested_columns:
-                    if (
-                        column not in actual_columns
-                        and column != self.vector.status.label_column
-                    ):
-                        data[column] = None
+            data = future.await_result()
+            actual_columns = data.keys()
+            if all([col in self._index_columns for col in actual_columns]):
+                # didn't get any data from the graph
+                results.append(None)
+                continue
+            for column in self._requested_columns:
+                if (
+                    column not in actual_columns
+                    and column != self.vector.status.label_column
+                ):
+                    data[column] = None
 
-                if self._impute_values:
-                    for name in data.keys():
-                        v = data[name]
-                        if v is None or (
-                            isinstance(v, float) and (np.isinf(v) or np.isnan(v))
-                        ):
-                            data[name] = self._impute_values.get(name, v)
-                if not self.vector.spec.with_indexes:
-                    for name in self.vector.status.index_keys:
-                        data.pop(name, None)
-                if not any(data.values()):
-                    data = None
+            if self._impute_values:
+                for name in data.keys():
+                    v = data[name]
+                    if v is None or (
+                        isinstance(v, float) and (np.isinf(v) or np.isnan(v))
+                    ):
+                        data[name] = self._impute_values.get(name, v)
+            if not self.vector.spec.with_indexes:
+                for name in self.vector.status.index_keys:
+                    data.pop(name, None)
+            if not any(data.values()):
+                data = None
 
             if as_list and data:
                 data = [


### PR DESCRIPTION
[ML-12095](https://iguazio.atlassian.net/browse/ML-12095)

Changes:
* Removed `.body` access from `await_result()` since the body is now returned directly
* Removed redundant `if data:` conditional - the processing logic should run regardless, with `None` results handled appropriately downstream
* Flattened indentation accordingly

[ML-12095]: https://iguazio.atlassian.net/browse/ML-12095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ