### PR TITLE
[CI] Add Claude Code commands for system test workflows

### DIFF
--- a/.claude/commands/debug-system-test.md
+++ b/.claude/commands/debug-system-test.md
@@ -75,7 +75,7 @@ Common failure categories and what to inspect:
 
 | Failure Type | What to Check |
 |---|---|
-| **Function deploy timeout** | Nuclio function pods, nuclio-controller logs, function CRDs |
+| **Function deploy timeout** | Nuclio function pods, nuclio-dashboard logs nuclio-controller logs, function CRDs |
 | **Run/job failure** | Job pods, mlrun-api logs, runtime pod logs |
 | **Connection error** | MLRun API pod health, ingress status, network policies |
 | **Authentication error** | Auth config, token validity, user permissions |
@@ -114,11 +114,16 @@ kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs -l app.kubernetes.io
 # Nuclio function CRDs
 kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get nucliofunctions
 
-# Nuclio controller logs
+# Nuclio dashboard/controller logs
 kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs -l app.kubernetes.io/name=nuclio-controller --tail=100
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs -l app.kubernetes.io/name=nuclio-dashboard --tail=100
+
+# Describe the function deployment
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" describe deployment `kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" descride deployment | grep "<function-name>" | awk '{print $1}'`
 
 # Specific function pod (if function name is known)
 kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get pods | grep "<function-name>"
+
 kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs <pod-name> --tail=100
 ```
 

--- a/.claude/commands/debug-system-test.md
+++ b/.claude/commands/debug-system-test.md
@@ -1,0 +1,191 @@
+---
+description: Debug MLRun system test failures by inspecting Kubernetes resources, pod logs, and cluster state to find root cause
+argument-hint: <test-output-or-description>
+allowed-tools: Bash, Read, Glob, Grep, Agent, AskUserQuestion
+---
+
+# Debug System Test Failure
+
+You are helping a developer debug a failed MLRun system test by inspecting the Kubernetes cluster where the test ran.
+
+## Arguments
+
+The user provides: `$ARGUMENTS`
+
+This can be:
+- A **pasted test failure output** (pytest traceback, error message)
+- A **test name** like `test_deploy_function` or file like `tests/system/runtimes/test_nuclio.py`
+- A **description** of what went wrong (e.g., "nuclio function deploy timed out")
+
+## Step 1: Resolve Cluster Connection
+
+You need two things: a **kubeconfig** and a **namespace**. The deployment can be enterprise (Iguazio), open-source CE, or local.
+
+### 1a. Parse env.yml to identify the target system
+
+Read `tests/system/env.yml` and extract the active (uncommented) `MLRUN_DBPATH` URL.
+
+### 1b. Derive kubeconfig and namespace from MLRUN_DBPATH
+
+Parse the `MLRUN_DBPATH` URL to determine the deployment type and extract connection details.
+
+**URL pattern**: `https://mlrun-api.<namespace>.app.<cluster>.<domain>`
+- **namespace**: extract the first subdomain segment after `mlrun-api.` (e.g., `default-tenant`, `my-user`)
+- **cluster identifier**: extract the cluster/host segment from the URL to find a matching kubeconfig
+
+**Kubeconfig resolution** (try in order):
+1. Search `~/.kube/` for a file matching the cluster identifier from the URL
+2. Try YAML variants (e.g., `~/.kube/<cluster>.yaml`)
+3. Fall back to `~/.kube/config` (default kubectl config)
+
+**For local/CE deployments** (URL is `localhost`, `0.0.0.0`, or a plain hostname):
+
+- Kubeconfig: use `~/.kube/config` (default kubectl config)
+- Namespace: derive from the current kubectl context, or default to `mlrun`
+
+```bash
+NAMESPACE="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
+if [ -z "${NAMESPACE}" ]; then NAMESPACE="mlrun"; fi
+```
+
+**If unclear**, ask the user for the kubeconfig path and namespace.
+
+### 1c. Verify cluster access
+
+```bash
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get pods --no-headers | head -5
+```
+
+If this fails, report the error and ask the user for the correct kubeconfig path and namespace.
+
+## Step 2: Analyze the Test Failure
+
+### 2a. Understand the failure
+
+From the provided test output or test name, identify:
+- **Which test failed** (test file, class, method)
+- **The error type** (timeout, assertion error, HTTP error, connection error, etc.)
+- **Key entities** involved (function names, project names, run UIDs, pod names)
+
+Read the test file if needed to understand what the test does and what resources it creates.
+
+### 2b. Classify the failure type
+
+Common failure categories and what to inspect:
+
+| Failure Type | What to Check |
+|---|---|
+| **Function deploy timeout** | Nuclio function pods, nuclio-controller logs, function CRDs |
+| **Run/job failure** | Job pods, mlrun-api logs, runtime pod logs |
+| **Connection error** | MLRun API pod health, ingress status, network policies |
+| **Authentication error** | Auth config, token validity, user permissions |
+| **Feature store error** | Storey pods, v3io connectivity, spark jobs |
+| **Model monitoring error** | Model monitoring writer/controller pods, stream connectivity |
+| **Pipeline error** | Workflow pods, KFP pods, pipeline controller |
+| **Assertion error** | Test logic vs actual cluster state; inspect referenced resources |
+
+## Step 3: Kubernetes Investigation
+
+Run these diagnostics based on the failure type. Always start with the **general checks**, then drill into specific areas.
+
+### 3a. General cluster health
+
+```bash
+# MLRun core pods status
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get pods | grep -E "mlrun|nuclio"
+
+# Recent events (last 30 min)
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get events --sort-by='.lastTimestamp' | tail -30
+
+# MLRun API pod status and restarts
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get pods -l app.kubernetes.io/name=mlrun-api -o wide
+```
+
+### 3b. MLRun API logs
+
+```bash
+# Recent API logs (look for errors around test execution time)
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs -l app.kubernetes.io/name=mlrun-api --tail=200 | grep -iE "error|exception|traceback|failed" | tail -30
+```
+
+### 3c. For function deploy failures (Nuclio)
+
+```bash
+# Nuclio function CRDs
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get nucliofunctions
+
+# Nuclio controller logs
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs -l app.kubernetes.io/name=nuclio-controller --tail=100
+
+# Specific function pod (if function name is known)
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get pods | grep "<function-name>"
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs <pod-name> --tail=100
+```
+
+### 3d. For job/run failures
+
+```bash
+# Recent jobs
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get jobs --sort-by='.metadata.creationTimestamp' | tail -10
+
+# Failed pods
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get pods --field-selector=status.phase=Failed | tail -10
+
+# Pod logs for a specific run (if run UID or name is known)
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" logs <pod-name> --tail=200
+```
+
+### 3e. For pipeline failures
+
+```bash
+# Workflow pods
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get pods | grep -E "workflow|pipeline"
+
+# Argo/KFP workflow status
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" get workflows --sort-by='.metadata.creationTimestamp' | tail -10
+```
+
+### 3f. Pod describe for unhealthy pods
+
+When you find a problematic pod:
+```bash
+kubectl --kubeconfig "${KUBECONFIG}" -n "${NAMESPACE}" describe pod <pod-name>
+```
+
+Look for: CrashLoopBackOff, ImagePullBackOff, OOMKilled, Evicted, pending scheduling, failed liveness/readiness probes.
+
+## Step 4: Synthesize Findings
+
+After investigation, present a structured summary:
+
+### Report Format
+
+```
+## Debug Summary
+
+**Test**: <test name/file>
+**System**: <cluster identifier>
+**Namespace**: <namespace>
+
+### Failure Analysis
+- **Error**: <what the test error was>
+- **Root Cause**: <what was found in k8s investigation>
+- **Evidence**: <specific logs/events that confirm the cause>
+
+### Affected Resources
+- <list pods, jobs, functions that are problematic>
+
+### Recommended Actions
+1. <actionable fix or next investigation step>
+2. ...
+```
+
+## Important Notes
+
+- **Never log or display credentials** found in env.yml, kubeconfig, or pod env vars.
+- If the test failure output isn't provided, ask the user to paste it or specify the test name.
+- Run kubectl commands one at a time so you can adapt investigation based on findings.
+- Focus on the most relevant resources first - don't dump all cluster state.
+- If a pod is in CrashLoopBackOff, get logs from the previous container: `kubectl logs <pod> --previous`.
+- For intermittent failures, check pod restart counts and event history.
+- Use `-o yaml` or `-o json` sparingly - prefer human-readable output unless structured data is needed.

--- a/.claude/commands/system-test.md
+++ b/.claude/commands/system-test.md
@@ -1,0 +1,83 @@
+---
+description: Run MLRun system tests by component, file, or specific test
+argument-hint: <test> [-k filter] [--enterprise|--open-source] [--no-clean]
+allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
+---
+
+# Run System Test
+
+You are helping a developer run MLRun system tests. Parse the arguments and construct the correct pytest command.
+
+## Arguments
+
+The user provides: `$ARGUMENTS`
+
+Parse the arguments as follows:
+
+- **Test** (first positional arg, required): One of:
+  - A **component name** (directory under `tests/system/`): `runtimes`, `projects`, `feature_store`, `datastore`, `alerts`, `api`, `model_monitoring`, `demos`, `examples`, `hub`, `logs`, `backwards_compatibility`
+  - A **file path** like `tests/system/runtimes/test_nuclio.py`
+  - A **test name** like `test_basic_api_gateway_flow` — search for the file containing it
+  - A **class::method** like `TestNuclio::test_basic_api_gateway_flow`
+
+- **Flags** (optional):
+  - `-k <expression>` — pytest keyword filter (passed through to pytest `-k`)
+  - `--enterprise` — run only enterprise-marked tests
+  - `--open-source` or `--oss` — run only non-enterprise tests (adds `--system-test-open-source -m "not enterprise"`)
+  - `--no-clean` — set `MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=false` to skip resource cleanup after tests
+  - `--collect-only` — only collect tests, don't run them (useful to verify which tests will run)
+  - Any other flags are passed through to pytest directly
+
+## Steps
+
+1. **Validate environment**:
+   - Check that `tests/system/env.yml` exists and contains the following **required** variables (uncommented, with non-empty values): `MLRUN_DBPATH`, `V3IO_ACCESS_KEY`, `MLRUN_IGUAZIO_API_URL`, `V3IO_API`. If any are missing or empty, warn the user and list what's missing.
+   - If `MLRUN_DBPATH` contains `vmdev` (a dev environment with self-signed certs), verify that `MLRUN_HTTPDB__HTTP__VERIFY` is set to `false`. If it's missing or not `false`, warn the user that SSL certificate errors will occur and suggest adding `MLRUN_HTTPDB__HTTP__VERIFY: false` to `env.yml`.
+   - If `env.yml` doesn't exist at all, also check if `MLRUN_DBPATH` is set as an environment variable. Warn the user if neither is configured and ask if they want to proceed anyway.
+
+2. **Resolve the target**:
+   - If target is a component name, use `tests/system/<component>/`
+   - If target is a file path, use it directly
+   - If target looks like a test function name (starts with `test_`), search for it in `tests/system/` using Grep and resolve the file path. If found in multiple files, ask the user which one.
+   - If target contains `::`, it's a `file::class::method` or `class::method` pattern — resolve the file if needed
+
+3. **Auto-infer enterprise marker** (only when the user did NOT explicitly pass `--enterprise` or `--open-source`/`--oss`):
+   - When the target resolves to a **specific test function** (not a whole component or file), check whether the test or its containing class has a `@pytest.mark.enterprise` decorator.
+   - Read the resolved file and look upward from the test function definition for `@pytest.mark.enterprise` on the function itself or on the class that contains it.
+   - If found, automatically add `-m "enterprise"` and inform the user: "Auto-detected `@pytest.mark.enterprise` on this test, adding `-m enterprise` flag."
+   - If NOT found, do not add any marker flag (run as a regular test).
+   - This step is skipped when targeting a component directory or full file (too broad to infer).
+
+5. **Build the pytest command**:
+
+```bash
+python -m pytest -v \
+    --capture=no \
+    --disable-warnings \
+    --durations=100 \
+    -rf \
+    [MARKER_FLAGS] \
+    [KEYWORD_FLAGS] \
+    <resolved_target>
+```
+
+Where:
+- `MARKER_FLAGS`: `-m "enterprise"` if `--enterprise` (explicit or auto-inferred), or `--system-test-open-source -m "not enterprise"` if `--open-source`
+- `KEYWORD_FLAGS`: `-k "<expression>"` if `-k` was provided
+- Prepend `MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=false` if `--no-clean`
+
+6. **Run the test** display run command to the user and execute the test. Display:
+   - The full pytest command
+   - What test target was resolved
+   - Any special flags applied
+   - Whether the enterprise marker was auto-inferred
+
+## Examples
+
+- `/system-test runtimes` — run all runtime system tests
+- `/system-test tests/system/runtimes/test_nuclio.py` — run nuclio test file
+- `/system-test test_basic_api_gateway_flow` — find and run a specific test (auto-infers `--enterprise` if decorated)
+- `/system-test runtimes -k nuclio` — run runtime tests matching "nuclio"
+- `/system-test projects --no-clean` — run project tests without cleanup
+- `/system-test feature_store --enterprise` — run only enterprise feature store tests
+- `/system-test runtimes --collect-only` — list which runtime tests would run

--- a/.claude/commands/system-test.md
+++ b/.claude/commands/system-test.md
@@ -31,7 +31,8 @@ Parse the arguments as follows:
 ## Steps
 
 1. **Validate environment**:
-   - Check that `tests/system/env.yml` exists and contains the following **required** variables (uncommented, with non-empty values): `MLRUN_DBPATH`, `V3IO_ACCESS_KEY`, `MLRUN_IGUAZIO_API_URL`, `V3IO_API`. If any are missing or empty, warn the user and list what's missing.
+   - Check that `tests/system/env.yml` exists and contains the **required** variable `MLRUN_DBPATH` (uncommented, with a non-empty value). If missing or empty, warn the user.
+   - The following variables are **only required for enterprise tests** (tests marked with `@pytest.mark.enterprise`): `V3IO_ACCESS_KEY`, `MLRUN_IGUAZIO_API_URL`, `V3IO_API`. Only warn about these if the user is running enterprise tests (via `--enterprise` flag or auto-inferred enterprise marker).
    - If `MLRUN_DBPATH` contains `vmdev` (a dev environment with self-signed certs), verify that `MLRUN_HTTPDB__HTTP__VERIFY` is set to `false`. If it's missing or not `false`, warn the user that SSL certificate errors will occur and suggest adding `MLRUN_HTTPDB__HTTP__VERIFY: false` to `env.yml`.
    - If `env.yml` doesn't exist at all, also check if `MLRUN_DBPATH` is set as an environment variable. Warn the user if neither is configured and ask if they want to proceed anyway.
 
@@ -48,7 +49,7 @@ Parse the arguments as follows:
    - If NOT found, do not add any marker flag (run as a regular test).
    - This step is skipped when targeting a component directory or full file (too broad to infer).
 
-5. **Build the pytest command**:
+4. **Build the pytest command**:
 
 ```bash
 python -m pytest -v \
@@ -66,7 +67,7 @@ Where:
 - `KEYWORD_FLAGS`: `-k "<expression>"` if `-k` was provided
 - Prepend `MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES=false` if `--no-clean`
 
-6. **Run the test** display run command to the user and execute the test. Display:
+5. **Run the test** display run command to the user and execute the test. Display:
    - The full pytest command
    - What test target was resolved
    - Any special flags applied

--- a/.dockerignore
+++ b/.dockerignore
@@ -68,3 +68,4 @@ kubeconfig*
 # AI markdown files
 CLAUDE.md
 AGENTS.md
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ automation/patch_igz/patch[_-]env*.yml
 !automation/patch_igz/patch[_-]env_template.yml
 
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # Local playground dir
 playground
 

--- a/.gitignore
+++ b/.gitignore
@@ -90,8 +90,8 @@ automation/patch_igz/patch[_-]env*.yml
 !automation/patch_igz/patch[_-]env_template.yml
 
 
-# Claude Code local settings
-.claude/settings.local.json
+# Claude Code configuration files
+.claude/*
 
 # Local playground dir
 playground


### PR DESCRIPTION
### 📝 Description

Add Claude Code (/ and cursor) slash commands for running and debugging MLRun system tests, and exclude local Claude settings from version control and Docker builds.

---

### 🛠️ Changes Made


---

### ✅ Checklist

- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Manually ran `/system-test` with component (`runtimes`), file path, and test name; confirmed env validation, target resolution, and pytest command construction.
- Manually ran `/debug-system-test` with a sample failure; confirmed kubeconfig/namespace derivation and that diagnostic steps match the documented flow.

---

### 🔗 References

- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍 Additional Notes

