### PR TITLE
[Nuclio] Fix JSONDecodeError when invoking function with HEAD method

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1145,7 +1145,7 @@ class RemoteRuntime(KubeResource):
             raise RuntimeError(f"bad function response {resp.status_code}: {resp.text}")
 
         data = resp.content
-        if resp.headers["content-type"] == "application/json":
+        if data and resp.headers["content-type"] == "application/json":
             data = json.loads(data)
         return data
 

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -466,15 +466,52 @@ def test_remote_function_step(rundb_mock, httpserver, engine):
 
 
 # ---------------------------------------------------------------------------
-# ML-12228 – RemoteRuntime.invoke() with HEAD method
+# RemoteRuntime.invoke() with HEAD method
 # ---------------------------------------------------------------------------
 
 
-def _make_nuclio_fn(address: str) -> mlrun.runtimes.RemoteRuntime:
-    fn = cast(
-        mlrun.runtimes.RemoteRuntime, mlrun.new_function("test-ml12228", kind="nuclio")
+def test_invoke_head_returns_empty_bytes() -> None:
+    """HEAD responses have no body; invoke() must return b"" without raising."""
+    fn = _make_nuclio_fn()
+    fn._http_session = MagicMock()
+    fn._http_session.request.return_value = _mock_response(b"", "application/json")
+
+    result = fn.invoke("/", method="HEAD")
+    assert result == b""
+
+
+def test_invoke_post_returns_parsed_json() -> None:
+    """Non-empty JSON body is parsed correctly."""
+    fn = _make_nuclio_fn()
+    fn._http_session = MagicMock()
+    fn._http_session.request.return_value = _mock_response(
+        b'{"echo": "hello"}', "application/json"
     )
-    fn.status.address = address
+
+    result = fn.invoke("/", body={"data": "hello"})
+    assert result == {"echo": "hello"}
+
+
+def test_invoke_non_json_content_type_returns_bytes() -> None:
+    """Responses with non-JSON content-type are returned as raw bytes."""
+    fn = _make_nuclio_fn()
+    fn._http_session = MagicMock()
+    fn._http_session.request.return_value = _mock_response(b"plain text", "text/plain")
+
+    result = fn.invoke("/", method="GET")
+    assert result == b"plain text"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_nuclio_fn() -> mlrun.runtimes.RemoteRuntime:
+    fn = cast(
+        mlrun.runtimes.RemoteRuntime, mlrun.new_function("test-nuclio", kind="nuclio")
+    )
+    fn.status.address = "http://localhost:8080"
     return fn
 
 
@@ -490,35 +527,3 @@ def _mock_response(
     resp.headers = {"content-type": content_type}
     resp.text = content.decode("utf-8", errors="replace")
     return resp
-
-
-def test_invoke_head_returns_empty_bytes() -> None:
-    """ML-12228: HEAD responses have no body; invoke() must return b"" without raising."""
-    fn = _make_nuclio_fn("http://localhost:8080")
-    fn._http_session = MagicMock()
-    fn._http_session.request.return_value = _mock_response(b"", "application/json")
-
-    result = fn.invoke("/", method="HEAD")
-    assert result == b""
-
-
-def test_invoke_post_returns_parsed_json() -> None:
-    """Non-empty JSON body is still parsed correctly after the ML-12228 fix."""
-    fn = _make_nuclio_fn("http://localhost:8080")
-    fn._http_session = MagicMock()
-    fn._http_session.request.return_value = _mock_response(
-        b'{"echo": "hello"}', "application/json"
-    )
-
-    result = fn.invoke("/", body={"data": "hello"})
-    assert result == {"echo": "hello"}
-
-
-def test_invoke_non_json_content_type_returns_bytes() -> None:
-    """Responses with non-JSON content-type are returned as raw bytes."""
-    fn = _make_nuclio_fn("http://localhost:8080")
-    fn._http_session = MagicMock()
-    fn._http_session.request.return_value = _mock_response(b"plain text", "text/plain")
-
-    result = fn.invoke("/", method="GET")
-    assert result == b"plain text"

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -470,52 +470,17 @@ def test_remote_function_step(rundb_mock, httpserver, engine):
 # ---------------------------------------------------------------------------
 
 
-def test_invoke_head_returns_empty_bytes() -> None:
-    """HEAD responses have no body; invoke() must return b"" without raising."""
-    fn = _make_nuclio_fn()
-    fn._http_session = MagicMock()
-    fn._http_session.request.return_value = _mock_response(b"", "application/json")
-
-    result = fn.invoke("/", method="HEAD")
-    assert result == b""
-
-
-def test_invoke_post_returns_parsed_json() -> None:
-    """Non-empty JSON body is parsed correctly."""
-    fn = _make_nuclio_fn()
-    fn._http_session = MagicMock()
-    fn._http_session.request.return_value = _mock_response(
-        b'{"echo": "hello"}', "application/json"
-    )
-
-    result = fn.invoke("/", body={"data": "hello"})
-    assert result == {"echo": "hello"}
-
-
-def test_invoke_non_json_content_type_returns_bytes() -> None:
-    """Responses with non-JSON content-type are returned as raw bytes."""
-    fn = _make_nuclio_fn()
-    fn._http_session = MagicMock()
-    fn._http_session.request.return_value = _mock_response(b"plain text", "text/plain")
-
-    result = fn.invoke("/", method="GET")
-    assert result == b"plain text"
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_nuclio_fn() -> mlrun.runtimes.RemoteRuntime:
+@pytest.fixture
+def nuclio_fn() -> mlrun.runtimes.RemoteRuntime:
     fn = cast(
         mlrun.runtimes.RemoteRuntime, mlrun.new_function("test-nuclio", kind="nuclio")
     )
     fn.status.address = "http://localhost:8080"
+    fn._http_session = MagicMock()
     return fn
 
 
-def _mock_response(
+def mock_response(
     content: bytes,
     content_type: str,
     status: HTTPStatus = HTTPStatus.OK,
@@ -527,3 +492,39 @@ def _mock_response(
     resp.headers = {"content-type": content_type}
     resp.text = content.decode("utf-8", errors="replace")
     return resp
+
+
+def test_invoke_head_returns_empty_bytes(
+    nuclio_fn: mlrun.runtimes.RemoteRuntime,
+) -> None:
+    """HEAD responses have no body; invoke() must return b"" without raising."""
+    nuclio_fn._http_session.request.return_value = mock_response(
+        b"", "application/json"
+    )
+
+    result = nuclio_fn.invoke("/", method="HEAD")
+    assert result == b""
+
+
+def test_invoke_post_returns_parsed_json(
+    nuclio_fn: mlrun.runtimes.RemoteRuntime,
+) -> None:
+    """Non-empty JSON body is parsed correctly."""
+    nuclio_fn._http_session.request.return_value = mock_response(
+        b'{"echo": "hello"}', "application/json"
+    )
+
+    result = nuclio_fn.invoke("/", body={"data": "hello"})
+    assert result == {"echo": "hello"}
+
+
+def test_invoke_non_json_content_type_returns_bytes(
+    nuclio_fn: mlrun.runtimes.RemoteRuntime,
+) -> None:
+    """Responses with non-JSON content-type are returned as raw bytes."""
+    nuclio_fn._http_session.request.return_value = mock_response(
+        b"plain text", "text/plain"
+    )
+
+    result = nuclio_fn.invoke("/", method="GET")
+    assert result == b"plain text"

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -14,10 +14,13 @@
 
 import re
 import time
+from http import HTTPStatus
+from typing import cast
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
 
 import pytest
+import requests
 from werkzeug.wrappers import Request, Response
 
 import mlrun
@@ -460,3 +463,62 @@ def test_remote_function_step(rundb_mock, httpserver, engine):
     finally:
         server.wait_for_completion()
     assert resp == {"cat": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# ML-12228 – RemoteRuntime.invoke() with HEAD method
+# ---------------------------------------------------------------------------
+
+
+def _make_nuclio_fn(address: str) -> mlrun.runtimes.RemoteRuntime:
+    fn = cast(
+        mlrun.runtimes.RemoteRuntime, mlrun.new_function("test-ml12228", kind="nuclio")
+    )
+    fn.status.address = address
+    return fn
+
+
+def _mock_response(
+    content: bytes,
+    content_type: str,
+    status: HTTPStatus = HTTPStatus.OK,
+) -> requests.Response:
+    resp = MagicMock(spec=requests.Response)
+    resp.ok = status < HTTPStatus.BAD_REQUEST
+    resp.status_code = status.value
+    resp.content = content
+    resp.headers = {"content-type": content_type}
+    resp.text = content.decode("utf-8", errors="replace")
+    return resp
+
+
+def test_invoke_head_returns_empty_bytes() -> None:
+    """ML-12228: HEAD responses have no body; invoke() must return b"" without raising."""
+    fn = _make_nuclio_fn("http://localhost:8080")
+    fn._http_session = MagicMock()
+    fn._http_session.request.return_value = _mock_response(b"", "application/json")
+
+    result = fn.invoke("/", method="HEAD")
+    assert result == b""
+
+
+def test_invoke_post_returns_parsed_json() -> None:
+    """Non-empty JSON body is still parsed correctly after the ML-12228 fix."""
+    fn = _make_nuclio_fn("http://localhost:8080")
+    fn._http_session = MagicMock()
+    fn._http_session.request.return_value = _mock_response(
+        b'{"echo": "hello"}', "application/json"
+    )
+
+    result = fn.invoke("/", body={"data": "hello"})
+    assert result == {"echo": "hello"}
+
+
+def test_invoke_non_json_content_type_returns_bytes() -> None:
+    """Responses with non-JSON content-type are returned as raw bytes."""
+    fn = _make_nuclio_fn("http://localhost:8080")
+    fn._http_session = MagicMock()
+    fn._http_session.request.return_value = _mock_response(b"plain text", "text/plain")
+
+    result = fn.invoke("/", method="GET")
+    assert result == b"plain text"

--- a/tests/system/runtimes/assets/echo_handler.py
+++ b/tests/system/runtimes/assets/echo_handler.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Iguazio
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+from http import HTTPStatus
+
+import nuclio_sdk
+
+
+def handler(
+    context: nuclio_sdk.Context, event: nuclio_sdk.Event
+) -> nuclio_sdk.Response:
+    """Plain Nuclio handler that echoes the request body as JSON.
+
+    Used by the ML-12228 regression test to verify that invoking any
+    Nuclio function with method="HEAD" raises JSONDecodeError in
+    RemoteRuntime.invoke() – independent of the API handler feature.
+    """
+    body = event.body
+    if isinstance(body, (bytes, bytearray)):
+        body = body.decode("utf-8")
+    if isinstance(body, str):
+        try:
+            body = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            body = body
+
+    return context.Response(
+        body=json.dumps({"echo": body}),
+        headers={},
+        content_type="application/json",
+        status_code=HTTPStatus.OK,
+    )

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -895,9 +895,9 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         """
         code_path = str(self.assets_path / "echo_handler.py")
 
-        self._logger.debug("Creating nuclio function for ML-12228 repro")
+        self._logger.debug("Creating nuclio function")
         function = mlrun.code_to_function(
-            name="ml12228-head-repro",
+            name="nuclio-head-repro",
             kind="nuclio",
             project=self.project_name,
             filename=code_path,
@@ -910,11 +910,11 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
 
         # POST: body present, JSON parsed normally.
         self._logger.debug("Invoking POST – should return parsed JSON")
-        result = function.invoke("/", body={"data": "ml12228"})
-        assert result == {"echo": {"data": "ml12228"}}
+        result = function.invoke("/", body={"data": "hello"})
+        assert result == {"echo": {"data": "hello"}}
 
         # HEAD: body stripped by HTTP; invoke() must return b"" without raising.
-        self._logger.debug("Invoking HEAD – must not raise (ML-12228 fix)")
+        self._logger.debug("Invoking HEAD – must not raise")
         result = function.invoke("/", method="HEAD")
         assert result == b""
 

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -881,6 +881,43 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
             f"running serving async mode took {timing} seconds should be < 7"
         )
 
+    def test_invoke_head_method_does_not_raise(self) -> None:
+        """Regression test for ML-12228.
+
+        HTTP HEAD responses carry no body (RFC 9110 §9.3.2).  Nuclio strips
+        the body but keeps ``Content-Type: application/json``.  Before the fix,
+        ``RemoteRuntime.invoke()`` unconditionally called
+        ``json.loads(resp.content)`` when that header was present, crashing
+        with ``JSONDecodeError`` on the empty body.
+
+        After the fix (guard: ``if data and ...``), invoking with HEAD returns
+        ``b""`` instead of raising.
+        """
+        code_path = str(self.assets_path / "echo_handler.py")
+
+        self._logger.debug("Creating nuclio function for ML-12228 repro")
+        function = mlrun.code_to_function(
+            name="ml12228-head-repro",
+            kind="nuclio",
+            project=self.project_name,
+            filename=code_path,
+            image=self.image,
+            handler="handler",
+        )
+
+        self._logger.debug("Deploying function")
+        function.deploy()
+
+        # POST: body present, JSON parsed normally.
+        self._logger.debug("Invoking POST – should return parsed JSON")
+        result = function.invoke("/", body={"data": "ml12228"})
+        assert result == {"echo": {"data": "ml12228"}}
+
+        # HEAD: body stripped by HTTP; invoke() must return b"" without raising.
+        self._logger.debug("Invoking HEAD – must not raise (ML-12228 fix)")
+        result = function.invoke("/", method="HEAD")
+        assert result == b""
+
 
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 @pytest.mark.enterprise


### PR DESCRIPTION
## Summary

- **Bug ([ML-12228](https://iguazio.atlassian.net/browse/ML-12228)):** `RemoteRuntime.invoke()` raised `JSONDecodeError` for any `method="HEAD"` call against a deployed Nuclio function
- **Root cause:** HTTP HEAD responses carry no body (RFC 9110 §9.3.2); Nuclio correctly strips it but keeps `Content-Type: application/json`. The previous code unconditionally called `json.loads(resp.content)`, crashing on the empty `b""`
- **Fix:** Guard `json.loads` with an emptiness check — `if data and resp.headers["content-type"] == "application/json"`

## Changes

- `mlrun/runtimes/nuclio/function.py` — one-line fix in `RemoteRuntime.invoke()`
- `tests/serving/test_remote.py` — three unit tests (mocked HTTP session, no deployment needed)
- `tests/system/runtimes/test_nuclio.py` — system regression test: deploys a plain `kind="nuclio"` function, asserts POST returns parsed JSON and HEAD returns `b""` without raising
- `tests/system/runtimes/assets/echo_handler.py` — new asset: plain Nuclio handler that echoes the request body as JSON (used by the system test)

## Test plan

- [x] Run unit tests: `pytest tests/serving/test_remote.py::test_invoke_head_returns_empty_bytes tests/serving/test_remote.py::test_invoke_post_returns_parsed_json tests/serving/test_remote.py::test_invoke_non_json_content_type_returns_bytes`
- [x] Run system test against a live cluster: `pytest tests/system/runtimes/test_nuclio.py::TestNuclioRuntime::test_invoke_head_method_does_not_raise`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ML-12228]: https://iguazio.atlassian.net/browse/ML-12228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ