### PR TITLE
[CI] Fix broken azure dataframe urls

### DIFF
--- a/tests/integration/azure_blob/test_azure_blob.py
+++ b/tests/integration/azure_blob/test_azure_blob.py
@@ -454,7 +454,12 @@ class TestAzureBlob:
 
 
 class TestAnonymousAccessAzureBlob:
-    account_name = "pandemicdatalake"
+    account_name = "azureopendatastorage"
+    # NYC Taxi dataset parquet file for anonymous access testing
+    parquet_path = (
+        "yellow/puYear=2018/puMonth=1/"
+        "part-00000-tid-8898858832658823408-a1de80bd-eed3-4d11-b9d4-fa74bfbd47bc-426339-114.c000.snappy.parquet"
+    )
 
     @pytest.fixture(autouse=True)
     def setup_before_each_test(self):
@@ -467,18 +472,18 @@ class TestAnonymousAccessAzureBlob:
         pop_env()
 
     def test_load_object_into_dask_dataframe(self):
-        # Load a parquet file from Azure Open Datasets
+        # Load a parquet file from Azure Open Datasets (NYC Taxi data)
 
         data_item = mlrun.datastore.store_manager.object(
-            "az://public/curated/covid-19/ecdc_cases/latest/ecdc_cases.parquet"
+            f"az://nyctlc/{self.parquet_path}"
         )
         ddf = data_item.as_df(df_module=dd)
         assert isinstance(ddf, dd.DataFrame)
 
     def test_load_object_into_dask_dataframe_using_wasbs_url(self):
-        # Load a parquet file from Azure Open Datasets
+        # Load a parquet file from Azure Open Datasets (NYC Taxi data)
         data_item = mlrun.run.get_dataitem(
-            "wasbs://public@dummyaccount/curated/covid-19/ecdc_cases/latest/ecdc_cases.parquet"
+            f"wasbs://nyctlc@dummyaccount/{self.parquet_path}"
         )
         ddf = data_item.as_df(df_module=dd)
         assert isinstance(ddf, dd.DataFrame)


### PR DESCRIPTION
### 📝 Description

Fix failing Azure blob integration tests by replacing the deprecated COVID-19 ECDC dataset with the NYC Taxi dataset from Azure Open Datasets.

The `pandemicdatalake` storage account no longer allows anonymous access, causing `TestAnonymousAccessAzureBlob` tests to fail with authentication errors. This PR switches to the `azureopendatastorage` account which hosts the NYC Taxi dataset and still supports anonymous access.

---

### 🛠️ Changes Made

- Changed `account_name` from `pandemicdatalake` to `azureopendatastorage`
- Replaced COVID-19 ECDC dataset path with NYC Taxi dataset parquet file
- Updated both `test_load_object_into_dask_dataframe` and `test_load_object_into_dask_dataframe_using_wasbs_url` to use the new dataset
- Added class-level `parquet_path` variable for better maintainability

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [] I confirmed whether my changes are covered by system tests
  - [] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- Ran `TestAnonymousAccessAzureBlob` tests locally: **2 passed**
- Verified both `az://` and `wasbs://` URL schemes work with the new dataset
- Confirmed linting passes with `make lint`

---

### 🔗 References
- Ticket link: N/A (CI fix)
- Design docs links: N/A
- External links:
  - [NYC Taxi Dataset - Azure Open Datasets](https://learn.microsoft.com/en-us/azure/open-datasets/dataset-taxi-yellow)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

