### PR TITLE
[Serving] Fix body_map to be usable across endpoints with different body formats

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -172,10 +172,6 @@ class MLRunMethodNotAllowedError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.METHOD_NOT_ALLOWED.value
 
 
-class MLRunUnprocessableEntityError(MLRunHTTPStatusError):
-    error_status_code = HTTPStatus.UNPROCESSABLE_ENTITY.value
-
-
 class MLRunInvalidArgumentError(MLRunHTTPStatusError, ValueError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -32,66 +32,7 @@ import mlrun.serving.states
 import mlrun.serving.utils as serving_utils
 import mlrun.utils
 from mlrun.common.schemas.serving import _APIEndpointKeys
-from mlrun.serving.utils import _MappedBody
-
-
-class _RequestContext(_MappedBody):
-    """Unified container for request parameters from multiple sources.
-
-    Consolidates parameters from body_map (JSONPath extraction), path templates,
-    and query strings into a single dict-like object that unpacks as kwargs.
-
-    Priority order: path > query > body_map (path parameters have highest priority)
-    Conflicts are not allowed - request will fail if same parameter appears in multiple sources.
-
-    Additionally, system-injected ``url_params`` (e.g. ``mlrun_request_path``) are merged
-    in after the conflict check without raising conflicts - they use the reserved ``mlrun_``
-    prefix to avoid collisions with user-defined parameters.
-    """
-
-    def __init__(
-        self,
-        path_params: dict[str, str] | None = None,
-        query_params: dict[str, str | list[str]] | None = None,
-        body_params: dict[str, Any] | None = None,
-        url_params: dict[str, Any] | None = None,
-    ):
-        merged = {}
-        sources = [
-            ("body_map", body_params or {}),
-            ("query", query_params or {}),
-            ("path", path_params or {}),
-        ]
-
-        # Track conflicts for better error messages
-        param_sources: dict[str, list[str]] = {}
-
-        for source_name, params in sources:
-            for key, value in params.items():
-                if key in merged:
-                    param_sources.setdefault(key, []).append(source_name)
-                else:
-                    param_sources[key] = [source_name]
-                merged[key] = value
-
-        # Check for conflicts (same param from multiple sources)
-        conflicts = {k: v for k, v in param_sources.items() if len(v) > 1}
-        if conflicts:
-            conflict_details = ", ".join(
-                f"{k} (from {' + '.join(sources)})" for k, sources in conflicts.items()
-            )
-            raise mlrun.errors.MLRunBadRequestError(
-                f"Parameter name conflict detected. Same parameter appears in multiple "
-                f"request sources: {conflict_details}. Parameters must be unique across "
-                f"path, query, and body_map."
-            )
-
-        # Merge system-injected URL params last, without conflict checking.
-        # These use the reserved 'mlrun_' prefix (e.g. 'mlrun_request_path').
-        if url_params:
-            merged.update(url_params)
-
-        super().__init__(merged)
+from mlrun.serving.utils import _RequestContext
 
 
 class _APIHandlerStep(mlrun.serving.states.TaskStep):
@@ -242,27 +183,23 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
 
         return template_patterns, star_patterns
 
-    def _apply_parsed_body_map(self, body: dict) -> "_MappedBody":
+    def _apply_parsed_body_map(self, body: dict) -> dict:
         """Apply pre-parsed JSONPath expressions to extract parameters from event body.
 
         :param body: The event body dict to extract parameters from.
-        :return: A :class:`_MappedBody` with extracted parameters.
-        :raises KeyError: If any JSONPath expression has no match in body.
+        :return: Dict of extracted parameters (missing JSONPath matches are silently skipped).
         """
         result = {}
         for param_name, parsed_expr in self._parsed_body_map.items():
             matches = parsed_expr.find(body)
             if not matches:
-                raise mlrun.errors.MLRunUnprocessableEntityError(
-                    f"JSONPath expression for parameter '{param_name}' "
-                    f"matched nothing in the event body"
-                )
+                continue
             # Single match: return value; multiple matches: return list
             if len(matches) == 1:
                 result[param_name] = matches[0].value
             else:
                 result[param_name] = [match.value for match in matches]
-        return _MappedBody(result)
+        return result
 
     @staticmethod
     def _parse_query_params(path_query: str) -> tuple[str, dict[str, str | list[str]]]:
@@ -322,7 +259,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
 
     def do(
         self, event: Union[nuclio_sdk.Event, "mlrun.serving.server.MockEvent"]
-    ) -> Union[nuclio_sdk.Event, "mlrun.serving.server.MockEvent", _RequestContext]:
+    ) -> Union[nuclio_sdk.Event, "mlrun.serving.server.MockEvent"]:
         """Handle incoming request and validate against configured endpoints
 
         :param event: Event object (Nuclio event or MockEvent)
@@ -420,24 +357,20 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                 body_params = {}
                 if self._parsed_body_map:
                     body = event.body if hasattr(event, "body") else event
-                    if not isinstance(body, dict):
-                        raise mlrun.errors.MLRunUnprocessableEntityError(
-                            f"body_map configured but request body is not a dict (got {type(body).__name__}). "
-                            f"A valid JSON body is required when body_map transformation is configured."
-                        )
-                    try:
-                        body_params = dict(self._apply_parsed_body_map(body))
-                        mlrun.utils.logger.debug(
-                            "Applied body_map transformation",
-                            body_map=self.config.body_map,
-                            extracted_params=list(body_params.keys()),
-                        )
-                    except mlrun.errors.MLRunUnprocessableEntityError:
-                        raise
-                    except Exception as exc:
-                        raise mlrun.errors.MLRunBadRequestError(
-                            f"Failed to process body_map transformation: {exc}"
-                        ) from exc
+                    if isinstance(body, dict):
+                        try:
+                            body_params = dict(self._apply_parsed_body_map(body))
+                            mlrun.utils.logger.debug(
+                                "Applied body_map transformation",
+                                body_map=self.config.body_map,
+                                extracted_params=list(body_params.keys()),
+                            )
+                        except Exception as exc:
+                            raise mlrun.errors.MLRunBadRequestError(
+                                f"Failed to process body_map transformation: {exc}"
+                            ) from exc
+                    # Non-dict body (e.g. None, string, bytes): body_map does not apply
+                    # to this endpoint's format — silently skip, same as a JSONPath miss.
 
                 # Build system-injected URL params when include_url_info is enabled.
                 # mlrun_request_path holds the normalized path of the matched request.
@@ -445,8 +378,11 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                 if self.config.include_url_info:
                     url_params["mlrun_request_path"] = normalized_path
 
-                # Only create RequestContext if we have extracted parameters or url_params.
-                # Otherwise, preserve the original event body.
+                # Build the event body for the next step.
+                # When any params are present, always use _RequestContext so the
+                # handler receives the original body as the first positional arg and all
+                # extracted params (body_map, path, query, url) as keyword args.
+                # When nothing was extracted, pass the original event body unchanged.
                 if body_params or path_params or query_params or url_params:
                     mlrun.utils.logger.debug(
                         "Creating RequestContext",
@@ -455,18 +391,19 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                         query_params=query_params,
                         url_params=url_params,
                     )
-                    request_context = _RequestContext(
+                    original_body = event.body if hasattr(event, "body") else event
+                    event_body = _RequestContext(
+                        original_body=original_body,
                         body_params=body_params,
                         path_params=path_params,
                         query_params=query_params,
                         url_params=url_params,
                     )
 
-                    # Replace event body with unified context
                     if hasattr(event, "body"):
-                        event.body = request_context
+                        event.body = event_body
                     else:
-                        event = request_context
+                        event = event_body
 
                 # Pass the event to the next step in the graph
                 return event

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -392,15 +392,13 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                         url_params=url_params,
                     )
                     original_body = event.body if hasattr(event, "body") else None
-                    event_body = _RequestContext(
+                    event.body = _RequestContext(
                         original_body=original_body,
                         body_params=body_params,
                         path_params=path_params,
                         query_params=query_params,
                         url_params=url_params,
                     )
-
-                    event.body = event_body
 
                 # Pass the event to the next step in the graph
                 return event

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -359,7 +359,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                     body = event.body if hasattr(event, "body") else event
                     if isinstance(body, dict):
                         try:
-                            body_params = dict(self._apply_parsed_body_map(body))
+                            body_params = self._apply_parsed_body_map(body)
                             mlrun.utils.logger.debug(
                                 "Applied body_map transformation",
                                 body_map=self.config.body_map,
@@ -391,7 +391,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                         query_params=query_params,
                         url_params=url_params,
                     )
-                    original_body = event.body if hasattr(event, "body") else event
+                    original_body = event.body if hasattr(event, "body") else None
                     event_body = _RequestContext(
                         original_body=original_body,
                         body_params=body_params,
@@ -400,10 +400,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                         url_params=url_params,
                     )
 
-                    if hasattr(event, "body"):
-                        event.body = event_body
-                    else:
-                        event = event_body
+                    event.body = event_body
 
                 # Pass the event to the next step in the graph
                 return event

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -73,7 +73,12 @@ from ..utils import (
     is_explicit_ack_supported,
     lock_hub_uri_version,
 )
-from .utils import StepToDict, _extract_input_data, _MappedBody, _update_result_body
+from .utils import (
+    StepToDict,
+    _extract_input_data,
+    _RequestContext,
+    _update_result_body,
+)
 
 callable_prefix = "_"
 path_splitter = "/"
@@ -4030,37 +4035,36 @@ def params_to_step(
 
 
 class _MappedBodyAwareHandler:
-    """Unpack _MappedBody as **kwargs before calling a step handler.
+    """Dispatch handler calls for API-handler-produced _RequestContext bodies.
 
-    _MappedBody (and its subclass _RequestContext) is a dict produced by
-    _APIHandlerStep.do() when body_map is configured.  It signals that the dict
-    should be spread as keyword arguments so handler signatures like
-    ``def fn(message: str)`` work correctly.
+    When _APIHandlerStep.do() produces a _RequestContext, the handler receives
+    the original event body as the first positional arg and all extracted params
+    (body_map, path, query, url) as keyword args::
+
+        def handler(body, model_name, version, **kwargs): ...
 
     Implemented as a named class rather than a closure so instances remain
     picklable for storey's multiprocessing (max_processes) mode.
 
     Use ``__call__`` for the sync path (TaskStep.run()) and ``async_call`` for
-    the async path (_init_async_objects).  Passing the bound ``async_call``
-    method to storey.Map lets asyncio.iscoroutinefunction detect it correctly
-    without resorting to private-API sentinels.
+    the async path (_init_async_objects).
     """
 
     def __init__(self, handler):
         self._fn = handler
 
     def __call__(self, body, *args, **kwargs):
-        if isinstance(body, _MappedBody):
-            # *args intentionally omitted: _MappedBody handlers use keyword-only
-            # signatures (e.g. def fn(message: str)), and the only callers
-            # (GraphServer.run → RootFlowStep.run, and storey.Map) never pass
-            # extra positional arguments.
-            return self._fn(**body, **kwargs)
+        if isinstance(body, _RequestContext):
+            return self._fn(
+                body.original_body, **{k: v for k, v in body.items()}, **kwargs
+            )
         return self._fn(body, *args, **kwargs)
 
     async def async_call(self, body, *args, **kwargs):
-        if isinstance(body, _MappedBody):
-            return await self._fn(**body, **kwargs)
+        if isinstance(body, _RequestContext):
+            return await self._fn(
+                body.original_body, **{k: v for k, v in body.items()}, **kwargs
+            )
         return await self._fn(body, *args, **kwargs)
 
 

--- a/mlrun/serving/utils.py
+++ b/mlrun/serving/utils.py
@@ -14,7 +14,9 @@
 
 import inspect
 from http import HTTPMethod
+from typing import Any
 
+import mlrun.errors
 from mlrun.utils import get_in, update_in
 
 # headers keys with underscore are getting ignored by werkzeug https://github.com/pallets/werkzeug/pull/2622
@@ -44,23 +46,64 @@ def _update_result_body(result_path, event_body, result):
     return event_body
 
 
-class _MappedBody(dict):
-    """Marker dict subclass for body_map-transformed event bodies.
+class _RequestContext(dict):
+    """Unified request context passed to handlers after API handler processing.
 
-    When a downstream :class:`TaskStep` receives a body that is an instance
-    of ``_MappedBody``, it unpacks the dict as ``**kwargs`` to the handler
-    instead of passing it as a single positional argument.  This allows
-    handler functions to declare named parameters that match the body_map
-    keys, e.g.::
+    Merges parameters from body_map (JSONPath extraction), path templates, query
+    string, and system-injected URL info into a single dict.  The original event
+    body is preserved as :attr:`original_body`.
 
-        body_map = {"book": "$.age"}
+    When a downstream :class:`TaskStep` receives this object it calls the handler
+    as ``fn(original_body, **params)`` so handlers can declare named parameters::
 
+        def handler(body, model_name, version, **kwargs): ...
 
-        def handler(book):
-            return f"{book} - this is the book"
+    Priority order (highest wins): path > query > body_map.
+    Conflicts between path/query/body_map raise :exc:`MLRunBadRequestError`.
+    System-injected ``url_params`` (``mlrun_`` prefix) are merged last without
+    conflict checking.
     """
 
-    pass
+    def __init__(
+        self,
+        original_body: Any = None,
+        path_params: dict[str, str] | None = None,
+        query_params: dict[str, str | list[str]] | None = None,
+        body_params: dict[str, Any] | None = None,
+        url_params: dict[str, Any] | None = None,
+    ):
+        merged: dict[str, Any] = {}
+        sources = [
+            ("body_map", body_params or {}),
+            ("query", query_params or {}),
+            ("path", path_params or {}),
+        ]
+
+        param_sources: dict[str, list[str]] = {}
+        for source_name, params in sources:
+            for key, value in params.items():
+                if key in merged:
+                    param_sources.setdefault(key, []).append(source_name)
+                else:
+                    param_sources[key] = [source_name]
+                merged[key] = value
+
+        conflicts = {k: v for k, v in param_sources.items() if len(v) > 1}
+        if conflicts:
+            conflict_details = ", ".join(
+                f"{k} (from {' + '.join(srcs)})" for k, srcs in conflicts.items()
+            )
+            raise mlrun.errors.MLRunBadRequestError(
+                f"Parameter name conflict detected. Same parameter appears in multiple "
+                f"request sources: {conflict_details}. Parameters must be unique across "
+                f"path, query, and body_map."
+            )
+
+        if url_params:
+            merged.update(url_params)
+
+        super().__init__(merged)
+        self.original_body = original_body
 
 
 class StepToDict:

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -28,7 +28,7 @@ import mlrun.errors
 from mlrun.common.schemas.serving import APIHandlerAction, _APIEndpointKeys
 from mlrun.runtimes.nuclio.serving import APIHandlerConfig, ServingRuntime
 from mlrun.serving import GraphContext
-from mlrun.serving.api_handler import _APIHandlerStep, _RequestContext
+from mlrun.serving.api_handler import _APIHandlerStep
 from mlrun.serving.server import (
     GraphServer,
     MockEvent,
@@ -37,6 +37,7 @@ from mlrun.serving.server import (
 )
 from mlrun.serving.utils import (
     _combine_serving_endpoint_key,
+    _RequestContext,
     _split_serving_endpoint_key,
 )
 
@@ -132,11 +133,8 @@ class TestRequestContext:
         assert ctx["body_only"] == "b1"
 
     def test_context_is_mapped_body(self) -> None:
-        """Test that RequestContext is a _MappedBody subclass"""
-        from mlrun.serving.utils import _MappedBody
-
+        """Test that RequestContext is a dict subclass"""
         ctx = _RequestContext(query_params={"test": "value"})
-        assert isinstance(ctx, _MappedBody)
         assert isinstance(ctx, dict)
 
     def test_context_unpacks_as_kwargs(self) -> None:
@@ -743,6 +741,7 @@ class TestIncludeUrlInfo:
         result = step.do(event)
 
         assert isinstance(result.body, _RequestContext)
+        assert result.body.original_body == "hello"
         assert result.body["mlrun_request_path"] == "/api/test"
 
     def test_include_url_info_path_without_query_string(self) -> None:
@@ -759,6 +758,7 @@ class TestIncludeUrlInfo:
         result = step.do(event)
 
         assert isinstance(result.body, _RequestContext)
+        assert result.body.original_body == "hello"
         # Path must be normalized (no query string)
         assert result.body["mlrun_request_path"] == "/api/items"
         # Query params are still extracted normally
@@ -779,6 +779,7 @@ class TestIncludeUrlInfo:
         result = step.do(event)
 
         assert isinstance(result.body, _RequestContext)
+        assert result.body.original_body == "hello"
         # Actual request path, not the template pattern
         assert result.body["mlrun_request_path"] == "/api/users/abc-123"
         # Path param is also present
@@ -796,6 +797,7 @@ class TestIncludeUrlInfo:
         result = step.do(event)
 
         assert isinstance(result.body, _RequestContext)
+        assert result.body.original_body == "hello"
         assert result.body["mlrun_request_path"] == "/api/deeply/nested/resource"
 
     def test_include_url_info_combined_with_existing_params(self) -> None:
@@ -817,6 +819,7 @@ class TestIncludeUrlInfo:
         result = step.do(event)
 
         assert isinstance(result.body, _RequestContext)
+        assert result.body.original_body == {"q": "Hello world"}
         assert result.body["mlrun_request_path"] == "/api/gpt4/ask"
         assert result.body["model_id"] == "gpt4"
         assert result.body["lang"] == "en"
@@ -909,8 +912,8 @@ class TestAPIHandlerMockServer:
     def test_api_handler_path_and_query_params_passed_to_handler(self) -> None:
         """Test that path params and query params are passed to handler arguments"""
 
-        def handler(**kwargs):
-            # All params come as kwargs via RequestContext
+        def handler(first_positional_arg, **kwargs):
+            # body is the original event body; path/query params come as kwargs
             return {
                 "item_id": kwargs.get("item_id"),
                 "source": kwargs.get("source"),
@@ -952,7 +955,7 @@ class TestAPIHandlerMockServer:
     def test_api_handler_body_map_with_path_query(self) -> None:
         """Test combining body_map, path params, and query params"""
 
-        def handler(**kwargs):
+        def handler(body, **kwargs):
             return {
                 "model": kwargs.get("model"),  # from body_map
                 "version": kwargs.get("version"),  # from path
@@ -994,7 +997,7 @@ class TestAPIHandlerMockServer:
     def test_api_handler_url_encoded_path_params(self) -> None:
         """Test that URL-encoded path parameters are properly decoded"""
 
-        def handler(**kwargs):
+        def handler(body, **kwargs):
             return {"filename": kwargs.get("filename")}
 
         fn = cast(
@@ -1027,7 +1030,7 @@ class TestAPIHandlerMockServer:
     def test_api_handler_multiple_path_params(self) -> None:
         """Test endpoint with multiple path parameters"""
 
-        def handler(**kwargs):
+        def handler(body, **kwargs):
             return {
                 "org": kwargs.get("org_id"),
                 "repo": kwargs.get("repo_id"),
@@ -1136,7 +1139,7 @@ class TestAPIHandlerMockServer:
     def test_api_handler_repeated_query_params(self) -> None:
         """Test that repeated query parameters are passed as lists"""
 
-        def handler(**kwargs):
+        def handler(body, **kwargs):
             return {"ids": kwargs.get("id"), "single": kwargs.get("name")}
 
         fn = cast(
@@ -1180,7 +1183,7 @@ class TestAPIHandlerMockServer:
         """
 
         def handler(
-            item_id: str, category: str, tags: list[str] | None = None, **kwargs
+            body, item_id: str, category: str, tags: list[str] | None = None, **kwargs
         ) -> dict:
             """Handler with explicit path params in signature.
 
@@ -1783,7 +1786,11 @@ class TestAPIHandlerStep:
             step.do(event)
 
     def test_run_body_map_with_missing_body(self) -> None:
-        """Test that body_map with missing/non-dict body raises 422 error"""
+        """body_map is silently skipped when the request body is not a dict.
+
+        Different endpoints share the same body_map config, so endpoints whose
+        body format is not a dict (e.g. a GET with no body) must not fail.
+        """
         config = APIHandlerConfig()
         config.body_map = {"$.name": "user_name"}
         config.add_endpoint_handler("/test", HTTPMethod.POST, APIHandlerAction.ALLOW)
@@ -1791,11 +1798,35 @@ class TestAPIHandlerStep:
         step = _APIHandlerStep(config=config)
         event = MockEvent(body=None, method="POST", path="/test")
 
-        with pytest.raises(
-            mlrun.errors.MLRunUnprocessableEntityError,
-            match="body_map configured but request body is not a dict",
-        ):
-            step.do(event)
+        # Should succeed; body_map is ignored when the body is not a dict
+        result = step.do(event)
+        assert result.body is None
+
+    def test_run_body_map_dict_body_no_fields_match(self) -> None:
+        """body_map is silently skipped when the dict body has no matching fields.
+
+        When body_map is configured globally but a particular endpoint's body does
+        not contain the mapped fields, the original body must be passed through
+        unchanged (not dropped). This covers the multi-endpoint case where different
+        endpoints have different body schemas.
+        """
+        config = APIHandlerConfig()
+        config.add_body_mapping("name", "$.user_name")
+        config.add_endpoint_handler(
+            "/test/{item_id}", HTTPMethod.POST, APIHandlerAction.ALLOW
+        )
+
+        step = _APIHandlerStep(config=config)
+        original_body = {"unrelated_field": "value"}
+        event = MockEvent(body=original_body, method="POST", path="/test/42")
+
+        result = step.do(event)
+
+        # Original body must be preserved; no body_map fields matched so it should
+        # come through as _RequestContext (original body + path param as kwarg).
+        assert isinstance(result.body, _RequestContext)
+        assert result.body.original_body == original_body
+        assert result.body["item_id"] == "42"
 
 
 class TestAddAPIHandlerStepToGraph:
@@ -2167,22 +2198,23 @@ class TestAPIHandlerEdgeCases:
         # Process the event
         result = handler.do(event)
 
-        # The handler modifies event.body to be a RequestContext when params are extracted
-        # (see api_handler.py line ~430: "if hasattr(event, 'body'): event.body = request_context")
+        # Path/query params extracted and no body_map → _RequestContext:
+        # original body passed as first positional arg, params as kwargs.
         assert isinstance(result, MockEvent)
         assert isinstance(result.body, _RequestContext)
+        assert result.body.original_body == "test"
         assert result.body["user_id"] == "123"
         assert result.body["fields"] == "name,email"
         assert result.body["limit"] == "10"
 
 
 class TestBodyMapMappedBodyUnpacking:
-    """body_map (_MappedBody → **kwargs) must work in both sync and async engines.
+    """body_map unpacking must work in both sync and async engines.
 
-    _APIHandlerStep.do() sets event.body to a _RequestContext (_MappedBody subclass).
-    TaskStep.run() unpacks it as **kwargs via _MappedBodyAwareHandler.  In the async
-    (storey) path storey.Map previously called the handler directly, bypassing that
-    unpacking.  _MappedBodyAwareHandler is now applied in both paths.
+    _APIHandlerStep.do() sets event.body to a _RequestContext that carries
+    the original body as the first positional arg and all extracted params as kwargs.
+    TaskStep.run() dispatches via _MappedBodyAwareHandler in both the sync and async
+    (storey) paths.
     """
 
     _EXPECTED = [
@@ -2193,7 +2225,7 @@ class TestBodyMapMappedBodyUnpacking:
     ]
 
     @staticmethod
-    def _streaming_word_handler(message: str) -> Iterator[dict]:
+    def _streaming_word_handler(body, message: str) -> Iterator[dict]:
         """Yields one dict per word; used to test body_map unpacking."""
         for i, word in enumerate(message.split()):
             yield {"chunk_id": i, "word": word}

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -249,8 +249,8 @@ class TestAPIHandlerStepBodyMap:
         assert result.body == {"model_name": "my-model", "input_data": [1, 2, 3]}
 
     @staticmethod
-    def test_body_map_missing_params_raises_error() -> None:
-        """Test that missing body_map params raise MLRunUnprocessableEntityError"""
+    def test_body_map_missing_params_skipped() -> None:
+        """Test that missing body_map params are silently skipped."""
         body_map = {
             "name": "$.name",
             "missing": "$.nonexistent.path",
@@ -262,11 +262,10 @@ class TestAPIHandlerStepBodyMap:
         event.path = "/predict"
         event.body = {"name": "test-model"}
 
-        # Should raise MLRunUnprocessableEntityError since $.nonexistent.path has no matches
-        with pytest.raises(
-            mlrun.errors.MLRunUnprocessableEntityError, match="matched nothing"
-        ):
-            step.do(event)
+        result = step.do(event)
+        # Only the matched field is present; missing JSONPath is silently skipped.
+        assert result.body["name"] == "test-model"
+        assert "missing" not in result.body
 
     def test_no_body_map_passes_event_through(self) -> None:
         """Test that without body_map the event passes through unchanged"""
@@ -285,8 +284,8 @@ class TestAPIHandlerStepBodyMap:
         assert result.body is original_body
 
     @staticmethod
-    def test_body_map_non_dict_body_raises_error() -> None:
-        """Test that non-dict body raises MLRunUnprocessableEntityError when body_map is configured"""
+    def test_body_map_non_dict_body_skipped() -> None:
+        """Test that non-dict body is silently skipped when body_map is configured."""
         body_map = {"param": "$.field"}
         step = TestAPIHandlerStepBodyMap._make_step_with_body_map(body_map)
 
@@ -295,12 +294,9 @@ class TestAPIHandlerStepBodyMap:
         event.path = "/predict"
         event.body = "plain string body"
 
-        # Should raise MLRunUnprocessableEntityError since body_map requires dict body
-        with pytest.raises(
-            mlrun.errors.MLRunUnprocessableEntityError,
-            match="body_map configured but request body is not a dict",
-        ):
-            step.do(event)
+        result = step.do(event)
+        # body_map cannot apply to a non-dict body; original body is passed through unchanged.
+        assert result.body == "plain string body"
 
     def test_body_map_applies_to_all_endpoints(self) -> None:
         """Test that the same body_map is applied regardless of which endpoint matched"""
@@ -340,7 +336,7 @@ class TestBodyMapMockServer:
     def test_body_map_e2e() -> None:
         """Test body_map end-to-end through mock server"""
 
-        def echo_handler(**kwargs):
+        def echo_handler(body, **kwargs):
             return kwargs
 
         fn = cast(
@@ -384,9 +380,9 @@ class TestBodyMapMockServer:
 
     @staticmethod
     def test_body_map_with_missing_fields_e2e() -> None:
-        """Test body_map with missing fields raises KeyError"""
+        """Test that body_map silently skips fields absent from the request body."""
 
-        def echo_handler(**kwargs):
+        def echo_handler(body, **kwargs):
             return kwargs
 
         fn = cast(
@@ -414,19 +410,19 @@ class TestBodyMapMockServer:
 
         server = fn.to_mock_server()
         try:
-            # Should raise since $.user.phone is missing
-            with pytest.raises(RuntimeError, match="matched nothing"):
-                server.test(
-                    "/register",
-                    method="POST",
-                    body={
-                        "user": {
-                            "name": "Alice",
-                            "email": "alice@example.com",
-                            # "phone" is intentionally missing
-                        }
-                    },
-                )
+            # Missing $.user.phone is silently skipped; matched fields are still extracted.
+            resp = server.test(
+                "/register",
+                method="POST",
+                body={
+                    "user": {
+                        "name": "Alice",
+                        "email": "alice@example.com",
+                        # "phone" is intentionally missing
+                    }
+                },
+            )
+            assert resp == {"name": "Alice", "email": "alice@example.com"}
         finally:
             server.wait_for_completion()
 
@@ -457,7 +453,7 @@ class TestBodyMapMockServer:
     def test_body_map_same_for_multiple_endpoints_e2e() -> None:
         """Test that the same body_map is applied to all endpoints"""
 
-        def echo_handler(**kwargs):
+        def echo_handler(body, **kwargs):
             return kwargs
 
         fn = cast(
@@ -499,7 +495,7 @@ class TestBodyMapMockServer:
     def test_body_map_kwargs_handler_e2e() -> None:
         """Test body_map unpacks as kwargs to a handler with named parameters"""
 
-        def fun(book):
+        def fun(body, book):
             return f"{book} - this is the book"
 
         fn = cast(
@@ -534,7 +530,7 @@ class TestBodyMapMockServer:
     def test_body_map_multi_kwargs_handler_e2e() -> None:
         """Test body_map with multiple kwargs passed to handler"""
 
-        def handler(name, age):
+        def handler(body, name, age):
             return f"{name} is {age} years old"
 
         fn = cast(
@@ -568,8 +564,8 @@ class TestBodyMapMockServer:
     def test_body_map_nested_extraction_e2e() -> None:
         """Test body_map with nested field extraction via JSONPath"""
 
-        def my_step(param1, param2):
-            return f"Received: {param1} and {param2}"
+        def my_step(first_arg, param1, param2):
+            return f"Received: {first_arg}, {param1=} and {param2=}"
 
         fn = cast(
             ServingRuntime,
@@ -603,7 +599,10 @@ class TestBodyMapMockServer:
                     "extra": "ignored",  # This won't be passed to the handler
                 },
             )
-            assert resp == "Received: value1 and value2"
+            assert resp == (
+                "Received: {'field1': 'value1', 'nested': {'field2': 'value2'}, "
+                "'extra': 'ignored'}, param1='value1' and param2='value2'"
+            )
         finally:
             server.wait_for_completion()
 
@@ -611,7 +610,7 @@ class TestBodyMapMockServer:
 def test_api_handler_with_body_map_and_processing_step(rundb_mock):
     """Test API handler with body_map followed by a processing step in the graph."""
 
-    def pass_through(arg1, arg2):
+    def pass_through(body, arg1, arg2):
         """Handler that passes through the mapped values"""
         return {"arg1": arg1, "arg2": arg2}
 

--- a/tests/serving/test_errors.py
+++ b/tests/serving/test_errors.py
@@ -51,7 +51,6 @@ def _make_error_handler(error_class: type[Exception], message: str) -> Callable:
         (mlrun.errors.MLRunConflictError, "Resource conflict", 409),
         (mlrun.errors.MLRunInternalServerError, "Internal server error", 500),
         (mlrun.errors.MLRunMethodNotAllowedError, "Method not allowed", 405),
-        (mlrun.errors.MLRunUnprocessableEntityError, "Unprocessable entity", 422),
         # Non-MLRun exceptions (backwards compatibility: should return 400)
         (ValueError, "Some generic error", 400),
         (RuntimeError, "Runtime error occurred", 400),
@@ -63,7 +62,6 @@ def _make_error_handler(error_class: type[Exception], message: str) -> Callable:
         "409_conflict",
         "500_internal_server_error",
         "405_method_not_allowed",
-        "422_unprocessable_entity",
         "400_value_error_backwards_compat",
         "400_runtime_error_backwards_compat",
     ],


### PR DESCRIPTION
## Summary

Fixes ML-12376: `body_map` was raising 422 errors for endpoints that don't match the configured JSONPath expressions, making it impossible to share a serving graph across endpoints with different body formats.

### Changes

**Bug fixes:**
- `body_map` no longer raises 422 when the request body is not a dict — non-dict bodies silently skip body_map extraction, so endpoints with different payload formats (e.g. one JSON, one plain text) can coexist in the same graph
- `body_map` no longer raises 422 when a JSONPath expression has no match — unmatched paths are silently skipped instead of erroring

**Refactor (internal):**
- Removed `MLRunUnprocessableEntityError` from `mlrun/errors.py` (was only used for the two cases above)
- Unified `_MappedBody`, the local `_RequestContext` in `api_handler.py`, and `_RequestContextWithBody` in `utils.py` into a single `_RequestContext` class in `utils.py`
  - The unified class carries the original event body as `original_body` and merges path/query/body_map params with conflict detection
  - `url_params` (reserved `mlrun_` prefix) are merged last without conflict checking
- `_MappedBodyAwareHandler` now consistently calls handlers as `fn(original_body, **params)` when the body is a `_RequestContext`, giving handlers clean access to both the raw body and all extracted parameters

## Test plan

- [x] `pytest tests/serving/test_body_map.py tests/serving/test_api_handler.py` — all 154 tests pass
- [x] Verify non-dict body no longer raises 422 (`test_body_map_non_dict_body_skipped`)
- [x] Verify missing JSONPath match no longer raises 422 (`test_body_map_missing_params_skipped`)
- [x] Verify dict body with no matching fields still passes original body through (`test_run_body_map_dict_body_no_fields_match`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)