### PR TITLE
[Build] Fix pkg_resources breakage from setuptools 82

### DIFF
--- a/dockerfiles/common/Dockerfile
+++ b/dockerfiles/common/Dockerfile
@@ -28,7 +28,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libffi-dev \
         python3-dev \
         unzip \
+    # TODO (ML-12122): remove setuptools<82 constraint once pkg_resources usage is dropped
+    && echo 'setuptools<82' > /tmp/constraints.txt \
     && python -m pip list --format=freeze \
         | grep -v '^\-e' \
         | cut -d = -f 1 \
-        | xargs python -m pip install --upgrade
+        | xargs python -m pip install --upgrade -c /tmp/constraints.txt

--- a/server/common/builder/schemas_compiler/docker/Dockerfile
+++ b/server/common/builder/schemas_compiler/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
+# TODO (ML-12122): remove setuptools<82 constraint once pkg_resources usage is dropped
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python -m pip install --upgrade setuptools grpcio-tools${GRPCIO_TOOLS_VERSION}
+    python -m pip install --upgrade 'setuptools<82' grpcio-tools${GRPCIO_TOOLS_VERSION}
 


### PR DESCRIPTION
## 📝 Description

Fix CI failure caused by `setuptools>=82` removing the `pkg_resources` module.

Fixes [ML-12122](https://iguazio.atlassian.net/browse/ML-12122) tracks the follow-up to fully remove `pkg_resources` usage and drop this constraint.

**Error:**
```
ModuleNotFoundError: No module named 'pkg_resources'
```

### Root cause

`setuptools` 82.0.0 removed `pkg_resources` entirely. Two Docker images are affected:

- **Common base image** (`dockerfiles/common/Dockerfile`): blanket `pip install --upgrade` of all pre-installed packages upgrades setuptools to 82+, breaking all downstream images (test, api, mlrun).
- **Schemas-compiler** (`server/common/builder/schemas_compiler/docker/Dockerfile`): `pip install --upgrade setuptools` pulls 82+, and `grpcio-tools~=1.59.0` imports `pkg_resources` at startup.

### Changes

Both Dockerfiles now constrain `setuptools<82`:

1. **`dockerfiles/common/Dockerfile`** — adds a pip constraint file (`-c`) so setuptools is still upgraded (79→81) but capped below 82.
2. **`server/common/builder/schemas_compiler/docker/Dockerfile`** — replaces bare `setuptools` with `'setuptools<82'` in the pip install.

Both have a `TODO (ML-12122)` comment for the follow-up removal.

### Verified locally

- ✅ `make common-image` (no-cache) — setuptools 81.0.0, `pkg_resources` available
- ✅ `make compile-schemas` — schemas-compiler builds, protobuf schemas compile successfully
- ✅ `make build-test` — test image builds, `pkg_resources` and `mlrun` imports work


[ML-12122]: https://iguazio.atlassian.net/browse/ML-12122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ