### PR TITLE
[Docs] Add graph API handler documentation [1.11.x]

### DIFF
--- a/docs/api/mlrun.common/mlrun.common.schemas/mlrun.common.schemas.serving.rst
+++ b/docs/api/mlrun.common/mlrun.common.schemas/mlrun.common.schemas.serving.rst
@@ -1,0 +1,7 @@
+mlrun.common.schemas.serving
+============================
+
+.. automodule:: mlrun.common.schemas.serving
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/api/mlrun.runtimes/mlrun.runtimes.rst
+++ b/docs/api/mlrun.runtimes/mlrun.runtimes.rst
@@ -12,3 +12,9 @@ mlrun.runtimes.nuclio
    :members:
    :show-inheritance:
    :undoc-members:
+
+mlrun.runtimes.serving
+======================
+.. autoclass:: mlrun.runtimes.nuclio.serving.APIHandlerConfig
+   :members:
+   :show-inheritance:

--- a/docs/serving/api-handler.md
+++ b/docs/serving/api-handler.md
@@ -120,8 +120,13 @@ config.add_body_mapping("titles", "$['store']['book'][*]['title']")
 Rules:
 - A single match → the value is returned as-is.
 - Multiple matches → a list is returned.
-- No match → the request fails with a 422 (Unprocessable Entity) error.
-- `body_map` applies to **all** ALLOW endpoints in the config. Every allowed request must supply a JSON dict body that satisfies all configured mappings.
+- No match → the request fails with HTTP 422 (Unprocessable Entity).
+- Non-JSON or non-dict body → the request fails with HTTP 422 (Unprocessable Entity).
+- `body_map` applies to **all** ALLOW endpoints in the config. Because the mapping is global, a `body_map` that matches one endpoint's body format may cause 422 errors for other endpoints whose requests do not share that format.
+
+```{note}
+The strict 422 behavior for missing body mappings and non-JSON bodies is a known limitation in the current release and will be relaxed in a future release to allow more flexible body handling.
+```
 
 To remove a mapping: `config.remove_body_mapping("model_name")`
 

--- a/docs/serving/api-handler.md
+++ b/docs/serving/api-handler.md
@@ -163,9 +163,9 @@ def step_handler(body, completion_id, limit, mlrun_request_path, **kwargs):
     # mlrun_request_path="/v1/chat/completions/abc123"  — from include_url_info
     ...
 
+
 class MyStep:
-    def do(self, body, completion_id, limit, mlrun_request_path, **kwargs):
-        ...
+    def do(self, body, completion_id, limit, mlrun_request_path, **kwargs): ...
 ```
 
 ## Complete example

--- a/docs/serving/api-handler.md
+++ b/docs/serving/api-handler.md
@@ -61,10 +61,10 @@ The configuration is serialized into `serving_fn.spec.api_handler_config` and is
 
 ```python
 config.add_endpoint_handler(
-    path,                                   # URL path, e.g. "/v1/chat" or "/v1/chat/*"
-    http_method=HTTPMethod.POST,            # HTTPMethod enum or string ("GET", "POST", ...)
-    action=APIHandlerAction.ALLOW,          # ALLOW or FORBID
-    description=None,                       # Optional human-readable description
+    path,  # URL path, e.g. "/v1/chat" or "/v1/chat/*"
+    http_method=HTTPMethod.POST,  # HTTPMethod enum or string ("GET", "POST", ...)
+    action=APIHandlerAction.ALLOW,  # ALLOW or FORBID
+    description=None,  # Optional human-readable description
 )
 ```
 
@@ -142,8 +142,8 @@ A `GET /v1/chat/completions/abc123?limit=10` request passes the following keywor
 
 ```python
 {
-    "completion_id": "abc123",                            # from path template
-    "limit": "10",                                        # from query string
+    "completion_id": "abc123",  # from path template
+    "limit": "10",  # from query string
     "mlrun_request_path": "/v1/chat/completions/abc123",  # from include_url_info
 }
 ```
@@ -153,14 +153,12 @@ A `GET /v1/chat/completions/abc123?limit=10` request passes the following keywor
 Extracted parameters are passed as keyword arguments to the handler function or `do()` method:
 
 ```python
-def predict(model_name, inputs, **kwargs):
-    ...
+def predict(model_name, inputs, **kwargs): ...
 ```
 
 ```python
 class InferenceStep:
-    def do(self, model_name, inputs, **kwargs):
-        ...
+    def do(self, model_name, inputs, **kwargs): ...
 ```
 
 ## Complete example
@@ -182,11 +180,13 @@ serving_fn = project.set_function(
     image="mlrun/mlrun",
 )
 
+
 # --- Define the graph step that processes chat completions ---
 # model_name and messages are passed as keyword arguments by the API handler
 def chat_handler(model_name, messages, mlrun_request_path, **kwargs):
     reply = f"Received {len(messages)} message(s) for model '{model_name}'"
     return {"reply": reply, "path": mlrun_request_path}
+
 
 graph = serving_fn.set_topology("flow", engine="sync")
 graph.to(name="chat", handler=chat_handler).respond()

--- a/docs/serving/api-handler.md
+++ b/docs/serving/api-handler.md
@@ -1,0 +1,238 @@
+(api-handler)=
+# API handler
+
+An API handler is a graph step that is automatically prepended to a serving graph when configured. It validates incoming HTTP requests against a set of user-defined endpoints, extracts parameters from path templates, query strings, and the request body, and passes them to the next step in the graph.
+
+Use an API handler to:
+- Implement industry-defined REST API schemas on your serving graph (for example, the OpenAI chat-completion interface for LLMs).
+- Gate access to specific paths using ALLOW and FORBID rules.
+
+API handlers are active only for HTTP-triggered invocations. When an event arrives through a non-HTTP trigger such as a stream, the API handler is bypassed (the path is always `/` in that case).
+
+**Supported runtimes**: Nuclio functions with an HTTP trigger, and the mock server (local testing).
+
+## Overview
+
+When the `GraphServer` receives an HTTP event and an API handler is configured, it runs the handler step before forwarding the event to the graph. The handler:
+
+1. Matches the request's HTTP method and URL path against the configured endpoint list.
+2. If a match is found:
+   - Extracts path template parameters and query string parameters.
+   - Optionally applies JSONPath transformations on the request body (`body_map`).
+   - Optionally injects the normalized request path into the event (`include_url_info`).
+   - Passes the enriched event to the graph root.
+3. If no match is found, the handler fails the request with an appropriate HTTP error (404 for unknown paths, 405 for method not allowed, 403 for FORBID action).
+
+## Configuration
+
+### APIHandlerConfig
+
+`APIHandlerConfig` holds the full configuration for the API handler. Create one, add endpoint rules and optional body mappings, then attach it to the serving function.
+
+```python
+from http import HTTPMethod
+
+from mlrun.common.schemas.serving import APIHandlerAction
+from mlrun.runtimes.nuclio.serving import APIHandlerConfig
+
+config = APIHandlerConfig()
+
+# Allow GET /v1/models
+config.add_endpoint_handler("/v1/models", HTTPMethod.GET, APIHandlerAction.ALLOW)
+
+# Allow POST /v1/models/{model_name}/predict  (path template)
+config.add_endpoint_handler(
+    "/v1/models/{model_name}/predict",
+    HTTPMethod.POST,
+    APIHandlerAction.ALLOW,
+    description="Run inference on a named model",
+)
+
+# Forbid access to admin endpoints
+config.add_endpoint_handler("/admin/*", HTTPMethod.GET, APIHandlerAction.FORBID)
+
+# Attach configuration to the serving function
+serving_fn.set_api_handler_config(config)
+```
+
+The configuration is serialized into `serving_fn.spec.api_handler_config` and is picked up at deployment time.
+
+### `add_endpoint_handler` signature
+
+```python
+config.add_endpoint_handler(
+    path,                                   # URL path, e.g. "/v1/chat" or "/v1/chat/*"
+    http_method=HTTPMethod.POST,            # HTTPMethod enum or string ("GET", "POST", ...)
+    action=APIHandlerAction.ALLOW,          # ALLOW or FORBID
+    description=None,                       # Optional human-readable description
+)
+```
+
+To remove an endpoint:
+
+```python
+config.remove_endpoint_handler("/v1/models", HTTPMethod.GET)
+```
+
+## Path matching rules
+
+Endpoints are matched in the following priority order:
+
+1. **Exact paths** — no wildcards or template parameters, e.g. `/v1/models`. O(1) dict lookup.
+2. **Path templates** — contain `{param}` placeholders, e.g. `/v1/models/{model_name}/predict`. Matched with a pre-compiled regex; insertion order wins when multiple templates match the same path.
+3. **Wildcard paths** — end with `*`, e.g. `/admin/*`. The `*` must be at the end and appear only once. Matched by prefix; the request path must contain at least one segment after the prefix. Insertion order wins.
+
+**Examples:**
+
+| Configured path           | Matches                             | Does not match   |
+|---------------------------|-------------------------------------|------------------|
+| `/v1/models`              | `/v1/models`                        | `/v1/models/gpt` |
+| `/v1/models/{model_name}` | `/v1/models/gpt`, `/v1/models/bert` | `/v1/models`     |
+| `/v1/*`                   | `/v1/chat`, `/v1/models/gpt`        | `/v1`            |
+
+## Extracting request parameters
+
+When the handler allows a request, it may extract parameters from three sources:
+
+| Source                   | How to configure                 | Available as               |
+|--------------------------|----------------------------------|----------------------------|
+| Path template parameters | `{param}` in the path pattern    | keyword argument           |
+| Query string parameters  | automatic                        | keyword argument           |
+| Request body fields      | `body_map` (JSONPath, see below) | keyword argument           |
+
+The extracted parameters are passed to the next step as keyword arguments. If the same parameter name appears in more than one source, the request fails with a 400 error.
+
+**Priority when no conflicts exist**: path > query > body_map (highest to lowest).
+
+If no parameters are extracted and `include_url_info` is not enabled, the original event body is passed through unchanged.
+
+### Body mapping (`body_map`)
+
+`body_map` maps parameter names to [JSONPath](https://goessner.net/articles/JsonPath/) expressions. It is **global** — the same mapping applies to every configured endpoint. The request body must be a JSON dict when `body_map` is configured.
+
+```python
+# Extract "model" field and nested "inputs" field from the request body
+config.add_body_mapping("model_name", "$.model")
+config.add_body_mapping("inputs", "$.data.inputs")
+
+# Multiple matches (e.g. all book titles) return a list
+config.add_body_mapping("titles", "$['store']['book'][*]['title']")
+```
+
+Rules:
+- A single match → the value is returned as-is.
+- Multiple matches → a list is returned.
+- No match → the request fails with a 422 (Unprocessable Entity) error.
+- `body_map` applies to **all** ALLOW endpoints in the config. Every allowed request must supply a JSON dict body that satisfies all configured mappings.
+
+To remove a mapping: `config.remove_body_mapping("model_name")`
+
+### URL info (`include_url_info`)
+
+When `include_url_info=True`, the handler injects an additional field `mlrun_request_path` into the event. This field contains the normalized URL path (without the query string). Query string parameters are always extracted as keyword arguments regardless of this setting.
+
+```python
+config = APIHandlerConfig(include_url_info=True)
+config.add_endpoint_handler(
+    "/v1/chat/completions/{completion_id}", HTTPMethod.GET, APIHandlerAction.ALLOW
+)
+```
+
+A `GET /v1/chat/completions/abc123?limit=10` request passes the following keyword arguments to the next step:
+
+```python
+{
+    "completion_id": "abc123",                            # from path template
+    "limit": "10",                                        # from query string
+    "mlrun_request_path": "/v1/chat/completions/abc123",  # from include_url_info
+}
+```
+
+## How downstream steps receive parameters
+
+Extracted parameters are passed as keyword arguments to the handler function or `do()` method:
+
+```python
+def predict(model_name, inputs, **kwargs):
+    ...
+```
+
+```python
+class InferenceStep:
+    def do(self, model_name, inputs, **kwargs):
+        ...
+```
+
+## Complete example
+
+The following example configures a serving function with an API handler that supports an OpenAI-compatible `POST /v1/chat/completions` endpoint. It extracts the `model` field and `messages` array from the request body, and makes the request path available to downstream steps.
+
+```python
+import mlrun
+from http import HTTPMethod
+
+from mlrun.common.schemas.serving import APIHandlerAction
+from mlrun.runtimes.nuclio.serving import APIHandlerConfig
+
+project = mlrun.get_or_create_project("chat-serving", context="./")
+
+serving_fn = project.set_function(
+    name="chat-completion",
+    kind="serving",
+    image="mlrun/mlrun",
+)
+
+# --- Define the graph step that processes chat completions ---
+# model_name and messages are passed as keyword arguments by the API handler
+def chat_handler(model_name, messages, mlrun_request_path, **kwargs):
+    reply = f"Received {len(messages)} message(s) for model '{model_name}'"
+    return {"reply": reply, "path": mlrun_request_path}
+
+graph = serving_fn.set_topology("flow", engine="sync")
+graph.to(name="chat", handler=chat_handler).respond()
+
+# --- Configure the API handler ---
+config = APIHandlerConfig(include_url_info=True)
+
+# Allow the OpenAI-compatible chat completion endpoint
+config.add_endpoint_handler(
+    "/v1/chat/completions",
+    HTTPMethod.POST,
+    APIHandlerAction.ALLOW,
+    description="OpenAI-compatible chat completion",
+)
+
+# Block all admin paths
+config.add_endpoint_handler("/admin/*", HTTPMethod.GET, APIHandlerAction.FORBID)
+config.add_endpoint_handler("/admin/*", HTTPMethod.POST, APIHandlerAction.FORBID)
+
+# Extract model and messages from the request body using JSONPath
+config.add_body_mapping("model_name", "$.model")
+config.add_body_mapping("messages", "$.messages")
+
+# Attach to the serving function
+serving_fn.set_api_handler_config(config)
+
+# --- Test locally with the mock server ---
+server = serving_fn.to_mock_server()
+
+# Allowed endpoint: body_map extracts model_name and messages; chat_handler receives them as kwargs
+result = server.test(
+    "/v1/chat/completions",
+    method="POST",
+    body={"model": "my-llm", "messages": [{"role": "user", "content": "Hello"}]},
+)
+# result: {"reply": "Received 1 message(s) for model 'my-llm'", "path": "/v1/chat/completions"}
+
+# Forbidden endpoint: raises 403
+try:
+    server.test("/admin/settings", method="GET", body={})
+except Exception as e:
+    print(e)  # Access forbidden
+
+# Unknown endpoint: raises 404
+try:
+    server.test("/unknown", method="GET", body={})
+except Exception as e:
+    print(e)  # Endpoint not found
+```

--- a/docs/serving/api-handler.md
+++ b/docs/serving/api-handler.md
@@ -9,7 +9,7 @@ Use an API handler to:
 
 API handlers are active only for HTTP-triggered invocations. When an event arrives through a non-HTTP trigger such as a stream, the API handler is bypassed (the path is always `/` in that case).
 
-**Supported runtimes**: Nuclio functions with an HTTP trigger, and the mock server (local testing).
+**Supported runtimes**: Serving functions with an HTTP trigger, and the mock server (local testing).
 
 ## Overview
 
@@ -78,7 +78,7 @@ config.remove_endpoint_handler("/v1/models", HTTPMethod.GET)
 
 Endpoints are matched in the following priority order:
 
-1. **Exact paths** — no wildcards or template parameters, e.g. `/v1/models`. O(1) dict lookup.
+1. **Exact paths** — no wildcards or template parameters, e.g. `/v1/models`.
 2. **Path templates** — contain `{param}` placeholders, e.g. `/v1/models/{model_name}/predict`. Matched with a pre-compiled regex; insertion order wins when multiple templates match the same path.
 3. **Wildcard paths** — end with `*`, e.g. `/admin/*`. The `*` must be at the end and appear only once. Matched by prefix; the request path must contain at least one segment after the prefix. Insertion order wins.
 
@@ -92,7 +92,7 @@ Endpoints are matched in the following priority order:
 
 ## Extracting request parameters
 
-When the handler allows a request, it may extract parameters from three sources:
+When the handler allows a request, it can extract parameters from three sources:
 
 | Source                   | How to configure                 | Available as               |
 |--------------------------|----------------------------------|----------------------------|
@@ -100,15 +100,13 @@ When the handler allows a request, it may extract parameters from three sources:
 | Query string parameters  | automatic                        | keyword argument           |
 | Request body fields      | `body_map` (JSONPath, see below) | keyword argument           |
 
-The extracted parameters are passed to the next step as keyword arguments. If the same parameter name appears in more than one source, the request fails with a 400 error.
+The extracted parameters are passed to the next step as keyword arguments. If the same parameter name appears in more than one source, the request fails with an error (400). Conflicts between `body_map` and path template parameters are detected at setup time.
 
-**Priority when no conflicts exist**: path > query > body_map (highest to lowest).
-
-If no parameters are extracted and `include_url_info` is not enabled, the original event body is passed through unchanged.
+Parameters are always forwarded to the next step. When any parameters are extracted or `include_url_info` is enabled, they are collected into a dict and passed as keyword arguments. Otherwise, the original event body is forwarded unchanged.
 
 ### Body mapping (`body_map`)
 
-`body_map` maps parameter names to [JSONPath](https://goessner.net/articles/JsonPath/) expressions. It is **global** — the same mapping applies to every configured endpoint. The request body must be a JSON dict when `body_map` is configured.
+`body_map` maps parameter names to [JSONPath](https://datatracker.ietf.org/doc/html/rfc9535) expressions. It is **global** — the same mapping applies to every configured endpoint. The request body must be a JSON dict when `body_map` is configured.
 
 ```python
 # Extract "model" field and nested "inputs" field from the request body
@@ -150,15 +148,19 @@ A `GET /v1/chat/completions/abc123?limit=10` request passes the following keywor
 
 ## How downstream steps receive parameters
 
-Extracted parameters are passed as keyword arguments to the handler function or `do()` method:
+Extracted parameters are passed as keyword arguments to the handler function or `do()` method. For example, given the endpoint `/v1/chat/completions/{completion_id}` with `include_url_info=True`, a `GET /v1/chat/completions/abc123?limit=10` request calls the next step as:
 
 ```python
-def predict(model_name, inputs, **kwargs): ...
-```
+def step_handler(body, completion_id, limit, mlrun_request_path, **kwargs):
+    # body: original request body
+    # completion_id="abc123"                            — from path template
+    # limit="10"                                        — from query string
+    # mlrun_request_path="/v1/chat/completions/abc123"  — from include_url_info
+    ...
 
-```python
-class InferenceStep:
-    def do(self, model_name, inputs, **kwargs): ...
+class MyStep:
+    def do(self, body, completion_id, limit, mlrun_request_path, **kwargs):
+        ...
 ```
 
 ## Complete example

--- a/docs/serving/serving-graph.md
+++ b/docs/serving/serving-graph.md
@@ -33,6 +33,7 @@ The serving graphs are used by [MLRun’s Feature Store](../feature-store/featur
 :maxdepth: 1
 basic-example
 getting-started
+api-handler
 building-graphs
 deploying-graphs
 demos

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -191,10 +191,10 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         action: schemas.serving.APIHandlerAction = schemas.serving.APIHandlerAction.ALLOW,
         description: str | None = None,
     ) -> None:
-        r"""Add an endpoint handler configuration.
+        """Add an endpoint handler configuration.
 
-        :param path: URL path for the endpoint (e.g., ``/v1/models`` or ``/api/v1/\*``)
-        :param http_method: HTTP method for the endpoint (HTTPMethod enum or string like 'GET', 'POST')
+        :param path: URL path for the endpoint (e.g., ``/v1/models`` or ``/api/v1/*``)
+        :param http_method: HTTP method for the endpoint (``HTTPMethod`` enum or string like ``"GET"``, ``"POST"``)
         :param action: Action to take for this endpoint (:py:class:`~mlrun.common.schemas.serving.APIHandlerAction`)
         :param description: Optional description of the endpoint
         :raises mlrun.errors.MLRunValueError: If the path contains an invalid wildcard ``*`` pattern

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -193,7 +193,7 @@ class APIHandlerConfig(mlrun.model.ModelObj):
     ) -> None:
         """Add an endpoint handler configuration.
 
-        :param path: URL path for the endpoint (e.g., '/v1/models' or '/api/v1/*')
+        :param path: URL path for the endpoint (e.g., ``/v1/models`` or ``/api/v1/\*``)
         :param http_method: HTTP method for the endpoint (HTTPMethod enum or string like 'GET', 'POST')
         :param action: Action to take for this endpoint (:py:class:`~mlrun.common.schemas.serving.APIHandlerAction`)
         :param description: Optional description of the endpoint
@@ -227,7 +227,8 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         """Remove an endpoint handler configuration.
 
         :param path: URL path for the endpoint to remove
-        :param http_method: HTTP method for the endpoint to remove (HTTPMethod enum or string like 'GET', 'POST')
+        :param http_method: HTTP method for the endpoint to remove (`HTTPMethod` enum or string like
+                            ``'GET'``, ``'POST'``)
         """
         http_method = self._validate_http_method(http_method)
         path = self._normalize_path(path)
@@ -243,7 +244,7 @@ class APIHandlerConfig(mlrun.model.ModelObj):
 
         :param parameter_name: Name of the parameter to pass to the handler
         :param json_path: JSONPath expression to extract the value from request body
-                         (e.g., '$.user.name' or '$.items[*].id')
+                         (e.g., ``'$.user.name'`` or ``'$.items[*].id'``)
         :raises mlrun.errors.MLRunValueError: If json_path is not a valid JSONPath expression
 
         Example::

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -191,7 +191,7 @@ class APIHandlerConfig(mlrun.model.ModelObj):
         action: schemas.serving.APIHandlerAction = schemas.serving.APIHandlerAction.ALLOW,
         description: str | None = None,
     ) -> None:
-        """Add an endpoint handler configuration.
+        r"""Add an endpoint handler configuration.
 
         :param path: URL path for the endpoint (e.g., ``/v1/models`` or ``/api/v1/\*``)
         :param http_method: HTTP method for the endpoint (HTTPMethod enum or string like 'GET', 'POST')


### PR DESCRIPTION
## Summary
[ML-12054](https://iguazio.atlassian.net/browse/ML-12054) | [ML-9565](https://iguazio.atlassian.net/browse/ML-9565)

- Adds `docs/serving/api-handler.md` documenting the graph API handler feature
- Adds the new page to the serving-graph TOC

The doc covers: configuration (`APIHandlerConfig`, `add_endpoint_handler`, `add_body_mapping`), path matching priority (exact → template → wildcard), parameter extraction as kwargs, `include_url_info`, and a complete runnable example.

All code snippets were validated against the real implementation using a mock server.

Notable corrections vs the draft PR (#9390):
- Removed unimplemented `mlrun_url_path_segments` / `mlrun_url_query_params` fields; documents actual `mlrun_request_path` field
- Removed out-of-scope admin API use-cases (model monitoring, add/remove models)
- `body_map` is global and applies to all ALLOW endpoints — documented with explicit note
- No distinction between class-based and function handler signatures (both use kwargs)

[ML-12054]: https://iguazio.atlassian.net/browse/ML-12054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-9565]: https://iguazio.atlassian.net/browse/ML-9565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ