### PR TITLE
[Mounts] Fix auto_mount() ignoring server-configured S3 mount type when MLRUN_PVC_MOUNT is set

### DIFF
--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -382,19 +382,25 @@ def auto_mount(
             volume_mount_path=volume_mount_path,
             volume_name=volume_name or "shared-persistency",
         )
+    # When auto_mount_type is explicitly configured (not the default "auto"),
+    # honour it regardless of env variables like MLRUN_PVC_MOUNT.  This ensures
+    # that an admin-configured S3 or secret_env mount type takes precedence over
+    # a PVC env var that may be set on the client machine (e.g., external Jupyter).
+    # Lazy import to avoid circular dependency (pod.py imports mounts.py at module level).
+    from mlrun.runtimes.pod import AutoMountType, _filter_modifier_params
+
+    auto_mount_type = AutoMountType(config.storage.auto_mount_type)
+    if auto_mount_type != AutoMountType.auto:
+        modifier = auto_mount_type.get_modifier()
+        if modifier:
+            params = _filter_modifier_params(
+                modifier, config.get_storage_auto_mount_params()
+            )
+            return modifier(**params)
     if "MLRUN_PVC_MOUNT" in os.environ:
         return mount_pvc(
             volume_name=volume_name or "shared-persistency",
         )
-    # In the case of CE when working remotely, no env variables will be defined but auto-mount
-    # parameters may still be declared - use them in that case.
-    # Lazy import to avoid circular dependency (pod.py imports mounts.py at module level).
-    from mlrun.runtimes.pod import AutoMountType
-
-    auto_mount_type = AutoMountType(config.storage.auto_mount_type)
-    modifier = auto_mount_type.get_modifier()
-    if modifier and auto_mount_type != AutoMountType.auto:
-        return modifier(**config.get_storage_auto_mount_params())
     if "V3IO_ACCESS_KEY" in os.environ:
         return mount_v3io(name=volume_name or "v3io")
 

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -378,6 +378,33 @@ def test_auto_mount_secret_env():
     assert env_from[0].secret_ref.name == "s3-credentials"
 
 
+def test_auto_mount_s3_takes_precedence_over_pvc_env():
+    """Test that auto_mount_type=s3 takes precedence over MLRUN_PVC_MOUNT env var.
+
+    When the server sets auto_mount_type=s3, it should be honoured even if
+    MLRUN_PVC_MOUNT is set on the client (e.g., external Jupyter). See ML-12370.
+    """
+    mlrun.mlconf.storage.auto_mount_type = "s3"
+    mlrun.mlconf.storage.auto_mount_params = (
+        "endpoint_url=https://minio-lab.example.com,secret_name=minio-credentials"
+    )
+    os.environ["MLRUN_PVC_MOUNT"] = "some-pvc:/home/jovyan/"
+    try:
+        function = mlrun.new_function(
+            "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+        )
+        function.apply(mlrun.runtimes.mounts.auto_mount())
+
+        env_dict = {
+            var["name"]: var.get("value", var.get("valueFrom"))
+            for var in function.spec.env
+        }
+        assert "AWS_ACCESS_KEY_ID" in env_dict
+        assert env_dict["AWS_ENDPOINT_URL_S3"] == "https://minio-lab.example.com"
+    finally:
+        os.environ.pop("MLRUN_PVC_MOUNT", None)
+
+
 def test_auto_mount_raises_without_config():
     """Test that auto_mount() raises ValueError when no mount type is configured."""
     mlrun.mlconf.storage.auto_mount_type = ""


### PR DESCRIPTION
## Summary

- `auto_mount()` now checks the server-configured `auto_mount_type` before the client-side `MLRUN_PVC_MOUNT` env var
- When the server explicitly sets `auto_mount_type=s3` (or `secret_env`, `pvc`, etc.), that takes precedence over `MLRUN_PVC_MOUNT` on the client

## Root cause

On IG4 with external Jupyter, `MLRUN_PVC_MOUNT=mlrun-jupyter:/home/jovyan/` is set on the Jupyter node. `auto_mount()` checked this env var **before** the server-configured `auto_mount_type=s3`, so it always returned `mount_pvc` instead of `mount_s3`. Spark pods received PVC mounts instead of S3 credentials, causing `NoAuthWithAWSException`.

`try_auto_mount_based_on_config()` (used by the launcher) was not affected — it goes directly to the server config. The bug was only in the `auto_mount()` standalone function used in notebooks.

## Changes

- `mlrun/runtimes/mounts.py`: Moved the explicit `auto_mount_type` config check before the `MLRUN_PVC_MOUNT` env var check in `auto_mount()`
- `tests/runtimes/test_mounts.py`: Added test verifying S3 mount takes precedence over PVC env var

## Test plan

- [x] `pytest tests/runtimes/test_mounts.py` — all pass
- [x] `pytest tests/runtimes/test_base.py::TestAutoMount::test_auto_mount_function_with_pvc_config` — pass
- [ ] Manual test on vmdev212ig4 external Jupyter with `MLRUN_PVC_MOUNT` set

Reference: ML-12370