### PR TITLE
[Application] Delete source artifacts on function deletion

### DIFF
--- a/server/py/framework/api/utils.py
+++ b/server/py/framework/api/utils.py
@@ -34,6 +34,7 @@ from fastapi.concurrency import run_in_threadpool
 from kubernetes.client import V1EnvVar, V1EnvVarSource
 from sqlalchemy.orm import Session
 
+import mlrun.common.constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.pod
@@ -1352,6 +1353,12 @@ async def _delete_function(
             )
             raise mlrun.errors.MLRunInternalServerError(error_message)
 
+    # For application runtime functions, clean up source artifacts that were uploaded during deploy
+    if functions[0].get("kind") == mlrun.runtimes.RuntimeKinds.application:
+        await _delete_application_source_artifacts(
+            db_session, project, function_name, auth_info
+        )
+
     # delete the function from the database
     await run_in_threadpool(
         services.api.crud.Functions().delete_function,
@@ -1359,6 +1366,48 @@ async def _delete_function(
         project,
         function_name,
     )
+
+
+async def _delete_application_source_artifacts(
+    db_session: sqlalchemy.orm.Session,
+    project: str,
+    function_name: str,
+    auth_info: mlrun.common.schemas.AuthInfo,
+):
+    """
+    Delete source artifacts associated with an application runtime function.
+
+    When an application runtime function is deployed with a local source file, the source is uploaded as an artifact
+    labeled with the function name.
+    This method cleans up those artifacts when the function is deleted.
+    """
+    labels = [
+        f"{mlrun.common.constants.MLRunInternalLabels.function_name}={function_name}",
+        f"{mlrun.common.constants.MLRunInternalLabels.system_generated}=true",
+    ]
+    logger.debug(
+        "Deleting application source artifacts",
+        project=project,
+        function_name=function_name,
+        labels=labels,
+    )
+    try:
+        await run_in_threadpool(
+            services.api.crud.Artifacts().delete_artifacts,
+            db_session,
+            project=project,
+            name="",
+            tag="*",
+            labels=labels,
+            auth_info=auth_info,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to delete application source artifacts, continuing with function deletion",
+            project=project,
+            function_name=function_name,
+            error=err_to_str(exc),
+        )
 
 
 async def _update_functions_with_deletion_info(functions, project, updates: dict):

--- a/server/py/services/api/tests/unit/api/test_utils.py
+++ b/server/py/services/api/tests/unit/api/test_utils.py
@@ -30,6 +30,7 @@ from kubernetes.client.models import V1ConfigMap, V1ObjectMeta
 from sqlalchemy.orm import Session
 
 import mlrun
+import mlrun.common.constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.k8s_utils
@@ -43,6 +44,7 @@ from server.py.framework.api.utils import (
 
 import framework.api.utils
 import framework.utils.clients.iguazio.v3
+import framework.utils.singletons.db
 import services.api.crud
 import services.api.crud.runtimes.nuclio
 import services.api.tests.unit.api.utils
@@ -1854,6 +1856,83 @@ async def test_update_functions_with_deletion_info(db: sqlalchemy.orm.Session):
         db, name=function_name, project=project, tag=function_tag
     )
     assert function["status"]["deletion_task_id"] == deletion_task_id
+
+
+@pytest.mark.asyncio
+async def test_delete_application_artifacts_handles_failure(
+    db: sqlalchemy.orm.Session,
+):
+    """Verify that deleting an application runtime function also deletes its source artifacts."""
+    project = "my_project"
+    function_name = "my-app"
+    function_tag = "latest"
+
+    function = {
+        "kind": "application",
+        "metadata": {"name": function_name, "tag": function_tag},
+        "status": {},
+    }
+    services.api.crud.Functions().store_function(
+        db, project=project, function=function, name=function_name, tag=function_tag
+    )
+
+    # Store a source artifact with the labels that _upload_source_as_artifact sets
+    source_artifact = {
+        "metadata": {
+            "labels": {
+                mlrun.common.constants.MLRunInternalLabels.function_name: function_name,
+                mlrun.common.constants.MLRunInternalLabels.system_generated: "true",
+            },
+            "tag": "latest",
+        },
+        "kind": "artifact",
+    }
+    framework.utils.singletons.db.get_db().store_artifact(
+        db,
+        key=f"{function_name}-source",
+        artifact=source_artifact,
+        tag="latest",
+        project=project,
+    )
+
+    # Verify the artifact exists
+    artifacts = services.api.crud.Artifacts().list_artifacts(
+        db,
+        project=project,
+        name=f"{function_name}-source",
+        tag="*",
+    )
+    assert len(artifacts) == 1
+
+    # Call the cleanup function
+    await framework.api.utils._delete_application_source_artifacts(
+        db, project, function_name, mlrun.common.schemas.AuthInfo()
+    )
+
+    # Verify the artifact was deleted
+    artifacts = services.api.crud.Artifacts().list_artifacts(
+        db,
+        project=project,
+        name=f"{function_name}-source",
+        tag="*",
+    )
+    assert len(artifacts) == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_application_source_artifacts_tolerates_failure():
+    """Verify that artifact cleanup failure does not raise."""
+    with patch.object(
+        services.api.crud.Artifacts,
+        "delete_artifacts",
+        side_effect=Exception("db error"),
+    ):
+        await framework.api.utils._delete_application_source_artifacts(
+            MagicMock(),
+            "my_project",
+            "my-app",
+            mlrun.common.schemas.AuthInfo(),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description
This PR add logic to clean up application runtime associated source artifacts when the function is deleted. 
Artifacts are identified by internal labels (`mlrun/function-name`, `mlrun/system-generated`) and deleted as a
best-effort operation that logs a warning on failure without blocking function deletion.

---

### 🛠️ Changes Made

- Updated `_delete_function` to trigger application source artifact cleanup for `RuntimeKinds.application`.
- Added `_delete_application_source_artifacts` helper that deletes labeled artifacts.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Added unit tests.
- Tested on vmdev and validate artifacts are cleaned up.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12030
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
