### PR TITLE
[Artifact] Enrich artifact owner on BE

### DIFF
--- a/server/py/services/api/crud/artifacts.py
+++ b/server/py/services/api/crud/artifacts.py
@@ -324,7 +324,7 @@ class Artifacts(
         producer = artifact.get("spec", {}).get("producer", {})
 
         if not producer:
-            # if producer is not set, set the default producer with the auth_info.username as the owner
+            # Enforcing producer for use-cases where raw api request do not set an explicit producer
             artifact.setdefault("spec", {})["producer"] = (
                 self._generate_default_producer(auth_info)
             )

--- a/server/py/services/api/crud/artifacts.py
+++ b/server/py/services/api/crud/artifacts.py
@@ -57,8 +57,7 @@ class Artifacts(
             )
         artifact["project"] = project
 
-        # calculate the size of the artifact
-        self._resolve_artifact_size(artifact, auth_info)
+        self._enrich_artifact(artifact, auth_info)
 
         return framework.utils.singletons.db.get_db().store_artifact(
             session=db_session,
@@ -92,8 +91,7 @@ class Artifacts(
 
         best_iteration = artifact.get("metadata", {}).get("best_iteration", False)
 
-        # calculate the size of the artifact
-        self._resolve_artifact_size(artifact, auth_info)
+        self._enrich_artifact(artifact, auth_info)
 
         return framework.utils.singletons.db.get_db().create_artifact(
             db_session,
@@ -286,6 +284,15 @@ class Artifacts(
             producer_id=producer_id,
         )
 
+    def _enrich_artifact(
+        self,
+        artifact: dict,
+        auth_info: typing.Optional[mlrun.common.schemas.AuthInfo],
+    ) -> None:
+        """Enrich artifact with size and producer before storing or creating."""
+        self._resolve_artifact_size(artifact, auth_info)
+        self._enrich_artifact_producer(artifact, auth_info)
+
     @staticmethod
     def _resolve_artifact_size(artifact, auth_info):
         if "spec" in artifact and "size" not in artifact["spec"]:
@@ -306,6 +313,37 @@ class Artifacts(
             mlrun.utils.helpers.validate_inline_artifact_body_size(
                 artifact["spec"]["inline"]
             )
+
+    def _enrich_artifact_producer(
+        self,
+        artifact: dict,
+        auth_info: typing.Optional[mlrun.common.schemas.AuthInfo],
+    ):
+        if not auth_info:
+            return
+        producer = artifact.get("spec", {}).get("producer", {})
+
+        if not producer:
+            # if producer is not set, set the default producer with the auth_info.username as the owner
+            artifact.setdefault("spec", {})["producer"] = (
+                self._generate_default_producer(auth_info)
+            )
+            return
+
+        if producer and "owner" in producer:
+            if producer["owner"] != auth_info.username:
+                logger.warning(
+                    "Artifact producer owner is different than the authenticated user. Overriding the artifact producer owner with the authenticated user.",
+                    artifact_name=artifact.get("metadata", {}).get("name"),
+                )
+        producer["owner"] = auth_info.username
+
+    @staticmethod
+    def _generate_default_producer(auth_info: mlrun.common.schemas.AuthInfo) -> dict:
+        return {
+            "owner": auth_info.username,
+            "kind": "api",
+        }
 
     def _delete_artifact_data(
         self,

--- a/server/py/services/api/crud/artifacts.py
+++ b/server/py/services/api/crud/artifacts.py
@@ -330,12 +330,13 @@ class Artifacts(
             )
             return
 
-        if producer and "owner" in producer:
-            if producer["owner"] != auth_info.username:
-                logger.warning(
-                    "Artifact producer owner is different than the authenticated user. Overriding the artifact producer owner with the authenticated user.",
-                    artifact_name=artifact.get("metadata", {}).get("name"),
-                )
+        owner = producer.get("owner")
+        if owner and owner != auth_info.username:
+            logger.warning(
+                "Artifact producer owner is different than the authenticated user. "
+                "Overriding the artifact producer owner with the authenticated user.",
+                artifact_name=artifact.get("metadata", {}).get("name"),
+            )
         producer["owner"] = auth_info.username
 
     @staticmethod

--- a/server/py/services/api/tests/unit/crud/test_artifacts.py
+++ b/server/py/services/api/tests/unit/crud/test_artifacts.py
@@ -18,6 +18,7 @@ import uuid
 import pytest
 import sqlalchemy.orm
 
+import mlrun.common.schemas
 import mlrun.common.schemas.artifact
 
 import services.api.crud
@@ -104,6 +105,55 @@ class TestArtifacts:
         # list with missing project should raise error
         with pytest.raises(mlrun.errors.MLRunMissingProjectError):
             services.api.crud.Artifacts().list_artifacts(db, project=None, tag="*")
+
+    @pytest.mark.parametrize(
+        "artifact_initial,auth_username,expected_producer",
+        [
+            # No producer: set default producer with owner and kind "api"
+            (
+                {"spec": {"db_key": "my-key"}},
+                "user1",
+                {"owner": "user1", "kind": "api"},
+            ),
+            # Producer without owner: set owner to authenticated user, keep kind
+            (
+                {"spec": {"producer": {"kind": "job"}}},
+                "user3",
+                {"owner": "user3", "kind": "job"},
+            ),
+            # Same owner as authenticated user: leave producer unchanged
+            (
+                {"spec": {"producer": {"owner": "user4", "kind": "run"}}},
+                "user4",
+                {"owner": "user4", "kind": "run"},
+            ),
+            # Different owner: override with authenticated user
+            (
+                {"spec": {"producer": {"owner": "other-user", "kind": "run"}}},
+                "user5",
+                {"owner": "user5", "kind": "run"},
+            ),
+            # No auth_info: do not add or change producer
+            ({"spec": {"db_key": "my-key"}}, None, None),
+        ],
+    )
+    def test_enrich_artifact_producer(
+        self, artifact_initial, auth_username, expected_producer
+    ):
+        artifacts_crud = services.api.crud.Artifacts()
+        artifact = artifact_initial
+        auth_info = (
+            mlrun.common.schemas.AuthInfo(username=auth_username)
+            if auth_username is not None
+            else None
+        )
+
+        artifacts_crud._enrich_artifact_producer(artifact, auth_info)
+
+        if expected_producer is None:
+            assert "producer" not in artifact.get("spec", {})
+        else:
+            assert artifact["spec"]["producer"] == expected_producer
 
     @staticmethod
     def _generate_artifact(


### PR DESCRIPTION
### 📝 Description
**Enforcing producer owner**: `_enrich_artifact_producer` ensures the artifact producer owner is always the authenticated user - sets a default producer (owner + kind `"api"`) when none is present, and sets/overrides `producer["owner"]` to `auth_info.username` when a producer exists (logs a warning when overriding a different owner).

---

### 🛠️ Changes Made
- **Artifacts CRUD** (`server/py/services/api/crud/artifacts.py`):
  - Added `_enrich_artifact(artifact, auth_info)` that calls `_resolve_artifact_size` and `_enrich_artifact_producer`; use it from both `store_artifact` and `create_artifact` instead of duplicating the two calls.
   - **Enforcing producer owner**: `_enrich_artifact_producer` ensures the artifact producer owner is always the authenticated user—sets a default producer (owner + kind `"api"`) when none is present, and sets/overrides `producer["owner"]` to `auth_info.username` when a producer exists (logs a warning when overriding a different owner).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
unit + vmdev

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-7955
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- No API or schema changes; behavior is unchanged except for safe handling when `auth_info` is `None`.
