### PR TITLE
[Pipelines] Fix KFP experiment listing to paginate through all results

### DIFF
--- a/automation/scripts/clean_pipelines/clean_pipelines.py
+++ b/automation/scripts/clean_pipelines/clean_pipelines.py
@@ -18,6 +18,7 @@ from time import sleep
 import pandas as pd
 
 import mlrun
+import mlrun.common.schemas
 import mlrun.utils
 import mlrun_pipelines
 import mlrun_pipelines.client

--- a/mlrun/common/schemas/pipeline.py
+++ b/mlrun/common/schemas/pipeline.py
@@ -19,7 +19,7 @@ import pydantic.v1
 
 class PipelinesPagination(str):
     default_page_size = 200
-    # https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/list/list.go#L363
+    # https://github.com/kubeflow/pipelines/blob/release-2.16/backend/src/apiserver/list/list.go#L385
     max_page_size = 200
 
 

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.6.3"
+version = "0.6.4"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
@@ -31,6 +31,7 @@ import kubernetes as k8s
 import orjson
 import yaml
 
+import mlrun.common.schemas
 import mlrun_pipelines.common.client
 import mlrun_pipelines.common.models
 import mlrun_pipelines.models
@@ -470,6 +471,7 @@ class Client(
             )
             candidate_experiments = self._get_candidate_experiments_for_projects(
                 project_names=project_names,
+                page_size=page_size,
             )
             candidate_experiment_ids = [
                 experiment.id for experiment in candidate_experiments
@@ -719,18 +721,23 @@ class Client(
             raise error
 
     def _get_candidate_experiments_for_projects(
-        self,
-        project_names: typing.Union[list[str], str],
+        self, project_names: typing.Union[list[str], str], page_size: int
     ) -> list[kfp_server_api.ApiExperiment]:
         """
-        Retrieve an experiment by project name.
-        This method searches for an experiment whose name matches the project name,
-        allowing for a dash-prefixed match (e.g., "myproject-").
+        Retrieve candidate experiments by project name with pagination.
+
+        This method searches for experiments whose name matches the project name
+        (substring filter), then filters to those starting with the project name.
+        Handles KFP API pagination to ensure all matching experiments are found.
+
         :param project_names: The names of the projects to search for.
+        :param page_size: The number of experiments to return per page.
         :return: A list of ApiExperiment objects representing the found experiments.
-        :raises ValueError: If no experiment is found with the specified project name.
         """
         matching_experiments = []
+        page_size = (
+            page_size or mlrun.common.schemas.PipelinesPagination.default_page_size
+        )
 
         for project_name in project_names:
             filter_json = orjson.dumps(
@@ -745,13 +752,21 @@ class Client(
                 }
             ).decode()
 
-            experiments = (
-                self._experiment_api.list_experiment(filter=filter_json).experiments
-                or []
-            )
-            for experiment in experiments:
-                if experiment.name.startswith(project_name):
-                    matching_experiments.append(experiment)
+            current_page_token = None
+
+            while current_page_token is not False:
+                response = self._experiment_api.list_experiment(
+                    filter=filter_json,
+                    page_token=current_page_token,
+                    page_size=page_size,
+                )
+                experiments = response.experiments or []
+                matching_experiments.extend(
+                    exp for exp in experiments if exp.name.startswith(project_name)
+                )
+
+                current_page_token = response.next_page_token or False
+
         return matching_experiments
 
     def _create_job_config(

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_experiment_pagination.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_experiment_pagination.py
@@ -1,0 +1,245 @@
+# Copyright 2025 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for KFP experiment listing pagination in _get_candidate_experiments_for_projects.
+
+Verifies that the method correctly follows next_page_token to retrieve all
+experiments across multiple pages, preventing silent data loss.
+
+See: issues/bug-kfp-experiment-listing-no-pagination/problem.md
+"""
+
+import unittest.mock
+from unittest.mock import MagicMock
+
+import kfp_server_api
+import pytest
+
+import mlrun.utils
+import mlrun_pipelines.client
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Create a Client instance with mocked infrastructure."""
+    client_klass = mlrun_pipelines.client.Client
+    client_klass.get_kfp_healthz = unittest.mock.MagicMock()
+    monkeypatch.setattr("kubernetes.config.load_incluster_config", lambda: None)
+    monkeypatch.setattr(client_klass, "_determine_server_major_version", lambda self: 2)
+    return client_klass(logger=mlrun.utils.logger)
+
+
+def _make_experiment(name, experiment_id=None):
+    """Helper to create a mock ApiExperiment."""
+    exp = MagicMock(spec=kfp_server_api.ApiExperiment)
+    exp.name = name
+    exp.id = experiment_id or f"id-{name}"
+    return exp
+
+
+def _make_list_response(experiments, next_page_token=None):
+    """Helper to create a mock list_experiment response."""
+    response = MagicMock()
+    response.experiments = experiments if experiments else None
+    response.next_page_token = next_page_token
+    return response
+
+
+DEFAULT_PAGE_SIZE = mlrun.common.schemas.PipelinesPagination.default_page_size
+
+
+class TestGetCandidateExperimentsPagination:
+    """Tests verifying that _get_candidate_experiments_for_projects paginates correctly."""
+
+    def test_multi_page_experiments_returns_all_pages(self, client, monkeypatch):
+        """
+        When list_experiment returns a next_page_token, the method follows it
+        and returns experiments from all pages.
+        """
+        page1_experiments = [_make_experiment(f"x-myproj-exp{i}") for i in range(5)]
+        page2_experiments = [
+            _make_experiment("myproj-exp1"),
+        ]
+
+        page1_response = _make_list_response(
+            page1_experiments, next_page_token="page2_token"
+        )
+        page2_response = _make_list_response(page2_experiments, next_page_token=None)
+
+        mock_list = MagicMock(side_effect=[page1_response, page2_response])
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        result = client._get_candidate_experiments_for_projects(
+            ["myproj"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        assert len(result) == 1
+        assert result[0].name == "myproj-exp1"
+        assert mock_list.call_count == 2
+
+    def test_page_token_passed_on_subsequent_calls(self, client, monkeypatch):
+        """
+        Verify that the next_page_token from page 1 is passed as page_token
+        to the second call.
+        """
+        page1_response = _make_list_response(
+            [_make_experiment("myproject-exp1")],
+            next_page_token="there_are_more_results",
+        )
+        page2_response = _make_list_response(
+            [_make_experiment("myproject-exp2")], next_page_token=None
+        )
+
+        mock_list = MagicMock(side_effect=[page1_response, page2_response])
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        result = client._get_candidate_experiments_for_projects(
+            ["myproject"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        assert len(result) == 2
+        assert mock_list.call_count == 2
+
+        first_call_kwargs = mock_list.call_args_list[0].kwargs
+        second_call_kwargs = mock_list.call_args_list[1].kwargs
+        assert first_call_kwargs["page_token"] is None
+        assert second_call_kwargs["page_token"] == "there_are_more_results"
+
+    def test_single_page_works_correctly(self, client, monkeypatch):
+        """
+        Regression test: Single page of results works correctly.
+        """
+        experiments = [
+            _make_experiment("proj-a-exp1"),
+            _make_experiment("proj-a-exp2"),
+            _make_experiment("other-proj-exp1"),
+        ]
+        response = _make_list_response(experiments, next_page_token=None)
+        mock_list = MagicMock(return_value=response)
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        result = client._get_candidate_experiments_for_projects(
+            ["proj-a"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        assert len(result) == 2
+        assert all(exp.name.startswith("proj-a") for exp in result)
+        assert mock_list.call_count == 1
+
+    def test_empty_results(self, client, monkeypatch):
+        """
+        Regression test: Empty experiment list is handled correctly.
+        """
+        response = _make_list_response(None, next_page_token=None)
+        mock_list = MagicMock(return_value=response)
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        result = client._get_candidate_experiments_for_projects(
+            ["nonexistent"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        assert result == []
+
+    def test_overlapping_names_experiments_on_later_pages_found(
+        self, client, monkeypatch
+    ):
+        """
+        Experiments on later pages are found when project names overlap.
+
+        Given projects with overlapping name substrings:
+        - "data-pipeline" (target project, 1 experiment on page 2)
+        - "pp-data-pipeline" (similar project, many experiments on page 1)
+        """
+        page1_experiments = [
+            _make_experiment(f"pp-data-pipeline-exp{i}") for i in range(10)
+        ]
+        page2_experiments = [
+            _make_experiment("data-pipeline-exp1"),
+        ]
+
+        page1_response = _make_list_response(
+            page1_experiments, next_page_token="next_page"
+        )
+        page2_response = _make_list_response(page2_experiments, next_page_token=None)
+
+        mock_list = MagicMock(side_effect=[page1_response, page2_response])
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        result = client._get_candidate_experiments_for_projects(
+            ["data-pipeline"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        assert len(result) == 1
+        assert result[0].name == "data-pipeline-exp1"
+
+    def test_all_matching_experiments_across_pages(self, client, monkeypatch):
+        """
+        When a project has many experiments spanning multiple pages, all are returned.
+        """
+        page1_experiments = [_make_experiment(f"bigproject-exp{i}") for i in range(10)]
+        page2_experiments = [
+            _make_experiment(f"bigproject-exp{i}") for i in range(10, 15)
+        ]
+
+        page1_response = _make_list_response(page1_experiments, next_page_token="page2")
+        page2_response = _make_list_response(page2_experiments, next_page_token=None)
+
+        mock_list = MagicMock(side_effect=[page1_response, page2_response])
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        result = client._get_candidate_experiments_for_projects(
+            ["bigproject"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        assert len(result) == 15
+
+    def test_page_size_passed_to_api(self, client, monkeypatch):
+        """
+        Verify that page_size is passed to the list_experiment API.
+        """
+        response = _make_list_response(
+            [_make_experiment("proj-exp1")], next_page_token=None
+        )
+        mock_list = MagicMock(return_value=response)
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        client._get_candidate_experiments_for_projects(
+            ["proj"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        call_kwargs = mock_list.call_args.kwargs
+        assert call_kwargs["page_size"] == DEFAULT_PAGE_SIZE
+
+    def test_three_pages_of_results(self, client, monkeypatch):
+        """
+        Verify pagination works across three pages.
+        """
+        page1 = _make_list_response(
+            [_make_experiment("proj-a")], next_page_token="tok2"
+        )
+        page2 = _make_list_response(
+            [_make_experiment("proj-b")], next_page_token="tok3"
+        )
+        page3 = _make_list_response([_make_experiment("proj-c")], next_page_token=None)
+
+        mock_list = MagicMock(side_effect=[page1, page2, page3])
+        monkeypatch.setattr(client._experiment_api, "list_experiment", mock_list)
+
+        result = client._get_candidate_experiments_for_projects(
+            ["proj"], page_size=DEFAULT_PAGE_SIZE
+        )
+
+        assert len(result) == 3
+        assert mock_list.call_count == 3

--- a/server/py/services/api/tests/unit/conftest.py
+++ b/server/py/services/api/tests/unit/conftest.py
@@ -142,7 +142,8 @@ def kfp_client_mock(monkeypatch):
             experiments=[
                 ApiExperiment(name="some-project"),
                 ApiExperiment(name="another"),
-            ]
+            ],
+            next_page_token=None,
         )
     )
     mock_experiment_api.api_client = mock.Mock()


### PR DESCRIPTION
### 📝 Description

Fixes incomplete KFP experiment discovery when listing pipelines for MLRun projects. 

`_get_candidate_experiments_for_projects` previously called `list_experiment` once and ignored `next_page_token`, so experiments beyond the first API page were dropped. That led to missing pipelines when many experiments existed or when substring-matched project names did not appear on the first page.

---

### 🛠️ Changes Made

- Paginate `list_experiment` in `mlrun-pipelines-kfp-v1-8` (`client.py`): loop until `next_page_token` is exhausted when resolving candidate experiments for projects.
- Minor related updates: `clean_pipelines` script and `mlrun-pipelines-kfp-v1-8` `pyproject.toml` as in the branch.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

- New adapter unit tests: `pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_experiment_pagination.py`

---

### 🔗 References

- Ticket link: ML-12328
- Design docs links: N/A
- External links: 

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes

- Root cause: single unpaginated `list_experiment` call in `_get_candidate_experiments_for_projects`, so only the first page of experiments was considered when matching MLRun projects to KFP experiments