### PR TITLE
[Application] Skip directory sources in local file validation

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -1134,7 +1134,7 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
                   deploy() uses these to restore the local path in a finally block.
         """
         source = self.spec.build.source
-        if not source or not self._is_local_path(source):
+        if not source or not self._is_local_path(source) or os.path.isdir(source):
             return None, None
 
         if not os.path.isfile(source):

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -45,7 +45,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         ]
         self._source = os.path.join(self.remote_code_dir, self._vizro_app_code_filename)
 
-    @pytest.mark.yacoub
     def test_deploy_application(self):
         self._upload_code_to_cluster()
 
@@ -90,7 +89,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             == f".mlrun/func-{self.project.metadata.name}-{function.metadata.name}:latest"
         )
 
-    @pytest.mark.yacoub
     def test_deploy_application_from_image(self):
         self._logger.debug("Creating first application")
         function, source = self._create_vizro_application(name="first-app")
@@ -115,7 +113,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         # make sure the build was skipped
         assert "(info) Skipping build" in output
 
-    @pytest.mark.yacoub
     def test_deploy_application_from_project_source(self):
         self._upload_code_to_cluster()
 
@@ -226,7 +223,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         response = function.invoke("/external", verify=False).content.decode("utf-8")
         assert response == "test message"
 
-    @pytest.mark.yacoub
     def test_deploy_application_with_source_reload(self):
         """
         Test that application source code can be updated and reloaded at runtime using the init container.
@@ -272,7 +268,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             response = function.invoke("/", verify=False)
             assert response.content.decode("utf-8") == "version-2"
 
-    @pytest.mark.yacoub
     def test_deploy_application_with_git_source(self):
         """
         Test that application runtime uses init container to load Git source at runtime.
@@ -352,7 +347,6 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         response = function.invoke("/rootlib.py", verify=False)
         assert response.status_code == 404
 
-    @pytest.mark.yacoub
     def test_deploy_application_with_archive_source(self):
         """
         Test that application runtime uses init container to load archive source at runtime.

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -45,6 +45,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         ]
         self._source = os.path.join(self.remote_code_dir, self._vizro_app_code_filename)
 
+    @pytest.mark.yacoub
     def test_deploy_application(self):
         self._upload_code_to_cluster()
 
@@ -89,6 +90,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             == f".mlrun/func-{self.project.metadata.name}-{function.metadata.name}:latest"
         )
 
+    @pytest.mark.yacoub
     def test_deploy_application_from_image(self):
         self._logger.debug("Creating first application")
         function, source = self._create_vizro_application(name="first-app")
@@ -113,6 +115,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         # make sure the build was skipped
         assert "(info) Skipping build" in output
 
+    @pytest.mark.yacoub
     def test_deploy_application_from_project_source(self):
         self._upload_code_to_cluster()
 
@@ -223,6 +226,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         response = function.invoke("/external", verify=False).content.decode("utf-8")
         assert response == "test message"
 
+    @pytest.mark.yacoub
     def test_deploy_application_with_source_reload(self):
         """
         Test that application source code can be updated and reloaded at runtime using the init container.
@@ -268,6 +272,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
             response = function.invoke("/", verify=False)
             assert response.content.decode("utf-8") == "version-2"
 
+    @pytest.mark.yacoub
     def test_deploy_application_with_git_source(self):
         """
         Test that application runtime uses init container to load Git source at runtime.
@@ -347,6 +352,7 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         response = function.invoke("/rootlib.py", verify=False)
         assert response.status_code == 404
 
+    @pytest.mark.yacoub
     def test_deploy_application_with_archive_source(self):
         """
         Test that application runtime uses init container to load archive source at runtime.


### PR DESCRIPTION
### 📝 Description
Source file validation in `_upload_source_as_artifact` incorrectly raised MLRunNotFoundError for directory paths like "./" set by `with_repo=True`, breaking `test_deploy_application_from_project_source`. 

Directory sources are handled by the project source flow, not the artifact upload flow.

---

### 🛠️ Changes Made
- Added dir check to the early return condition, so directory paths are skipped.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
system test passes now

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12270
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
