### PR TITLE
[Model Monitoring] Bump storey to 1.11.21 and add predictions uniqueness

### DIFF
--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -3543,8 +3543,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.20 \
-    --hash=sha256:11a66a222d7fb00e7af7a7936d5b5a7950f8728ad2eb423012925a9f1c9a3cf1
+storey==1.11.21 \
+    --hash=sha256:b58e760b20baf77e93d1491c1d5a4bb14f51282af8e3de7c80e17a30579dd5ea
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -3297,8 +3297,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.20 \
-    --hash=sha256:11a66a222d7fb00e7af7a7936d5b5a7950f8728ad2eb423012925a9f1c9a3cf1
+storey==1.11.21 \
+    --hash=sha256:b58e760b20baf77e93d1491c1d5a4bb14f51282af8e3de7c80e17a30579dd5ea
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -2952,8 +2952,8 @@ starlette==0.49.3 \
     --hash=sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284 \
     --hash=sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f
     # via fastapi
-storey==1.11.20 \
-    --hash=sha256:11a66a222d7fb00e7af7a7936d5b5a7950f8728ad2eb423012925a9f1c9a3cf1
+storey==1.11.21 \
+    --hash=sha256:b58e760b20baf77e93d1491c1d5a4bb14f51282af8e3de7c80e17a30579dd5ea
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -2771,8 +2771,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.20 \
-    --hash=sha256:11a66a222d7fb00e7af7a7936d5b5a7950f8728ad2eb423012925a9f1c9a3cf1
+storey==1.11.21 \
+    --hash=sha256:b58e760b20baf77e93d1491c1d5a4bb14f51282af8e3de7c80e17a30579dd5ea
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -3543,8 +3543,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.11.20 \
-    --hash=sha256:11a66a222d7fb00e7af7a7936d5b5a7950f8728ad2eb423012925a9f1c9a3cf1
+storey==1.11.21 \
+    --hash=sha256:b58e760b20baf77e93d1491c1d5a4bb14f51282af8e3de7c80e17a30579dd5ea
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -4512,8 +4512,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.11.20 \
-    --hash=sha256:11a66a222d7fb00e7af7a7936d5b5a7950f8728ad2eb423012925a9f1c9a3cf1
+storey==1.11.21 \
+    --hash=sha256:b58e760b20baf77e93d1491c1d5a4bb14f51282af8e3de7c80e17a30579dd5ea
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -4628,8 +4628,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.11.20 \
-    --hash=sha256:11a66a222d7fb00e7af7a7936d5b5a7950f8728ad2eb423012925a9f1c9a3cf1
+storey==1.11.21 \
+    --hash=sha256:b58e760b20baf77e93d1491c1d5a4bb14f51282af8e3de7c80e17a30579dd5ea
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_operations.py
@@ -179,6 +179,7 @@ class TimescaleDBOperationsManager:
 
             # Create indexes
             statements.extend(table._create_indexes_query())
+            statements.extend(table._create_unique_indexes_query())
 
             # Create pre-aggregate tables if config provided
             if config:

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_schema.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_schema.py
@@ -94,6 +94,7 @@ class TimescaleDBSchema:
         schema: str | None = None,
         chunk_time_interval: str = "1 day",
         indexes: list[str] | None = None,
+        unique_indexes: list[str] | None = None,
     ):
         self.table_name = f"{table_name}_{project.replace('-', '_')}"
         self.columns = columns
@@ -101,6 +102,7 @@ class TimescaleDBSchema:
         self.schema = schema or _MODEL_MONITORING_SCHEMA
         self.chunk_time_interval = chunk_time_interval
         self.indexes = indexes or []
+        self.unique_indexes = unique_indexes or []
         self.project = project
 
     def full_name(self) -> str:
@@ -129,6 +131,22 @@ class TimescaleDBSchema:
             index_name = f"idx_{self.table_name}_{index_columns.replace(',', '_').replace(' ', '_')}"
             queries.append(
                 f"CREATE INDEX IF NOT EXISTS {index_name} "
+                f"ON {self.full_name()} ({index_columns});"
+            )
+        return queries
+
+    def _create_unique_indexes_query(self) -> list[str]:
+        """Create unique indexes for the table.
+
+        Unique indexes on TimescaleDB hypertables must include the time
+        partitioning column. They enable deduplication when combined with
+        INSERT ... ON CONFLICT DO NOTHING on the write path.
+        """
+        queries = []
+        for index_columns in self.unique_indexes:
+            index_name = f"uq_{self.table_name}_{index_columns.replace(',', '_').replace(' ', '_')}"
+            queries.append(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {index_name} "
                 f"ON {self.full_name()} ({index_columns});"
             )
         return queries
@@ -462,6 +480,12 @@ class Predictions(TimescaleDBSchema):
             mm_schemas.WriterEvent.END_INFER_TIME,
             f"{mm_schemas.WriterEvent.END_INFER_TIME}, {mm_schemas.WriterEvent.ENDPOINT_ID}",
         ]
+        # Unique index on (endpoint_id, end_infer_time) enables deduplication
+        # of prediction records from Kafka at-least-once delivery.
+        # TimescaleDB requires unique indexes to include the time partitioning column.
+        unique_indexes = [
+            f"{mm_schemas.WriterEvent.ENDPOINT_ID}, {mm_schemas.WriterEvent.END_INFER_TIME}",
+        ]
         super().__init__(
             table_name=table_name,
             columns=columns,
@@ -469,6 +493,7 @@ class Predictions(TimescaleDBSchema):
             schema=schema,
             project=project,
             indexes=indexes,
+            unique_indexes=unique_indexes,
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2025.5.1, <=2025.7.0
 v3iofs~=0.1.17
-storey~=1.11.20
+storey~=1.11.21
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_operations.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_operations.py
@@ -161,6 +161,56 @@ class TestTimescaleDBOperationsManagerIntegration:
         )
         assert len(result.data) == 4
 
+    def test_predictions_unique_index_created(self, query_test_helper):
+        """Test that a unique index on (endpoint_id, end_infer_time) is created on the predictions table."""
+        connection = query_test_helper.connection
+        tables = query_test_helper.operations_handler.tables
+        predictions_table = tables[mm_schemas.TimescaleDBTables.PREDICTIONS]
+        schema_name = predictions_table.schema
+
+        # Query actual unique indexes and their column order from pg catalog
+        result = connection.run(
+            query=f"""
+            SELECT ic.relname AS index_name,
+                   array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) AS columns
+            FROM pg_index ix
+            JOIN pg_class t ON t.oid = ix.indrelid
+            JOIN pg_class ic ON ic.oid = ix.indexrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+            WHERE n.nspname = '{schema_name}'
+              AND t.relname = '{predictions_table.table_name}'
+              AND ix.indisunique = true
+              AND NOT ix.indisprimary
+            GROUP BY ic.relname
+            """
+        )
+
+        # Exactly one unique index on predictions
+        assert len(result.data) == 1
+        _, columns = result.data[0]
+        assert columns == ["endpoint_id", "end_infer_time"]
+
+        # Verify other tables have no unique indexes
+        for table_type in [
+            mm_schemas.TimescaleDBTables.METRICS,
+            mm_schemas.TimescaleDBTables.APP_RESULTS,
+            mm_schemas.TimescaleDBTables.ERRORS,
+        ]:
+            table = tables[table_type]
+            other_result = connection.run(
+                query=f"""
+                SELECT COUNT(*) FROM pg_index ix
+                JOIN pg_class t ON t.oid = ix.indrelid
+                JOIN pg_namespace n ON n.oid = t.relnamespace
+                WHERE n.nspname = '{schema_name}'
+                  AND t.relname = '{table.table_name}'
+                  AND ix.indisunique = true
+                  AND NOT ix.indisprimary
+                """
+            )
+            assert other_result.data[0][0] == 0
+
     def test_create_tables_with_pre_aggregates(self, query_test_helper_with_aggregates):
         """Test table creation with pre-aggregate configuration."""
         # Tables are already created by the fixture

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,7 +128,7 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"~=1.11.20"},
+        "storey": {"~=1.11.21"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "scipy": {"~=1.16.3"},


### PR DESCRIPTION
## Summary
- **Bump storey** from `1.11.20` to `1.11.21` — switches the TSDB write path from `COPY` to `INSERT ... ON CONFLICT DO NOTHING`, enabling deduplication of prediction records from Kafka at-least-once delivery (ML-11979)
- **Add unique index** on `(endpoint_id, end_infer_time)` to the predictions TimescaleDB hypertable — activates the dedup behavior of `ON CONFLICT DO NOTHING`

### Backward compatibility
No issues:
- **Existing tables** (no unique index): storey 1.11.21 uses `ON CONFLICT DO NOTHING` without a conflict target, so it behaves like a plain `INSERT` — no errors, no behavior change.
- **New tables**: `create_tables()` is only called during `enable_model_monitoring()` for new projects; the unique index is created on an empty table. All DDL uses `IF NOT EXISTS`.

### Changes
- `requirements.txt` + locked requirements: storey `1.11.20` → `1.11.21`
- `timescaledb_schema.py`: new `unique_indexes` parameter on `TimescaleDBSchema`; `Predictions` defines `UNIQUE(endpoint_id, end_infer_time)`
- `timescaledb_operations.py`: `create_tables` calls `_create_unique_indexes_query()` alongside regular indexes
- `test_timescaledb_operations.py`: integration test verifying unique index is created
- `tests/test_requirements.py`: update ignored specifier for storey `~=1.11.21`

## Test plan
- [x] All 22 TimescaleDB integration tests pass against real DB
- [x] `test_requirement_specifiers_convention` passes
- [ ] System test with Kafka streaming confirms deduplication on a live cluster

## References
- ML-11979