### PR TITLE
[Go] Bump to 1.25.8

### DIFF
--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/mlrun
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.79.2
+	google.golang.org/protobuf v1.36.11
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
@@ -45,7 +46,6 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
### 📝 Description

Bump Go to 1.25.8 to get the latest greatest security fixes.

---

### 🛠️ Changes Made

- Update `server/go/go.mod` with go version to 1.25.8