### PR TITLE
[Serving] Fix QueueStep initialization 

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -805,7 +805,7 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
                     class_args,
                     name=key,
                     handler=handler,
-                    function=child_function,
+                    function=child_function or graph.function,
                     model_endpoint_creation_strategy=creation_strategy,
                     endpoint_type=schemas.EndpointType.LEAF_EP,
                 )

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -654,7 +654,9 @@ def v2_serving_init(context, namespace=None):
         **kwargs,
     )
     context.logger.info("Initializing graph steps")
-    server.init_object(namespace or get_caller_globals())
+    server.init_object(
+        namespace or get_caller_globals(),
+    )
 
     # Select the appropriate handler based on streaming mode
     if server.streaming:
@@ -806,7 +808,9 @@ async def async_execute_graph(
         **kwargs,
     )
     context.logger.info("Initializing graph steps")
-    server.init_object(namespace)
+    server.init_object(
+        namespace,
+    )
 
     context.logger.info_with("Graph was initialized", verbose=server.verbose)
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -3689,6 +3689,8 @@ class RootFlowStep(FlowStep):
             if isinstance(step, mlrun.serving.MonitoredStep)
         }
 
+    def _is_local_function(self, context, current_function=None) -> bool:
+        return True
 
 class HubTaskStep(TaskStep):
     """hub task execution step, runs a class or handler from a hub"""

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -3692,6 +3692,7 @@ class RootFlowStep(FlowStep):
     def _is_local_function(self, context, current_function=None) -> bool:
         return True
 
+
 class HubTaskStep(TaskStep):
     """hub task execution step, runs a class or handler from a hub"""
 

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -134,6 +134,7 @@ class BaseStep(ModelObj):
         "on_error",
         "max_iterations",
         "cycle_from",
+        "function",
     ]
     _default_fields_to_strip = _default_fields_to_strip_from_step
 
@@ -143,6 +144,7 @@ class BaseStep(ModelObj):
         after: list | None = None,
         shape: str | None = None,
         max_iterations: int | None = None,
+        function: str | None = None,
     ):
         self.name = name
         self._parent = None
@@ -158,6 +160,8 @@ class BaseStep(ModelObj):
         )
         self._max_iterations = max_iterations
         self.cycle_from = []
+        self.function = function
+        self._should_init = True  # flag to control whether to initialize object
 
     def get_shape(self):
         """graphviz shape"""
@@ -289,12 +293,31 @@ class BaseStep(ModelObj):
 
         return self
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        """init the step class"""
+    def init_object(
+        self,
+        context,
+        namespace: str,
+        mode: str = "sync",
+        reset: bool = False,
+        engine: str = "async",
+        **extra_kwargs,
+    ):
         self.context = context
+        # determine if this step should be initialized
+        self._should_init = self._is_local_function(context)
 
-    def _is_local_function(self, context, current_function=None):
-        return True
+    def _is_local_function(self, context, current_function=None) -> bool:
+        # detect if the class is local (and should be initialized)
+        current_function = current_function or get_current_function(context)
+        if current_function == "*":
+            return True
+        if not self.function and not current_function:
+            return True
+        if (
+            self.function and self.function == "*"
+        ) or self.function == current_function:
+            return True
+        return False
 
     def get_children(self):
         """get child steps (for router/flow)"""
@@ -725,7 +748,6 @@ class TaskStep(BaseStep):
         "class_args",
         "handler",
         "skip_context",
-        "function",
         "shape",
         "full_event",
         "responder",
@@ -752,11 +774,10 @@ class TaskStep(BaseStep):
         | None = schemas.ModelEndpointCreationStrategy.SKIP,
         endpoint_type: schemas.EndpointType | None = schemas.EndpointType.NODE_EP,
     ):
-        super().__init__(name, after)
+        super().__init__(name, after, function=function)
         self.class_name = class_name
         self.class_args = class_args or {}
         self.handler = handler
-        self.function = function
         self._handler = None
         self._outlets_selector = None
         self._object = None
@@ -807,31 +828,23 @@ class TaskStep(BaseStep):
             if hasattr(self._object, "select_outlets"):
                 self._outlets_selector = self._object.select_outlets
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        self.context = context
+    def init_object(
+        self,
+        context,
+        namespace: str,
+        mode: str = "sync",
+        reset: bool = False,
+        engine: str = "async",
+        **extra_kwargs,
+    ):
+        super().init_object(context, namespace, mode, reset, engine, **extra_kwargs)
+        if not self._should_init:
+            # skip further initialization for non-local functions
+            return
         self._async_object = None
-        if not self._is_local_function(context):
-            # skip init of non local functions
-            return
-
-        if self.handler and not self.class_name:
-            # link to function
-            if callable(self.handler):
-                self._handler = self.handler
-                self.handler = self.handler.__name__
-            else:
-                self._handler = get_function(self.handler, namespace)
-            args = signature(self._handler).parameters
-            if args and "context" in list(args.keys()):
-                self._inject_context = True
-            self._set_error_handler()
-            return
-
-        self._class_object, self.class_name = self.get_step_class_object(
-            namespace=namespace
-        )
-
-        self._init_class_object_and_handler(namespace, reset, **extra_kwargs)
+        self.set_class_object_or_handler(namespace)
+        if self._class_object:
+            self._init_class_object_and_handler(namespace, reset, **extra_kwargs)
 
         self._set_error_handler()
         if mode != "skip":
@@ -872,18 +885,22 @@ class TaskStep(BaseStep):
                 class_object = get_class(class_name or self._default_class, namespace)
         return class_object, class_name
 
-    def _is_local_function(self, context, current_function=None) -> bool:
-        # detect if the class is local (and should be initialized)
-        current_function = current_function or get_current_function(context)
-        if current_function == "*":
-            return True
-        if not self.function and not current_function:
-            return True
-        if (
-            self.function and self.function == "*"
-        ) or self.function == current_function:
-            return True
-        return False
+    def set_class_object_or_handler(self, namespace) -> None:
+        if self.handler and not self.class_name:
+            # link to function
+            if callable(self.handler):
+                self._handler = self.handler
+                self.handler = self.handler.__name__
+            else:
+                self._handler = get_function(self.handler, namespace)
+            args = signature(self._handler).parameters
+            if args and "context" in list(args.keys()):
+                self._inject_context = True
+            self._class_object = None
+        else:
+            self._class_object, self.class_name = self.get_step_class_object(
+                namespace=namespace
+            )
 
     @property
     def async_object(self):
@@ -1157,18 +1174,26 @@ class RouterStep(TaskStep):
         for key in routes:
             del self._routes[key]
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
+    def init_object(
+        self,
+        context,
+        namespace: str,
+        mode: str = "sync",
+        reset: bool = False,
+        engine: str = "async",
+        **extra_kwargs,
+    ):
         if not self.routes:
             raise mlrun.errors.MLRunRuntimeError(
                 "You have to add models to the router step before initializing it"
             )
-        if not self._is_local_function(context):
-            return
-
         self.class_args = self.class_args or {}
         super().init_object(
             context, namespace, "skip", reset=reset, routes=self._routes, **extra_kwargs
         )
+        if not self._should_init:
+            # skip further initialization for non-local functions
+            return
 
         for route in self._routes.values():
             if self.function and not route.function:
@@ -2487,11 +2512,7 @@ class ModelRunnerStep(MonitoredStep):
         self.max_threads = max_threads
         self.pool_factor = pool_factor
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        self.context = context
-        if not self._is_local_function(context):
-            # skip init of non local functions
-            return
+    def _init_class_object_and_handler(self, namespace, reset, **extra_kwargs):
         model_selector, model_selector_params = self.class_args.get(
             "model_selector", (None, None)
         )
@@ -2540,7 +2561,7 @@ class ModelRunnerStep(MonitoredStep):
                 model_name
             )
             model._streaming_enabled = getattr(
-                getattr(context, "server", None), "streaming", False
+                getattr(self.context, "server", None), "streaming", False
             )
             model_objects.append(model)
         self._async_object = ModelRunner(
@@ -2549,7 +2570,7 @@ class ModelRunnerStep(MonitoredStep):
             execution_mechanism_by_runnable_name=execution_mechanism_by_model_name,
             shared_proxy_mapping=self._shared_proxy_mapping or None,
             name=self.name,
-            context=context,
+            context=self.context,
             max_processes=self.max_processes,
             max_threads=self.max_threads,
             pool_factor=self.pool_factor,
@@ -2649,9 +2670,20 @@ class QueueStep(BaseStep, StepToDict):
         self._stream = None
         self._async_object = None
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        self.context = context
-        if self.path:
+    def init_object(
+        self,
+        context,
+        namespace: str,
+        mode: str = "sync",
+        reset: bool = False,
+        engine: str = "async",
+        **extra_kwargs,
+    ):
+        super().init_object(context, namespace, mode, reset, engine, **extra_kwargs)
+        if not self._should_init:
+            # skip further initialization for non-local functions
+            return
+        if engine == "sync" and self.path:
             self._stream = get_stream_pusher(
                 self.path,
                 shards=self.shards,
@@ -2912,15 +2944,26 @@ class FlowStep(BaseStep):
     def __iter__(self):
         yield from self._steps.keys()
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        """initialize graph objects and classes"""
-        self.context = context
+    def init_object(
+        self,
+        context,
+        namespace: str,
+        mode: str = "sync",
+        reset: bool = False,
+        engine: str = "async",
+        **extra_kwargs,
+    ):
+        super().init_object(context, namespace, mode, reset, engine, **extra_kwargs)
+        if not self._should_init:
+            # skip further initialization for non-local functions
+            return
+        self._init_shared_resources(namespace=namespace)
         self._insert_all_error_handlers()
         self.check_and_process_graph()
 
         for step in self.steps.values():
             step.set_parent(self)
-            step.init_object(context, namespace, mode, reset=reset)
+            step.init_object(context, namespace, mode, reset=reset, engine=self.engine)
         self._set_error_handler()
         self._post_init(mode)
 
@@ -3123,7 +3166,7 @@ class FlowStep(BaseStep):
         """create the streams used in this flow"""
         for step in self.get_children():
             if step.kind == StepKinds.queue:
-                step.init_object(self.context, None)
+                step.init_object(self.context, None, engine=self.engine)
 
     def list_child_functions(self):
         """return a list of child function names referred to in the steps"""
@@ -3285,6 +3328,12 @@ class FlowStep(BaseStep):
 
     def supports_termination(self):
         return self.engine != "sync"
+
+    def _init_shared_resources(
+        self,
+        namespace: str | None = None,
+    ):
+        pass
 
 
 class RootFlowStep(FlowStep):
@@ -3520,8 +3569,7 @@ class RootFlowStep(FlowStep):
         self.shared_max_threads = max_threads
         self.pool_factor = pool_factor
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        self.context = context
+    def _init_shared_resources(self, namespace: str | None = None):
         if self.shared_models:
             self.context.executor = storey.flow.RunnableExecutor(
                 max_processes=self.shared_max_processes,
@@ -3555,7 +3603,6 @@ class RootFlowStep(FlowStep):
                 self.context.executor.add_runnable(
                     model, self._shared_models_mechanism[model.name]
                 )
-        super().init_object(context, namespace, mode, reset=reset, **extra_kwargs)
 
     @property
     def model_endpoints_names(self) -> list[str]:
@@ -3701,12 +3748,7 @@ class HubTaskStep(TaskStep):
         finally:
             shutil.rmtree(path, ignore_errors=True)
 
-    def init_object(self, context, namespace, mode="sync", reset=False, **extra_kwargs):
-        self.context = context
-        self._async_object = None
-        if not self._is_local_function(context):
-            return
-
+    def set_class_object_or_handler(self, namespace) -> None:
         with self.hub_step_tempdir() as local_path:  # self-cleaning tmp dir util
             hub_step = mlrun.get_hub_step(self.class_name, local_path=local_path)
             mod = hub_step.module()
@@ -3716,16 +3758,9 @@ class HubTaskStep(TaskStep):
             args = signature(self._handler).parameters
             if args and "context" in list(args.keys()):
                 self._inject_context = True
-            self._set_error_handler()
-            return
-
-        self._class_object = getattr(mod, hub_step.class_name)
-
-        self._init_class_object_and_handler(namespace, reset, **extra_kwargs)
-
-        self._set_error_handler()
-        if mode != "skip":
-            self._post_init(mode)
+            self._class_object = None
+        else:
+            self._class_object = getattr(mod, hub_step.class_name)
 
 
 classes_map = {


### PR DESCRIPTION
### 📝 Description
#### Refactor Serving Graph Step Initialization for Multi-Function Support

##### Overview

Refactors step initialization to support multi-function deployments. Introduces a centralized `_should_init` flag that controls whether steps initialize their class objects, ensuring efficient resource usage.

##### Problem

- All steps initialize class objects regardless of their assigned function
- No unified initialization control mechanism across step types
- `function` property only in `TaskStep`, not available to all step types
- Duplicate `_is_local_function()` logic across classes

##### Solution

###### 1. Centralized Control via `_should_init` Flag

Added to `BaseStep`:
```python
self._should_init = self._is_local_function(context)
```

###### 2. Unified Pattern

All steps follow this pattern:
```python
def init_object(self, context, namespace, mode="sync", reset=False, engine="async", **extra_kwargs):
    super().init_object(context, namespace, mode, reset, engine, **extra_kwargs)
    if not self._should_init:
        return  # skip initialization for non-local functions
    # ... step-specific initialization ...
```

**Updated Classes:** `TaskStep`, `RouterStep`, `ModelRunnerStep`, `QueueStep`, `FlowStep`, `RootFlowStep`, `HubTaskStep`

###### 3. Key Changes

- Moved `function` property to `BaseStep` (all steps support multi-function assignment)
- Moved `_is_local_function()` to `BaseStep`
- Extracted `set_class_object_or_handler()` in `TaskStep` and `HubTaskStep`
- Refactored `ModelRunnerStep.init_object()` to `_init_class_object_and_handler()`
- Extracted `_init_shared_resources()` in `RootFlowStep`
- Added `engine` parameter to all `init_object()` methods

###### 4. Special Note: RootFlowStep

**`RootFlowStep` is always local** - it always initializes because it manages the entire flow and shared resources. The `_should_init` check is not skipped for RootFlowStep; it always proceeds with initialization.

##### Key Points

- ✅ `self.context` is **always** set (even for non-local functions)
- ✅ Heavy initialization only happens when `_should_init=True`
- ✅ Backward compatible - no breaking changes
- ✅ Single-function deployments work unchanged

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12209
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
