### PR TITLE
[Model Monitoring] Fix wrong kwarg in delete_model_monitoring_lag_alert

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2838,7 +2838,7 @@ class MlrunProject(ModelObj):
         with contextlib.suppress(mlrun.errors.MLRunNotFoundError):
             db.delete_alert_config(
                 mm_constants.MonitoringAlertNames.LAG_DETECTED,
-                project_name=self.name,
+                project=self.name,
             )
 
     def set_function(

--- a/tests/model_monitoring/test_lag_detection.py
+++ b/tests/model_monitoring/test_lag_detection.py
@@ -426,7 +426,7 @@ _LAG_ALERT_PROJECT = "test-lag-alert"
 
 @pytest.fixture()
 def lag_alert_mock_db():
-    mock = unittest.mock.Mock()
+    mock = unittest.mock.Mock(spec=mlrun.db.httpdb.HTTPRunDB)
     with unittest.mock.patch("mlrun.db.get_run_db", return_value=mock):
         yield mock
 
@@ -521,7 +521,7 @@ class TestDeleteModelMonitoringLagAlert:
 
         lag_alert_mock_db.delete_alert_config.assert_called_once_with(
             MonitoringAlertNames.LAG_DETECTED,
-            project_name=_LAG_ALERT_PROJECT,
+            project=_LAG_ALERT_PROJECT,
         )
 
     def test_ignores_not_found_errors(self, lag_alert_mock_db, lag_alert_project):


### PR DESCRIPTION
## Summary
- `delete_model_monitoring_lag_alert` passed `project_name=` to `delete_alert_config`, but the method expects `project=`, causing a `TypeError` at runtime.
- The unit test had the same typo and the mock lacked `spec=HTTPRunDB`, so the mismatch was invisible.
- Added `spec=mlrun.db.httpdb.HTTPRunDB` to the test fixture mock so any future signature drift is caught at test time.

## Test plan
- [x] `tests/model_monitoring/test_lag_detection.py` — all 31 tests pass
- [x] Manually verified on live Iguazio cluster (vmdev76) that `project.delete_model_monitoring_lag_alert()` no longer raises `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)