### PR TITLE
[Serving] Fix lost outlet step in child function graph

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -373,6 +373,7 @@ def add_error_raiser_step(
             after=monitored_step.name,
             full_event=True,
             model_endpoint_creation_strategy=mlrun.common.schemas.ModelEndpointCreationStrategy.SKIP,
+            function=monitored_step.function,
         )
 
         # Add error raiser step after the unpacker

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1883,9 +1883,13 @@ class ModelRunner(storey.ParallelExecution):
         if "background_task_status_step" in self._name_to_outlet:
             sys_outlets.append("background_task_status_step")
         if self._raise_exception and self._is_error(event):
+            logger.info("error option, select_outlets returned", outlets=sys_outlets)
             return sys_outlets
         user_outlets = self.model_runner_selector.select_outlets(event)
         if user_outlets:
+            logger.info("model runner outlets option, select_outlets returned", outlets=(
+                user_outlets if isinstance(user_outlets, list) else [user_outlets]
+            ) + sys_outlets)
             return (
                 user_outlets if isinstance(user_outlets, list) else [user_outlets]
             ) + sys_outlets
@@ -1896,6 +1900,7 @@ class ModelRunner(storey.ParallelExecution):
             all_outlets.remove(f"{self.name}_error_raise")
         else:
             all_outlets.remove(f"{self.name}_unpacker")
+        logger.info("select_outlets returned", outlets=all_outlets)
         return all_outlets
 
     def _is_error(self, event: Union[dict, list]) -> bool:
@@ -2646,6 +2651,7 @@ class QueueStep(BaseStep, StepToDict):
         self._async_object = None
 
     def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
+        logger.info("Initializing QueueStep", step_name=self.name, path=self.path)
         self.context = context
         if self.path:
             self._stream = get_stream_pusher(
@@ -4033,6 +4039,7 @@ def _init_async_objects(context, steps, root):
         if hasattr(step, "async_object") and step._is_local_function(context):
             max_iterations = step._max_iterations or root.max_iterations
             if step.kind == StepKinds.queue:
+                logger.info("initializing async object for queue step '%s'", step.name)
                 skip_stream = context.is_mock and step.next
                 if step.path and not skip_stream:
                     stream_path = step.path

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1883,13 +1883,9 @@ class ModelRunner(storey.ParallelExecution):
         if "background_task_status_step" in self._name_to_outlet:
             sys_outlets.append("background_task_status_step")
         if self._raise_exception and self._is_error(event):
-            logger.info("error option, select_outlets returned", outlets=sys_outlets)
             return sys_outlets
         user_outlets = self.model_runner_selector.select_outlets(event)
         if user_outlets:
-            logger.info("model runner outlets option, select_outlets returned", outlets=(
-                user_outlets if isinstance(user_outlets, list) else [user_outlets]
-            ) + sys_outlets)
             return (
                 user_outlets if isinstance(user_outlets, list) else [user_outlets]
             ) + sys_outlets
@@ -1900,7 +1896,6 @@ class ModelRunner(storey.ParallelExecution):
             all_outlets.remove(f"{self.name}_error_raise")
         else:
             all_outlets.remove(f"{self.name}_unpacker")
-        logger.info("select_outlets returned", outlets=all_outlets)
         return all_outlets
 
     def _is_error(self, event: Union[dict, list]) -> bool:
@@ -2651,7 +2646,6 @@ class QueueStep(BaseStep, StepToDict):
         self._async_object = None
 
     def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        logger.info("Initializing QueueStep", step_name=self.name, path=self.path)
         self.context = context
         if self.path:
             self._stream = get_stream_pusher(
@@ -4039,7 +4033,6 @@ def _init_async_objects(context, steps, root):
         if hasattr(step, "async_object") and step._is_local_function(context):
             max_iterations = step._max_iterations or root.max_iterations
             if step.kind == StepKinds.queue:
-                logger.info("initializing async object for queue step '%s'", step.name)
                 skip_stream = context.is_mock and step.next
                 if step.path and not skip_stream:
                     stream_path = step.path
@@ -4060,6 +4053,7 @@ def _init_async_objects(context, steps, root):
                             DatastoreProfileKafkaTarget | DatastoreProfileKafkaStream,
                         ):
                             step._async_object = KafkaStoreyTarget(
+                                name=step.name,
                                 path=stream_path,
                                 context=context,
                                 max_iterations=max_iterations,
@@ -4067,6 +4061,7 @@ def _init_async_objects(context, steps, root):
                             )
                         elif isinstance(datastore_profile, DatastoreProfileV3io):
                             step._async_object = StreamStoreyTarget(
+                                name=step.name,
                                 stream_path=stream_path,
                                 context=context,
                                 max_iterations=max_iterations,
@@ -4085,6 +4080,7 @@ def _init_async_objects(context, steps, root):
                         )
 
                         step._async_object = storey.KafkaTarget(
+                            name=step.name,
                             topic=topic,
                             brokers=brokers,
                             producer_options=kafka_producer_options,
@@ -4094,6 +4090,7 @@ def _init_async_objects(context, steps, root):
                         )
                     elif stream_path.startswith("dummy://"):
                         step._async_object = _DummyStream(
+                            name=step.name,
                             context=context,
                             max_iterations=max_iterations,
                             **options,
@@ -4105,6 +4102,7 @@ def _init_async_objects(context, steps, root):
                         step._async_object = storey.StreamTarget(
                             storey.V3ioDriver(endpoint or config.v3io_api),
                             stream_path,
+                            name=step.name,
                             context=context,
                             max_iterations=max_iterations,
                             **options,


### PR DESCRIPTION
### 📝 Description

Fix while deploying function with child function graph got disconnected due to wrong function assignment to model runner outlet step.

---

### 🛠️ Changes Made

1. Added function field to unpack_step initialization
2. Add name to stream target initialization in `_init_async_objects`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

manual plus CI

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12175
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
