### PR TITLE
[Application] Support any file extension in for single-file source

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -6031,6 +6031,7 @@ def _init_function_from_dict(
         )
 
     elif kind == mlrun.runtimes.RuntimeKinds.application and path.isfile(url):
+        # For application runtime we set the source path directly, deploy will upload it as an artifact
         func = new_function(
             name,
             image=image,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -6030,18 +6030,18 @@ def _init_function_from_dict(
             name, filename=url, image=image, kind=kind, handler=handler, tag=tag
         )
 
+    elif kind == mlrun.runtimes.RuntimeKinds.application and path.isfile(url):
+        func = new_function(
+            name,
+            image=image,
+            kind=kind,
+            handler=handler,
+            tag=tag,
+        )
+        func.spec.build.source = url
+
     elif url.endswith(".py"):
-        # For application runtime we set the source path directly, deploy will upload it as an artifact
-        if kind == mlrun.runtimes.RuntimeKinds.application:
-            func = new_function(
-                name,
-                image=image,
-                kind=kind,
-                handler=handler,
-                tag=tag,
-            )
-            func.spec.build.source = url
-        elif in_context and with_repo:
+        if in_context and with_repo:
             # when load_source_on_run is used we allow not providing image as code will be loaded pre-run. ML-4994
             if (
                 not image

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -1129,10 +1129,17 @@ def test_upload_source_as_artifact_no_project_error():
             fn._upload_source_as_artifact()
 
 
-def test_set_function_single_file_application(tmp_path):
-    # Test that set_function with single .py file works for application runtime
-    source_file = tmp_path / "handler.py"
-    source_file.write_text("def handler(): pass")
+@pytest.mark.parametrize(
+    "filename,content",
+    [
+        ("handler.py", "def handler(): pass"),
+        ("app.sh", "#!/bin/bash\necho hello"),
+        ("server.js", "console.log('hello')"),
+    ],
+)
+def test_set_function_single_file_application(tmp_path, filename, content):
+    source_file = tmp_path / filename
+    source_file.write_text(content)
 
     project = mlrun.get_or_create_project("test-proj", allow_cross_project=True)
     fn = project.set_function(


### PR DESCRIPTION
### 📝 Description
`set_function` only handled `.py` files for the single-file source flow. 
Since Application runtime is file-type agnostic any local file should be accepted.

---

### 🛠️ Changes Made
- Accept any local file extension in `_init_function_from_dict` for application runtime (not just .py).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- updated existing unit test to cover not only `.py` files

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12187
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
