### PR TITLE
[Config] Propagate function_defaults.image_by_kind through client spec

### DIFF
--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -71,4 +71,4 @@ class ClientSpec(pydantic.v1.BaseModel):
     oauth_internal_token_endpoint: str | None
     oauth_external_token_endpoint: str | None
     authorization_namespaces_resources: str | None
-    default_image_by_kind: dict[str, str] | None
+    default_runtime_image_by_kind: dict[str, str] | None

--- a/mlrun/common/schemas/client_spec.py
+++ b/mlrun/common/schemas/client_spec.py
@@ -71,3 +71,4 @@ class ClientSpec(pydantic.v1.BaseModel):
     oauth_internal_token_endpoint: str | None
     oauth_external_token_endpoint: str | None
     authorization_namespaces_resources: str | None
+    default_image_by_kind: dict[str, str] | None

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -687,6 +687,10 @@ class HTTPRunDB(RunDBInterface):
 
                 config.auth_with_oauth_token.enabled = True
 
+            default_image_by_kind = server_cfg.get("default_image_by_kind")
+            if default_image_by_kind is not None:
+                config.function_defaults.image_by_kind.update(default_image_by_kind)
+
         except Exception as exc:
             logger.warning(
                 "Failed syncing config from server",

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -687,13 +687,12 @@ class HTTPRunDB(RunDBInterface):
 
                 config.auth_with_oauth_token.enabled = True
 
-            default_runtime_image_by_kind = server_cfg.get(
-                "default_runtime_image_by_kind"
+            default_runtime_image_by_kind = (
+                server_cfg.get("default_runtime_image_by_kind") or {}
             )
-            if default_runtime_image_by_kind is not None:
-                config.function_defaults.image_by_kind.update(
-                    default_runtime_image_by_kind
-                )
+            for kind, image_value in default_runtime_image_by_kind.items():
+                if hasattr(config.function_defaults.image_by_kind, kind):
+                    setattr(config.function_defaults.image_by_kind, kind, image_value)
 
         except Exception as exc:
             logger.warning(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -687,9 +687,13 @@ class HTTPRunDB(RunDBInterface):
 
                 config.auth_with_oauth_token.enabled = True
 
-            default_image_by_kind = server_cfg.get("default_image_by_kind")
-            if default_image_by_kind is not None:
-                config.function_defaults.image_by_kind.update(default_image_by_kind)
+            default_runtime_image_by_kind = server_cfg.get(
+                "default_runtime_image_by_kind"
+            )
+            if default_runtime_image_by_kind is not None:
+                config.function_defaults.image_by_kind.update(
+                    default_runtime_image_by_kind
+                )
 
         except Exception as exc:
             logger.warning(

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -200,6 +200,15 @@ class ClientSpec(
 
     @staticmethod
     def _get_config_value_diff_from_default(config_key: str) -> dict[Any, Any] | None:
+        """
+        For a key in the configuration pointing to a dictionary return a
+        dictionary of all keys within that differ from the default. If no keys
+        differ it will return None instead. If either the current or default
+        value at this key is not a dictionary it will raise a TypeError.
+
+        :param config_key: the key within the config, multiple keys can be joined with .
+        :return: either a dict of changed keys with their new value or None
+        """
         current_config_value, default_config_value = (
             ClientSpec._get_config_value_current_and_default(config_key)
         )

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -141,6 +141,9 @@ class ClientSpec(
             ),
             oauth_internal_token_endpoint=oauth_internal_token_endpoint,
             oauth_external_token_endpoint=oauth_external_token_endpoint,
+            default_image_by_kind=self._get_config_value_if_not_default(
+                "function_defaults.image_by_kind"
+            ),
         )
 
     @staticmethod

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from typing import Any
 
 import mlrun.common.schemas
 import mlrun.utils.singleton
@@ -141,8 +142,8 @@ class ClientSpec(
             ),
             oauth_internal_token_endpoint=oauth_internal_token_endpoint,
             oauth_external_token_endpoint=oauth_external_token_endpoint,
-            default_runtime_image_by_kind=self._get_config_value_if_not_default(
-                "function_defaults.image_by_kind", delta=True
+            default_runtime_image_by_kind=self._get_config_value_diff_from_default(
+                "function_defaults.image_by_kind"
             ),
         )
 
@@ -170,39 +171,48 @@ class ClientSpec(
             return mlrun.utils.helpers.enrich_image_url(image)
 
     @staticmethod
-    def _get_config_value_if_not_default(config_key, delta=False):
+    def _get_config_value_current_and_default(config_key: str) -> tuple[Any, Any]:
         config_key_parts = config_key.split(".")
+
         current_config_value = config
-        current_default_config_value = default_config
+        default_config_value = default_config
+
         for config_key_part in config_key_parts:
             current_config_value = getattr(current_config_value, config_key_part)
-            current_default_config_value = current_default_config_value.get(
-                config_key_part, ""
-            )
+            default_config_value = default_config_value.get(config_key_part, "")
+
         # when accessing attribute in Config, if the object is of type Mapping it returns the object in type Config
         if isinstance(current_config_value, Config):
             current_config_value = current_config_value.to_dict()
 
-        if delta:
-            if not isinstance(current_config_value, dict) or not isinstance(
-                current_default_config_value, dict
-            ):
-                raise TypeError(
-                    "delta can only be computed if both the current and default values are dictionaries"
-                )
+        return current_config_value, default_config_value
 
-            # Convert current value to a subset of the dict that differs from the default dict
-            current_config_value = {
-                key: value
-                for key, value in current_config_value.items()
-                if key not in current_default_config_value
-                or value != current_default_config_value[key]
-            }
+    @staticmethod
+    def _get_config_value_if_not_default(config_key: str) -> Any:
+        current_config_value, default_config_value = (
+            ClientSpec._get_config_value_current_and_default(config_key)
+        )
 
-            return current_config_value or None
-
-        elif current_config_value == current_default_config_value:
+        if current_config_value == default_config_value:
             return None
-
         else:
             return current_config_value
+
+    @staticmethod
+    def _get_config_value_diff_from_default(config_key: str) -> dict[Any, Any] | None:
+        current_config_value, default_config_value = (
+            ClientSpec._get_config_value_current_and_default(config_key)
+        )
+
+        if not isinstance(current_config_value, dict) or not isinstance(
+            default_config_value, dict
+        ):
+            raise TypeError("can only compute diff between two dictionaries")
+
+        changes = {
+            key: value
+            for key, value in current_config_value.items()
+            if key not in default_config_value or value != default_config_value[key]
+        }
+
+        return changes or None

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -141,7 +141,7 @@ class ClientSpec(
             ),
             oauth_internal_token_endpoint=oauth_internal_token_endpoint,
             oauth_external_token_endpoint=oauth_external_token_endpoint,
-            default_image_by_kind=self._get_config_value_if_not_default(
+            default_runtime_image_by_kind=self._get_config_value_if_not_default(
                 "function_defaults.image_by_kind"
             ),
         )

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -142,7 +142,7 @@ class ClientSpec(
             oauth_internal_token_endpoint=oauth_internal_token_endpoint,
             oauth_external_token_endpoint=oauth_external_token_endpoint,
             default_runtime_image_by_kind=self._get_config_value_if_not_default(
-                "function_defaults.image_by_kind"
+                "function_defaults.image_by_kind", delta=True
             ),
         )
 
@@ -170,7 +170,7 @@ class ClientSpec(
             return mlrun.utils.helpers.enrich_image_url(image)
 
     @staticmethod
-    def _get_config_value_if_not_default(config_key):
+    def _get_config_value_if_not_default(config_key, delta=False):
         config_key_parts = config_key.split(".")
         current_config_value = config
         current_default_config_value = default_config
@@ -182,7 +182,27 @@ class ClientSpec(
         # when accessing attribute in Config, if the object is of type Mapping it returns the object in type Config
         if isinstance(current_config_value, Config):
             current_config_value = current_config_value.to_dict()
-        if current_config_value == current_default_config_value:
+
+        if delta:
+            if not isinstance(current_config_value, dict) or not isinstance(
+                current_default_config_value, dict
+            ):
+                raise TypeError(
+                    "delta can only be computed if both the current and default values are dictionaries"
+                )
+
+            # Convert current value to a subset of the dict that differs from the default dict
+            current_config_value = {
+                key: value
+                for key, value in current_config_value.items()
+                if key not in current_default_config_value
+                or value != current_default_config_value[key]
+            }
+
+            return current_config_value or None
+
+        elif current_config_value == current_default_config_value:
             return None
+
         else:
             return current_config_value

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -309,7 +309,7 @@ def test_client_spec_does_not_include_oauth_config_when_not_iguazio_v4_mode(
     assert response_body.get("oauth_internal_token_endpoint") is None
 
 
-def test_client_spec_includes_default_image_by_kind_when_configured(
+def test_client_spec_includes_default_runtime_image_by_kind_when_configured(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
     # Set custom image_by_kind values (different from defaults)
@@ -327,13 +327,16 @@ def test_client_spec_includes_default_image_by_kind_when_configured(
     response_body = response.json()
 
     # Should include the custom values
-    assert response_body["default_image_by_kind"] is not None
-    assert response_body["default_image_by_kind"]["job"] == custom_job_image
-    assert response_body["default_image_by_kind"]["serving"] == custom_serving_image
-    assert response_body["default_image_by_kind"]["nuclio"] == "mlrun/mlrun"
+    assert response_body["default_runtime_image_by_kind"] is not None
+    assert response_body["default_runtime_image_by_kind"]["job"] == custom_job_image
+    assert (
+        response_body["default_runtime_image_by_kind"]["serving"]
+        == custom_serving_image
+    )
+    assert response_body["default_runtime_image_by_kind"]["nuclio"] == "mlrun/mlrun"
 
 
-def test_client_spec_excludes_default_image_by_kind_when_default(
+def test_client_spec_excludes_default_runtime_image_by_kind_when_default(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
     # Set image_by_kind to default values
@@ -347,4 +350,4 @@ def test_client_spec_excludes_default_image_by_kind_when_default(
     response_body = response.json()
 
     # Should be None when values match defaults
-    assert response_body["default_image_by_kind"] is None
+    assert response_body["default_runtime_image_by_kind"] is None

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -326,23 +326,23 @@ def test_client_spec_includes_default_runtime_image_by_kind_when_configured(
     assert response.status_code == http.HTTPStatus.OK.value
     response_body = response.json()
 
-    # Should include the custom values
-    assert response_body["default_runtime_image_by_kind"] is not None
-    assert response_body["default_runtime_image_by_kind"]["job"] == custom_job_image
-    assert (
-        response_body["default_runtime_image_by_kind"]["serving"]
-        == custom_serving_image
-    )
-    assert response_body["default_runtime_image_by_kind"]["nuclio"] == "mlrun/mlrun"
+    # Should include the custom values but not the default
+    assert response_body["default_runtime_image_by_kind"] == {
+        "job": custom_job_image,
+        "serving": custom_serving_image,
+    }
 
 
 def test_client_spec_excludes_default_runtime_image_by_kind_when_default(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
-    # Set image_by_kind to default values
-    mlrun.mlconf.function_defaults.image_by_kind = mlrun.config.default_config[
-        "function_defaults"
-    ]["image_by_kind"]
+    # Set only defaults
+    mlrun.mlconf.function_defaults.image_by_kind = {
+        "job": "mlrun/mlrun",
+        "serving": "mlrun/mlrun",
+        "nuclio": "mlrun/mlrun",
+    }
+
     services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
 
     response = client.get("client-spec")

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -318,7 +318,8 @@ def test_client_spec_includes_default_runtime_image_by_kind_when_configured(
     mlrun.mlconf.function_defaults.image_by_kind = {
         "job": custom_job_image,
         "serving": custom_serving_image,
-        "nuclio": "mlrun/mlrun",  # keep default
+        # keep default
+        "nuclio": "mlrun/mlrun",
     }
     services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
 

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -337,11 +337,9 @@ def test_client_spec_excludes_default_image_by_kind_when_default(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:
     # Set image_by_kind to default values
-    mlrun.mlconf.function_defaults.image_by_kind = {
-        "job": "mlrun/mlrun",
-        "serving": "mlrun/mlrun",
-        "nuclio": "mlrun/mlrun",
-    }
+    mlrun.mlconf.function_defaults.image_by_kind = mlrun.config.default_config[
+        "function_defaults"
+    ]["image_by_kind"]
     services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
 
     response = client.get("client-spec")

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -307,3 +307,46 @@ def test_client_spec_does_not_include_oauth_config_when_not_iguazio_v4_mode(
 
     assert response_body.get("oauth_external_token_endpoint") is None
     assert response_body.get("oauth_internal_token_endpoint") is None
+
+
+def test_client_spec_includes_default_image_by_kind_when_configured(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    # Set custom image_by_kind values (different from defaults)
+    custom_job_image = "custom/job-image"
+    custom_serving_image = "custom/serving-image"
+    mlrun.mlconf.function_defaults.image_by_kind = {
+        "job": custom_job_image,
+        "serving": custom_serving_image,
+        "nuclio": "mlrun/mlrun",  # keep default
+    }
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    response_body = response.json()
+
+    # Should include the custom values
+    assert response_body["default_image_by_kind"] is not None
+    assert response_body["default_image_by_kind"]["job"] == custom_job_image
+    assert response_body["default_image_by_kind"]["serving"] == custom_serving_image
+    assert response_body["default_image_by_kind"]["nuclio"] == "mlrun/mlrun"
+
+
+def test_client_spec_excludes_default_image_by_kind_when_default(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    # Set image_by_kind to default values
+    mlrun.mlconf.function_defaults.image_by_kind = {
+        "job": "mlrun/mlrun",
+        "serving": "mlrun/mlrun",
+        "nuclio": "mlrun/mlrun",
+    }
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    response_body = response.json()
+
+    # Should be None when values match defaults
+    assert response_body["default_image_by_kind"] is None

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -396,7 +396,7 @@ def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
         ),
     ],
 )
-def test_client_spec_default_image_by_kind_enrichment(
+def test_client_spec_default_runtime_image_by_kind_enrichment(
     requests_mock,
     server_image_by_kind,
     expected_image_by_kind,
@@ -409,7 +409,10 @@ def test_client_spec_default_image_by_kind_enrichment(
 
     requests_mock.get(
         "https://fake-url/api/v1/client-spec",
-        json={"version": "v1.1.0", "default_image_by_kind": server_image_by_kind},
+        json={
+            "version": "v1.1.0",
+            "default_runtime_image_by_kind": server_image_by_kind,
+        },
     )
 
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -362,3 +362,53 @@ def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
     assert "This method is only supported in an Iguazio V4 system" in str(
         exc_info.value
     )
+
+
+@pytest.mark.parametrize(
+    "server_image_by_kind,expected_image_by_kind",
+    [
+        # Server provides custom images for a subset of kinds
+        (
+            {"job": "custom/job-image", "serving": "custom/serving-image"},
+            {"job": "custom/job-image", "serving": "custom/serving-image", "nuclio": "mlrun/mlrun"},
+        ),
+        # Server provides custom images for all kinds
+        (
+            {
+                "job": "custom/job-image",
+                "serving": "custom/serving-image",
+                "nuclio": "custom/nuclio-image",
+            },
+            {
+                "job": "custom/job-image",
+                "serving": "custom/serving-image",
+                "nuclio": "custom/nuclio-image",
+            },
+        ),
+        # Server does not override (returns None)
+        (
+            None,
+            {"job": "mlrun/mlrun", "serving": "mlrun/mlrun", "nuclio": "mlrun/mlrun"},
+        ),
+    ],
+)
+def test_client_spec_default_image_by_kind_enrichment(
+    requests_mock,
+    server_image_by_kind,
+    expected_image_by_kind,
+):
+    mlrun.mlconf.function_defaults.image_by_kind = {
+        "job": "mlrun/mlrun",
+        "serving": "mlrun/mlrun",
+        "nuclio": "mlrun/mlrun",
+    }
+
+    requests_mock.get(
+        "https://fake-url/api/v1/client-spec",
+        json={"version": "v1.1.0", "default_image_by_kind": server_image_by_kind},
+    )
+
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+    db.connect()
+
+    assert mlrun.mlconf.function_defaults.image_by_kind.to_dict() == expected_image_by_kind

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -364,12 +364,23 @@ def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
     )
 
 
+DEFAULTS = {
+    "job": "mlrun/mlrun",
+    "serving": "mlrun/mlrun",
+    "nuclio": "mlrun/mlrun",
+}
+
+
 @pytest.mark.parametrize(
-    "server_image_by_kind,expected_image_by_kind",
+    "client_image_by_kind,server_image_by_kind,expected_image_by_kind",
     [
         # Server provides custom images for a subset of kinds
         (
-            {"job": "custom/job-image", "serving": "custom/serving-image"},
+            DEFAULTS,
+            {
+                "job": "custom/job-image",
+                "serving": "custom/serving-image",
+            },
             {
                 "job": "custom/job-image",
                 "serving": "custom/serving-image",
@@ -378,6 +389,7 @@ def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
         ),
         # Server provides custom images for all kinds
         (
+            DEFAULTS,
             {
                 "job": "custom/job-image",
                 "serving": "custom/serving-image",
@@ -387,25 +399,37 @@ def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
                 "job": "custom/job-image",
                 "serving": "custom/serving-image",
                 "nuclio": "custom/nuclio-image",
+            },
+        ),
+        # User has an override and server provides another override
+        (
+            {
+                "job": "custom/job-image",
+                "serving": "mlrun/mlrun",
+                "nuclio": "mlrun/mlrun",
+            },
+            {
+                "serving": "custom/serving-image",
+            },
+            {
+                "job": "custom/job-image",
+                "serving": "custom/serving-image",
+                "nuclio": "mlrun/mlrun",
             },
         ),
         # Server does not override (returns None)
-        (
-            None,
-            {"job": "mlrun/mlrun", "serving": "mlrun/mlrun", "nuclio": "mlrun/mlrun"},
-        ),
+        (DEFAULTS, None, DEFAULTS),
+        # Server provides a kind not in the whitelist (dropped)
+        (DEFAULTS, {"foo": "foo"}, DEFAULTS),
     ],
 )
 def test_client_spec_default_runtime_image_by_kind_enrichment(
     requests_mock,
+    client_image_by_kind,
     server_image_by_kind,
     expected_image_by_kind,
 ):
-    mlrun.mlconf.function_defaults.image_by_kind = {
-        "job": "mlrun/mlrun",
-        "serving": "mlrun/mlrun",
-        "nuclio": "mlrun/mlrun",
-    }
+    mlrun.mlconf.function_defaults.image_by_kind = client_image_by_kind.copy()
 
     requests_mock.get(
         "https://fake-url/api/v1/client-spec",

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -370,7 +370,11 @@ def test_restricted_methods_in_wrong_mode(monkeypatch, method_name):
         # Server provides custom images for a subset of kinds
         (
             {"job": "custom/job-image", "serving": "custom/serving-image"},
-            {"job": "custom/job-image", "serving": "custom/serving-image", "nuclio": "mlrun/mlrun"},
+            {
+                "job": "custom/job-image",
+                "serving": "custom/serving-image",
+                "nuclio": "mlrun/mlrun",
+            },
         ),
         # Server provides custom images for all kinds
         (
@@ -411,4 +415,6 @@ def test_client_spec_default_image_by_kind_enrichment(
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
     db.connect()
 
-    assert mlrun.mlconf.function_defaults.image_by_kind.to_dict() == expected_image_by_kind
+    assert (
+        mlrun.mlconf.function_defaults.image_by_kind.to_dict() == expected_image_by_kind
+    )


### PR DESCRIPTION
### 📝 Description
Propagates the `function_defaults.image_by_kind`-configuration from the server to the client.

---

### 🛠️ Changes Made
- Added a new field `default_image_by_kind` to the client spec returned by the server which gets filled with the value of the `function_defaults.image_by_kind`-configuration.
- On httpdb connect update the `function_defaults.image_by_kind`-configuration with the values in `default_image_by_kind`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
I added unittests that cover if the server returns the configuration properly and unittests that confirm the client properly uses the value returned by the API.

I have set env settings on an IG4 dev vm to update some default images server side, then connected to that vm locally to verify the settings were propagated.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12319
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
