### PR TITLE
[Serving] Fix asyncio execution mechanism in streaming models

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1275,14 +1275,9 @@ class Model(storey.ParallelExecutionRunnable, ModelObj):
                 raise_missing_schema_exception=False,
             )
 
-        # Check if the relevant predict method is implemented when trying to initialize the model.
-        # For asyncio, allow sync-only streaming models (generator predict) since
-        # run_async falls back to predict() for generator functions.
+        # Check if the relevant predict method is implemented when trying to initialize the model
         if self._execution_mechanism == storey.ParallelExecutionMechanisms.asyncio:
-            if (
-                self.__class__.predict_async is Model.predict_async
-                and not inspect.isgeneratorfunction(self.predict)
-            ):
+            if self.__class__.predict_async is Model.predict_async:
                 raise mlrun.errors.ModelRunnerError(
                     {
                         self.name: f"is running with {self._execution_mechanism} "
@@ -1356,10 +1351,6 @@ class Model(storey.ParallelExecutionRunnable, ModelObj):
     def run_async(self, body: Any, path: str, origin_name: Optional[str] = None) -> Any:
         if isinstance(body, list):
             body = self.format_batch(body)
-        if inspect.isasyncgenfunction(self.predict_async):
-            return self.predict_async(body)
-        if inspect.isgeneratorfunction(self.predict):
-            return self.predict(body)
         return self.predict_async(body)
 
     def get_local_model_path(self, suffix="") -> (str, dict):

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1275,9 +1275,14 @@ class Model(storey.ParallelExecutionRunnable, ModelObj):
                 raise_missing_schema_exception=False,
             )
 
-        # Check if the relevant predict method is implemented when trying to initialize the model
+        # Check if the relevant predict method is implemented when trying to initialize the model.
+        # For asyncio, allow sync-only streaming models (generator predict) since
+        # run_async falls back to predict() for generator functions.
         if self._execution_mechanism == storey.ParallelExecutionMechanisms.asyncio:
-            if self.__class__.predict_async is Model.predict_async:
+            if (
+                self.__class__.predict_async is Model.predict_async
+                and not inspect.isgeneratorfunction(self.predict)
+            ):
                 raise mlrun.errors.ModelRunnerError(
                     {
                         self.name: f"is running with {self._execution_mechanism} "
@@ -1348,10 +1353,14 @@ class Model(storey.ParallelExecutionRunnable, ModelObj):
             body = self.format_batch(body)
         return self.predict(body)
 
-    async def run_async(
-        self, body: Any, path: str, origin_name: Optional[str] = None
-    ) -> Any:
-        return await self.predict_async(body)
+    def run_async(self, body: Any, path: str, origin_name: Optional[str] = None) -> Any:
+        if isinstance(body, list):
+            body = self.format_batch(body)
+        if inspect.isasyncgenfunction(self.predict_async):
+            return self.predict_async(body)
+        if inspect.isgeneratorfunction(self.predict):
+            return self.predict(body)
+        return self.predict_async(body)
 
     def get_local_model_path(self, suffix="") -> (str, dict):
         """

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1642,6 +1642,10 @@ class StreamingModel(Model):
         for i in range(self.num_chunks):
             yield f"{body}_chunk_{i}"
 
+    async def predict_async(self, body: typing.Any, **kwargs) -> typing.Any:
+        for i in range(self.num_chunks):
+            yield f"{body}_chunk_{i}"
+
 
 class StreamingModelRunnerSelector(ModelRunnerSelector):
     """A selector that always picks the streaming_model."""
@@ -1650,35 +1654,12 @@ class StreamingModelRunnerSelector(ModelRunnerSelector):
         return ["streaming_model"]
 
 
-def test_model_runner_streaming_naive():
-    """Test that streaming models work with naive execution mechanism."""
-    function = mlrun.new_function("tests", kind="serving")
-    graph = function.set_topology("flow", engine="async")
-    model_runner_step = ModelRunnerStep(name="my_model_runner")
-    model_runner_step.add_model(
-        model_class="StreamingModel",
-        execution_mechanism="naive",
-        endpoint_name="streaming_model",
-        num_chunks=3,
-    )
-    graph.to(model_runner_step).to(
-        name="collector", class_name="storey.Collector"
-    ).respond()
-
-    server = function.to_mock_server()
-    try:
-        resp = server.test(body="test")
-        assert resp == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
-    finally:
-        server.wait_for_completion()
-
-
 @pytest.mark.parametrize(
     "execution_mechanism",
-    ["process_pool", "dedicated_process"],
+    ["naive", "thread_pool", "asyncio", "process_pool", "dedicated_process"],
 )
-def test_model_runner_streaming_process_based(execution_mechanism):
-    """Test that streaming models work with process-based execution mechanisms."""
+def test_model_runner_streaming(execution_mechanism):
+    """Test that streaming models work with all execution mechanisms."""
     function = mlrun.new_function("tests", kind="serving")
     graph = function.set_topology("flow", engine="async")
     model_runner_step = ModelRunnerStep(name="my_model_runner")

--- a/tests/system/model_monitoring/assets/models.py
+++ b/tests/system/model_monitoring/assets/models.py
@@ -233,12 +233,6 @@ class StreamingModel(mlrun.serving.Model):
         for i in range(self.num_chunks):
             yield f"{prompt}_chunk_{i}"
 
-    async def predict_async(self, body, **kwargs):
-        """Yield streaming chunks for aggregation testing."""
-        prompt = body.get("prompt", "default") if isinstance(body, dict) else str(body)
-        for i in range(self.num_chunks):
-            yield f"{prompt}_chunk_{i}"
-
 
 class MyModelSelector(mlrun.serving.states.ModelRunnerSelector):
     """Selector that reads a 'models' key (comma-separated string) from the

--- a/tests/system/model_monitoring/assets/models.py
+++ b/tests/system/model_monitoring/assets/models.py
@@ -233,6 +233,12 @@ class StreamingModel(mlrun.serving.Model):
         for i in range(self.num_chunks):
             yield f"{prompt}_chunk_{i}"
 
+    async def predict_async(self, body, **kwargs):
+        """Yield streaming chunks for aggregation testing."""
+        prompt = body.get("prompt", "default") if isinstance(body, dict) else str(body)
+        for i in range(self.num_chunks):
+            yield f"{prompt}_chunk_{i}"
+
 
 class MyModelSelector(mlrun.serving.states.ModelRunnerSelector):
     """Selector that reads a 'models' key (comma-separated string) from the

--- a/tests/system/runtimes/assets/streaming_function.py
+++ b/tests/system/runtimes/assets/streaming_function.py
@@ -43,6 +43,13 @@ class StreamingModel(Model):
         for i in range(self.num_chunks):
             yield f"{body}_chunk_{i}"
 
+    async def predict_async(self, body, **kwargs):
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+
+        for i in range(self.num_chunks):
+            yield f"{body}_chunk_{i}"
+
 
 class Echo:
     def do(self, x):

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -605,7 +605,11 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         ):
             function.invoke(path="/", body={"counter": -5})
 
-    def test_streaming_serving_function(self):
+    @pytest.mark.parametrize(
+        "execution_mechanism",
+        ("naive", "thread_pool", "asyncio", "process_pool", "dedicated_process"),
+    )
+    def test_streaming_serving_function(self, execution_mechanism):
         """Test that streaming serving functions return chunked HTTP responses.
 
         Tests both StreamingStep (async generator do() method) and ModelRunnerStep
@@ -628,7 +632,7 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         model_runner_step = ModelRunnerStep(name="model_runner")
         model_runner_step.add_model(
             model_class="StreamingModel",
-            execution_mechanism="naive",
+            execution_mechanism=execution_mechanism,
             endpoint_name="streaming_model",
             num_chunks=3,
         )


### PR DESCRIPTION
[ML-10863](https://iguazio.atlassian.net/browse/ML-10863)

Make `Model.run_async` a regular (non-async) method so that storey can detect async generator results for streaming. The previous `async def` + `await` pattern made it impossible for storey to identify async generators as streaming output, causing `TypeError` under the `asyncio` execution mechanism.

Consolidate and parameterize streaming unit and system tests to cover all five execution mechanisms (`naive`, `thread_pool`, `asyncio`, `process_pool`, `dedicated_process`). The `asyncio` case fails without the `run_async` fix.

[ML-10863]: https://iguazio.atlassian.net/browse/ML-10863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ