### PR TITLE
[CI] Adjust post-coverage-comment for branch that created from fork repo

### DIFF
--- a/.github/workflows/post-coverage-comment.yaml
+++ b/.github/workflows/post-coverage-comment.yaml
@@ -57,20 +57,28 @@ jobs:
       - name: Get PR number
         id: pr
         shell: bash
-        env:
-          PULL_REQUESTS_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
         run: |
           set -euo pipefail
 
-          PR_NUMBER=$(echo "${PULL_REQUESTS_JSON}" | jq -r '.[0].number // empty')
+          # Define variables for readability
+          REPO="${{ github.repository }}"
+          HEAD_OWNER="${{ github.event.workflow_run.head_repository.owner.login }}"
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
 
-          if [ -z "${PR_NUMBER}" ] || [ "${PR_NUMBER}" = "null" ]; then
-            echo "Error: No PR number found in workflow_run payload"
+          echo "Searching for PR from $HEAD_OWNER:$HEAD_BRANCH in $REPO..."
+
+          # Use the API to find the PR number
+          PR_NUMBER=$(curl -s -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/pulls?head=${HEAD_OWNER}:${HEAD_BRANCH}" \
+            | jq -r '.[0].number // empty')
+
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "Error: Could not find a PR number"
             exit 1
           fi
 
-          echo "Found PR number: ${PR_NUMBER}"
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Found PR number: $PR_NUMBER"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Build coverage comment file
         shell: bash


### PR DESCRIPTION
### 📝 Description

Fix coverage workflow to find the PR via API so it works for fork-based PRs.

---

### 🛠️ Changes Made

- Edit `.github/workflows/post-coverage-comment.yaml:` switch PR-number detection to a REST API lookup by head_owner:head_branch (instead of workflow_run.pull_requests) so coverage comments work for fork-based PRs.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: [ML-9709](https://iguazio.atlassian.net/browse/ML-9709)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
A demo PR for additional details:
https://github.com/tomerm-iguazio/coverage_report_generator/pull/17

[ML-9709]: https://iguazio.atlassian.net/browse/ML-9709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ