### PR TITLE
[KFP] Enhance pipeline run deletion with retry logic for transient KFP errors

### DIFF
--- a/server/py/services/api/crud/pipelines.py
+++ b/server/py/services/api/crud/pipelines.py
@@ -127,7 +127,15 @@ class Pipelines(
     def delete_pipelines_runs(
         self, db_session: sqlalchemy.orm.Session, project_name: str
     ):
-        _, _, project_pipeline_runs = self.list_pipelines(
+        # Retry listing pipelines to handle transient KFP connection errors
+        # (e.g. "invalid connection" from KFP's internal DB pool)
+        _, _, project_pipeline_runs = mlrun.utils.helpers.retry_until_successful(
+            backoff=2,
+            timeout=60,
+            logger=mlrun.utils.logger,
+            verbose=True,
+            _function=self.list_pipelines,
+            fatal_exceptions=(mlrun.errors.MLRunInvalidArgumentError,),
             db_session=db_session,
             project=project_name,
             format_=mlrun.common.formatters.PipelineFormat.metadata_only,
@@ -198,7 +206,7 @@ class Pipelines(
                         experiment_id,
                     )
                 )
-            for future in concurrent.futures.as_completed(delete_run_futures):
+            for future in concurrent.futures.as_completed(delete_experiment_futures):
                 delete_experiment_exception = future.exception()
                 if delete_experiment_exception is not None:
                     experiments_failed += 1


### PR DESCRIPTION
### 📝 Description

Fixes pipeline run deletion failures caused by transient Kubeflow Pipelines (KFP) errors (e.g. "invalid connection" from KFP's internal DB pool) during project deletion. Adds retry logic when listing pipelines and corrects a bug where the experiment-deletion loop waited on the wrong futures.

---

### 🛠️ Changes Made

- **Retry logic for pipeline listing**  
  In `delete_pipelines_runs`, the call to `list_pipelines` is now wrapped with `mlrun.utils.helpers.retry_until_successful` (2s backoff, 60s timeout, verbose logging) so transient KFP connection/API errors are retried instead of failing the entire project deletion. `MLRunInvalidArgumentError` is treated as fatal and not retried.

- **Bugfix: experiment deletion loop**  
  The loop that processes experiment-deletion futures was incorrectly using `delete_run_futures` in `concurrent.futures.as_completed(...)`. It now correctly uses `delete_experiment_futures`, so we wait on and handle the experiment-deletion futures rather than the pipeline-run-deletion futures.

---

### ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- UT

---

### 🔗 References

- Ticket link: https://iguazio.atlassian.net/browse/ML-12062
- Design docs links: —
- External links: —

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- Retry parameters (backoff=2s, timeout=60s) are chosen to tolerate short-lived KFP connection issues without blocking project deletion for too long.
- `fatal_exceptions=(mlrun.errors.MLRunInvalidArgumentError,)` ensures invalid-argument errors are not retried.
