### PR TITLE
[Model Monitoring] Add SDK methods and wildcard cache for lag detection alerts

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -345,6 +345,10 @@ class MonitoringFunctionNames(MonitoringStrEnum):
     WRITER = "model-monitoring-writer"
 
 
+class MonitoringAlertNames(MonitoringStrEnum):
+    LAG_DETECTED = "monitoring-lag-detected"
+
+
 class V3IOTSDBTables(MonitoringStrEnum):
     APP_RESULTS = "app-results"
     METRICS = "metrics"

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import contextlib
 import datetime
 import getpass
 import glob
@@ -44,6 +46,7 @@ import mlrun.common.runtimes.constants
 import mlrun.common.schemas.alert
 import mlrun.common.schemas.artifact
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
+import mlrun.common.schemas.notification
 import mlrun.common.secrets
 import mlrun.datastore.datastore_profile
 import mlrun.db
@@ -2738,8 +2741,15 @@ class MlrunProject(ModelObj):
             user_application_list=user_application_list,
         )
         if succeed and delete_resources:
-            if delete_resources:
-                logger.info("Model Monitoring disabled", project=self.name)
+            try:
+                self.delete_model_monitoring_lag_alert()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to delete lag detection alerts during disable",
+                    project=self.name,
+                    error=mlrun.errors.err_to_str(exc),
+                )
+            logger.info("Model Monitoring disabled", project=self.name)
             if delete_user_applications:
                 logger.info(
                     "All the desired monitoring application were deleted",
@@ -2755,6 +2765,74 @@ class MlrunProject(ModelObj):
                     "Some of the desired monitoring application were not deleted",
                     project=self.name,
                 )
+
+    def set_model_monitoring_lag_alert(
+        self,
+        notifications: typing.Union[
+            list[mlrun.common.schemas.notification.Notification],
+            mlrun.common.schemas.notification.Notification,
+        ],
+        *,
+        period: Optional[str] = None,
+        count: Optional[int] = None,
+    ) -> None:
+        """Configure an alert for model monitoring lag detection.
+
+        When the monitoring infrastructure detects that it is processing events
+        whose inference timestamp is significantly in the past, it emits a
+        ``MODEL_MONITORING_LAG_DETECTED`` event.  This method creates a single
+        alert configuration (using a wildcard entity) that matches lag events
+        from any monitoring component.
+
+        :param notifications: One or more notification objects to attach to the
+            alert (e.g. Slack webhook, email).
+        :param period:        Optional sliding-window period for the alert
+            criteria (e.g. ``"10m"``).
+        :param count:         Number of events within *period* before the alert
+            fires.  Defaults to ``1``.
+        """
+        alert_constants = mlrun.common.schemas.alert
+
+        if isinstance(notifications, mlrun.common.schemas.notification.Notification):
+            notifications = [notifications]
+
+        alert_notifications = [
+            alert_constants.AlertNotification(notification=n) for n in notifications
+        ]
+
+        alert_name = mm_constants.MonitoringAlertNames.LAG_DETECTED
+        alert_data = mlrun.alerts.alert.AlertConfig(
+            project=self.name,
+            name=alert_name,
+            summary="Model monitoring lag detected in project {{project}}.",
+            severity=alert_constants.AlertSeverity.MEDIUM,
+            entities=alert_constants.EventEntities(
+                kind=alert_constants.EventEntityKind.MODEL_MONITORING_INFRA,
+                project=self.name,
+                # Wildcard matches lag events from any monitoring entity
+                ids=["*"],
+            ),
+            trigger=alert_constants.AlertTrigger(
+                events=[alert_constants.EventKind.MODEL_MONITORING_LAG_DETECTED]
+            ),
+            criteria=alert_constants.AlertCriteria(
+                count=count or 1,
+                **({"period": period} if period else {}),
+            ),
+            notifications=alert_notifications,
+            reset_policy=alert_constants.ResetPolicy.AUTO,
+        )
+        db = mlrun.db.get_run_db(secrets=self._secrets)
+        db.store_alert_config(alert_name, alert_data, project=self.name)
+
+    def delete_model_monitoring_lag_alert(self) -> None:
+        """Delete the lag detection alert for this project."""
+        db = mlrun.db.get_run_db(secrets=self._secrets)
+        with contextlib.suppress(mlrun.errors.MLRunNotFoundError):
+            db.delete_alert_config(
+                mm_constants.MonitoringAlertNames.LAG_DETECTED,
+                project_name=self.name,
+            )
 
     def set_function(
         self,

--- a/server/py/services/alerts/crud/alerts.py
+++ b/server/py/services/alerts/crud/alerts.py
@@ -362,6 +362,7 @@ class Alerts(
 
     @staticmethod
     def _event_entity_matches(alert_entity, event_entity):
+        # A wildcard id ("*") matches any incoming entity id
         if "*" in alert_entity.ids:
             return True
 

--- a/server/py/services/alerts/crud/events.py
+++ b/server/py/services/alerts/crud/events.py
@@ -27,10 +27,10 @@ import services.alerts.crud
 class Events(
     metaclass=mlrun.utils.singleton.Singleton,
 ):
-    # we cache alert names based on project and event name as key
-    # (project, name, entity_id) -> set[alert_id]
-    # TODO: Rethink the cache structure once a single alert supports more than a single id
-    _cache: dict[(str, str, str), set[int]] = {}
+    # Exact-match cache: (project, event_kind, entity_id) -> set[alert_id]
+    _cache: dict[tuple[str, str, str], set[int]] = {}
+    # Wildcard cache for alerts with ids=["*"]: (project, event_kind) -> set[alert_id]
+    _wildcard_cache: dict[tuple[str, str], set[int]] = {}
     cache_initialized = False
 
     @staticmethod
@@ -38,24 +38,46 @@ class Events(
         if event_data.entity.project != project:
             return False
 
-        if len(event_data.entity.ids) > 1:
-            return False
-
-        return bool(event_data.is_valid())
+        return False if len(event_data.entity.ids) > 1 else bool(event_data.is_valid())
 
     def add_event_configuration(self, project, event_kind, alert_id, entity_id):
-        self._cache.setdefault((project, event_kind, entity_id), set()).add(alert_id)
+        """Register an alert to be triggered by a specific event kind and entity.
+
+        When ``entity_id`` is ``"*"``, the alert matches events from *any*
+        entity of the given kind (stored in ``_wildcard_cache``).  Otherwise,
+        it matches only events with the exact entity id (``_cache``).
+        """
+        if entity_id == "*":
+            self._wildcard_cache.setdefault((project, event_kind), set()).add(alert_id)
+        else:
+            self._cache.setdefault((project, event_kind, entity_id), set()).add(
+                alert_id
+            )
 
     def remove_event_configuration(self, project, event_kind, alert_id, entity_id):
-        alerts = self._cache.get((project, event_kind, entity_id), set())
-        if alert_id in alerts:
-            alerts.remove(alert_id)
-            if len(alerts) == 0:
-                self._cache.pop((project, event_kind, entity_id))
+        if entity_id == "*":
+            key = (project, event_kind)
+            alerts = self._wildcard_cache.get(key, set())
+            if alert_id in alerts:
+                alerts.remove(alert_id)
+                if not alerts:
+                    self._wildcard_cache.pop(key)
+        else:
+            key = (project, event_kind, entity_id)
+            alerts = self._cache.get(key, set())
+            if alert_id in alerts:
+                alerts.remove(alert_id)
+                if not alerts:
+                    self._cache.pop(key)
 
     def delete_project_alert_events(self, project):
         self._cache = {
             key: value for key, value in self._cache.items() if key[0] != project
+        }
+        self._wildcard_cache = {
+            key: value
+            for key, value in self._wildcard_cache.items()
+            if key[0] != project
         }
 
     def process_event(
@@ -66,7 +88,9 @@ class Events(
         project: Optional[str] = None,
         validate_event: bool = False,
     ):
-        if validate_event and not self.is_valid_event(project, event_data):
+        if validate_event and (
+            project is None or not self.is_valid_event(project, event_data)
+        ):
             raise mlrun.errors.MLRunBadRequestError(
                 f"Invalid event specified {event_name}"
             )
@@ -79,22 +103,27 @@ class Events(
             )
             return
 
+        if project is None:
+            return
+
         try:
+            entity_id = event_data.entity.ids[0]
+            exact_alerts = self._cache.get((project, event_name, entity_id), set())
+            wildcard_alerts = self._wildcard_cache.get((project, event_name), set())
+
             # TODO: Remove log once the flow is stable
             logger.debug(
                 "Processing alerts for event",
                 project=project,
                 event_name=event_name,
-                entity=event_data.entity.ids[0],
-                num_of_alerts=len(
-                    self._cache.get(
-                        (project, event_name, event_data.entity.ids[0]), set()
-                    )
-                ),
+                entity=entity_id,
+                num_of_alerts=len(exact_alerts) + len(wildcard_alerts),
             )
-            for alert_id in self._cache.get(
-                (project, event_name, event_data.entity.ids[0]), set()
-            ):
+            for alert_id in exact_alerts:
+                services.alerts.crud.Alerts().process_event(
+                    session, alert_id, event_data
+                )
+            for alert_id in wildcard_alerts:
                 services.alerts.crud.Alerts().process_event(
                     session, alert_id, event_data
                 )

--- a/server/py/services/alerts/tests/unit/crud/test_events.py
+++ b/server/py/services/alerts/tests/unit/crud/test_events.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock
+
+import pytest
+
+import mlrun.common.schemas.alert as alert_objects
+
+import services.alerts.crud
+
+
+@pytest.fixture()
+def events():
+    """Provide a fresh Events instance with cleared caches."""
+    instance = services.alerts.crud.Events()
+    instance._cache.clear()
+    instance._wildcard_cache.clear()
+    instance.cache_initialized = True
+    yield instance
+    instance._cache.clear()
+    instance._wildcard_cache.clear()
+
+
+PROJECT = "test-project"
+EVENT_KIND = alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED
+
+
+class TestAddEventConfiguration:
+    def test_exact_entity_goes_to_exact_cache(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="ep1")
+
+        assert 1 in events._cache[(PROJECT, EVENT_KIND, "ep1")]
+        assert not events._wildcard_cache
+
+    def test_wildcard_entity_goes_to_wildcard_cache(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="*")
+
+        assert 1 in events._wildcard_cache[(PROJECT, EVENT_KIND)]
+        assert not events._cache
+
+    def test_multiple_alerts_same_key(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="*")
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=2, entity_id="*")
+
+        assert events._wildcard_cache[(PROJECT, EVENT_KIND)] == {1, 2}
+
+
+class TestRemoveEventConfiguration:
+    def test_remove_exact(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="ep1")
+        events.remove_event_configuration(
+            PROJECT, EVENT_KIND, alert_id=1, entity_id="ep1"
+        )
+
+        assert not events._cache
+
+    def test_remove_wildcard(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="*")
+        events.remove_event_configuration(
+            PROJECT, EVENT_KIND, alert_id=1, entity_id="*"
+        )
+
+        assert not events._wildcard_cache
+
+    def test_remove_one_of_many(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="*")
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=2, entity_id="*")
+        events.remove_event_configuration(
+            PROJECT, EVENT_KIND, alert_id=1, entity_id="*"
+        )
+
+        assert events._wildcard_cache[(PROJECT, EVENT_KIND)] == {2}
+
+    def test_remove_nonexistent_is_noop(self, events):
+        events.remove_event_configuration(
+            PROJECT, EVENT_KIND, alert_id=99, entity_id="*"
+        )
+
+        assert not events._wildcard_cache
+
+
+class TestDeleteProjectAlertEvents:
+    def test_clears_both_caches_for_project(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="ep1")
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=2, entity_id="*")
+        events.add_event_configuration(
+            "other-project", EVENT_KIND, alert_id=3, entity_id="ep2"
+        )
+        events.add_event_configuration(
+            "other-project", EVENT_KIND, alert_id=4, entity_id="*"
+        )
+
+        events.delete_project_alert_events(PROJECT)
+
+        assert all(k[0] != PROJECT for k in events._cache)
+        assert all(k[0] != PROJECT for k in events._wildcard_cache)
+        assert 3 in events._cache[("other-project", EVENT_KIND, "ep2")]
+        assert 4 in events._wildcard_cache[("other-project", EVENT_KIND)]
+
+
+class TestProcessEventWildcard:
+    @staticmethod
+    def _make_event(entity_id: str) -> alert_objects.Event:
+        return alert_objects.Event(
+            kind=EVENT_KIND,
+            entity=alert_objects.EventEntities(
+                kind=alert_objects.EventEntityKind.MODEL_MONITORING_INFRA,
+                project=PROJECT,
+                ids=[entity_id],
+            ),
+        )
+
+    def test_wildcard_alert_matches_any_entity(self, events):
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=1, entity_id="*")
+        session = unittest.mock.Mock()
+        event = self._make_event("myproject.writer.3")
+
+        with unittest.mock.patch.object(
+            services.alerts.crud.Alerts, "process_event"
+        ) as mock_process:
+            events.process_event(session, event, EVENT_KIND, project=PROJECT)
+
+        mock_process.assert_called_once_with(session, 1, event)
+
+    def test_exact_alert_does_not_match_other_entity(self, events):
+        events.add_event_configuration(
+            PROJECT, EVENT_KIND, alert_id=1, entity_id="writer.0"
+        )
+        session = unittest.mock.Mock()
+        event = self._make_event("writer.1")
+
+        with unittest.mock.patch.object(
+            services.alerts.crud.Alerts, "process_event"
+        ) as mock_process:
+            events.process_event(session, event, EVENT_KIND, project=PROJECT)
+
+        mock_process.assert_not_called()
+
+    def test_both_exact_and_wildcard_fire(self, events):
+        events.add_event_configuration(
+            PROJECT, EVENT_KIND, alert_id=1, entity_id="writer.0"
+        )
+        events.add_event_configuration(PROJECT, EVENT_KIND, alert_id=2, entity_id="*")
+        session = unittest.mock.Mock()
+        event = self._make_event("writer.0")
+
+        with unittest.mock.patch.object(
+            services.alerts.crud.Alerts, "process_event"
+        ) as mock_process:
+            events.process_event(session, event, EVENT_KIND, project=PROJECT)
+
+        assert mock_process.call_count == 2
+        fired_ids = {call.args[1] for call in mock_process.call_args_list}
+        assert fired_ids == {1, 2}

--- a/tests/model_monitoring/test_lag_detection.py
+++ b/tests/model_monitoring/test_lag_detection.py
@@ -19,14 +19,21 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 import mlrun
+import mlrun.common.schemas.notification
 import mlrun.db.httpdb
 import mlrun.model_monitoring
 from mlrun.common.schemas.alert import (
+    AlertCriteria,
+    AlertSeverity,
+    AlertTrigger,
+    EventEntities,
     EventEntityKind,
     EventKind,
+    ResetPolicy,
     _event_kind_entity_map,
 )
 from mlrun.common.schemas.model_monitoring.constants import (
+    MonitoringAlertNames,
     WriterEvent,
     WriterEventKind,
 )
@@ -410,3 +417,120 @@ class TestHTTPDBLagParams:
         params = db.api_call.call_args.kwargs["params"]
         assert "lag_threshold" not in params
         assert "lag_event_cooldown" not in params
+
+
+# -- SDK lag alert methods tests (ML-11675) --
+
+_LAG_ALERT_PROJECT = "test-lag-alert"
+
+
+@pytest.fixture()
+def lag_alert_mock_db():
+    mock = unittest.mock.Mock()
+    with unittest.mock.patch("mlrun.db.get_run_db", return_value=mock):
+        yield mock
+
+
+@pytest.fixture()
+def lag_alert_project():
+    mock = unittest.mock.Mock()
+    mock.name = _LAG_ALERT_PROJECT
+    return mock
+
+
+def _make_notification(name: str = "test-notif"):
+    return mlrun.common.schemas.notification.Notification(
+        kind="slack",
+        name=name,
+        secret_params={"webhook": "https://hooks.slack.com/test"},
+    )
+
+
+class TestSetModelMonitoringLagAlert:
+    def test_creates_single_wildcard_alert(self, lag_alert_mock_db, lag_alert_project):
+        mlrun.projects.MlrunProject.set_model_monitoring_lag_alert(
+            lag_alert_project,
+            notifications=_make_notification(),
+        )
+
+        lag_alert_mock_db.store_alert_config.assert_called_once()
+        call_args = lag_alert_mock_db.store_alert_config.call_args
+        assert call_args.args[0] == MonitoringAlertNames.LAG_DETECTED
+        assert call_args.args[1].entities.ids == ["*"]
+
+    def test_alert_config_fields(self, lag_alert_mock_db, lag_alert_project):
+        period = "10m"
+        count = 2
+
+        mlrun.projects.MlrunProject.set_model_monitoring_lag_alert(
+            lag_alert_project,
+            notifications=_make_notification(),
+            period=period,
+            count=count,
+        )
+
+        alert_data = lag_alert_mock_db.store_alert_config.call_args.args[1]
+        assert alert_data.severity == AlertSeverity.MEDIUM
+        assert alert_data.reset_policy == ResetPolicy.AUTO
+        assert alert_data.trigger == AlertTrigger(
+            events=[EventKind.MODEL_MONITORING_LAG_DETECTED]
+        )
+        assert alert_data.criteria == AlertCriteria(count=count, period=period)
+        assert alert_data.entities == EventEntities(
+            kind=EventEntityKind.MODEL_MONITORING_INFRA,
+            project=_LAG_ALERT_PROJECT,
+            ids=["*"],
+        )
+
+    def test_wraps_single_notification_in_list(
+        self, lag_alert_mock_db, lag_alert_project
+    ):
+        notification = _make_notification()
+
+        mlrun.projects.MlrunProject.set_model_monitoring_lag_alert(
+            lag_alert_project,
+            notifications=notification,
+        )
+
+        alert_data = lag_alert_mock_db.store_alert_config.call_args.args[1]
+        assert len(alert_data.notifications) == 1
+        assert alert_data.notifications[0].notification.name == notification.name
+
+    def test_accepts_list_of_notifications(self, lag_alert_mock_db, lag_alert_project):
+        notifications = [
+            _make_notification("n1"),
+            _make_notification("n2"),
+        ]
+
+        mlrun.projects.MlrunProject.set_model_monitoring_lag_alert(
+            lag_alert_project,
+            notifications=notifications,
+        )
+
+        alert_data = lag_alert_mock_db.store_alert_config.call_args.args[1]
+        assert len(alert_data.notifications) == len(notifications)
+        actual_names = [n.notification.name for n in alert_data.notifications]
+        assert actual_names == ["n1", "n2"]
+
+
+class TestDeleteModelMonitoringLagAlert:
+    def test_deletes_alert(self, lag_alert_mock_db, lag_alert_project):
+        mlrun.projects.MlrunProject.delete_model_monitoring_lag_alert(
+            lag_alert_project,
+        )
+
+        lag_alert_mock_db.delete_alert_config.assert_called_once_with(
+            MonitoringAlertNames.LAG_DETECTED,
+            project_name=_LAG_ALERT_PROJECT,
+        )
+
+    def test_ignores_not_found_errors(self, lag_alert_mock_db, lag_alert_project):
+        lag_alert_mock_db.delete_alert_config.side_effect = (
+            mlrun.errors.MLRunNotFoundError("not found")
+        )
+
+        mlrun.projects.MlrunProject.delete_model_monitoring_lag_alert(
+            lag_alert_project,
+        )
+
+        lag_alert_mock_db.delete_alert_config.assert_called_once()

--- a/tests/system/model_monitoring/test_writer_lag.py
+++ b/tests/system/model_monitoring/test_writer_lag.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import time
+from datetime import UTC, datetime, timedelta
+
+import deepdiff
+import pytest
+
+import mlrun
+import mlrun.common.schemas
+import mlrun.common.schemas.alert as alert_objects
+import mlrun.common.schemas.model_monitoring.constants as mm_constants
+import mlrun.model_monitoring.api
+import tests.system.common.helpers.notifications as notification_helpers
+from mlrun import mlconf
+from mlrun.datastore import get_stream_pusher
+from mlrun.datastore.datastore_profile import (
+    register_temporary_client_datastore_profile,
+)
+from mlrun.model_monitoring.helpers import get_stream_path
+from tests.system.base import TestMLRunSystem
+from tests.system.model_monitoring import TestMLRunSystemModelMonitoring
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+class TestWriterLag(TestMLRunSystemModelMonitoring):
+    """System tests for model monitoring writer lag detection and alerting."""
+
+    # Set image to "<repo>/mlrun:<tag>" for local testing
+    image: str | None = None
+
+    @pytest.mark.model_monitoring
+    def test_writer_lag_alert(self):
+        """
+        Validate that a lag event is generated and triggers an alert when the
+        writer processes events with old inference timestamps.
+
+        Flow:
+        1. Enable model monitoring with a low lag threshold.
+        2. Configure a lag alert using set_model_monitoring_lag_alert().
+        3. Push events with old END_INFER_TIME through the writer stream.
+        4. Verify that the notification is sent and alert activation is created.
+        """
+        self.set_mm_credentials()
+        register_temporary_client_datastore_profile(self.mm_stream_profile)
+
+        lag_threshold = 5
+        lag_event_cooldown = 1
+        self.project.enable_model_monitoring(
+            image=self.image or "mlrun/mlrun",
+            lag_threshold=lag_threshold,
+            lag_event_cooldown=lag_event_cooldown,
+        )
+
+        nuclio_function_url = notification_helpers.deploy_notification_nuclio(
+            self.project, self.image
+        )
+
+        notification_data = "writer lag detected"
+        notification = mlrun.common.schemas.Notification(
+            kind="webhook",
+            name="lag-notif",
+            params={
+                "url": nuclio_function_url,
+                "override_body": {
+                    "operation": "add",
+                    "data": notification_data,
+                },
+            },
+        )
+        self.project.set_model_monitoring_lag_alert(
+            notifications=notification,
+        )
+
+        model_endpoint = mlrun.model_monitoring.api.get_or_create_model_endpoint(
+            project=self.project.metadata.name,
+            model_endpoint_name="test-lag-endpoint",
+            context=mlrun.get_or_create_ctx("demo"),
+        )
+
+        writer = self.project.get_function(
+            key=mm_constants.MonitoringFunctionNames.WRITER
+        )
+        writer._wait_for_function_deployment(db=writer._get_db())
+
+        stream_uri = get_stream_path(
+            project=self.project.metadata.name,
+            function_name=mm_constants.MonitoringFunctionNames.WRITER,
+            profile=self.mm_stream_profile,
+        )
+        output_stream = get_stream_pusher(stream_uri)
+
+        old_time = (datetime.now(tz=UTC) - timedelta(hours=1)).isoformat()
+        result_name = (
+            mm_constants.HistogramDataDriftApplicationConstants.GENERAL_RESULT_NAME
+        )
+        output_stream.push(
+            {
+                mm_constants.WriterEvent.ENDPOINT_ID: model_endpoint.metadata.uid,
+                mm_constants.WriterEvent.ENDPOINT_NAME: model_endpoint.metadata.name,
+                mm_constants.WriterEvent.APPLICATION_NAME: mm_constants.HistogramDataDriftApplicationConstants.NAME,
+                mm_constants.WriterEvent.START_INFER_TIME: old_time,
+                mm_constants.WriterEvent.END_INFER_TIME: old_time,
+                mm_constants.WriterEvent.EVENT_KIND: "result",
+                mm_constants.WriterEvent.DATA: json.dumps(
+                    {
+                        mm_constants.ResultData.RESULT_NAME: result_name,
+                        mm_constants.ResultData.RESULT_KIND: mm_constants.ResultKindApp.data_drift.value,
+                        mm_constants.ResultData.RESULT_VALUE: 0.1,
+                        mm_constants.ResultData.RESULT_STATUS: mm_constants.ResultStatusApp.no_detection.value,
+                        mm_constants.ResultData.RESULT_EXTRA_DATA: json.dumps({}),
+                    }
+                ),
+            }
+        )
+
+        time.sleep(
+            5 + mlconf.model_endpoint_monitoring.writer_graph.flush_after_seconds
+        )
+
+        def _check_notification():
+            sent = list(
+                notification_helpers.get_notifications_from_nuclio_and_reset_notification_cache(
+                    nuclio_function_url
+                )
+            )
+            assert deepdiff.DeepDiff(sent, [notification_data], ignore_order=True) == {}
+
+        self.wait_for_condition(
+            _check_notification,
+            timeout=30,
+            retry_interval=3,
+            condition_description="lag notification received",
+        )
+
+        activations = mlrun.get_run_db().list_alert_activations(
+            project=self.project_name,
+            entity_kind=alert_objects.EventEntityKind.MODEL_MONITORING_INFRA,
+            event_kind=alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED,
+        )
+        assert len(activations) >= 1
+        assert activations[0].entity_id.startswith(f"{self.project_name}.writer.")
+
+        self.project.delete_model_monitoring_lag_alert()


### PR DESCRIPTION
## Summary
- Add `set_model_monitoring_lag_alert` and `delete_model_monitoring_lag_alert` SDK methods to `MlrunProject`
- Add wildcard entity (`ids=["*"]`) support to the alerts service event cache, enabling a single alert to match lag events from any writer worker
- Clean up lag alerts automatically when model monitoring is disabled

## Changes Made

### SDK (`mlrun/projects/project.py`)
- `set_model_monitoring_lag_alert()`: creates a single wildcard alert matching lag events from all writer workers
- `delete_model_monitoring_lag_alert()`: idempotent deletion using `contextlib.suppress`
- `disable_model_monitoring()`: cleans up lag alerts on disable with error handling

### Alerts service (`server/py/services/alerts/crud/events.py`)
- Two-tier event cache: `_cache` for exact entity matching, `_wildcard_cache` for `ids=["*"]` alerts
- Both exact and wildcard alerts fire independently when an event matches
- Type-safe `tuple[...]` annotations, `Optional[str]` narrowing for project parameter

### Shared constant (`mlrun/common/schemas/model_monitoring/constants.py`)
- `MonitoringAlertNames.WRITER_LAG_DETECTED = "writer-lag-detected"`

## Testing
- 8 new SDK unit tests (set/delete alert methods, notification wrapping, field validation)
- 11 new alerts cache unit tests (add/remove/delete operations, wildcard matching, mixed exact+wildcard)
- 1 new system test for end-to-end lag alert flow
- All 42 new tests passing locally

## Reference
- Jira: ML-11675
- Depends on: #9285 (lag detection param wiring)