### PR TITLE
[Model Monitoring] Add configurable absolute HPA target for stream function

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -626,6 +626,7 @@ default_config = {
                 "num_workers": 2,
                 "min_replicas": 1,
                 "max_replicas": 4,
+                "target_cpu": "400m",
             },
         },
         "application_stream_args": {

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -82,6 +82,7 @@ class ApplicationSpec(nuclio_function.NuclioSpec):
         add_templated_ingress_host_mode=None,
         state_thresholds=None,
         disable_default_http_trigger=None,
+        custom_scaling_metric_specs=None,
         serving_spec=None,
         graph=None,
         parameters=None,
@@ -136,6 +137,7 @@ class ApplicationSpec(nuclio_function.NuclioSpec):
             track_models=track_models,
             state_thresholds=state_thresholds,
             disable_default_http_trigger=disable_default_http_trigger,
+            custom_scaling_metric_specs=custom_scaling_metric_specs,
             auth=auth,
         )
 

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -124,6 +124,7 @@ class NuclioSpec(KubeResourceSpec):
         "service_type",
         "add_templated_ingress_host_mode",
         "disable_default_http_trigger",
+        "custom_scaling_metric_specs",
         "auth",
     ]
 
@@ -168,6 +169,7 @@ class NuclioSpec(KubeResourceSpec):
         add_templated_ingress_host_mode=None,
         state_thresholds=None,
         disable_default_http_trigger=None,
+        custom_scaling_metric_specs=None,
         serving_spec=None,
         graph=None,
         parameters=None,
@@ -228,6 +230,7 @@ class NuclioSpec(KubeResourceSpec):
         self.max_replicas = max_replicas or 4
 
         self.disable_default_http_trigger = disable_default_http_trigger
+        self.custom_scaling_metric_specs = custom_scaling_metric_specs or []
 
         # When True it will set Nuclio spec.noBaseImagesPull to False (negative logic)
         # indicate that the base image should be pulled from the container registry (not cached)

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -386,6 +386,7 @@ class ServingSpec(nuclio_function.NuclioSpec):
         add_templated_ingress_host_mode=None,
         state_thresholds=None,
         disable_default_http_trigger=None,
+        custom_scaling_metric_specs=None,
         model_endpoint_creation_task_name=None,
         serving_spec=None,
         auth=None,
@@ -433,6 +434,7 @@ class ServingSpec(nuclio_function.NuclioSpec):
             service_type=service_type,
             add_templated_ingress_host_mode=add_templated_ingress_host_mode,
             disable_default_http_trigger=disable_default_http_trigger,
+            custom_scaling_metric_specs=custom_scaling_metric_specs,
             serving_spec=serving_spec,
             auth=auth,
         )

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -497,6 +497,7 @@ class MonitoringDeployment:
             function.with_annotations(nuclio_annotations)
         function.spec.min_replicas = stream_args.kafka.min_replicas
         function.spec.max_replicas = stream_args.kafka.max_replicas
+        self._set_scaling_metric_specs(function, stream_args.kafka)
 
     # TODO: Remove in 1.13.0 — one-time offset migration from the old
     # shared consumer group to per-topic groups (ML-11979).
@@ -687,6 +688,32 @@ class MonitoringDeployment:
         )
         function.spec.min_replicas = stream_args.v3io.min_replicas
         function.spec.max_replicas = stream_args.v3io.max_replicas
+
+    @staticmethod
+    def _set_scaling_metric_specs(
+        function: mlrun.runtimes.ServingRuntime,
+        stream_config: mlrun.config.Config,
+    ) -> None:
+        """Set absolute CPU HPA target on the function if configured.
+
+        When ``target_cpu`` is set (e.g. ``"400m"``), the Nuclio HPA is
+        configured with an absolute ``AverageValue`` metric instead of the
+        default percentage-based ``Utilization``.  This avoids spurious
+        autoscaling caused by brief CPU spikes on low-request pods.
+        """
+        if getattr(stream_config, "target_cpu", ""):
+            function.spec.custom_scaling_metric_specs = [
+                {
+                    "type": "Resource",
+                    "resource": {
+                        "name": "cpu",
+                        "target": {
+                            "type": "AverageValue",
+                            "averageValue": stream_config.target_cpu,
+                        },
+                    },
+                }
+            ]
 
     def _initial_model_monitoring_stream_processing_function(
         self,

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -641,6 +641,12 @@ def _set_misc_specs(function, nuclio_spec):
             "spec.disableDefaultHTTPTrigger", function.spec.disable_default_http_trigger
         )
 
+    if function.spec.custom_scaling_metric_specs:
+        nuclio_spec.set_config(
+            "spec.customScalingMetricSpecs",
+            function.spec.custom_scaling_metric_specs,
+        )
+
     # Nuclio supports spec.envFrom (mount all keys from secrets/configmaps)
     if function.spec.env_from:
         nuclio_spec.set_config(

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -215,6 +215,10 @@ def test_apply_and_create_kafka_source(
     assert (
         fn.spec.base_spec.get("metadata", {}).get("annotations") == nuclio_annotations
     ), "The set annotations are different than expected"
+    assert fn.spec.custom_scaling_metric_specs[0]["resource"]["target"] == {
+        "type": "AverageValue",
+        "averageValue": "400m",
+    }
 
 
 @patch("mlrun.datastore.sources.KafkaSource.create_topics")
@@ -318,3 +322,34 @@ def test_kafka_existing_non_stream_topic_skips_migration(
     )
 
     migrate_offsets_mock.assert_not_called()
+
+
+@patch("mlrun.datastore.sources.KafkaSource.create_topics")
+def test_kafka_source_no_hpa_target_when_not_configured(
+    create_topics_mock: Mock,
+    monitoring_deployment: mm_dep.MonitoringDeployment,
+) -> None:
+    """ML-11991: When target_cpu is empty, custom_scaling_metric_specs
+    should remain at its default (empty list)."""
+    kafka_profile = DatastoreProfileKafkaStream(
+        name="test-kafka-profile",
+        brokers=["localhost:9092"],
+        topics=[],
+    )
+
+    fn = mlrun.runtimes.ServingRuntime()
+    stream_args = mlrun.mlconf.model_endpoint_monitoring.serving_stream
+    original_target_cpu = stream_args.kafka.target_cpu
+    try:
+        stream_args.kafka.target_cpu = ""
+        monitoring_deployment._apply_and_create_kafka_source(
+            kafka_profile=kafka_profile,
+            function=fn,
+            function_name="model-monitoring-stream",
+            stream_args=stream_args,
+            ignore_stream_already_exists_failure=True,
+        )
+    finally:
+        stream_args.kafka.target_cpu = original_target_cpu
+
+    assert fn.spec.custom_scaling_metric_specs == []

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -81,6 +81,44 @@ def test_compiled_function_config_sidecar_image_enrichment():
     ), "Image not enriched"
 
 
+def test_custom_scaling_metric_specs_forwarded_to_nuclio():
+    name = f"{assets_path}/training.py"
+    fn = mlrun.code_to_function(
+        "nuclio", filename=name, kind="nuclio", handler="my_hand"
+    )
+    metric_specs = [
+        {
+            "type": "Resource",
+            "resource": {
+                "name": "cpu",
+                "target": {"type": "AverageValue", "averageValue": "400m"},
+            },
+        }
+    ]
+    fn.spec.custom_scaling_metric_specs = metric_specs
+    (
+        _name,
+        _project,
+        config,
+    ) = services.api.crud.runtimes.nuclio.function._compile_function_config(fn)
+    assert mlrun.utils.get_in(config, "spec.customScalingMetricSpecs") == metric_specs
+
+
+def test_custom_scaling_metric_specs_omitted_when_empty():
+    """ML-11991: When custom_scaling_metric_specs is empty, the key should
+    not appear in the compiled Nuclio config."""
+    name = f"{assets_path}/training.py"
+    fn = mlrun.code_to_function(
+        "nuclio", filename=name, kind="nuclio", handler="my_hand"
+    )
+    (
+        _name,
+        _project,
+        config,
+    ) = services.api.crud.runtimes.nuclio.function._compile_function_config(fn)
+    assert not mlrun.utils.get_in(config, "spec.customScalingMetricSpecs")
+
+
 @pytest.mark.parametrize(
     "handler, expected",
     [


### PR DESCRIPTION
## Summary
- Configure Nuclio HPA with an absolute `AverageValue` CPU target instead of the default percentage-based `Utilization`
- Prevents spurious autoscaling of model-monitoring-stream pods caused by brief CPU spikes from internal NOP event processing on low-request pods
- Default kafka `target_cpu` set to `400m`; when omitted/empty, existing behavior is preserved

## Changes Made
- **`mlrun/config.py`**: Add `target_cpu` config field to `serving_stream` kafka (default `"400m"`) and v3io (default `""`) settings
- **`mlrun/runtimes/nuclio/function.py`**: Add `custom_scaling_metric_specs` field to `NuclioSpec`
- **`server/py/services/api/crud/runtimes/nuclio/function.py`**: Wire `custom_scaling_metric_specs` through to Nuclio config in `_set_misc_specs()`
- **`server/py/services/api/crud/model_monitoring/deployment.py`**: Read `target_cpu` from stream config and translate to `customScalingMetricSpecs` via `_set_scaling_metric_specs()` helper

## Testing
- Added assertion to existing `test_apply_and_create_kafka_source` for the configured path
- Added `test_kafka_source_no_hpa_target_when_not_configured` for the empty/omitted path
- Added `test_custom_scaling_metric_specs_forwarded_to_nuclio` for Nuclio spec wiring
- Added `test_custom_scaling_metric_specs_omitted_when_empty` for no-op when empty
- All tests pass locally

## Reference
- Jira: [ML-11991](https://iguazio.atlassian.net/browse/ML-11991)

[ML-11991]: https://iguazio.atlassian.net/browse/ML-11991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ