### PR TITLE
[Serving] Block custom handler usage in jobs from serving functions

### DIFF
--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -187,6 +187,13 @@ def run_function(
                             If not provided, the default backoff delay is 30 seconds.
     :return: MLRun RunObject or PipelineNodeWrapper
     """
+    if (
+        isinstance(function, mlrun.runtimes.KubejobRuntime) and function.serving_spec
+    ) and handler is not None:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "handler cannot be specified when running a KubeJobRuntime with a serving spec"
+        )
+
     if artifact_path:
         warnings.warn(
             "'artifact_path' parameter is deprecated in 1.10.0 and will be removed in 1.12.0, "

--- a/mlrun/projects/operations.py
+++ b/mlrun/projects/operations.py
@@ -188,8 +188,10 @@ def run_function(
     :return: MLRun RunObject or PipelineNodeWrapper
     """
     if (
-        isinstance(function, mlrun.runtimes.KubejobRuntime) and function.serving_spec
-    ) and handler is not None:
+        isinstance(function, mlrun.runtimes.KubejobRuntime)
+        and function.serving_spec
+        and handler is not None
+    ):
         raise mlrun.errors.MLRunInvalidArgumentError(
             "handler cannot be specified when running a KubeJobRuntime with a serving spec"
         )

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4187,8 +4187,8 @@ class MlrunProject(ModelObj):
             )
 
         :param function:        name of the function (in the project) or function object
-        :param handler:         name of the function handler, for serving function/job handler should not be provided as
-                                the default handler is defined in the serving spec.
+        :param handler:         name of the function handler. should not be set for serving graph deployed as job,
+                                as in this case the handler is predefined
         :param name:            execution name
         :param params:          input parameters (dict)
         :param hyperparams:     hyper parameters

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4187,7 +4187,8 @@ class MlrunProject(ModelObj):
             )
 
         :param function:        name of the function (in the project) or function object
-        :param handler:         name of the function handler
+        :param handler:         name of the function handler, for serving functions handler should not be provided as
+                                the default handler is defined in the serving spec.
         :param name:            execution name
         :param params:          input parameters (dict)
         :param hyperparams:     hyper parameters

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4251,6 +4251,14 @@ class MlrunProject(ModelObj):
             )
         output_path = output_path or artifact_path
 
+        if (
+            isinstance(function, mlrun.runtimes.KubejobRuntime)
+            and function.serving_spec
+        ) and handler is not None:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "handler cannot be specified when running a KubeJobRuntime with a serving spec"
+            )
+
         # remove this filter once the artifact_path parameter is deprecated in 1.12.0
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=FutureWarning)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4187,7 +4187,7 @@ class MlrunProject(ModelObj):
             )
 
         :param function:        name of the function (in the project) or function object
-        :param handler:         name of the function handler, for serving functions handler should not be provided as
+        :param handler:         name of the function handler, for serving function/job handler should not be provided as
                                 the default handler is defined in the serving spec.
         :param name:            execution name
         :param params:          input parameters (dict)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4252,14 +4252,6 @@ class MlrunProject(ModelObj):
             )
         output_path = output_path or artifact_path
 
-        if (
-            isinstance(function, mlrun.runtimes.KubejobRuntime)
-            and function.serving_spec
-        ) and handler is not None:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "handler cannot be specified when running a KubeJobRuntime with a serving spec"
-            )
-
         # remove this filter once the artifact_path parameter is deprecated in 1.12.0
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=FutureWarning)

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1897,11 +1897,9 @@ class ModelRunner(storey.ParallelExecution):
         #  fall to default behavior of routing to all valid outlets
         all_outlets = list(self._name_to_outlet.keys())
         if is_batched:
-            if (error_raiser := f"{self.name}_error_raise") in all_outlets:
-                all_outlets.remove(error_raiser)
+            all_outlets.remove(f"{self.name}_error_raise")
         else:
-            if (unpacker := f"{self.name}_unpacker") in all_outlets:
-                all_outlets.remove(unpacker)
+            all_outlets.remove(f"{self.name}_unpacker")
         return all_outlets
 
     def _is_error(self, event: Union[dict, list]) -> bool:

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -1897,9 +1897,11 @@ class ModelRunner(storey.ParallelExecution):
         #  fall to default behavior of routing to all valid outlets
         all_outlets = list(self._name_to_outlet.keys())
         if is_batched:
-            all_outlets.remove(f"{self.name}_error_raise")
+            if (error_raiser := f"{self.name}_error_raise") in all_outlets:
+                all_outlets.remove(error_raiser)
         else:
-            all_outlets.remove(f"{self.name}_unpacker")
+            if (unpacker := f"{self.name}_unpacker") in all_outlets:
+                all_outlets.remove(unpacker)
         return all_outlets
 
     def _is_error(self, event: Union[dict, list]) -> bool:

--- a/tests/runtimes/test_to_job.py
+++ b/tests/runtimes/test_to_job.py
@@ -321,4 +321,3 @@ def test_run_function_with_job_from_serving_fails_with_handler(
         else:
             project = mlrun.new_project("test-project", save=False)
             project.run_function(job, handler="custom_handler", local=True)
-

--- a/tests/runtimes/test_to_job.py
+++ b/tests/runtimes/test_to_job.py
@@ -272,3 +272,39 @@ def test_to_job_backward_compatibility():
     assert local_fn.metadata.name == long_name
     job = local_fn.to_job()
     assert job.metadata.name == long_name  # Name unchanged
+
+
+def test_run_function_with_job_from_serving_fails_with_handler():
+    """Test that run_function raises error when handler is specified for a job from serving function.
+
+    When a serving function is converted to a job via to_job(), the job retains a serving_spec.
+    Running such a job with a custom handler should fail because the serving spec already
+    defines the default handler (execute_graph).
+    """
+    # Create a serving function
+    serving_fn = mlrun.new_function(name="test-serving", kind="serving")
+    serving_fn.spec.image = "mlrun/mlrun"  # Set an image to avoid build requirements
+
+    # Set up a simple graph
+    graph = serving_fn.set_topology("flow", engine="async")
+    graph.to(name="step1", handler="handler")
+
+    # Convert to job - this creates a KubejobRuntime with serving_spec
+    job = serving_fn.to_job()
+
+    # Verify the job has a serving_spec
+    assert job.serving_spec is not None, (
+        "Job should have a serving_spec from the serving function"
+    )
+    assert job.kind == "job", f"Job should have kind='job', got '{job.kind}'"
+
+    # Create a project to use run_function
+    project = mlrun.new_project("test-project", save=False)
+    project.set_function(job, "test-job")
+
+    # Running with a handler should raise MLRunInvalidArgumentError
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="handler cannot be specified when running a KubeJobRuntime with a serving spec",
+    ):
+        project.run_function(job, handler="custom_handler", local=True)

--- a/tests/runtimes/test_to_job.py
+++ b/tests/runtimes/test_to_job.py
@@ -284,7 +284,7 @@ def test_run_function_with_job_from_serving_fails_with_handler(
 ):
     """Test that run_function raises error when handler is specified for a job from serving function.
 
-    When a serving function is converted to a job via to_job(), the job retains a serving_spec.
+    When a serving function is deployed to a job via to_job(), the job contains a serving_spec.
     Running such a job with a custom handler should fail because the serving spec already
     defines the default handler (execute_graph).
 
@@ -292,7 +292,8 @@ def test_run_function_with_job_from_serving_fails_with_handler(
     - project.run_function (use_operations_run_function=False)
     - operations.run_function directly (use_operations_run_function=True)
     """
-    from mlrun.projects.operations import run_function as operations_run_function
+    if use_operations_run_function:
+        from mlrun.projects.operations import run_function as operations_run_function
 
     # Create a serving function
     serving_fn = mlrun.new_function(name="test-serving", kind="serving")
@@ -302,7 +303,7 @@ def test_run_function_with_job_from_serving_fails_with_handler(
     graph = serving_fn.set_topology("flow", engine="async")
     graph.to(name="step1", handler="handler")
 
-    # Convert to job - this creates a KubejobRuntime with serving_spec
+    # Deploy to job - this creates a KubejobRuntime with serving_spec
     job = serving_fn.to_job()
 
     # Verify the job has a serving_spec

--- a/tests/runtimes/test_to_job.py
+++ b/tests/runtimes/test_to_job.py
@@ -274,13 +274,26 @@ def test_to_job_backward_compatibility():
     assert job.metadata.name == long_name  # Name unchanged
 
 
-def test_run_function_with_job_from_serving_fails_with_handler():
+@pytest.mark.parametrize(
+    "use_operations_run_function",
+    [False, True],
+    ids=["project.run_function", "operations.run_function"],
+)
+def test_run_function_with_job_from_serving_fails_with_handler(
+    use_operations_run_function,
+):
     """Test that run_function raises error when handler is specified for a job from serving function.
 
     When a serving function is converted to a job via to_job(), the job retains a serving_spec.
     Running such a job with a custom handler should fail because the serving spec already
     defines the default handler (execute_graph).
+
+    This test validates both:
+    - project.run_function (use_operations_run_function=False)
+    - operations.run_function directly (use_operations_run_function=True)
     """
+    from mlrun.projects.operations import run_function as operations_run_function
+
     # Create a serving function
     serving_fn = mlrun.new_function(name="test-serving", kind="serving")
     serving_fn.spec.image = "mlrun/mlrun"  # Set an image to avoid build requirements
@@ -298,13 +311,14 @@ def test_run_function_with_job_from_serving_fails_with_handler():
     )
     assert job.kind == "job", f"Job should have kind='job', got '{job.kind}'"
 
-    # Create a project to use run_function
-    project = mlrun.new_project("test-project", save=False)
-    project.set_function(job, "test-job")
-
     # Running with a handler should raise MLRunInvalidArgumentError
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
         match="handler cannot be specified when running a KubeJobRuntime with a serving spec",
     ):
-        project.run_function(job, handler="custom_handler", local=True)
+        if use_operations_run_function:
+            operations_run_function(job, handler="custom_handler", local=True)
+        else:
+            project = mlrun.new_project("test-project", save=False)
+            project.run_function(job, handler="custom_handler", local=True)
+


### PR DESCRIPTION
### 📝 Description

Prevent specifying a custom handler when executing jobs that originate from serving functions while using `project.run_function`.

---

### 🛠️ Changes Made

 Blocking user handler for running a serving origin job.
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12215
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
