### PR TITLE
[Tests] Fix `TestServingAPIHandler::test_api_handler_forbidden`

### DIFF
--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -126,7 +126,7 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         self._logger.debug("Testing forbidden API handler endpoint")
         with pytest.raises(
             RuntimeError,
-            match=r"MLRunBadRequestError: Access forbidden to GET /api/v1/admin",
+            match=r"MLRunAccessDeniedError: Access forbidden to GET /api/v1/admin",
         ):
             function.invoke(
                 path="/api/v1/admin", method="GET", body={"test": "restricted"}


### PR DESCRIPTION
### 📝 Description

[Tests] Fix `TestServingAPIHandler::test_api_handler_forbidden`, which failed due to a wrong expected exception type.

Found during verification of #9392.

---

### 🛠️ Changes Made
Fixed assertion.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
This is a test fix.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
