### PR TITLE
[Docs] Add config default references for lag detection parameters

### DIFF
--- a/docs/model-monitoring/running-applications.md
+++ b/docs/model-monitoring/running-applications.md
@@ -135,7 +135,13 @@ than a configurable threshold (minimum 5 minutes).
 
 Enable lag detection by passing `lag_threshold` and `lag_event_cooldown` (both in minutes,
 both optional) to {py:meth}`~mlrun.projects.MlrunProject.enable_model_monitoring`, then
-register a notification with {py:meth}`~mlrun.projects.MlrunProject.set_model_monitoring_lag_alert`:
+register a notification with {py:meth}`~mlrun.projects.MlrunProject.set_model_monitoring_lag_alert`.
+
+When omitted, both values are computed from the server-side config
+(`model_endpoint_monitoring.lag_detection`):
+
+- **`lag_threshold`** = `min(default_lag_threshold_minutes, base_period)`
+- **`lag_event_cooldown`** = `min(default_lag_event_cooldown_minutes, base_period // 2)`
 
 ```py
 project.enable_model_monitoring(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2633,10 +2633,15 @@ class MlrunProject(ModelObj):
         :param fetch_credentials_from_sys_config: Deprecated. If true, fetch the credentials from the project
                                                   configuration.
         :param lag_threshold:                     Duration in minutes that will be considered as lag in the writer.
-                                                  Must be at least ``min_lag_threshold_minutes`` from config.
-                                                  Default computed server-side from config and ``base_period``.
+                                                  Must be at least
+                                                  ``model_endpoint_monitoring.lag_detection.min_lag_threshold_minutes``
+                                                  from config. When not provided, computed as
+                                                  ``min(default_lag_threshold_minutes, base_period)``
+                                                  (see ``model_endpoint_monitoring.lag_detection`` in config).
         :param lag_event_cooldown:                Duration in minutes between consecutive lag events per worker.
-                                                  Default computed server-side from config and ``base_period``.
+                                                  When not provided, computed as
+                                                  ``min(default_lag_event_cooldown_minutes, base_period // 2)``
+                                                  (see ``model_endpoint_monitoring.lag_detection`` in config).
         """
         if fetch_credentials_from_sys_config:
             warnings.warn(


### PR DESCRIPTION
## Summary
- Add references to `model_endpoint_monitoring.lag_detection` config keys in both the docs and `enable_model_monitoring` docstring
- Follow-up to #9425 per review feedback from @assaf758

## Changes Made
- **`docs/model-monitoring/running-applications.md`**: Add section explaining how `lag_threshold` and `lag_event_cooldown` defaults are computed from server-side config
- **`mlrun/projects/project.py`**: Update `enable_model_monitoring` docstring to reference config keys and default formulas

## Testing
- Docs-only + docstring change, no runtime behavior affected
- `ruff check` passes on both files

## Reference
- Jira: [ML-11648](https://iguazio.atlassian.net/browse/ML-11648)
- Follow-up to: #9425

[ML-11648]: https://iguazio.atlassian.net/browse/ML-11648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ