### PR TITLE
[Model Monitoring] Use per-project Kafka consumer group

### DIFF
--- a/mlrun/datastore/datastore_profile.py
+++ b/mlrun/datastore/datastore_profile.py
@@ -173,7 +173,7 @@ class DatastoreProfileKafkaStream(DatastoreProfile):
     _private_attributes = ("kwargs_private", "sasl_user", "sasl_pass")
     brokers: typing.Union[str, list[str]]
     topics: typing.Union[str, list[str]]
-    group: str | None = "serving"
+    group: str | None = None
     initial_offset: str | None = "earliest"
     partitions: typing.Union[str, list[str]] | None
     sasl_user: str | None

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4044,6 +4044,20 @@ class MlrunProject(ModelObj):
         """
         db = mlrun.db.get_run_db(secrets=self._secrets)
 
+        stream_profile = db.get_datastore_profile(stream_profile_name, self.name)
+        if (
+            isinstance(
+                stream_profile,
+                mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
+            )
+            and stream_profile.group is not None
+        ):
+            logger.warning(
+                "Kafka profile 'group' is ignored for model monitoring;"
+                " the consumer group is set to the topic name"
+                " to prevent cross-project rebalance storms",
+            )
+
         db.set_model_monitoring_credentials(
             project=self.name,
             credentials={

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -441,12 +441,21 @@ class MonitoringDeployment:
         topic = mlrun.common.model_monitoring.helpers.get_kafka_topic(
             project=self.project, function_name=function_name
         )
+        if kafka_profile.group is not None:
+            logger.warning(
+                "Kafka profile 'group' is ignored for model monitoring;"
+                " using topic name as consumer group to prevent"
+                " cross-project rebalance storms",
+                project=self.project,
+                configured_group=kafka_profile.group,
+                effective_group=topic,
+            )
         profile_attributes = kafka_profile.attributes()
         stream_source = mlrun.datastore.sources.KafkaSource(
             brokers=kafka_profile.brokers,
             topics=[topic],
             # Use topic as consumer group to isolate per project+function,
-            # preventing cross-project rebalance storms (ML-11979).
+            # preventing cross-project rebalance storms.
             group=topic,
             initial_offset=kafka_profile.initial_offset,
             partitions=kafka_profile.partitions,
@@ -474,7 +483,7 @@ class MonitoringDeployment:
                     # from the old shared consumer group to per-topic groups.
                     self._migrate_consumer_group_offsets(
                         kafka_profile=kafka_profile,
-                        old_group=kafka_profile.group,
+                        old_group="serving",
                         new_group=topic,
                         topic=topic,
                     )

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -469,12 +469,38 @@ class MonitoringDeployment:
             )
         except kafka.errors.TopicAlreadyExistsError as exc:
             if ignore_stream_already_exists_failure:
-                logger.info(
-                    "Kafka topic of model monitoring stream already exists. "
-                    "Skipping topic creation and using `earliest` offset",
-                    project=self.project,
-                    error_message=mlrun.errors.err_to_str(exc),
-                )
+                if function_name == mm_constants.MonitoringFunctionNames.STREAM:
+                    # TODO: Remove in 1.13.0 — one-time upgrade handling
+                    # from the old shared consumer group to per-topic groups.
+                    if not self._consumer_group_has_offsets(
+                        kafka_profile=kafka_profile,
+                        group=topic,
+                        topic=topic,
+                    ):
+                        # First upgrade: the new per-topic group has no
+                        # committed offsets yet.  Use "latest" so the new
+                        # consumer starts from the current end of the topic
+                        # rather than replaying from the beginning.
+                        stream_source.attributes["initial_offset"] = "latest"
+                        logger.info(
+                            "Upgrade detected: setting initial_offset to latest "
+                            "for new per-topic consumer group",
+                            project=self.project,
+                            topic=topic,
+                        )
+                    else:
+                        logger.info(
+                            "Kafka topic of model monitoring stream already "
+                            "exists, skipping topic creation",
+                            project=self.project,
+                            topic=topic,
+                        )
+                else:
+                    logger.debug(
+                        "Kafka topic already exists",
+                        project=self.project,
+                        topic=topic,
+                    )
             else:
                 raise exc
 
@@ -488,6 +514,46 @@ class MonitoringDeployment:
             function.with_annotations(nuclio_annotations)
         function.spec.min_replicas = stream_args.kafka.min_replicas
         function.spec.max_replicas = stream_args.kafka.max_replicas
+
+    # TODO: Remove in 1.13.0 — one-time upgrade detection from the old
+    # shared consumer group to per-topic groups (ML-11979).
+    def _consumer_group_has_offsets(
+        self,
+        *,
+        kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
+        group: str,
+        topic: str,
+    ) -> bool:
+        """Check whether *group* has committed offsets for *topic*.
+
+        :param kafka_profile: Kafka datastore profile with broker credentials.
+        :param group:         Consumer group name to check.
+        :param topic:         Topic to filter offsets by.
+        """
+        from kafka.admin import KafkaAdminClient
+
+        try:
+            profile_attributes = kafka_profile.attributes()
+            admin_kwargs = mlrun.datastore.utils.KafkaParameters(
+                profile_attributes
+            ).admin()
+            admin = KafkaAdminClient(
+                bootstrap_servers=kafka_profile.brokers, **admin_kwargs
+            )
+            try:
+                offsets = admin.list_consumer_group_offsets(group)
+                return any(tp.topic == topic for tp in offsets)
+            finally:
+                admin.close()
+        except Exception as exc:
+            logger.warning(
+                "Failed to check consumer group offsets, assuming upgrade (no offsets)",
+                project=self.project,
+                group=group,
+                topic=topic,
+                exc=mlrun.errors.err_to_str(exc),
+            )
+            return False
 
     @staticmethod
     def create_model_monitoring_stream(

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -472,29 +472,12 @@ class MonitoringDeployment:
                 if function_name == mm_constants.MonitoringFunctionNames.STREAM:
                     # TODO: Remove in 1.13.0 — one-time upgrade handling
                     # from the old shared consumer group to per-topic groups.
-                    if not self._consumer_group_has_offsets(
+                    self._migrate_consumer_group_offsets(
                         kafka_profile=kafka_profile,
-                        group=topic,
+                        old_group=kafka_profile.group,
+                        new_group=topic,
                         topic=topic,
-                    ):
-                        # First upgrade: the new per-topic group has no
-                        # committed offsets yet.  Use "latest" so the new
-                        # consumer starts from the current end of the topic
-                        # rather than replaying from the beginning.
-                        stream_source.attributes["initial_offset"] = "latest"
-                        logger.info(
-                            "Upgrade detected: setting initial_offset to latest "
-                            "for new per-topic consumer group",
-                            project=self.project,
-                            topic=topic,
-                        )
-                    else:
-                        logger.info(
-                            "Kafka topic of model monitoring stream already "
-                            "exists, skipping topic creation",
-                            project=self.project,
-                            topic=topic,
-                        )
+                    )
                 else:
                     logger.debug(
                         "Kafka topic already exists",
@@ -515,45 +498,113 @@ class MonitoringDeployment:
         function.spec.min_replicas = stream_args.kafka.min_replicas
         function.spec.max_replicas = stream_args.kafka.max_replicas
 
-    # TODO: Remove in 1.13.0 — one-time upgrade detection from the old
+    # TODO: Remove in 1.13.0 — one-time offset migration from the old
     # shared consumer group to per-topic groups (ML-11979).
-    def _consumer_group_has_offsets(
+    def _migrate_consumer_group_offsets(
         self,
         *,
         kafka_profile: mlrun.datastore.datastore_profile.DatastoreProfileKafkaStream,
-        group: str,
+        old_group: str,
+        new_group: str,
         topic: str,
-    ) -> bool:
-        """Check whether *group* has committed offsets for *topic*.
+    ) -> None:
+        """Copy committed offsets from *old_group* to *new_group* for *topic*.
+
+        If the new group already has offsets, this is a no-op (already migrated).
+        If the old group has no offsets for this topic, nothing to migrate.
 
         :param kafka_profile: Kafka datastore profile with broker credentials.
-        :param group:         Consumer group name to check.
-        :param topic:         Topic to filter offsets by.
+        :param old_group:     The previous shared consumer group name.
+        :param new_group:     The new per-topic consumer group name.
+        :param topic:         Topic to migrate offsets for.
         """
+        from kafka import KafkaConsumer, TopicPartition
         from kafka.admin import KafkaAdminClient
+        from kafka.structs import OffsetAndMetadata
 
         try:
             profile_attributes = kafka_profile.attributes()
             admin_kwargs = mlrun.datastore.utils.KafkaParameters(
                 profile_attributes
             ).admin()
+            consumer_kwargs = mlrun.datastore.utils.KafkaParameters(
+                profile_attributes
+            ).consumer()
             admin = KafkaAdminClient(
                 bootstrap_servers=kafka_profile.brokers, **admin_kwargs
             )
             try:
-                offsets = admin.list_consumer_group_offsets(group)
-                return any(tp.topic == topic for tp in offsets)
+                # Check if the new group already has offsets (already migrated)
+                new_offsets = admin.list_consumer_group_offsets(new_group)
+                if any(tp.topic == topic for tp in new_offsets):
+                    logger.debug(
+                        "New consumer group already has offsets, skipping migration",
+                        project=self.project,
+                        new_group=new_group,
+                        topic=topic,
+                    )
+                    return
+
+                # Read offsets from the old shared group for this topic
+                old_offsets = admin.list_consumer_group_offsets(old_group)
+                topic_offsets = {
+                    tp: offset
+                    for tp, offset in old_offsets.items()
+                    if tp.topic == topic
+                }
+
+                if not topic_offsets:
+                    logger.info(
+                        "Old consumer group has no offsets for topic, "
+                        "nothing to migrate",
+                        project=self.project,
+                        old_group=old_group,
+                        topic=topic,
+                    )
+                    return
             finally:
                 admin.close()
+
+            # Commit old offsets under the new group using a temporary consumer
+            # (kafka-python's KafkaAdminClient lacks an offset commit API).
+            consumer = KafkaConsumer(
+                bootstrap_servers=kafka_profile.brokers,
+                group_id=new_group,
+                enable_auto_commit=False,
+                **consumer_kwargs,
+            )
+            try:
+                partitions = [
+                    TopicPartition(tp.topic, tp.partition) for tp in topic_offsets
+                ]
+                consumer.assign(partitions)
+                offsets_to_commit = {
+                    TopicPartition(tp.topic, tp.partition): OffsetAndMetadata(
+                        offset.offset, offset.metadata, offset.leader_epoch
+                    )
+                    for tp, offset in topic_offsets.items()
+                }
+                consumer.commit(offsets_to_commit)
+                logger.info(
+                    "Migrated consumer group offsets from old group to new group",
+                    project=self.project,
+                    old_group=old_group,
+                    new_group=new_group,
+                    topic=topic,
+                    partitions=len(offsets_to_commit),
+                )
+            finally:
+                consumer.close()
         except Exception as exc:
             logger.warning(
-                "Failed to check consumer group offsets, assuming upgrade (no offsets)",
+                "Failed to migrate consumer group offsets, "
+                "new group will start from initial_offset",
                 project=self.project,
-                group=group,
+                old_group=old_group,
+                new_group=new_group,
                 topic=topic,
                 exc=mlrun.errors.err_to_str(exc),
             )
-            return False
 
     @staticmethod
     def create_model_monitoring_stream(
@@ -1292,15 +1343,17 @@ class MonitoringDeployment:
     ):
         import kafka
 
-        consumer = kafka.KafkaConsumer(
-            bootstrap_servers=self.__stream_profile.brokers,
-            group_id=self.__stream_profile.group,
-        )
         # Iterate over each function and get the stream stats
         for function in function_summaries:
             normalized_function_name = mlrun.utils.normalize_name(function.name)
             topic = mlrun.common.model_monitoring.helpers.get_kafka_topic(
                 project=self.project, function_name=normalized_function_name
+            )
+            # Use the topic as consumer group to match the per-topic
+            # group used by the Nuclio trigger (ML-11979).
+            consumer = kafka.KafkaConsumer(
+                bootstrap_servers=self.__stream_profile.brokers,
+                group_id=topic,
             )
             try:
                 partitions = consumer.partitions_for_topic(topic)
@@ -1347,6 +1400,8 @@ class MonitoringDeployment:
                     topic=topic,
                     error_message=mlrun.errors.err_to_str(exc),
                 )
+            finally:
+                consumer.close()
 
     async def _get_function_summary_applications(
         self,

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -445,7 +445,9 @@ class MonitoringDeployment:
         stream_source = mlrun.datastore.sources.KafkaSource(
             brokers=kafka_profile.brokers,
             topics=[topic],
-            group=kafka_profile.group,
+            # Use topic as consumer group to isolate per project+function,
+            # preventing cross-project rebalance storms (ML-11979).
+            group=topic,
             initial_offset=kafka_profile.initial_offset,
             partitions=kafka_profile.partitions,
             attributes={

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -441,15 +441,6 @@ class MonitoringDeployment:
         topic = mlrun.common.model_monitoring.helpers.get_kafka_topic(
             project=self.project, function_name=function_name
         )
-        if kafka_profile.group is not None:
-            logger.warning(
-                "Kafka profile 'group' is ignored for model monitoring;"
-                " using topic name as consumer group to prevent"
-                " cross-project rebalance storms",
-                project=self.project,
-                configured_group=kafka_profile.group,
-                effective_group=topic,
-            )
         profile_attributes = kafka_profile.attributes()
         stream_source = mlrun.datastore.sources.KafkaSource(
             brokers=kafka_profile.brokers,

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -283,7 +283,7 @@ def test_kafka_upgrade_calls_offset_migration(
 
     migrate_offsets_mock.assert_called_once()
     call_kwargs = migrate_offsets_mock.call_args.kwargs
-    assert call_kwargs["old_group"] == kafka_profile.group
+    assert call_kwargs["old_group"] == "serving"
     assert call_kwargs["new_group"] == call_kwargs["topic"]
 
 

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -215,3 +215,106 @@ def test_apply_and_create_kafka_source(
     assert (
         fn.spec.base_spec.get("metadata", {}).get("annotations") == nuclio_annotations
     ), "The set annotations are different than expected"
+
+
+@patch("mlrun.datastore.sources.KafkaSource.create_topics")
+def test_kafka_consumer_group_uses_topic_name(
+    create_topics_mock: Mock,
+    monitoring_deployment: mm_dep.MonitoringDeployment,
+) -> None:
+    """ML-11979: Consumer group should be the topic name to isolate
+    per project+function and prevent cross-project rebalance storms."""
+    kafka_profile = DatastoreProfileKafkaStream(
+        name="test-kafka-profile",
+        brokers=["localhost:9092"],
+        topics=[],
+    )
+
+    fn = mlrun.runtimes.ServingRuntime()
+    monitoring_deployment._apply_and_create_kafka_source(
+        kafka_profile=kafka_profile,
+        function=fn,
+        function_name="model-monitoring-stream",
+        stream_args=mlrun.mlconf.model_endpoint_monitoring.serving_stream,
+        ignore_stream_already_exists_failure=True,
+    )
+
+    kafka_trigger_conf = fn.spec.config.get("spec.triggers.kafka")
+    assert kafka_trigger_conf, "Expected a Kafka trigger"
+
+    trigger_attrs = kafka_trigger_conf.get("attributes", {})
+    topic = trigger_attrs["topics"][0]
+    consumer_group = trigger_attrs["consumerGroup"]
+    assert consumer_group == topic, (
+        f"ML-11979: Consumer group should equal topic for isolation, "
+        f"got group={consumer_group!r}, topic={topic!r}"
+    )
+
+
+@patch(
+    "mlrun.datastore.sources.KafkaSource.create_topics",
+    side_effect=kafka.errors.TopicAlreadyExistsError(),
+)
+@patch(
+    "services.api.crud.model_monitoring.deployment.MonitoringDeployment"
+    "._consumer_group_has_offsets",
+    return_value=False,
+)
+def test_kafka_upgrade_sets_latest_offset(
+    has_offsets_mock: Mock,
+    create_topics_mock: Mock,
+    monitoring_deployment: mm_dep.MonitoringDeployment,
+) -> None:
+    """ML-11979: On upgrade (topic exists, new consumer group has no
+    offsets), initial_offset should be set to 'latest'."""
+    kafka_profile = DatastoreProfileKafkaStream(
+        name="test-kafka-profile",
+        brokers=["localhost:9092"],
+        topics=[],
+    )
+
+    fn = mlrun.runtimes.ServingRuntime()
+    monitoring_deployment._apply_and_create_kafka_source(
+        kafka_profile=kafka_profile,
+        function=fn,
+        function_name="model-monitoring-stream",
+        stream_args=mlrun.mlconf.model_endpoint_monitoring.serving_stream,
+        ignore_stream_already_exists_failure=True,
+    )
+
+    has_offsets_mock.assert_called_once()
+    trigger_attrs = fn.spec.config["spec.triggers.kafka"]["attributes"]
+    assert trigger_attrs["initialOffset"] == "latest"
+
+
+@patch(
+    "mlrun.datastore.sources.KafkaSource.create_topics",
+    side_effect=kafka.errors.TopicAlreadyExistsError(),
+)
+@patch(
+    "services.api.crud.model_monitoring.deployment.MonitoringDeployment"
+    "._consumer_group_has_offsets",
+)
+def test_kafka_existing_non_stream_topic_skips_group_check(
+    has_offsets_mock: Mock,
+    create_topics_mock: Mock,
+    monitoring_deployment: mm_dep.MonitoringDeployment,
+) -> None:
+    """Non-stream functions (writer, controller, apps) should not
+    check consumer group offsets when their topic already exists."""
+    kafka_profile = DatastoreProfileKafkaStream(
+        name="test-kafka-profile",
+        brokers=["localhost:9092"],
+        topics=[],
+    )
+
+    fn = mlrun.runtimes.ServingRuntime()
+    monitoring_deployment._apply_and_create_kafka_source(
+        kafka_profile=kafka_profile,
+        function=fn,
+        function_name="model-monitoring-writer",
+        stream_args=mlrun.mlconf.model_endpoint_monitoring.writer_stream_args,
+        ignore_stream_already_exists_failure=True,
+    )
+
+    has_offsets_mock.assert_not_called()

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -257,16 +257,15 @@ def test_kafka_consumer_group_uses_topic_name(
 )
 @patch(
     "services.api.crud.model_monitoring.deployment.MonitoringDeployment"
-    "._consumer_group_has_offsets",
-    return_value=False,
+    "._migrate_consumer_group_offsets",
 )
-def test_kafka_upgrade_sets_latest_offset(
-    has_offsets_mock: Mock,
+def test_kafka_upgrade_calls_offset_migration(
+    migrate_offsets_mock: Mock,
     create_topics_mock: Mock,
     monitoring_deployment: mm_dep.MonitoringDeployment,
 ) -> None:
-    """ML-11979: On upgrade (topic exists, new consumer group has no
-    offsets), initial_offset should be set to 'latest'."""
+    """ML-11979: On upgrade (topic already exists), offset migration
+    should be called for the stream function."""
     kafka_profile = DatastoreProfileKafkaStream(
         name="test-kafka-profile",
         brokers=["localhost:9092"],
@@ -282,9 +281,10 @@ def test_kafka_upgrade_sets_latest_offset(
         ignore_stream_already_exists_failure=True,
     )
 
-    has_offsets_mock.assert_called_once()
-    trigger_attrs = fn.spec.config["spec.triggers.kafka"]["attributes"]
-    assert trigger_attrs["initialOffset"] == "latest"
+    migrate_offsets_mock.assert_called_once()
+    call_kwargs = migrate_offsets_mock.call_args.kwargs
+    assert call_kwargs["old_group"] == kafka_profile.group
+    assert call_kwargs["new_group"] == call_kwargs["topic"]
 
 
 @patch(
@@ -293,15 +293,15 @@ def test_kafka_upgrade_sets_latest_offset(
 )
 @patch(
     "services.api.crud.model_monitoring.deployment.MonitoringDeployment"
-    "._consumer_group_has_offsets",
+    "._migrate_consumer_group_offsets",
 )
-def test_kafka_existing_non_stream_topic_skips_group_check(
-    has_offsets_mock: Mock,
+def test_kafka_existing_non_stream_topic_skips_migration(
+    migrate_offsets_mock: Mock,
     create_topics_mock: Mock,
     monitoring_deployment: mm_dep.MonitoringDeployment,
 ) -> None:
     """Non-stream functions (writer, controller, apps) should not
-    check consumer group offsets when their topic already exists."""
+    trigger offset migration when their topic already exists."""
     kafka_profile = DatastoreProfileKafkaStream(
         name="test-kafka-profile",
         brokers=["localhost:9092"],
@@ -317,4 +317,4 @@ def test_kafka_existing_non_stream_topic_skips_group_check(
         ignore_stream_already_exists_failure=True,
     )
 
-    has_offsets_mock.assert_not_called()
+    migrate_offsets_mock.assert_not_called()


### PR DESCRIPTION
## Summary

- Set the Kafka consumer group to the topic name (already unique per project+function) instead of the shared profile group
- Prevents cross-project rebalance storms that cause data loss when multiple monitoring projects share the same consumer group
- Migrate committed offsets from the old shared group to the new per-topic group on upgrade

From [Kafka Consumer Group Rebalance (Lydtech)](https://www.lydtechconsulting.com/blog/kafka-consumer-group-rebalance---part-1-of-2):
> "If a service has multiple consumers that listen to mutually exclusive topics but that share the same group.id then any rebalance triggered by any one consumer would still affect the other consumers in the group."

## Changes Made

- **`server/py/services/api/crud/model_monitoring/deployment.py`**:
  - `group=kafka_profile.group` → `group=topic` for per-project+function isolation
  - Add `_migrate_consumer_group_offsets()` — on upgrade, copies committed offsets from the old `"serving"` group to the new per-topic group
- **`mlrun/datastore/datastore_profile.py`**: Change `DatastoreProfileKafkaStream.group` default from `"serving"` to `None`
- **`mlrun/projects/project.py`**: Warn in `set_model_monitoring_credentials()` when Kafka profile has explicit `group` (ignored for model monitoring)
- **`server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py`**: Tests for consumer group assignment and offset migration

## Backward Compatibility

On upgrade, `_migrate_consumer_group_offsets()` copies committed offsets from the old `"serving"` group to the new per-topic group so consumers resume where they left off.

## Reference

- Jira: ML-11979
- [Kafka Consumer Group Rebalance - Lydtech](https://www.lydtechconsulting.com/blog/kafka-consumer-group-rebalance---part-1-of-2)