### PR TITLE
[Model Monitoring] Fix SQL operator precedence in TimescaleDB metrics queries

### DIFF
--- a/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/utils/timescaledb_query_builder.py
@@ -163,6 +163,9 @@ class TimescaleDBQueryBuilder:
         """
         Combine multiple filter conditions with AND operator.
 
+        Each filter is wrapped in parentheses to ensure correct SQL operator
+        precedence when individual filters contain OR expressions.
+
         :param filters: List of filter condition strings
         :return: Combined filter string or None if no filters
         """
@@ -170,7 +173,7 @@ class TimescaleDBQueryBuilder:
             return (
                 valid_filters[0]
                 if len(valid_filters) == 1
-                else " AND ".join(valid_filters)
+                else " AND ".join(f"({f})" for f in valid_filters)
             )
         else:
             return None

--- a/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_validation.py
+++ b/tests/model_monitoring/db/tsdb/timescaledb/test_timescaledb_queries_validation.py
@@ -96,6 +96,44 @@ class TestParameterValidation:
             == "Invalid 'endpoint_ids' filter: must be a string or a list of strings"
         )
 
+    def test_combine_filters_parenthesizes_or_with_and(self):
+        """combine_filters must wrap each operand so OR doesn't escape AND scope.
+
+        Without wrapping, ``endpoint_id='x' AND (a=1) OR (a=2)`` is parsed as
+        ``(endpoint_id='x' AND a=1) OR (a=2)`` — the second branch bypasses the
+        endpoint filter and scans the entire table (ML-11691).
+        """
+        from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_query_builder import (
+            TimescaleDBQueryBuilder,
+        )
+
+        endpoint_filter = TimescaleDBQueryBuilder.build_endpoint_filter("ep1")
+        results_filter = TimescaleDBQueryBuilder.build_results_filter(
+            [
+                mm_schemas.ModelEndpointMonitoringMetric(
+                    project="p",
+                    app="app1",
+                    name="drift",
+                    type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
+                ),
+                mm_schemas.ModelEndpointMonitoringMetric(
+                    project="p",
+                    app="app2",
+                    name="perf",
+                    type=mm_schemas.ModelEndpointMonitoringMetricType.RESULT,
+                ),
+            ]
+        )
+        combined = TimescaleDBQueryBuilder.combine_filters(
+            [endpoint_filter, results_filter]
+        )
+
+        assert combined == (
+            "(endpoint_id='ep1') AND "
+            "((application_name = 'app1' AND result_name = 'drift') "
+            "OR (application_name = 'app2' AND result_name = 'perf'))"
+        )
+
 
 class TestPreAggregateExceptionHandling:
     """Tests for pre-aggregate exception handling and fallback logic."""


### PR DESCRIPTION
## Summary
- Fix SQL operator precedence bug in `combine_filters()` that caused multi-metric queries to scan the entire `app_results` table instead of filtering by endpoint
- Measured impact: 2-metric query went from **70s / 33MB** to sub-second (single endpoint query)

## Changes Made
- **`timescaledb_query_builder.py`**: Wrap each operand in `combine_filters()` with parentheses so OR expressions don't escape the AND scope
- **`test_timescaledb_queries_validation.py`**: Add regression test for multi-metric filter combined with endpoint filter

## Root Cause
`build_results_filter` / `build_metrics_filter` return OR-joined conditions:
```sql
(app = 'app1' AND result_name = 'drift') OR (app = 'app2' AND result_name = 'perf')
```
`combine_filters` joined with AND **without wrapping**:
```sql
endpoint_id='x' AND (app='app1' AND result='drift') OR (app='app2' AND result='perf')
```
Since AND binds tighter than OR, the second branch had **no endpoint filter**, scanning all 8.5M rows.

## Testing
- Unit test added and passing locally
- Existing TimescaleDB test suite: 27 passed, 0 failed
- Reproduced on vmdev37 (4000 MEPs, 8.5M rows in app_results)

## Reference
- Jira: ML-11691

🤖 Generated with [Claude Code](https://claude.com/claude-code)