### PR TITLE
[K8s] Enhance Kubernetes API timeout handling

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -60,6 +60,13 @@ default_config = {
             "list_pods_limit": 200,
             "list_crd_objects_limit": 200,
         },
+        "timeouts": {
+            # per-request timeouts (in seconds) for k8s API calls
+            # 0 disables timeout for the given tier
+            "default": 30,  # single-resource ops (get, create, delete, update)
+            "list": 60,  # list operations (may return large result sets)
+            "logs": 120,  # pod log retrieval
+        },
     },
     "dbpath": "",  # db/api url
     # url to nuclio dashboard api (can be with user & token, e.g. https://username:password@dashboard-url.com)

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -48,6 +48,11 @@ import framework.utils.runtimes.mpijob
 
 _k8s = None
 
+# Timeout type constants for _resolve_k8s_timeout
+K8S_TIMEOUT_DEFAULT = "default"
+K8S_TIMEOUT_LIST = "list"
+K8S_TIMEOUT_LOGS = "logs"
+
 
 def get_k8s_helper(namespace=None, silent=True, log=False) -> "K8sHelper":
     """
@@ -147,7 +152,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         resp = self.v1api.list_namespaced_pod(
             self.resolve_namespace(namespace),
             label_selector=selector,
-            _request_timeout=self._resolve_k8s_timeout("list"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
         )
         items = []
         for i in resp.items:
@@ -183,7 +188,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     watch=False,
                     limit=limit,
                     _continue=_continue,
-                    _request_timeout=self._resolve_k8s_timeout("list"),
+                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
                 )
             except k8s_client_rest.ApiException as exc:
                 self._validate_paginated_list_retry(
@@ -239,7 +244,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     limit=limit,
                     _continue=_continue,
                     watch=False,
-                    _request_timeout=self._resolve_k8s_timeout("list"),
+                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
                 )
             except k8s_client_rest.ApiException as exc:
                 # ignore error if crd is not defined
@@ -277,7 +282,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 resp = self.v1api.create_namespaced_pod(
                     pod.metadata.namespace,
                     pod,
-                    _request_timeout=self._resolve_k8s_timeout("default"),
+                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
                 )
             except k8s_client_rest.ApiException as exc:
                 if retry_count > max_retry:
@@ -324,7 +329,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 self.resolve_namespace(namespace),
                 grace_period_seconds=grace_period_seconds,
                 propagation_policy="Background",
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -348,7 +353,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return self.v1api.list_namespaced_service(
             self.resolve_namespace(namespace),
             label_selector=label_selector,
-            _request_timeout=self._resolve_k8s_timeout("list"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
         )
 
     @raise_for_status_code
@@ -362,7 +367,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             name,
             self.resolve_namespace(namespace),
             grace_period_seconds=grace_period_seconds,
-            _request_timeout=self._resolve_k8s_timeout("default"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
         )
 
     def get_pod(
@@ -375,7 +380,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             api_response = self.v1api.read_namespaced_pod(
                 name=name,
                 namespace=self.resolve_namespace(namespace),
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -425,7 +430,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 crd_plural,
                 name,
                 grace_period_seconds=grace_period_seconds,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
             logger.info(
                 "Deleted crd object",
@@ -463,7 +468,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             namespace,
             crd_plural,
             label_selector=label_selector,
-            _request_timeout=self._resolve_k8s_timeout("list"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
         )
         return crd_objects.get("items", [])
 
@@ -483,7 +488,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             namespace=namespace,
             plural=crd_plural,
             body=body,
-            _request_timeout=self._resolve_k8s_timeout("default"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
         )
 
     @raise_for_status_code
@@ -502,7 +507,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             namespace,
             crd_plural,
             name,
-            _request_timeout=self._resolve_k8s_timeout("default"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
         )
 
     def logs(self, name, namespace=None):
@@ -510,7 +515,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             resp = self.v1api.read_namespaced_pod_log(
                 name=name,
                 namespace=self.resolve_namespace(namespace),
-                _request_timeout=self._resolve_k8s_timeout("logs"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LOGS),
             )
         except k8s_client_rest.ApiException as exc:
             logger.error("Failed to get pod logs", exc=mlrun.errors.err_to_str(exc))
@@ -564,7 +569,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             service_account = self.v1api.read_namespaced_service_account(
                 service_account_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
         except k8s_client_rest.ApiException as exc:
             # It's valid for the service account to not exist. Simply return None
@@ -614,7 +619,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             secret_data = self.v1api.read_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             ).data
         except k8s_client_rest.ApiException as exc:
             logger.error(
@@ -777,7 +782,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.v1api.read_namespaced_secret(
                 name=secret_name,
                 namespace=namespace,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
 
             if labels:
@@ -876,7 +881,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.create_namespaced_secret(
                 namespace=namespace,
                 body=k8s_secret,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
         except k8s_client_rest.ApiException as exc:
             exc = k8s_dynamic_exceptions.api_exception(exc)
@@ -926,7 +931,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 secret_name,
                 namespace,
                 k8s_secret,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
         except k8s_client_rest.ApiException as exc:
             raise k8s_dynamic_exceptions.api_exception(exc)
@@ -965,7 +970,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.v1api.read_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
         except k8s_client_rest.ApiException as exc:
             if exc.status == 404:
@@ -990,7 +995,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.delete_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
             return mlrun.common.schemas.SecretEventActions.deleted
 
@@ -1019,7 +1024,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 secret_name,
                 namespace,
                 k8s_secret,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
             return mlrun.common.schemas.SecretEventActions.updated
 
@@ -1027,7 +1032,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         self.v1api.delete_namespaced_secret(
             secret_name,
             namespace,
-            _request_timeout=self._resolve_k8s_timeout("default"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
         )
         return mlrun.common.schemas.SecretEventActions.deleted
 
@@ -1072,7 +1077,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     configmap_name,
                     namespace=namespace,
                     body=body,
-                    _request_timeout=self._resolve_k8s_timeout("default"),
+                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
                 )
             except k8s_client_rest.ApiException as exc:
                 logger.error(
@@ -1086,7 +1091,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 self.v1api.create_namespaced_config_map(
                     namespace=namespace,
                     body=body,
-                    _request_timeout=self._resolve_k8s_timeout("default"),
+                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
                 )
             except k8s_client_rest.ApiException as exc:
                 logger.error(
@@ -1108,7 +1113,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         configmaps_with_label = self.v1api.list_namespaced_config_map(
             namespace=namespace,
             label_selector=f"{label_name}={name}",
-            _request_timeout=self._resolve_k8s_timeout("list"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
         )
         if len(configmaps_with_label.items) > 1:
             raise mlrun.errors.MLRunInternalServerError(
@@ -1132,7 +1137,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 name=name,
                 namespace=namespace,
                 grace_period_seconds=grace_period_seconds,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
         except k8s_client_rest.ApiException as exc:
             logger.error(
@@ -1152,7 +1157,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return self.v1api.create_namespaced_config_map(
             self.resolve_namespace(namespace),
             body,
-            _request_timeout=self._resolve_k8s_timeout("default"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
         )
 
     @raise_for_status_code
@@ -1164,7 +1169,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return self.v1api.list_namespaced_config_map(
             namespace=self.resolve_namespace(namespace),
             label_selector=label_selector,
-            _request_timeout=self._resolve_k8s_timeout("list"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
         )
 
     @staticmethod
@@ -1218,7 +1223,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.v1api.read_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
         except k8s_client_rest.ApiException:
             return None
@@ -1261,7 +1266,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         resp = self.v1api.list_namespaced_event(
             self.resolve_namespace(namespace),
             field_selector=field_selector,
-            _request_timeout=self._resolve_k8s_timeout("list"),
+            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
         )
         return resp.items
 
@@ -1311,7 +1316,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             api_response = self.v1api.read_namespaced_pod_status(
                 name=name,
                 namespace=self.resolve_namespace(namespace),
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -1543,7 +1548,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             secrets_list = self.v1api.list_namespaced_secret(
                 namespace=namespace,
                 label_selector=label_selector,
-                _request_timeout=self._resolve_k8s_timeout("list"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LIST),
             )
         except Exception as exc:
             logger.error(
@@ -1808,7 +1813,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.delete_namespaced_secret(
                 name=secret_name,
                 namespace=namespace,
-                _request_timeout=self._resolve_k8s_timeout("default"),
+                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
             )
             logger.debug(
                 "Successfully deleted user token secret",
@@ -1849,11 +1854,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return k8s_secrets[0]
 
     @staticmethod
-    def _resolve_k8s_timeout(timeout_type: str) -> typing.Optional[int]:
+    def _resolve_k8s_timeout(timeout_type: str = K8S_TIMEOUT_DEFAULT) -> int | None:
         """
         Resolve the k8s request timeout for the given operation type.
 
-        :param timeout_type: one of "default", "list", or "logs"
+        :param timeout_type: one of K8S_TIMEOUT_DEFAULT, K8S_TIMEOUT_LIST, or K8S_TIMEOUT_LOGS
         :return: timeout in seconds, or None if timeout is disabled (set to 0)
         """
         timeout = int(getattr(mlrun.mlconf.kubernetes.timeouts, timeout_type))

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -282,7 +282,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 resp = self.v1api.create_namespaced_pod(
                     pod.metadata.namespace,
                     pod,
-                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                    _request_timeout=self._resolve_k8s_timeout(),
                 )
             except k8s_client_rest.ApiException as exc:
                 if retry_count > max_retry:
@@ -329,7 +329,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 self.resolve_namespace(namespace),
                 grace_period_seconds=grace_period_seconds,
                 propagation_policy="Background",
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -367,7 +367,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             name,
             self.resolve_namespace(namespace),
             grace_period_seconds=grace_period_seconds,
-            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+            _request_timeout=self._resolve_k8s_timeout(),
         )
 
     def get_pod(
@@ -380,7 +380,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             api_response = self.v1api.read_namespaced_pod(
                 name=name,
                 namespace=self.resolve_namespace(namespace),
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -430,7 +430,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 crd_plural,
                 name,
                 grace_period_seconds=grace_period_seconds,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
             logger.info(
                 "Deleted crd object",
@@ -488,7 +488,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             namespace=namespace,
             plural=crd_plural,
             body=body,
-            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+            _request_timeout=self._resolve_k8s_timeout(),
         )
 
     @raise_for_status_code
@@ -507,7 +507,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             namespace,
             crd_plural,
             name,
-            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+            _request_timeout=self._resolve_k8s_timeout(),
         )
 
     def logs(self, name, namespace=None):
@@ -569,7 +569,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             service_account = self.v1api.read_namespaced_service_account(
                 service_account_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
         except k8s_client_rest.ApiException as exc:
             # It's valid for the service account to not exist. Simply return None
@@ -619,7 +619,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             secret_data = self.v1api.read_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             ).data
         except k8s_client_rest.ApiException as exc:
             logger.error(
@@ -782,7 +782,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.v1api.read_namespaced_secret(
                 name=secret_name,
                 namespace=namespace,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
 
             if labels:
@@ -881,7 +881,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.create_namespaced_secret(
                 namespace=namespace,
                 body=k8s_secret,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
         except k8s_client_rest.ApiException as exc:
             exc = k8s_dynamic_exceptions.api_exception(exc)
@@ -931,7 +931,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 secret_name,
                 namespace,
                 k8s_secret,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
         except k8s_client_rest.ApiException as exc:
             raise k8s_dynamic_exceptions.api_exception(exc)
@@ -970,7 +970,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.v1api.read_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
         except k8s_client_rest.ApiException as exc:
             if exc.status == 404:
@@ -995,7 +995,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.delete_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
             return mlrun.common.schemas.SecretEventActions.deleted
 
@@ -1024,7 +1024,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 secret_name,
                 namespace,
                 k8s_secret,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
             return mlrun.common.schemas.SecretEventActions.updated
 
@@ -1032,7 +1032,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         self.v1api.delete_namespaced_secret(
             secret_name,
             namespace,
-            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+            _request_timeout=self._resolve_k8s_timeout(),
         )
         return mlrun.common.schemas.SecretEventActions.deleted
 
@@ -1077,7 +1077,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     configmap_name,
                     namespace=namespace,
                     body=body,
-                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                    _request_timeout=self._resolve_k8s_timeout(),
                 )
             except k8s_client_rest.ApiException as exc:
                 logger.error(
@@ -1091,7 +1091,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 self.v1api.create_namespaced_config_map(
                     namespace=namespace,
                     body=body,
-                    _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                    _request_timeout=self._resolve_k8s_timeout(),
                 )
             except k8s_client_rest.ApiException as exc:
                 logger.error(
@@ -1137,7 +1137,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 name=name,
                 namespace=namespace,
                 grace_period_seconds=grace_period_seconds,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
         except k8s_client_rest.ApiException as exc:
             logger.error(
@@ -1157,7 +1157,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         return self.v1api.create_namespaced_config_map(
             self.resolve_namespace(namespace),
             body,
-            _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+            _request_timeout=self._resolve_k8s_timeout(),
         )
 
     @raise_for_status_code
@@ -1223,7 +1223,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.v1api.read_namespaced_secret(
                 secret_name,
                 namespace,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
         except k8s_client_rest.ApiException:
             return None
@@ -1316,7 +1316,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             api_response = self.v1api.read_namespaced_pod_status(
                 name=name,
                 namespace=self.resolve_namespace(namespace),
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -1813,7 +1813,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.delete_namespaced_secret(
                 name=secret_name,
                 namespace=namespace,
-                _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_DEFAULT),
+                _request_timeout=self._resolve_k8s_timeout(),
             )
             logger.debug(
                 "Successfully deleted user token secret",

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -23,6 +23,7 @@ from datetime import UTC, datetime
 import kubernetes.client.rest as k8s_client_rest
 import kubernetes.dynamic.exceptions as k8s_dynamic_exceptions
 import urllib3
+import urllib3.exceptions
 import yaml
 from kubernetes import client, config
 
@@ -66,6 +67,8 @@ def raise_for_status_code(func):
     """
     A decorator for calls to k8s api when no error handling is needed.
     Raises the matching mlrun exception to the status code.
+    Also catches urllib3 timeout errors (MaxRetryError wrapping ReadTimeoutError)
+    and raises a clear MLRunRuntimeError.
     """
 
     def wrapper(*args, **kwargs):
@@ -75,6 +78,12 @@ def raise_for_status_code(func):
             raise mlrun.errors.err_for_status_code(
                 exc.status, message=mlrun.errors.err_to_str(exc)
             ) from exc
+        except urllib3.exceptions.MaxRetryError as exc:
+            if isinstance(exc.reason, urllib3.exceptions.ReadTimeoutError):
+                raise mlrun.errors.MLRunRuntimeError(
+                    f"Kubernetes API request timed out: {mlrun.errors.err_to_str(exc)}"
+                ) from exc
+            raise
 
     return wrapper
 
@@ -136,7 +145,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         states=None,
     ):
         resp = self.v1api.list_namespaced_pod(
-            self.resolve_namespace(namespace), label_selector=selector
+            self.resolve_namespace(namespace),
+            label_selector=selector,
+            _request_timeout=self._resolve_k8s_timeout("list"),
         )
         items = []
         for i in resp.items:
@@ -172,6 +183,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     watch=False,
                     limit=limit,
                     _continue=_continue,
+                    _request_timeout=self._resolve_k8s_timeout("list"),
                 )
             except k8s_client_rest.ApiException as exc:
                 self._validate_paginated_list_retry(
@@ -227,6 +239,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     limit=limit,
                     _continue=_continue,
                     watch=False,
+                    _request_timeout=self._resolve_k8s_timeout("list"),
                 )
             except k8s_client_rest.ApiException as exc:
                 # ignore error if crd is not defined
@@ -261,7 +274,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         retry_count = 0
         while True:
             try:
-                resp = self.v1api.create_namespaced_pod(pod.metadata.namespace, pod)
+                resp = self.v1api.create_namespaced_pod(
+                    pod.metadata.namespace,
+                    pod,
+                    _request_timeout=self._resolve_k8s_timeout("default"),
+                )
             except k8s_client_rest.ApiException as exc:
                 if retry_count > max_retry:
                     logger.error(
@@ -307,6 +324,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 self.resolve_namespace(namespace),
                 grace_period_seconds=grace_period_seconds,
                 propagation_policy="Background",
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -321,6 +339,32 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     exc.status, message=mlrun.errors.err_to_str(exc)
                 ) from exc
 
+    @raise_for_status_code
+    def list_services(
+        self,
+        namespace: str = "",
+        label_selector: typing.Optional[str] = None,
+    ):
+        return self.v1api.list_namespaced_service(
+            self.resolve_namespace(namespace),
+            label_selector=label_selector,
+            _request_timeout=self._resolve_k8s_timeout("list"),
+        )
+
+    @raise_for_status_code
+    def delete_service(
+        self,
+        name: str,
+        namespace: str = "",
+        grace_period_seconds: typing.Optional[int] = None,
+    ):
+        return self.v1api.delete_namespaced_service(
+            name,
+            self.resolve_namespace(namespace),
+            grace_period_seconds=grace_period_seconds,
+            _request_timeout=self._resolve_k8s_timeout("default"),
+        )
+
     def get_pod(
         self,
         name,
@@ -329,7 +373,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
     ):
         try:
             api_response = self.v1api.read_namespaced_pod(
-                name=name, namespace=self.resolve_namespace(namespace)
+                name=name,
+                namespace=self.resolve_namespace(namespace),
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -379,6 +425,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 crd_plural,
                 name,
                 grace_period_seconds=grace_period_seconds,
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
             logger.info(
                 "Deleted crd object",
@@ -400,10 +447,70 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     exc.status, message=mlrun.errors.err_to_str(exc)
                 ) from exc
 
+    @raise_for_status_code
+    def list_crds(
+        self,
+        crd_group: str,
+        crd_version: str,
+        crd_plural: str,
+        namespace: str = "",
+        label_selector: typing.Optional[str] = None,
+    ) -> list[dict]:
+        namespace = self.resolve_namespace(namespace)
+        crd_objects = self.crdapi.list_namespaced_custom_object(
+            crd_group,
+            crd_version,
+            namespace,
+            crd_plural,
+            label_selector=label_selector,
+            _request_timeout=self._resolve_k8s_timeout("list"),
+        )
+        return crd_objects.get("items", [])
+
+    @raise_for_status_code
+    def create_crd(
+        self,
+        crd_group: str,
+        crd_version: str,
+        crd_plural: str,
+        namespace: str = "",
+        body: typing.Optional[dict] = None,
+    ) -> dict:
+        namespace = self.resolve_namespace(namespace)
+        return self.crdapi.create_namespaced_custom_object(
+            crd_group,
+            crd_version,
+            namespace=namespace,
+            plural=crd_plural,
+            body=body,
+            _request_timeout=self._resolve_k8s_timeout("default"),
+        )
+
+    @raise_for_status_code
+    def get_crd(
+        self,
+        crd_group: str,
+        crd_version: str,
+        crd_plural: str,
+        namespace: str = "",
+        name: str = "",
+    ) -> dict:
+        namespace = self.resolve_namespace(namespace)
+        return self.crdapi.get_namespaced_custom_object(
+            crd_group,
+            crd_version,
+            namespace,
+            crd_plural,
+            name,
+            _request_timeout=self._resolve_k8s_timeout("default"),
+        )
+
     def logs(self, name, namespace=None):
         try:
             resp = self.v1api.read_namespaced_pod_log(
-                name=name, namespace=self.resolve_namespace(namespace)
+                name=name,
+                namespace=self.resolve_namespace(namespace),
+                _request_timeout=self._resolve_k8s_timeout("logs"),
             )
         except k8s_client_rest.ApiException as exc:
             logger.error("Failed to get pod logs", exc=mlrun.errors.err_to_str(exc))
@@ -455,7 +562,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         try:
             service_account = self.v1api.read_namespaced_service_account(
-                service_account_name, namespace
+                service_account_name,
+                namespace,
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
         except k8s_client_rest.ApiException as exc:
             # It's valid for the service account to not exist. Simply return None
@@ -502,7 +611,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         namespace = self.resolve_namespace(namespace)
 
         try:
-            secret_data = self.v1api.read_namespaced_secret(secret_name, namespace).data
+            secret_data = self.v1api.read_namespaced_secret(
+                secret_name,
+                namespace,
+                _request_timeout=self._resolve_k8s_timeout("default"),
+            ).data
         except k8s_client_rest.ApiException as exc:
             logger.error(
                 "Failed to read secret",
@@ -664,6 +777,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             k8s_secret = self.v1api.read_namespaced_secret(
                 name=secret_name,
                 namespace=namespace,
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
 
             if labels:
@@ -762,6 +876,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.create_namespaced_secret(
                 namespace=namespace,
                 body=k8s_secret,
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
         except k8s_client_rest.ApiException as exc:
             exc = k8s_dynamic_exceptions.api_exception(exc)
@@ -807,7 +922,12 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             )
         k8s_secret.data = secret_data
         try:
-            self.v1api.replace_namespaced_secret(secret_name, namespace, k8s_secret)
+            self.v1api.replace_namespaced_secret(
+                secret_name,
+                namespace,
+                k8s_secret,
+                _request_timeout=self._resolve_k8s_timeout("default"),
+            )
         except k8s_client_rest.ApiException as exc:
             raise k8s_dynamic_exceptions.api_exception(exc)
 
@@ -842,7 +962,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         namespace = self.resolve_namespace(namespace)
 
         try:
-            k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
+            k8s_secret = self.v1api.read_namespaced_secret(
+                secret_name,
+                namespace,
+                _request_timeout=self._resolve_k8s_timeout("default"),
+            )
         except k8s_client_rest.ApiException as exc:
             if exc.status == 404:
                 logger.info(
@@ -863,7 +987,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 "No data found in the Kubernetes secret",
                 secret_name=secret_name,
             )
-            self.v1api.delete_namespaced_secret(secret_name, namespace)
+            self.v1api.delete_namespaced_secret(
+                secret_name,
+                namespace,
+                _request_timeout=self._resolve_k8s_timeout("default"),
+            )
             return mlrun.common.schemas.SecretEventActions.deleted
 
         # Create a copy of the k8s secret data, filtering out specified secrets if any
@@ -887,11 +1015,20 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         if secret_data:
             # Update the existing secret with modified data
             k8s_secret.data = secret_data
-            self.v1api.replace_namespaced_secret(secret_name, namespace, k8s_secret)
+            self.v1api.replace_namespaced_secret(
+                secret_name,
+                namespace,
+                k8s_secret,
+                _request_timeout=self._resolve_k8s_timeout("default"),
+            )
             return mlrun.common.schemas.SecretEventActions.updated
 
         # No secrets left, so delete the secret
-        self.v1api.delete_namespaced_secret(secret_name, namespace)
+        self.v1api.delete_namespaced_secret(
+            secret_name,
+            namespace,
+            _request_timeout=self._resolve_k8s_timeout("default"),
+        )
         return mlrun.common.schemas.SecretEventActions.deleted
 
     @raise_for_status_code
@@ -932,7 +1069,10 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         if have_confmap:
             try:
                 self.v1api.replace_namespaced_config_map(
-                    configmap_name, namespace=namespace, body=body
+                    configmap_name,
+                    namespace=namespace,
+                    body=body,
+                    _request_timeout=self._resolve_k8s_timeout("default"),
                 )
             except k8s_client_rest.ApiException as exc:
                 logger.error(
@@ -943,7 +1083,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 raise exc
         else:
             try:
-                self.v1api.create_namespaced_config_map(namespace=namespace, body=body)
+                self.v1api.create_namespaced_config_map(
+                    namespace=namespace,
+                    body=body,
+                    _request_timeout=self._resolve_k8s_timeout("default"),
+                )
             except k8s_client_rest.ApiException as exc:
                 logger.error(
                     "Failed to create k8s config map",
@@ -962,7 +1106,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         namespace = self.resolve_namespace(namespace)
         label_name = mlrun_constants.MLRunInternalLabels.resource_name
         configmaps_with_label = self.v1api.list_namespaced_config_map(
-            namespace=namespace, label_selector=f"{label_name}={name}"
+            namespace=namespace,
+            label_selector=f"{label_name}={name}",
+            _request_timeout=self._resolve_k8s_timeout("list"),
         )
         if len(configmaps_with_label.items) > 1:
             raise mlrun.errors.MLRunInternalServerError(
@@ -977,6 +1123,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         name: str,
         namespace: str = "",
         raise_on_error=True,
+        grace_period_seconds: typing.Optional[int] = None,
     ):
         namespace = self.resolve_namespace(namespace)
 
@@ -984,6 +1131,8 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.delete_namespaced_config_map(
                 name=name,
                 namespace=namespace,
+                grace_period_seconds=grace_period_seconds,
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
         except k8s_client_rest.ApiException as exc:
             logger.error(
@@ -993,6 +1142,30 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             )
             if raise_on_error:
                 raise exc
+
+    @raise_for_status_code
+    def create_configmap(
+        self,
+        namespace: str = "",
+        body: typing.Optional[client.V1ConfigMap] = None,
+    ):
+        return self.v1api.create_namespaced_config_map(
+            self.resolve_namespace(namespace),
+            body,
+            _request_timeout=self._resolve_k8s_timeout("default"),
+        )
+
+    @raise_for_status_code
+    def list_configmaps(
+        self,
+        namespace: str = "",
+        label_selector: typing.Optional[str] = None,
+    ):
+        return self.v1api.list_namespaced_config_map(
+            namespace=self.resolve_namespace(namespace),
+            label_selector=label_selector,
+            _request_timeout=self._resolve_k8s_timeout("list"),
+        )
 
     @staticmethod
     def _hash_access_key(access_key: str):
@@ -1042,7 +1215,11 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         namespace = self.resolve_namespace(namespace)
 
         try:
-            k8s_secret = self.v1api.read_namespaced_secret(secret_name, namespace)
+            k8s_secret = self.v1api.read_namespaced_secret(
+                secret_name,
+                namespace,
+                _request_timeout=self._resolve_k8s_timeout("default"),
+            )
         except k8s_client_rest.ApiException:
             return None
 
@@ -1082,7 +1259,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         field_selector="",
     ):
         resp = self.v1api.list_namespaced_event(
-            self.resolve_namespace(namespace), field_selector=field_selector
+            self.resolve_namespace(namespace),
+            field_selector=field_selector,
+            _request_timeout=self._resolve_k8s_timeout("list"),
         )
         return resp.items
 
@@ -1130,7 +1309,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
     ) -> typing.Optional[client.V1Pod]:
         try:
             api_response = self.v1api.read_namespaced_pod_status(
-                name=name, namespace=self.resolve_namespace(namespace)
+                name=name,
+                namespace=self.resolve_namespace(namespace),
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
             return api_response
         except k8s_client_rest.ApiException as exc:
@@ -1362,6 +1543,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             secrets_list = self.v1api.list_namespaced_secret(
                 namespace=namespace,
                 label_selector=label_selector,
+                _request_timeout=self._resolve_k8s_timeout("list"),
             )
         except Exception as exc:
             logger.error(
@@ -1626,6 +1808,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             self.v1api.delete_namespaced_secret(
                 name=secret_name,
                 namespace=namespace,
+                _request_timeout=self._resolve_k8s_timeout("default"),
             )
             logger.debug(
                 "Successfully deleted user token secret",
@@ -1664,6 +1847,17 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             return None
 
         return k8s_secrets[0]
+
+    @staticmethod
+    def _resolve_k8s_timeout(timeout_type: str) -> typing.Optional[int]:
+        """
+        Resolve the k8s request timeout for the given operation type.
+
+        :param timeout_type: one of "default", "list", or "logs"
+        :return: timeout in seconds, or None if timeout is disabled (set to 0)
+        """
+        timeout = int(getattr(mlrun.mlconf.kubernetes.timeouts, timeout_type))
+        return timeout if timeout > 0 else None
 
 
 class BasePod:

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -933,19 +933,17 @@ class BaseRuntimeHandler(ABC):
         crd_objects = []
         if crd_group and crd_version and crd_plural:
             try:
-                crd_objects = framework.utils.singletons.k8s.get_k8s_helper().crdapi.list_namespaced_custom_object(
+                crd_objects = framework.utils.singletons.k8s.get_k8s_helper().list_crds(
                     crd_group,
                     crd_version,
-                    namespace,
                     crd_plural,
+                    namespace,
                     label_selector=label_selector,
                 )
             except ApiException as exc:
                 # ignore error if crd is not defined
                 if exc.status != 404:
                     raise
-            else:
-                crd_objects = crd_objects["items"]
         return crd_objects
 
     def _list_crd_objects_paginated(
@@ -1178,11 +1176,11 @@ class BaseRuntimeHandler(ABC):
         crd_group, crd_version, crd_plural = self._get_crd_info()
         deleted_crds = []
         try:
-            crd_objects = framework.utils.singletons.k8s.get_k8s_helper().crdapi.list_namespaced_custom_object(
+            crd_objects = framework.utils.singletons.k8s.get_k8s_helper().list_crds(
                 crd_group,
                 crd_version,
-                namespace,
                 crd_plural,
+                namespace,
                 label_selector=label_selector,
             )
         except ApiException as exc:
@@ -1190,7 +1188,7 @@ class BaseRuntimeHandler(ABC):
             if exc.status != 404:
                 raise
         else:
-            for crd_object in crd_objects["items"]:
+            for crd_object in crd_objects:
                 # best effort - don't let one failure in pod deletion to cut the whole operation
                 try:
                     (

--- a/server/py/services/api/runtime_handlers/daskjob.py
+++ b/server/py/services/api/runtime_handlers/daskjob.py
@@ -116,7 +116,7 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
         enrich_needed = self._validate_if_enrich_is_needed_by_group_by(group_by)
         if not enrich_needed:
             return response
-        _services = framework.utils.singletons.k8s.get_k8s_helper().v1api.list_namespaced_service(
+        _services = framework.utils.singletons.k8s.get_k8s_helper().list_services(
             namespace, label_selector=label_selector
         )
         service_resources = []
@@ -221,13 +221,13 @@ class DaskRuntimeHandler(BaseRuntimeHandler):
             if dask_component == "scheduler" and cluster_name:
                 service_names.append(cluster_name)
 
-        _services = framework.utils.singletons.k8s.get_k8s_helper().v1api.list_namespaced_service(
+        _services = framework.utils.singletons.k8s.get_k8s_helper().list_services(
             namespace, label_selector=label_selector
         )
         for service in _services.items:
             try:
                 if force or service.metadata.name in service_names:
-                    framework.utils.singletons.k8s.get_k8s_helper().v1api.delete_namespaced_service(
+                    framework.utils.singletons.k8s.get_k8s_helper().delete_service(
                         service.metadata.name,
                         namespace,
                         grace_period_seconds=resource_deletion_grace_period,

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -108,8 +108,8 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             namespace
         )
         try:
-            resp = framework.utils.singletons.k8s.get_k8s_helper().crdapi.get_namespaced_custom_object(
-                mpi_group, mpi_version, namespace, mpi_plural, name
+            resp = framework.utils.singletons.k8s.get_k8s_helper().get_crd(
+                mpi_group, mpi_version, mpi_plural, namespace, name
             )
         except client.exceptions.ApiException as exc:
             logger.warning(
@@ -158,11 +158,11 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             namespace
         )
         try:
-            resp = framework.utils.singletons.k8s.get_k8s_helper().crdapi.create_namespaced_custom_object(
+            resp = framework.utils.singletons.k8s.get_k8s_helper().create_crd(
                 mpi_group,
                 mpi_version,
+                mpi_plural,
                 namespace=namespace,
-                plural=mpi_plural,
                 body=job,
             )
             name = mlrun.utils.helpers.get_in(resp, "metadata.name", "unknown")

--- a/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
@@ -366,9 +366,7 @@ with ctx:
             k8s_config_map.metadata = meta
             k8s_config_map.metadata.name += "-script"
             k8s_config_map.data = {runtime.code_script: code}
-            config_map = k8s.v1api.create_namespaced_config_map(
-                namespace, k8s_config_map
-            )
+            config_map = k8s.create_configmap(namespace, k8s_config_map)
             config_map_name = config_map.metadata.name
 
             vol_src = k8s_client.V1ConfigMapVolumeSource(name=config_map_name)
@@ -387,11 +385,11 @@ with ctx:
             )
 
         try:
-            resp = k8s.crdapi.create_namespaced_custom_object(
+            resp = k8s.create_crd(
                 Spark3Runtime.group,
                 Spark3Runtime.version,
+                Spark3Runtime.plural,
                 namespace=namespace,
-                plural=Spark3Runtime.plural,
                 body=job,
             )
             name = get_in(resp, "metadata.name", "unknown")
@@ -587,7 +585,7 @@ with ctx:
             )
             uids.append(uid)
 
-        config_maps = framework.utils.singletons.k8s.get_k8s_helper().v1api.list_namespaced_config_map(
+        config_maps = framework.utils.singletons.k8s.get_k8s_helper().list_configmaps(
             namespace, label_selector=label_selector
         )
         for config_map in config_maps.items:
@@ -596,7 +594,7 @@ with ctx:
                     mlrun_constants.MLRunInternalLabels.uid, None
                 )
                 if force or uid in uids:
-                    framework.utils.singletons.k8s.get_k8s_helper().v1api.delete_namespaced_config_map(
+                    framework.utils.singletons.k8s.get_k8s_helper().delete_configmap(
                         config_map.metadata.name,
                         namespace,
                         grace_period_seconds=resource_deletion_grace_period,

--- a/server/py/services/api/tests/unit/runtime_handlers/base.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/base.py
@@ -223,6 +223,7 @@ class TestRuntimeHandlerBase:
         get_k8s_helper().v1api.list_namespaced_pod.assert_called_once_with(
             get_k8s_helper().resolve_namespace(),
             label_selector=label_selector,
+            _request_timeout=unittest.mock.ANY,
         )
         if expected_crds:
             get_k8s_helper().crdapi.list_namespaced_custom_object.assert_called_once_with(
@@ -231,11 +232,13 @@ class TestRuntimeHandlerBase:
                 get_k8s_helper().resolve_namespace(),
                 crd_plural,
                 label_selector=label_selector,
+                _request_timeout=unittest.mock.ANY,
             )
         if expected_services:
             get_k8s_helper().v1api.list_namespaced_service.assert_called_once_with(
                 get_k8s_helper().resolve_namespace(),
                 label_selector=label_selector,
+                _request_timeout=unittest.mock.ANY,
             )
         assertion_func(
             self,
@@ -416,6 +419,7 @@ class TestRuntimeHandlerBase:
                 expected_pod_namespace,
                 grace_period_seconds=None,
                 propagation_policy="Background",
+                _request_timeout=unittest.mock.ANY,
             )
             for expected_pod_name in expected_pod_names
         ]
@@ -434,6 +438,7 @@ class TestRuntimeHandlerBase:
                 expected_service_name,
                 expected_service_namespace,
                 grace_period_seconds=None,
+                _request_timeout=unittest.mock.ANY,
             )
             for expected_service_name in expected_service_names
         ]
@@ -457,6 +462,7 @@ class TestRuntimeHandlerBase:
                 crd_plural,
                 expected_custom_object_name,
                 grace_period_seconds=None,
+                _request_timeout=unittest.mock.ANY,
             )
             for expected_custom_object_name in expected_custom_object_names
         ]
@@ -534,13 +540,17 @@ class TestRuntimeHandlerBase:
         expected_label_selector = (
             expected_label_selector or runtime_handler._get_default_label_selector()
         )
-        kwargs = {}
+        kwargs = {
+            "_request_timeout": unittest.mock.ANY,
+        }
         if paginated:
-            kwargs = {
-                "watch": False,
-                "limit": int(mlrun.mlconf.kubernetes.pagination.list_pods_limit),
-                "_continue": None,
-            }
+            kwargs.update(
+                {
+                    "watch": False,
+                    "limit": int(mlrun.mlconf.kubernetes.pagination.list_pods_limit),
+                    "_continue": None,
+                }
+            )
         get_k8s_helper().v1api.list_namespaced_pod.assert_any_call(
             get_k8s_helper().resolve_namespace(),
             label_selector=expected_label_selector,
@@ -556,13 +566,19 @@ class TestRuntimeHandlerBase:
             get_k8s_helper().crdapi.list_namespaced_custom_object.call_count
             == expected_number_of_calls
         )
-        kwargs = {}
+        kwargs = {
+            "_request_timeout": unittest.mock.ANY,
+        }
         if paginated:
-            kwargs = {
-                "watch": False,
-                "limit": int(mlrun.mlconf.kubernetes.pagination.list_crd_objects_limit),
-                "_continue": None,
-            }
+            kwargs.update(
+                {
+                    "watch": False,
+                    "limit": int(
+                        mlrun.mlconf.kubernetes.pagination.list_crd_objects_limit
+                    ),
+                    "_continue": None,
+                }
+            )
         get_k8s_helper().crdapi.list_namespaced_custom_object.assert_any_call(
             crd_group,
             crd_version,
@@ -584,6 +600,7 @@ class TestRuntimeHandlerBase:
             get_k8s_helper().v1api.read_namespaced_pod_log.assert_called_once_with(
                 name=logger_pod_name,
                 namespace=get_k8s_helper().resolve_namespace(),
+                _request_timeout=unittest.mock.ANY,
             )
         _, logs = await services.api.crud.Logs().get_logs(
             db, project, uid, source=LogSources.PERSISTENCY

--- a/server/py/services/api/tests/unit/runtime_handlers/test_remotespark.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_remotespark.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from services.api.tests.unit.runtime_handlers.test_kubejob import (
-    TestKubejobRuntimeHandler,
+    TestKubejobRuntimeHandler as _TestKubejobRuntimeHandler,
 )
 
 
-class TestRemoteSparkjobRuntimeHandler(TestKubejobRuntimeHandler):
+class TestRemoteSparkjobRuntimeHandler(_TestKubejobRuntimeHandler):
     """
     Remote Spark runtime behaving pretty much like the kubejob runtime just with few modifications (several automations
     we want to do for the user) so we're simply running the same tests as the ones of the job runtime

--- a/server/py/services/api/tests/unit/runtimes/base.py
+++ b/server/py/services/api/tests/unit/runtimes/base.py
@@ -317,7 +317,7 @@ class TestRuntimeBase(services.api.tests.unit.conftest.MockedK8sHelper):
         )
 
     def _mock_create_namespaced_pod(self):
-        def _generate_pod(namespace, pod):
+        def _generate_pod(namespace, pod, **kwargs):
             terminated_container_state = client.V1ContainerStateTerminated(
                 finished_at=datetime.now(UTC), exit_code=0
             )

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -24,9 +24,11 @@ import kubernetes.dynamic.exceptions as k8s_dynamic_exceptions
 import pytest
 import yaml
 
+import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.runtimes
 import mlrun.common.schemas
+import mlrun.errors
 import mlrun.runtimes
 from mlrun.common.schemas import SecretEventActions
 
@@ -353,7 +355,11 @@ def test_delete_secrets(
     assert result == expected_action
 
     k8s_helper.v1api.read_namespaced_secret.assert_called_once_with(
-        "my-secret", k8s_helper.namespace
+        "my-secret",
+        k8s_helper.namespace,
+        _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            "default"
+        ),
     )
 
     if expected_action == mlrun.common.schemas.SecretEventActions.updated:
@@ -783,7 +789,11 @@ def test_list_secrets_with_labels(k8s_helper):
 
     assert result == [secret1, secret2]
     k8s_helper.v1api.list_namespaced_secret.assert_called_once_with(
-        namespace="default", label_selector="mlrun/user-id=test-user-id"
+        namespace="default",
+        label_selector="mlrun/user-id=test-user-id",
+        _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            "list"
+        ),
     )
 
 
@@ -802,7 +812,11 @@ def test_list_secrets_no_labels(k8s_helper):
 
     assert result == [secret]
     k8s_helper.v1api.list_namespaced_secret.assert_called_once_with(
-        namespace="default", label_selector=None
+        namespace="default",
+        label_selector=None,
+        _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            "list"
+        ),
     )
 
 
@@ -970,6 +984,9 @@ def test_delete_user_token_secret_success(k8s_helper):
     k8s_helper.v1api.delete_namespaced_secret.assert_called_once_with(
         name=secret_name,
         namespace="default",
+        _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            "default"
+        ),
     )
 
 
@@ -993,6 +1010,9 @@ def test_delete_user_token_secret_not_found(k8s_helper):
     k8s_helper.v1api.delete_namespaced_secret.assert_called_once_with(
         name=secret_name,
         namespace="default",
+        _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            "default"
+        ),
     )
 
 
@@ -1016,6 +1036,9 @@ def test_delete_user_token_secret_api_error(k8s_helper):
     k8s_helper.v1api.delete_namespaced_secret.assert_called_once_with(
         name=secret_name,
         namespace="default",
+        _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            "default"
+        ),
     )
 
 
@@ -1039,6 +1062,9 @@ def test_delete_user_token_secret_unexpected_error(k8s_helper):
     k8s_helper.v1api.delete_namespaced_secret.assert_called_once_with(
         name=secret_name,
         namespace="default",
+        _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            "default"
+        ),
     )
 
 
@@ -1238,3 +1264,56 @@ def _make_user_token_secret(
 def _make_k8s_secret(name, labels=None):
     metadata = k8s_client.V1ObjectMeta(name=name, labels=labels or {})
     return k8s_client.V1Secret(metadata=metadata, data={})
+
+
+class TestK8sTimeouts:
+    """Tests for k8s API call timeout configuration."""
+
+    @pytest.mark.parametrize("timeout_type", ["default", "list", "logs"])
+    def test_get_k8s_timeout_returns_configured_value(self, timeout_type):
+        """Test that each timeout tier returns its configured value."""
+        expected = int(getattr(mlrun.mlconf.kubernetes.timeouts, timeout_type))
+        resolved = framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
+            timeout_type
+        )
+        assert resolved == expected
+
+    def test_timeout_zero_disables_timeout_on_api_call(self, k8s_helper, monkeypatch):
+        """Test that timeout=0 passes None to _request_timeout, disabling it."""
+        monkeypatch.setattr(mlrun.mlconf.kubernetes.timeouts, "default", 0)
+        k8s_helper.v1api.read_namespaced_pod.return_value = k8s_client.V1Pod()
+        k8s_helper.get_pod(name="test-pod", namespace="test-ns")
+        call_kwargs = k8s_helper.v1api.read_namespaced_pod.call_args
+        assert call_kwargs.kwargs["_request_timeout"] is None
+
+    def test_raise_for_status_code_catches_read_timeout(self):
+        """Test that raise_for_status_code catches MaxRetryError with ReadTimeoutError."""
+        import urllib3.exceptions
+
+        @framework.utils.singletons.k8s.raise_for_status_code
+        def fake_k8s_call():
+            raise urllib3.exceptions.MaxRetryError(
+                pool=None,
+                url="/api/v1/pods",
+                reason=urllib3.exceptions.ReadTimeoutError(
+                    pool=None, url="/api/v1/pods", message="Read timed out"
+                ),
+            )
+
+        with pytest.raises(mlrun.errors.MLRunRuntimeError, match="timed out"):
+            fake_k8s_call()
+
+    def test_raise_for_status_code_reraises_non_timeout_max_retry(self):
+        """Test that raise_for_status_code re-raises MaxRetryError without ReadTimeoutError."""
+        import urllib3.exceptions
+
+        @framework.utils.singletons.k8s.raise_for_status_code
+        def fake_k8s_call():
+            raise urllib3.exceptions.MaxRetryError(
+                pool=None,
+                url="/api/v1/pods",
+                reason=urllib3.exceptions.ConnectTimeoutError("Connect failed"),
+            )
+
+        with pytest.raises(urllib3.exceptions.MaxRetryError):
+            fake_k8s_call()

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -358,7 +358,7 @@ def test_delete_secrets(
         "my-secret",
         k8s_helper.namespace,
         _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
-            "default"
+            framework.utils.singletons.k8s.K8S_TIMEOUT_DEFAULT
         ),
     )
 
@@ -792,7 +792,7 @@ def test_list_secrets_with_labels(k8s_helper):
         namespace="default",
         label_selector="mlrun/user-id=test-user-id",
         _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
-            "list"
+            framework.utils.singletons.k8s.K8S_TIMEOUT_LIST
         ),
     )
 
@@ -815,7 +815,7 @@ def test_list_secrets_no_labels(k8s_helper):
         namespace="default",
         label_selector=None,
         _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
-            "list"
+            framework.utils.singletons.k8s.K8S_TIMEOUT_LIST
         ),
     )
 
@@ -985,7 +985,7 @@ def test_delete_user_token_secret_success(k8s_helper):
         name=secret_name,
         namespace="default",
         _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
-            "default"
+            framework.utils.singletons.k8s.K8S_TIMEOUT_DEFAULT
         ),
     )
 
@@ -1011,7 +1011,7 @@ def test_delete_user_token_secret_not_found(k8s_helper):
         name=secret_name,
         namespace="default",
         _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
-            "default"
+            framework.utils.singletons.k8s.K8S_TIMEOUT_DEFAULT
         ),
     )
 
@@ -1037,7 +1037,7 @@ def test_delete_user_token_secret_api_error(k8s_helper):
         name=secret_name,
         namespace="default",
         _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
-            "default"
+            framework.utils.singletons.k8s.K8S_TIMEOUT_DEFAULT
         ),
     )
 
@@ -1063,7 +1063,7 @@ def test_delete_user_token_secret_unexpected_error(k8s_helper):
         name=secret_name,
         namespace="default",
         _request_timeout=framework.utils.singletons.k8s.K8sHelper._resolve_k8s_timeout(
-            "default"
+            framework.utils.singletons.k8s.K8S_TIMEOUT_DEFAULT
         ),
     )
 
@@ -1269,7 +1269,14 @@ def _make_k8s_secret(name, labels=None):
 class TestK8sTimeouts:
     """Tests for k8s API call timeout configuration."""
 
-    @pytest.mark.parametrize("timeout_type", ["default", "list", "logs"])
+    @pytest.mark.parametrize(
+        "timeout_type",
+        [
+            framework.utils.singletons.k8s.K8S_TIMEOUT_DEFAULT,
+            framework.utils.singletons.k8s.K8S_TIMEOUT_LIST,
+            framework.utils.singletons.k8s.K8S_TIMEOUT_LOGS,
+        ],
+    )
     def test_get_k8s_timeout_returns_configured_value(self, timeout_type):
         """Test that each timeout tier returns its configured value."""
         expected = int(getattr(mlrun.mlconf.kubernetes.timeouts, timeout_type))


### PR DESCRIPTION
### 📝 Description

K8s API calls from the MLRun server can hang indefinitely, tying up API workers. The K8sHelper singleton (and some runtime handlers) make ~30+ k8s API calls with no timeout configured at any level. When the k8s control plane is slow or unresponsive, workers block forever instead of returning an error. The fix is to add _request_timeout to every k8s API call, following the https://github.com/kubernetes-client/python/issues/2227#issuecomment-2105058007 from the k8s Python client. 


---

### 🛠️ Changes Made


  - Add per-request _request_timeout to all Kubernetes API calls made from the MLRun server, preventing API workers from
  hanging indefinitely when the k8s control plane is slow or unresponsive
  - Introduce three configurable timeout tiers: default (30s) for single-resource ops, list (60s) for list operations, and
   logs (120s) for pod log retrieval
  - Centralize all direct k8s API calls from runtime handlers into K8sHelper, eliminating scattered v1api/crdapi usage

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Manual + Unit testings

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-9615
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
