### PR TITLE
[Tests] Fix async mode system tests

### DIFF
--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -780,7 +780,7 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         assert resp["tool_b"] == 2
 
     @staticmethod
-    def _test_timing_per_thread(function, time_limit: int):
+    def check_invocation_time_less_than(function, time_limit: int):
         start = time.time()
         function.invoke(path="/", body={"inputs": [[1, 2], [1, 2]]})
         end = time.time()
@@ -813,7 +813,7 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
             # Submit tasks
             futures = [
                 executor.submit(
-                    self._test_timing_per_thread,
+                    self.check_invocation_time_less_than,
                     function=function,
                     time_limit=7,
                 )
@@ -877,7 +877,7 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
             # Submit tasks
             futures = [
                 executor.submit(
-                    self._test_timing_per_thread,
+                    self.check_invocation_time_less_than,
                     function=async_function,
                     time_limit=7,
                 )

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -44,7 +44,7 @@ from tests.system.runtimes.assets.function_with_model import DummyModel, MyModel
 class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
     project_name = "test-nuclio-runtime"
 
-    image: str = "artifactory.iguazeng.com:10557/roys/mlrun:1.11.0"
+    image: str = "mlrun/mlrun"
 
     def test_deploy_function_with_error_handler(self):
         code_path = str(self.assets_path / "function-with-catcher.py")

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -44,7 +44,7 @@ from tests.system.runtimes.assets.function_with_model import DummyModel, MyModel
 class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
     project_name = "test-nuclio-runtime"
 
-    image: str = "mlrun/mlrun"
+    image: str = "artifactory.iguazeng.com:10557/roys/mlrun:1.11.0"
 
     def test_deploy_function_with_error_handler(self):
         code_path = str(self.assets_path / "function-with-catcher.py")
@@ -779,6 +779,16 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         assert resp["tool_a"] == 2
         assert resp["tool_b"] == 2
 
+    @staticmethod
+    def _test_timing_per_thread(function, time_limit: int):
+        start = time.time()
+        function.invoke(path="/", body={"inputs": [[1, 2], [1, 2]]})
+        end = time.time()
+        timing = end - start
+        assert timing < time_limit, (
+            f"running nuclio async mode took {timing} seconds should be < {time_limit}"
+        )
+
     def test_async_http_mode(self):
         code_path = str(self.assets_path / "async_nuclio_func.py")
 
@@ -799,20 +809,19 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         function.deploy()
 
         self._logger.debug("Triggering nuclio function")
-        start = time.time()
         with ThreadPoolExecutor(max_workers=100) as executor:
             # Submit tasks
             futures = [
-                executor.submit(function.invoke, path="/", body=[i]) for i in range(100)
+                executor.submit(
+                    self._test_timing_per_thread,
+                    function=function,
+                    time_limit=7,
+                )
+                for _ in range(100)
             ]
             # Retrieve results as they complete
             for future in as_completed(futures):
                 future.result()
-        end = time.time()
-        timing = end - start
-        assert timing < 7, (
-            f"running nuclio async mode took {timing} seconds should be < 7"
-        )
 
     @pytest.mark.parametrize("with_code", [True, False])
     def test_async_http_mode_serving_graph(self, with_code):
@@ -868,9 +877,11 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
             # Submit tasks
             futures = [
                 executor.submit(
-                    async_function.invoke, path="/", body={"inputs": [[1, 2], [1, 2]]}
+                    self._test_timing_per_thread,
+                    function=async_function,
+                    time_limit=7,
                 )
-                for i in range(16)
+                for _ in range(16)
             ]
             # Retrieve results as they complete
             for future in as_completed(futures):


### PR DESCRIPTION
### 📝 Description

This pr fixes `test_async_http_mode`, `test_async_http_mode_serving_graph` timing inside the thread avoid from thread pool creation overhead.

---

### 🛠️ Changes Made

Introduce a method _test_timing_per_thread that invoke the nuclio/serving function and make sure function doesn't wait more than limit time. Make sure the serving function with async mode doesn't block the request.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

system tests

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
