### PR TITLE
[Serving] Detect body_map vs path template param name conflicts at init time

### DIFF
--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -223,6 +223,23 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                 )
             # else: exact endpoint – handled by dict lookup, no compilation needed
 
+        # Validate that body_map parameter names don't overlap with path template
+        # parameter names. This is a static conflict that can be caught early,
+        # before any request arrives.
+        if self._parsed_body_map and template_patterns:
+            body_map_names = set(self._parsed_body_map.keys())
+            for _, compiled_pattern, _, _ in template_patterns:
+                path_param_names = set(compiled_pattern.groupindex.keys())
+                overlapping = body_map_names & path_param_names
+                if overlapping:
+                    raise mlrun.errors.MLRunValueError(
+                        f"Configuration conflict: body_map parameter(s) "
+                        f"{', '.join(sorted(overlapping))} overlap with path template "
+                        f"parameter(s) in pattern '{compiled_pattern.pattern}'. "
+                        f"Rename the body_map parameter(s) or the path template "
+                        f"placeholder(s) to avoid ambiguity."
+                    )
+
         return template_patterns, star_patterns
 
     def _apply_parsed_body_map(self, body: dict) -> "_MappedBody":

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -1059,10 +1059,8 @@ class TestAPIHandlerMockServer:
         finally:
             server.wait_for_completion()
 
-    def test_api_handler_parameter_conflict_error(
-        self,
-    ) -> None:
-        """Test that parameter conflicts from multiple sources raise error"""
+    def test_api_handler_body_map_path_conflict_at_init(self) -> None:
+        """Test that body_map vs path template conflicts are caught at init time"""
 
         def handler(**kwargs):
             return {"id": kwargs.get("id")}
@@ -1084,14 +1082,47 @@ class TestAPIHandlerMockServer:
         graph = fn.set_topology("flow", engine="sync")
         graph.to(name="handler", handler=handler).respond()
 
+        # Conflict should be raised at mock server init, not at request time
+        with pytest.raises(
+            mlrun.errors.MLRunValueError,
+            match="Configuration conflict.*body_map parameter.*id.*overlap with path template",
+        ):
+            fn.to_mock_server()
+
+    def test_api_handler_parameter_conflict_error(
+        self,
+    ) -> None:
+        """Test that parameter conflicts from multiple sources raise error at request time"""
+
+        def handler(**kwargs):
+            return {"limit": kwargs.get("limit")}
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-param-conflict", kind="serving"),
+        )
+
+        config = APIHandlerConfig()
+        # Use a path template with 'category' (no body_map overlap) so init passes,
+        # but the query string at request time will conflict with 'limit' from path.
+        config.add_endpoint_handler(
+            "/items/{category}/{limit}",
+            HTTPMethod.GET,
+            APIHandlerAction.ALLOW,
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="handler", handler=handler).respond()
+
         server = fn.to_mock_server()
         try:
-            # Should raise 400 Bad Request due to parameter conflict
+            # Should raise 400 Bad Request due to runtime parameter conflict
+            # (path 'limit' = "50" vs query 'limit' = "100")
             with pytest.raises(RuntimeError, match="400.*Parameter name conflict"):
                 server.test(
-                    "/items/path-id",
-                    method="POST",
-                    body={"identifier": "body-id"},
+                    "/items/electronics/50?limit=100",
+                    method="GET",
                 )
         finally:
             server.wait_for_completion()


### PR DESCRIPTION
## What
Detect overlapping parameter names between body_map and path template placeholders at init time rather than only at request time.

## Why
When a user configures a body_map key that collides with a path template placeholder, the conflict is deterministic and known at configuration time. Previously this only raised a 400 error on every request. Now it raises MLRunValueError eagerly during graph initialization.

Runtime conflicts (path vs query param with the same name) remain detected at request time with the existing 400 response.

## Changes
- mlrun/serving/api_handler.py: Added validation in _compile_patterns that cross-references body_map parameter names against path template named groups.
- tests/serving/test_api_handler.py: Added test for init-time detection. Updated runtime conflict test to cover the path-vs-query scenario from the bug report.

## Jira
[ML-12210](https://iguazio.atlassian.net/browse/ML-12210)


[ML-12210]: https://iguazio.atlassian.net/browse/ML-12210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ