### PR TITLE
[Requirments] Revert Storey to 1.11.16 (MM / test_app_flow is failing)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2025.5.1, <=2025.7.0
 v3iofs~=0.1.17
-storey~=1.11.18
+storey==1.11.16
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,7 +128,6 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"==1.11.16"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "scipy": {"~=1.16.3"},

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,7 +128,7 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"~=1.11.18"},
+        "storey": {"==1.11.16"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "scipy": {"~=1.16.3"},


### PR DESCRIPTION
## Summary

Storey 1.11.18 introduced a regression where test_app_flow is not passing:
- committed stat is updated (in async) on termination only
- some issue in the monitoring stream processing in the serving graph

Therefore, reverting Storey to 1.11.16

## Test plan

- [x] Verify `test_app_flow[True-True]` passes consistently on the OSS system test runner