### PR TITLE
[Docs] Document model monitoring lag detection (ML-11648)

### DIFF
--- a/docs/model-monitoring/running-applications.md
+++ b/docs/model-monitoring/running-applications.md
@@ -19,6 +19,7 @@ You can also import model monitoring applications from the [MLRun hub](https://w
 
 - [Overview](#overview)
 - [Usage](#usage)
+- [Lag detection alerts](#lag-detection-alerts)
 
 ## Overview
 
@@ -125,3 +126,32 @@ data written by the application (identified with `func_name`) for the specified 
 
 The `"skip_overlap"` value allows to pass potential overlaps, but with a later start time for the new
 data (ignoring the overlap data) so that it coincides with the `start` time of the already written data.
+
+## Lag detection alerts
+
+The monitoring writer may fall behind when processing many endpoints. **Lag detection**
+generates an alert when the writer processes events whose inference timestamps are older
+than a configurable threshold (minimum 5 minutes).
+
+Enable lag detection by passing `lag_threshold` and `lag_event_cooldown` (both in minutes,
+both optional) to {py:meth}`~mlrun.projects.MlrunProject.enable_model_monitoring`, then
+register a notification with {py:meth}`~mlrun.projects.MlrunProject.set_model_monitoring_lag_alert`:
+
+```py
+project.enable_model_monitoring(
+    base_period=10,
+    lag_threshold=15,  # fire a lag event if writer is 15+ min behind
+    lag_event_cooldown=10,  # minimum interval between consecutive lag events per worker
+)
+
+project.set_model_monitoring_lag_alert(
+    notifications=mlrun.common.schemas.Notification(
+        kind="slack",
+        name="lag-slack",
+        secret_params={"webhook": "https://hooks.slack.com/..."},
+    )
+)
+```
+
+To remove the alert, call `project.delete_model_monitoring_lag_alert()`.
+Note that `disable_model_monitoring(delete_resources=True)` also removes the lag alert.

--- a/docs/tutorials/05-model-monitoring.ipynb
+++ b/docs/tutorials/05-model-monitoring.ipynb
@@ -180,6 +180,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{tip}\n",
+    "You can also pass `lag_threshold` and `lag_event_cooldown` (in minutes) to\n",
+    "`enable_model_monitoring` to enable **lag detection** — alerts when the monitoring\n",
+    "writer falls behind processing inference events. See [Lag detection alerts](../model-monitoring/running-applications.md#lag-detection-alerts) for details.\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
@@ -570,6 +581,45 @@
     ")\n",
     "for alert_config in alert_configs:\n",
     "    project.store_alert_config(alert_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure a lag detection alert\n",
+    "\n",
+    "In addition to data-drift alerts, you can configure an alert that fires when the\n",
+    "monitoring writer falls behind — i.e., when the events it processes carry inference\n",
+    "timestamps older than a configurable threshold. This is especially useful when\n",
+    "monitoring many endpoints, where processing delays can go unnoticed.\n",
+    "\n",
+    "The lag alert reuses the same notification you already defined above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Configure lag alert with the same Slack notification\n",
+    "project.set_model_monitoring_lag_alert(\n",
+    "    notifications=mlrun.common.schemas.Notification(\n",
+    "        kind=\"slack\",\n",
+    "        name=\"lag-slack\",\n",
+    "        secret_params={\n",
+    "            \"webhook\": \"https://hooks.slack.com/\",\n",
+    "        },\n",
+    "    )\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To remove the lag alert later, call `project.delete_model_monitoring_lag_alert()`."
    ]
   },
   {

--- a/docs/tutorials/genai-02-model-monitor-llm.ipynb
+++ b/docs/tutorials/genai-02-model-monitor-llm.ipynb
@@ -87,9 +87,7 @@
    "id": "16cc6980-47d9-487a-8a98-cb9e3282c23c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "enable_model_monitoring(project=project, base_period=2)"
-   ]
+   "source": "enable_model_monitoring(\n    project=project,\n    base_period=2,\n    # Uncomment to enable lag detection (see running-applications.md):\n    # lag_threshold=10,       # alert if writer is 10+ min behind\n    # lag_event_cooldown=5,   # min interval between lag events per worker\n)"
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/src/model_monitoring_utils.py
+++ b/docs/tutorials/src/model_monitoring_utils.py
@@ -15,6 +15,8 @@ def enable_model_monitoring(
     base_period: int = 10,
     wait_for_deployment: bool = False,
     deploy_histogram_data_drift_app: bool = True,
+    lag_threshold: int | None = None,
+    lag_event_cooldown: int | None = None,
 ) -> mlrun.projects.MlrunProject:
     # Setting model monitoring creds
     tsdb_profile = DatastoreProfileV3io(name=tsdb_profile_name)
@@ -52,5 +54,7 @@ def enable_model_monitoring(
         base_period=base_period,
         wait_for_deployment=wait_for_deployment,
         deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
+        lag_threshold=lag_threshold,
+        lag_event_cooldown=lag_event_cooldown,
     )
     return project


### PR DESCRIPTION
## Summary
- Add "Lag detection alerts" reference section to `docs/model-monitoring/running-applications.md` covering enabling, configuring, and removing lag alerts
- Integrate lag detection into existing tutorial notebooks inline with their flow:
  - `05-model-monitoring.ipynb`: tip after `enable_model_monitoring()` call + lag alert subsection after drift alert configuration
  - `genai-02-model-monitor-llm.ipynb`: commented-out `lag_threshold`/`lag_event_cooldown` params in the `enable_model_monitoring()` call
- Forward `lag_threshold` / `lag_event_cooldown` params in `model_monitoring_utils.py`

## Test plan
- [ ] Verify Sphinx docs build without warnings (`make html`)
- [ ] Verify cross-references resolve correctly
- [ ] Confirm notebooks render properly in docs site