### PR TITLE
[Serving] Fix _MappedBody unpacking bypassed in async engine

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -937,12 +937,7 @@ class TaskStep(BaseStep):
                 )
 
             body = _extract_input_data(self.input_path, event.body)
-            if isinstance(body, _MappedBody):
-                # body_map-transformed bodies are unpacked as **kwargs
-                # so handler signatures like def fun(book: str) work
-                result = self._handler(**body, **kwargs)
-            else:
-                result = self._handler(body, *args, **kwargs)
+            result = _MappedBodyAwareHandler(self._handler)(body, *args, **kwargs)
             event.body = _update_result_body(self.result_path, event.body, result)
         except Exception as exc:
             if self._on_error_handler:
@@ -4034,6 +4029,41 @@ def params_to_step(
     return name, step
 
 
+class _MappedBodyAwareHandler:
+    """Unpack _MappedBody as **kwargs before calling a step handler.
+
+    _MappedBody (and its subclass _RequestContext) is a dict produced by
+    _APIHandlerStep.do() when body_map is configured.  It signals that the dict
+    should be spread as keyword arguments so handler signatures like
+    ``def fn(message: str)`` work correctly.
+
+    Implemented as a named class rather than a closure so instances remain
+    picklable for storey's multiprocessing (max_processes) mode.
+
+    Use ``__call__`` for the sync path (TaskStep.run()) and ``async_call`` for
+    the async path (_init_async_objects).  Passing the bound ``async_call``
+    method to storey.Map lets asyncio.iscoroutinefunction detect it correctly
+    without resorting to private-API sentinels.
+    """
+
+    def __init__(self, handler):
+        self._fn = handler
+
+    def __call__(self, body, *args, **kwargs):
+        if isinstance(body, _MappedBody):
+            # *args intentionally omitted: _MappedBody handlers use keyword-only
+            # signatures (e.g. def fn(message: str)), and the only callers
+            # (GraphServer.run → RootFlowStep.run, and storey.Map) never pass
+            # extra positional arguments.
+            return self._fn(**body, **kwargs)
+        return self._fn(body, *args, **kwargs)
+
+    async def async_call(self, body, *args, **kwargs):
+        if isinstance(body, _MappedBody):
+            return await self._fn(**body, **kwargs)
+        return await self._fn(body, *args, **kwargs)
+
+
 def _init_async_objects(context, steps, root):
     try:
         import storey
@@ -4137,8 +4167,14 @@ def _init_async_objects(context, steps, root):
                         f"Step '{step.name}' does not have a handler that can be called"
                     )
                 # if regular class, wrap with storey Map
+                wrapped = _MappedBodyAwareHandler(step._handler)
+                if inspect.iscoroutinefunction(step._handler):
+                    # Pass the bound async method so asyncio.iscoroutinefunction detects it correctly
+                    handler = wrapped.async_call
+                else:
+                    handler = wrapped
                 step._async_object = storey.Map(
-                    step._handler,
+                    handler,
                     full_event=step.full_event or step._call_with_event,
                     input_path=step.input_path,
                     result_path=step.result_path,

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -16,6 +16,7 @@
 
 import logging
 import re
+from collections.abc import Iterator
 from http import HTTPMethod
 from typing import cast
 from unittest.mock import MagicMock
@@ -28,7 +29,12 @@ from mlrun.common.schemas.serving import APIHandlerAction, _APIEndpointKeys
 from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
 from mlrun.serving import GraphContext
 from mlrun.serving.api_handler import _APIHandlerStep, _RequestContext
-from mlrun.serving.server import MockEvent, RootFlowStep, _add_api_handler_step_to_graph
+from mlrun.serving.server import (
+    GraphServer,
+    MockEvent,
+    RootFlowStep,
+    _add_api_handler_step_to_graph,
+)
 from mlrun.serving.utils import (
     _combine_serving_endpoint_key,
     _split_serving_endpoint_key,
@@ -2168,3 +2174,88 @@ class TestAPIHandlerEdgeCases:
         assert result.body["user_id"] == "123"
         assert result.body["fields"] == "name,email"
         assert result.body["limit"] == "10"
+
+
+class TestBodyMapMappedBodyUnpacking:
+    """body_map (_MappedBody → **kwargs) must work in both sync and async engines.
+
+    _APIHandlerStep.do() sets event.body to a _RequestContext (_MappedBody subclass).
+    TaskStep.run() unpacks it as **kwargs via _MappedBodyAwareHandler.  In the async
+    (storey) path storey.Map previously called the handler directly, bypassing that
+    unpacking.  _MappedBodyAwareHandler is now applied in both paths.
+    """
+
+    _EXPECTED = [
+        {"chunk_id": 0, "word": "Hello"},
+        {"chunk_id": 1, "word": "streaming"},
+        {"chunk_id": 2, "word": "world"},
+        {"chunk_id": -1, "word": "[END]", "final": True},
+    ]
+
+    @staticmethod
+    def _streaming_word_handler(message: str) -> Iterator[dict]:
+        """Yields one dict per word; used to test body_map unpacking."""
+        for i, word in enumerate(message.split()):
+            yield {"chunk_id": i, "word": word}
+        yield {"chunk_id": -1, "word": "[END]", "final": True}
+
+    @staticmethod
+    def _make_body_map_serving_fn(engine: str) -> ServingRuntime:
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/stream/data", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+        config.add_body_mapping("message", "$.text")
+
+        fn = mlrun.new_function("test-body-map", kind="serving")
+        fn.set_api_handler_config(config)
+        graph = fn.set_topology("flow", engine=engine)
+        graph.to(
+            name="streaming_handler",
+            handler="streaming_word_handler",
+            streaming=True,
+        ).respond()
+        fn.set_streaming(enabled=True)
+        return fn
+
+    @pytest.fixture
+    def body_map_sync_server(self) -> Iterator[GraphServer]:
+        """Serving function with engine="sync" and body_map configured."""
+        fn = self._make_body_map_serving_fn(engine="sync")
+        server = fn.to_mock_server(
+            namespace={"streaming_word_handler": self._streaming_word_handler}
+        )
+        yield server
+        server.wait_for_completion()
+
+    @pytest.fixture
+    def body_map_async_server(self) -> Iterator[GraphServer]:
+        """Serving function with engine="async" and body_map configured."""
+        fn = self._make_body_map_serving_fn(engine="async")
+        server = fn.to_mock_server(
+            namespace={"streaming_word_handler": self._streaming_word_handler}
+        )
+        yield server
+        server.wait_for_completion()
+
+    def test_sync_engine_unpacks_body_map(
+        self, body_map_sync_server: GraphServer
+    ) -> None:
+        """engine="sync" routes through TaskStep.run() — _MappedBody unpacked as **kwargs."""
+        result = body_map_sync_server.test(
+            "/stream/data",
+            body={"text": "Hello streaming world"},
+            method="POST",
+        )
+        assert list(result) == self._EXPECTED
+
+    def test_async_engine_unpacks_body_map(
+        self, body_map_async_server: GraphServer
+    ) -> None:
+        """engine="async" must unpack _MappedBody as **kwargs, matching engine="sync"."""
+        result = body_map_async_server.test(
+            "/stream/data",
+            body={"text": "Hello streaming world"},
+            method="POST",
+        )
+        assert list(result) == self._EXPECTED

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -134,7 +134,8 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
 
         self._logger.info("Forbidden API handler test passed")
 
-    def test_api_handler_with_body_mapping(self) -> None:
+    @pytest.mark.parametrize("engine", ["sync", "async"])
+    def test_api_handler_with_body_mapping(self, engine: str) -> None:
         """Test API handler with body_map JSONPath extraction."""
         self._logger.info("Testing API handler with body_map functionality")
 
@@ -161,7 +162,7 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         )
 
         # Set up topology with handler that receives kwargs from body_map
-        graph = function.set_topology("flow", engine="sync", exist_ok=True)
+        graph = function.set_topology("flow", engine=engine, exist_ok=True)
         graph.to(
             name="processor", handler="process_mapped_data"
         ).respond()  # Reference handler by name


### PR DESCRIPTION
## Summary

Fixes [ML-12217](https://iguazio.atlassian.net/browse/ML-12217): `AttributeError: '_RequestContext' object has no attribute 'split'` when using `body_map` with a generator step and `engine="async"`.

- `_init_async_objects()` wraps user step handlers in `storey.Map`, which calls `handler(event.body)` as a positional arg, bypassing `TaskStep.run()` and its `_MappedBody → **kwargs` unpacking
- `_APIHandlerStep.do()` sets `event.body` to `_RequestContext` (a `_MappedBody`/`dict` subclass) when `body_map` is configured — this arrived in the handler as a dict instead of being spread as `**kwargs`, causing `AttributeError` on the first string operation
- The downstream `async_generator is not JSON serializable` error in Nuclio was a symptom: the generator body never executed because the handler received a dict instead of a string

**Fix:** extend `_MappedBodyAwareHandler` with an `async_call` method for the async engine path:
- `TaskStep.run()` (sync engine) uses `__call__` as before — picklable, works with storey's `max_processes` multiprocessing
- `_init_async_objects()` passes the bound `async_call` method to `storey.Map` — storey's `asyncio.iscoroutinefunction` check naturally returns `True` for a bound `async def` method, with no private-API sentinels needed

## Test plan

- [x] `TestBodyMapMappedBodyUnpacking::test_sync_engine_unpacks_body_map` — verifies `engine="sync"` path
- [x] `TestBodyMapMappedBodyUnpacking::test_async_engine_unpacks_body_map` — verifies `engine="async"` path (the regression)
- [x] `test_configure_model_runner_step_max_threads_processes[max_processes]` — verifies picklability is preserved
- [x] System test `test_api_handler_with_body_mapping` now parametrized over both engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ML-12237]: https://iguazio.atlassian.net/browse/ML-12237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ML-12217]: https://iguazio.atlassian.net/browse/ML-12217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ