### PR TITLE
[Serving] Fix add max_iterations to task step init

### DIFF
--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -762,8 +762,9 @@ class TaskStep(BaseStep):
         model_endpoint_creation_strategy: schemas.ModelEndpointCreationStrategy
         | None = schemas.ModelEndpointCreationStrategy.SKIP,
         endpoint_type: schemas.EndpointType | None = schemas.EndpointType.NODE_EP,
+        max_iterations: int | None = None,
     ):
-        super().__init__(name, after)
+        super().__init__(name, after, max_iterations=max_iterations)
         self.class_name = class_name
         self.class_args = class_args or {}
         self.handler = handler

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -997,6 +997,7 @@ class MonitoringApplicationStep(TaskStep):
         responder: bool | None = None,
         input_path: str | None = None,
         result_path: str | None = None,
+        max_iterations: int | None = None,
     ):
         super().__init__(
             class_name=class_name,
@@ -1009,6 +1010,7 @@ class MonitoringApplicationStep(TaskStep):
             responder=responder,
             input_path=input_path,
             result_path=result_path,
+            max_iterations=max_iterations,
         )
 
 
@@ -1031,6 +1033,7 @@ class ErrorStep(TaskStep):
         responder: bool | None = None,
         input_path: str | None = None,
         result_path: str | None = None,
+        max_iterations: int | None = None,
     ):
         super().__init__(
             class_name=class_name,
@@ -1043,6 +1046,7 @@ class ErrorStep(TaskStep):
             responder=responder,
             input_path=input_path,
             result_path=result_path,
+            max_iterations=max_iterations,
         )
         self.before = None
         self.base_step = None
@@ -1066,6 +1070,7 @@ class RouterStep(TaskStep):
         function: str | None = None,
         input_path: str | None = None,
         result_path: str | None = None,
+        max_iterations: int | None = None,
     ):
         super().__init__(
             class_name,
@@ -1075,6 +1080,7 @@ class RouterStep(TaskStep):
             function=function,
             input_path=input_path,
             result_path=result_path,
+            max_iterations=max_iterations,
         )
         self._routes: ObjectDict = None
         self.routes = routes
@@ -2645,9 +2651,10 @@ class QueueStep(BaseStep, StepToDict):
         shards: int | None = None,
         retention_in_hours: int | None = None,
         trigger_args: dict | None = None,
+        max_iterations: int | None = None,
         **options,
     ):
-        super().__init__(name, after)
+        super().__init__(name, after, max_iterations=max_iterations)
         self.path = path
         self.shards = shards
         self.retention_in_hours = retention_in_hours
@@ -3674,6 +3681,7 @@ class HubTaskStep(TaskStep):
         | None = schemas.ModelEndpointCreationStrategy.SKIP,
         endpoint_type: schemas.EndpointType | None = schemas.EndpointType.NODE_EP,
         requirements: list | None = None,
+        max_iterations: int | None = None,
     ):
         super().__init__(
             class_name=class_name,
@@ -3688,6 +3696,7 @@ class HubTaskStep(TaskStep):
             result_path=result_path,
             model_endpoint_creation_strategy=model_endpoint_creation_strategy,
             endpoint_type=endpoint_type,
+            max_iterations=max_iterations,
         )
         self.hub_step_class_name = hub_step_class_name
         self.requirements = requirements

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -640,6 +640,27 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
 
         function.deploy()
 
+        # Verify max_iterations is preserved after get_function
+        retrieved_function = mlrun.get_run_db().get_function(
+            function.metadata.name, self.project_name
+        )
+        retrieved_graph = retrieved_function.get("spec", {}).get("graph", {})
+
+        # Check graph-level max_iterations
+        expected_graph_max_iter = 1 if max_iter == "global" else 10
+        assert retrieved_graph.get("max_iterations") == expected_graph_max_iter, (
+            f"Graph max_iterations mismatch: expected {expected_graph_max_iter}, "
+            f"got {retrieved_graph.get('max_iterations')}"
+        )
+
+        # Check step-level max_iterations for 'route' step
+        route_step = retrieved_graph.get("steps", {}).get("route", {})
+        expected_step_max_iter = 1 if max_iter == "local" else None
+        assert route_step.get("max_iterations") == expected_step_max_iter, (
+            f"Step 'route' max_iterations mismatch: expected {expected_step_max_iter}, "
+            f"got {route_step.get('max_iterations')}"
+        )
+
         if max_iter == "local":
             expected_error = r"Max iterations exceeded in step 'route'"
         else:


### PR DESCRIPTION
### 📝 Description
Fixed an issue where `max_iterations` field for individual steps in serving graphs was not being preserved when retrieving functions via the API endpoint. While the graph-level `max_iterations` was visible, step-level `max_iterations` was being lost during the serialization/deserialization round-trip when storing functions through the API.

The root cause was that step classes (`TaskStep`, `RouterStep`, etc.) did not accept `max_iterations` as a constructor parameter and therefore didn't pass it to `BaseStep.__init__()`. This caused `_max_iterations` to be initialized as `None` when objects were created via `from_dict()`, even though the value was later set via `setattr`.

---

### 🛠️ Changes Made
- Added `max_iterations` parameter to `__init__` methods of the following step classes in `mlrun/serving/states.py`:
  - `TaskStep`
  - `RouterStep`
  - `MonitoringApplicationStep`
  - `ErrorStep`
  - `HubTaskStep`
  - `QueueStep`
- Added test assertions to `test_max_iter_of_cyclic_graph` in `tests/system/runtimes/test_nuclio.py` to verify that both graph-level and step-level `max_iterations` are preserved after `get_function` API call

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Extended existing system test `test_max_iter_of_cyclic_graph` to verify `max_iterations` persistence:
  - Retrieves function from DB after deployment using `get_function`
  - Asserts graph-level `max_iterations` matches expected value
  - Asserts step-level `max_iterations` for the 'route' step matches expected value
- Test covers both "local" (step-level) and "global" (graph-level) `max_iterations` scenarios

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12282

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The fix is backward compatible - `max_iterations` parameter has a default value of `None`
- The issue specifically occurred when functions were stored via API with `auth_info` present, which triggers the `new_function()` → `to_dict()` round-trip in `server/py/services/api/crud/functions.py`
