### PR TITLE
[Auth] Infer auth info from selected user auth token

### DIFF
--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -36,10 +36,15 @@ class TokenProvider(ABC):
     def is_iguazio_session(self):
         pass
 
+    @property
+    def token_name(self) -> str | None:
+        return None
+
 
 class StaticTokenProvider(TokenProvider):
-    def __init__(self, token: str):
+    def __init__(self, token: str, token_name: str | None = None):
         self.token = token
+        self._token_name: str | None = token_name
 
     def get_token(self):
         return self.token
@@ -385,19 +390,20 @@ class IGTokenProvider(DynamicTokenProvider):
             * mlconf.auth_with_oauth_token.refresh_threshold
         )
 
-    def _build_token_request(self, raise_on_error=False):
+    def _build_token_request(self, raise_on_error=False) -> tuple[dict, dict, str]:
         """
         Build the request body and headers for the token request.
 
         :param raise_on_error: Whether to raise an error if the request cannot be built.
         :return: A tuple containing the request body and headers.
         """
-        offline_token = mlrun.auth.utils.load_offline_token(
+        offline_token, token_name = mlrun.auth.utils.load_offline_token(
             raise_on_error=raise_on_error
         )
+        self._token_name = token_name
         if not offline_token:
             # Error already handled in `_load_offline_token`
-            return None, None
+            return None, None, None
 
         headers = {"Content-Type": "application/json"}
         request_body = {"refreshToken": offline_token}

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -36,15 +36,10 @@ class TokenProvider(ABC):
     def is_iguazio_session(self):
         pass
 
-    @property
-    def token_name(self) -> str | None:
-        return None
-
 
 class StaticTokenProvider(TokenProvider):
     def __init__(self, token: str, token_name: str | None = None):
         self.token = token
-        self._token_name: str | None = token_name
 
     def get_token(self):
         return self.token
@@ -70,6 +65,7 @@ class DynamicTokenProvider(TokenProvider):
                 "No token endpoint provided, cannot initialize token provider"
             )
         self._token = None
+        self._token_name = None
         self._token_endpoint = token_endpoint
         self._timeout = timeout
         self._max_retries = max_retries
@@ -82,6 +78,10 @@ class DynamicTokenProvider(TokenProvider):
         )
         self._cleanup()
         self._refresh_token_if_needed()
+
+    @property
+    def token_name(self) -> str | None:
+        return self._token_name
 
     def get_token(self):
         """
@@ -185,6 +185,13 @@ class DynamicTokenProvider(TokenProvider):
 
         return self._token
 
+    def _cleanup(self):
+        """
+        Clean up the token and related metadata.
+        """
+        self._token = None
+        self._token_name = None
+
     @abstractmethod
     def _post_fetch_hook(self, raise_on_error=True):
         """
@@ -200,13 +207,6 @@ class DynamicTokenProvider(TokenProvider):
 
         :param cleanup_if_expired: Whether to clean up the token if it is expired.
         :return: True if the token is valid, False otherwise.
-        """
-        pass
-
-    @abstractmethod
-    def _cleanup(self):
-        """
-        Clean up the token and related metadata.
         """
         pass
 
@@ -360,7 +360,7 @@ class IGTokenProvider(DynamicTokenProvider):
             )
 
     def _cleanup(self):
-        self._token = None
+        super()._cleanup()
         self._token_total_lifetime = 0
         self._token_expiry_time = None
 

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -211,7 +211,9 @@ class DynamicTokenProvider(TokenProvider):
         pass
 
     @abstractmethod
-    def _build_token_request(self, raise_on_error=False):
+    def _build_token_request(
+        self, raise_on_error: bool = False
+    ) -> tuple[dict | None, dict | None, str | None]:
         """
         Build the request body and headers for the token request.
 
@@ -244,7 +246,9 @@ class OAuthClientIDTokenProvider(DynamicTokenProvider):
         super().__init__(token_endpoint=token_endpoint, timeout=timeout)
 
     def _cleanup(self):
-        self._token = self.token_expiry_time = self.token_refresh_time = None
+        super()._cleanup()
+        self.token_expiry_time = None
+        self.token_refresh_time = None
 
     def _is_token_within_refresh_threshold(self, cleanup_if_expired=True) -> bool:
         """
@@ -272,7 +276,9 @@ class OAuthClientIDTokenProvider(DynamicTokenProvider):
             self._cleanup()
         return False
 
-    def _build_token_request(self, raise_on_error=False):
+    def _build_token_request(
+        self, raise_on_error: bool = False
+    ) -> tuple[dict | None, dict | None, str | None]:
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         request_body = {
             "grant_type": "client_credentials",
@@ -390,7 +396,9 @@ class IGTokenProvider(DynamicTokenProvider):
             * mlconf.auth_with_oauth_token.refresh_threshold
         )
 
-    def _build_token_request(self, raise_on_error=False) -> tuple[dict, dict, str]:
+    def _build_token_request(
+        self, raise_on_error: bool = False
+    ) -> tuple[dict | None, dict | None, str | None]:
         """
         Build the request body and headers for the token request.
 

--- a/mlrun/auth/providers.py
+++ b/mlrun/auth/providers.py
@@ -38,7 +38,7 @@ class TokenProvider(ABC):
 
 
 class StaticTokenProvider(TokenProvider):
-    def __init__(self, token: str, token_name: str | None = None):
+    def __init__(self, token: str):
         self.token = token
 
     def get_token(self):

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -51,7 +51,9 @@ def load_offline_token(raise_on_error=True) -> typing.Optional[str]:
     :return: The offline token if found, otherwise None.
     """
     if token_env := get_offline_token_from_env():
-        return token_env
+        return token_env, mlrun.secrets.get_secret_or_env(
+            "MLRUN_AUTH_OFFLINE_TOKEN_NAME", default="default"
+        )
     return get_offline_token_from_file(raise_on_error=raise_on_error)
 
 
@@ -68,7 +70,7 @@ def get_offline_token_from_file(raise_on_error: bool = True) -> typing.Optional[
     """
     tokens = load_secret_tokens_from_file(raise_on_error=raise_on_error)
     if not tokens:
-        return None
+        return None, None
     return parse_offline_token_data(tokens=tokens, raise_on_error=raise_on_error)
 
 
@@ -161,7 +163,7 @@ def read_secret_tokens_file(
 
 def parse_offline_token_data(
     tokens: list[dict[str, typing.Any]], raise_on_error: bool = True
-) -> typing.Optional[str]:
+) -> tuple[typing.Optional[str], typing.Optional[str]]:
     """
     Extract the correct offline token entry from the parsed tokens list.
 
@@ -189,7 +191,7 @@ def parse_offline_token_data(
             "Invalid token file: 'secretTokens' must be a non-empty list",
             raise_on_error,
         )
-        return None
+        return None, None
 
     name = mlconf.auth_with_oauth_token.token_name or "default"
     matches = [t for t in tokens if t.get("name") == name] or (
@@ -201,7 +203,7 @@ def parse_offline_token_data(
             f"Failed to resolve a unique token. Found {len(matches)} entries for name '{name}'",
             raise_on_error,
         )
-        return None
+        return None, None
 
     token_value = matches[0].get("token")
     if not token_value:
@@ -209,9 +211,9 @@ def parse_offline_token_data(
             "Resolved token entry missing 'token' field",
             raise_on_error,
         )
-        return None
+        return None, None
 
-    return token_value
+    return token_value, name
 
 
 def get_offline_token_from_env() -> typing.Optional[str]:

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -38,7 +38,9 @@ class Claims:
     PREFERRED_USERNAME = "preferred_username"
 
 
-def load_offline_token(raise_on_error=True) -> typing.Optional[str]:
+def load_offline_token(
+    raise_on_error: bool = True,
+) -> tuple[typing.Optional[str], typing.Optional[str]]:
     """
     Load the offline token from the environment variable or YAML file.
 
@@ -48,16 +50,17 @@ def load_offline_token(raise_on_error=True) -> typing.Optional[str]:
 
     :param raise_on_error: If True, raises an error when the offline token cannot be resolved.
                            If False, logs a warning instead.
-    :return: The offline token if found, otherwise None.
+    :return: A tuple containing the offline token and its resolved token name.
+             Returns (None, None) when token resolution fails.
     """
     if token_env := get_offline_token_from_env():
-        return token_env, mlrun.secrets.get_secret_or_env(
-            "MLRUN_AUTH_OFFLINE_TOKEN_NAME", default="default"
-        )
+        return token_env, mlconf.auth_with_oauth_token.token_name or "default"
     return get_offline_token_from_file(raise_on_error=raise_on_error)
 
 
-def get_offline_token_from_file(raise_on_error: bool = True) -> typing.Optional[str]:
+def get_offline_token_from_file(
+    raise_on_error: bool = True,
+) -> tuple[typing.Optional[str], typing.Optional[str]]:
     """
     Retrieve the offline token from a configured file.
 
@@ -66,7 +69,8 @@ def get_offline_token_from_file(raise_on_error: bool = True) -> typing.Optional[
     raises an error or logs a warning based on the `raise_on_error` parameter.
 
     :param raise_on_error: Whether to raise an error or log a warning on failure.
-    :return: The offline token if found, otherwise None.
+    :return: A tuple containing the offline token and its resolved token name.
+             Returns (None, None) when token resolution fails.
     """
     tokens = load_secret_tokens_from_file(raise_on_error=raise_on_error)
     if not tokens:
@@ -184,7 +188,8 @@ def parse_offline_token_data(
 
     :param tokens: List of token dictionaries loaded from the YAML file.
     :param raise_on_error: Whether to raise an error or log a warning on failure.
-    :return: The resolved offline token, or None if resolution fails.
+    :return: A tuple of (resolved offline token, resolved token name),
+             or (None, None) if resolution fails.
     """
     if not isinstance(tokens, list) or not tokens:
         mlrun.utils.helpers.raise_or_log_error(
@@ -193,14 +198,14 @@ def parse_offline_token_data(
         )
         return None, None
 
-    name = mlconf.auth_with_oauth_token.token_name or "default"
-    matches = [t for t in tokens if t.get("name") == name] or (
+    default_token_name = mlconf.auth_with_oauth_token.token_name or "default"
+    matches = [t for t in tokens if t.get("name") == default_token_name] or (
         [tokens[0]] if not mlconf.auth_with_oauth_token.token_name else []
     )
 
     if len(matches) != 1:
         mlrun.utils.helpers.raise_or_log_error(
-            f"Failed to resolve a unique token. Found {len(matches)} entries for name '{name}'",
+            f"Failed to resolve a unique token. Found {len(matches)} entries for name '{default_token_name}'",
             raise_on_error,
         )
         return None, None
@@ -213,7 +218,8 @@ def parse_offline_token_data(
         )
         return None, None
 
-    return token_value, name
+    token_name = matches[0].get("name")
+    return token_value, token_name
 
 
 def get_offline_token_from_env() -> typing.Optional[str]:

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -32,6 +32,7 @@ from .base import RunDBInterface
 class NopDB(RunDBInterface):
     def __init__(self, url=None, *args, **kwargs):
         self.url = url
+        self.token_provider = None
 
     def __getattribute__(self, attr):
         def nop(*args, **kwargs):

--- a/mlrun/runtime_configuration_context.py
+++ b/mlrun/runtime_configuration_context.py
@@ -67,6 +67,8 @@ class RuntimeConfigurationContext:
             return ctx.auth_token_name
 
         rundb = mlrun.get_run_db()
-        if rundb and rundb.token_provider:
+
+        # ensure that rundb of SQLDB wont get into here
+        if rundb and getattr(rundb, "token_provider", None):
             return getattr(rundb.token_provider, "token_name", None)
         return None

--- a/mlrun/runtime_configuration_context.py
+++ b/mlrun/runtime_configuration_context.py
@@ -15,6 +15,8 @@
 import contextvars
 from typing import Optional
 
+import mlrun
+
 # Context storage for RuntimeConfigurationContext
 runtime_configuration_context: contextvars.ContextVar[
     Optional["RuntimeConfigurationContext"]
@@ -63,4 +65,8 @@ class RuntimeConfigurationContext:
         ctx = runtime_configuration_context.get()
         if ctx and ctx.auth_token_name:
             return ctx.auth_token_name
+
+        rundb = mlrun.get_run_db()
+        if rundb and rundb.token_provider:
+            return rundb.token_provider.token_name
         return None

--- a/mlrun/runtime_configuration_context.py
+++ b/mlrun/runtime_configuration_context.py
@@ -68,5 +68,5 @@ class RuntimeConfigurationContext:
 
         rundb = mlrun.get_run_db()
         if rundb and rundb.token_provider:
-            return rundb.token_provider.token_name
+            return getattr(rundb.token_provider, "token_name", None)
         return None

--- a/tests/auth/test_auth_providers.py
+++ b/tests/auth/test_auth_providers.py
@@ -47,7 +47,9 @@ def test_ig_token_provider_successful_flow(encoded_jwt_token):
     encoded_jwt, iat, exp = encoded_jwt_token
 
     with patch.object(
-        mlrun.auth.utils, "load_offline_token", return_value="offline-token"
+        mlrun.auth.utils,
+        "load_offline_token",
+        return_value=("offline-token", "offline-token-name"),
     ):
         with patch("mlrun.utils.HTTPSessionWithRetry") as mock_session:
             mock_session_instance = mock_session.return_value
@@ -307,9 +309,12 @@ def test_runtime_retry_succeeds_after_initial_failures(encoded_jwt_token, monkey
 
     monkeypatch.setenv("MLRUN_RUNTIME_KIND", "job")
     monkeypatch.setattr("mlrun.mlconf.httpdb.http.verify", True)
-    # Use a timeout longer than backoff (10 seconds) to allow retries
+    # Keep runtime retry behavior but avoid real sleep in tests.
     monkeypatch.setattr(
-        "mlrun.mlconf.auth_with_oauth_token.runtime_token_refresh_timeout", 30
+        "mlrun.mlconf.auth_with_oauth_token.runtime_token_refresh_timeout", 1
+    )
+    monkeypatch.setattr(
+        "mlrun.mlconf.auth_with_oauth_token.runtime_token_refresh_backoff", 0
     )
 
     provider = IGTokenProvider.__new__(IGTokenProvider)
@@ -318,7 +323,7 @@ def test_runtime_retry_succeeds_after_initial_failures(encoded_jwt_token, monkey
     provider._token_expiry_time = None
     provider._max_retries = 2
     provider._token_endpoint = "http://example.com"
-    provider._timeout = 5
+    provider._timeout = 1
 
     # Track number of calls
     call_count = [0]
@@ -327,9 +332,9 @@ def test_runtime_retry_succeeds_after_initial_failures(encoded_jwt_token, monkey
         call_count[0] += 1
         if call_count[0] <= 2:
             # First 2 calls return old/invalid token
-            return "old-invalid-token"
+            return "old-invalid-token", "old-token"
         # Third call returns new valid token
-        return "new-valid-token"
+        return "new-valid-token", "new-token"
 
     monkeypatch.setattr("mlrun.auth.utils.load_offline_token", mock_load_offline_token)
 

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -134,20 +134,23 @@ def test_parse_offline_token_data_raise_exception(data, token_name, monkeypatch)
     "env_token, file_token, expected",
     [
         # env token exists
-        ("env-token", None, "env-token"),
+        ("env-token", None, ("env-token", None)),
         # only file token exists
-        (None, "file-token", "file-token"),
+        (None, ("file-token", "default"), ("file-token", "default")),
         # token missing
-        (None, None, None),
+        (None, (None, None), (None, None)),
     ],
 )
-def test_load_offline_token_parametrized(env_token, file_token, expected):
+def test_load_offline_token_parametrized(env_token, file_token, expected, monkeypatch):
+    monkeypatch.setattr(config.auth_with_oauth_token, "token_name", None)
     with (
         patch.object(
             mlrun.auth.utils, "get_offline_token_from_env", return_value=env_token
         ),
         patch.object(
-            mlrun.auth.utils, "get_offline_token_from_file", return_value=file_token
+            mlrun.auth.utils,
+            "get_offline_token_and_name_from_file",
+            return_value=file_token,
         ),
     ):
         token = mlrun.auth.utils.load_offline_token(raise_on_error=False)

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -53,24 +53,26 @@ def test_get_offline_token_from_env(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "data, token_name, expected_token",
+    "data, token_name, expected_token, expected_name",
     [
         # 1. Valid default token
         (
             [{"name": "default", "token": "file-token"}],
             None,
             "file-token",
+            "default",
         ),
         # 2. Valid token with custom name
         (
             [{"name": "custom", "token": "custom-token"}],
             "custom",
             "custom-token",
+            "custom",
         ),
         # # 3. secretTokens not a list
-        ("not-a-list", None, None),
+        ("not-a-list", None, None, None),
         # # 4. secretTokens empty list
-        ([], None, None),
+        ([], None, None, None),
         # 5. Multiple matching tokens
         (
             [
@@ -79,26 +81,31 @@ def test_get_offline_token_from_env(monkeypatch):
             ],
             None,
             None,
+            None,
         ),
         # 6. Token entry missing 'token' field
-        ([{"name": "default"}], None, None),
+        ([{"name": "default"}], None, None, None),
         # 7. Empty default token name, no default, use 1st token
         (
             [
                 {"name": "token1", "token": "file-token1"},
                 {"name": "token2", "token": "file-token2"},
             ],
-            None,
+            "token1",
             "file-token1",
+            "token1",
         ),
     ],
 )
-def test_parse_offline_token_data_cases(data, token_name, expected_token, monkeypatch):
+def test_parse_offline_token_data_cases(
+    data, token_name, expected_token, expected_name, monkeypatch
+):
     monkeypatch.setattr(
         "mlrun.config.config.auth_with_oauth_token.token_name", token_name
     )
     # Suppress raising errors, we just check return value
-    token = mlrun.auth.utils.parse_offline_token_data(data, raise_on_error=False)
+    token, name = mlrun.auth.utils.parse_offline_token_data(data, raise_on_error=False)
+    assert name == expected_name
     assert token == expected_token
 
 
@@ -149,19 +156,19 @@ def test_load_offline_token_parametrized(env_token, file_token, expected, monkey
         ),
         patch.object(
             mlrun.auth.utils,
-            "get_offline_token_and_name_from_file",
+            "get_offline_token_from_file",
             return_value=file_token,
         ),
     ):
-        token = mlrun.auth.utils.load_offline_token(raise_on_error=False)
-        assert token == expected
+        token, _ = mlrun.auth.utils.load_offline_token(raise_on_error=False)
+        assert token == expected[0]
 
 
 def test_token_file_not_exists(monkeypatch):
     fake_file = "no_such_file.yaml"
     monkeypatch.setattr(config.auth_with_oauth_token, "token_file", str(fake_file))
 
-    result = mlrun.auth.utils.get_offline_token_from_file(raise_on_error=False)
+    result, _ = mlrun.auth.utils.get_offline_token_from_file(raise_on_error=False)
     assert result is None
 
     with pytest.raises(mlrun.errors.MLRunRuntimeError):
@@ -210,7 +217,7 @@ def test_get_offline_token_from_file(
         with pytest.raises(mlrun.errors.MLRunRuntimeError):
             mlrun.auth.utils.get_offline_token_from_file(raise_on_error=True)
     else:
-        token = mlrun.auth.utils.get_offline_token_from_file(
+        token, _ = mlrun.auth.utils.get_offline_token_from_file(
             raise_on_error=raise_on_error
         )
         assert token == expected_token

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -91,7 +91,7 @@ def test_get_offline_token_from_env(monkeypatch):
                 {"name": "token1", "token": "file-token1"},
                 {"name": "token2", "token": "file-token2"},
             ],
-            "token1",
+            None,
             "file-token1",
             "token1",
         ),
@@ -141,7 +141,7 @@ def test_parse_offline_token_data_raise_exception(data, token_name, monkeypatch)
     "env_token, file_token, expected",
     [
         # env token exists
-        ("env-token", None, ("env-token", None)),
+        ("env-token", None, ("env-token", "default")),
         # only file token exists
         (None, ("file-token", "default"), ("file-token", "default")),
         # token missing

--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -338,6 +338,7 @@ class RunDBMock:
         self._api_gateways = {}
         self._get_model_endpoint_calls = 0
         self._get_background_task_calls = 1
+        self.token_provider = None
 
     def reset(self):
         self._functions = {}
@@ -347,6 +348,7 @@ class RunDBMock:
         self._artifacts = {}
         self._runs = {}
         self._api_gateways = {}
+        self.token_provider = None
 
     # Expected to return a hash-key
     def store_function(self, function, name, project="", tag=None, versioned=False):

--- a/tests/launcher/test_remote.py
+++ b/tests/launcher/test_remote.py
@@ -137,3 +137,24 @@ def test_run_error_status(rundb_mock):
     with pytest.raises(mlrun.runtimes.utils.RunError) as exc:
         launcher.launch(runtime, run, watch=True)
     assert "some error" in str(exc.value)
+
+
+def test_store_function_set_token_name():
+    launcher = mlrun.launcher.remote.ClientRemoteLauncher()
+    runtime = mlrun.code_to_function(
+        name="test",
+        kind="job",
+        filename=str(func_path),
+        handler=handler,
+    )
+    runtime.kind = "handler"
+    db = mlrun.get_run_db()
+    db.token_provider = unittest.mock.MagicMock(token_name="provider-run-token")
+    run = mlrun.run.RunObject(spec=mlrun.model.RunSpec())
+
+    launcher._store_function(runtime, run)
+    assert run.spec.auth["token_name"] == "provider-run-token"
+
+    with mlrun.RuntimeConfigurationContext(auth_token_name="context-run-token"):
+        launcher._store_function(runtime, run)
+        assert run.spec.auth["token_name"] == "context-run-token"

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -478,7 +478,9 @@ def _encode_jwt(payload: dict) -> str:
 @contextmanager
 def _mock_httpdb_connect(server_cfg):
     """Context manager to mock HTTPRunDB connect flow for iguazio v4 oauth tests."""
-    with patch.object(mlrun.auth.utils, "load_offline_token", return_value="offline"):
+    with patch.object(
+        mlrun.auth.utils, "load_offline_token", return_value=("offline", "default")
+    ):
         with patch.object(HTTPRunDB, "api_call") as api_call:
             with patch.object(mlrun.secrets, "sync_secret_tokens"):
                 api_response = MagicMock()
@@ -1556,6 +1558,30 @@ def test_enable_model_monitoring_passes_none_without_context():
         assert params["auth_token_name"] is None
 
 
+def test_enable_model_monitoring_falls_back_to_token_provider_token_name():
+    db = HTTPRunDB("http://fake-api:8080")
+    db.token_provider = MagicMock(token_name="provider-mm-token")
+
+    with (
+        patch.object(db, "api_call") as mock_api_call,
+        patch(
+            "mlrun.runtime_configuration_context.mlrun.get_run_db",
+            return_value=db,
+        ),
+    ):
+        db.enable_model_monitoring(
+            project="test-project",
+            base_period=10,
+            image="mlrun/mlrun",
+            deploy_histogram_data_drift_app=False,
+        )
+
+        mock_api_call.assert_called_once()
+        call_kwargs = mock_api_call.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["auth_token_name"] == "provider-mm-token"
+
+
 def test_submit_workflow_passes_auth_token_from_context():
     """Test that submit_workflow passes auth_token_name from RuntimeConfigurationContext."""
     import mlrun.runtime_configuration_context
@@ -1617,6 +1643,42 @@ def test_submit_workflow_passes_none_without_context():
         call_kwargs = mock_api_call.call_args
         json_body = call_kwargs.kwargs.get("json")
         assert json_body["spec"]["auth_token_name"] is None
+
+
+def test_submit_workflow_set_token_name():
+    db = HTTPRunDB("http://fake-api:8080")
+    db.token_provider = MagicMock(token_name="provider-wf-token")
+
+    workflow_spec = {
+        "name": "test-workflow",
+        "image": "mlrun/mlrun",
+    }
+
+    with (
+        patch.object(db, "api_call") as mock_api_call,
+        patch(
+            "mlrun.runtime_configuration_context.mlrun.get_run_db",
+            return_value=db,
+        ),
+    ):
+        mock_api_call.return_value = MagicMock(
+            ok=True,
+            json=MagicMock(
+                return_value={
+                    "data": {"run_id": "test-run-id", "status": {}, "workflow": {}}
+                }
+            ),
+        )
+        db.submit_workflow(
+            project="test-project",
+            name="test-workflow",
+            workflow_spec=workflow_spec,
+        )
+
+        mock_api_call.assert_called_once()
+        call_kwargs = mock_api_call.call_args
+        json_body = call_kwargs.kwargs.get("json")
+        assert json_body["spec"]["auth_token_name"] == "provider-wf-token"
 
 
 def _assert_projects(expected_project, project):

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -15,7 +15,7 @@
 import pathlib
 import sys
 from contextlib import nullcontext as does_not_raise
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from deepdiff import DeepDiff
@@ -133,6 +133,26 @@ def test_http_trigger():
         trigger["annotations"]["nginx.ingress.kubernetes.io/proxy-connect-timeout"]
         == "65"
     )
+
+
+def test_nuclio_deploy_set_token_name():
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    db = mlrun.get_run_db()
+    db.token_provider = MagicMock(token_name="provider-nuclio-token")
+    db.deploy_nuclio_function = MagicMock(
+        return_value={"data": {"status": {}, "spec": function.spec}}
+    )
+    function._wait_for_function_deployment = MagicMock()
+    function._update_credentials_from_remote_build = MagicMock()
+    function._enrich_command_from_status = MagicMock(return_value={})
+
+    function.deploy()
+
+    assert function.spec.auth["token_name"] == "provider-nuclio-token"
+
+    with mlrun.RuntimeConfigurationContext(auth_token_name="context-nuclio-token"):
+        function.deploy()
+        assert function.spec.auth["token_name"] == "context-nuclio-token"
 
 
 def test_v3io_stream_trigger():


### PR DESCRIPTION
### 📝 Description

Fix OAuth token-name propagation by inferring `auth_token_name` from the active token provider when runtime context is missing, and keep token metadata available throughout remote execution flows.

In other words, when running a kubejob / workflows / nuclio / mm or any other vegetable - take the auth info from the rundb 
*unless specified otherwise*.

---

### 🛠️ Changes Made
- Added `token_name` support to token providers
- Added fallback in `RuntimeConfigurationContext.get_auth_token_name()`:
  - If context has no `auth_token_name`, infer it from `mlrun.get_run_db().token_provider.token_name`.
- Expanded tests across auth, launcher, runtimes, and rundb flows to validate:
  - Token-name inference from provider.
  - Context override precedence over provider value.
  - Updated tuple-based token utility behavior.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Unit tests
- Manual validation over kubejobs

---

### 🔗 References
- Ticket link: [ML-12098](https://iguazio.atlassian.net/browse/ML-12098)
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- Precedence is intentionally: `RuntimeConfigurationContext.auth_token_name` > provider-derived `token_name`.
- This PR focuses on inference/propagation correctness and test coverage; no API contract changes were introduced.

[ML-12098]: https://iguazio.atlassian.net/browse/ML-12098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ