### PR TITLE
[Pipelines] Fix parameter name

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-common"
-version = "0.6.2"
+version = "0.6.3"
 description = "MLRun Pipelines adapter package for providing KFP common functionality"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/src/mlrun_pipelines/common/ops.py
@@ -272,7 +272,7 @@ def mlrun_op(
     if name:
         cmd += ["--name", name]
     if auth_token_name:
-        cmd += ["--run-config", f"auth_token_name={auth_token_name}"]
+        cmd += ["--runtime-config", f"auth_token_name={auth_token_name}"]
     if func_url:
         cmd += ["-f", func_url]
     for secret in secrets:


### PR DESCRIPTION
### Description

Fixes workflow authentication when submitting Kubeflow Pipelines (KFP) workflows by passing `auth_token_name` via the correct CLI option. The KFP common ops were using `--run-config`, which is not consumed by MLRun’s CLI for `RuntimeConfigurationContext`. The change switches to `--runtime-config`, so `auth_token_name` is correctly applied to workflow step pods.

---

### Changes Made

---

### Checklist

- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### Testing

- UT

---

### References

- Ticket link: https://iguazio.atlassian.net/browse/ML-12181
- Design docs links:
- External links:

---

### Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### Additional Notes

- **Root cause**: The pipeline ops invoked `mlrun run` with `--run-config auth_token_name=...`, but the CLI only exposes `--runtime-config` (alias `-rc`) for `RuntimeConfigurationContext`. As a result, the auth token was never passed into the runtime context, and KFP workflow steps failed to authenticate.