### PR TITLE
[Smoke-test] Install yq for k3s cluster setup

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -190,6 +190,9 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install --yes build-essential libpq-dev libffi-dev libssl-dev python3-dev pkg-config curl jq make
+        # yq is required by jupyterhub/action-k3s-helm (v4.1.0+) for calico setup
+        sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+        sudo chmod +x /usr/local/bin/yq
         uv venv venv --seed --clear
         source venv/bin/activate
         make install-requirements install-complete-requirements install-automation-requirements


### PR DESCRIPTION
### 📝 Description
The jupyterhub/action-k3s-helm bump from v4.0.1 to v4.1.0 (#9452) introduced a dependency on yq for splitting the calico manifest. The self-hosted runners don't have yq pre-installed, causing the "Start a local k8s cluster" step to fail with exit code 127.

---
 ### 🛠️ Changes Made

  - Install `yq` in the "Install automation scripts dependencies" step of the system-tests-opensource workflow. The
  v4.1.0 of `jupyterhub/action-k3s-helm` switched from `sed` to `yq` for splitting the calico YAML manifest, but the
  self-hosted runners don't have `yq` pre-installed.

  ---

  ### ✅ Checklist
  - [ ] I updated the documentation (if applicable)
  - [x] I have tested the changes in this PR
  - [x] I confirmed whether my changes are covered by system tests
    - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
    - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
  - [ ] If I introduced a deprecation:
    - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
    - [ ] I updated the relevant Jira ticket for documentation
  - [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml)
  workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to
  the RP)

  ---

  ### 🧪 Testing

  - The fix was validated by running the Smoke-tests workflow: https://github.com/mlrun/mlrun/actions/runs/23486301717 that passed.
  ---

  ### 🔗 References
  - Failed run: https://github.com/mlrun/mlrun/actions/runs/23481086479/job/68325634256
  - Root cause PR: #9452 (Dependabot bump of jupyterhub/action-k3s-helm from 4.0.1 to 4.1.0)

  ---

  ### 🚨 Breaking Changes?

  - [ ] Yes (explain below)
  - [x] No

  ---

  ### 🔍️ Additional Notes

  All smoke test runs have been consistently failing since the action-k3s-helm bump on March 12. The last successful
  run was [#22995449084](https://github.com/mlrun/mlrun/actions/runs/22995449084) which still used v4.0.1.