### PR TITLE
[System tests] Add retry to new application runtime system tests

### DIFF
--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -24,7 +24,6 @@ from nuclio.auth import AuthInfo as NuclioAuthInfo
 import mlrun.common.schemas
 import mlrun.runtimes
 import mlrun.runtimes.utils
-import mlrun.utils.helpers
 import tests.system.base
 
 
@@ -238,13 +237,15 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             function = self._create_simple_flask_application(
                 name="source-reload-app", source=source_path
             )
+            function.set_probe(type="readiness", http_path="/health", period_seconds=2)
 
             # First deploy - auto-uploads source as artifact
             self._logger.debug("Deploying application with version-1 source")
             function.deploy(with_mlrun=False)
 
             # Invoke and verify version-1
-            self._invoke_and_assert(function, "/", expected_body="version-1")
+            response = function.invoke("/", verify=False)
+            assert response.content.decode("utf-8") == "version-1"
 
             # Update source to version-2 by modifying the VERSION constant
             self._logger.debug("Updating source to version-2")
@@ -267,7 +268,8 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             assert function.status.application_image == image_before
 
             # Invoke and verify version-2
-            self._invoke_and_assert(function, "/", expected_body="version-2")
+            response = function.invoke("/", verify=False)
+            assert response.content.decode("utf-8") == "version-2"
 
     def test_deploy_application_with_git_source(self):
         """
@@ -292,6 +294,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         function.spec.command = "python"
         function.spec.args = ["-m", "http.server", "8050"]
         function.set_internal_application_port(8050)
+        function.set_probe(type="readiness", http_path="/", period_seconds=2)
 
         # First deploy
         self._logger.debug("First deploy with Git source and pull_at_runtime=True")
@@ -299,8 +302,11 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.state == "ready"
 
         # Verify Git repo was cloned and files are accessible
-        self._invoke_and_assert(function, "/subdir/mylib.py")
-        self._invoke_and_assert(function, "/rootlib.py")
+        response = function.invoke("/subdir/mylib.py", verify=False)
+        assert response.status_code == 200
+
+        response = function.invoke("/rootlib.py", verify=False)
+        assert response.status_code == 200
 
         # Redeploy - sidecar image should not be rebuilt
         image_before = function.status.application_image
@@ -310,7 +316,8 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.application_image == image_before
 
         # Verify source is still accessible after redeploy
-        self._invoke_and_assert(function, "/subdir/mylib.py")
+        response = function.invoke("/subdir/mylib.py", verify=False)
+        assert response.status_code == 200
 
         # force_build=True should trigger sidecar image build
         self._logger.debug("Redeploying with force_build=True")
@@ -319,7 +326,8 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.application_image != image_before
 
         # Verify source is still accessible after forced rebuild
-        self._invoke_and_assert(function, "/subdir/mylib.py")
+        response = function.invoke("/subdir/mylib.py", verify=False)
+        assert response.status_code == 200
 
     def test_deploy_application_with_archive_source(self):
         """
@@ -346,6 +354,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         function.spec.command = "python"
         function.spec.args = ["-m", "http.server", "8050"]
         function.set_internal_application_port(8050)
+        function.set_probe(type="readiness", http_path="/", period_seconds=2)
 
         # First deploy
         self._logger.debug("First deploy with archive source and pull_at_runtime=True")
@@ -353,7 +362,8 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.state == "ready"
 
         # Verify extracted archive files are accessible
-        self._invoke_and_assert(function, "/rootlib.py")
+        response = function.invoke("/rootlib.py", verify=False)
+        assert response.status_code == 200
 
         # Redeploy - sidecar image should not be rebuilt
         image_before = function.status.application_image
@@ -444,23 +454,3 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             "--port=5000",
         ]
         return function
-
-    def _invoke_and_assert(
-        self, function, path, expected_status=200, expected_body=None, timeout=30
-    ):
-        """Invoke with retry — the sidecar may need a few seconds after deploy to start serving."""
-
-        def _do_invoke():
-            resp = function.invoke(path, verify=False)
-            assert (
-                resp.status_code == expected_status
-            ), f"Expected {expected_status}, got {resp.status_code}: {resp.content.decode()}"
-            if expected_body is not None:
-                assert (
-                    resp.content.decode("utf-8") == expected_body
-                ), f"Expected body '{expected_body}', got '{resp.content.decode('utf-8')}'"
-            return resp
-
-        return mlrun.utils.helpers.retry_until_successful(
-            2, timeout, self._logger, True, _do_invoke
-        )

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -305,6 +305,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         response = function.invoke("/subdir/mylib.py", verify=False)
         assert response.status_code == 200
 
+        # Verify a root level file is also accessible
         response = function.invoke("/rootlib.py", verify=False)
         assert response.status_code == 200
 

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -24,6 +24,7 @@ from nuclio.auth import AuthInfo as NuclioAuthInfo
 import mlrun.common.schemas
 import mlrun.runtimes
 import mlrun.runtimes.utils
+import mlrun.utils.helpers
 import tests.system.base
 
 
@@ -243,8 +244,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             function.deploy(with_mlrun=False)
 
             # Invoke and verify version-1
-            response = function.invoke("/", verify=False)
-            assert response.content.decode("utf-8") == "version-1"
+            self._invoke_and_assert(function, "/", expected_body="version-1")
 
             # Update source to version-2 by modifying the VERSION constant
             self._logger.debug("Updating source to version-2")
@@ -267,8 +267,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             assert function.status.application_image == image_before
 
             # Invoke and verify version-2
-            response = function.invoke("/", verify=False)
-            assert response.content.decode("utf-8") == "version-2"
+            self._invoke_and_assert(function, "/", expected_body="version-2")
 
     def test_deploy_application_with_git_source(self):
         """
@@ -300,12 +299,8 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.state == "ready"
 
         # Verify Git repo was cloned and files are accessible
-        response = function.invoke("/subdir/mylib.py", verify=False)
-        assert response.status_code == 200
-
-        # Verify a root level file is also accessible
-        response = function.invoke("/rootlib.py", verify=False)
-        assert response.status_code == 200
+        self._invoke_and_assert(function, "/subdir/mylib.py")
+        self._invoke_and_assert(function, "/rootlib.py")
 
         # Redeploy - sidecar image should not be rebuilt
         image_before = function.status.application_image
@@ -315,8 +310,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.application_image == image_before
 
         # Verify source is still accessible after redeploy
-        response = function.invoke("/subdir/mylib.py", verify=False)
-        assert response.status_code == 200
+        self._invoke_and_assert(function, "/subdir/mylib.py")
 
         # force_build=True should trigger sidecar image build
         self._logger.debug("Redeploying with force_build=True")
@@ -325,8 +319,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.application_image != image_before
 
         # Verify source is still accessible after forced rebuild
-        response = function.invoke("/subdir/mylib.py", verify=False)
-        assert response.status_code == 200
+        self._invoke_and_assert(function, "/subdir/mylib.py")
 
     def test_deploy_application_with_archive_source(self):
         """
@@ -360,8 +353,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         assert function.status.state == "ready"
 
         # Verify extracted archive files are accessible
-        response = function.invoke("/rootlib.py", verify=False)
-        assert response.status_code == 200
+        self._invoke_and_assert(function, "/rootlib.py")
 
         # Redeploy - sidecar image should not be rebuilt
         image_before = function.status.application_image
@@ -452,3 +444,23 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             "--port=5000",
         ]
         return function
+
+    def _invoke_and_assert(
+        self, function, path, expected_status=200, expected_body=None, timeout=30
+    ):
+        """Invoke with retry — the sidecar may need a few seconds after deploy to start serving."""
+
+        def _do_invoke():
+            resp = function.invoke(path, verify=False)
+            assert (
+                resp.status_code == expected_status
+            ), f"Expected {expected_status}, got {resp.status_code}: {resp.content.decode()}"
+            if expected_body is not None:
+                assert (
+                    resp.content.decode("utf-8") == expected_body
+                ), f"Expected body '{expected_body}', got '{resp.content.decode('utf-8')}'"
+            return resp
+
+        return mlrun.utils.helpers.retry_until_successful(
+            2, timeout, self._logger, True, _do_invoke
+        )


### PR DESCRIPTION
### 📝 Description
This PR adds invoke retry logic to the init-container application system tests (source reload, Git source, archive source) that were failing in CI with 503/404 on the first invoke after deploy.

---

### 🛠️ Changes Made
- Added `_invoke_and_assert` helper with retry
- Replaced raw invoke+assert calls in the three init-container tests with the retry helper

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- All system tests passed locally

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12174
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
