### PR TITLE
[Client] Per thread client and dummy cookie jar

### DIFF
--- a/mlrun/utils/async_http.py
+++ b/mlrun/utils/async_http.py
@@ -48,9 +48,14 @@ class AsyncClientWithRetry(RetryClient):
         raise_for_status: bool = True,
         blacklisted_methods: typing.Optional[list[str]] = None,
         logger: Optional[logging.Logger] = None,
+        cookie_jar: Optional[aiohttp.abc.AbstractCookieJar] = None,
         *args,
         **kwargs,
     ):
+        # Use DummyCookieJar by default to prevent cookie storage and identity leakage
+        if cookie_jar is None:
+            cookie_jar = aiohttp.DummyCookieJar()
+
         super().__init__(
             *args,
             retry_options=ExponentialRetryOverride(
@@ -64,6 +69,7 @@ class AsyncClientWithRetry(RetryClient):
             ),
             logger=logger or mlrun_logger,
             raise_for_status=raise_for_status,
+            cookie_jar=cookie_jar,
             **kwargs,
         )
 

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -25,6 +25,25 @@ from ..errors import err_to_str
 from . import logger
 
 
+class DummyCookieJar(requests.cookies.RequestsCookieJar):
+    """
+    Cookie jar that doesn't store any cookies.
+
+    This prevents identity leakage by ensuring cookies from authentication services
+    are not stored or sent in subsequent requests. Note that this does NOT affect
+    reading incoming cookies from request headers - you can still access request.cookies
+    or request.headers.get('Cookie') to read cookies sent TO your service.
+    """
+
+    def set_cookie(self, cookie, *args, **kwargs):
+        """Override to prevent storing cookies"""
+        pass
+
+    def __setitem__(self, name, value):
+        """Override to prevent storing cookies"""
+        pass
+
+
 class HTTPSessionWithRetry(requests.Session):
     """
     Extend requests.Session to add retry logic on both error statuses and certain exceptions.
@@ -90,6 +109,9 @@ class HTTPSessionWithRetry(requests.Session):
         self.verbose = verbose
         self._logger = logger.get_child("http-client")
         self._retry_methods = self._resolve_retry_methods(retry_on_post, retry_on_put)
+
+        # Disable cookie storage to prevent identity leakage
+        self.cookies = DummyCookieJar()
 
         if retry_on_status:
             self._http_adapter = requests.adapters.HTTPAdapter(

--- a/mlrun/utils/thread.py
+++ b/mlrun/utils/thread.py
@@ -14,7 +14,8 @@
 
 import inspect
 import threading
-from typing import Callable, Optional, TypeVar
+from collections.abc import Callable
+from typing import Optional, TypeVar
 
 T = TypeVar("T")
 

--- a/mlrun/utils/thread.py
+++ b/mlrun/utils/thread.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import threading
+from typing import Callable, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+# Holds one object per thread
+class ThreadLocalClient:
+    def __init__(
+        self,
+        factory: Callable[[], T],
+        close_callback: Optional[Callable[[T], None]] = None,
+    ):
+        """
+        Create a thread-local client holder.
+
+        Args:
+            factory: Function to create a new instance for each thread
+            close_callback: Optional function (sync or async) to close an instance
+        """
+        self._factory = factory
+        self._close_callback = close_callback
+        self._local = threading.local()
+
+    def get(self) -> T:
+        if not hasattr(self._local, "instance"):
+            self._local.instance = self._factory()
+        return self._local.instance
+
+    async def async_close(self):
+        """Close the current thread's instance, works for both sync and async callbacks."""
+        if hasattr(self._local, "instance") and self._close_callback:
+            result = self._close_callback(self._local.instance)
+            # If it's a coroutine, await it
+            if inspect.iscoroutine(result):
+                await result
+            delattr(self._local, "instance")

--- a/server/py/framework/utils/auth/providers/opa.py
+++ b/server/py/framework/utils/auth/providers/opa.py
@@ -24,6 +24,7 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.helpers
 import mlrun.utils.singleton
+import mlrun.utils.thread
 from mlrun.utils import logger
 
 import framework.utils.auth.providers.base as auth
@@ -36,7 +37,10 @@ class Provider(
 ):
     def __init__(self) -> None:
         super().__init__()
-        self._session: typing.Optional[mlrun.utils.AsyncClientWithRetry] = None
+        self._sessions = mlrun.utils.thread.ThreadLocalClient(
+            factory=self._get_new_async_session,
+            close_callback=lambda async_session: async_session.close(),
+        )
         self._api_url = mlrun.mlconf.httpdb.authorization.opa.address
         self._permission_query_path = (
             mlrun.mlconf.httpdb.authorization.opa.permission_query_path
@@ -204,10 +208,10 @@ class Provider(
         url = f"{self._api_url}{path}"
         if kwargs.get("timeout") is None:
             kwargs["timeout"] = self._request_timeout
-        await self._ensure_session()
+        async_session = self._sessions.get()
         response = None
         try:
-            response = await self._session.request(
+            response = await async_session.request(
                 method, url, verify_ssl=False, **kwargs
             )
             if not response.ok:
@@ -262,8 +266,8 @@ class Provider(
         }
         return body
 
-    async def _ensure_session(self):
-        if not self._session:
-            self._session = mlrun.utils.AsyncClientWithRetry(
-                logger=logger,
-            )
+    @staticmethod
+    def _get_new_async_session():
+        return mlrun.utils.AsyncClientWithRetry(
+            logger=logger,
+        )

--- a/server/py/framework/utils/clients/async_nuclio.py
+++ b/server/py/framework/utils/clients/async_nuclio.py
@@ -23,6 +23,7 @@ import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils
+import mlrun.utils.thread
 from mlrun.common.helpers import generate_api_gateway_name
 from mlrun.utils import logger
 
@@ -42,7 +43,10 @@ class Client:
     def __init__(self, auth_info: mlrun.common.schemas.AuthInfo):
         self._logger = logger.get_child("nuclio-client")
         self._nuclio_dashboard_url = mlrun.mlconf.nuclio_dashboard_url
-        self._session = None
+        self._sessions = mlrun.utils.thread.ThreadLocalClient(
+            factory=self._get_new_async_session,
+            close_callback=lambda async_session: async_session.close(),
+        )
         self._auth_headers = None
         self._auth = None
 
@@ -53,7 +57,8 @@ class Client:
             self._auth = aiohttp.BasicAuth(login, auth_info.session) if login else None
 
     async def __aenter__(self):
-        await self._ensure_async_session()
+        # triggers session creation for current thread
+        self._sessions.get()
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
@@ -206,30 +211,29 @@ class Client:
             "true"
         )
 
-    async def _ensure_async_session(self):
-        if not self._session:
-            self._session = mlrun.utils.AsyncClientWithRetry(
-                raise_for_status=False,
-                retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
-                == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value,
-                logger=logger,
-            )
+    @staticmethod
+    def _get_new_async_session():
+        return mlrun.utils.AsyncClientWithRetry(
+            raise_for_status=False,
+            retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
+            == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value,
+            logger=logger,
+        )
 
     async def _close_session(self):
-        if self._session:
-            await self._session.close()
-            self._session = None
+        """Close the thread-local session for the current thread."""
+        await self._sessions.async_close()
 
     async def _send_request_to_api(
         self, method, path="/", error_message: str = "", **kwargs
     ):
-        await self._ensure_async_session()
+        async_session = self._sessions.get()
         self._prepare_auth_kwargs(kwargs)
         kwargs["headers"] = framework.utils.clients.helpers.enrich_headers(
             headers=kwargs.get("headers"),
             path=path,
         )
-        response = await self._session.request(
+        response = await async_session.request(
             method=method,
             url=urllib.parse.urljoin(self._nuclio_dashboard_url, path),
             verify_ssl=False,

--- a/server/py/framework/utils/clients/iguazio/base.py
+++ b/server/py/framework/utils/clients/iguazio/base.py
@@ -25,6 +25,7 @@ from fastapi.concurrency import run_in_threadpool
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.singleton
+import mlrun.utils.thread
 from mlrun.utils import logger
 
 
@@ -135,7 +136,10 @@ class BaseAsyncClient(BaseClient):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._run_in_threadpool_callback = run_in_threadpool
-        self._async_session: typing.Optional[mlrun.utils.AsyncClientWithRetry] = None
+        self._async_sessions = mlrun.utils.thread.ThreadLocalClient(
+            factory=self._get_new_async_session,
+            close_callback=lambda async_session: async_session.close(),
+        )
 
     @property
     def is_sync(self) -> bool:
@@ -225,8 +229,7 @@ class BaseAsyncClient(BaseClient):
     ) -> typing.AsyncGenerator[aiohttp.ClientResponse, None]:
         url = f"{self._api_url}/api/{path}"
         self._prepare_request_kwargs(session, path, kwargs=kwargs)
-        await self._ensure_async_session()
-
+        async_session = self._async_sessions.get()
         # take the session default
         retry_options = copy.deepcopy(self._async_session.retry_options)
 
@@ -242,7 +245,7 @@ class BaseAsyncClient(BaseClient):
 
         response = None
         try:
-            response = await self._async_session.request(
+            response = await async_session.request(
                 method,
                 url,
                 verify_ssl=mlrun.mlconf.iguazio_api_ssl_verify,
@@ -277,10 +280,10 @@ class BaseAsyncClient(BaseClient):
             if response:
                 response.release()
 
-    async def _ensure_async_session(self):
-        if not self._async_session:
-            self._async_session = mlrun.utils.AsyncClientWithRetry(
-                retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
-                == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value,
-                logger=logger,
-            )
+    @staticmethod
+    def _get_new_async_session():
+        return mlrun.utils.AsyncClientWithRetry(
+            retry_on_exception=mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
+            == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value,
+            logger=logger,
+        )

--- a/server/py/framework/utils/clients/iguazio/base.py
+++ b/server/py/framework/utils/clients/iguazio/base.py
@@ -231,7 +231,7 @@ class BaseAsyncClient(BaseClient):
         self._prepare_request_kwargs(session, path, kwargs=kwargs)
         async_session = self._async_sessions.get()
         # take the session default
-        retry_options = copy.deepcopy(self._async_session.retry_options)
+        retry_options = copy.deepcopy(async_session.retry_options)
 
         # override with cherry-picked options
         if retry_options_override:

--- a/server/py/framework/utils/clients/iguazio/v3.py
+++ b/server/py/framework/utils/clients/iguazio/v3.py
@@ -30,6 +30,8 @@ import mlrun.common.schemas
 import mlrun.common.types
 import mlrun.errors
 import mlrun.utils.helpers
+import mlrun.utils.singleton
+import mlrun.utils.thread
 from mlrun.utils import get_in, logger
 
 import framework.utils.helpers

--- a/server/py/framework/utils/clients/iguazio/v3.py
+++ b/server/py/framework/utils/clients/iguazio/v3.py
@@ -30,8 +30,6 @@ import mlrun.common.schemas
 import mlrun.common.types
 import mlrun.errors
 import mlrun.utils.helpers
-import mlrun.utils.singleton
-import mlrun.utils.thread
 from mlrun.utils import get_in, logger
 
 import framework.utils.helpers

--- a/server/py/framework/utils/clients/messaging.py
+++ b/server/py/framework/utils/clients/messaging.py
@@ -16,7 +16,6 @@ import copy
 import http
 import http.cookies
 import re
-import threading
 import typing
 import urllib
 import urllib.parse
@@ -28,6 +27,7 @@ import requests
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.singleton
+import mlrun.utils.thread
 from mlrun.utils import logger
 
 import framework.utils.clients.discovery
@@ -38,8 +38,16 @@ PREFIX_GROUPING = re.compile(r"^([a-z/-]+)/((?:v\d+)?).*")
 class Client(metaclass=mlrun.utils.singleton.AbstractSingleton):
     def __init__(self) -> None:
         super().__init__()
-        # Stores per-thread sessions in `session` attribute
-        self._local = threading.local()
+        # Stores per-thread sessions with close callbacks
+        self._async_sessions = mlrun.utils.thread.ThreadLocalClient(
+            factory=self._get_new_async_session,
+            close_callback=lambda async_session: async_session.close(),
+        )
+        self._sync_sessions = mlrun.utils.thread.ThreadLocalClient(
+            factory=self._get_new_sync_session,
+            close_callback=lambda sync_session: sync_session.close(),
+        )
+
         self._discovery = framework.utils.clients.discovery.Client()
 
     ##### Sync HTTP requests #####
@@ -186,7 +194,7 @@ class Client(metaclass=mlrun.utils.singleton.AbstractSingleton):
         raise_on_failure: bool = False,
         **kwargs,
     ) -> aiohttp.ClientResponse:
-        session = await self._resolve_session()
+        async_session = self._async_sessions.get()
         if kwargs.get("timeout") is None:
             kwargs["timeout"] = (
                 mlrun.mlconf.httpdb.clusterization.worker.request_timeout or 20
@@ -202,7 +210,9 @@ class Client(metaclass=mlrun.utils.singleton.AbstractSingleton):
         )
         response = None
         try:
-            response = await session.request(method, url, verify_ssl=False, **kwargs)
+            response = await async_session.request(
+                method, url, verify_ssl=False, **kwargs
+            )
             if not response.ok:
                 await self._on_request_failure(
                     service_name=service_name,
@@ -235,7 +245,7 @@ class Client(metaclass=mlrun.utils.singleton.AbstractSingleton):
         **kwargs,
     ) -> requests.Response:
         self._prepare_request_kwargs(headers=headers, kwargs=kwargs)
-        session = self._resolve_sync_retry_session()
+        sync_session = self._sync_sessions.get()
         kwargs_to_log = self._resolve_kwargs_to_log(kwargs)
         logger.debug(
             "Sending sync request to service",
@@ -244,7 +254,7 @@ class Client(metaclass=mlrun.utils.singleton.AbstractSingleton):
             url=url,
             **kwargs_to_log,
         )
-        response = session.request(
+        response = sync_session.request(
             method, url, verify=mlrun.mlconf.httpdb.http.verify, **kwargs
         )
         if not response.ok:
@@ -294,18 +304,12 @@ class Client(metaclass=mlrun.utils.singleton.AbstractSingleton):
         path, version, service_instance = self._prepare_request_data(method, path)
         return service_instance is not None
 
-    async def _resolve_session(self):
-        if not hasattr(self._local, "session"):
-            self._local.session = self._get_new_session()
-        return self._local.session
-
-    def _resolve_sync_retry_session(self):
-        if not hasattr(self._local, "sync_retry_session"):
-            self._local.sync_retry_session = mlrun.utils.HTTPSessionWithRetry()
-        return self._local.sync_retry_session
+    @staticmethod
+    def _get_new_sync_session():
+        return mlrun.utils.HTTPSessionWithRetry()
 
     @staticmethod
-    def _get_new_session():
+    def _get_new_async_session():
         session = mlrun.utils.AsyncClientWithRetry(
             # This client handles forwarding requests from api to other services.
             # if we receive 5XX error, the code will be returned to the client.

--- a/server/py/services/api/tests/unit/utils/auth/providers/test_opa.py
+++ b/server/py/services/api/tests/unit/utils/auth/providers/test_opa.py
@@ -67,8 +67,7 @@ async def opa_provider() -> (
     yield provider
 
     # explicitly closing the provider's session to avoid "unclosed session" warning between tests
-    if provider._session:
-        await provider._session.close()
+    await provider._sessions.async_close()
 
 
 @pytest.mark.asyncio

--- a/server/py/services/api/tests/unit/utils/clients/test_chief.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_chief.py
@@ -53,8 +53,8 @@ async def chief_client(
     try:
         yield client
     finally:
-        if client._messaging_client._local.session:
-            await client._messaging_client._local.session.close()
+        await client._messaging_client._async_sessions.async_close()
+        await client._messaging_client._sync_sessions.async_close()
 
 
 @pytest.mark.asyncio
@@ -123,10 +123,8 @@ async def test_retry_on_exception(
     chief_client: framework.utils.clients.chief.Client,
     aioresponses_mock: aioresponses_mock,
 ):
-    # ensure the session to make sure the retry options are set
-    await chief_client._messaging_client._resolve_session()
     retry_attempts = (
-        chief_client._messaging_client._local.session.retry_options.attempts
+        chief_client._messaging_client._async_sessions.get().retry_options.attempts
     )
 
     task_name = "test-for-chief"
@@ -296,7 +294,7 @@ def _generate_background_task(
 )
 @pytest.mark.asyncio
 async def test_do_not_escape_cookie(
-    chief_client, session_cookie, expected_cookie_header
+    chief_client, session_cookie, expected_cookie_header, monkeypatch
 ):
     async def handler(request):
         assert (
@@ -325,9 +323,12 @@ async def test_do_not_escape_cookie(
     app.router.add_post("/api/v1/operations/migrations", handler)
     async with TestClient(TestServer(app)) as client:
         chief_client._api_url = ""
-        chief_client._messaging_client._resolve_session()
-        await chief_client._messaging_client._resolve_session()
-        chief_client._messaging_client._local.session._client = client
+        # Use monkeypatch to temporarily replace factory (will be auto-restored)
+        monkeypatch.setattr(
+            chief_client._messaging_client._async_sessions,
+            "_factory",
+            lambda: client,
+        )
 
         # set that to make sure session escaping is on
         # coupled with chief_client._resolve_request_kwargs_from_request logic.

--- a/server/py/services/api/tests/unit/utils/clients/test_messaging.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_messaging.py
@@ -206,18 +206,18 @@ def test_sessions_are_different_per_thread():
     def thread_worker(index):
         async def get_session():
             client = framework.utils.clients.messaging.Client()
-            session = await client._resolve_session()
-            session_ids[index] = id(session) if session else None
-            sessions[index] = session
+            async_session = client._async_sessions.get()
+            session_ids[index] = id(async_session) if async_session else None
+            sessions[index] = async_session
             # sleep to ensure multiple threads remain active simultaneously
             time.sleep(2)
+            # close the session after getting it
+            await client._async_sessions.async_close()
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
-        # close the session before closing the loop
         loop.run_until_complete(get_session())
-        sessions[index].close()
         loop.close()
 
     for i in range(num_threads):
@@ -233,3 +233,24 @@ def test_sessions_are_different_per_thread():
     assert (
         len(set(session_ids)) == num_threads
     ), f"Sessions should be unique per thread, got: {session_ids}"
+
+
+@pytest.mark.asyncio
+async def test_messaging_client_close_without_exceptions():
+    """Test that closing messaging client sessions doesn't raise exceptions"""
+    client = framework.utils.clients.messaging.Client()
+
+    # Get async session (creates it)
+    async_session = client._async_sessions.get()
+    assert async_session is not None
+
+    # Close should not raise any exceptions (async)
+    await client._async_sessions.async_close()
+
+    # Verify we can get a new session after closing
+    new_session = client._async_sessions.get()
+    assert new_session is not None
+    assert id(new_session) != id(async_session), "Should create new session after close"
+
+    # Clean up
+    await client._async_sessions.async_close()

--- a/tests/utils/test_async_http.py
+++ b/tests/utils/test_async_http.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 import http.server
+import json
+import socketserver
+import threading
+import time
 from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
@@ -217,3 +221,59 @@ async def test_session_retry(
         )
     with expected:
         await async_client.get("http://localhost:30678")
+
+
+@pytest.mark.asyncio
+async def test_async_client_does_not_persist_cookies():
+    """Test that AsyncClientWithRetry doesn't store or send cookies"""
+
+    class MockServer(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):  # noqa: N802
+            cookie_header = self.headers.get("Cookie", "")
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Set-Cookie", "test_cookie=test_value; Path=/")
+            self.end_headers()
+            self.wfile.write(json.dumps({"cookies_received": cookie_header}).encode())
+
+    # Use ephemeral port (OS-chosen)
+    server = socketserver.TCPServer(("127.0.0.1", 0), MockServer)
+    port = server.server_address[1]
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    time.sleep(0.1)  # Minimal sleep for server readiness
+
+    try:
+        client = AsyncClientWithRetry(retry_on_exception=False)
+
+        # Request 1 - server sets cookie
+        async with client.get(f"http://127.0.0.1:{port}/first") as resp:
+            data = await resp.json()
+            # Check what cookies the server RECEIVED (should be none)
+            assert data["cookies_received"] == ""
+
+            # Check what cookies the server SENT (in Set-Cookie header)
+            # Access via response.cookies (SimpleCookie object)
+            assert "test_cookie" in resp.cookies
+            assert resp.cookies["test_cookie"].value == "test_value"
+
+        # Request 2 - verify cookie was NOT sent back to server
+        async with client.get(f"http://127.0.0.1:{port}/second") as resp:
+            data = await resp.json()
+            # This verifies the cookie we received in Request 1 was NOT sent back
+            assert data["cookies_received"] == ""
+
+            # Server still sets cookies in response, but we don't store them
+            assert (
+                "test_cookie" in resp.cookies
+            ), "Server still sends cookies in response"
+
+        await client.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=1)

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http.server
+import json
+import socketserver
+import threading
+import time
 import unittest
 from contextlib import nullcontext as does_not_raise
 
@@ -62,3 +67,61 @@ def test_session_retry(http_session: HTTPSessionWithRetry, error_to_raise, expec
     ):
         with expected:
             http_session.request("GET", "http://localhost:30678")
+
+
+def test_http_session_does_not_persist_cookies():
+    """Test that HTTPSessionWithRetry doesn't store or send cookies"""
+
+    class MockServer(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):  # noqa: N802
+            cookie_header = self.headers.get("Cookie", "")
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Set-Cookie", "test_cookie=test_value; Path=/")
+            self.end_headers()
+            self.wfile.write(json.dumps({"cookies_received": cookie_header}).encode())
+
+    # Use ephemeral port (OS-chosen)
+    server = socketserver.TCPServer(("127.0.0.1", 0), MockServer)
+    port = server.server_address[1]
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    time.sleep(0.1)  # Minimal sleep for server readiness
+
+    try:
+        session = HTTPSessionWithRetry()
+
+        # Request 1 - server sets cookie
+        resp1 = session.get(f"http://127.0.0.1:{port}/first")
+        # Check what cookies the server RECEIVED from us (should be none)
+        assert resp1.json()["cookies_received"] == ""
+
+        # Check what cookies the server SENT to us (in response)
+        # We CAN read cookies from the response, they're just not stored for future requests
+        assert "Set-Cookie" in resp1.headers, "Server should send Set-Cookie header"
+        assert "test_cookie=test_value" in resp1.headers["Set-Cookie"]
+
+        # Request 2 - verify cookie was NOT sent back to server
+        resp2 = session.get(f"http://127.0.0.1:{port}/second")
+        # This verifies the cookie from Request 1 was NOT sent back
+        # (proves DummyCookieJar didn't store it)
+        assert (
+            resp2.json()["cookies_received"] == ""
+        ), "HTTPSessionWithRetry should not persist cookies"
+
+        # Server still sets cookies in response, and we can still read them
+        # But they won't be stored or sent in future requests
+        assert "Set-Cookie" in resp2.headers, "Server still sends cookies in response"
+
+        # Verify cookie jar is empty (cookies were not stored)
+        assert len(session.cookies) == 0, "Cookie jar should be empty"
+
+        session.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=1)


### PR DESCRIPTION
backport https://github.com/mlrun/mlrun/pull/9258 + adopt for 1.11 changes (some clients were moved and changed)

jira - https://iguazio.atlassian.net/browse/ML-12156