### PR TITLE
[RemoteRuntime] Fix adding http trigger mode for sync

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -561,9 +561,9 @@ class RemoteRuntime(KubeResource):
             )
         elif validate_nuclio_version_compatibility("1.15.3"):
             trigger._struct["mode"] = (
-                "async" if async_spec and async_spec.enabled else "sync"
+                "async" if getattr(async_spec, "enabled", False) else "sync"
             )
-            if async_spec.enabled:
+            if getattr(async_spec, "enabled", False):
                 trigger._struct["async"] = {
                     "maxConnectionsNumber": async_spec.max_connections,
                     "connectionAvailabilityTimeout": async_spec.connection_availability_timeout,

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -513,7 +513,14 @@ class RemoteRuntime(KubeResource):
                 "Adding HTTP trigger despite the default HTTP trigger creation being disabled"
             )
 
-        if async_spec and async_spec.enabled:
+        nuclio_version_support_async = validate_nuclio_version_compatibility("1.15.3")
+        if async_spec is not None and not nuclio_version_support_async:
+            raise mlrun.errors.MLRunValueError(
+                "Async spec is only supported from Nuclio 1.15.3"
+            )
+
+        async_enabled = getattr(async_spec, "enabled", False)
+        if async_enabled:
             workers = 1 if workers is None else workers
         else:
             workers = 8 if workers is None else workers
@@ -555,15 +562,9 @@ class RemoteRuntime(KubeResource):
                 )
             trigger._struct["batch"] = batching_config
 
-        if async_spec and not validate_nuclio_version_compatibility("1.15.3"):
-            raise mlrun.errors.MLRunValueError(
-                "Async spec is only supported on Nuclio 1.15.3 and higher"
-            )
-        elif validate_nuclio_version_compatibility("1.15.3"):
-            trigger._struct["mode"] = (
-                "async" if getattr(async_spec, "enabled", False) else "sync"
-            )
-            if getattr(async_spec, "enabled", False):
+        if nuclio_version_support_async:
+            trigger._struct["mode"] = "async" if async_enabled else "sync"
+            if async_enabled:
                 trigger._struct["async"] = {
                     "maxConnectionsNumber": async_spec.max_connections,
                     "connectionAvailabilityTimeout": async_spec.connection_availability_timeout,

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -503,8 +503,9 @@ class RemoteRuntime(KubeResource):
         :param batching_spec: BatchingSpec object that defines batching configuration.
             By default, batching is disabled.
 
-        :param async_spec: AsyncSpec object defines async configuration. If number of max connections
-            won't be set, the default value will be set to 1000 according to nuclio default.
+        :param async_spec: AsyncSpec object defines async configuration. By default, mode will be sync.
+            If number of max connections won't be set, the default value will be set to 1000 according to nuclio
+            default.
 
         :return: function object (self)
         """

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -555,13 +555,15 @@ class RemoteRuntime(KubeResource):
                 )
             trigger._struct["batch"] = batching_config
 
-        if async_spec:
-            if not validate_nuclio_version_compatibility("1.15.3"):
-                raise mlrun.errors.MLRunValueError(
-                    "Async spec is only supported on Nuclio 1.15.3 and higher"
-                )
+        if async_spec and not validate_nuclio_version_compatibility("1.15.3"):
+            raise mlrun.errors.MLRunValueError(
+                "Async spec is only supported on Nuclio 1.15.3 and higher"
+            )
+        elif validate_nuclio_version_compatibility("1.15.3"):
+            trigger._struct["mode"] = (
+                "async" if async_spec and async_spec.enabled else "sync"
+            )
             if async_spec.enabled:
-                trigger._struct["mode"] = "async"
                 trigger._struct["async"] = {
                     "maxConnectionsNumber": async_spec.max_connections,
                     "connectionAvailabilityTimeout": async_spec.connection_availability_timeout,

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -19,6 +19,7 @@ import semver
 
 import mlrun
 import mlrun.runtimes
+from mlrun.runtimes.nuclio.function import validate_nuclio_version_compatibility
 from mlrun.utils import logger
 
 import framework.utils.clients.nuclio
@@ -134,6 +135,9 @@ def enrich_function_with_ingress(config, mode, service_type):
             "workerAvailabilityTimeoutMilliseconds": 10000,  # 10 seconds
             "attributes": {},
         }
+        # Provide trigger mode for nuclio 1.15.3 and above.
+        if validate_nuclio_version_compatibility("1.15.3"):
+            http_trigger["mode"] = "sync"
 
     def enrich():
         http_trigger.setdefault("attributes", {}).setdefault("ingresses", {})["0"] = {

--- a/server/py/services/api/tests/unit/api/test_nuclio.py
+++ b/server/py/services/api/tests/unit/api/test_nuclio.py
@@ -269,29 +269,45 @@ def test_mlrun_function_translation_to_nuclio(
         ),
     ],
 )
+@pytest.mark.parametrize("nuclio_support_async", [True, False])
 def test_with_http_async_spec(
-    async_spec, expected_mode, expected_async_struct, expected_workers
+    async_spec,
+    expected_mode,
+    expected_async_struct,
+    expected_workers,
+    nuclio_support_async,
 ):
     """Test with_http method with various async_spec configurations."""
     func = mlrun.runtimes.nuclio.function.RemoteRuntime()
 
     with patch(
         "mlrun.runtimes.nuclio.function.validate_nuclio_version_compatibility",
-        return_value=True,
+        return_value=nuclio_support_async,
     ):
-        func.with_http(async_spec=async_spec)
+        if not nuclio_support_async and async_spec is not None:
+            with pytest.raises(
+                mlrun.errors.MLRunValueError,
+                match="Async spec is only supported from Nuclio 1.15.3",
+            ):
+                func.with_http(async_spec=async_spec)
+        else:
+            func.with_http(async_spec=async_spec)
+            trigger = func.spec.config.get("spec.triggers.http")
+            assert trigger is not None
+            if nuclio_support_async:
+                # Check mode
+                assert trigger.get("mode") == expected_mode
 
-    trigger = func.spec.config.get("spec.triggers.http")
-    assert trigger is not None
+                # Check workers
+                assert trigger.get("maxWorkers") == expected_workers
+            else:
+                assert trigger.get("mode") is None
+                assert (
+                    trigger.get("maxWorkers") == 8
+                )  # Default workers when async is not supported
 
-    # Check mode
-    assert trigger.get("mode") == expected_mode
-
-    # Check workers
-    assert trigger.get("maxWorkers") == expected_workers
-
-    # Check async struct
-    if expected_async_struct is not None:
-        assert trigger.get("async") == expected_async_struct
-    else:
-        assert "async" not in trigger
+            # Check async struct
+            if expected_async_struct is not None:
+                assert trigger.get("async") == expected_async_struct
+            else:
+                assert "async" not in trigger

--- a/server/py/services/api/tests/unit/api/test_nuclio.py
+++ b/server/py/services/api/tests/unit/api/test_nuclio.py
@@ -237,3 +237,61 @@ def test_mlrun_function_translation_to_nuclio(
         api_gateway_with_replaced_nuclio_names_to_mlrun.get_function_names()
         == api_gateway_client_side.spec.functions
     )
+
+
+@pytest.mark.parametrize(
+    "async_spec, expected_mode, expected_async_struct, expected_workers",
+    [
+        # None case - sync mode with default workers
+        (None, "sync", None, 8),
+        # Async enabled with default max_connections
+        (
+            mlrun.runtimes.nuclio.function.AsyncSpec(enabled=True),
+            "async",
+            {"maxConnectionsNumber": None, "connectionAvailabilityTimeout": None},
+            1,
+        ),
+        # Async enabled with custom settings
+        (
+            mlrun.runtimes.nuclio.function.AsyncSpec(
+                enabled=True, max_connections=500, connection_availability_timeout=30
+            ),
+            "async",
+            {"maxConnectionsNumber": 500, "connectionAvailabilityTimeout": 30},
+            1,
+        ),
+        # Async explicitly disabled
+        (
+            mlrun.runtimes.nuclio.function.AsyncSpec(enabled=False),
+            "sync",
+            None,
+            8,
+        ),
+    ],
+)
+def test_with_http_async_spec(
+    async_spec, expected_mode, expected_async_struct, expected_workers
+):
+    """Test with_http method with various async_spec configurations."""
+    func = mlrun.runtimes.nuclio.function.RemoteRuntime()
+
+    with patch(
+        "mlrun.runtimes.nuclio.function.validate_nuclio_version_compatibility",
+        return_value=True,
+    ):
+        func.with_http(async_spec=async_spec)
+
+    trigger = func.spec.config.get("spec.triggers.http")
+    assert trigger is not None
+
+    # Check mode
+    assert trigger.get("mode") == expected_mode
+
+    # Check workers
+    assert trigger.get("maxWorkers") == expected_workers
+
+    # Check async struct
+    if expected_async_struct is not None:
+        assert trigger.get("async") == expected_async_struct
+    else:
+        assert "async" not in trigger

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -519,6 +519,51 @@ class TestNuclioRuntime(TestRuntimeBase):
         )
         assert ingresses == []
 
+    @pytest.mark.parametrize("nuclio_support_async", [True, False])
+    def test_enrich_with_ingress_trigger_mode_field(
+        self, db: Session, client: TestClient, nuclio_support_async
+    ):
+        """
+        Test that enrich_function_with_ingress correctly sets the mode field in the trigger spec
+        based on nuclio version compatibility.
+        """
+        function = self._generate_runtime(self.runtime_kind)
+        (
+            function_name,
+            project_name,
+            config,
+        ) = services.api.crud.runtimes.nuclio.function._compile_function_config(
+            function
+        )
+        service_type = "NodePort"
+
+        with unittest.mock.patch(
+            "services.api.crud.runtimes.nuclio.helpers.validate_nuclio_version_compatibility",
+            return_value=nuclio_support_async,
+        ):
+            services.api.crud.runtimes.nuclio.helpers.enrich_function_with_ingress(
+                config, NuclioIngressAddTemplatedIngressModes.always, service_type
+            )
+
+        # Check that trigger was created
+        http_trigger = (
+            services.api.crud.runtimes.nuclio.helpers.resolve_function_http_trigger(
+                config["spec"]
+            )
+        )
+        assert http_trigger is not None
+
+        # Check mode field based on nuclio version support
+        if nuclio_support_async:
+            assert http_trigger.get("mode") == "sync"
+        else:
+            assert http_trigger.get("mode") is None
+
+        # Verify other trigger fields are set correctly
+        assert http_trigger.get("kind") == "http"
+        assert http_trigger.get("name") == "http"
+        assert http_trigger.get("maxWorkers") == 1
+
     def test_nuclio_config_spec_env(self, db: Session, client: TestClient):
         function = self._generate_runtime(self.runtime_kind)
 


### PR DESCRIPTION
### 📝 Description

Fix https://iguazio.atlassian.net/browse/ML-12025 adding http trigger mode to trigger spec when using sync mode

---

### 🛠️ Changes Made

Added mode field for default http trigger of serving function + adding to `with_http` method the mode when sync mode is chosen, by default or explicit

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

added unit test to check the trigger spec, checked that serving behave as expected for both modes

---

### 🔗 References
- Ticket link: [Ticket](https://iguazio.atlassian.net/browse/ML-12025)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
