### PR TITLE
[Alerts] Fix wildcard alert activation storing "*" as entity_id

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -7020,6 +7020,9 @@ class SQLDB(DBInterface):
             run_name = alert_data.entities.ids[0]
             run_uid = event_data.value_dict.get("uid")
             entity_id = f"{run_name}.{run_uid}" if run_uid else run_name
+        elif alert_data.entities.ids[0] == "*":
+            # Wildcard alert — use the actual entity_id from the event
+            entity_id = event_data.entity.ids[0]
         else:
             entity_id = alert_data.entities.ids[0]
 


### PR DESCRIPTION
## Summary
- Fix `store_alert_activation()` storing literal `"*"` as `entity_id` instead of the actual event entity ID when the alert uses a wildcard entity match (`ids=["*"]`)

## Changes Made
- **`server/py/framework/db/sqldb/db.py`**: Add `elif` branch in `store_alert_activation()` — when `alert_data.entities.ids[0] == "*"`, use `event_data.entity.ids[0]` (the real entity ID from the incoming event) instead of the wildcard

## Root Cause
The model monitoring lag detection alert (PR #9315) introduced wildcard entity matching (`ids=["*"]`) to catch lag events from any writer worker. However, `store_alert_activation()` unconditionally used the alert config's entity ID for non-JOB entities, storing `"*"` in the activation record instead of the actual source like `"project.writer.0"`.

## Testing
- System test: `test_writer_lag_alert` passes on vmdev76 with patched API + alerts service

## Reference
- Fixes: ML-12242