### PR TITLE
[Alerts] Fix docs to reflect auto reset behavior

### DIFF
--- a/docs/concepts/alerts.md
+++ b/docs/concepts/alerts.md
@@ -156,7 +156,7 @@ The {py:class}`mlrun.common.schemas.alert.ResetPolicy` specifies when to clear t
 becomes inactive, its notifications cease. When it is re-activated, notifications are renewed.
 The `ResetPolicy` options are:
 - manual &mdash; for manual reset of the alert
-- auto &mdash; if the criteria contains a time period such that the alert is reset once there are no more invocations in the relevant time window.
+- auto &mdash; the alert is reset immediately after it is triggered and its notifications are sent.
 
 ``` {Admonition} Note
 If you change the `reset-policy` of an active alert from manual to auto, the alert is immediately reset. 

--- a/mlrun/alerts/alert.py
+++ b/mlrun/alerts/alert.py
@@ -112,8 +112,9 @@ class AlertConfig(ModelObj):
                                complex trigger which is based on a prometheus alert
         :param criteria:       When the alert will be triggered based on the specified number of events within the
                                defined time period.
-        :param reset_policy:   When to clear the alert. Either "manual" for manual reset of the alert, or
-                               "auto" if the criteria contains a time period
+        :param reset_policy:   When to clear the alert. "manual" means the alert stays active after triggering
+                               and must be reset explicitly. "auto" means the alert is reset immediately
+                               after triggering and sending notifications.
         :param notifications:  List of notifications to invoke once the alert is triggered
         :param entities:       Entities that the event relates to. The entity object will contain fields that
                                uniquely identify a given entity in the system

--- a/mlrun/common/schemas/alert.py
+++ b/mlrun/common/schemas/alert.py
@@ -132,7 +132,9 @@ class AlertNotification(pydantic.v1.BaseModel):
         pydantic.v1.Field(
             description="Period during which notifications "
             "will not be sent after initial send. The format of this would be in time."
-            " e.g. 1d, 3h, 5m, 15s"
+            " e.g. 1d, 3h, 5m, 15s. Note: this field is currently persisted but not "
+            "enforced - notifications are sent on every qualifying event regardless "
+            "of this value."
         ),
     ] = None
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2308,8 +2308,9 @@ class MlrunProject(ModelObj):
         :param severity:               Severity of the alert.
         :param criteria:               The threshold for triggering the alert based on the
                                        specified number of events within the defined time period.
-        :param reset_policy:           When to clear the alert. Either "manual" for manual reset of the alert,
-                                       or "auto" if the criteria contains a time period.
+        :param reset_policy:           When to clear the alert. "manual" means the alert stays active after
+                                       triggering and must be reset explicitly. "auto" means the alert is reset
+                                       immediately after triggering and sending notifications.
 
         :returns:                      List of AlertConfig according to endpoints results,
                                        filtered by result_names.


### PR DESCRIPTION
### 📝 Description
The auto-reset policy documentation claimed the alert resets after a quiet time window, but the implementation resets immediately after triggering. Additionally, cooldown_period on AlertNotification is documented as functional but is not enforced. This PR aligns the docs and docstrings with actual behavior.

---

### 🛠️ Changes Made
- Updated alerts docs to accurately describe manual and auto reset policies
- Updated `reset_policy` param docstrings
- Marked `cooldown_period` field description as reserved/not yet enforced in the alert schema

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11969
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
