### PR TITLE
[Launcher] Fix unexpected `local` argument

### DIFF
--- a/mlrun/launcher/factory.py
+++ b/mlrun/launcher/factory.py
@@ -43,11 +43,11 @@ class LauncherFactory(
         if mlrun.config.is_running_as_api():
             return self._launcher_container.server_side_launcher(**kwargs)
 
-        local = kwargs.get("local", False)
+        local = kwargs.pop("local", False)
         if is_remote and not local:
             return self._launcher_container.client_remote_launcher(**kwargs)
 
-        return self._launcher_container.client_local_launcher(**kwargs)
+        return self._launcher_container.client_local_launcher(local=local, **kwargs)
 
 
 class LauncherContainer(containers.DeclarativeContainer):

--- a/tests/launcher/test_factory.py
+++ b/tests/launcher/test_factory.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import typing
+import warnings
 
 import pytest
 
@@ -59,9 +60,24 @@ def test_create_client_launcher(
         mlrun.launcher.local.ClientLocalLauncher,
     ],
 ):
-    launcher = mlrun.launcher.factory.LauncherFactory().create_launcher(
-        is_remote, local=local
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        launcher = mlrun.launcher.factory.LauncherFactory().create_launcher(
+            is_remote, local=local
+        )
+
+    unexpected = [
+        w
+        for w in caught
+        if issubclass(w.category, UserWarning)
+        and "Unexpected run keyword argument" in str(w.message)
+    ]
+    assert not unexpected, (
+        f"Spurious warning(s) for is_remote={is_remote}, local={local}: "
+        f"{[str(w.message) for w in unexpected]}"
     )
+
     assert type(launcher) is expected_instance
 
     if local:


### PR DESCRIPTION
### 📝 Description

The bug is a false "Unexpected run keyword argument 'local' was ignored" warning emitted on every remote function run (Spark, Kubejob, etc.). The root cause is in the launcher factory — create_launcher() reads local from **kwargs to decide which launcher to instantiate, but doesn't remove it before forwarding kwargs to the launcher constructor. When ClientRemoteLauncher is chosen, its __init__ (inherited from BaseLauncher) doesn't recognize local as valid and fires the warning. 

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

unit testings

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12201
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
