### PR TITLE
[Notifications] Fix mail subject header newline handling

### DIFF
--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -190,9 +190,8 @@ class MailNotification(base.NotificationBase):
 
     @staticmethod
     def _sanitize_subject(subject: str) -> str:
-        # Email headers must not contain CR/LF. Collapse any whitespace sequence so multiline notification messages
-        # can still produce a valid subject.
-        return " ".join(subject.split())
+        # Keep only the first line for the email subject.
+        return subject.splitlines()[0].strip()
 
     @staticmethod
     def _enrich_params(params):

--- a/mlrun/utils/notifications/notification/mail.py
+++ b/mlrun/utils/notifications/notification/mail.py
@@ -77,7 +77,7 @@ class MailNotification(base.NotificationBase):
         alert: mlrun.common.schemas.AlertConfig | None = None,
         event_data: mlrun.common.schemas.Event | None = None,
     ):
-        self.params["subject"] = f"[{severity}] {message}"
+        self.params["subject"] = self._sanitize_subject(f"[{severity}] {message}")
         message_body_override = self.params.get("message_body_override", None)
 
         runs_html = self._get_html(
@@ -187,6 +187,12 @@ class MailNotification(base.NotificationBase):
             send_kwargs["password"] = password
 
         await aiosmtplib.send(message, **send_kwargs)
+
+    @staticmethod
+    def _sanitize_subject(subject: str) -> str:
+        # Email headers must not contain CR/LF. Collapse any whitespace sequence so multiline notification messages
+        # can still produce a valid subject.
+        return " ".join(subject.split())
 
     @staticmethod
     def _enrich_params(params):

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1734,6 +1734,18 @@ class TestMailNotification:
                     "password": "pass",
                 },
             ),
+            (
+                "multiline_message",
+                {},
+                "Run failed\nRetries attempted: 3\nRetry limit reached",
+                "info",
+                {
+                    "subject": "[info] Run failed Retries attempted: 3 Retry limit reached",
+                    "body": MOCKED_HTML,
+                    "username": None,
+                    "password": None,
+                },
+            ),
         ],
     )
     async def test_push(self, name, params, message, severity, expected):

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -1735,12 +1735,13 @@ class TestMailNotification:
                 },
             ),
             (
+                # The Subject should take only the first line of the message
                 "multiline_message",
                 {},
                 "Run failed\nRetries attempted: 3\nRetry limit reached",
                 "info",
                 {
-                    "subject": "[info] Run failed Retries attempted: 3 Retry limit reached",
+                    "subject": "[info] Run failed",
                     "body": MOCKED_HTML,
                     "username": None,
                     "password": None,


### PR DESCRIPTION
### 📝 Description
This PR fixes a bug where email notifications could fail with `email.errors.HeaderWriteError` when the notification message contained newline characters.
The fix normalizes the generated email subject before sending so header values are always valid and single-line.

---

### 🛠️ Changes Made

- Updated `MailNotification.push()` to sanitize the computed subject before assigning it.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- unit test for the multiline subject scenario in mail notifications.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12305
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
