### PR TITLE
[Model Monitoring] Fix TimescaleDB pool hanging 120s on bad credentials

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connection.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_connection.py
@@ -120,10 +120,14 @@ class TimescaleDBConnection:
         self._timescaledb_version: str | None = None
         self._version_checked: bool = False
 
+    # Maximum seconds for the initial connectivity pre-check (ML-12229).
+    _CONNECTIVITY_CHECK_TIMEOUT = 10
+
     @property
     def pool(self) -> ConnectionPool:
         """Get or create the synchronous connection pool."""
         if self._pool is None:
+            self._verify_connectivity()
             self._pool = ConnectionPool(
                 conninfo=self._dsn,
                 min_size=self._min_connections,
@@ -133,6 +137,21 @@ class TimescaleDBConnection:
                 ),
             )
         return self._pool
+
+    def _verify_connectivity(self) -> None:
+        """Quick connection test so bad credentials / unreachable hosts fail
+        fast instead of waiting for the full pool timeout (ML-12229)."""
+        try:
+            with psycopg.connect(
+                self._dsn,
+                connect_timeout=self._CONNECTIVITY_CHECK_TIMEOUT,
+                autocommit=True,
+            ) as conn:
+                conn.execute("SELECT 1")
+        except psycopg.Error as e:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"Failed to connect to TimescaleDB: {e}"
+            ) from e
 
     def close(self) -> None:
         """Close the connection pool if it exists."""

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connection.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_connection.py
@@ -285,9 +285,14 @@ class TestTimescaleDBConnectionPoolTimeout:
         mlrun.config.config.model_endpoint_monitoring.tsdb.connection_pool_timeout = 90
 
         try:
-            with patch(
-                "mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection.ConnectionPool"
-            ) as mock_pool_class:
+            with (
+                patch(
+                    "mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection.ConnectionPool"
+                ) as mock_pool_class,
+                patch(
+                    "mlrun.model_monitoring.db.tsdb.timescaledb.timescaledb_connection.psycopg.connect"
+                ),
+            ):
                 conn = TimescaleDBConnection(
                     dsn="postgres://test:test@localhost:5432/test",
                     max_connections=5,
@@ -309,3 +314,26 @@ class TestTimescaleDBConnectionPoolTimeout:
             mlrun.config.config.model_endpoint_monitoring.tsdb.connection_pool_timeout
         )
         assert default_timeout == 120
+
+    def test_bad_credentials_fail_fast(self, connection_string):
+        """run() with bad credentials fails in seconds, not 120s (ML-12229).
+
+        We derive the bad DSN from connection_string rather than hardcoding one
+        because the host must be *reachable*.  A bogus host (e.g. 127.0.0.1:15432)
+        fails instantly on TCP connect-refused, which doesn't reproduce the real
+        bug: the pool retrying bad credentials against a live server for 120s.
+        """
+        import time
+        from urllib.parse import urlparse, urlunparse
+
+        parsed = urlparse(connection_string)
+        bad_dsn = urlunparse(
+            parsed._replace(netloc=f"baduser:badpass@{parsed.hostname}:{parsed.port}")
+        )
+        conn = TimescaleDBConnection(dsn=bad_dsn)
+        start = time.monotonic()
+        with pytest.raises(mlrun.errors.MLRunRuntimeError, match="Failed to connect"):
+            conn.run(query="SELECT 1")
+        elapsed = time.monotonic() - start
+        assert elapsed < 15, f"Bad credentials took {elapsed:.1f}s, expected <15s"
+        assert conn._pool is None


### PR DESCRIPTION
## Summary
When `TimescaleDBConnection` was initialized with bad credentials or an unreachable host, `ConnectionPool` would silently retry connections until its timeout expired (default 120s), causing the model monitoring stream function to hang.

This PR adds a lightweight connectivity pre-check that validates the DSN with a single `psycopg.connect()` + `SELECT 1` before creating the pool. Bad configurations now fail in seconds with a clear `MLRunRuntimeError`.

## Changes Made
- Add `_verify_connectivity()` method to `TimescaleDBConnection` that runs before pool creation
- Add `_CONNECTIVITY_CHECK_TIMEOUT = 10` class constant for the pre-check timeout
- Add integration test that verifies bad credentials fail fast against a real TimescaleDB
- Update existing `test_pool_uses_configured_timeout` to mock the new pre-check

## Testing
- All 12 unit tests pass (mock-based, no DB required)
- 1 integration test passes against real TimescaleDB on vmdev76 (skipped when DB unavailable)
- Verified without fix: bad credentials hang for 120s
- Verified with fix: bad credentials fail in <1s

## Reference
- Jira: ML-12229