### PR TITLE
[Model Monitoring] Fix histogram data drift crash on empty sample data

### DIFF
--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -203,3 +203,4 @@ class _ApplicationErrorHandler(StepToDict):
             name=alert_objects.EventKind.MM_APP_FAILED, event_data=event_data
         )
         logger.info("Event generated successfully")
+        return event

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -165,6 +165,11 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
             monitoring_context.sample_df_stats
         )
         common_features = set(feature_stats.columns) & set(sample_df_stats.columns)
+        if common_features != set(feature_stats.columns):
+            monitoring_context.logger.warning(
+                "Some reference features are missing from the sample data",
+                missing_features=set(feature_stats.columns) - common_features,
+            )
         for feature_name in common_features:
             sample_hist = np.asarray(sample_df_stats[feature_name])
             reference_hist = np.asarray(feature_stats[feature_name])

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -259,7 +259,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         return stats
 
     @staticmethod
-    def _get_common_features_sample_stats(
+    def _get_shared_features_sample_stats(
         monitoring_context: mm_context.MonitoringApplicationContext,
     ) -> mlrun.common.model_monitoring.helpers.FeatureStats:
         """
@@ -338,7 +338,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
 
         if self._produce_plotly_artifact:
             self._log_plotly_table_artifact(
-                sample_set_statistics=self._get_common_features_sample_stats(
+                sample_set_statistics=self._get_shared_features_sample_stats(
                     monitoring_context
                 ),
                 inputs_statistics=monitoring_context.feature_stats,

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -164,7 +164,8 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         sample_df_stats = monitoring_context.dict_to_histogram(
             monitoring_context.sample_df_stats
         )
-        for feature_name in feature_stats:
+        common_features = set(feature_stats.columns) & set(sample_df_stats.columns)
+        for feature_name in common_features:
             sample_hist = np.asarray(sample_df_stats[feature_name])
             reference_hist = np.asarray(feature_stats[feature_name])
             monitoring_context.logger.info(
@@ -258,7 +259,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         return stats
 
     @staticmethod
-    def _get_shared_features_sample_stats(
+    def _get_common_features_sample_stats(
         monitoring_context: mm_context.MonitoringApplicationContext,
     ) -> mlrun.common.model_monitoring.helpers.FeatureStats:
         """
@@ -268,6 +269,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
             {
                 key: monitoring_context.sample_df_stats[key]
                 for key in monitoring_context.feature_stats
+                if key in monitoring_context.sample_df_stats
             }
         )
 
@@ -336,7 +338,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
 
         if self._produce_plotly_artifact:
             self._log_plotly_table_artifact(
-                sample_set_statistics=self._get_shared_features_sample_stats(
+                sample_set_statistics=self._get_common_features_sample_stats(
                     monitoring_context
                 ),
                 inputs_statistics=monitoring_context.feature_stats,
@@ -362,6 +364,11 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
             monitoring_context.logger.warning(
                 "No feature statistics found, skipping the application. \n"
                 "In order to run the application, training set must be provided when logging the model."
+            )
+            return []
+        if monitoring_context.sample_df.empty:
+            monitoring_context.logger.warning(
+                "No sample data found for the given interval, skipping the application."
             )
             return []
         metrics_per_feature = self._compute_metrics_per_feature(

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -362,7 +362,7 @@ class TestGetSharedFeaturesSampleStats:
             {"f1": {"count": 50}}
         )
 
-        result = application._get_common_features_sample_stats(ctx)
+        result = application._get_shared_features_sample_stats(ctx)
         assert set(result.keys()) == {"f1"}, (
             "Should only include features present in both stats dicts"
         )

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -187,6 +187,7 @@ class TestApplication:
         )
         monitoring_context._sample_df_stats = sample_df_stats
         monitoring_context._feature_stats = feature_stats
+        monitoring_context._sample_df = pd.DataFrame({"f1": [1], "f2": [2], "l": [3]})
 
         return monitoring_context
 
@@ -230,6 +231,49 @@ class TestApplication:
             "drift_table_plot.html",
             "features_drift_results.json",
         }, "The artifact files were not found or are different than expected"
+
+
+class TestEmptySampleDf:
+    """Reproduce ML-12380: do_tracking should handle empty sample data gracefully."""
+
+    @staticmethod
+    def test_do_tracking_with_empty_sample_df(
+        application: HistogramDataDriftApplication,
+        logger: mlrun.utils.Logger,
+        project: mlrun.MlrunProject,
+    ) -> None:
+        monitoring_context = mm_context.MonitoringApplicationContext(
+            application_name=application.NAME,
+            event={},
+            artifacts_logger=project,
+            logger=logger,
+            project=project,
+            nuclio_logger=logger,
+        )
+        monitoring_context._feature_stats = (
+            mlrun.common.model_monitoring.helpers.FeatureStats(
+                {
+                    "f1": {
+                        "count": 100,
+                        "hist": [
+                            [0, 0, 0, 30, 70, 0],
+                            [-10, -5, 0, 5, 10, 15, 20],
+                        ],
+                    },
+                    "f2": {
+                        "count": 100,
+                        "hist": [
+                            [0, 45, 5, 15, 35, 0],
+                            [66, 67, 68, 69, 70, 71, 72],
+                        ],
+                    },
+                }
+            )
+        )
+        monitoring_context._sample_df = pd.DataFrame()
+
+        results = application.do_tracking(monitoring_context)
+        assert results == [], "Expected empty results when sample data is empty"
 
 
 class TestMetricsPerFeature:
@@ -276,4 +320,76 @@ class TestMetricsPerFeature:
         }, "Different metrics than expected"
         assert set(metrics_per_feature.index) == set(feature_stats.columns), (
             "The features are different than expected"
+        )
+
+    @staticmethod
+    def test_compute_metrics_mismatched_features(
+        application: HistogramDataDriftApplication,
+        monitoring_context: Mock,
+    ) -> None:
+        """feature_stats has features not present in sample_df_stats (ML-12380)."""
+        feature_stats = pd.DataFrame(
+            {"f1": [1, 2, 3], "f2": [4, 5, 6], "f3": [7, 8, 9]}
+        )
+        sample_df_stats = pd.DataFrame({"f1": [10, 20, 30]})
+
+        monitoring_context.sample_df_stats = sample_df_stats
+        monitoring_context.feature_stats = feature_stats
+
+        metrics_per_feature = application._compute_metrics_per_feature(
+            monitoring_context=monitoring_context
+        )
+        assert set(metrics_per_feature.index) == {"f1"}, (
+            "Should only compute metrics for shared features"
+        )
+
+
+class TestGetSharedFeaturesSampleStats:
+    @staticmethod
+    def test_missing_keys(
+        application: HistogramDataDriftApplication,
+    ) -> None:
+        """feature_stats keys not in sample_df_stats should not cause KeyError (ML-12380)."""
+        ctx = Mock()
+        ctx.feature_stats = mlrun.common.model_monitoring.helpers.FeatureStats(
+            {"f1": {"count": 100}, "f2": {"count": 200}}
+        )
+        ctx.sample_df_stats = mlrun.common.model_monitoring.helpers.FeatureStats(
+            {"f1": {"count": 50}}
+        )
+
+        result = application._get_common_features_sample_stats(ctx)
+        assert set(result.keys()) == {"f1"}, (
+            "Should only include features present in both stats dicts"
+        )
+
+
+class TestApplicationErrorHandler:
+    """ML-12380 secondary issue: _ApplicationErrorHandler.do() must return the event."""
+
+    @staticmethod
+    def test_do_returns_event() -> None:
+        from mlrun.model_monitoring.applications._application_steps import (
+            _ApplicationErrorHandler,
+        )
+
+        handler = _ApplicationErrorHandler(project="test-project")
+
+        event = Mock()
+        event.body.endpoint_id = "ep-123"
+        event.body.application_name = "test-app"
+        event.error = ValueError("test error")
+        event.timestamp = "2024-01-01T00:00:00"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mock_db = Mock()
+            mp.setattr(
+                "mlrun.model_monitoring.applications._application_steps.mlrun.get_run_db",
+                lambda: mock_db,
+            )
+            result = handler.do(event)
+
+        assert result is event, (
+            "_ApplicationErrorHandler.do() must return the event to avoid "
+            "passing None downstream in the serving graph"
         )

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -29,12 +29,16 @@ from mlrun.common.schemas.model_monitoring.constants import (
     ResultKindApp,
     ResultStatusApp,
 )
+from mlrun.model_monitoring.applications._application_steps import (
+    _ApplicationErrorHandler,
+)
 from mlrun.model_monitoring.applications.histogram_data_drift import (
     DataDriftClassifier,
     HistogramDataDriftApplication,
     InvalidMetricValueError,
     InvalidThresholdValueError,
 )
+from mlrun.serving.server import MockEvent
 
 assets_folder = Path(__file__).parent / "assets"
 
@@ -369,15 +373,10 @@ class TestApplicationErrorHandler:
 
     @staticmethod
     def test_do_returns_event() -> None:
-        from mlrun.model_monitoring.applications._application_steps import (
-            _ApplicationErrorHandler,
-        )
-
         handler = _ApplicationErrorHandler(project="test-project")
 
-        event = Mock()
-        event.body.endpoint_id = "ep-123"
-        event.body.application_name = "test-app"
+        event = MockEvent()
+        event.body = Mock(endpoint_id="ep-123", application_name="test-app")
         event.error = ValueError("test error")
         event.timestamp = "2024-01-01T00:00:00"
 

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -330,6 +330,7 @@ class TestMetricsPerFeature:
     def test_compute_metrics_mismatched_features(
         application: HistogramDataDriftApplication,
         monitoring_context: Mock,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """feature_stats has features not present in sample_df_stats (ML-12380)."""
         feature_stats = pd.DataFrame(
@@ -346,6 +347,7 @@ class TestMetricsPerFeature:
         assert set(metrics_per_feature.index) == {"f1"}, (
             "Should only compute metrics for shared features"
         )
+        assert "missing from the sample data" in caplog.text
 
 
 class TestGetSharedFeaturesSampleStats:


### PR DESCRIPTION
### 📝 Description

A stream processing topology change in v1.11.0 (#9063) introduced a timing gap where TSDB data becomes available before Parquet data flushes. This exposed three latent bugs in the histogram data drift application (present since v1.7.0) that caused `KeyError` and `NoneType` crashes when the application was triggered before sample data was available. [ML-12380](https://iguazio.atlassian.net/browse/ML-12380)

---

### 🛠️ Changes Made

- Add `sample_df.empty` guard in `do_tracking()` to skip processing when no sample data is available for the given interval (mirrors the existing guard in the local `evaluate()` path)
- Iterate the intersection of `feature_stats` and `sample_df_stats` columns in `_compute_metrics_per_feature()` instead of assuming all reference features exist in the sample
- Guard `_get_shared_features_sample_stats()` against missing keys in `sample_df_stats`
- Return `event` from `_ApplicationErrorHandler.do()` to prevent `None` from propagating downstream in the serving graph

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- 4 new unit tests added covering all fixed scenarios:
  - `TestEmptySampleDf::test_do_tracking_with_empty_sample_df` — verifies graceful handling of empty sample data
  - `TestMetricsPerFeature::test_compute_metrics_mismatched_features` — verifies intersection-based iteration when feature sets differ
  - `TestGetSharedFeaturesSampleStats::test_missing_keys` — verifies missing keys don't cause `KeyError`
  - `TestApplicationErrorHandler::test_do_returns_event` — verifies error handler returns the event
- All 18 tests in `test_histogram_data_drift.py` pass (14 existing + 4 new)
- Verified in k8s logs (project `jvlhtrcbaa`) that the production error matches the reproduced `KeyError: 'sepal_length_cm'`

Smoke passed – https://github.com/mlrun/mlrun/actions/runs/23795615062.

---

### 🔗 References
- Ticket link: [ML-12380](https://iguazio.atlassian.net/browse/ML-12380)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

**Root cause**: The regression trigger is commit #9063 which moved `FilterNOP` earlier in the stream processing pipeline, causing the TSDB branch to diverge before `flatten_events`/`MapFeatureNames`. This creates a window where TSDB has data but `ParquetTarget` hasn't flushed yet. The controller queries TSDB, finds data, triggers the app — but the app reads an empty `sample_df` from Parquet.

This PR does not revert the topology change. Instead, it adds defensive guards so the application gracefully skips processing when sample data is unavailable. The only consequence is that the first monitoring cycle after deployment may silently skip drift computation for some endpoints; subsequent cycles work normally once Parquet catches up.

The topology issue is non-deterministic (depends on flush timing), which explains why QA tests could pass on one RC and fail on another.

[ML-12380]: https://iguazio.atlassian.net/browse/ML-12380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ML-12380]: https://iguazio.atlassian.net/browse/ML-12380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ