### PR TITLE
[Run] Warn on unexpected run kwargs and suggest typos

### DIFF
--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -14,8 +14,11 @@
 import abc
 import ast
 import copy
+import difflib
+import inspect
 import os
 import uuid
+import warnings
 from collections.abc import Callable
 from typing import Any, Optional, Union
 
@@ -43,7 +46,26 @@ class BaseLauncher(abc.ABC):
     """
 
     def __init__(self, **kwargs):
-        pass
+        if not kwargs:
+            return
+
+        valid_launch_params = set(inspect.signature(self.launch).parameters) - {"self"}
+        for key in sorted(kwargs):
+            if key in valid_launch_params:
+                continue
+
+            suggestion = ""
+            close_match = difflib.get_close_matches(
+                key, valid_launch_params, n=1, cutoff=0.8
+            )
+            if close_match:
+                suggestion = f" Did you mean '{close_match[0]}'?"
+
+            warnings.warn(
+                f"Unexpected run keyword argument '{key}' was ignored.{suggestion}",
+                UserWarning,
+                stacklevel=3,
+            )
 
     @abc.abstractmethod
     def launch(

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -16,6 +16,7 @@ import io
 import pathlib
 import sys
 import tempfile
+import warnings
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -130,6 +131,42 @@ def test_schedule_with_local_exploding():
         "Unexpected schedule='* * * * *' parameter for local function execution"
         in str(excinfo.value)
     )
+
+
+def test_run_warns_on_unexpected_kwarg_with_suggestion():
+    def handler(context):
+        return None
+
+    # ensure warning is raised
+    with pytest.warns(
+        UserWarning,
+    ) as caught:
+        mlrun.new_function().run(
+            local=True,
+            handler=handler,
+            param={"x": 1},
+            does_not_exists_parameter=None,
+        )
+        assert len(caught) == 2, "Expected 2 warnings, but got: {caught}"
+
+        # verify warnings are correct, could be in any order
+        assert any(
+            caught_warning.message.args[0]
+            == "Unexpected run keyword argument 'param' was ignored. Did you mean 'params'?"
+            for caught_warning in caught
+        )
+        assert any(
+            caught_warning.message.args[0]
+            == "Unexpected run keyword argument 'does_not_exists_parameter' was ignored."
+            for caught_warning in caught
+        )
+
+    # ensure no warning is raised
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        mlrun.new_function().run(local=True, handler=handler, params={"x": 1})
+
+    assert not caught, "Expected no warnings, but got: {caught}"
 
 
 def test_invalid_name():


### PR DESCRIPTION
### 📝 Description

Add runtime-level validation for unexpected `run()` keyword arguments that leak into launcher creation, so common typos (for example `param` instead of `params`) are surfaced to users as warnings instead of being silently ignored.

---

### 🛠️ Changes Made
- Added unexpected-kwargs handling in `BaseLauncher.__init__`:
- Added / updated test coverage in `tests/run/test_run.py`:
  - Verifies warnings are raised for invalid kwargs.
  - Verifies no warning is raised for valid kwargs (`params`).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Manual and unit tests

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-9272
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

This change is intentionally non-breaking: it warns (does not fail) on unknown `run()` kwargs to improve UX and help catch typo-driven bugs earlier.