### PR TITLE
[Datastore] Use AWS default credential chain before falling back to anonymous S3 access

### DIFF
--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -118,19 +118,34 @@ class S3Store(DataStore):
                 endpoint_url=endpoint_url,
             )
         else:
-            # from env variables
+            # No explicit credentials provided. Let boto3 use the default
+            # credential chain (env vars, instance profile, IRSA, etc.).
             self.s3 = boto3.resource(
                 "s3", region_name=region, endpoint_url=endpoint_url
             )
-            if not token_file:
-                # If not using credentials, boto will still attempt to sign the requests, and will fail any operations
-                # due to no credentials found. These commands disable signing and allow anonymous mode (same as
-                # anon in the storage_options when working with fsspec).
+            if not token_file and not self._has_default_credentials():
+                # No credentials available through any provider — fall back to
+                # anonymous (unsigned) access for public buckets.
                 from botocore.handlers import disable_signing
 
                 self.s3.meta.client.meta.events.register(
                     "choose-signer.s3.*", disable_signing
                 )
+
+    @staticmethod
+    def _has_default_credentials() -> bool:
+        """Check if the AWS default credential chain can provide credentials.
+
+        Returns True if credentials are available through any provider
+        (environment variables, instance profile, IRSA, config files, etc.).
+        This avoids falling back to anonymous access when IAM roles or other
+        implicit credential sources are available (e.g., on EKS).
+        """
+        try:
+            credentials = boto3.Session().get_credentials()
+            return credentials is not None and credentials.access_key is not None
+        except Exception:
+            return False
 
     @staticmethod
     def get_range(size, offset):

--- a/tests/datastore/test_s3.py
+++ b/tests/datastore/test_s3.py
@@ -225,3 +225,52 @@ class TestS3StoreExceptionHandling:
         # Test with size=0 (should be treated as no size)
         range_header = S3Store.get_range(0, 50)
         assert range_header == "bytes=50-"
+
+
+class TestS3StoreAnonymousAccessFallback:
+    """Tests for ML-11829: S3Store should use the AWS default credential chain
+    (IAM roles, IRSA, etc.) when no explicit credentials are provided, and only
+    fall back to anonymous access when no credentials are available at all.
+    """
+
+    @patch("mlrun.datastore.s3.S3Store._has_default_credentials", return_value=True)
+    @patch("boto3.resource")
+    @patch("mlrun.datastore.s3.DataStore.__init__", return_value=None)
+    @patch("mlrun.datastore.s3.S3Store._get_secret_or_env", return_value=None)
+    def test_no_anonymous_when_default_credentials_available(
+        self,
+        mock_get_secret: Mock,
+        mock_init: Mock,
+        mock_boto3_resource: Mock,
+        mock_has_creds: Mock,
+    ):
+        """When IAM role or other default credentials exist, request signing stays enabled."""
+        mock_resource = Mock()
+        mock_boto3_resource.return_value = mock_resource
+
+        S3Store(parent=None, schema="s3", name="test", endpoint="bucket")
+
+        mock_resource.meta.client.meta.events.register.assert_not_called()
+
+    @patch("mlrun.datastore.s3.S3Store._has_default_credentials", return_value=False)
+    @patch("boto3.resource")
+    @patch("mlrun.datastore.s3.DataStore.__init__", return_value=None)
+    @patch("mlrun.datastore.s3.S3Store._get_secret_or_env", return_value=None)
+    def test_anonymous_when_no_credentials_available(
+        self,
+        mock_get_secret: Mock,
+        mock_init: Mock,
+        mock_boto3_resource: Mock,
+        mock_has_creds: Mock,
+    ):
+        """When no credentials are available at all, falls back to anonymous access."""
+        mock_resource = Mock()
+        mock_boto3_resource.return_value = mock_resource
+
+        S3Store(parent=None, schema="s3", name="test", endpoint="bucket")
+
+        mock_resource.meta.client.meta.events.register.assert_called_once()
+        assert (
+            mock_resource.meta.client.meta.events.register.call_args[0][0]
+            == "choose-signer.s3.*"
+        )


### PR DESCRIPTION
## Summary

- When no explicit AWS credentials are provided, S3Store now checks the boto3 default credential chain (IAM instance roles, IRSA, config files, etc.) before disabling request signing
- Previously, it always fell back to anonymous access, which caused 403 errors on private buckets accessible via IAM roles (e.g., on EKS)

## Changes

- Added `_has_default_credentials()` static method to `S3Store` that checks if boto3's default credential chain can provide credentials
- Modified the anonymous access fallback in `__init__` to only disable signing when no credentials are available through any provider
- Added 2 unit tests covering both paths (credentials available → signed, no credentials → anonymous)

## Test plan

- [x] `pytest tests/datastore/test_s3.py -xvs` — all 9 tests pass
- [ ] Manual test on AWS EKS cluster with IAM role (no explicit keys)

Reference: ML-11829