### PR TITLE
[Alerts] Fix notification message not resolving template placeholders

### DIFF
--- a/server/py/framework/utils/notifications/notification_pusher.py
+++ b/server/py/framework/utils/notifications/notification_pusher.py
@@ -211,7 +211,9 @@ class AlertNotificationPusher(_NotificationPusherBase):
         notification_object: mlrun.common.schemas.Notification,
         event_data: mlrun.common.schemas.Event,
     ):
-        message, severity = self._prepare_notification_args(alert, notification_object)
+        message, severity = self._prepare_notification_args(
+            alert, notification_object, event_data
+        )
         logger.debug(
             "Pushing async notification",
             notification=notification_object,
@@ -255,11 +257,12 @@ class AlertNotificationPusher(_NotificationPusherBase):
     def _prepare_notification_args(
         alert: mlrun.common.schemas.AlertConfig,
         notification_object: mlrun.common.schemas.Notification,
+        event_data: mlrun.common.schemas.Event,
     ):
         message = (
             f": {notification_object.message}"
             if notification_object.message
-            else alert.summary
+            else mlrun.utils.helpers.format_alert_summary(alert, event_data)
         )
 
         severity = alert.severity

--- a/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
@@ -149,12 +149,14 @@ def _normalize_error_messages(state):
 class TestPrepareNotificationArgs:
     """Tests for AlertNotificationPusher._prepare_notification_args (ML-12248)."""
 
-    def test_message_resolves_project_placeholder(self):
+    def test_message_resolves_all_placeholders(self):
         """When no custom notification message is set, the fallback message
-        must resolve {{project}} instead of leaving it literal."""
-        alert, event_data = self._make_alert_and_event(
+        must resolve all template placeholders ({{project}}, {{name}}, {{entity}})."""
+        alert, event_data = self._create_alert_and_event(
             project="lag-detection-tutorial",
-            summary="Model monitoring lag detected in project {{project}}.",
+            name="my-lag-alert",
+            summary="Alert {{name}} in project {{project}}, entity {{entity}}.",
+            entity_id="lag-detection-tutorial.writer.0",
         )
         notification_object = Notification(name="n", kind="slack")
 
@@ -164,14 +166,14 @@ class TestPrepareNotificationArgs:
             )
         )
 
-        assert (
-            message
-            == "Model monitoring lag detected in project lag-detection-tutorial."
+        assert message == (
+            "Alert my-lag-alert in project lag-detection-tutorial, "
+            "entity lag-detection-tutorial.writer.0."
         )
 
     def test_custom_notification_message_used_as_is(self):
         """When the notification has its own message, use it directly."""
-        alert, event_data = self._make_alert_and_event()
+        alert, event_data = self._create_alert_and_event()
         notification_object = Notification(name="n", kind="slack", message="custom msg")
 
         message, _ = (
@@ -183,8 +185,9 @@ class TestPrepareNotificationArgs:
         assert message == ": custom msg"
 
     @staticmethod
-    def _make_alert_and_event(
+    def _create_alert_and_event(
         project="my-project",
+        name="monitoring-lag-detected",
         summary="Lag in project {{project}}.",
         entity_id="my-project.writer.0",
     ):
@@ -192,7 +195,7 @@ class TestPrepareNotificationArgs:
         entity_kind = alert_objects.EventEntityKind.MODEL_MONITORING_INFRA
         alert = mlrun.common.schemas.AlertConfig(
             project=project,
-            name="monitoring-lag-detected",
+            name=name,
             summary=summary,
             severity=alert_objects.AlertSeverity.MEDIUM,
             entities=alert_objects.EventEntities(

--- a/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
@@ -14,8 +14,11 @@
 
 import pytest
 
+import mlrun.common.schemas
+import mlrun.common.schemas.alert as alert_objects
 from mlrun.common.schemas import (
     AlertNotification,
+    Event,
     Notification,
     NotificationState,
     NotificationSummary,
@@ -141,3 +144,71 @@ def _normalize_error_messages(state):
         prefix, errors = state["err"].split("Errors: ")
         state["err"] = f"{prefix}Errors: {', '.join(sorted(errors.split(', ')))}"
     return state
+
+
+def _make_alert_and_event(
+    project="my-project",
+    summary="Lag in project {{project}}.",
+    entity_id="my-project.writer.0",
+):
+    """Helper to build a minimal AlertConfig and Event for _prepare_notification_args tests."""
+    entity_kind = alert_objects.EventEntityKind.MODEL_MONITORING_INFRA
+    alert = mlrun.common.schemas.AlertConfig(
+        project=project,
+        name="monitoring-lag-detected",
+        summary=summary,
+        severity=alert_objects.AlertSeverity.MEDIUM,
+        entities=alert_objects.EventEntities(
+            kind=entity_kind, project=project, ids=[entity_id]
+        ),
+        trigger=alert_objects.AlertTrigger(
+            events=[alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED]
+        ),
+        notifications=[
+            AlertNotification(notification=Notification(name="n", kind="slack"))
+        ],
+    )
+    event_data = Event(
+        kind=alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED,
+        entity=alert_objects.EventEntities(
+            kind=entity_kind, project=project, ids=[entity_id]
+        ),
+    )
+    return alert, event_data
+
+
+class TestPrepareNotificationArgs:
+    """Tests for AlertNotificationPusher._prepare_notification_args (ML-12248)."""
+
+    def test_message_resolves_project_placeholder(self):
+        """When no custom notification message is set, the fallback message
+        must resolve {{project}} instead of leaving it literal."""
+        alert, event_data = _make_alert_and_event(
+            project="lag-detection-tutorial",
+            summary="Model monitoring lag detected in project {{project}}.",
+        )
+        notification_object = Notification(name="n", kind="slack")
+
+        message, _ = (
+            framework.utils.notifications.notification_pusher.AlertNotificationPusher._prepare_notification_args(
+                alert, notification_object, event_data
+            )
+        )
+
+        assert (
+            message
+            == "Model monitoring lag detected in project lag-detection-tutorial."
+        )
+
+    def test_custom_notification_message_used_as_is(self):
+        """When the notification has its own message, use it directly."""
+        alert, event_data = _make_alert_and_event()
+        notification_object = Notification(name="n", kind="slack", message="custom msg")
+
+        message, _ = (
+            framework.utils.notifications.notification_pusher.AlertNotificationPusher._prepare_notification_args(
+                alert, notification_object, event_data
+            )
+        )
+
+        assert message == ": custom msg"

--- a/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
+++ b/server/py/services/alerts/tests/unit/crud/test_alert_activations.py
@@ -146,44 +146,13 @@ def _normalize_error_messages(state):
     return state
 
 
-def _make_alert_and_event(
-    project="my-project",
-    summary="Lag in project {{project}}.",
-    entity_id="my-project.writer.0",
-):
-    """Helper to build a minimal AlertConfig and Event for _prepare_notification_args tests."""
-    entity_kind = alert_objects.EventEntityKind.MODEL_MONITORING_INFRA
-    alert = mlrun.common.schemas.AlertConfig(
-        project=project,
-        name="monitoring-lag-detected",
-        summary=summary,
-        severity=alert_objects.AlertSeverity.MEDIUM,
-        entities=alert_objects.EventEntities(
-            kind=entity_kind, project=project, ids=[entity_id]
-        ),
-        trigger=alert_objects.AlertTrigger(
-            events=[alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED]
-        ),
-        notifications=[
-            AlertNotification(notification=Notification(name="n", kind="slack"))
-        ],
-    )
-    event_data = Event(
-        kind=alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED,
-        entity=alert_objects.EventEntities(
-            kind=entity_kind, project=project, ids=[entity_id]
-        ),
-    )
-    return alert, event_data
-
-
 class TestPrepareNotificationArgs:
     """Tests for AlertNotificationPusher._prepare_notification_args (ML-12248)."""
 
     def test_message_resolves_project_placeholder(self):
         """When no custom notification message is set, the fallback message
         must resolve {{project}} instead of leaving it literal."""
-        alert, event_data = _make_alert_and_event(
+        alert, event_data = self._make_alert_and_event(
             project="lag-detection-tutorial",
             summary="Model monitoring lag detected in project {{project}}.",
         )
@@ -202,7 +171,7 @@ class TestPrepareNotificationArgs:
 
     def test_custom_notification_message_used_as_is(self):
         """When the notification has its own message, use it directly."""
-        alert, event_data = _make_alert_and_event()
+        alert, event_data = self._make_alert_and_event()
         notification_object = Notification(name="n", kind="slack", message="custom msg")
 
         message, _ = (
@@ -212,3 +181,34 @@ class TestPrepareNotificationArgs:
         )
 
         assert message == ": custom msg"
+
+    @staticmethod
+    def _make_alert_and_event(
+        project="my-project",
+        summary="Lag in project {{project}}.",
+        entity_id="my-project.writer.0",
+    ):
+        """Build a minimal AlertConfig and Event for _prepare_notification_args tests."""
+        entity_kind = alert_objects.EventEntityKind.MODEL_MONITORING_INFRA
+        alert = mlrun.common.schemas.AlertConfig(
+            project=project,
+            name="monitoring-lag-detected",
+            summary=summary,
+            severity=alert_objects.AlertSeverity.MEDIUM,
+            entities=alert_objects.EventEntities(
+                kind=entity_kind, project=project, ids=[entity_id]
+            ),
+            trigger=alert_objects.AlertTrigger(
+                events=[alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED]
+            ),
+            notifications=[
+                AlertNotification(notification=Notification(name="n", kind="slack"))
+            ],
+        )
+        event_data = Event(
+            kind=alert_objects.EventKind.MODEL_MONITORING_LAG_DETECTED,
+            entity=alert_objects.EventEntities(
+                kind=entity_kind, project=project, ids=[entity_id]
+            ),
+        )
+        return alert, event_data


### PR DESCRIPTION
## Summary
- Fix `_prepare_notification_args()` to resolve `{{project}}`, `{{name}}`, `{{entity}}` placeholders in the notification `message` field via `format_alert_summary()`
- Clarify `lag_threshold` and `lag_event_cooldown` docstrings to show actual default formulas

## Changes Made
- **`server/py/framework/utils/notifications/notification_pusher.py`**: Pass `event_data` to `_prepare_notification_args()` and use `format_alert_summary()` instead of raw `alert.summary` for the fallback message
- **`server/py/services/alerts/tests/unit/crud/test_alert_activations.py`**: Add 2 tests verifying template resolution and custom message passthrough
- **`mlrun/projects/project.py`**: Improve docstrings for `lag_threshold` and `lag_event_cooldown` to show the actual server-side default computation formulas

## Testing
- `pytest server/py/services/alerts/tests/unit/crud/test_alert_activations.py` - 6 passed
- `pytest tests/utils/test_alerts.py` - 3 passed
- `ruff check` on all changed files - all passed

## Reference
- Jira: [ML-12248](https://iguazio.atlassian.net/browse/ML-12248)
- Related: [ML-9954](https://iguazio.atlassian.net/browse/ML-9954)

[ML-12248]: https://iguazio.atlassian.net/browse/ML-12248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ