### PR TITLE
[Serving] Fix MLRunAPIRemoteStep authorization on IG4 sys

### DIFF
--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -506,8 +506,18 @@ class MLRunAPIRemoteStep(RemoteStep):
                     session_cookie = f'session=j:{{"sid": "{token}"}}'
                     headers["cookie"] = session_cookie
                 else:
-                    if "Authorization" not in kw.setdefault("headers", {}):
-                        headers.update({"Authorization": "Bearer " + token})
+                    if mlrun.common.schemas.HeaderNames.authorization not in headers:
+                        logger.info(
+                            "Adding authorization header with bearer token for MLRun API request"
+                        )
+                        headers.update(
+                            {
+                                mlrun.common.schemas.HeaderNames.authorization: (
+                                    mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer
+                                    + token
+                                )
+                            }
+                        )
 
         if mlrun.common.schemas.HeaderNames.client_version not in headers:
             headers.update(


### PR DESCRIPTION
### 📝 Description
Fix update `headers` and not `kw["headers"]` when running outside of Iguazio session  

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12091
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
