### PR TITLE
[SDK] Fix HTTPDB http client socket leak

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -309,9 +309,13 @@ class HTTPRunDB(RunDBInterface):
 
         retry_on_put = self._is_retry_put_allowed(method, path)
 
-        # if the method is POST or PUT, we need to update the session with the appropriate retry policy
-        if not self.session or method in ("POST", "PUT"):
+        # Reuse the existing session across all requests. For POST/PUT, update the
+        # retry policy in-place instead of creating a new session (which would leak
+        # the old session's urllib3 PoolManager and its TCP connections).
+        if not self.session:
             self.session = self._init_session(retry_on_post, retry_on_put)
+        elif method in ("POST", "PUT"):
+            self.session.update_retry_methods(retry_on_post, retry_on_put)
 
         try:
             response = self.session.request(

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -232,7 +232,14 @@ class HTTPSessionWithRetry(requests.Session):
         :param retry_on_post: Whether POST requests should be retried.
         :param retry_on_put:  Whether PUT requests should be retried.
         """
-        self._retry_methods = self._resolve_retry_methods(retry_on_post, retry_on_put)
+        new_methods = self._resolve_retry_methods(retry_on_post, retry_on_put)
+
+        # Skip Retry object re-allocation when the allowed methods haven't changed
+        # consecutive calls with the same policy (common case) don't need a new Retry object
+        if new_methods == self._retry_methods:
+            return
+
+        self._retry_methods = new_methods
         if hasattr(self, "_http_adapter"):
             self._http_adapter.max_retries = urllib3.util.retry.Retry(
                 total=self.max_retries,

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -222,6 +222,26 @@ class HTTPSessionWithRetry(requests.Session):
             return False
         return True
 
+    def update_retry_methods(self, retry_on_post: bool, retry_on_put: bool) -> None:
+        """Update the retry method set on the session and its mounted adapter.
+
+        This allows reusing a single session across requests with different
+        retry policies (e.g., POST paths that are retriable vs. non-retriable),
+        avoiding the overhead of creating a new session per request.
+
+        :param retry_on_post: Whether POST requests should be retried.
+        :param retry_on_put:  Whether PUT requests should be retried.
+        """
+        self._retry_methods = self._resolve_retry_methods(retry_on_post, retry_on_put)
+        if hasattr(self, "_http_adapter"):
+            self._http_adapter.max_retries = urllib3.util.retry.Retry(
+                total=self.max_retries,
+                backoff_factor=self.retry_backoff_factor,
+                status_forcelist=config.http_retry_defaults.status_codes,
+                allowed_methods=self._retry_methods,
+                raise_on_status=False,
+            )
+
     def _method_retryable(self, method: str):
         return method in self._retry_methods
 

--- a/tests/rundb/test_httpdb_sessions.py
+++ b/tests/rundb/test_httpdb_sessions.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import unittest.mock
 
+import pytest
 import requests_mock as requests_mock_module
 
+import mlrun.common.types
 import mlrun.db.httpdb
 import mlrun.utils.http
 
-import mlrun.common.types
-
 http_methods = [method.value for method in mlrun.common.types.HTTPMethod]
+
 
 @pytest.mark.parametrize("method", http_methods)
 def test_calls_reuse_same_session(method: str):
@@ -41,7 +41,6 @@ def test_calls_reuse_same_session(method: str):
         assert first_session is second_session, (
             f"{method} should reuse the existing session, not create a new one"
         )
-
 
 
 def test_mixed_methods_reuse_same_session():

--- a/tests/rundb/test_httpdb_sessions.py
+++ b/tests/rundb/test_httpdb_sessions.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tests for HTTPRunDB session reuse on POST/PUT calls.
-
-After the fix, a single session is created and reused across all requests.
-POST/PUT calls update the retry policy in-place via update_retry_methods()
-instead of replacing the session.
-"""
-
+import pytest
 import unittest.mock
 
 import requests_mock as requests_mock_module
@@ -27,59 +20,28 @@ import requests_mock as requests_mock_module
 import mlrun.db.httpdb
 import mlrun.utils.http
 
+import mlrun.common.types
 
-def test_post_calls_reuse_same_session():
-    """POST calls should reuse the existing session, not create a new one."""
+http_methods = [method.value for method in mlrun.common.types.HTTPMethod]
+
+@pytest.mark.parametrize("method", http_methods)
+def test_calls_reuse_same_session(method: str):
+    """{method} calls should reuse the existing session, not create a new one."""
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
 
     with requests_mock_module.Mocker() as adapter:
-        adapter.register_uri("POST", "https://fake-url/api/v1/some/path", json={})
+        adapter.register_uri(method, "https://fake-url/api/v1/some/path", json={})
 
-        db.api_call("POST", "some/path")
+        db.api_call(method, "some/path")
         first_session = db.session
 
-        db.api_call("POST", "some/path")
+        db.api_call(method, "some/path")
         second_session = db.session
 
         assert first_session is second_session, (
-            "POST should reuse the existing session, not create a new one"
+            f"{method} should reuse the existing session, not create a new one"
         )
 
-
-def test_put_calls_reuse_same_session():
-    """PUT calls should reuse the existing session, not create a new one."""
-    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
-
-    with requests_mock_module.Mocker() as adapter:
-        adapter.register_uri("PUT", "https://fake-url/api/v1/some/path", json={})
-
-        db.api_call("PUT", "some/path")
-        first_session = db.session
-
-        db.api_call("PUT", "some/path")
-        second_session = db.session
-
-        assert first_session is second_session, (
-            "PUT should reuse the existing session, not create a new one"
-        )
-
-
-def test_get_requests_reuse_same_session():
-    """GET requests should reuse the same session (unchanged behavior)."""
-    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
-
-    with requests_mock_module.Mocker() as adapter:
-        adapter.register_uri("GET", "https://fake-url/api/v1/some/path", json={})
-
-        db.api_call("GET", "some/path")
-        first_session = db.session
-
-        db.api_call("GET", "some/path")
-        second_session = db.session
-
-        assert first_session is second_session, (
-            "GET should reuse the existing session"
-        )
 
 
 def test_mixed_methods_reuse_same_session():

--- a/tests/rundb/test_httpdb_sessions.py
+++ b/tests/rundb/test_httpdb_sessions.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Iguazio
+# Copyright 2026 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -93,19 +93,25 @@ def test_multiple_post_calls_no_session_leak():
         )
 
 
-def test_update_retry_methods_updates_frozenset():
+@pytest.mark.parametrize(
+    "retry_on_post, retry_on_put",
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+        (False, False),
+    ],
+)
+def test_update_retry_methods_updates_frozenset(retry_on_post, retry_on_put):
     """update_retry_methods() should update _retry_methods on the session."""
     session = mlrun.utils.http.HTTPSessionWithRetry(
-        retry_on_post=False, retry_on_put=True
+        retry_on_post=False, retry_on_put=False
     )
 
-    assert "POST" not in session._retry_methods
-    assert "PUT" in session._retry_methods
+    session.update_retry_methods(retry_on_post=retry_on_post, retry_on_put=retry_on_put)
 
-    session.update_retry_methods(retry_on_post=True, retry_on_put=False)
-
-    assert "POST" in session._retry_methods
-    assert "PUT" not in session._retry_methods
+    assert ("POST" in session._retry_methods) == retry_on_post
+    assert ("PUT" in session._retry_methods) == retry_on_put
 
 
 def test_update_retry_methods_updates_adapter():

--- a/tests/rundb/test_session_leak.py
+++ b/tests/rundb/test_session_leak.py
@@ -1,0 +1,199 @@
+# Copyright 2023 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for HTTPRunDB session reuse on POST/PUT calls.
+
+After the fix, a single session is created and reused across all requests.
+POST/PUT calls update the retry policy in-place via update_retry_methods()
+instead of replacing the session.
+"""
+
+import unittest.mock
+
+import requests_mock as requests_mock_module
+
+import mlrun.db.httpdb
+import mlrun.utils.http
+
+
+def test_post_calls_reuse_same_session():
+    """POST calls should reuse the existing session, not create a new one."""
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+
+    with requests_mock_module.Mocker() as adapter:
+        adapter.register_uri("POST", "https://fake-url/api/v1/some/path", json={})
+
+        db.api_call("POST", "some/path")
+        first_session = db.session
+
+        db.api_call("POST", "some/path")
+        second_session = db.session
+
+        assert first_session is second_session, (
+            "POST should reuse the existing session, not create a new one"
+        )
+
+
+def test_put_calls_reuse_same_session():
+    """PUT calls should reuse the existing session, not create a new one."""
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+
+    with requests_mock_module.Mocker() as adapter:
+        adapter.register_uri("PUT", "https://fake-url/api/v1/some/path", json={})
+
+        db.api_call("PUT", "some/path")
+        first_session = db.session
+
+        db.api_call("PUT", "some/path")
+        second_session = db.session
+
+        assert first_session is second_session, (
+            "PUT should reuse the existing session, not create a new one"
+        )
+
+
+def test_get_requests_reuse_same_session():
+    """GET requests should reuse the same session (unchanged behavior)."""
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+
+    with requests_mock_module.Mocker() as adapter:
+        adapter.register_uri("GET", "https://fake-url/api/v1/some/path", json={})
+
+        db.api_call("GET", "some/path")
+        first_session = db.session
+
+        db.api_call("GET", "some/path")
+        second_session = db.session
+
+        assert first_session is second_session, (
+            "GET should reuse the existing session"
+        )
+
+
+def test_mixed_methods_reuse_same_session():
+    """GET, POST, PUT calls should all share the same session object."""
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+
+    with requests_mock_module.Mocker() as adapter:
+        adapter.register_uri("GET", "https://fake-url/api/v1/some/path", json={})
+        adapter.register_uri("POST", "https://fake-url/api/v1/some/path", json={})
+        adapter.register_uri("PUT", "https://fake-url/api/v1/some/path", json={})
+
+        db.api_call("GET", "some/path")
+        session_after_get = db.session
+
+        db.api_call("POST", "some/path")
+        session_after_post = db.session
+
+        db.api_call("PUT", "some/path")
+        session_after_put = db.session
+
+        assert session_after_get is session_after_post is session_after_put, (
+            "All HTTP methods should share the same session object"
+        )
+
+
+def test_multiple_post_calls_no_session_leak():
+    """N POST calls should create exactly 1 session, not N."""
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+    sessions_created = []
+
+    original_init_session = db._init_session
+
+    def tracking_init_session(*args, **kwargs):
+        session = original_init_session(*args, **kwargs)
+        sessions_created.append(session)
+        return session
+
+    db._init_session = tracking_init_session
+
+    with requests_mock_module.Mocker() as adapter:
+        adapter.register_uri("POST", "https://fake-url/api/v1/some/path", json={})
+
+        num_calls = 5
+        for _ in range(num_calls):
+            db.api_call("POST", "some/path")
+
+        assert len(sessions_created) == 1, (
+            f"Expected 1 session created for {num_calls} POST calls, "
+            f"got {len(sessions_created)}"
+        )
+
+
+def test_update_retry_methods_updates_frozenset():
+    """update_retry_methods() should update _retry_methods on the session."""
+    session = mlrun.utils.http.HTTPSessionWithRetry(
+        retry_on_post=False, retry_on_put=True
+    )
+
+    assert "POST" not in session._retry_methods
+    assert "PUT" in session._retry_methods
+
+    session.update_retry_methods(retry_on_post=True, retry_on_put=False)
+
+    assert "POST" in session._retry_methods
+    assert "PUT" not in session._retry_methods
+
+
+def test_update_retry_methods_updates_adapter():
+    """update_retry_methods() should update the adapter's Retry.allowed_methods."""
+    session = mlrun.utils.http.HTTPSessionWithRetry(
+        retry_on_post=False, retry_on_put=True, retry_on_status=True
+    )
+
+    assert "POST" not in session._http_adapter.max_retries.allowed_methods
+
+    session.update_retry_methods(retry_on_post=True, retry_on_put=True)
+
+    assert "POST" in session._http_adapter.max_retries.allowed_methods
+    assert "PUT" in session._http_adapter.max_retries.allowed_methods
+
+
+def test_update_retry_methods_without_adapter():
+    """update_retry_methods() should work when retry_on_status=False (no adapter)."""
+    session = mlrun.utils.http.HTTPSessionWithRetry(
+        retry_on_post=False, retry_on_put=True, retry_on_status=False
+    )
+
+    assert not hasattr(session, "_http_adapter")
+
+    # Should not raise
+    session.update_retry_methods(retry_on_post=True, retry_on_put=False)
+
+    assert "POST" in session._retry_methods
+    assert "PUT" not in session._retry_methods
+
+
+def test_update_retry_methods_called_on_post_api_call():
+    """api_call() should call update_retry_methods() on POST when session exists."""
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+
+    with requests_mock_module.Mocker() as adapter:
+        adapter.register_uri("GET", "https://fake-url/api/v1/some/path", json={})
+        adapter.register_uri("POST", "https://fake-url/api/v1/some/path", json={})
+
+        # Create session via GET
+        db.api_call("GET", "some/path")
+        assert db.session is not None
+
+        # Spy on update_retry_methods
+        db.session.update_retry_methods = unittest.mock.Mock(
+            wraps=db.session.update_retry_methods
+        )
+
+        # POST should call update_retry_methods instead of replacing session
+        db.api_call("POST", "some/path")
+
+        db.session.update_retry_methods.assert_called_once()


### PR DESCRIPTION
### 📝 Description

`HTTPRunDB.api_call()` creates a new `HTTPSessionWithRetry` on every POST/PUT request, replacing `self.session` without closing the previous one. Each orphaned session retains its urllib3 `PoolManager` (configured with `pool_maxsize=64`), keeping TCP sockets alive until GC. In long-running processes this causes `CLOSE_WAIT` socket accumulation and eventually `OSError: [Errno 24] Too many open files`.

---

### 🛠️ Changes Made

- **`mlrun/db/httpdb.py`**: Changed `api_call()` to create the session once and reuse it. For POST/PUT, the retry policy is updated in-place via `session.update_retry_methods()` instead of replacing the entire session.
- **`mlrun/utils/http.py`**: Added `update_retry_methods()` to `HTTPSessionWithRetry` that updates both the internal `_retry_methods` frozenset and the mounted adapter's `Retry` object without recreating the session or adapter.
- **`tests/rundb/test_httpdb_sessions.py`**: New test file with 8 tests covering session reuse across all HTTP methods (parametrized), mixed-method reuse, leak prevention, and `update_retry_methods()` correctness (frozenset update, adapter update, no-adapter guard, integration with `api_call`).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- unit tests + manual testings

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12369
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

The root cause was that retry policies are baked into the `urllib3.util.retry.Retry` object at `HTTPAdapter` construction time. The old code created a fresh session per POST/PUT to get the right retry config for each path. The fix updates the retry config in-place on the existing session, which also improves performance by preserving the connection pool across requests.
