### PR TITLE
[Dockerfiles] Remove setuptools 82 constraint

### DIFF
--- a/dockerfiles/common/Dockerfile
+++ b/dockerfiles/common/Dockerfile
@@ -28,9 +28,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libffi-dev \
         python3-dev \
         unzip \
-    # TODO (ML-12122): remove setuptools<82 constraint once pkg_resources usage is dropped
-    && echo 'setuptools<82' > /tmp/constraints.txt \
     && python -m pip list --format=freeze \
         | grep -v '^\-e' \
         | cut -d = -f 1 \
-        | xargs python -m pip install --upgrade -c /tmp/constraints.txt
+        | xargs python -m pip install --upgrade

--- a/server/common/builder/schemas_compiler/docker/Dockerfile
+++ b/server/common/builder/schemas_compiler/docker/Dockerfile
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 ARG PYTHON_VERSION=3.11
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.25
 
 FROM gcr.io/iguazio/golang:${GO_VERSION}-alpine AS golang
 
 FROM gcr.io/iguazio/python:${PYTHON_VERSION}-alpine
 
-ARG PROTOC_GEN_GO_VERSION=v1.28
-ARG PROTOC_GEN_GO_GRPC_VERSION=v1.2
-ARG GRPCIO_TOOLS_VERSION="~=1.59.0"
+ARG PROTOC_GEN_GO_VERSION=v1.36.11
+ARG PROTOC_GEN_GO_GRPC_VERSION=v1.6.1
+ARG GRPCIO_TOOLS_VERSION="~=1.76.0"
 
 WORKDIR /app
 
@@ -38,7 +38,5 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
-# TODO (ML-12122): remove setuptools<82 constraint once pkg_resources usage is dropped
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python -m pip install --upgrade 'setuptools<82' grpcio-tools${GRPCIO_TOOLS_VERSION}
-
+    python -m pip install --upgrade grpcio-tools${GRPCIO_TOOLS_VERSION}


### PR DESCRIPTION
### 📝 Description

Dependency and build updates: remove the setuptools constraint (ML-12122) and update the schema compiler Docker image (Go, protoc, grpcio-tools). The branch also includes prior dependency bumps and lock file upgrades from development.


---

### 🛠️ Changes Made

- **dockerfiles/common/Dockerfile**: Remove `setuptools<82` constraint and constraints file; base image pip upgrade no longer uses a constraint (addresses TODO ML-12122).
- **server/common/builder/schemas_compiler/docker/Dockerfile**: Update schema builder image: Go 1.21 → 1.25, protoc-gen-go v1.28 → v1.36.11, protoc-gen-go-grpc v1.2 → v1.6.1, grpcio-tools ~=1.59.0 → ~=1.76.0; remove `setuptools<82` install.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Build and usage of `dockerfiles/common` and schema compiler image (e.g. `make log-collector` or schema compilation) to confirm no setuptools/grpcio/protoc regressions.
- Existing CI (lint, unit tests) and, if applicable, system/smoke tests for the branch.


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12251 https://iguazio.atlassian.net/browse/ML-12252 https://iguazio.atlassian.net/browse/ML-12253
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
