### PR TITLE
[Application] Validate local source file exists before deploy

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -1134,7 +1134,16 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
                   deploy() uses these to restore the local path in a finally block.
         """
         source = self.spec.build.source
-        if not source or not self._is_single_local_file(source):
+        if not source or not self._is_local_path(source):
+            return None, None
+
+        if not os.path.isfile(source):
+            # On redeploy the remote artifact from the previous deploy is still available
+            if not getattr(self.status, "application_source", None):
+                raise mlrun.errors.MLRunNotFoundError(
+                    f"Source file not found: '{source}'. "
+                    "The file must exist locally to be uploaded as a source artifact."
+                )
             return None, None
 
         project_name = self.metadata.project
@@ -1175,14 +1184,8 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
         return source, artifact.uri
 
     @staticmethod
-    def _is_single_local_file(source: str) -> bool:
-        # Skip if the source is already a store URI
+    def _is_local_path(source: str) -> bool:
+        """Check if source looks like a local filesystem path (not a URL or store URI)."""
         if mlrun.datastore.is_store_uri(source):
             return False
-
-        # Skip if it's a remote URL (not a relative/local path)
-        if not (is_relative_path(source) or os.path.isabs(source)):
-            return False
-
-        # Check if it's a local file (not a directory)
-        return os.path.isfile(source)
+        return is_relative_path(source) or os.path.isabs(source)

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -1056,19 +1056,19 @@ def test_set_probe_invalid_config_does_not_override_valid_probe():
 
 
 @pytest.mark.parametrize(
-    "source,setup_file,expected",
+    "source,expected",
     [
-        ("local_file.py", True, True),
-        ("directory_path", False, False),
-        ("", False, False),
-        ("store://artifacts/project/file", False, False),
-        ("https://example.com/file.py", False, False),
-        ("git://github.com/repo.git", False, False),
-        ("/non/existent/path.py", False, False),
+        ("local_file.py", True),
+        ("/absolute/path/file.py", True),
+        ("relative/path/file.py", True),
+        ("", False),
+        ("store://artifacts/project/file", False),
+        ("https://example.com/file.py", False),
+        ("git://github.com/repo.git", False),
     ],
 )
-def test_is_single_local_file(tmp_path, source, setup_file, expected):
-    # Test _is_single_local_file identifies local files vs remote/invalid sources.
+def test_is_local_path(source, expected):
+    """Verify local paths are distinguished from remote URLs and store URIs."""
     func_name = "application-test"
     fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
         func_name,
@@ -1076,18 +1076,37 @@ def test_is_single_local_file(tmp_path, source, setup_file, expected):
         image="mlrun/mlrun",
     )
 
-    if setup_file:
-        # Create a temporary file for local file case
-        file_path = tmp_path / source
-        file_path.write_text("def handler(): pass")
-        test_source = str(file_path)
-    elif source == "directory_path":
-        # Use tmp_path as directory
-        test_source = str(tmp_path)
-    else:
-        test_source = source
+    assert fn._is_local_path(source) is expected
 
-    assert fn._is_single_local_file(test_source) is expected
+
+def test_upload_source_as_artifact_missing_file_first_deploy(tmp_path):
+    """First deploy with a non-existent local source should raise a clear error."""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        project="test-project",
+    )
+    fn.spec.build.source = str(tmp_path / "nonexistent-file.py")
+
+    with pytest.raises(mlrun.errors.MLRunNotFoundError, match="Source file not found"):
+        fn._upload_source_as_artifact()
+
+
+def test_upload_source_as_artifact_missing_file_redeploy(tmp_path):
+    """Redeploy with deleted local file should skip upload when remote artifact already exists."""
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test",
+        kind="application",
+        image="mlrun/mlrun",
+        project="test-project",
+    )
+    fn.spec.build.source = str(tmp_path / "deleted-file.py")
+    fn.status.application_source = "store://artifacts/test-project/app-source:latest"
+
+    original_path, artifact_uri = fn._upload_source_as_artifact()
+    assert original_path is None
+    assert artifact_uri is None
 
 
 def test_upload_source_as_artifact(tmp_path):


### PR DESCRIPTION
### 📝 Description
When deploying an application runtime with `spec.build.source` set directly to a non-existent local path (bypassing set_function), the deploy would proceed silently without loading source code. 
The user only saw a confusing error at invocation. 
This PR adds client-side validation to fail fast with a clear error message.

---

### 🛠️ Changes Made
- `_upload_source_as_artifact`: Added validation that raises `MLRunNotFoundError` if source is a local path but the file doesn't exist and no remote artifact is available from a previous deploy. On redeploy with a deleted local file, the existing remote artifact is used gracefully.
- Renamed `_is_single_local_file`to `_is_local_path`: Now checks if a source string looks like a local path (not a URL or store URI), without checking file existence.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
Unit tests:
- `test_is_local_path`: Verifies local paths are distinguished from remote URLs and store URIs.
- `test_upload_source_as_artifact_missing_file_first_deploy`: Verifies `MLRunNotFoundError` is raised on first deploy with a non-existent local source file.
- `test_upload_source_as_artifact_missing_file_redeploy`: Verifies redeploy with a deleted local file skips upload when a remote artifact already exists.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12259
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
