### PR TITLE
[Mounts] Support S3 and secret_env auto mount types in client-side auto_mount()

### DIFF
--- a/docs/runtimes/function-storage.md
+++ b/docs/runtimes/function-storage.md
@@ -19,12 +19,17 @@ The common types of shared storage are:
 storage through paths such as `v3io:///projects/my_projects/file.csv`. To enable this type of access, several
 environment variables need to be configured in the pod that provide the v3io API URL and access keys.
 2. `v3io` storage through FUSE mount &mdash; Some tools cannot utilize the `v3io` API to access it and need basic filesystem
-semantics. For that purpose, `v3io` provides a FUSE (Filesystem in user-space) driver that can be used to mount `v3io` 
-containers as specific paths in the pod itself. For example `/User`. To enable this, several specific volume mount 
+semantics. For that purpose, `v3io` provides a FUSE (Filesystem in user-space) driver that can be used to mount `v3io`
+containers as specific paths in the pod itself. For example `/User`. To enable this, several specific volume mount
 configurations need to be applied to the pod spec.
 3. NFS storage access &mdash; When MLRun is deployed as open-source, independent of Iguazio, the deployment automatically adds
 a pod running NFS storage. To access this NFS storage through pods, a kubernetes `pvc` mount is needed.
-4. Others &mdash; As use-cases evolve, other cases of storage access may be needed. This will require various configurations 
+4. S3-compatible object storage &mdash; When MLRun is deployed on Kubernetes without Iguazio (for example on IG4 systems
+using MinIO), S3 credentials need to be injected into pods as environment variables so that functions can access object
+storage. MLRun supports this via the `s3` auto-mount type, which reads credentials from a Kubernetes secret and sets
+the standard AWS environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally
+`AWS_ENDPOINT_URL_S3`) on each pod.
+5. Others &mdash; As use-cases evolve, other cases of storage access may be needed. This will require various configurations
 to be applied to function execution pods.
 
 MLRun attempts to offload this storage configuration task from the user by automatically applying the most common 
@@ -65,10 +70,18 @@ The following code demonstrates how to apply the `v3io` FUSE driver by default:
     mlrun.mlconf.storage.auto_mount_type = "v3io_fuse"
 
 Each of the auto-mount supported methods applies a specific modifier function. The supported methods are:
-* `v3io_credentials` &mdash; apply `v3io` credentials needed for `v3io` API usage. Applies the 
+* `v3io_credentials` &mdash; apply `v3io` credentials needed for `v3io` API usage. Applies the
 {py:meth}`~mlrun.platforms.v3io_cred` modifier.
 * `v3io_fuse` &mdash; create Fuse driver mount. Applies the {py:meth}`~mlrun.platforms.mount_v3io` modifier.
 * `pvc` &mdash; create a `pvc` mount. Applies the {py:meth}`~mlrun.platforms.mount_pvc` modifier.
+* `s3` &mdash; inject S3 credentials as environment variables from a Kubernetes secret. Applies the
+{py:meth}`~mlrun.platforms.mount_s3` modifier. Use this for S3-compatible object storage (AWS S3, MinIO) on
+Kubernetes deployments without Iguazio v3io. Requires `secret_name` in `auto_mount_params` pointing to a secret
+that contains `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` keys (and optionally `AWS_ENDPOINT_URL_S3` for
+non-AWS endpoints).
+* `secret_env` &mdash; inject arbitrary Kubernetes secret keys as environment variables into pods. Applies the
+{py:meth}`~mlrun.platforms.set_env_vars_from_secret` modifier. Use this to expose any secret as pod environment
+variables. Requires `secret_name` and `secret_keys` in `auto_mount_params`.
 * `auto` &mdash; the default auto-mount logic as described above (either `v3io_credentials` or `pvc`).
 * `none` &mdash; perform no auto-mount (same as using `disable_auto_mount = True`).
 
@@ -91,4 +104,11 @@ parameters or strings that contain special characters:
 
     pvc_params_str = base64.b64encode(json.dumps(pvc_params).encode())
     mlrun.mlconf.storage.auto_mount_params = pvc_params_str
+
+The following code demonstrates how to configure S3-compatible object storage (for example MinIO on an IG4 system):
+
+    import mlrun.mlconf
+
+    mlrun.mlconf.storage.auto_mount_type = "s3"
+    mlrun.mlconf.storage.auto_mount_params = "secret_name=minio-credentials,endpoint_url=http://minio.iguazio.svc:9000"
 

--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -371,6 +371,8 @@ def auto_mount(
     - k8s PVC volume when both pvc_name and volume_mount_path are set
     - k8s PVC volume when env var is set: MLRUN_PVC_MOUNT=<pvc-name>:<mount-path>
     - k8s PVC volume if it's configured as the auto mount type
+    - S3 credentials when configured as the auto mount type
+    - Secret-based env vars when configured as the auto mount type
     - iguazio v3io volume when V3IO_ACCESS_KEY and V3IO_USERNAME env vars are set
 
     """
@@ -388,6 +390,10 @@ def auto_mount(
     # parameters may still be declared - use them in that case.
     if config.storage.auto_mount_type == "pvc":
         return mount_pvc(**config.get_storage_auto_mount_params())
+    if config.storage.auto_mount_type == "s3":
+        return mount_s3(**config.get_storage_auto_mount_params())
+    if config.storage.auto_mount_type == "secret_env":
+        return set_env_vars_from_secret(**config.get_storage_auto_mount_params())
     if "V3IO_ACCESS_KEY" in os.environ:
         return mount_v3io(name=volume_name or "v3io")
 

--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -388,12 +388,13 @@ def auto_mount(
         )
     # In the case of CE when working remotely, no env variables will be defined but auto-mount
     # parameters may still be declared - use them in that case.
-    if config.storage.auto_mount_type == "pvc":
-        return mount_pvc(**config.get_storage_auto_mount_params())
-    if config.storage.auto_mount_type == "s3":
-        return mount_s3(**config.get_storage_auto_mount_params())
-    if config.storage.auto_mount_type == "secret_env":
-        return set_env_vars_from_secret(**config.get_storage_auto_mount_params())
+    # Lazy import to avoid circular dependency (pod.py imports mounts.py at module level).
+    from mlrun.runtimes.pod import AutoMountType
+
+    auto_mount_type = AutoMountType(config.storage.auto_mount_type)
+    modifier = auto_mount_type.get_modifier()
+    if modifier and auto_mount_type != AutoMountType.auto:
+        return modifier(**config.get_storage_auto_mount_params())
     if "V3IO_ACCESS_KEY" in os.environ:
         return mount_v3io(name=volume_name or "v3io")
 

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -333,6 +333,64 @@ def test_mount_v3io():
             )
 
 
+def test_auto_mount_s3():
+    """Test that auto_mount() returns s3 mount modifier when auto_mount_type is 's3'."""
+    mlrun.mlconf.storage.auto_mount_type = "s3"
+    mlrun.mlconf.storage.auto_mount_params = (
+        "endpoint_url=http://seaweedfs:8333,secret_name=minio-credentials"
+    )
+
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    function.apply(mlrun.runtimes.mounts.auto_mount())
+
+    env_dict = {
+        var["name"]: var.get("value", var.get("valueFrom")) for var in function.spec.env
+    }
+    assert env_dict == {
+        "AWS_ENDPOINT_URL_S3": "http://seaweedfs:8333",
+        "AWS_ACCESS_KEY_ID": {
+            "secretKeyRef": {"key": "AWS_ACCESS_KEY_ID", "name": "minio-credentials"}
+        },
+        "AWS_SECRET_ACCESS_KEY": {
+            "secretKeyRef": {
+                "key": "AWS_SECRET_ACCESS_KEY",
+                "name": "minio-credentials",
+            }
+        },
+    }
+
+
+def test_auto_mount_secret_env():
+    """Test that auto_mount() returns secret_env mount modifier when auto_mount_type is 'secret_env'."""
+    mlrun.mlconf.storage.auto_mount_type = "secret_env"
+    mlrun.mlconf.storage.auto_mount_params = "secret_name=s3-credentials"
+
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    function.apply(mlrun.runtimes.mounts.auto_mount())
+
+    env_from = function.spec.env_from
+    assert len(env_from) == 1
+    assert env_from[0].config_map_ref is None
+    assert env_from[0].secret_ref.name == "s3-credentials"
+
+
+def test_auto_mount_raises_without_config():
+    """Test that auto_mount() raises ValueError when no mount type is configured."""
+    mlrun.mlconf.storage.auto_mount_type = ""
+    mlrun.mlconf.storage.auto_mount_params = ""
+
+    # Clear env vars that could trigger other paths
+    os.environ.pop("MLRUN_PVC_MOUNT", None)
+    os.environ.pop("V3IO_ACCESS_KEY", None)
+
+    with pytest.raises(ValueError, match="Failed to auto mount"):
+        mlrun.runtimes.mounts.auto_mount()
+
+
 def _auth_prefix() -> str:
     # Matches how the code builds the pattern: format(hashed_access_key="")
     return mlrun.mlconf.secret_stores.kubernetes.auth_secret_name.format(


### PR DESCRIPTION
### 📝 Description
Extend `auto_mount()` to handle `s3` and `secret_env` auto mount types, delegating to existing `mount_s3()` and `set_env_vars_from_secret()` functions. Previously only `pvc` was supported as a config-driven auto mount type; S3 and secret-env users had to manually apply mount modifiers.

---

### 🛠️ Changes Made
- Added `s3` and `secret_env` branches in `auto_mount()` (`mlrun/runtimes/mounts.py`)
- Added 3 unit tests covering both new paths and the error case (`tests/runtimes/test_mounts.py`)

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR


---

### 🔗 References
- Ticket link: [IG4-1658](https://iguazio.atlassian.net/browse/IG4-1658)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

[IG4-1658]: https://iguazio.atlassian.net/browse/IG4-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ