### PR TITLE
[Model Monitoring] Reduce drift_table_plot artifact size via configurable include_plotlyjs

### DIFF
--- a/mlrun/artifacts/plots.py
+++ b/mlrun/artifacts/plots.py
@@ -79,13 +79,23 @@ class PlotlyArtifact(Artifact):
         figure: typing.Optional["Figure"] = None,
         key: str | None = None,
         target_path: str | None = None,
+        include_plotlyjs: bool | str = True,
     ) -> None:
         """
         Initialize a Plotly artifact with the given figure.
 
-        :param figure:      Plotly figure ('plotly.graph_objs.Figure' object) to save as an artifact.
-        :param key:         Key for the artifact to be stored in the database.
-        :param target_path: Path to save the artifact.
+        :param figure:           Plotly figure ('plotly.graph_objs.Figure' object) to save as an artifact.
+        :param key:              Key for the artifact to be stored in the database.
+        :param target_path:      Path to save the artifact.
+        :param include_plotlyjs: How to include Plotly.js in the exported HTML. Passed directly to
+                                 ``plotly.io.to_html(include_plotlyjs=...)``. Common values:
+
+                                 * ``True`` (default) - embed the full ~3.4 MB Plotly.js bundle inline.
+                                   The artifact is self-contained but large.
+                                 * ``"cdn"`` - reference Plotly.js from the official CDN. The artifact
+                                   is ~8 KB but requires network access to render.
+                                 * ``False`` - omit Plotly.js entirely. Use when the viewer (e.g. the
+                                   MLRun UI) already loads Plotly.js independently.
         """
         # Validate the plotly package:
         try:
@@ -114,6 +124,7 @@ class PlotlyArtifact(Artifact):
 
         # Continue initializing the plotly artifact:
         self._figure = figure
+        self._include_plotlyjs = include_plotlyjs
         self.spec.format = "html"
 
     def get_body(self) -> str:
@@ -122,4 +133,4 @@ class PlotlyArtifact(Artifact):
 
         :return: The figure's html code.
         """
-        return self._figure.to_html()
+        return self._figure.to_html(include_plotlyjs=self._include_plotlyjs)

--- a/mlrun/model_monitoring/features_drift_table.py
+++ b/mlrun/model_monitoring/features_drift_table.py
@@ -123,6 +123,7 @@ class FeaturesDriftTablePlot:
         inputs_statistics: dict,
         metrics: dict[str, Union[dict, float]],
         drift_results: dict[str, DriftResultType],
+        include_plotlyjs: bool | str = "cdn",
     ) -> _PlotlyTableArtifact:
         """
         Produce the html code of the table plot with the given information and the stored configurations in the class.
@@ -131,6 +132,8 @@ class FeaturesDriftTablePlot:
         :param inputs_statistics:     The inputs calculated statistics dictionary.
         :param metrics:               The drift detection metrics calculated on the sample set and inputs.
         :param drift_results:         The drift results per feature according to the rules of the monitor.
+        :param include_plotlyjs:      How to include Plotly.js in the exported HTML (passed to
+                                      ``PlotlyArtifact``). Defaults to ``"cdn"``.
 
         :return: The drift table as a plotly artifact.
         """
@@ -141,7 +144,9 @@ class FeaturesDriftTablePlot:
             metrics=metrics,
             drift_results=drift_results,
         )
-        return _PlotlyTableArtifact(figure=figure, key="drift_table_plot")
+        return _PlotlyTableArtifact(
+            figure=figure, key="drift_table_plot", include_plotlyjs=include_plotlyjs
+        )
 
     def _read_columns_names(self, statistics_dictionary: dict, drift_metrics: dict):
         """


### PR DESCRIPTION
## Summary

Relates to [ML-12267](https://iguazio.atlassian.net/browse/ML-12267) — `drift_table_plot` artifact creation takes much longer than before on IG4.

The original issue was not reproduced, but based on the symptom (slow artifact creation/upload), the suspected cause is artifact size: by default, `plotly.Figure.to_html()` embeds the full Plotly.js bundle (~3.4 MB) inline in every HTML artifact.

This PR is an effort to improve the situation under that assumption:

- Add `include_plotlyjs: bool | str = True` parameter to `PlotlyArtifact.__init__`, passed directly to [`plotly.io.to_html(include_plotlyjs=...)`](https://plotly.com/python-api-reference/generated/plotly.io.to_html.html). This makes the behavior configurable for all Plotly artifacts.
- Add `include_plotlyjs: bool | str = "cdn"` parameter to `FeaturesDriftTablePlot.produce`, defaulting to `"cdn"` for the drift table plot specifically. With `"cdn"`, the exported HTML references Plotly.js from the official CDN instead of embedding it, reducing the artifact from ~3.4 MB to ~8 KB.

## Test plan

- [x] Existing unit tests pass
- [x] Verify `drift_table_plot` artifact size is reduced when `include_plotlyjs="cdn"`
- [x] Verify artifact still renders correctly in MLRun UI (requires network access to CDN)

[ML-12267]: https://iguazio.atlassian.net/browse/ML-12267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ