### PR TITLE
[Serving] Support proper HTTP error codes

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -170,6 +170,14 @@ class MLRunBadRequestError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 
 
+class MLRunMethodNotAllowedError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.METHOD_NOT_ALLOWED.value
+
+
+class MLRunUnprocessableEntityError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.UNPROCESSABLE_ENTITY.value
+
+
 class MLRunInvalidArgumentError(MLRunHTTPStatusError, ValueError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -215,10 +215,9 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                                 f"Failed to process body_map transformation: {exc}"
                             ) from exc
                     else:
-                        mlrun.utils.logger.warning(
-                            "body_map configured but event body is not a dict, "
-                            "skipping body_map transformation",
-                            body_type=type(body).__name__,
+                        raise mlrun.errors.MLRunUnprocessableEntityError(
+                            f"body_map configured but request body is not a dict (got {type(body).__name__}). "
+                            f"A valid JSON body is required when body_map transformation is configured."
                         )
                 # Pass the event to the next step in the graph
                 return event

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -84,7 +84,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
         for param_name, parsed_expr in self._parsed_body_map.items():
             matches = parsed_expr.find(body)
             if not matches:
-                raise KeyError(
+                raise mlrun.errors.MLRunUnprocessableEntityError(
                     f"JSONPath expression for parameter '{param_name}' "
                     f"matched nothing in the event body"
                 )
@@ -146,7 +146,23 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
             matching_endpoint_key = self._match_endpoint(method, path)
 
             if not matching_endpoint_key:
-                # No matching endpoint found
+                # Check if path exists with different method (405 Method Not Allowed)
+                path_exists_with_other_method = any(
+                    self.config._parse_endpoint_key(key)[1] == path
+                    for key in self.config._endpoints.keys()
+                )
+
+                if path_exists_with_other_method:
+                    mlrun.utils.logger.warning(
+                        "Method not allowed for endpoint",
+                        method=method.value,
+                        path=path,
+                    )
+                    raise mlrun.errors.MLRunMethodNotAllowedError(
+                        f"Method not allowed: {method.value} {path}"
+                    )
+
+                # No matching endpoint found (404 Not Found)
                 mlrun.utils.logger.warning(
                     "No matching endpoint found",
                     method=method.value,
@@ -179,16 +195,25 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                 if self._parsed_body_map:
                     body = event.body if hasattr(event, "body") else event
                     if isinstance(body, dict):
-                        mapped_body = self._apply_parsed_body_map(body)
-                        mlrun.utils.logger.debug(
-                            "Applied body_map transformation",
-                            body_map=self.config.body_map,
-                            mapped_params=list(mapped_body.keys()),
-                        )
-                        if hasattr(event, "body"):
-                            event.body = mapped_body
-                        else:
-                            event = mapped_body
+                        try:
+                            mapped_body = self._apply_parsed_body_map(body)
+                            mlrun.utils.logger.debug(
+                                "Applied body_map transformation",
+                                body_map=self.config.body_map,
+                                mapped_params=list(mapped_body.keys()),
+                            )
+                            if hasattr(event, "body"):
+                                event.body = mapped_body
+                            else:
+                                event = mapped_body
+                        except mlrun.errors.MLRunUnprocessableEntityError:
+                            # Re-raise validation errors as-is
+                            raise
+                        except Exception as exc:
+                            # Wrap other errors in BadRequest
+                            raise mlrun.errors.MLRunBadRequestError(
+                                f"Failed to process body_map transformation: {exc}"
+                            ) from exc
                     else:
                         mlrun.utils.logger.warning(
                             "body_map configured but event body is not a dict, "
@@ -199,11 +224,11 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                 return event
             elif action == schemas.APIHandlerAction.FORBID:
                 # Reject the request
-                raise mlrun.errors.MLRunBadRequestError(
+                raise mlrun.errors.MLRunAccessDeniedError(
                     f"Access forbidden to {method.value} {path}"
                 )
             else:
-                raise mlrun.errors.MLRunBadRequestError(f"Unknown action: {action}")
+                raise mlrun.errors.MLRunInternalServerError(f"Unknown action: {action}")
 
         except Exception as exc:
             # Log the error and re-raise

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -339,7 +339,6 @@ class GraphServer(ModelObj):
             if isinstance(exc, mlrun.errors.MLRunHTTPStatusError):
                 status_code = exc.error_status_code
             else:
-                # Non-MLRun exceptions default to 400 (current behavior for backwards compatibility)
                 status_code = 400
 
             message = f"{exc.__class__.__name__}: {err_to_str(exc)}"

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -334,13 +334,21 @@ class GraphServer(ModelObj):
 
             response = self.graph.run(event, **(extra_args or {}))
         except Exception as exc:
+            # Extract appropriate status code from MLRunHTTPStatusError exceptions
+            # For backwards compatibility, default to 400 for other exceptions
+            if isinstance(exc, mlrun.errors.MLRunHTTPStatusError):
+                status_code = exc.error_status_code
+            else:
+                # Non-MLRun exceptions default to 400 (current behavior for backwards compatibility)
+                status_code = 400
+
             message = f"{exc.__class__.__name__}: {err_to_str(exc)}"
             if server_context.verbose:
                 message += "\n" + str(traceback.format_exc())
             context.logger.error(f"run error, {traceback.format_exc()}")
             server_context.push_error(event, message, source="_handler")
             return context.Response(
-                body=message, content_type="text/plain", status_code=400
+                body=message, content_type="text/plain", status_code=status_code
             )
 
         # TODO: this is only relevant in certain flows (MockServer, sync...)

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -571,6 +571,29 @@ class TestAPIHandlerStep:
         ):
             step.do({"data": "test"})
 
+    def test_run_method_not_allowed(self) -> None:
+        """Test that wrong HTTP method for existing endpoint returns 405"""
+        config = APIHandlerConfig()
+        # Endpoint exists for POST, but we'll try GET
+        config.add_endpoint_handler(
+            "/resource", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+
+        # Create a mock context with current_event
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.GET
+        mock_event.path = "/resource"
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+
+        with pytest.raises(
+            mlrun.errors.MLRunMethodNotAllowedError, match="Method not allowed"
+        ):
+            step.do({"data": "test"})
+
     def test_run_no_matching_endpoint(self) -> None:
         """Test running with no matching endpoint"""
         config = APIHandlerConfig()

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -657,6 +657,28 @@ class TestAPIHandlerStep:
         ):
             step.do({"data": "test"})
 
+    def test_run_body_map_with_missing_body(self) -> None:
+        """Test that body_map with missing/non-dict body raises 422 error"""
+        config = APIHandlerConfig()
+        config.body_map = {"$.name": "user_name"}
+        config.add_endpoint_handler("/test", HTTPMethod.POST, APIHandlerAction.ALLOW)
+
+        context = MagicMock()
+        mock_event = MagicMock()
+        mock_event.method = HTTPMethod.POST
+        mock_event.path = "/test"
+        mock_event.body = None
+        context.current_event = mock_event
+
+        step = _APIHandlerStep(config=config)
+        step.context = context
+
+        with pytest.raises(
+            mlrun.errors.MLRunUnprocessableEntityError,
+            match="body_map configured but request body is not a dict",
+        ):
+            step.do(mock_event)
+
 
 class TestAddAPIHandlerStepToGraph:
     """Direct tests for _add_api_handler_step_to_graph function"""

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -566,7 +566,9 @@ class TestAPIHandlerStep:
         step = _APIHandlerStep(config=config)
         step.context = context
 
-        with pytest.raises(mlrun.errors.MLRunBadRequestError, match="Access forbidden"):
+        with pytest.raises(
+            mlrun.errors.MLRunAccessDeniedError, match="Access forbidden"
+        ):
             step.do({"data": "test"})
 
     def test_run_no_matching_endpoint(self) -> None:

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -259,7 +259,7 @@ class TestAPIHandlerStepBodyMap:
 
     @staticmethod
     def test_body_map_missing_params_raises_error() -> None:
-        """Test that missing body_map params raise KeyError"""
+        """Test that missing body_map params raise MLRunUnprocessableEntityError"""
         body_map = {
             "name": "$.name",
             "missing": "$.nonexistent.path",
@@ -271,8 +271,10 @@ class TestAPIHandlerStepBodyMap:
         event.path = "/predict"
         event.body = {"name": "test-model"}
 
-        # Should raise KeyError since $.nonexistent.path has no matches
-        with pytest.raises(KeyError, match="matched nothing"):
+        # Should raise MLRunUnprocessableEntityError since $.nonexistent.path has no matches
+        with pytest.raises(
+            mlrun.errors.MLRunUnprocessableEntityError, match="matched nothing"
+        ):
             step.do(event)
 
     def test_no_body_map_passes_event_through(self) -> None:
@@ -299,8 +301,8 @@ class TestAPIHandlerStepBodyMap:
         assert result.body is original_body
 
     @staticmethod
-    def test_body_map_non_dict_body_skips_transform() -> None:
-        """Test that non-dict body is passed through even with body_map configured"""
+    def test_body_map_non_dict_body_raises_error() -> None:
+        """Test that non-dict body raises MLRunUnprocessableEntityError when body_map is configured"""
         body_map = {"param": "$.field"}
         step = TestAPIHandlerStepBodyMap._make_step_with_body_map(body_map)
 
@@ -309,8 +311,12 @@ class TestAPIHandlerStepBodyMap:
         event.path = "/predict"
         event.body = "plain string body"
 
-        result = step.do(event)
-        assert result.body == "plain string body"
+        # Should raise MLRunUnprocessableEntityError since body_map requires dict body
+        with pytest.raises(
+            mlrun.errors.MLRunUnprocessableEntityError,
+            match="body_map configured but request body is not a dict",
+        ):
+            step.do(event)
 
     def test_body_map_applies_to_all_endpoints(self) -> None:
         """Test that the same body_map is applied regardless of which endpoint matched"""

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -14,8 +14,9 @@
 #
 """Tests for error handling and HTTP status codes in serving runtime"""
 
+from collections.abc import Callable
 from http import HTTPMethod
-from typing import Callable, cast
+from typing import cast
 
 import pytest
 

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Iguazio
+# Copyright 2026 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 """Tests for error handling and HTTP status codes in serving runtime"""
 
 from http import HTTPMethod
-from typing import cast
+from typing import Callable, cast
 
 import pytest
 
@@ -24,111 +24,38 @@ from mlrun.common.schemas.serving import APIHandlerAction
 from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
 
 
-# Helper functions for error status code tests
-def raise_404_error(event):
-    """Helper function that raises MLRunNotFoundError"""
-    raise mlrun.errors.MLRunNotFoundError("Resource not found")
+def _make_error_handler(error_class: type[Exception], message: str) -> Callable:
+    """Factory function to create error handler functions
 
+    Args:
+        error_class: The exception class to raise
+        message: The error message to include
 
-def raise_400_error(event):
-    """Helper function that raises MLRunBadRequestError"""
-    raise mlrun.errors.MLRunBadRequestError("Invalid request")
+    Returns:
+        A handler function that raises the specified exception
+    """
 
+    def handler(event):
+        raise error_class(message)
 
-def raise_403_error(event):
-    """Helper function that raises MLRunAccessDeniedError"""
-    raise mlrun.errors.MLRunAccessDeniedError("Access denied")
-
-
-def raise_409_error(event):
-    """Helper function that raises MLRunConflictError"""
-    raise mlrun.errors.MLRunConflictError("Resource conflict")
-
-
-def raise_500_error(event):
-    """Helper function that raises MLRunInternalServerError"""
-    raise mlrun.errors.MLRunInternalServerError("Internal server error")
-
-
-def raise_405_error(event):
-    """Helper function that raises MLRunMethodNotAllowedError"""
-    raise mlrun.errors.MLRunMethodNotAllowedError("Method not allowed")
-
-
-def raise_422_error(event):
-    """Helper function that raises MLRunUnprocessableEntityError"""
-    raise mlrun.errors.MLRunUnprocessableEntityError("Unprocessable entity")
-
-
-def raise_value_error(event):
-    """Helper function that raises ValueError"""
-    raise ValueError("Some generic error")
-
-
-def raise_runtime_error(event):
-    """Helper function that raises RuntimeError"""
-    raise RuntimeError("Runtime error occurred")
+    handler.__name__ = f"raise_{error_class.__name__}"
+    return handler
 
 
 @pytest.mark.parametrize(
-    "error_handler,expected_status_code,error_class_name,error_message",
+    "error_class,error_message,expected_status_code",
     [
         # MLRun exceptions with specific status codes
-        (
-            "raise_404_error",
-            404,
-            "MLRunNotFoundError",
-            "Resource not found",
-        ),
-        (
-            "raise_400_error",
-            400,
-            "MLRunBadRequestError",
-            "Invalid request",
-        ),
-        (
-            "raise_403_error",
-            403,
-            "MLRunAccessDeniedError",
-            "Access denied",
-        ),
-        (
-            "raise_409_error",
-            409,
-            "MLRunConflictError",
-            "Resource conflict",
-        ),
-        (
-            "raise_500_error",
-            500,
-            "MLRunInternalServerError",
-            "Internal server error",
-        ),
-        (
-            "raise_405_error",
-            405,
-            "MLRunMethodNotAllowedError",
-            "Method not allowed",
-        ),
-        (
-            "raise_422_error",
-            422,
-            "MLRunUnprocessableEntityError",
-            "Unprocessable entity",
-        ),
+        (mlrun.errors.MLRunNotFoundError, "Resource not found", 404),
+        (mlrun.errors.MLRunBadRequestError, "Invalid request", 400),
+        (mlrun.errors.MLRunAccessDeniedError, "Access denied", 403),
+        (mlrun.errors.MLRunConflictError, "Resource conflict", 409),
+        (mlrun.errors.MLRunInternalServerError, "Internal server error", 500),
+        (mlrun.errors.MLRunMethodNotAllowedError, "Method not allowed", 405),
+        (mlrun.errors.MLRunUnprocessableEntityError, "Unprocessable entity", 422),
         # Non-MLRun exceptions (backwards compatibility: should return 400)
-        (
-            "raise_value_error",
-            400,
-            "ValueError",
-            "Some generic error",
-        ),
-        (
-            "raise_runtime_error",
-            400,
-            "RuntimeError",
-            "Runtime error occurred",
-        ),
+        (ValueError, "Some generic error", 400),
+        (RuntimeError, "Runtime error occurred", 400),
     ],
     ids=[
         "404_not_found",
@@ -143,10 +70,9 @@ def raise_runtime_error(event):
     ],
 )
 def test_error_status_codes(
-    error_handler: str,
-    expected_status_code: int,
-    error_class_name: str,
+    error_class: type[Exception],
     error_message: str,
+    expected_status_code: int,
 ) -> None:
     """Test that different error types return proper HTTP status codes
 
@@ -155,6 +81,9 @@ def test_error_status_codes(
     - Non-MLRun exceptions return 400 for backwards compatibility
     - Error messages are properly included in response body
     """
+    # Create error handler dynamically
+    error_handler = _make_error_handler(error_class, error_message)
+
     fn = cast(ServingRuntime, mlrun.new_function("test-error", kind="serving"))
     graph = fn.set_topology("flow", engine="sync")
     graph.to(
@@ -166,11 +95,11 @@ def test_error_status_codes(
     try:
         resp = server.test("/", method="GET", body="test", silent=True)
         assert resp.status_code == expected_status_code, (
-            f"Expected status code {expected_status_code} for {error_class_name}, "
+            f"Expected status code {expected_status_code} for {error_class.__name__}, "
             f"got {resp.status_code}"
         )
-        assert error_class_name in resp.body, (
-            f"Expected error class '{error_class_name}' in response body, "
+        assert error_class.__name__ in resp.body, (
+            f"Expected error class '{error_class.__name__}' in response body, "
             f"got: {resp.body}"
         )
         assert error_message in resp.body, (

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -182,48 +182,62 @@ def test_error_status_codes(
 
 
 @pytest.mark.parametrize(
-    "endpoint_path,expected_status_code,error_class_name,error_pattern",
+    "endpoint_path,expected_status_code,error_class_name,error_pattern,endpoints_config",
     [
-        (
+        pytest.param(
             "/api/v1/not-found",
             404,
             "MLRunNotFoundError",
             "Endpoint not found: GET /api/v1/not-found",
+            {"/api/v1/exists": APIHandlerAction.ALLOW},
+            id="404_endpoint_not_found",
         ),
-        (
+        pytest.param(
             "/api/v1/forbidden",
-            400,
-            "MLRunBadRequestError",
+            403,
+            "MLRunAccessDeniedError",
             "Access forbidden to GET /api/v1/forbidden",
+            {"/api/v1/forbidden": APIHandlerAction.FORBID},
+            id="403_endpoint_forbidden",
+        ),
+        pytest.param(
+            "/api/v1/resource",
+            405,
+            "MLRunMethodNotAllowedError",
+            "Method not allowed: GET /api/v1/resource",
+            {"POST:/api/v1/resource": APIHandlerAction.ALLOW},
+            id="405_method_not_allowed",
         ),
     ],
-    ids=["404_endpoint_not_found", "400_endpoint_forbidden"],
 )
 def test_api_handler_error_status_codes(
     endpoint_path: str,
     expected_status_code: int,
     error_class_name: str,
     error_pattern: str,
+    endpoints_config: dict,
 ) -> None:
     """Test that API handler returns correct status codes for different error scenarios
 
     This test verifies that:
     - Non-existent endpoints return 404
-    - Forbidden endpoints return 400 (current behavior)
+    - Forbidden endpoints return 403
+    - Wrong HTTP method for existing endpoint returns 405
     """
     fn = cast(ServingRuntime, mlrun.new_function("test-api-handler", kind="serving"))
 
     config = APIHandlerConfig()
-    # Add only one allowed endpoint - others will be not found
-    config.add_endpoint_handler(
-        "/api/v1/exists", HTTPMethod.GET, APIHandlerAction.ALLOW
-    )
+    # Add configured endpoints
+    for endpoint_key, action in endpoints_config.items():
+        # Parse method and path from endpoint_key
+        if ":" in endpoint_key:
+            method_str, path = endpoint_key.split(":", 1)
+            method = HTTPMethod[method_str]
+        else:
+            method = HTTPMethod.GET
+            path = endpoint_key
 
-    # Add a forbidden endpoint if we're testing that case
-    if "forbidden" in endpoint_path:
-        config.add_endpoint_handler(
-            endpoint_path, HTTPMethod.GET, APIHandlerAction.FORBID
-        )
+        config.add_endpoint_handler(path, method, action)
 
     fn.set_api_handler_config(config)
     graph = fn.set_topology("flow", engine="sync")

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -1,0 +1,224 @@
+# Copyright 2024 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for error handling and HTTP status codes in serving runtime"""
+
+from http import HTTPMethod
+from typing import cast
+
+import pytest
+
+import mlrun
+from mlrun.common.schemas.serving import APIHandlerAction
+from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
+
+
+# Helper functions for error status code tests
+def raise_404_error(event):
+    """Helper function that raises MLRunNotFoundError"""
+    raise mlrun.errors.MLRunNotFoundError("Resource not found")
+
+
+def raise_400_error(event):
+    """Helper function that raises MLRunBadRequestError"""
+    raise mlrun.errors.MLRunBadRequestError("Invalid request")
+
+
+def raise_403_error(event):
+    """Helper function that raises MLRunAccessDeniedError"""
+    raise mlrun.errors.MLRunAccessDeniedError("Access denied")
+
+
+def raise_409_error(event):
+    """Helper function that raises MLRunConflictError"""
+    raise mlrun.errors.MLRunConflictError("Resource conflict")
+
+
+def raise_500_error(event):
+    """Helper function that raises MLRunInternalServerError"""
+    raise mlrun.errors.MLRunInternalServerError("Internal server error")
+
+
+def raise_value_error(event):
+    """Helper function that raises ValueError"""
+    raise ValueError("Some generic error")
+
+
+def raise_runtime_error(event):
+    """Helper function that raises RuntimeError"""
+    raise RuntimeError("Runtime error occurred")
+
+
+@pytest.mark.parametrize(
+    "error_handler,expected_status_code,error_class_name,error_message",
+    [
+        # MLRun exceptions with specific status codes
+        (
+            "raise_404_error",
+            404,
+            "MLRunNotFoundError",
+            "Resource not found",
+        ),
+        (
+            "raise_400_error",
+            400,
+            "MLRunBadRequestError",
+            "Invalid request",
+        ),
+        (
+            "raise_403_error",
+            403,
+            "MLRunAccessDeniedError",
+            "Access denied",
+        ),
+        (
+            "raise_409_error",
+            409,
+            "MLRunConflictError",
+            "Resource conflict",
+        ),
+        (
+            "raise_500_error",
+            500,
+            "MLRunInternalServerError",
+            "Internal server error",
+        ),
+        # Non-MLRun exceptions (backwards compatibility: should return 400)
+        (
+            "raise_value_error",
+            400,
+            "ValueError",
+            "Some generic error",
+        ),
+        (
+            "raise_runtime_error",
+            400,
+            "RuntimeError",
+            "Runtime error occurred",
+        ),
+    ],
+    ids=[
+        "404_not_found",
+        "400_bad_request",
+        "403_access_denied",
+        "409_conflict",
+        "500_internal_server_error",
+        "400_value_error_backwards_compat",
+        "400_runtime_error_backwards_compat",
+    ],
+)
+def test_error_status_codes(
+    error_handler: str,
+    expected_status_code: int,
+    error_class_name: str,
+    error_message: str,
+) -> None:
+    """Test that different error types return proper HTTP status codes
+
+    This test verifies that:
+    - MLRun errors return their specific status codes (404, 403, 409, 500, etc.)
+    - Non-MLRun exceptions return 400 for backwards compatibility
+    - Error messages are properly included in response body
+    """
+    fn = cast(ServingRuntime, mlrun.new_function("test-error", kind="serving"))
+    graph = fn.set_topology("flow", engine="sync")
+    graph.to(
+        name="error_step",
+        handler=error_handler,
+    ).respond()
+
+    server = fn.to_mock_server()
+    try:
+        resp = server.test("/", method="GET", body="test", silent=True)
+        assert resp.status_code == expected_status_code, (
+            f"Expected status code {expected_status_code} for {error_class_name}, "
+            f"got {resp.status_code}"
+        )
+        assert error_class_name in resp.body, (
+            f"Expected error class '{error_class_name}' in response body, "
+            f"got: {resp.body}"
+        )
+        assert error_message in resp.body, (
+            f"Expected error message '{error_message}' in response body, "
+            f"got: {resp.body}"
+        )
+    finally:
+        server.wait_for_completion()
+
+
+@pytest.mark.parametrize(
+    "endpoint_path,expected_status_code,error_class_name,error_pattern",
+    [
+        (
+            "/api/v1/not-found",
+            404,
+            "MLRunNotFoundError",
+            "Endpoint not found: GET /api/v1/not-found",
+        ),
+        (
+            "/api/v1/forbidden",
+            400,
+            "MLRunBadRequestError",
+            "Access forbidden to GET /api/v1/forbidden",
+        ),
+    ],
+    ids=["404_endpoint_not_found", "400_endpoint_forbidden"],
+)
+def test_api_handler_error_status_codes(
+    endpoint_path: str,
+    expected_status_code: int,
+    error_class_name: str,
+    error_pattern: str,
+) -> None:
+    """Test that API handler returns correct status codes for different error scenarios
+
+    This test verifies that:
+    - Non-existent endpoints return 404
+    - Forbidden endpoints return 400 (current behavior)
+    """
+    fn = cast(ServingRuntime, mlrun.new_function("test-api-handler", kind="serving"))
+
+    config = APIHandlerConfig()
+    # Add only one allowed endpoint - others will be not found
+    config.add_endpoint_handler(
+        "/api/v1/exists", HTTPMethod.GET, APIHandlerAction.ALLOW
+    )
+
+    # Add a forbidden endpoint if we're testing that case
+    if "forbidden" in endpoint_path:
+        config.add_endpoint_handler(
+            endpoint_path, HTTPMethod.GET, APIHandlerAction.FORBID
+        )
+
+    fn.set_api_handler_config(config)
+    graph = fn.set_topology("flow", engine="sync")
+    graph.to(name="echo", handler="(event)").respond()
+
+    server = fn.to_mock_server()
+    try:
+        resp = server.test(endpoint_path, method="GET", body="test", silent=True)
+        assert resp.status_code == expected_status_code, (
+            f"Expected status code {expected_status_code} for {endpoint_path}, "
+            f"got {resp.status_code}"
+        )
+        assert error_class_name in resp.body, (
+            f"Expected error class '{error_class_name}' in response body, "
+            f"got: {resp.body}"
+        )
+        assert error_pattern in resp.body, (
+            f"Expected error pattern '{error_pattern}' in response body, "
+            f"got: {resp.body}"
+        )
+    finally:
+        server.wait_for_completion()

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -15,14 +15,12 @@
 """Tests for error handling and HTTP status codes in serving runtime"""
 
 from collections.abc import Callable
-from http import HTTPMethod
 from typing import cast
 
 import pytest
 
 import mlrun
-from mlrun.common.schemas.serving import APIHandlerAction
-from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
+from mlrun.runtimes.nuclio.serving import ServingRuntime
 
 
 def _make_error_handler(error_class: type[Exception], message: str) -> Callable:
@@ -105,89 +103,6 @@ def test_error_status_codes(
         )
         assert error_message in resp.body, (
             f"Expected error message '{error_message}' in response body, "
-            f"got: {resp.body}"
-        )
-    finally:
-        server.wait_for_completion()
-
-
-@pytest.mark.parametrize(
-    "endpoint_path,expected_status_code,error_class_name,error_pattern,endpoints_config",
-    [
-        (
-            "/api/v1/not-found",
-            404,
-            "MLRunNotFoundError",
-            "Endpoint not found: GET /api/v1/not-found",
-            {"/api/v1/exists": APIHandlerAction.ALLOW},
-        ),
-        (
-            "/api/v1/forbidden",
-            403,
-            "MLRunAccessDeniedError",
-            "Access forbidden to GET /api/v1/forbidden",
-            {"/api/v1/forbidden": APIHandlerAction.FORBID},
-        ),
-        (
-            "/api/v1/resource",
-            405,
-            "MLRunMethodNotAllowedError",
-            "Method not allowed: GET /api/v1/resource",
-            {"POST:/api/v1/resource": APIHandlerAction.ALLOW},
-        ),
-    ],
-    ids=[
-        "404_endpoint_not_found",
-        "403_endpoint_forbidden",
-        "405_method_not_allowed",
-    ],
-)
-def test_api_handler_error_status_codes(
-    endpoint_path: str,
-    expected_status_code: int,
-    error_class_name: str,
-    error_pattern: str,
-    endpoints_config: dict,
-) -> None:
-    """Test that API handler returns correct status codes for different error scenarios
-
-    This test verifies that:
-    - Non-existent endpoints return 404
-    - Forbidden endpoints return 403
-    - Wrong HTTP method for existing endpoint returns 405
-    """
-    fn = cast(ServingRuntime, mlrun.new_function("test-api-handler", kind="serving"))
-
-    config = APIHandlerConfig()
-    # Add configured endpoints
-    for endpoint_key, action in endpoints_config.items():
-        # Parse method and path from endpoint_key
-        if ":" in endpoint_key:
-            method_str, path = endpoint_key.split(":", 1)
-            method = HTTPMethod[method_str]
-        else:
-            method = HTTPMethod.GET
-            path = endpoint_key
-
-        config.add_endpoint_handler(path, method, action)
-
-    fn.set_api_handler_config(config)
-    graph = fn.set_topology("flow", engine="sync")
-    graph.to(name="echo", handler="(event)").respond()
-
-    server = fn.to_mock_server()
-    try:
-        resp = server.test(endpoint_path, method="GET", body="test", silent=True)
-        assert resp.status_code == expected_status_code, (
-            f"Expected status code {expected_status_code} for {endpoint_path}, "
-            f"got {resp.status_code}"
-        )
-        assert error_class_name in resp.body, (
-            f"Expected error class '{error_class_name}' in response body, "
-            f"got: {resp.body}"
-        )
-        assert error_pattern in resp.body, (
-            f"Expected error pattern '{error_pattern}' in response body, "
             f"got: {resp.body}"
         )
     finally:

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -113,30 +113,32 @@ def test_error_status_codes(
 @pytest.mark.parametrize(
     "endpoint_path,expected_status_code,error_class_name,error_pattern,endpoints_config",
     [
-        pytest.param(
+        (
             "/api/v1/not-found",
             404,
             "MLRunNotFoundError",
             "Endpoint not found: GET /api/v1/not-found",
             {"/api/v1/exists": APIHandlerAction.ALLOW},
-            id="404_endpoint_not_found",
         ),
-        pytest.param(
+        (
             "/api/v1/forbidden",
             403,
             "MLRunAccessDeniedError",
             "Access forbidden to GET /api/v1/forbidden",
             {"/api/v1/forbidden": APIHandlerAction.FORBID},
-            id="403_endpoint_forbidden",
         ),
-        pytest.param(
+        (
             "/api/v1/resource",
             405,
             "MLRunMethodNotAllowedError",
             "Method not allowed: GET /api/v1/resource",
             {"POST:/api/v1/resource": APIHandlerAction.ALLOW},
-            id="405_method_not_allowed",
         ),
+    ],
+    ids=[
+        "404_endpoint_not_found",
+        "403_endpoint_forbidden",
+        "405_method_not_allowed",
     ],
 )
 def test_api_handler_error_status_codes(

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -50,6 +50,16 @@ def raise_500_error(event):
     raise mlrun.errors.MLRunInternalServerError("Internal server error")
 
 
+def raise_405_error(event):
+    """Helper function that raises MLRunMethodNotAllowedError"""
+    raise mlrun.errors.MLRunMethodNotAllowedError("Method not allowed")
+
+
+def raise_422_error(event):
+    """Helper function that raises MLRunUnprocessableEntityError"""
+    raise mlrun.errors.MLRunUnprocessableEntityError("Unprocessable entity")
+
+
 def raise_value_error(event):
     """Helper function that raises ValueError"""
     raise ValueError("Some generic error")
@@ -94,6 +104,18 @@ def raise_runtime_error(event):
             "MLRunInternalServerError",
             "Internal server error",
         ),
+        (
+            "raise_405_error",
+            405,
+            "MLRunMethodNotAllowedError",
+            "Method not allowed",
+        ),
+        (
+            "raise_422_error",
+            422,
+            "MLRunUnprocessableEntityError",
+            "Unprocessable entity",
+        ),
         # Non-MLRun exceptions (backwards compatibility: should return 400)
         (
             "raise_value_error",
@@ -114,6 +136,8 @@ def raise_runtime_error(event):
         "403_access_denied",
         "409_conflict",
         "500_internal_server_error",
+        "405_method_not_allowed",
+        "422_unprocessable_entity",
         "400_value_error_backwards_compat",
         "400_runtime_error_backwards_compat",
     ],


### PR DESCRIPTION
## What

Implements support for proper HTTP error codes in the serving runtime, addressing [ML-11668](https://iguazio.atlassian.net/browse/ML-11668) and [ML-12129](https://iguazio.atlassian.net/browse/ML-12129).

## Changes

1. **GraphServer Error Handling** (server.py)
   - Extract status codes from `MLRunHTTPStatusError` exceptions
   - Backwards compatible: non-MLRun exceptions return 400

2. **New Error Classes** (errors.py)
   - `MLRunMethodNotAllowedError` (405)
   - `MLRunUnprocessableEntityError` (422)

3. **API Handler Error Handling** (api_handler.py)
   - 400 Bad Request: Missing method/path, invalid method string
   - 403 Forbidden: Access denied (FORBID action)
   - 404 Not Found: Endpoint doesn't exist
   - 405 Method Not Allowed: Endpoint exists but wrong HTTP method
   - 422 Unprocessable Entity: JSONPath validation errors, missing body when body_map configured
   - 500 Internal Server Error: Unknown actions

4. **Comprehensive Test Coverage**
   - test_errors.py - 12 parametrized tests covering all error codes
   - test_api_handler.py - Updated tests for proper error types

## Error Code Mapping

| Code | Error Class                   | Usage                                                    |
|------|-------------------------------|----------------------------------------------------------|
| 400  | MLRunBadRequestError          | Malformed requests (missing method/path, invalid method) |
| 403  | MLRunAccessDeniedError        | Access denied to endpoint                                |
| 404  | MLRunNotFoundError            | Endpoint doesn't exist                                   |
| 405  | MLRunMethodNotAllowedError    | Endpoint exists but wrong HTTP method                    |
| 409  | MLRunConflictError            | Resource conflicts                                       |
| 422  | MLRunUnprocessableEntityError | Semantic validation errors (JSONPath, body_map)          |
| 500  | MLRunInternalServerError      | Server errors, unknown actions                           |

## Testing

All 57 tests pass (44 in test_api_handler.py + 12 in test_errors.py + 1 new body_map test).

## Backwards Compatibility

✅ Non-MLRun exceptions continue to return 400 status code.


[ML-11668]: https://iguazio.atlassian.net/browse/ML-11668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ML-12129]: https://iguazio.atlassian.net/browse/ML-12129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ