### PR TITLE
[Config] Fix set_env_from_file values overridden by ~/.mlrun.env

### DIFF
--- a/mlrun/__init__.py
+++ b/mlrun/__init__.py
@@ -269,6 +269,7 @@ def set_env_from_file(env_file: str, return_dict: bool = False) -> Optional[dict
     for key, value in env_vars.items():
         environ[key] = value
 
-    # reload mlrun configuration
-    mlconf.reload()
+    # reload mlrun configuration, skipping the default env file to prevent
+    # ~/.mlrun.env from overriding the env vars we just set explicitly
+    mlconf.reload(skip_env_file=True)
     return env_vars if return_dict else None

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1332,8 +1332,8 @@ class Config:
         return copy.deepcopy(self._cfg)
 
     @staticmethod
-    def reload():
-        _populate()
+    def reload(skip_env_file=False):
+        _populate(skip_env_file=skip_env_file)
 
     @property
     def version(self):
@@ -1503,7 +1503,7 @@ class Config:
 config = Config.from_dict(default_config)
 
 
-def _populate(skip_errors=False):
+def _populate(skip_errors=False, skip_env_file=False):
     """Populate configuration from config file (if exists in environment) and
     from environment variables.
 
@@ -1512,13 +1512,15 @@ def _populate(skip_errors=False):
     global _loaded
 
     with _load_lock:
-        _do_populate(skip_errors=skip_errors)
+        _do_populate(skip_errors=skip_errors, skip_env_file=skip_env_file)
 
 
-def _do_populate(env=None, skip_errors=False):
+def _do_populate(env=None, skip_errors=False, skip_env_file=False):
     global config
 
-    if not os.environ.get("MLRUN_IGNORE_ENV_FILE"):
+    # we get into this block when we want to load the defaults from the env file.
+    # other use cases, like set_env_from_file / running api - skip this block.
+    if not skip_env_file and not os.environ.get("MLRUN_IGNORE_ENV_FILE"):
         if "MLRUN_ENV_FILE" in os.environ:
             env_file = os.path.expanduser(os.environ["MLRUN_ENV_FILE"])
             dotenv.load_dotenv(env_file, override=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -613,6 +613,34 @@ def test_env_from_file():
         del os.environ[key]
 
 
+def test_env_from_file_overrides_default_env_file(tmp_path):
+    """Test that set_env_from_file values take precedence over ~/.mlrun.env"""
+    # Create a "default" env file simulating ~/.mlrun.env
+    default_env = tmp_path / "default.env"
+    default_env.write_text("MLRUN_KFP_TTL=111\n")
+
+    # Create a project-specific env file with different value
+    project_env = tmp_path / "project.env"
+    project_env.write_text("MLRUN_KFP_TTL=222\n")
+
+    original_default = mlrun.config.default_env_file
+    original_kfp_ttl = os.environ.get("MLRUN_KFP_TTL")
+    try:
+        mlrun.config.default_env_file = str(default_env)
+        env_dict = mlrun.set_env_from_file(str(project_env), return_dict=True)
+
+        # The project file value must win over the default env file
+        assert os.environ["MLRUN_KFP_TTL"] == "222"
+        assert env_dict["MLRUN_KFP_TTL"] == "222"
+        assert mlrun.mlconf.kfp_ttl == 222
+    finally:
+        mlrun.config.default_env_file = original_default
+        if original_kfp_ttl is None:
+            os.environ.pop("MLRUN_KFP_TTL", None)
+        else:
+            os.environ["MLRUN_KFP_TTL"] = original_kfp_ttl
+
+
 def test_mock_functions():
     mock_nuclio_config = mlrun.mlconf.mock_nuclio_deployment
     local_config = mlrun.mlconf.force_run_local


### PR DESCRIPTION
### 📝 Description

Fixes config precedence when calling `mlrun.set_env_from_file(...)`: values loaded from the explicit env file are no longer overridden by the default `~/.mlrun.env` during config reload.

---

### 🛠️ Changes Made

- Added `skip_env_file` support to config reload path

---

### ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- unit testings

---

### 🔗 References

- Ticket link: [ML-11354](https://iguazio.atlassian.net/browse/ML-11354)
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

[ML-11354]: https://iguazio.atlassian.net/browse/ML-11354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ