### PR TITLE
[Serving] Add wildcard star path matching to API handler

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -138,14 +138,16 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         :param path: Normalized path (with leading ``/``) to validate.
         :raises mlrun.errors.MLRunValueError: If the path contains an invalid ``*`` pattern.
         """
-        if "*" not in path:
+        star_count = path.count("*")
+        if star_count == 0:
             return
-        if not path.endswith("*"):
+        # We know there is a wildcard, validate its position and count
+        if path[-1] != "*":
             raise mlrun.errors.MLRunValueError(
                 f"Invalid endpoint path '{path}': "
                 f"wildcard '*' must be at the end of the path"
             )
-        if path.count("*") > 1:
+        if star_count > 1:
             raise mlrun.errors.MLRunValueError(
                 f"Invalid endpoint path '{path}': "
                 f"wildcard '*' must appear only once at the end of the path"

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -59,17 +59,19 @@ serving_subkind = "serving_v2"
 class APIHandlerConfig(mlrun.model.ModelObj):
     """Configuration for API handler in serving graph"""
 
-    _dict_fields = ["enabled", "endpoints", "body_map"]
+    _dict_fields = ["enabled", "endpoints", "body_map", "include_url_info"]
 
     def __init__(
         self,
         enabled: bool = True,
         endpoints: dict[str, dict] | None = None,
         body_map: dict[str, str] | None = None,
+        include_url_info: bool = False,
     ):
         self.enabled = enabled
         self._endpoints = endpoints or {}
         self._body_map = body_map or {}
+        self.include_url_info = include_url_info
 
     @property
     def body_map(self) -> dict[str, str]:
@@ -125,6 +127,31 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         return path
 
     @staticmethod
+    def _validate_path(path: str) -> None:
+        """Validate an endpoint path for structural correctness.
+
+        Currently enforces wildcard ``*`` rules:
+
+        * ``*`` may only appear once.
+        * ``*`` must be the last character in the path.
+
+        :param path: Normalized path (with leading ``/``) to validate.
+        :raises mlrun.errors.MLRunValueError: If the path contains an invalid ``*`` pattern.
+        """
+        if "*" not in path:
+            return
+        if not path.endswith("*"):
+            raise mlrun.errors.MLRunValueError(
+                f"Invalid endpoint path '{path}': "
+                f"wildcard '*' must be at the end of the path"
+            )
+        if path.count("*") > 1:
+            raise mlrun.errors.MLRunValueError(
+                f"Invalid endpoint path '{path}': "
+                f"wildcard '*' must appear only once at the end of the path"
+            )
+
+    @staticmethod
     def _validate_http_method(http_method: HTTPMethod | str) -> HTTPMethod:
         """Validate and normalize the provided HTTP method.
 
@@ -164,13 +191,15 @@ class APIHandlerConfig(mlrun.model.ModelObj):
     ) -> None:
         """Add an endpoint handler configuration.
 
-        :param path: URL path for the endpoint (e.g., '/v1/models')
+        :param path: URL path for the endpoint (e.g., '/v1/models' or '/api/v1/*')
         :param http_method: HTTP method for the endpoint (HTTPMethod enum or string like 'GET', 'POST')
         :param action: Action to take for this endpoint (:py:class:`~mlrun.common.schemas.serving.APIHandlerAction`)
         :param description: Optional description of the endpoint
+        :raises mlrun.errors.MLRunValueError: If the path contains an invalid wildcard ``*`` pattern
         """
         http_method = self._validate_http_method(http_method)
         path = self._normalize_path(path)
+        self._validate_path(path)
         endpoint_key = serving_utils._combine_serving_endpoint_key(http_method, path)
 
         # Warn if overriding an existing endpoint

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -43,6 +43,10 @@ class _RequestContext(_MappedBody):
 
     Priority order: path > query > body_map (path parameters have highest priority)
     Conflicts are not allowed - request will fail if same parameter appears in multiple sources.
+
+    Additionally, system-injected ``url_params`` (e.g. ``mlrun_request_path``) are merged
+    in after the conflict check without raising conflicts - they use the reserved ``mlrun_``
+    prefix to avoid collisions with user-defined parameters.
     """
 
     def __init__(
@@ -50,6 +54,7 @@ class _RequestContext(_MappedBody):
         path_params: dict[str, str] | None = None,
         query_params: dict[str, str | list[str]] | None = None,
         body_params: dict[str, Any] | None = None,
+        url_params: dict[str, Any] | None = None,
     ):
         merged = {}
         sources = [
@@ -80,6 +85,11 @@ class _RequestContext(_MappedBody):
                 f"request sources: {conflict_details}. Parameters must be unique across "
                 f"path, query, and body_map."
             )
+
+        # Merge system-injected URL params last, without conflict checking.
+        # These use the reserved 'mlrun_' prefix (e.g. 'mlrun_request_path').
+        if url_params:
+            merged.update(url_params)
 
         super().__init__(merged)
 
@@ -125,64 +135,95 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                         f"'{jsonpath_expr}'. Error: {exc}"
                     ) from exc
 
-        # Pre-compile regex patterns for path template matching (performance optimization)
-        # Pattern format: /api/{user_id}/items/{item_id} → /api/(?P<user_id>[^/]+)/items/(?P<item_id>[^/]+)
-        # This converts {param_name} placeholders to named capture groups
-        self._endpoint_patterns: list[tuple[HTTPMethod, Pattern, str, dict]] = (
-            self._compile_endpoint_patterns()
-        )
+        # Pre-compile patterns in a single pass for performance.
+        # Template patterns: /api/{user_id}/items → regex with named groups.
+        # Star patterns:     /api/v1/*           → plain prefix string.
+        self._endpoint_patterns: list[tuple[HTTPMethod, Pattern, str, dict]]
+        self._star_patterns: list[tuple[HTTPMethod, str, str, dict]]
+        self._endpoint_patterns, self._star_patterns = self._compile_patterns()
 
         mlrun.utils.logger.debug("The context in API handler", context=self.context)
 
-    def _compile_endpoint_patterns(
+    def _compile_patterns(
         self,
-    ) -> list[tuple[HTTPMethod, Pattern, str, dict]]:
-        """Pre-compile regex patterns for all endpoint path templates.
+    ) -> tuple[
+        list[tuple[HTTPMethod, Pattern, str, dict]],
+        list[tuple[HTTPMethod, str, str, dict]],
+    ]:
+        """Compile all non-exact endpoint patterns in a single pass.
 
-        This optimization builds regex patterns once during initialization rather than
-        doing string manipulation on every request.
+        Exact endpoints (no ``{`` or ``*``) are handled by O(1) dict lookup at
+        request time and do not need pre-compilation.
 
-        Pattern explanation:
+        Template patterns (``{param}``):
             /api/{user_id}/items/{item_id}
             ↓ becomes ↓
             ^/api/(?P<user_id>[^/]+)/items/(?P<item_id>[^/]+)$
 
-        Regex components:
-            - ^ and $ → match entire path (anchors)
-            - (?P<name>...) → named capture group for extracted param
-            - [^/]+ → match one or more non-slash characters (greedy path segment)
+            - ^ and $ anchor the full path
+            - ``(?P<name>[^/]+)`` captures one non-slash path segment per parameter
 
-        :return: List of (method, compiled_pattern, endpoint_key, endpoint_config) tuples
+        Star (wildcard) patterns (``*`` at end only):
+            /api/v1/*  → prefix ``/api/v1/``
+            Matches any path that starts with the prefix and has at least one
+            additional character after it.
+
+        :return: Tuple of (template_patterns, star_patterns) where
+
+            * ``template_patterns`` is a list of
+              ``(method, compiled_regex, endpoint_key, endpoint_config)``
+            * ``star_patterns`` is a list of
+              ``(method, prefix, endpoint_key, endpoint_config)``
         """
-        patterns = []
+        template_patterns: list[tuple[HTTPMethod, Pattern, str, dict]] = []
+        star_patterns: list[tuple[HTTPMethod, str, str, dict]] = []
+
         for endpoint_key, endpoint_config in self.config._endpoints.items():
             method, path_pattern = self.config._parse_endpoint_key(endpoint_key)
 
-            # Skip endpoints without path parameters (handled by exact match)
-            if "{" not in path_pattern:
-                continue
+            if "*" in path_pattern:
+                # --- Star (wildcard) pattern ---
+                if not path_pattern.endswith("*"):
+                    raise mlrun.errors.MLRunValueError(
+                        f"Invalid endpoint path '{path_pattern}': "
+                        f"wildcard '*' must be at the end of the path"
+                    )
+                if path_pattern.count("*") > 1:
+                    raise mlrun.errors.MLRunValueError(
+                        f"Invalid endpoint path '{path_pattern}': "
+                        f"wildcard '*' must appear only once at the end of the path"
+                    )
+                # Strip trailing '*'; guarantee a trailing '/' for prefix matching.
+                # Examples: /api/v1/* → /api/v1/   /* → /
+                prefix = path_pattern.rstrip("*")
+                if not prefix.endswith("/"):
+                    prefix += "/"
+                star_patterns.append((method, prefix, endpoint_key, endpoint_config))
 
-            # Convert path template to regex pattern
-            # Example: /api/{user_id}/data → ^/api/(?P<user_id>[^/]+)/data$
-            regex_pattern = re.escape(path_pattern)  # Escape special chars first
-            # Replace escaped braces with capture groups
-            regex_pattern = re.sub(
-                r"\\\{([^}]+)\\\}",  # Match escaped {param_name}
-                r"(?P<\1>[^/]+)",  # Replace with named group (?P<param_name>[^/]+)
-                regex_pattern,
-            )
-            regex_pattern = f"^{regex_pattern}$"  # Add anchors
+            elif "{" in path_pattern:
+                # --- Template pattern ---
+                # Convert {param} placeholders to named regex capture groups.
+                # Example: /api/{user_id}/data → ^/api/(?P<user_id>[^/]+)/data$
+                regex_pattern = re.escape(path_pattern)
+                regex_pattern = re.sub(
+                    r"\\\{([^}]+)\\\}",  # Match escaped {param_name}
+                    r"(?P<\1>[^/]+)",  # Replace with (?P<param_name>[^/]+)
+                    regex_pattern,
+                )
+                regex_pattern = f"^{regex_pattern}$"
+                try:
+                    compiled = re.compile(regex_pattern)
+                except re.error as exc:
+                    raise mlrun.errors.MLRunValueError(
+                        f"Failed to compile regex for endpoint pattern '{path_pattern}' "
+                        f"(key: {endpoint_key}): {exc}"
+                    ) from exc
+                template_patterns.append(
+                    (method, compiled, endpoint_key, endpoint_config)
+                )
+            # else: exact endpoint – handled by dict lookup, no compilation needed
 
-            try:
-                compiled = re.compile(regex_pattern)
-                patterns.append((method, compiled, endpoint_key, endpoint_config))
-            except re.error as exc:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Failed to compile regex for endpoint pattern '{path_pattern}' "
-                    f"(key: {endpoint_key}): {exc}"
-                ) from exc
-
-        return patterns
+        return template_patterns, star_patterns
 
     def _apply_parsed_body_map(self, body: dict) -> "_MappedBody":
         """Apply pre-parsed JSONPath expressions to extract parameters from event body.
@@ -406,19 +447,27 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                             f"Failed to process body_map transformation: {exc}"
                         ) from exc
 
-                # Only create RequestContext if we have extracted parameters
-                # Otherwise, preserve the original event body
-                if body_params or path_params or query_params:
+                # Build system-injected URL params when include_url_info is enabled.
+                # mlrun_request_path holds the normalized path of the matched request.
+                url_params: dict[str, Any] = {}
+                if self.config.include_url_info:
+                    url_params["mlrun_request_path"] = normalized_path
+
+                # Only create RequestContext if we have extracted parameters or url_params.
+                # Otherwise, preserve the original event body.
+                if body_params or path_params or query_params or url_params:
                     mlrun.utils.logger.debug(
                         "Creating RequestContext",
                         body_params=body_params,
                         path_params=path_params,
                         query_params=query_params,
+                        url_params=url_params,
                     )
                     request_context = _RequestContext(
                         body_params=body_params,
                         path_params=path_params,
                         query_params=query_params,
+                        url_params=url_params,
                     )
 
                     # Replace event body with unified context
@@ -452,9 +501,10 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
     ) -> tuple[str | None, dict[str, str]]:
         """Find matching endpoint key for the given method and path.
 
-        Uses a two-phase search strategy:
+        Uses a three-phase search strategy with strict precedence:
         1. Fast exact match lookup (O(1) dict lookup)
-        2. Pre-compiled regex pattern matching for path templates (O(n) but optimized)
+        2. Pre-compiled regex pattern matching for path templates (O(n), insertion order)
+        3. Star (wildcard) prefix matching (O(n), insertion order)
 
         :param method: HTTP method to match
         :param path: Request path to match
@@ -484,5 +534,27 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                     name: unquote(value) for name, value in match.groupdict().items()
                 }
                 return pattern_endpoint_key, path_params
+
+        # Phase 3: Try star (wildcard) patterns for prefix matching
+        # Ensure path ends with / for comparison with prefix
+        # Using trailing slash ensures /apiv2/users doesn't match /api/* prefix
+        # Path must be strictly "under" the prefix, not equal to it
+        path_with_slash = path if path.endswith("/") else path + "/"
+        for (
+            star_method,
+            prefix,
+            star_endpoint_key,
+            _,
+        ) in self._star_patterns:
+            if star_method != method:
+                continue
+
+            # Path must start with prefix AND be longer than prefix (at least one more char)
+            # This ensures /api/ doesn't match /api/* (only /api/something does)
+            if path_with_slash.startswith(prefix) and len(path_with_slash) > len(
+                prefix
+            ):
+                # Star patterns don't extract parameters
+                return star_endpoint_key, {}
 
         return None, {}

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -152,6 +152,31 @@ class TestRequestContext:
         assert ctx["id"] == ["1", "4", "1"]
         assert ctx["single"] == "value"
 
+    def test_url_params_injected_without_conflict(self) -> None:
+        """Test that url_params are merged without conflict checking"""
+        ctx = _RequestContext(
+            path_params={"user_id": "123"},
+            url_params={"mlrun_request_path": "/api/users/123"},
+        )
+        assert ctx["user_id"] == "123"
+        assert ctx["mlrun_request_path"] == "/api/users/123"
+
+    def test_url_params_only(self) -> None:
+        """Test context with only url_params"""
+        ctx = _RequestContext(url_params={"mlrun_request_path": "/api/health"})
+        assert ctx["mlrun_request_path"] == "/api/health"
+
+    def test_url_params_do_not_raise_on_overwrite(self) -> None:
+        """Test that url_params silently overwrite user params with the same name (reserved prefix)"""
+        # This documents that 'mlrun_' prefixed params are reserved; user params
+        # with the same name will be overwritten by system-injected url_params.
+        ctx = _RequestContext(
+            query_params={"mlrun_request_path": "user-supplied"},
+            url_params={"mlrun_request_path": "/api/real"},
+        )
+        # System-injected value wins
+        assert ctx["mlrun_request_path"] == "/api/real"
+
 
 class TestPathTemplateRegex:
     """Tests for pre-compiled regex patterns and path template matching"""
@@ -398,6 +423,398 @@ class TestPathTemplateRegex:
         # Should not crash, and pattern should not match
         match, params = step._match_endpoint(HTTPMethod.GET, "/api/test")
         # The regex compilation should handle this gracefully
+
+
+class TestStarPatternMatching:
+    """Tests for wildcard/star pattern matching in API handler (ML-11658)"""
+
+    def test_basic_star_match(self) -> None:
+        """Test that a star pattern matches any path under the prefix"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+        assert len(step._star_patterns) == 1
+        assert len(step._endpoint_patterns) == 0
+
+        # Should match paths under /api/
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/users")
+        assert match == "GET:/api/*"
+        assert params == {}
+
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/items/123")
+        assert match == "GET:/api/*"
+        assert params == {}
+
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/deeply/nested/path")
+        assert match == "GET:/api/*"
+        assert params == {}
+
+    def test_star_at_end_validation(self) -> None:
+        """Test that * must be at the end of the path"""
+        config = APIHandlerConfig()
+        # Manually insert invalid endpoint with * not at end
+        config._endpoints["GET:/api/*/users"] = {
+            _APIEndpointKeys.ACTION: "allow",
+            _APIEndpointKeys.DESCRIPTION: "Invalid star position",
+        }
+
+        with pytest.raises(
+            mlrun.errors.MLRunValueError,
+            match="wildcard.*must be at the end",
+        ):
+            _APIHandlerStep(config=config)
+
+    def test_star_patterns_not_in_endpoint_patterns(self) -> None:
+        """Test that star patterns are stored separately from template patterns"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/api/{user_id}", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+        config.add_endpoint_handler("/admin/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+        assert len(step._endpoint_patterns) == 1
+        assert len(step._star_patterns) == 1
+
+    def test_precedence_exact_over_star(self) -> None:
+        """Test that exact matches take precedence over star patterns"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.FORBID)
+        config.add_endpoint_handler(
+            "/api/health", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+
+        step = _APIHandlerStep(config=config)
+
+        # Exact match should win
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/health")
+        assert match == "GET:/api/health"
+        assert params == {}
+
+        # Non-exact path should fall through to star
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/other")
+        assert match == "GET:/api/*"
+        assert params == {}
+
+    def test_precedence_template_over_star(self) -> None:
+        """Test that template matches take precedence over star patterns"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.FORBID)
+        config.add_endpoint_handler(
+            "/api/{resource}", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+
+        step = _APIHandlerStep(config=config)
+
+        # Template match should win over star match
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/users")
+        assert match == "GET:/api/{resource}"
+        assert params == {"resource": "users"}
+
+    def test_precedence_all_three_types(self) -> None:
+        """Test full precedence: exact > template > star"""
+        config = APIHandlerConfig()
+        # Add in reverse precedence order to ensure ordering is correct
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.FORBID)
+        config.add_endpoint_handler(
+            "/api/{version}/users", HTTPMethod.GET, APIHandlerAction.FORBID
+        )
+        config.add_endpoint_handler(
+            "/api/v2/users", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+
+        step = _APIHandlerStep(config=config)
+
+        # Exact match wins
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/v2/users")
+        assert match == "GET:/api/v2/users"
+        assert params == {}
+
+        # Template match wins over star
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/v1/users")
+        assert match == "GET:/api/{version}/users"
+        assert params == {"version": "v1"}
+
+        # Star match for paths not covered by exact/template
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/v1/items")
+        assert match == "GET:/api/*"
+        assert params == {}
+
+    def test_star_insertion_order(self) -> None:
+        """Test that within star patterns, insertion order is respected"""
+        config = APIHandlerConfig()
+        # More specific prefix added first should win
+        config.add_endpoint_handler("/api/v1/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.FORBID)
+
+        step = _APIHandlerStep(config=config)
+        assert len(step._star_patterns) == 2
+
+        # /api/v1/ prefix added first, should match first
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/v1/users")
+        assert match == "GET:/api/v1/*"
+        assert params == {}
+
+        # /api/other should fall through to second star pattern
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/v2/users")
+        assert match == "GET:/api/*"
+        assert params == {}
+
+    def test_star_method_isolation(self) -> None:
+        """Test that star patterns only match for the correct HTTP method"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+
+        # GET should match
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/users")
+        assert match == "GET:/api/*"
+
+        # POST should not match GET star pattern
+        match, params = step._match_endpoint(HTTPMethod.POST, "/api/users")
+        assert match is None
+        assert params == {}
+
+    def test_star_no_match_outside_prefix(self) -> None:
+        """Test that star patterns only match paths under their prefix"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+
+        # Path not under /api/ should not match
+        match, params = step._match_endpoint(HTTPMethod.GET, "/other/path")
+        assert match is None
+        assert params == {}
+
+        # /apiv2 should not match /api/*
+        match, params = step._match_endpoint(HTTPMethod.GET, "/apiv2/users")
+        assert match is None
+        assert params == {}
+
+    def test_star_prefix_slash_handling(self) -> None:
+        """Test that star patterns: /api/* matches /api/something"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+
+        # Verify prefix is correct
+        assert len(step._star_patterns) == 1
+        star_method, prefix, star_key, _ = step._star_patterns[0]
+        assert star_method == HTTPMethod.GET
+        assert prefix == "/api/"  # Prefix should have trailing slash
+
+        # /api alone should NOT match (it's the exact prefix, not under it)
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api")
+        assert match is None
+        assert params == {}
+
+        # /api/anything should match
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/something")
+        assert match == "GET:/api/*"
+        assert params == {}
+
+    def test_star_with_allow_action(self) -> None:
+        """Test full flow with star pattern and ALLOW action"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/v1/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+        event = MockEvent(method=HTTPMethod.GET, path="/v1/anything", body="test")
+        result = step.do(event)
+        assert result is not None
+
+    def test_star_with_forbid_action(self) -> None:
+        """Test full flow with star pattern and FORBID action"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/v1/*", HTTPMethod.GET, APIHandlerAction.FORBID)
+
+        step = _APIHandlerStep(config=config)
+        event = MockEvent(method=HTTPMethod.GET, path="/v1/anything", body="test")
+        with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+            step.do(event)
+
+    def test_template_insertion_order(self) -> None:
+        """Within template patterns, the first registered pattern wins when multiple templates match."""
+        config = APIHandlerConfig()
+        # /api/{a}/resource is registered first
+        config.add_endpoint_handler(
+            "/api/{a}/resource", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+        # Inject a second overlapping template with a different param name directly (same key structure)
+        config._endpoints["GET:/api/{b}/resource"] = {
+            _APIEndpointKeys.ACTION: "allow",
+            _APIEndpointKeys.DESCRIPTION: None,
+        }
+
+        step = _APIHandlerStep(config=config)
+        assert len(step._endpoint_patterns) == 2
+
+        # First-inserted template should win — params carry its name
+        match, params = step._match_endpoint(HTTPMethod.GET, "/api/foo/resource")
+        assert match == "GET:/api/{a}/resource"
+        assert params == {"a": "foo"}
+
+    def test_multiple_star_patterns_different_methods(self) -> None:
+        """Test multiple star patterns with different HTTP methods"""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/read/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        config.add_endpoint_handler("/write/*", HTTPMethod.POST, APIHandlerAction.ALLOW)
+
+        step = _APIHandlerStep(config=config)
+        assert len(step._star_patterns) == 2
+
+        # GET /read should match /read/*
+        match, params = step._match_endpoint(HTTPMethod.GET, "/read/something")
+        assert match == "GET:/read/*"
+
+        # POST /write should match /write/*
+        match, params = step._match_endpoint(HTTPMethod.POST, "/write/something")
+        assert match == "POST:/write/*"
+
+        # GET /write should NOT match (wrong method)
+        match, params = step._match_endpoint(HTTPMethod.GET, "/write/something")
+        assert match is None
+
+
+class TestIncludeUrlInfo:
+    """Tests for include_url_info parameter (ML-11658)
+
+    When include_url_info=True, the API handler injects 'mlrun_request_path'
+    (the normalized request path, without query string) into the RequestContext
+    that is forwarded to the next step.
+    """
+
+    def test_include_url_info_default_false(self) -> None:
+        """include_url_info should default to False"""
+        from mlrun.runtimes.nuclio.serving import APIHandlerConfig
+
+        config = APIHandlerConfig()
+        assert config.include_url_info is False
+
+    def test_include_url_info_can_be_set_true(self) -> None:
+        """include_url_info should be settable to True"""
+        from mlrun.runtimes.nuclio.serving import APIHandlerConfig
+
+        config = APIHandlerConfig(include_url_info=True)
+        assert config.include_url_info is True
+
+    def test_include_url_info_in_dict_fields(self) -> None:
+        """include_url_info must round-trip through APIHandlerConfig.to_dict/from_dict"""
+        from mlrun.runtimes.nuclio.serving import APIHandlerConfig
+
+        config = APIHandlerConfig(include_url_info=True)
+        config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        d = config.to_dict()
+        assert d["include_url_info"] is True
+
+        config2 = APIHandlerConfig.from_dict(d)
+        # from_dict round-trip
+        assert config2.include_url_info is True
+
+    def test_include_url_info_disabled_no_path_injected(self) -> None:
+        """When include_url_info=False, mlrun_request_path is NOT in the context"""
+        config = APIHandlerConfig(include_url_info=False)
+        config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        step = _APIHandlerStep(config=config)
+
+        event = MockEvent(method=HTTPMethod.GET, path="/api/test", body="hello")
+        result = step.do(event)
+
+        # No params extracted and include_url_info=False → body stays as-is
+        assert result.body == "hello"
+
+    def test_include_url_info_enabled_exact_path(self) -> None:
+        """When include_url_info=True the RequestContext contains mlrun_request_path"""
+        config = APIHandlerConfig(include_url_info=True)
+        config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        step = _APIHandlerStep(config=config)
+
+        event = MockEvent(method=HTTPMethod.GET, path="/api/test", body="hello")
+        result = step.do(event)
+
+        assert isinstance(result.body, _RequestContext)
+        assert result.body["mlrun_request_path"] == "/api/test"
+
+    def test_include_url_info_path_without_query_string(self) -> None:
+        """mlrun_request_path must NOT include query string"""
+        config = APIHandlerConfig(include_url_info=True)
+        config.add_endpoint_handler(
+            "/api/items", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+        step = _APIHandlerStep(config=config)
+
+        event = MockEvent(
+            method=HTTPMethod.GET, path="/api/items?limit=5&offset=10", body="hello"
+        )
+        result = step.do(event)
+
+        assert isinstance(result.body, _RequestContext)
+        # Path must be normalized (no query string)
+        assert result.body["mlrun_request_path"] == "/api/items"
+        # Query params are still extracted normally
+        assert result.body["limit"] == "5"
+        assert result.body["offset"] == "10"
+
+    def test_include_url_info_with_path_template(self) -> None:
+        """mlrun_request_path must be the actual request path, not the template"""
+        config = APIHandlerConfig(include_url_info=True)
+        config.add_endpoint_handler(
+            "/api/users/{user_id}", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+        step = _APIHandlerStep(config=config)
+
+        event = MockEvent(
+            method=HTTPMethod.GET, path="/api/users/abc-123", body="hello"
+        )
+        result = step.do(event)
+
+        assert isinstance(result.body, _RequestContext)
+        # Actual request path, not the template pattern
+        assert result.body["mlrun_request_path"] == "/api/users/abc-123"
+        # Path param is also present
+        assert result.body["user_id"] == "abc-123"
+
+    def test_include_url_info_with_star_pattern(self) -> None:
+        """mlrun_request_path is the actual path matched by a star pattern"""
+        config = APIHandlerConfig(include_url_info=True)
+        config.add_endpoint_handler("/api/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        step = _APIHandlerStep(config=config)
+
+        event = MockEvent(
+            method=HTTPMethod.GET, path="/api/deeply/nested/resource", body="hello"
+        )
+        result = step.do(event)
+
+        assert isinstance(result.body, _RequestContext)
+        assert result.body["mlrun_request_path"] == "/api/deeply/nested/resource"
+
+    def test_include_url_info_combined_with_existing_params(self) -> None:
+        """mlrun_request_path is available alongside path, query, and body params"""
+        config = APIHandlerConfig(
+            include_url_info=True,
+            body_map={"question": "$.q"},
+        )
+        config.add_endpoint_handler(
+            "/api/{model_id}/ask", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+        step = _APIHandlerStep(config=config)
+
+        event = MockEvent(
+            method=HTTPMethod.POST,
+            path="/api/gpt4/ask?lang=en",
+            body={"q": "Hello world"},
+        )
+        result = step.do(event)
+
+        assert isinstance(result.body, _RequestContext)
+        assert result.body["mlrun_request_path"] == "/api/gpt4/ask"
+        assert result.body["model_id"] == "gpt4"
+        assert result.body["lang"] == "en"
+        assert result.body["question"] == "Hello world"
 
 
 class TestAPIHandlerMockServer:
@@ -1020,6 +1437,28 @@ class TestAPIHandlerConfig:
         endpoint_config = config.get_endpoint_config(HTTPMethod.POST, "/api/test")
         assert endpoint_config[_APIEndpointKeys.ACTION] == "forbid"
         assert endpoint_config[_APIEndpointKeys.DESCRIPTION] == "Second config"
+
+    def test_add_endpoint_star_not_at_end_raises(self) -> None:
+        """SDK rejects '*' that is not at the tail of the path at config time."""
+        config = APIHandlerConfig()
+        with pytest.raises(
+            mlrun.errors.MLRunValueError, match="wildcard.*must be at the end"
+        ):
+            config.add_endpoint_handler(
+                "/api/*/users", HTTPMethod.GET, APIHandlerAction.ALLOW
+            )
+
+    def test_add_endpoint_multiple_stars_raises(self) -> None:
+        """SDK rejects paths with more than one '*'."""
+        config = APIHandlerConfig()
+        with pytest.raises(mlrun.errors.MLRunValueError, match="wildcard.*only once"):
+            config.add_endpoint_handler("/*/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+    def test_add_endpoint_valid_star_pattern(self) -> None:
+        """A single trailing '*' is accepted by the SDK."""
+        config = APIHandlerConfig()
+        config.add_endpoint_handler("/api/v1/*", HTTPMethod.GET, APIHandlerAction.ALLOW)
+        assert config.get_endpoint_config(HTTPMethod.GET, "/api/v1/*") is not None
 
 
 class TestSetAPIHandlerConfig:

--- a/tests/system/runtimes/assets/wildcard_path_handler.py
+++ b/tests/system/runtimes/assets/wildcard_path_handler.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Iguazio
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def handle_wildcard(mlrun_request_path: str | None = None, **kwargs) -> dict:
+    """Handler that receives mlrun_request_path injected by the API handler.
+
+    Used by system tests to verify that:
+    - wildcard ``*`` patterns route requests to the correct handler
+    - ``include_url_info=True`` injects ``mlrun_request_path`` with the
+      normalized request path (no query string)
+
+    Args:
+        mlrun_request_path: Injected by APIHandler when include_url_info=True.
+        **kwargs: Any additional parameters from query string / body_map.
+
+    Returns:
+        Dict with matched_path and any extra params for verification.
+    """
+    return {
+        "matched_path": mlrun_request_path,
+        "extra": kwargs,
+    }

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from http import HTTPMethod
 
 import pytest
@@ -250,3 +251,53 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         # assert response["tags_count"] == 3, "tags_count should match number of tags"
 
         self._logger.info("Path and query params API handler test passed")
+
+    def test_api_handler_wildcard_path(self) -> None:
+        """Test API handler with a wildcard '*' path pattern."""
+        self._logger.info("Testing API handler with wildcard star path")
+
+        config = APIHandlerConfig(include_url_info=True)
+        config.add_endpoint_handler(
+            "/api/wildcard/*",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            "Wildcard catch-all endpoint",
+        )
+
+        function = self._create_serving_function(
+            name="wildcard-handler",
+            api_config=config,
+            func=str(self.assets_path / "wildcard_path_handler.py"),
+        )
+
+        graph = function.set_topology("flow", engine="sync", exist_ok=True)
+        graph.to(name="handler", handler="handle_wildcard").respond()
+
+        self._logger.debug("Deploying serving function with wildcard path")
+        function.deploy()
+        time.sleep(5)  # Wait for deployment to complete
+
+        # Verify a nested path under the wildcard is routed correctly
+        self._logger.debug("Invoking /api/wildcard/v1/data")
+        response = function.invoke(
+            path="/api/wildcard/v1/data",
+            method="POST",
+            body={},
+        )
+        assert response is not None, "Handler should return a response"
+        assert (
+            response["matched_path"] == "/api/wildcard/v1/data"
+        ), "mlrun_request_path should reflect the exact request path"
+
+        # Verify a different nested path also routes correctly
+        self._logger.debug("Invoking /api/wildcard/users/42")
+        response2 = function.invoke(
+            path="/api/wildcard/users/42",
+            method="POST",
+            body={},
+        )
+        assert (
+            response2["matched_path"] == "/api/wildcard/users/42"
+        ), "mlrun_request_path should reflect the request path for a different sub-path"
+
+        self._logger.info("Wildcard path API handler test passed")


### PR DESCRIPTION
## Summary

Implements wildcard `*` path matching for the serving API handler - [ML-11658](https://iguazio.atlassian.net/browse/ML-11658).

## Changes

### SDK (`mlrun/runtimes/nuclio/serving.py`)
- New `APIHandlerConfig._validate_path()` validates `*` rules at `add_endpoint_handler` time — fails early on the client side
- Rejects `*` that is not the last character (e.g. `/api/*/users`)
- Rejects paths with more than one `*`
- Raises `MLRunValueError`

### API Handler (`mlrun/serving/api_handler.py`)
- Three-phase matching with strict precedence: **exact → template → star**; insertion order respected within each group
- Star patterns compiled to a plain prefix string (`/api/*` → prefix `/api/`)
- `/api` does **not** match `/api/*`; `/apiv2/x` does **not** match `/api/*`
- All wildcard validation errors use `MLRunValueError`

### Tests (`tests/serving/test_api_handler.py`)
- 127 unit tests, all passing
- `TestStarPatternMatching`: 14 tests — basic match, validation, precedence, insertion order, method isolation, prefix boundary, allow/forbid
- `TestAPIHandlerConfig`: 3 new SDK-side validation tests
- Template insertion-order precedence test

### System test (`tests/system/runtimes/test_serving.py`)
- New `test_api_handler_wildcard_path`: serving function with `include_url_info=True` and `POST /api/wildcard/*`, asserts `mlrun_request_path`
- New asset: `tests/system/runtimes/assets/wildcard_path_handler.py`

## Testing
- Unit: `pytest tests/serving/test_api_handler.py` — 127 passed
- System - passed.

[ML-11658]: https://iguazio.atlassian.net/browse/ML-11658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ