### PR TITLE
[Auth] Fix project-summaries endpoint bypassing authorization filter [1.11.x]

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3568,7 +3568,7 @@ class SQLDB(DBInterface):
             project_query = self._add_labels_filter(
                 session, project_query, Project, labels
             )
-        if names:
+        if names is not None:
             project_query = project_query.filter(Project.name.in_(names))
 
         project_subquery = project_query.subquery()

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3568,6 +3568,8 @@ class SQLDB(DBInterface):
             project_query = self._add_labels_filter(
                 session, project_query, Project, labels
             )
+        # Use `is not None` to distinguish between "no filter" (None) and
+        # "empty allowed list" ([]) from OPA when the user has no permissions.
         if names is not None:
             project_query = project_query.filter(Project.name.in_(names))
 

--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -386,6 +386,7 @@ async def list_projects(
             projects_output.projects,
             auth_info,
         )
+    # Short-circuit when the user has no project permissions (OPA returned an empty allowed list).
     if allowed_project_names is not None and not allowed_project_names:
         return mlrun.common.schemas.ProjectsOutput(projects=[])
     return await run_in_threadpool(
@@ -433,6 +434,7 @@ async def list_project_summaries(
             allowed_project_names,
             auth_info,
         )
+    # Short-circuit when the user has no project permissions (OPA returned an empty allowed list).
     if allowed_project_names is not None and not allowed_project_names:
         return mlrun.common.schemas.ProjectSummariesOutput(project_summaries=[])
     return await get_project_member().list_project_summaries(

--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -386,6 +386,8 @@ async def list_projects(
             projects_output.projects,
             auth_info,
         )
+    if allowed_project_names is not None and not allowed_project_names:
+        return mlrun.common.schemas.ProjectsOutput(projects=[])
     return await run_in_threadpool(
         get_project_member().list_projects,
         db_session,
@@ -431,6 +433,8 @@ async def list_project_summaries(
             allowed_project_names,
             auth_info,
         )
+    if allowed_project_names is not None and not allowed_project_names:
+        return mlrun.common.schemas.ProjectSummariesOutput(project_summaries=[])
     return await get_project_member().list_project_summaries(
         db_session,
         auth_info,

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -949,9 +949,9 @@ async def test_list_project_summaries_returns_empty_when_no_permissions(
     project_summaries_output = mlrun.common.schemas.ProjectSummariesOutput(
         **response.json()
     )
-    assert (
-        project_summaries_output.project_summaries == []
-    ), "Expected no project summaries when user has no permissions, but got some"
+    assert project_summaries_output.project_summaries == [], (
+        "Expected no project summaries when user has no permissions, but got some"
+    )
 
 
 def test_delete_project_deletion_strategy_check(

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -910,6 +910,50 @@ async def test_list_project_summaries_filters_by_project_permissions(
     assert forbidden_project not in returned_names
 
 
+@pytest.mark.asyncio
+async def test_list_project_summaries_returns_empty_when_no_permissions(
+    db: Session, client: TestClient, project_member_mode: str
+) -> None:
+    """Verify that project-summaries returns no projects when the user has no
+    permissions at all (empty allowed list from OPA), rather than leaking all
+    projects due to `if names:` treating [] as falsy."""
+    _create_project(client, "project-a")
+    _create_project(client, "project-b")
+
+    services.api.crud.Pipelines().list_pipelines = unittest.mock.Mock(
+        return_value=(0, None, [])
+    )
+
+    # mock alert activations logic as it requires MySQL-specific logic not supported by SQLite.
+    framework.utils.singletons.db.SQLDB._calculate_alert_activations_counters = (
+        unittest.mock.Mock(
+            return_value=(
+                {},
+                {},
+                {},
+                {},
+            )
+        )
+    )
+
+    await services.api.crud.Projects().refresh_project_resources_counters_cache(db)
+
+    # Mock filter_projects_by_permissions to return an empty list,
+    # simulating a user with zero project access.
+    framework.utils.auth.verifier.AuthVerifier().filter_projects_by_permissions = (
+        unittest.mock.AsyncMock(return_value=[])
+    )
+
+    response = client.get("project-summaries")
+    assert response.status_code == HTTPStatus.OK.value
+    project_summaries_output = mlrun.common.schemas.ProjectSummariesOutput(
+        **response.json()
+    )
+    assert (
+        project_summaries_output.project_summaries == []
+    ), "Expected no project summaries when user has no permissions, but got some"
+
+
 def test_delete_project_deletion_strategy_check(
     db: Session,
     client: TestClient,


### PR DESCRIPTION
### 📝 Description

The `/api/v1/project-summaries` endpoint returned all projects to users with zero project permissions, bypassing OPA authorization. The `/api/v1/projects` endpoint correctly returned an empty list for the same user. This is a security issue where unauthorized users can see all project summaries.

---

### 🛠️ Changes Made

- **`server/py/framework/db/sqldb/db.py`**: Changed `if names:` to `if names is not None:` in `list_project_summaries` DB query. An empty list `[]` from OPA (no permissions) was treated as falsy, skipping the SQL name filter and returning all projects. This matches the existing pattern in `list_projects` (line 3503).
- **`server/py/services/api/api/endpoints/projects.py`**: Added early return for both `/projects` and `/project-summaries` endpoints when `allowed_project_names` is an empty list, avoiding unnecessary DB queries when the user has no permissions.
- **`server/py/services/api/tests/unit/api/test_projects.py`**: Added `test_list_project_summaries_returns_empty_when_no_permissions` to verify the endpoint returns no projects when `filter_projects_by_permissions` returns an empty list.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- **Unit test**: Added `test_list_project_summaries_returns_empty_when_no_permissions` — mocks `filter_projects_by_permissions` to return `[]` and asserts the endpoint returns no summaries. Existing `test_list_project_summaries_filters_by_project_permissions` also passes.
- **Manual testing on live system (vmdev212ig4)**: Patched mlrun-api, verified with two users:
  - `admin`: `/projects` → 15, `/project-summaries` → 15 ✅
  - `test1` (no permissions): `/projects` → 0, `/project-summaries` → 0 ✅ (was 15 before fix)

---

### 🔗 References
- Ticket link: [ML-12342](https://iguazio.atlassian.net/browse/ML-12342)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

**Root cause**: In `list_project_summaries` (db.py:3571), `if names:` treated `[]` as falsy (Python truthiness), so when OPA returned an empty allowed list, no SQL filter was applied and all projects were returned. The equivalent check in `list_projects` (db.py:3503) correctly uses `if names is not None:`.


[ML-12342]: https://iguazio.atlassian.net/browse/ML-12342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ