### PR TITLE
[SDK] Fix warning on launcher consumed arguments

### DIFF
--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -49,7 +49,7 @@ class BaseLauncher(abc.ABC):
         if not kwargs:
             return
 
-        valid_launch_params = set(inspect.signature(self.launch).parameters) - {"self"}
+        valid_launch_params = self._get_valid_launcher_params()
         for key in sorted(kwargs):
             if key in valid_launch_params:
                 continue
@@ -469,3 +469,22 @@ class BaseLauncher(abc.ABC):
         runtime: "mlrun.runtimes.BaseRuntime", result: dict, run: "mlrun.run.RunObject"
     ):
         pass
+
+    def _get_valid_launcher_params(self) -> frozenset[str]:
+        """
+        Union of params valid for launcher __init__ (should not warn on these).
+        Derived from: (1) launch() signature, (2) explicit __init__ params of launcher
+        subclasses (local, auth_info, etc.), (3) pass-through params (builder_env).
+        """
+        valid = set(inspect.signature(self.launch).parameters) - {"self"}
+
+        # Collect explicit __init__ params from this class and subclasses
+        for cls in type(self).__mro__:
+            if cls is object or not issubclass(cls, BaseLauncher):
+                continue
+            if "__init__" in cls.__dict__:
+                for name, param in inspect.signature(cls.__init__).parameters.items():
+                    if name != "self" and param.kind != inspect.Parameter.VAR_KEYWORD:
+                        valid.add(name)
+
+        return frozenset(valid)

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -473,8 +473,9 @@ class BaseLauncher(abc.ABC):
     def _get_valid_launcher_params(self) -> frozenset[str]:
         """
         Union of params valid for launcher __init__ (should not warn on these).
-        Derived from: (1) launch() signature, (2) explicit __init__ params of launcher
-        subclasses (local, auth_info, etc.), (3) pass-through params (builder_env).
+        Derived from:
+            (1) launch() signature,
+            (2) explicit __init__ params of launcher subclasses (local, auth_info, etc.).
         """
         valid = set(inspect.signature(self.launch).parameters) - {"self"}
 

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -77,7 +77,7 @@ def run_function(
     artifact_path: str | None = None,
     notifications: list[mlrun.model.Notification] | None = None,
     returns: "list[str | mlrun.LogHint] | None" = None,
-    builder_env: list | None = None,
+    builder_env: dict | None = None,
     reset_on_run: bool | None = None,
     output_path: str | None = None,
     retry: Union[mlrun.model.Retry, dict] | None = None,
@@ -236,6 +236,12 @@ def run_function(
         if local and project and function.spec.build.source:
             workdir = workdir or project.spec.get_code_path()
 
+        # builder_env is used when auto_build triggers deploy(); set on build spec so it
+        # reaches the build flow via func.to_dict() when launcher calls runtime.deploy()
+        if builder_env:
+            existing = function.spec.build.builder_env or {}
+            function.spec.build.builder_env = {**existing, **builder_env}
+
         # remove this filter once the artifact_path parameter is deprecated in 1.12.0
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=FutureWarning)
@@ -254,7 +260,6 @@ def run_function(
                 auto_build=auto_build,
                 schedule=schedule,
                 notifications=notifications,
-                builder_env=builder_env,
                 reset_on_run=reset_on_run,
             )
         if run_result:

--- a/server/py/services/api/runtime_handlers/kubejob.py
+++ b/server/py/services/api/runtime_handlers/kubejob.py
@@ -22,6 +22,7 @@ from packaging.version import parse as parse_version
 import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
+import mlrun.errors
 from mlrun.runtimes.base import RuntimeClassMode
 from mlrun.utils import logger
 

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -169,30 +169,6 @@ def test_run_warns_on_unexpected_kwarg_with_suggestion():
     assert not caught, "Expected no warnings, but got: {caught}"
 
 
-def test_run_no_warning_on_launcher_init_kwargs():
-    """ML-12201: local, builder_env etc. are valid launcher-init kwargs; no spurious warnings."""
-
-    def handler(context):
-        return None
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        # local is used for launcher routing; builder_env from pipeline ops
-        mlrun.new_function().run(
-            local=True,
-            handler=handler,
-            params={"x": 1},
-            builder_env={"GIT_TOKEN": "secret"},
-        )
-
-    unexpected = [
-        w for w in caught if "Unexpected run keyword argument" in str(w.message)
-    ]
-    assert not unexpected, (
-        f"Should not warn on launcher-init kwargs (local, builder_env): {unexpected}"
-    )
-
-
 def test_invalid_name():
     with pytest.raises(ValueError) as excinfo:
         # name cannot have / in it

--- a/tests/run/test_run.py
+++ b/tests/run/test_run.py
@@ -169,6 +169,30 @@ def test_run_warns_on_unexpected_kwarg_with_suggestion():
     assert not caught, "Expected no warnings, but got: {caught}"
 
 
+def test_run_no_warning_on_launcher_init_kwargs():
+    """ML-12201: local, builder_env etc. are valid launcher-init kwargs; no spurious warnings."""
+
+    def handler(context):
+        return None
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # local is used for launcher routing; builder_env from pipeline ops
+        mlrun.new_function().run(
+            local=True,
+            handler=handler,
+            params={"x": 1},
+            builder_env={"GIT_TOKEN": "secret"},
+        )
+
+    unexpected = [
+        w for w in caught if "Unexpected run keyword argument" in str(w.message)
+    ]
+    assert not unexpected, (
+        f"Should not warn on launcher-init kwargs (local, builder_env): {unexpected}"
+    )
+
+
 def test_invalid_name():
     with pytest.raises(ValueError) as excinfo:
         # name cannot have / in it


### PR DESCRIPTION
### Description

Addresses **ML-12201**: "Unexpected run keyword argument 'local' was ignored" (and similar warnings for `auth_info`, `builder_env`, etc.). These warnings appeared after PR #9331, which started validating kwargs in `BaseLauncher.__init__` against `launch()` parameters only, but some valid run-level arguments are used elsewhere (launcher init, routing, build flow) and were incorrectly reported as unknown.

This PR updates validation so launcher init considers all valid parameters, and ensures `builder_env` from `run_function` correctly reaches the build flow when `ClientRemoteLauncher` triggers deploy via `auto_build`.

---

### Changes Made


---

### Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### Testing

- Unite + manual runs to ensure warnings disappeared

---

### References

- Ticket link: https://iguazio.atlassian.net/browse/ML-12201
- Design docs links: —
- External links: —

---

### Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### Additional Notes

- `builder_env` is now applied on the function spec before `run()`, so it is included in `func.to_dict()` when `ClientRemoteLauncher` calls `runtime.deploy()`. The API server reads it from the function spec during the build.
- The new validation logic covers subclass `__init__` params, so future launcher kwargs (e.g. auth-related) do not need explicit pass-through entries.