### PR TITLE
[Tests] Drop timing assertion in new system test

### DIFF
--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -652,26 +652,13 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
 
         # Test 1: StreamingStep path (async generator do() method)
         self._logger.info("Testing StreamingStep path...")
-        start_time = time.monotonic()
         resp = requests.post(f"{url}/step", data="test", stream=True)
         self._logger.info(f"StreamingStep response: {resp}")
         assert resp.ok, f"StreamingStep request failed: {resp.status_code} {resp.text}"
         assert resp.headers.get("Transfer-Encoding") == "chunked"
 
-        chunks = []
-        for chunk in resp.iter_content(decode_unicode=True, chunk_size=1024):
-            chunks.append(chunk)
-            time_since_start = time.monotonic() - start_time
-            self._logger.info(
-                f"Received chunk '{chunk}' after {time_since_start:.2f} seconds"
-            )
-            response_text = "".join(chunks)
-            if response_text:
-                iteration = int(response_text[-1]) + 1
-                assert (
-                    iteration - 1 < time_since_start < iteration + 1
-                ), "Time between chunks should be about 1 second"
-
+        chunks = list(resp.iter_content(decode_unicode=True, chunk_size=1024))
+        self._logger.info(f"StreamingStep chunks: {chunks}")
         assert chunks == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
 
         # Test 2: ModelRunnerStep path (generator predict() method)


### PR DESCRIPTION
As it cannot be relied on in CI.

Following test failure in https://github.com/mlrun/mlrun/actions/runs/22123290962/job/63948573423.

This test was added in #9263.