### PR TITLE
[Serving] Fix - enforce step max_iterations on cyclic graph

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -209,6 +209,14 @@ class BaseStep(ModelObj):
                 self.after.append(name)
         return self
 
+    @property
+    def max_iterations(self):
+        return self._max_iterations
+
+    @max_iterations.setter
+    def max_iterations(self, max_iterations: int):
+        self._max_iterations = max_iterations
+
     def error_handler(
         self,
         name: str | None = None,
@@ -3337,14 +3345,6 @@ class RootFlowStep(FlowStep):
         self._shared_max_processes = None
         self._shared_max_threads = None
         self._pool_factor = None
-
-    @property
-    def max_iterations(self) -> int:
-        return self._max_iterations
-
-    @max_iterations.setter
-    def max_iterations(self, max_iterations: int):
-        self._max_iterations = max_iterations
 
     @property
     def allow_cyclic(self) -> bool:

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -606,6 +606,49 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
             function.invoke(path="/", body={"counter": -5})
 
     @pytest.mark.parametrize(
+        "max_iter",
+        ["local", "global"],
+    )
+    def test_max_iter_of_cyclic_graph(self, max_iter):
+        """Test max_iterations parameter for cyclic graphs at local and global levels.
+
+        When max_iter is "local", the max_iterations is set on the Route step itself.
+        When max_iter is "global", the max_iterations is set in set_topology().
+        """
+        code_path = str(self.assets_path / "cyclic_function.py")
+        function = mlrun.code_to_function(
+            name=f"cyclic-max-iter-{max_iter}",
+            kind="serving",
+            project=self.project_name,
+            filename=code_path,
+            image=self.image,
+        )
+        graph = function.set_topology(
+            "flow",
+            engine="async",
+            allow_cyclic=True,
+            max_iterations=1 if max_iter == "global" else 10,
+        )
+        graph.to(name="start", class_name="Echo").to(
+            class_name="Counter", name="count"
+        ).to(
+            name="route",
+            class_name="Route",
+            cycle_to="count",
+            max_iterations=1 if max_iter == "local" else None,
+        ).to(name="end", class_name="Echo").respond()
+
+        function.deploy()
+
+        if max_iter == "local":
+            expected_error = r"Max iterations exceeded in step 'route'"
+        else:
+            expected_error = r"Max iterations exceeded in step 'count'"
+
+        with pytest.raises(RuntimeError, match=rf"{expected_error}"):
+            function.invoke(path="/", body={"counter": 1})
+
+    @pytest.mark.parametrize(
         "execution_mechanism",
         ("naive", "thread_pool", "asyncio", "process_pool", "dedicated_process"),
     )


### PR DESCRIPTION
### 📝 Description

This pr include a fix for `TaskStep.max_iterations` serialization allowing to enforce step max_iterations in deployment of cyclic serving graph.

---

### 🛠️ Changes Made

Introducing setter and getter for max_iterations property for BaseStep.
Adding system test that check this case of enforce lower max_iterations on cyclic graph, defined by the step.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

System test - `test_max_iter_of_cyclic_graph`

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12278
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
