### PR TITLE
[API] Fix IG4 Project Delete Strategy Handling

### DIFF
--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -333,7 +333,7 @@ class Client(BaseClient, project_follower.Member):
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ):
-        if deletion_strategy.strategy_to_check():
+        if deletion_strategy == mlrun.common.schemas.DeletionStrategy.check:
             return
 
         self._logger.debug("Deleting project policies in Iguazio")

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -333,6 +333,9 @@ class Client(BaseClient, project_follower.Member):
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ):
+        if deletion_strategy.strategy_to_check():
+            return
+
         self._logger.debug("Deleting project policies in Iguazio")
 
         def _delete_project_policies():

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -849,7 +849,7 @@ def test_delete_project_ig4_check_skips_igz_delete(
     k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
     with unittest.mock.patch(
         "framework.utils.clients.iguazio.v4.iguazio.Client"
-    ) as igz_clmakient_mock:
+    ) as igz_client_mock:
         framework.utils.singletons.project_member.initialize_project_member()
         _create_project(client, TEST_PROJECT_NAME)
         response = client.delete(
@@ -860,8 +860,8 @@ def test_delete_project_ig4_check_skips_igz_delete(
                 )
             },
         )
-    assert response.status_code == HTTPStatus.NO_CONTENT.value
-    igz_client_mock.return_value.delete_project_policies.assert_not_called()
+        assert response.status_code == HTTPStatus.NO_CONTENT.value
+        igz_client_mock.return_value.delete_project_policies.assert_not_called()
 
 
 @pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -79,8 +79,6 @@ ORIGINAL_VERSIONED_API_PREFIX = daemon.service.base_versioned_service_prefix
 FUNCTIONS_API = "projects/{project}/functions/{name}"
 LIST_FUNCTION_API = "projects/{project}/functions"
 PERMISSIONS_PROJECT_NAME = "permissions-project"
-TEST_PROJECT_NAME = "test-project"
-IGZ_FOLLOWER_NAME = "igz"
 
 
 @pytest.fixture(params=["leader", "follower"])
@@ -829,80 +827,6 @@ def test_delete_project_deletion_strategy_check(
         },
     )
     assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
-
-
-@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
-def test_delete_project_ig4_check_skips_igz_delete(
-    db: Session,
-    client: TestClient,
-    project_member_mode: str,
-    k8s_secrets_mock: services.api.tests.unit.conftest.K8sSecretsMock,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Ensure IG4 check does not call igz delete."""
-    monkeypatch.setattr(
-        mlrun.mlconf.httpdb.authentication,
-        "mode",
-        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
-    )
-    monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
-    k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
-    with unittest.mock.patch(
-        "framework.utils.clients.iguazio.v4.iguazio.Client"
-    ) as igz_client_mock:
-        framework.utils.singletons.project_member.initialize_project_member()
-        _create_project(client, TEST_PROJECT_NAME)
-        response = client.delete(
-            f"projects/{TEST_PROJECT_NAME}",
-            headers={
-                mlrun.common.schemas.HeaderNames.deletion_strategy: (
-                    mlrun.common.schemas.DeletionStrategy.check.value
-                )
-            },
-        )
-        assert response.status_code == HTTPStatus.NO_CONTENT.value
-        igz_client_mock.return_value.delete_project_policies.assert_not_called()
-
-
-@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
-@pytest.mark.parametrize(
-    "deletion_strategy",
-    (
-        mlrun.common.schemas.DeletionStrategy.restricted,
-        mlrun.common.schemas.DeletionStrategy.cascading,
-    ),
-)
-def test_delete_project_ig4_delete_calls_igz_delete(
-    db: Session,
-    client: TestClient,
-    project_member_mode: str,
-    k8s_secrets_mock: services.api.tests.unit.conftest.K8sSecretsMock,
-    monkeypatch: pytest.MonkeyPatch,
-    deletion_strategy: mlrun.common.schemas.DeletionStrategy,
-) -> None:
-    """Ensure IG4 delete calls igz delete once."""
-    monkeypatch.setattr(
-        mlrun.mlconf.httpdb.authentication,
-        "mode",
-        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
-    )
-    monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
-    k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
-    with unittest.mock.patch(
-        "framework.utils.clients.iguazio.v4.iguazio.Client"
-    ) as igz_client_mock:
-        framework.utils.singletons.project_member.initialize_project_member()
-        _create_project(client, TEST_PROJECT_NAME)
-        response = client.delete(
-            f"projects/{TEST_PROJECT_NAME}",
-            headers={
-                mlrun.common.schemas.HeaderNames.deletion_strategy: deletion_strategy.value
-            },
-        )
-    assert response.status_code == HTTPStatus.NO_CONTENT.value
-    igz_client_mock.return_value.delete_project_policies.assert_called_once_with(
-        project=TEST_PROJECT_NAME
-    )
 
 
 def test_delete_project_not_deleting_versioned_objects_multiple_times(

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -832,10 +832,13 @@ def test_delete_project_deletion_strategy_check(
 
 
 @pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
-@pytest.mark.parametrize("deletion_strategy", (
-    mlrun.common.schemas.DeletionStrategy.check,
-    mlrun.common.schemas.DeletionStrategy.restricted,
-))
+@pytest.mark.parametrize(
+    "deletion_strategy",
+    (
+        mlrun.common.schemas.DeletionStrategy.check,
+        mlrun.common.schemas.DeletionStrategy.restricted,
+    ),
+)
 def test_delete_project_ig4_check_skips_igz_delete(
     db: Session,
     client: TestClient,
@@ -844,15 +847,23 @@ def test_delete_project_ig4_check_skips_igz_delete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ensure IG4 check/restricted does not call igz delete."""
-    monkeypatch.setattr(mlrun.mlconf.httpdb.authentication, "mode", mlrun.common.types.AuthenticationMode.IGUAZIO_V4)
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+    )
     monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
     k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
-    with unittest.mock.patch("framework.utils.clients.iguazio.v4.iguazio.Client") as igz_client_mock:
+    with unittest.mock.patch(
+        "framework.utils.clients.iguazio.v4.iguazio.Client"
+    ) as igz_client_mock:
         framework.utils.singletons.project_member.initialize_project_member()
         _create_project(client, TEST_PROJECT_NAME)
         response = client.delete(
             f"projects/{TEST_PROJECT_NAME}",
-            headers={mlrun.common.schemas.HeaderNames.deletion_strategy: deletion_strategy.value},
+            headers={
+                mlrun.common.schemas.HeaderNames.deletion_strategy: deletion_strategy.value
+            },
         )
     assert response.status_code == HTTPStatus.NO_CONTENT.value
     igz_client_mock.return_value.delete_project_policies.assert_not_called()
@@ -867,10 +878,16 @@ def test_delete_project_ig4_cascading_calls_igz_delete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ensure IG4 cascading calls igz delete once."""
-    monkeypatch.setattr(mlrun.mlconf.httpdb.authentication, "mode", mlrun.common.types.AuthenticationMode.IGUAZIO_V4)
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+    )
     monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
     k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
-    with unittest.mock.patch("framework.utils.clients.iguazio.v4.iguazio.Client") as igz_client_mock:
+    with unittest.mock.patch(
+        "framework.utils.clients.iguazio.v4.iguazio.Client"
+    ) as igz_client_mock:
         framework.utils.singletons.project_member.initialize_project_member()
         _create_project(client, TEST_PROJECT_NAME)
         response = client.delete(

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -832,13 +832,6 @@ def test_delete_project_deletion_strategy_check(
 
 
 @pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
-@pytest.mark.parametrize(
-    "deletion_strategy",
-    (
-        mlrun.common.schemas.DeletionStrategy.check,
-        mlrun.common.schemas.DeletionStrategy.restricted,
-    ),
-)
 def test_delete_project_ig4_check_skips_igz_delete(
     db: Session,
     client: TestClient,
@@ -846,7 +839,48 @@ def test_delete_project_ig4_check_skips_igz_delete(
     k8s_secrets_mock: services.api.tests.unit.conftest.K8sSecretsMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Ensure IG4 check/restricted does not call igz delete."""
+    """Ensure IG4 check does not call igz delete."""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+    )
+    monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
+    k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
+    with unittest.mock.patch(
+        "framework.utils.clients.iguazio.v4.iguazio.Client"
+    ) as igz_clmakient_mock:
+        framework.utils.singletons.project_member.initialize_project_member()
+        _create_project(client, TEST_PROJECT_NAME)
+        response = client.delete(
+            f"projects/{TEST_PROJECT_NAME}",
+            headers={
+                mlrun.common.schemas.HeaderNames.deletion_strategy: (
+                    mlrun.common.schemas.DeletionStrategy.check.value
+                )
+            },
+        )
+    assert response.status_code == HTTPStatus.NO_CONTENT.value
+    igz_client_mock.return_value.delete_project_policies.assert_not_called()
+
+
+@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
+@pytest.mark.parametrize(
+    "deletion_strategy",
+    (
+        mlrun.common.schemas.DeletionStrategy.restricted,
+        mlrun.common.schemas.DeletionStrategy.cascading,
+    ),
+)
+def test_delete_project_ig4_delete_calls_igz_delete(
+    db: Session,
+    client: TestClient,
+    project_member_mode: str,
+    k8s_secrets_mock: services.api.tests.unit.conftest.K8sSecretsMock,
+    monkeypatch: pytest.MonkeyPatch,
+    deletion_strategy: mlrun.common.schemas.DeletionStrategy,
+) -> None:
+    """Ensure IG4 delete calls igz delete once."""
     monkeypatch.setattr(
         mlrun.mlconf.httpdb.authentication,
         "mode",
@@ -863,37 +897,6 @@ def test_delete_project_ig4_check_skips_igz_delete(
             f"projects/{TEST_PROJECT_NAME}",
             headers={
                 mlrun.common.schemas.HeaderNames.deletion_strategy: deletion_strategy.value
-            },
-        )
-    assert response.status_code == HTTPStatus.NO_CONTENT.value
-    igz_client_mock.return_value.delete_project_policies.assert_not_called()
-
-
-@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
-def test_delete_project_ig4_cascading_calls_igz_delete(
-    db: Session,
-    client: TestClient,
-    project_member_mode: str,
-    k8s_secrets_mock: services.api.tests.unit.conftest.K8sSecretsMock,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Ensure IG4 cascading calls igz delete once."""
-    monkeypatch.setattr(
-        mlrun.mlconf.httpdb.authentication,
-        "mode",
-        mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
-    )
-    monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
-    k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
-    with unittest.mock.patch(
-        "framework.utils.clients.iguazio.v4.iguazio.Client"
-    ) as igz_client_mock:
-        framework.utils.singletons.project_member.initialize_project_member()
-        _create_project(client, TEST_PROJECT_NAME)
-        response = client.delete(
-            f"projects/{TEST_PROJECT_NAME}",
-            headers={
-                mlrun.common.schemas.HeaderNames.deletion_strategy: mlrun.common.schemas.DeletionStrategy.cascading.value
             },
         )
     assert response.status_code == HTTPStatus.NO_CONTENT.value

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -79,6 +79,8 @@ ORIGINAL_VERSIONED_API_PREFIX = daemon.service.base_versioned_service_prefix
 FUNCTIONS_API = "projects/{project}/functions/{name}"
 LIST_FUNCTION_API = "projects/{project}/functions"
 PERMISSIONS_PROJECT_NAME = "permissions-project"
+TEST_PROJECT_NAME = "test-project"
+IGZ_FOLLOWER_NAME = "igz"
 
 
 @pytest.fixture(params=["leader", "follower"])
@@ -827,6 +829,60 @@ def test_delete_project_deletion_strategy_check(
         },
     )
     assert response.status_code == HTTPStatus.PRECONDITION_FAILED.value
+
+
+@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
+@pytest.mark.parametrize("deletion_strategy", (
+    mlrun.common.schemas.DeletionStrategy.check,
+    mlrun.common.schemas.DeletionStrategy.restricted,
+))
+def test_delete_project_ig4_check_skips_igz_delete(
+    db: Session,
+    client: TestClient,
+    project_member_mode: str,
+    k8s_secrets_mock: services.api.tests.unit.conftest.K8sSecretsMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure IG4 check/restricted does not call igz delete."""
+    monkeypatch.setattr(mlrun.mlconf.httpdb.authentication, "mode", mlrun.common.types.AuthenticationMode.IGUAZIO_V4)
+    monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
+    k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
+    with unittest.mock.patch("framework.utils.clients.iguazio.v4.iguazio.Client") as igz_client_mock:
+        framework.utils.singletons.project_member.initialize_project_member()
+        _create_project(client, TEST_PROJECT_NAME)
+        response = client.delete(
+            f"projects/{TEST_PROJECT_NAME}",
+            headers={mlrun.common.schemas.HeaderNames.deletion_strategy: deletion_strategy.value},
+        )
+    assert response.status_code == HTTPStatus.NO_CONTENT.value
+    igz_client_mock.return_value.delete_project_policies.assert_not_called()
+
+
+@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
+def test_delete_project_ig4_cascading_calls_igz_delete(
+    db: Session,
+    client: TestClient,
+    project_member_mode: str,
+    k8s_secrets_mock: services.api.tests.unit.conftest.K8sSecretsMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure IG4 cascading calls igz delete once."""
+    monkeypatch.setattr(mlrun.mlconf.httpdb.authentication, "mode", mlrun.common.types.AuthenticationMode.IGUAZIO_V4)
+    monkeypatch.setattr(mlrun.mlconf.httpdb.projects, "followers", IGZ_FOLLOWER_NAME)
+    k8s_secrets_mock.set_is_running_in_k8s_cluster(False)
+    with unittest.mock.patch("framework.utils.clients.iguazio.v4.iguazio.Client") as igz_client_mock:
+        framework.utils.singletons.project_member.initialize_project_member()
+        _create_project(client, TEST_PROJECT_NAME)
+        response = client.delete(
+            f"projects/{TEST_PROJECT_NAME}",
+            headers={
+                mlrun.common.schemas.HeaderNames.deletion_strategy: mlrun.common.schemas.DeletionStrategy.cascading.value
+            },
+        )
+    assert response.status_code == HTTPStatus.NO_CONTENT.value
+    igz_client_mock.return_value.delete_project_policies.assert_called_once_with(
+        project=TEST_PROJECT_NAME
+    )
 
 
 def test_delete_project_not_deleting_versioned_objects_multiple_times(

--- a/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/clients/iguazio/test_iguazio_v4.py
@@ -337,6 +337,41 @@ async def test_verify_request_session_single_group_untyped(
     assert auth_info.user_group_ids == ["valid-group-id"]
 
 
+@pytest.mark.parametrize("iguazio_client", [("v4", "sync")], indirect=True)
+def test_delete_project_check_skips_igz_delete(
+    iguazio_client, mock_service_account_auth_headers
+) -> None:
+    """Ensure IG4 check does not call igz delete project policies."""
+    iguazio_client.delete_project(
+        None,
+        TEST_PROJECT_NAME,
+        deletion_strategy=mlrun.common.schemas.DeletionStrategy.check,
+    )
+    iguazio_client._client.delete_project_policies.assert_not_called()
+
+
+@pytest.mark.parametrize("iguazio_client", [("v4", "sync")], indirect=True)
+@pytest.mark.parametrize(
+    "deletion_strategy",
+    (
+        mlrun.common.schemas.DeletionStrategy.restricted,
+        mlrun.common.schemas.DeletionStrategy.cascading,
+    ),
+)
+def test_delete_project_calls_igz_delete(
+    iguazio_client,
+    deletion_strategy: mlrun.common.schemas.DeletionStrategy,
+    mock_service_account_auth_headers,
+) -> None:
+    """Ensure IG4 delete calls igz delete project policies once."""
+    iguazio_client.delete_project(
+        None, TEST_PROJECT_NAME, deletion_strategy=deletion_strategy
+    )
+    iguazio_client._client.delete_project_policies.assert_called_once_with(
+        project=TEST_PROJECT_NAME
+    )
+
+
 def sample_user_info(username="dummy-user", user_id="dummy-user-id", group_ids=None):
     group_ids = group_ids or ["dummy-group-id-g1", "dummy-group-id-g2"]
     return {


### PR DESCRIPTION
### 📝 Description
Fix IG4 project deletion handling by skipping igz delete calls on check/restricted strategies while preserving cascading behavior, and add unit coverage for IG4 delete flows.

---
### 🛠️ Changes Made
- Skip igz v4 delete for checkdeletion strategies in the IG4 client
- Add IG4-specific delete tests covering check/restricted and cascading scenarios

---
### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---
### 🧪 Testing
- Manual (lab): IG4 delete flow
  - Empty project: `restricted` → success
  - Empty project: `cascade` → success
  - Non-empty project (stored job function): `restricted` → failure, `cascade` → success
- Unit tests

---
### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12029

---
### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
