### PR TITLE
[Serving] Add JSONPath body mapping support for API handler

### DIFF
--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -1325,6 +1325,11 @@ joblib==1.5.3 \
     # via
     #   scikit-learn
     #   scikit-plot
+jsonpath-ng==1.7.0 \
+    --hash=sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e \
+    --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
+    --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -2415,6 +2420,10 @@ plotly==5.24.1 \
     --hash=sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae \
     --hash=sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089
     # via -r extras-requirements.txt
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via jsonpath-ng
 prompt-toolkit==3.0.52 \
     --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
     --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -1291,6 +1291,11 @@ joblib==1.5.3 \
     # via
     #   scikit-learn
     #   scikit-plot
+jsonpath-ng==1.7.0 \
+    --hash=sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e \
+    --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
+    --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -2186,6 +2191,10 @@ plotly==5.24.1 \
     --hash=sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae \
     --hash=sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089
     # via -r extras-requirements.txt
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via jsonpath-ng
 prompt-toolkit==3.0.52 \
     --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
     --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -1218,6 +1218,11 @@ jmespath==0.10.0 \
     #   aliyun-python-sdk-core
     #   boto3
     #   botocore
+jsonpath-ng==1.7.0 \
+    --hash=sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e \
+    --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
+    --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -1937,6 +1942,10 @@ plotly==5.24.1 \
     --hash=sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae \
     --hash=sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089
     # via -r extras-requirements.txt
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via jsonpath-ng
 prompt-toolkit==3.0.52 \
     --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
     --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -1178,6 +1178,11 @@ jmespath==0.10.0 \
     #   aliyun-python-sdk-core
     #   boto3
     #   botocore
+jsonpath-ng==1.7.0 \
+    --hash=sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e \
+    --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
+    --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -1835,6 +1840,10 @@ plotly==5.24.1 \
     --hash=sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae \
     --hash=sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089
     # via -r extras-requirements.txt
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via jsonpath-ng
 prompt-toolkit==3.0.52 \
     --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
     --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -1325,6 +1325,11 @@ joblib==1.5.3 \
     # via
     #   scikit-learn
     #   scikit-plot
+jsonpath-ng==1.7.0 \
+    --hash=sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e \
+    --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
+    --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -2415,6 +2420,10 @@ plotly==5.24.1 \
     --hash=sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae \
     --hash=sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089
     # via -r extras-requirements.txt
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via jsonpath-ng
 prompt-toolkit==3.0.52 \
     --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
     --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -1887,6 +1887,11 @@ joblib==1.5.3 \
     # via
     #   nltk
     #   scikit-learn
+jsonpath-ng==1.7.0 \
+    --hash=sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e \
+    --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
+    --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -3033,6 +3038,10 @@ pluggy==1.6.0 \
     # via
     #   diff-cover
     #   pytest
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via jsonpath-ng
 polyfactory==3.2.0 \
     --hash=sha256:5945799cce4c56cd44ccad96fb0352996914553cc3efaa5a286930599f569571 \
     --hash=sha256:879242f55208f023eee1de48522de5cb1f9fd2d09b2314e999a9592829d596d1

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -1947,6 +1947,11 @@ joblib==1.5.3 \
     # via
     #   nltk
     #   scikit-learn
+jsonpath-ng==1.7.0 \
+    --hash=sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e \
+    --hash=sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6 \
+    --hash=sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -3132,6 +3137,10 @@ pluggy==1.6.0 \
     # via
     #   diff-cover
     #   pytest
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via jsonpath-ng
 polyfactory==3.2.0 \
     --hash=sha256:5945799cce4c56cd44ccad96fb0352996914553cc3efaa5a286930599f569571 \
     --hash=sha256:879242f55208f023eee1de48522de5cb1f9fd2d09b2314e999a9592829d596d1

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -19,11 +19,10 @@ from http import HTTPMethod
 from typing import Optional, Union
 
 import nuclio
-from nuclio import KafkaTrigger
-from nuclio.triggers import NuclioTrigger
-
 from jsonpath_ng import parse as jsonpath_parse
 from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
+from nuclio import KafkaTrigger
+from nuclio.triggers import NuclioTrigger
 
 import mlrun
 import mlrun.common.schemas as schemas
@@ -76,14 +75,6 @@ class APIHandlerConfig(mlrun.model.ModelObj):
     def body_map(self) -> dict[str, str]:
         """Get the body_map configuration as a dictionary."""
         return self._body_map
-
-    @body_map.setter
-    def body_map(self, value: dict[str, str] | None) -> None:
-        """Set the body_map configuration.
-
-        :param value: Dictionary mapping parameter names to JSONPath expressions, or None.
-        """
-        self._body_map = value or {}
 
     @property
     def endpoints(self) -> dict[str, dict]:
@@ -155,6 +146,23 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         path = self._normalize_path(path)
         endpoint_key = serving_utils._combine_serving_endpoint_key(method, path)
         return self._endpoints.get(endpoint_key)
+
+    def to_dict(self, fields=None, exclude=None):
+        """Convert object to dictionary."""
+        return super().to_dict(fields=fields, exclude=exclude)
+
+    @classmethod
+    def from_dict(
+        cls, struct=None, fields=None, deprecated_fields=None, init_with_params=False
+    ):
+        """Create object from dictionary, handling private _body_map attribute."""
+        if struct and "body_map" in struct:
+            # Extract body_map and set it via __init__ to avoid property setter issues
+            body_map = struct.pop("body_map")
+            obj = super().from_dict(struct, fields, deprecated_fields, init_with_params)
+            obj._body_map = body_map or {}
+            return obj
+        return super().from_dict(struct, fields, deprecated_fields, init_with_params)
 
     def add_endpoint_handler(
         self,

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -57,11 +57,17 @@ serving_subkind = "serving_v2"
 class APIHandlerConfig(mlrun.model.ModelObj):
     """Configuration for API handler in serving graph"""
 
-    _dict_fields = ["enabled", "endpoints"]
+    _dict_fields = ["enabled", "endpoints", "body_map"]
 
-    def __init__(self, enabled: bool = True, endpoints: dict[str, dict] | None = None):
+    def __init__(
+        self,
+        enabled: bool = True,
+        endpoints: dict[str, dict] | None = None,
+        body_map: dict[str, str] | None = None,
+    ):
         self.enabled = enabled
         self._endpoints = endpoints or {}
+        self.body_map = body_map
 
     @property
     def endpoints(self) -> dict[str, dict]:
@@ -181,6 +187,48 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         path = self._normalize_path(path)
         endpoint_key = serving_utils._combine_serving_endpoint_key(http_method, path)
         self._endpoints.pop(endpoint_key, None)
+
+    def add_body_mapping(self, parameter_name: str, json_path: str) -> None:
+        """Add a JSONPath body mapping for extracting request parameters.
+
+        Maps a JSONPath expression to a parameter name. When a request is received,
+        the JSONPath will be evaluated against the request body and the result
+        will be passed as a named parameter to the handler function.
+
+        :param parameter_name: Name of the parameter to pass to the handler
+        :param json_path: JSONPath expression to extract the value from request body
+                         (e.g., '$.user.name' or '$.items[*].id')
+
+        Example::
+
+            config = APIHandlerConfig()
+            config.add_body_mapping("user_name", "$.user.name")
+            config.add_body_mapping("user_email", "$.user.contact.email")
+            config.add_body_mapping(
+                "item_ids", "$.items[*].id"
+            )  # Multiple matches return list
+        """
+        if self.body_map is None:
+            self.body_map = {}
+
+        # Warn if overriding an existing mapping
+        if parameter_name in self.body_map:
+            logger.warning(
+                "Overriding existing body mapping",
+                parameter_name=parameter_name,
+                old_json_path=self.body_map[parameter_name],
+                new_json_path=json_path,
+            )
+
+        self.body_map[parameter_name] = json_path
+
+    def remove_body_mapping(self, parameter_name: str) -> None:
+        """Remove a body mapping by parameter name.
+
+        :param parameter_name: Name of the parameter mapping to remove
+        """
+        if self.body_map:
+            self.body_map.pop(parameter_name, None)
 
 
 def new_v2_model_server(

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -76,6 +76,14 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         """Get the body_map configuration as a dictionary."""
         return self._body_map
 
+    @body_map.setter
+    def body_map(self, value: dict[str, str] | None) -> None:
+        """Set the body_map configuration from a dictionary."""
+        self._body_map = {}
+        if value:
+            for parameter_name, json_path in value.items():
+                self.add_body_mapping(parameter_name, json_path)
+
     @property
     def endpoints(self) -> dict[str, dict]:
         """Get the endpoints configuration as a dictionary."""

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -22,6 +22,9 @@ import nuclio
 from nuclio import KafkaTrigger
 from nuclio.triggers import NuclioTrigger
 
+from jsonpath_ng import parse as jsonpath_parse
+from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
+
 import mlrun
 import mlrun.common.schemas as schemas
 import mlrun.common.secrets
@@ -211,7 +214,7 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         :param parameter_name: Name of the parameter to pass to the handler
         :param json_path: JSONPath expression to extract the value from request body
                          (e.g., '$.user.name' or '$.items[*].id')
-        :raises mlrun.errors.MLRunInvalidArgumentError: If json_path is not a valid JSONPath expression
+        :raises mlrun.errors.MLRunValueError: If json_path is not a valid JSONPath expression
 
         Example::
 
@@ -223,13 +226,10 @@ class APIHandlerConfig(mlrun.model.ModelObj):
             )  # Multiple matches return list
         """
         # Validate JSONPath expression by parsing it
-        from jsonpath_ng import parse as jsonpath_parse
-        from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
-
         try:
             jsonpath_parse(json_path)
         except (JsonPathLexerError, JsonPathParserError) as exc:
-            raise mlrun.errors.MLRunInvalidArgumentError(
+            raise mlrun.errors.MLRunValueError(
                 f"Invalid JSON path expression for parameter '{parameter_name}': "
                 f"'{json_path}'. Error: {exc}"
             ) from exc

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -147,10 +147,6 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         endpoint_key = serving_utils._combine_serving_endpoint_key(method, path)
         return self._endpoints.get(endpoint_key)
 
-    def to_dict(self, fields=None, exclude=None):
-        """Convert object to dictionary."""
-        return super().to_dict(fields=fields, exclude=exclude)
-
     @classmethod
     def from_dict(
         cls, struct=None, fields=None, deprecated_fields=None, init_with_params=False

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -67,7 +67,20 @@ class APIHandlerConfig(mlrun.model.ModelObj):
     ):
         self.enabled = enabled
         self._endpoints = endpoints or {}
-        self.body_map = body_map
+        self._body_map = body_map or {}
+
+    @property
+    def body_map(self) -> dict[str, str]:
+        """Get the body_map configuration as a dictionary."""
+        return self._body_map
+
+    @body_map.setter
+    def body_map(self, value: dict[str, str] | None) -> None:
+        """Set the body_map configuration.
+
+        :param value: Dictionary mapping parameter names to JSONPath expressions, or None.
+        """
+        self._body_map = value or {}
 
     @property
     def endpoints(self) -> dict[str, dict]:
@@ -198,6 +211,7 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         :param parameter_name: Name of the parameter to pass to the handler
         :param json_path: JSONPath expression to extract the value from request body
                          (e.g., '$.user.name' or '$.items[*].id')
+        :raises mlrun.errors.MLRunInvalidArgumentError: If json_path is not a valid JSONPath expression
 
         Example::
 
@@ -208,27 +222,35 @@ class APIHandlerConfig(mlrun.model.ModelObj):
                 "item_ids", "$.items[*].id"
             )  # Multiple matches return list
         """
-        if self.body_map is None:
-            self.body_map = {}
+        # Validate JSONPath expression by parsing it
+        from jsonpath_ng import parse as jsonpath_parse
+        from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
+
+        try:
+            jsonpath_parse(json_path)
+        except (JsonPathLexerError, JsonPathParserError) as exc:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Invalid JSON path expression for parameter '{parameter_name}': "
+                f"'{json_path}'. Error: {exc}"
+            ) from exc
 
         # Warn if overriding an existing mapping
-        if parameter_name in self.body_map:
+        if parameter_name in self._body_map:
             logger.warning(
                 "Overriding existing body mapping",
                 parameter_name=parameter_name,
-                old_json_path=self.body_map[parameter_name],
+                old_json_path=self._body_map[parameter_name],
                 new_json_path=json_path,
             )
 
-        self.body_map[parameter_name] = json_path
+        self._body_map[parameter_name] = json_path
 
     def remove_body_mapping(self, parameter_name: str) -> None:
         """Remove a body mapping by parameter name.
 
         :param parameter_name: Name of the parameter mapping to remove
         """
-        if self.body_map:
-            self.body_map.pop(parameter_name, None)
+        self._body_map.pop(parameter_name, None)
 
 
 def new_v2_model_server(

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -147,19 +147,6 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         endpoint_key = serving_utils._combine_serving_endpoint_key(method, path)
         return self._endpoints.get(endpoint_key)
 
-    @classmethod
-    def from_dict(
-        cls, struct=None, fields=None, deprecated_fields=None, init_with_params=False
-    ):
-        """Create object from dictionary, handling private _body_map attribute."""
-        if struct and "body_map" in struct:
-            # Extract body_map and set it via __init__ to avoid property setter issues
-            body_map = struct.pop("body_map")
-            obj = super().from_dict(struct, fields, deprecated_fields, init_with_params)
-            obj._body_map = body_map or {}
-            return obj
-        return super().from_dict(struct, fields, deprecated_fields, init_with_params)
-
     def add_endpoint_handler(
         self,
         path: str,

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -16,6 +16,9 @@
 
 from http import HTTPMethod
 
+from jsonpath_ng import parse as jsonpath_parse
+from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
+
 import mlrun.common.schemas as schemas
 import mlrun.errors
 import mlrun.runtimes.nuclio.serving
@@ -24,6 +27,7 @@ import mlrun.serving.states
 import mlrun.serving.utils as serving_utils
 import mlrun.utils
 from mlrun.common.schemas.serving import _APIEndpointKeys
+from mlrun.serving.utils import _MappedBody
 
 
 class _APIHandlerStep(mlrun.serving.states.TaskStep):
@@ -54,7 +58,42 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
         else:
             self.config = mlrun.runtimes.nuclio.serving.APIHandlerConfig()
         self.context = context
+
+        # Parse JSONPath expressions during initialization for performance and early error detection
+        self._parsed_body_map = {}
+        if self.config.body_map:
+            for param_name, jsonpath_expr in self.config.body_map.items():
+                try:
+                    self._parsed_body_map[param_name] = jsonpath_parse(jsonpath_expr)
+                except (JsonPathLexerError, JsonPathParserError) as exc:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Invalid JSON path expression for parameter '{param_name}': "
+                        f"'{jsonpath_expr}'. Error: {exc}"
+                    ) from exc
+
         mlrun.utils.logger.debug("The context in API handler", context=self.context)
+
+    def _apply_parsed_body_map(self, body: dict) -> "_MappedBody":
+        """Apply pre-parsed JSONPath expressions to extract parameters from event body.
+
+        :param body: The event body dict to extract parameters from.
+        :return: A :class:`_MappedBody` with extracted parameters.
+        :raises KeyError: If any JSONPath expression has no match in body.
+        """
+        result = {}
+        for param_name, parsed_expr in self._parsed_body_map.items():
+            matches = parsed_expr.find(body)
+            if not matches:
+                raise KeyError(
+                    f"JSONPath expression for parameter '{param_name}' "
+                    f"matched nothing in the event body"
+                )
+            # Single match: return value; multiple matches: return list
+            if len(matches) == 1:
+                result[param_name] = matches[0].value
+            else:
+                result[param_name] = [match.value for match in matches]
+        return _MappedBody(result)
 
     def do(self, event):
         """Handle incoming request and validate against configured endpoints"""
@@ -136,6 +175,26 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
 
             # Handle the action
             if action == schemas.APIHandlerAction.ALLOW:
+                # Apply body_map transformation if configured at the config level
+                if self._parsed_body_map:
+                    body = event.body if hasattr(event, "body") else event
+                    if isinstance(body, dict):
+                        mapped_body = self._apply_parsed_body_map(body)
+                        mlrun.utils.logger.debug(
+                            "Applied body_map transformation",
+                            body_map=self.config.body_map,
+                            mapped_params=list(mapped_body.keys()),
+                        )
+                        if hasattr(event, "body"):
+                            event.body = mapped_body
+                        else:
+                            event = mapped_body
+                    else:
+                        mlrun.utils.logger.warning(
+                            "body_map configured but event body is not a dict, "
+                            "skipping body_map transformation",
+                            body_type=type(body).__name__,
+                        )
                 # Pass the event to the next step in the graph
                 return event
             elif action == schemas.APIHandlerAction.FORBID:

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -73,7 +73,7 @@ from ..utils import (
     is_explicit_ack_supported,
     lock_hub_uri_version,
 )
-from .utils import StepToDict, _extract_input_data, _update_result_body
+from .utils import StepToDict, _extract_input_data, _MappedBody, _update_result_body
 
 callable_prefix = "_"
 path_splitter = "/"
@@ -931,9 +931,13 @@ class TaskStep(BaseStep):
                     f"step {self.name} does not have a handler"
                 )
 
-            result = self._handler(
-                _extract_input_data(self.input_path, event.body), *args, **kwargs
-            )
+            body = _extract_input_data(self.input_path, event.body)
+            if isinstance(body, _MappedBody):
+                # body_map-transformed bodies are unpacked as **kwargs
+                # so handler signatures like def fun(book: str) work
+                result = self._handler(**body, **kwargs)
+            else:
+                result = self._handler(body, *args, **kwargs)
             event.body = _update_result_body(self.result_path, event.body, result)
         except Exception as exc:
             if self._on_error_handler:

--- a/mlrun/serving/utils.py
+++ b/mlrun/serving/utils.py
@@ -45,6 +45,25 @@ def _update_result_body(result_path, event_body, result):
     return event_body
 
 
+class _MappedBody(dict):
+    """Marker dict subclass for body_map-transformed event bodies.
+
+    When a downstream :class:`TaskStep` receives a body that is an instance
+    of ``_MappedBody``, it unpacks the dict as ``**kwargs`` to the handler
+    instead of passing it as a single positional argument.  This allows
+    handler functions to declare named parameters that match the body_map
+    keys, e.g.::
+
+        body_map = {"book": "$.age"}
+
+
+        def handler(book):
+            return f"{book} - this is the book"
+    """
+
+    pass
+
+
 class StepToDict:
     """auto serialization of graph steps to a python dictionary"""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ aiosmtplib~=3.0
 # # deepdiff 8.6.0 has a vulnerability (Class Pollution in Delta class leading to DoS)
 deepdiff>=8.6.1,<9.0.0
 pyjwt~=2.10
+jsonpath-ng~=1.7

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -168,7 +168,7 @@ class TestAPIHandlerConfigBodyMap:
 
         # Should raise for invalid JSONPath syntax
         with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError,
+            mlrun.errors.MLRunValueError,
             match=r"Invalid JSON path expression for parameter 'bad_param'",
         ):
             config.add_body_mapping("bad_param", "$.invalid[[[syntax")

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -1,0 +1,593 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for JSONPath body_map support in the serving endpoint"""
+
+import logging
+from http import HTTPMethod
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+import mlrun
+from mlrun.common.schemas.serving import APIHandlerAction
+from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
+from mlrun.serving.api_handler import _APIHandlerStep
+
+
+# ---------------------------------------------------------------------------
+# APIHandlerConfig body_map tests (config-level)
+# ---------------------------------------------------------------------------
+class TestAPIHandlerConfigBodyMap:
+    """Tests for body_map on the APIHandlerConfig level"""
+
+    def test_config_with_body_map(self) -> None:
+        """Test creating APIHandlerConfig with a body_map"""
+        body_map = {"model_name": "$.model", "input_data": "$.data.inputs"}
+        config = APIHandlerConfig(body_map=body_map)
+        assert config.body_map == body_map
+
+    def test_config_without_body_map(self) -> None:
+        """Test that body_map defaults to None"""
+        config = APIHandlerConfig()
+        assert config.body_map is None
+
+    def test_body_map_serialization_roundtrip(self) -> None:
+        """Test body_map survives to_dict / from_dict round-trip"""
+        body_map = {"user_name": "$.name", "user_email": "$.contact.email"}
+        config = APIHandlerConfig(body_map=body_map)
+        config.add_endpoint_handler(
+            "/users", HTTPMethod.POST, APIHandlerAction.ALLOW, "Create user"
+        )
+
+        # Serialize
+        config_dict = config.to_dict()
+        assert config_dict["body_map"] == body_map
+
+        # Deserialize
+        restored = APIHandlerConfig.from_dict(config_dict)
+        assert restored.body_map == body_map
+
+    def test_body_map_shared_across_endpoints(self) -> None:
+        """Test that body_map applies to all endpoints (not per-endpoint)"""
+        body_map = {"input": "$.data"}
+        config = APIHandlerConfig(body_map=body_map)
+        config.add_endpoint_handler("/predict", HTTPMethod.POST, APIHandlerAction.ALLOW)
+        config.add_endpoint_handler(
+            "/classify", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+
+        # body_map is on the config, not on individual endpoints
+        assert config.body_map == body_map
+        predict_cfg = config.get_endpoint_config(HTTPMethod.POST, "/predict")
+        classify_cfg = config.get_endpoint_config(HTTPMethod.POST, "/classify")
+        assert "body_map" not in predict_cfg
+        assert "body_map" not in classify_cfg
+
+    @staticmethod
+    def test_add_body_mapping() -> None:
+        """Test add_body_mapping helper method"""
+        config = APIHandlerConfig()
+        assert config.body_map is None
+
+        # Add first mapping - should initialize body_map
+        config.add_body_mapping("user_name", "$.user.name")
+        assert config.body_map == {"user_name": "$.user.name"}
+
+        # Add second mapping
+        config.add_body_mapping("user_email", "$.user.contact.email")
+        assert config.body_map == {
+            "user_name": "$.user.name",
+            "user_email": "$.user.contact.email",
+        }
+
+        # Add mapping with wildcard (multiple matches)
+        config.add_body_mapping("item_ids", "$.items[*].id")
+        assert config.body_map == {
+            "user_name": "$.user.name",
+            "user_email": "$.user.contact.email",
+            "item_ids": "$.items[*].id",
+        }
+
+    @staticmethod
+    def test_add_body_mapping_overwrites_existing(caplog) -> None:
+        """Test that add_body_mapping overwrites existing mappings and logs warning"""
+
+        config = APIHandlerConfig(body_map={"param": "$.old.path"})
+
+        with caplog.at_level(logging.WARNING):
+            config.add_body_mapping("param", "$.new.path")
+
+        assert config.body_map == {"param": "$.new.path"}
+
+        # Verify warning was logged
+        assert any(
+            "Overriding existing body mapping" in record.message
+            for record in caplog.records
+        )
+
+    @staticmethod
+    def test_remove_body_mapping() -> None:
+        """Test remove_body_mapping helper method"""
+        config = APIHandlerConfig(
+            body_map={
+                "user_name": "$.user.name",
+                "user_email": "$.user.contact.email",
+                "item_ids": "$.items[*].id",
+            }
+        )
+
+        # Remove one mapping
+        config.remove_body_mapping("user_email")
+        assert config.body_map == {
+            "user_name": "$.user.name",
+            "item_ids": "$.items[*].id",
+        }
+
+        # Remove another
+        config.remove_body_mapping("item_ids")
+        assert config.body_map == {"user_name": "$.user.name"}
+
+        # Remove last one
+        config.remove_body_mapping("user_name")
+        assert config.body_map == {}
+
+    @staticmethod
+    def test_remove_body_mapping_nonexistent() -> None:
+        """Test that removing non-existent mapping doesn't raise error"""
+        config = APIHandlerConfig(body_map={"param": "$.path"})
+        config.remove_body_mapping("nonexistent")  # Should not raise
+        assert config.body_map == {"param": "$.path"}
+
+    @staticmethod
+    def test_remove_body_mapping_when_none() -> None:
+        """Test removing mapping when body_map is None"""
+        config = APIHandlerConfig()
+        assert config.body_map is None
+        config.remove_body_mapping("param")  # Should not raise
+        assert config.body_map is None
+
+
+# ---------------------------------------------------------------------------
+# _APIHandlerStep body_map integration tests
+# ---------------------------------------------------------------------------
+class TestAPIHandlerStepBodyMap:
+    """Tests for body_map integration in _APIHandlerStep"""
+
+    @staticmethod
+    def test_invalid_jsonpath_raises_error_on_init() -> None:
+        """Test that invalid JSONPath expression raises error during initialization"""
+        import mlrun.errors
+
+        config = APIHandlerConfig(body_map={"param": "$.invalid[[[syntax"})
+        config.add_endpoint_handler(
+            "/predict", HTTPMethod.POST, APIHandlerAction.ALLOW, "Test"
+        )
+
+        # Should raise during step initialization, not during request handling
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match=r"Invalid JSON path expression for parameter 'param'",
+        ):
+            _APIHandlerStep(config=config)
+
+    @staticmethod
+    def _make_step_with_body_map(body_map, path="/predict"):
+        """Helper to create an _APIHandlerStep with a config-level body_map"""
+        config = APIHandlerConfig(body_map=body_map)
+        config.add_endpoint_handler(
+            path, HTTPMethod.POST, APIHandlerAction.ALLOW, "Test"
+        )
+
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.POST
+        mock_event.path = path
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+        return step
+
+    @staticmethod
+    def test_body_map_transforms_event_body() -> None:
+        """Test that body_map transforms the event body via JSONPath"""
+        body_map = {
+            "model_name": "$.request.model",
+            "input_data": "$.request.data",
+        }
+        step = TestAPIHandlerStepBodyMap._make_step_with_body_map(body_map)
+
+        event = MagicMock()
+        event.method = HTTPMethod.POST
+        event.path = "/predict"
+        event.body = {
+            "request": {
+                "model": "my-model",
+                "data": [1, 2, 3],
+            },
+            "metadata": {"trace_id": "abc"},
+        }
+
+        result = step.do(event)
+        assert result.body == {"model_name": "my-model", "input_data": [1, 2, 3]}
+
+    @staticmethod
+    def test_body_map_missing_params_raises_error() -> None:
+        """Test that missing body_map params raise KeyError"""
+        body_map = {
+            "name": "$.name",
+            "missing": "$.nonexistent.path",
+        }
+        step = TestAPIHandlerStepBodyMap._make_step_with_body_map(body_map)
+
+        event = MagicMock()
+        event.method = HTTPMethod.POST
+        event.path = "/predict"
+        event.body = {"name": "test-model"}
+
+        # Should raise KeyError since $.nonexistent.path has no matches
+        with pytest.raises(KeyError, match="matched nothing"):
+            step.do(event)
+
+    def test_no_body_map_passes_event_through(self) -> None:
+        """Test that without body_map the event passes through unchanged"""
+        config = APIHandlerConfig()  # no body_map
+        config.add_endpoint_handler("/predict", HTTPMethod.POST, APIHandlerAction.ALLOW)
+
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.POST
+        mock_event.path = "/predict"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+
+        event = MagicMock()
+        event.method = HTTPMethod.POST
+        event.path = "/predict"
+        original_body = {"data": [1, 2, 3]}
+        event.body = original_body
+
+        result = step.do(event)
+        assert result.body is original_body
+
+    @staticmethod
+    def test_body_map_non_dict_body_skips_transform() -> None:
+        """Test that non-dict body is passed through even with body_map configured"""
+        body_map = {"param": "$.field"}
+        step = TestAPIHandlerStepBodyMap._make_step_with_body_map(body_map)
+
+        event = MagicMock()
+        event.method = HTTPMethod.POST
+        event.path = "/predict"
+        event.body = "plain string body"
+
+        result = step.do(event)
+        assert result.body == "plain string body"
+
+    def test_body_map_applies_to_all_endpoints(self) -> None:
+        """Test that the same body_map is applied regardless of which endpoint matched"""
+        body_map = {"input": "$.payload.data"}
+        config = APIHandlerConfig(body_map=body_map)
+        config.add_endpoint_handler("/predict", HTTPMethod.POST, APIHandlerAction.ALLOW)
+        config.add_endpoint_handler(
+            "/classify", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+
+        step = _APIHandlerStep(config=config)
+
+        # Test /predict
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.POST
+        mock_event.path = "/predict"
+        context.current_event = mock_event
+        step.context = context
+
+        event = MagicMock()
+        event.method = HTTPMethod.POST
+        event.path = "/predict"
+        event.body = {"payload": {"data": [1, 2]}}
+        result = step.do(event)
+        assert result.body == {"input": [1, 2]}
+
+        # Test /classify — same body_map applies
+        mock_event.path = "/classify"
+        event2 = MagicMock()
+        event2.method = HTTPMethod.POST
+        event2.path = "/classify"
+        event2.body = {"payload": {"data": "cats"}}
+        result2 = step.do(event2)
+        assert result2.body == {"input": "cats"}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end mock-server tests
+# ---------------------------------------------------------------------------
+class TestBodyMapMockServer:
+    """End-to-end tests for body_map with mock server"""
+
+    @staticmethod
+    def test_body_map_e2e() -> None:
+        """Test body_map end-to-end through mock server"""
+
+        def echo_handler(**kwargs):
+            return kwargs
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map", kind="serving"),
+        )
+
+        body_map = {
+            "model_name": "$.request.model",
+            "input_data": "$.request.data",
+        }
+
+        config = APIHandlerConfig(body_map=body_map)
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            "Prediction with body_map",
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler=echo_handler).respond()
+
+        server = fn.to_mock_server()
+        try:
+            resp = server.test(
+                "/predict",
+                method="POST",
+                body={
+                    "request": {
+                        "model": "my-model",
+                        "data": [1, 2, 3],
+                    },
+                    "extra_field": "ignored",
+                },
+            )
+            assert resp == {"model_name": "my-model", "input_data": [1, 2, 3]}
+        finally:
+            server.wait_for_completion()
+
+    @staticmethod
+    def test_body_map_with_missing_fields_e2e() -> None:
+        """Test body_map with missing fields raises KeyError"""
+
+        def echo_handler(**kwargs):
+            return kwargs
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map-missing", kind="serving"),
+        )
+
+        body_map = {
+            "name": "$.user.name",
+            "email": "$.user.email",
+            "phone": "$.user.phone",  # This will be missing
+        }
+
+        config = APIHandlerConfig(body_map=body_map)
+        config.add_endpoint_handler(
+            "/register",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            "Register with body_map",
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler=echo_handler).respond()
+
+        server = fn.to_mock_server()
+        try:
+            # Should raise since $.user.phone is missing
+            with pytest.raises(RuntimeError, match="matched nothing"):
+                server.test(
+                    "/register",
+                    method="POST",
+                    body={
+                        "user": {
+                            "name": "Alice",
+                            "email": "alice@example.com",
+                            # "phone" is intentionally missing
+                        }
+                    },
+                )
+        finally:
+            server.wait_for_completion()
+
+    def test_endpoint_without_body_map_unaffected(self) -> None:
+        """Test that endpoints without body_map still work normally"""
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-no-body-map", kind="serving"),
+        )
+
+        config = APIHandlerConfig()  # no body_map
+        config.add_endpoint_handler(
+            "/health", HTTPMethod.GET, APIHandlerAction.ALLOW, "Health check"
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler="(event)").respond()
+
+        server = fn.to_mock_server()
+        try:
+            resp = server.test("/health", method="GET", body="ping")
+            assert resp == "ping"
+        finally:
+            server.wait_for_completion()
+
+    @staticmethod
+    def test_body_map_same_for_multiple_endpoints_e2e() -> None:
+        """Test that the same body_map is applied to all endpoints"""
+
+        def echo_handler(**kwargs):
+            return kwargs
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map-multi", kind="serving"),
+        )
+
+        body_map = {"input": "$.payload.data"}
+
+        config = APIHandlerConfig(body_map=body_map)
+        config.add_endpoint_handler("/predict", HTTPMethod.POST, APIHandlerAction.ALLOW)
+        config.add_endpoint_handler(
+            "/classify", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler=echo_handler).respond()
+
+        server = fn.to_mock_server()
+        try:
+            resp1 = server.test(
+                "/predict",
+                method="POST",
+                body={"payload": {"data": [1, 2]}},
+            )
+            assert resp1 == {"input": [1, 2]}
+
+            resp2 = server.test(
+                "/classify",
+                method="POST",
+                body={"payload": {"data": "cats"}},
+            )
+            assert resp2 == {"input": "cats"}
+        finally:
+            server.wait_for_completion()
+
+    @staticmethod
+    def test_body_map_kwargs_handler_e2e() -> None:
+        """Test body_map unpacks as kwargs to a handler with named parameters"""
+
+        def fun(book):
+            return f"{book} - this is the book"
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map-kwargs", kind="serving"),
+        )
+
+        config = APIHandlerConfig(body_map={"book": "$.age"})
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            "Kwargs handler",
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="process", handler=fun).respond()
+
+        server = fn.to_mock_server()
+        try:
+            resp = server.test(
+                "/predict",
+                method="POST",
+                body={"firstName": "John", "lastName": "doe", "age": 26},
+            )
+            assert resp == "26 - this is the book"
+        finally:
+            server.wait_for_completion()
+
+    @staticmethod
+    def test_body_map_multi_kwargs_handler_e2e() -> None:
+        """Test body_map with multiple kwargs passed to handler"""
+
+        def handler(name, age):
+            return f"{name} is {age} years old"
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map-multi-kwargs", kind="serving"),
+        )
+
+        config = APIHandlerConfig(body_map={"name": "$.firstName", "age": "$.age"})
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="process", handler=handler).respond()
+
+        server = fn.to_mock_server()
+        try:
+            resp = server.test(
+                "/predict",
+                method="POST",
+                body={"firstName": "John", "lastName": "doe", "age": 26},
+            )
+            assert resp == "John is 26 years old"
+        finally:
+            server.wait_for_completion()
+
+    @staticmethod
+    def test_body_map_nested_extraction_e2e() -> None:
+        """Test body_map with nested field extraction via JSONPath"""
+
+        def my_step(param1, param2):
+            return f"Received: {param1} and {param2}"
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-nested-extraction", kind="serving"),
+        )
+
+        config = APIHandlerConfig(
+            body_map={
+                "param1": "$.field1",  # Extract "field1" and pass as param1
+                "param2": "$.nested.field2",  # Extract nested field and pass as param2
+            }
+        )
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="process", handler=my_step).respond()
+
+        server = fn.to_mock_server()
+        try:
+            resp = server.test(
+                "/predict",
+                method="POST",
+                body={
+                    "field1": "value1",
+                    "nested": {"field2": "value2"},
+                    "extra": "ignored",  # This won't be passed to the handler
+                },
+            )
+            assert resp == "Received: value1 and value2"
+        finally:
+            server.wait_for_completion()

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -40,9 +40,9 @@ class TestAPIHandlerConfigBodyMap:
         assert config.body_map == body_map
 
     def test_config_without_body_map(self) -> None:
-        """Test that body_map defaults to None"""
+        """Test that body_map defaults to empty dict"""
         config = APIHandlerConfig()
-        assert config.body_map is None
+        assert config.body_map == {}
 
     def test_body_map_serialization_roundtrip(self) -> None:
         """Test body_map survives to_dict / from_dict round-trip"""
@@ -80,9 +80,9 @@ class TestAPIHandlerConfigBodyMap:
     def test_add_body_mapping() -> None:
         """Test add_body_mapping helper method"""
         config = APIHandlerConfig()
-        assert config.body_map is None
+        assert config.body_map == {}
 
-        # Add first mapping - should initialize body_map
+        # Add first mapping
         config.add_body_mapping("user_name", "$.user.name")
         assert config.body_map == {"user_name": "$.user.name"}
 
@@ -152,12 +152,30 @@ class TestAPIHandlerConfigBodyMap:
         assert config.body_map == {"param": "$.path"}
 
     @staticmethod
-    def test_remove_body_mapping_when_none() -> None:
-        """Test removing mapping when body_map is None"""
+    def test_remove_body_mapping_when_empty() -> None:
+        """Test removing mapping when body_map is empty"""
         config = APIHandlerConfig()
-        assert config.body_map is None
+        assert config.body_map == {}
         config.remove_body_mapping("param")  # Should not raise
-        assert config.body_map is None
+        assert config.body_map == {}
+
+    @staticmethod
+    def test_add_body_mapping_validates_jsonpath() -> None:
+        """Test that add_body_mapping validates JSONPath expression"""
+        import mlrun.errors
+
+        config = APIHandlerConfig()
+
+        # Should raise for invalid JSONPath syntax
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match=r"Invalid JSON path expression for parameter 'bad_param'",
+        ):
+            config.add_body_mapping("bad_param", "$.invalid[[[syntax")
+
+        # Should not raise for valid JSONPath
+        config.add_body_mapping("good_param", "$.valid.path")
+        assert config.body_map == {"good_param": "$.valid.path"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -28,6 +28,21 @@ from mlrun.serving.api_handler import _APIHandlerStep
 
 
 # ---------------------------------------------------------------------------
+# Helper classes for tests
+# ---------------------------------------------------------------------------
+class PrefixStep:
+    """Processing step that adds prefix to mapped values"""
+
+    def __init__(self, prefix: str = "", **kwargs):
+        self.prefix = prefix
+
+    def do(self, event):
+        # Extract the mapped values and add prefix
+        result = f"{self.prefix}: arg1={event['arg1']}, arg2={event['arg2']}"
+        return result
+
+
+# ---------------------------------------------------------------------------
 # APIHandlerConfig body_map tests (config-level)
 # ---------------------------------------------------------------------------
 class TestAPIHandlerConfigBodyMap:
@@ -609,3 +624,54 @@ class TestBodyMapMockServer:
             assert resp == "Received: value1 and value2"
         finally:
             server.wait_for_completion()
+
+
+def test_api_handler_with_body_map_and_processing_step(rundb_mock):
+    """Test API handler with body_map followed by a processing step in the graph."""
+
+    def pass_through(arg1, arg2):
+        """Handler that passes through the mapped values"""
+        return {"arg1": arg1, "arg2": arg2}
+
+    fn = cast(
+        ServingRuntime,
+        mlrun.new_function("test-func", kind="serving", image="mlrun/mlrun"),
+    )
+
+    # Configure API handler with body mapping
+    config = APIHandlerConfig()
+    config.add_body_mapping("arg1", "$.data.field1")
+    config.add_body_mapping("arg2", "$.data.nested.field2")
+    config.add_endpoint_handler(
+        "/predict",
+        HTTPMethod.POST,
+        APIHandlerAction.ALLOW,
+        "Predict with body_map",
+    )
+    fn.set_api_handler_config(config)
+
+    # Build graph: handler -> processor
+    graph = fn.set_topology("flow", engine="sync")
+    graph.to(name="my-handler", handler=pass_through).to(
+        class_name="tests.serving.test_body_map.PrefixStep",
+        name="processor",
+        prefix="Result",
+    ).respond()
+
+    server = fn.to_mock_server()
+    try:
+        # Test with request body
+        resp = server.test(
+            "/predict",
+            method="POST",
+            body={
+                "data": {
+                    "field1": "hello",
+                    "nested": {"field2": "world"},
+                },
+                "metadata": "ignored",
+            },
+        )
+        assert resp == "Result: arg1=hello, arg2=world"
+    finally:
+        server.wait_for_completion()

--- a/tests/system/runtimes/assets/body_map_handler.py
+++ b/tests/system/runtimes/assets/body_map_handler.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Iguazio
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def process_mapped_data(user_name: str, user_email: str, book_titles: list) -> dict:
+    """Handler that receives mapped parameters from body_map."""
+    return {
+        "name": user_name,
+        "email": user_email,
+        "titles": book_titles,
+        "count": len(book_titles),
+    }

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -32,10 +32,12 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         self,
         name: str,
         api_config: APIHandlerConfig | None = None,
+        func: str | None = None,
     ) -> mlrun.runtimes.ServingRuntime:
         """Create a basic serving function for testing."""
         # Create serving function using project (no external file needed)
         function = self.project.set_function(
+            func=func,
             name=name,
             kind="serving",
             image=self.image,
@@ -130,3 +132,71 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
             )
 
         self._logger.info("Forbidden API handler test passed")
+
+    def test_api_handler_with_body_mapping(self) -> None:
+        """Test API handler with body_map JSONPath extraction."""
+        self._logger.info("Testing API handler with body_map functionality")
+
+        # Create API handler config with body_map for JSONPath extraction
+        config = APIHandlerConfig(
+            body_map={
+                "user_name": "$.user.name",
+                "user_email": "$.user.contact.email",
+                "book_titles": "$.purchases[*].title",  # Multiple matches return list
+            }
+        )
+        config.add_endpoint_handler(
+            "/api/v1/process",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            "Process endpoint with body mapping",
+        )
+
+        # Create serving function with handler source file using helper method
+        function = self._create_serving_function(
+            name="body-map-handler",
+            api_config=config,
+            func=str(self.assets_path / "body_map_handler.py"),
+        )
+
+        # Set up topology with handler that receives kwargs from body_map
+        graph = function.set_topology("flow", engine="sync", exist_ok=True)
+        graph.to(
+            name="processor", handler="process_mapped_data"
+        ).respond()  # Reference handler by name
+
+        # Deploy the function
+        self._logger.debug("Deploying serving function with body_map")
+        function.deploy()
+
+        # Test with request body that has nested structure
+        test_body = {
+            "user": {
+                "name": "Alice Smith",
+                "contact": {"email": "alice@example.com", "phone": "+1234567890"},
+            },
+            "purchases": [
+                {"title": "MLOps Handbook", "price": 29.99},
+                {"title": "Python Guide", "price": 19.99},
+                {"title": "Data Science Intro", "price": 39.99},
+            ],
+            "timestamp": "2026-02-11T10:00:00Z",
+        }
+
+        self._logger.debug("Testing body_map with nested JSONPath extraction")
+        response = function.invoke(path="/api/v1/process", body=test_body)
+
+        # Verify the mapped values were extracted correctly
+        assert response is not None, "Handler should return a response"
+        assert response["name"] == "Alice Smith", "user_name should be extracted"
+        assert (
+            response["email"] == "alice@example.com"
+        ), "user_email should be extracted from nested path"
+        assert response["titles"] == [
+            "MLOps Handbook",
+            "Python Guide",
+            "Data Science Intro",
+        ], "book_titles should extract multiple matches as list"
+        assert response["count"] == 3, "count should match number of books"
+
+        self._logger.info("Body mapping API handler test passed")

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -138,13 +138,13 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         self._logger.info("Testing API handler with body_map functionality")
 
         # Create API handler config with body_map for JSONPath extraction
-        config = APIHandlerConfig(
-            body_map={
-                "user_name": "$.user.name",
-                "user_email": "$.user.contact.email",
-                "book_titles": "$.purchases[*].title",  # Multiple matches return list
-            }
-        )
+        config = APIHandlerConfig()
+
+        config.add_body_mapping("user_name", "$.user.name")
+        config.add_body_mapping("user_email", "$.user.contact.email")
+        # Multiple matches return list
+        config.add_body_mapping("book_titles", "$.purchases[*].title")
+
         config.add_endpoint_handler(
             "/api/v1/process",
             HTTPMethod.POST,


### PR DESCRIPTION
## What
Add support for JSONPath-based body parameter extraction in serving API handlers via `body_map` configuration at the APIHandlerConfig level.

## Why
Enables serving functions to extract specific fields from nested JSON request bodies and pass them as named parameters to handler functions, eliminating the need for manual parsing in every handler.

## Changes

### Core Implementation
- Add `body_map` field to `APIHandlerConfig` with JSONPath string mapping (parameter_name → JSONPath expression)
- Implement `_apply_parsed_body_map()` in `_APIHandlerStep` for JSONPath extraction with pre-parsed expressions
- Add `_MappedBody` marker class in `mlrun/serving/utils.py` for kwargs unpacking
- Modify `TaskStep.run()` to unpack `_MappedBody` as `**kwargs` instead of single positional arg

### Helper Methods
- `APIHandlerConfig.add_body_mapping(parameter_name, json_path)` - add mappings with override warnings
- `APIHandlerConfig.remove_body_mapping(parameter_name)` - remove mappings

### Dependencies
- Add `jsonpath-ng~=1.7` to `requirements.txt` and all 7 `locked-requirements.txt` files

### Testing
- 24 unit tests in `tests/serving/test_body_map.py` covering:
  - Config-level body_map (serialization, helpers, warnings)
  - _APIHandlerStep integration (parsing, transformation, errors)
  - End-to-end mock server tests with kwargs unpacking
  - Multi-step graph processing with body_map
- System test in `tests/system/runtimes/test_serving.py::TestServingAPIHandler::test_api_handler_with_body_mapping`
- Test asset handler in `tests/system/runtimes/assets/body_map_handler.py`

### Example Usage
```python
config = APIHandlerConfig()
config.add_body_mapping("user_name", "$.user.name")
config.add_body_mapping("user_email", "$.user.contact.email")
config.add_body_mapping("book_titles", "$.purchases[*].title")  # Multiple matches → list

config.add_endpoint_handler("/api/v1/process", HTTPMethod.POST, APIHandlerAction.ALLOW)

function.set_api_handler_config(config)
graph = function.set_topology("flow", engine="sync")
graph.to(handler=lambda user_name, user_email, book_titles: ...).respond()
```

### Performance Optimization
- JSONPath expressions are parsed once during `_APIHandlerStep.__init__()` and stored in `self._parsed_body_map`
- No per-request parsing overhead

## Related
Implements [ML-11667](https://iguazio.atlassian.net/browse/ML-11667)


[ML-11667]: https://iguazio.atlassian.net/browse/ML-11667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
