### PR TITLE
[CI] Update uv version to 0.10.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,7 +264,7 @@ jobs:
 
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: |
-        uv venv venv --seed
+        uv venv venv --seed --clear
         source venv/bin/activate
         make install-automation-requirements
         uv pip install -e .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,6 +261,7 @@ jobs:
       with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+          cache-dependency-glob: "**/*requirements*.txt"
 
     - name: Install automation scripts dependencies and add mlrun to dev packages
       run: |

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -206,7 +206,7 @@ jobs:
 
     - name: Install automation scripts dependencies
       run: |
-        uv venv venv --seed
+        uv venv venv --seed --clear
         . venv/bin/activate
         make install-automation-requirements
 
@@ -439,7 +439,7 @@ jobs:
         # https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
         # ensure mlrun git is safe to use
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        uv venv venv --seed
+        uv venv venv --seed --clear
         . venv/bin/activate
         MLRUN_VERSION="${{ needs.prepare-system-tests-enterprise-ci.outputs.mlrunVersion }}" \
           make install-requirements install-complete-requirements update-version-file

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -139,8 +139,7 @@ jobs:
       with:
         enable-cache: true
         python-version: 3.11
-        cache-dependency-glob: |
-          **/*requirements*.txt
+        cache-dependency-glob: "**/*requirements*.txt"
 
     - name: Copy state branch file from remote
       run: |
@@ -411,8 +410,7 @@ jobs:
       with:
         enable-cache: true
         python-version: 3.11
-        cache-dependency-glob: |
-          **/*requirements*.txt
+        cache-dependency-glob: "**/*requirements*.txt"
 
     - uses: actions/download-artifact@v8
       with:

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -190,7 +190,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install --yes build-essential libpq-dev libffi-dev libssl-dev python3-dev pkg-config curl jq make
-        uv venv venv --seed
+        uv venv venv --seed --clear
         source venv/bin/activate
         make install-requirements install-complete-requirements install-automation-requirements
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ MLRUN_POSTGRES_IMAGE = gcr.io/iguazio/postgres:17
 MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=
 MLRUN_PIP_VERSION ?= 25.0.0
-MLRUN_UV_VERSION ?= 0.7.14
+MLRUN_UV_VERSION ?= 0.10.9
 MLRUN_UV_IMAGE ?= ghcr.io/astral-sh/uv:$(MLRUN_UV_VERSION)
 MLRUN_CACHE_DATE ?= $(shell date +%s)
 # empty by default, can be set to something like "tag-name" which will cause to:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ author = "Iguazio"
 docstring-code-format = true
 
 [tool.uv]
-required-version = ">=0.7.14"
+required-version = ">=0.10.9"
 
 [tool.uv.pip]
 python-version = "3.11"


### PR DESCRIPTION
### 📝 Description

Bump uv from 0.7.14 to 0.10.9 and address breaking changes introduced across 0.8.0, 0.9.0, and 0.10.0 versions.

to update your local uv - run `uv self update`.

---

### 🛠️ Changes Made


- Added `--clear` flag to all `uv venv venv --seed` calls in CI workflows - required since uv 0.10.0 which errors when overwriting an existing venv without `--clear`
- Aligned `cache-dependency-glob` format in `system-tests-enterprise.yml`

**Notable and relevant uv changes in this range:**
- 0.10.0: `uv venv` requires `--clear` to overwrite existing venvs

**Verified no impact:**
- Lock files were regenerated with `make upgrade-mlrun-deps-lock` - no changes in resolved dependencies

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Ran `make upgrade-mlrun-deps-lock -j` locally to verify lock files compile successfully with uv 0.10.9 - resolved deps are identical (no diff)
- CI workflows should be validated by running the package-tests and system-tests jobs

---

### 🔗 References
- [uv releases](https://github.com/astral-sh/uv/releases)
- [uv 0.8.0 breaking changes](https://github.com/astral-sh/uv/releases/tag/0.8.0)
- [uv 0.10.0 breaking changes](https://github.com/astral-sh/uv/releases/tag/0.10.0)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

Docker builds will now pull `ghcr.io/astral-sh/uv:0.10.9` instead of `ghcr.io/astral-sh/uv:0.7.14`. The `--clear` flag on `uv venv` is a no-op on fresh CI runners (directory doesn't exist), so it's purely defensive.
