### PR TITLE
[API] Fix project-summaries endpoint bypassing project permissions

### DIFF
--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -427,16 +427,9 @@ async def list_project_summaries(
         mlrun.mlconf.is_iguazio_v4_mode()
         or not framework.utils.helpers.is_request_from_leader(auth_info.projects_role)
     ):
-        auth_verifier = framework.utils.auth.verifier.AuthVerifier()
-        allowed_project_names = await auth_verifier.filter_project_resources_by_permissions(
-            resource_type=mlrun.common.schemas.AuthorizationResourceTypes.project_summaries,
-            resources=allowed_project_names,
-            project_and_resource_name_extractor=lambda project: (
-                project,
-                "",
-            ),
-            auth_info=auth_info,
-            action=mlrun.common.schemas.AuthorizationAction.read,
+        allowed_project_names = await framework.utils.auth.verifier.AuthVerifier().filter_projects_by_permissions(
+            allowed_project_names,
+            auth_info,
         )
     return await get_project_member().list_project_summaries(
         db_session,

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -862,6 +862,51 @@ async def test_list_project_summaries_different_installation_modes(
     )
 
 
+@pytest.mark.asyncio
+async def test_list_project_summaries_filters_by_project_permissions(
+    db: Session, client: TestClient, project_member_mode: str
+) -> None:
+    """Verify that project-summaries only returns summaries for projects the user
+    has permission to see, consistent with GET /projects behaviour."""
+    allowed_project = "allowed-project"
+    forbidden_project = "forbidden-project"
+    _create_project(client, allowed_project)
+    _create_project(client, forbidden_project)
+
+    services.api.crud.Pipelines().list_pipelines = unittest.mock.Mock(
+        return_value=(0, None, [])
+    )
+
+    # mock alert activations logic as it requires MySQL-specific logic not supported by SQLite.
+    framework.utils.singletons.db.SQLDB._calculate_alert_activations_counters = (
+        unittest.mock.Mock(
+            return_value=(
+                {},
+                {},
+                {},
+            )
+        )
+    )
+
+    await services.api.crud.Projects().refresh_project_resources_counters_cache(db)
+
+    # Mock filter_projects_by_permissions to only allow one project.
+    # The filter branch is always entered when the request is not from the leader,
+    # which is the case for regular user requests (projects_role is None).
+    framework.utils.auth.verifier.AuthVerifier().filter_projects_by_permissions = (
+        unittest.mock.AsyncMock(return_value=[allowed_project])
+    )
+
+    response = client.get("project-summaries")
+    assert response.status_code == HTTPStatus.OK.value
+    project_summaries_output = mlrun.common.schemas.ProjectSummariesOutput(
+        **response.json()
+    )
+    returned_names = [s.name for s in project_summaries_output.project_summaries]
+    assert returned_names == [allowed_project]
+    assert forbidden_project not in returned_names
+
+
 def test_delete_project_deletion_strategy_check(
     db: Session,
     client: TestClient,


### PR DESCRIPTION
### 📝 Description

Fix authorization bypass in the `GET /api/v1/project-summaries` endpoint where all project summaries were returned regardless of the user's project-level permissions.

**Root cause:** The endpoint used `filter_project_resources_by_permissions` with an empty resource name (`""`), which was wildcarded to `"*"` internally, causing OPA to evaluate against `/projects/{name}/project-summaries/*` instead of the project itself.

---

### 🛠️ Changes Made

- Replaced `filter_project_resources_by_permissions` (sub-resource level) with `filter_projects_by_permissions` (project level) in the `list_project_summaries` endpoint, matching the behavior of `GET /projects`


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Verified the test fails on the old code (returns both projects) and passes with the fix
- Added `test_list_project_summaries_filters_by_project_permissions` unit test that creates two projects, mocks `filter_projects_by_permissions` to allow only one, and asserts the endpoint returns only the allowed project


---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12342
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

The bug was in `_generate_resource_string_from_project_resource` (`server/py/framework/utils/auth/verifier.py:339`) which converts falsy resource names to `"*"`. Rather than fixing the wildcard logic (which other callers may depend on), the endpoint was changed to use the correct project-level permission check.
