### PR TITLE
[CI] Fix building images [1.10.x]

### DIFF
--- a/dockerfiles/gpu/Dockerfile
+++ b/dockerfiles/gpu/Dockerfile
@@ -33,14 +33,18 @@ RUN rm -rf /opt/conda/lib/python${MLRUN_PYTHON_VERSION}/ensurepip
 # e.g.: wheel, requests, etc.
 RUN conda update --all --use-local --yes && conda clean --all --quiet --yes
 
-RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION}
-
 WORKDIR /mlrun
 
 # non-recursive chmod for the run to be able to create the handler file with any security context
 RUN chmod 777 /mlrun
 
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
+ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1 UV_NO_BUILD_ISOLATION=1
+
+# mpi4py 3.1.x fails to build with setuptools>=69 ("new_compiler() got an unexpected keyword argument 'dry_run'").
+# See pypa/setuptools#4136. Use setuptools<69 and no build isolation so uv builds mpi4py with it; the lock file
+# will then install setuptools==80.9.0 for the rest of the environment.
+RUN --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/pip \
+    python -m pip install --upgrade 'setuptools>=40.9,<69' pip~=${MLRUN_PIP_VERSION}
 
 # do not require hashes as PyHive is installed via remote repo
 # and do not have a hash set in the locked-requirements.txt

--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -28,7 +28,7 @@ ENV MAMBA_DOWNLOAD_THREADS=16
 ENV MAMBA_EXTRACT_THREADS=8
 
 RUN micromamba install -y -n base -c conda-forge \
-        python=$MLRUN_PYTHON_VERSION openmpi-mpicc=$OMPI_VERSION && \
+        python=$MLRUN_PYTHON_VERSION 'setuptools<82' openmpi-mpicc=$OMPI_VERSION && \
     micromamba clean -afy
 RUN --mount=type=cache,target=/opt/conda/pkgs \
     micromamba config set channel_priority strict && \
@@ -37,6 +37,7 @@ RUN --mount=type=cache,target=/opt/conda/pkgs \
     micromamba install -y -n base -c conda-forge \
         python=${MLRUN_PYTHON_VERSION} \
         pip=${MLRUN_PIP_VERSION} \
+        'setuptools<82' \
         openmpi-mpicc=${OMPI_VERSION} && \
     micromamba clean -afy
 
@@ -50,17 +51,23 @@ ARG MLRUN_PYTHON_VERSION
 ARG MLRUN_PIP_VERSION
 
 COPY --from=conda-build /opt/conda /opt/conda
-ENV PATH="/opt/conda/bin:${PATH}"
 
-RUN --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/pip \
-    /opt/conda/bin/python -m pip install --upgrade setuptools pip~=${MLRUN_PIP_VERSION}
+ENV PATH="/opt/conda/bin:${PATH}" \
+    UV_SYSTEM_PYTHON=true \
+    UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_BUILD_ISOLATION=1
 
 WORKDIR /mlrun
 # non-recursive chmod for the run to be able to create the handler file with any security context
 RUN chmod 777 /mlrun
 
-ARG MLRUN_PYTHON_VERSION
-ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
+
+# mpi4py 3.1.x fails to build with setuptools>=69 ("new_compiler() got an unexpected keyword argument 'dry_run'").
+# See pypa/setuptools#4136. Use setuptools<69 and no build isolation so uv builds mpi4py with it; the lock file
+# will then install setuptools==80.9.0 for the rest of the environment.
+RUN --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/pip \
+    /opt/conda/bin/python -m pip install --upgrade 'setuptools>=40.9,<69' pip~=${MLRUN_PIP_VERSION}
 
 # Install MLRun:
 # no-deps to ignore existing dependencies, just add the locked requirements


### PR DESCRIPTION
### 📝 Description

Building images were failing due to recent changes on setuptools >= 82.0.0.
This PR ensures the openmpi is built with lower version of setuptools, in which later on, would be upgraded according to locked requirement files. `UV_NO_BUILD_ISOLATION` is being used to ensure the mpi4py build uses that env (and thus that setuptools) instead of an isolated one that would get setuptools 80.9.0.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

make mlrun mlrun-gpu passes

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
