### PR TITLE
[Tests] Avoid assuming exact number of chunks returned by streaming function

### DIFF
--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -673,14 +673,15 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         # Both branches merge into a single responder
         graph = function.set_topology("flow", engine="async")
         model_runner_step = ModelRunnerStep(name="model_runner")
+        num_chunks = 3
         model_runner_step.add_model(
             model_class="StreamingModel",
             execution_mechanism=execution_mechanism,
             endpoint_name="streaming_model",
-            num_chunks=3,
+            num_chunks=num_chunks,
         )
         choice = graph.to(name="choice", class_name="StreamingChoice")
-        choice.to(name="step", class_name="StreamingStep", num_chunks=3)
+        choice.to(name="step", class_name="StreamingStep", num_chunks=num_chunks)
         choice.to(model_runner_step)
         graph.add_step(
             name="responder",
@@ -702,7 +703,10 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
 
         chunks = list(resp.iter_content(decode_unicode=True, chunk_size=1024))
         self._logger.info(f"StreamingStep chunks: {chunks}")
-        assert chunks == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
+        # The number of chunks returned is anywhere between 1 and the number of chunks that reach the responder step,
+        # subject to Nuclio's flush mechanism
+        assert 1 <= len(chunks) <= num_chunks
+        assert "".join(chunks) == "test_chunk_0test_chunk_1test_chunk_2"
 
         # Test 2: ModelRunnerStep path (generator predict() method)
         self._logger.info("Testing ModelRunnerStep path...")
@@ -715,7 +719,10 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
 
         chunks = list(resp.iter_content(decode_unicode=True, chunk_size=1024))
         self._logger.info(f"ModelRunnerStep chunks: {chunks}")
-        assert chunks == ["test_chunk_0", "test_chunk_1", "test_chunk_2"]
+        # The number of chunks returned is anywhere between 1 and the number of chunks that reach the responder step,
+        # subject to Nuclio's flush mechanism
+        assert 1 <= len(chunks) <= num_chunks
+        assert "".join(chunks) == "test_chunk_0test_chunk_1test_chunk_2"
 
     def test_stream_response_termination_on_error(self):
         """


### PR DESCRIPTION
### 📝 Description
As it isn't guaranteed in nuclio, and is likely to break in CI.

---

### 🛠️ Changes Made
* Loosened test assertions
* Added explanation in comment

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
I ran the test.

---

### 🔗 References
- Ticket link: [ML-12317](https://iguazio.atlassian.net/browse/ML-12317)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-12317]: https://iguazio.atlassian.net/browse/ML-12317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ