### PR TITLE
[Alerts] Split other_alerts_count into application and infra counters

### DIFF
--- a/mlrun/common/schemas/project.py
+++ b/mlrun/common/schemas/project.py
@@ -144,7 +144,8 @@ class ProjectSummary(pydantic.v1.BaseModel):
     updated: datetime.datetime | None = None
     endpoint_alerts_count: int = 0
     job_alerts_count: int = 0
-    other_alerts_count: int = 0
+    application_alerts_count: int = 0
+    infra_alerts_count: int = 0
     datasets_count: int = 0
     documents_count: int = 0
     llm_prompts_count: int = 0

--- a/server/py/framework/db/base.py
+++ b/server/py/framework/db/base.py
@@ -551,6 +551,7 @@ class DBInterface(ABC):
         dict[str, int],
         dict[str, int],
         dict[str, int],
+        dict[str, int],
     ]:
         pass
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3667,6 +3667,7 @@ class SQLDB(DBInterface):
         dict[str, int],
         dict[str, int],
         dict[str, int],
+        dict[str, int],
     ]:
         results = await asyncio.gather(
             fastapi.concurrency.run_in_threadpool(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3715,7 +3715,8 @@ class SQLDB(DBInterface):
             (
                 project_to_endpoint_alerts_count,
                 project_to_job_alerts_count,
-                project_to_other_alerts_count,
+                project_to_application_alerts_count,
+                project_to_infra_alerts_count,
             ),
             (
                 project_to_running_mm_functions,
@@ -3746,7 +3747,8 @@ class SQLDB(DBInterface):
             project_to_running_runs_count,
             project_to_endpoint_alerts_count,
             project_to_job_alerts_count,
-            project_to_other_alerts_count,
+            project_to_application_alerts_count,
+            project_to_infra_alerts_count,
             category_to_project_artifact_count.get(
                 mlrun.common.schemas.ArtifactCategories.dataset,
                 collections.defaultdict(lambda: 0),
@@ -4027,14 +4029,16 @@ class SQLDB(DBInterface):
         dict[str, int],
         dict[str, int],
         dict[str, int],
+        dict[str, int],
     ]:
         if mlrun.mlconf.httpdb.dsn.startswith(mlrun.common.db.dialects.Dialects.SQLITE):
             logger.debug("Partition management not supported for SQLite")
-            return {}, {}, {}
+            return {}, {}, {}, {}
 
         project_to_endpoint_alerts_count = collections.defaultdict(int)
         project_to_job_alerts_count = collections.defaultdict(int)
-        project_to_other_alerts_count = collections.defaultdict(int)
+        project_to_application_alerts_count = collections.defaultdict(int)
+        project_to_infra_alerts_count = collections.defaultdict(int)
 
         last_day = mlrun.utils.datetime_now() - timedelta(hours=24)
 
@@ -4064,17 +4068,23 @@ class SQLDB(DBInterface):
             func.count(
                 case(
                     (
-                        AlertActivation.entity_kind.notin_(
-                            [
-                                mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT,
-                                mlrun.common.schemas.alert.EventEntityKind.JOB,
-                            ]
-                        ),
+                        AlertActivation.entity_kind
+                        == mlrun.common.schemas.alert.EventEntityKind.MODEL_MONITORING_APPLICATION,
                         1,
                     ),
                     else_=None,
                 )
-            ).label("other_alerts_count"),
+            ).label("application_alerts_count"),
+            func.count(
+                case(
+                    (
+                        AlertActivation.entity_kind
+                        == mlrun.common.schemas.alert.EventEntityKind.MODEL_MONITORING_INFRA,
+                        1,
+                    ),
+                    else_=None,
+                )
+            ).label("infra_alerts_count"),
         )
 
         # filter by project, creation time, and activations within the last 24 hours
@@ -4087,15 +4097,23 @@ class SQLDB(DBInterface):
             .all()
         )
 
-        for project, endpoint_counter, job_counter, other_counter in query_results:
+        for (
+            project,
+            endpoint_counter,
+            job_counter,
+            application_counter,
+            infra_counter,
+        ) in query_results:
             project_to_endpoint_alerts_count[project] = endpoint_counter
             project_to_job_alerts_count[project] = job_counter
-            project_to_other_alerts_count[project] = other_counter
+            project_to_application_alerts_count[project] = application_counter
+            project_to_infra_alerts_count[project] = infra_counter
 
         return (
             project_to_endpoint_alerts_count,
             project_to_job_alerts_count,
-            project_to_other_alerts_count,
+            project_to_application_alerts_count,
+            project_to_infra_alerts_count,
         )
 
     @staticmethod

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -474,7 +474,8 @@ class Projects(
             project_to_running_runs_count,
             project_to_endpoint_alerts_count,
             project_to_job_alerts_count,
-            project_to_other_alerts_count,
+            project_to_application_alerts_count,
+            project_to_infra_alerts_count,
             project_to_datasets_count,
             project_to_documents_count,
             project_to_llm_prompts_count,
@@ -533,7 +534,10 @@ class Projects(
                         project_name, 0
                     ),
                     job_alerts_count=project_to_job_alerts_count.get(project_name, 0),
-                    other_alerts_count=project_to_other_alerts_count.get(
+                    application_alerts_count=project_to_application_alerts_count.get(
+                        project_name, 0
+                    ),
+                    infra_alerts_count=project_to_infra_alerts_count.get(
                         project_name, 0
                     ),
                     datasets_count=project_to_datasets_count.get(project_name, 0),

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -680,6 +680,7 @@ async def test_list_and_get_project_summaries(
                 {},
                 {},
                 {},
+                {},
             )
         )
     )
@@ -749,6 +750,7 @@ async def test_list_project_summaries_different_installation_modes(
     framework.utils.singletons.db.SQLDB._calculate_alert_activations_counters = (
         unittest.mock.Mock(
             return_value=(
+                {},
                 {},
                 {},
                 {},

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -886,6 +886,7 @@ async def test_list_project_summaries_filters_by_project_permissions(
                 {},
                 {},
                 {},
+                {},
             )
         )
     )

--- a/tests/alerts/test_alert_activations.py
+++ b/tests/alerts/test_alert_activations.py
@@ -18,6 +18,7 @@ from datetime import UTC
 import pytest
 
 import mlrun.common.schemas
+import mlrun.common.schemas.project
 
 
 @pytest.fixture
@@ -138,6 +139,32 @@ def test_aggregate_by_severity(sample_alert_activations):
         (mlrun.common.schemas.alert.AlertSeverity.LOW): 3,
         (mlrun.common.schemas.alert.AlertSeverity.MEDIUM): 1,
     }
+
+
+def test_all_entity_kinds_have_project_summary_counter():
+    """Ensure every EventEntityKind has a corresponding *_alerts_count field in ProjectSummary.
+
+    If a new EventEntityKind is added without a matching counter, this test will fail,
+    reminding the developer to update _calculate_alert_activations_counters and ProjectSummary.
+    """
+    entity_kind_to_counter_field = {
+        mlrun.common.schemas.alert.EventEntityKind.MODEL_ENDPOINT_RESULT: "endpoint_alerts_count",
+        mlrun.common.schemas.alert.EventEntityKind.JOB: "job_alerts_count",
+        mlrun.common.schemas.alert.EventEntityKind.MODEL_MONITORING_APPLICATION: "application_alerts_count",
+        mlrun.common.schemas.alert.EventEntityKind.MODEL_MONITORING_INFRA: "infra_alerts_count",
+    }
+    all_entity_kinds = set(mlrun.common.schemas.alert.EventEntityKind)
+    mapped_entity_kinds = set(entity_kind_to_counter_field.keys())
+    assert all_entity_kinds == mapped_entity_kinds, (
+        f"EventEntityKind values not mapped to ProjectSummary counter fields: "
+        f"{all_entity_kinds - mapped_entity_kinds}. "
+        f"Update _calculate_alert_activations_counters in db.py and ProjectSummary schema."
+    )
+    summary_fields = set(mlrun.common.schemas.project.ProjectSummary.__fields__.keys())
+    for entity_kind, counter_field in entity_kind_to_counter_field.items():
+        assert counter_field in summary_fields, (
+            f"Counter field '{counter_field}' for {entity_kind} missing from ProjectSummary"
+        )
 
 
 def test_aggregate_by_event_and_entity_kind(sample_alert_activations):

--- a/tests/system/alerts/test_alerts.py
+++ b/tests/system/alerts/test_alerts.py
@@ -424,14 +424,19 @@ class TestAlerts(TestMLRunSystem):
         self,
         expected_job_alerts_count=0,
         expected_endpoint_alerts_count=0,
-        expected_other_alerts_count=0,
+        expected_application_alerts_count=0,
+        expected_infra_alerts_count=0,
     ):
         project_summary = mlrun.get_run_db().get_project_summary(
             project=self.project_name
         )
         assert project_summary.job_alerts_count == expected_job_alerts_count
         assert project_summary.endpoint_alerts_count == expected_endpoint_alerts_count
-        assert project_summary.other_alerts_count == expected_other_alerts_count
+        assert (
+            project_summary.application_alerts_count
+            == expected_application_alerts_count
+        )
+        assert project_summary.infra_alerts_count == expected_infra_alerts_count
 
     @staticmethod
     def _validate_notifications_on_nuclio(nuclio_function_url, expected_notifications):


### PR DESCRIPTION
## Summary
- Split the catch-all `other_alerts_count` in ProjectSummary into explicit `application_alerts_count` and `infra_alerts_count` fields
- Enables UI to distinguish between model-monitoring-application and model-monitoring-infra alerts for filtering and counter display
- Addresses the discrepancy where lag detection alerts (entity_kind=model-monitoring-infra) were invisible in the UI alerts page

## Changes Made
- **`mlrun/common/schemas/project.py`**: Replace `other_alerts_count` with `application_alerts_count` + `infra_alerts_count`
- **`server/py/framework/db/sqldb/db.py`**: Replace catch-all `notin_` SQL CASE with explicit CASE per entity kind; return 4-tuple
- **`server/py/services/api/crud/projects.py`**: Wire new counter fields into ProjectSummary construction
- **`tests/alerts/test_alert_activations.py`**: Add guard test ensuring all EventEntityKind values have corresponding counters
- **`tests/system/alerts/test_alerts.py`**: Update assertions for new field names
- **`server/py/services/api/tests/unit/api/test_projects.py`**: Update mock return value from 3-tuple to 4-tuple

## Testing
- Unit tests pass (tests/alerts/test_alert_activations.py - 5/5)
- Guard test validates all EventEntityKind values are mapped to ProjectSummary counter fields
- Lint passes on all changed files

## Breaking Changes
- **Yes**: REST API response for `GET /api/v1/project-summaries` changes field name from `other_alerts_count` to `application_alerts_count` + `infra_alerts_count`. UI must be updated in the same release.

## References
- Jira: [ML-12247](https://iguazio.atlassian.net/browse/ML-12247)
- Parent feature: [ML-9954](https://iguazio.atlassian.net/browse/ML-9954)

[ML-12247]: https://iguazio.atlassian.net/browse/ML-12247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ