### PR TITLE
[Model Monitoring] Preserve auth token when updating controller

### DIFF
--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -33,6 +33,7 @@ import framework.api.utils
 import framework.utils.auth.verifier
 import services.api.api.endpoints.model_endpoints
 import services.api.common.constants as api_constants
+import services.api.crud
 from framework.api import deps
 from framework.constants import MINIMUM_CLIENT_VERSION_FOR_MM
 from services.api.api.endpoints.nuclio import process_model_monitoring_secret
@@ -219,6 +220,26 @@ def update_model_monitoring_controller(
             f"{mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER} does not exist. "
             f"Run `project.enable_model_monitoring()` first."
         )
+
+    # Preserve existing auth token when redeploying (ML-12021)
+    if not commons.auth_token_name:
+        try:
+            existing_fn = services.api.crud.Functions().get_function(
+                db_session=commons.db_session,
+                name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
+                project=commons.project,
+            )
+            existing_token = (
+                existing_fn.get("spec", {}).get("auth", {}).get("token_name")
+            )
+            if existing_token:
+                commons.auth_token_name = existing_token
+        except Exception:
+            logger.debug(
+                "Could not read existing controller function from DB, "
+                "skipping auth token preservation",
+                project=commons.project,
+            )
 
     return commons.get_monitoring_deployment().deploy_model_monitoring_controller(
         controller_image=image,

--- a/server/py/services/api/tests/unit/api/test_model_monitoring.py
+++ b/server/py/services/api/tests/unit/api/test_model_monitoring.py
@@ -20,6 +20,10 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+import mlrun.common.schemas
+import mlrun.runtimes.nuclio.function
+import mlrun.utils.helpers
+
 
 @pytest.fixture
 def mock_delete_application_records() -> Iterator[Mock]:
@@ -71,3 +75,45 @@ def test_delete_model_monitoring_metrics(
             application_name=params.get("application-name"),
             endpoint_ids=params.get("endpoint-id"),
         )
+
+
+class TestUpdateControllerAuthToken:
+    """Tests for ML-12021: Preserve auth token in update_model_monitoring_controller"""
+
+    TOKEN_NAME = "my-iguazio-token"
+
+    def test_auth_token_round_trips_through_nuclio_spec(self):
+        spec = mlrun.runtimes.nuclio.function.NuclioSpec()
+        mlrun.utils.helpers.set_auth_token_name(spec, self.TOKEN_NAME)
+
+        spec_dict = spec.to_dict()
+        extracted = spec_dict.get("auth", {}).get("token_name")
+
+        assert extracted == self.TOKEN_NAME
+
+    def test_nuclio_spec_without_auth_extracts_none(self):
+        spec = mlrun.runtimes.nuclio.function.NuclioSpec()
+
+        spec_dict = spec.to_dict()
+        extracted = spec_dict.get("auth", {}).get("token_name")
+
+        assert extracted is None
+
+    @patch(
+        "services.api.api.endpoints.model_monitoring.process_model_monitoring_secret"
+    )
+    def test_common_params_propagates_token_to_monitoring_deployment(
+        self, _mock_secret
+    ):
+        from services.api.api.endpoints.model_monitoring import _CommonParams
+
+        commons = _CommonParams(
+            project="test-project",
+            auth_info=mlrun.common.schemas.AuthInfo(),
+            db_session=Mock(),
+            auth_token_name=self.TOKEN_NAME,
+        )
+
+        deployment = commons.get_monitoring_deployment()
+
+        assert deployment._auth_token_name == self.TOKEN_NAME

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1538,6 +1538,55 @@ class TestModelMonitoringInitialize(TestMLRunSystemModelMonitoring):
 
 @TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
+class TestUpdateControllerPreservesAuthToken(TestMLRunSystemModelMonitoring):
+    """ML-12021: Verify that update_model_monitoring_controller preserves
+    the auth token that was set during enable_model_monitoring."""
+
+    project_name = "test-mm-auth-token"
+    image: typing.Optional[str] = None
+
+    @pytest.mark.timeout(600)
+    def test_auth_token_preserved_after_controller_update(self) -> None:
+        self.set_mm_credentials()
+
+        # Clean up any leftover monitoring from a previous run
+        try:
+            self.project.disable_model_monitoring()
+        except Exception:
+            pass
+
+        token_name = "test-auth-token"
+        with mlrun.RuntimeConfigurationContext(auth_token_name=token_name):
+            self.project.enable_model_monitoring(
+                image=self.image or "mlrun/mlrun",
+                deploy_histogram_data_drift_app=False,
+                wait_for_deployment=True,
+            )
+
+        # Verify the controller has the auth token after initial deploy
+        controller = self.project.get_function(
+            key=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
+            ignore_cache=True,
+        )
+        assert controller.spec.auth.get("token_name") == token_name
+
+        # Update controller (no RuntimeConfigurationContext active)
+        self.project.update_model_monitoring_controller(
+            image=self.image or "mlrun/mlrun",
+            base_period=1,
+            wait_for_deployment=True,
+        )
+
+        # Verify the auth token is still preserved after update
+        controller = self.project.get_function(
+            key=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
+            ignore_cache=True,
+        )
+        assert controller.spec.auth.get("token_name") == token_name
+
+
+@TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
+@pytest.mark.enterprise
 class TestMonitoredServings(TestMLRunSystemModelMonitoring):
     project_name = "test-mm-serving"
     # Set image to "<repo>/mlrun:<tag>" for local testing


### PR DESCRIPTION
## Summary
In IG4 mode, `update_model_monitoring_controller` loses the auth token that was set during `enable_model_monitoring`. This PR reads the existing controller's auth token from the DB before redeploying and passes it through.

## Changes Made
- **Endpoint fix** (`server/py/services/api/api/endpoints/model_monitoring.py`): Before redeploying, read the existing controller function from DB and extract `spec.auth.token_name`. If present and no explicit token was provided, set it on `_CommonParams` so `MonitoringDeployment` picks it up. Wrapped in try/except for resilience.
- **Unit tests** (`server/py/services/api/tests/unit/api/test_model_monitoring.py`): 3 tests using real classes (`NuclioSpec`, `_CommonParams`, `MonitoringDeployment`) verifying token round-trip through serialization, no-auth safety, and propagation chain.
- **System test** (`tests/system/model_monitoring/test_app.py`): End-to-end test that enables monitoring with `RuntimeConfigurationContext(auth_token_name=...)`, calls `update_model_monitoring_controller`, and verifies the token is preserved. Confirmed: passes with fix, fails without.


## Reference
- Jira: [ML-12021](https://iguazio.atlassian.net/browse/ML-12021)

## Breaking Changes
No

[ML-12021]: https://iguazio.atlassian.net/browse/ML-12021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ