### PR TITLE
[Spark] Mount auth token secret to driver and executor pods

### DIFF
--- a/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
@@ -186,11 +186,15 @@ class Spark3RuntimeHandler(KubeRuntimeHandler, abc.ABC):
             ),
         )
 
-        update_in(job, "spec.volumes", runtime.spec.volumes)
-
         self.add_secrets_to_spec_before_running(
-            runtime, project_name=run.metadata.project
+            runtime,
+            project_name=run.metadata.project,
+            token_name=(run.spec.auth or {}).get("token_name"),
+            auth_info=auth_info,
         )
+
+        # Update volumes after secrets are added to ensure secret volumes are included
+        update_in(job, "spec.volumes", runtime.spec.volumes)
 
         command, args, extra_env = self._get_cmd_args(runtime, run, auth_info=auth_info)
         code = None

--- a/server/py/services/api/tests/unit/runtimes/test_spark.py
+++ b/server/py/services/api/tests/unit/runtimes/test_spark.py
@@ -1187,8 +1187,7 @@ class TestSpark3Runtime(services.api.tests.unit.runtimes.base.TestRuntimeBase):
                 expected_runspec,
                 # excluding function attribute as it contains hash of the object, excluding this path because any change
                 # in the structure of the run will require to update the function hash
-                # TODO remove the excluded path of 'auth' once ML-11590 is resolved
-                exclude_paths=["root['function']", "root['auth']"],
+                exclude_paths=["root['function']"],
             )
             == {}
         )
@@ -1243,4 +1242,102 @@ class TestSpark3Runtime(services.api.tests.unit.runtimes.base.TestRuntimeBase):
         assert (
             str(exc.value) == "Sparkjob does not support loading source code on run, "
             "use func.with_source_archive(pull_at_runtime=False)"
+        )
+
+    def test_mount_secret_token_to_spark_driver_and_executor(
+        self, db: sqlalchemy.orm.Session, k8s_secrets_mock
+    ):
+        """
+        Test that auth token secret is mounted to both driver and executor pods.
+        This test addresses ML-11590.
+        """
+        import mlrun.common.constants
+        from mlrun.common.types import AuthenticationMode
+
+        token_name = "test-token"
+
+        runtime: mlrun.runtimes.Spark3Runtime = self._generate_runtime()
+        runtime.metadata.name = "test-spark-auth-mount"
+        runtime.metadata.project = self.project
+
+        # Create a mock secret
+        mock_secret = kubernetes.client.V1Secret(
+            metadata=kubernetes.client.V1ObjectMeta(
+                name="mlrun-auth-secrets.abcdef123456"
+            ),
+            data={"tokensFile": base64.b64encode(b"dummy-token").decode("utf-8")},
+        )
+
+        # Set authentication mode to IG4 to enable token mounting
+        original_auth_mode = mlrun.mlconf.httpdb.authentication.mode
+        mlrun.mlconf.httpdb.authentication.mode = AuthenticationMode.IGUAZIO_V4
+
+        # Get the existing k8s helper and add our mocks to it
+        k8s_helper = framework.utils.singletons.k8s.get_k8s_helper()
+        k8s_helper._get_user_token_secret = unittest.mock.Mock(return_value=mock_secret)
+        k8s_helper.get_user_secret_tokens_as_igz_yml_data = unittest.mock.Mock(
+            return_value=""
+        )
+        k8s_helper.get_project_secret_keys = unittest.mock.Mock(return_value=[])
+
+        try:
+            with unittest.mock.patch(
+                "services.api.crud.secrets.Secrets.list_project_secrets",
+                return_value=mlrun.common.schemas.SecretsData(
+                    provider="kubernetes", secrets={"tokensFile": "dummy-token"}
+                ),
+            ), unittest.mock.patch(
+                "services.api.utils.helpers.resolve_auth_token_name",
+                return_value=token_name,
+            ):
+                # Execute function with auth in run_spec
+                run_spec = {"parameters": {}, "auth": {"token_name": token_name}}
+                self.execute_function(runtime, run_spec=run_spec)
+        finally:
+            # Restore original auth mode
+            mlrun.mlconf.httpdb.authentication.mode = original_auth_mode
+
+        # Get the created SparkApplication CRD
+        body = self._get_custom_object_creation_body()
+
+        # Verify that the auth secret is mounted to both driver and executor
+        expected_secret_volume_mount_path = (
+            mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH
+        )
+
+        # Check driver volume mounts
+        driver_volume_mounts = body["spec"]["driver"]["volumeMounts"]
+        driver_auth_mount = [
+            vm
+            for vm in driver_volume_mounts
+            if vm["mountPath"] == expected_secret_volume_mount_path
+        ]
+        assert len(driver_auth_mount) == 1, (
+            f"Auth secret should be mounted to driver. "
+            f"Expected mount path: {expected_secret_volume_mount_path}. "
+            f"Actual mounts: {driver_volume_mounts}"
+        )
+
+        # Check executor volume mounts
+        executor_volume_mounts = body["spec"]["executor"]["volumeMounts"]
+        executor_auth_mount = [
+            vm
+            for vm in executor_volume_mounts
+            if vm["mountPath"] == expected_secret_volume_mount_path
+        ]
+        assert (
+            len(executor_auth_mount) == 1
+        ), "Auth secret should be mounted to executor"
+
+        # Verify the secret volume is in the volumes list
+        volumes = body["spec"]["volumes"]
+        auth_volumes = [
+            vol
+            for vol in volumes
+            if vol.get("secret", {}).get("secretName") == mock_secret.metadata.name
+        ]
+        assert len(auth_volumes) == 1, (
+            f"Auth secret volume should be in volumes list. "
+            f"Expected secret name: {mock_secret.metadata.name}. "
+            f"Actual volumes: {volumes}"
         )

--- a/server/py/services/api/tests/unit/runtimes/test_spark.py
+++ b/server/py/services/api/tests/unit/runtimes/test_spark.py
@@ -1281,14 +1281,17 @@ class TestSpark3Runtime(services.api.tests.unit.runtimes.base.TestRuntimeBase):
         k8s_helper.get_project_secret_keys = unittest.mock.Mock(return_value=[])
 
         try:
-            with unittest.mock.patch(
-                "services.api.crud.secrets.Secrets.list_project_secrets",
-                return_value=mlrun.common.schemas.SecretsData(
-                    provider="kubernetes", secrets={"tokensFile": "dummy-token"}
+            with (
+                unittest.mock.patch(
+                    "services.api.crud.secrets.Secrets.list_project_secrets",
+                    return_value=mlrun.common.schemas.SecretsData(
+                        provider="kubernetes", secrets={"tokensFile": "dummy-token"}
+                    ),
                 ),
-            ), unittest.mock.patch(
-                "services.api.utils.helpers.resolve_auth_token_name",
-                return_value=token_name,
+                unittest.mock.patch(
+                    "services.api.utils.helpers.resolve_auth_token_name",
+                    return_value=token_name,
+                ),
             ):
                 # Execute function with auth in run_spec
                 run_spec = {"parameters": {}, "auth": {"token_name": token_name}}


### PR DESCRIPTION
### 📝 Description

Implements ML-11590: Mount kubernetes secret token as file for Spark operator runtime.

- Pass token_name and auth_info to add_secrets_to_spec_before_running()
- Reorder volume updates to occur after secrets are added
- Add test to verify auth secret is mounted to both driver and executor
- Remove TODO comment for ML-11590

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Manual testing, until blocked by https://iguazio.atlassian.net/browse/IG4-1488

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11590
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
