### PR TITLE
[Auth] Cache AuthInfo based on JWT token for IG4

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -425,7 +425,7 @@ def resolve_jwt_expiration(
         )
         return None
 
-    if not isinstance(value, (int, float)):
+    if value is not None and not isinstance(value, (int, float)):
         mlrun.utils.helpers.raise_or_log_error(
             f"Invalid expiration claim: {value}", raise_on_error
         )

--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -402,6 +402,38 @@ def resolve_jwt_username(token: str, raise_on_error: bool = False) -> str | None
         return None
 
 
+def resolve_jwt_expiration(
+    token: str, raise_on_error: bool = False
+) -> int | float | None:
+    """
+    Extract the 'exp' claim from a JWT token.
+
+    The token is decoded without signature verification since it has already
+    been verified earlier during the authentication process.
+
+    :param token: The JWT token string.
+    :param raise_on_error: Whether to raise an error or log a warning on failure.
+    :return: The 'exp' claim value, or None if not present or extraction fails.
+    """
+    try:
+        # This method is used from the client side after receiving this token from the server, there's no need or
+        # ability to verify its signature here.
+        value = _decode_token_unverified(token).get(Claims.EXPIRATION)
+    except mlrun.errors.MLRunInvalidArgumentError as exc:
+        mlrun.utils.helpers.raise_or_log_error(
+            f"Failed to decode JWT token: {exc}", raise_on_error
+        )
+        return None
+
+    if not isinstance(value, (int, float)):
+        mlrun.utils.helpers.raise_or_log_error(
+            f"Invalid expiration claim: {value}", raise_on_error
+        )
+        return None
+
+    return value
+
+
 def is_token_expired(token: str, buffer_seconds: int = 0) -> bool:
     """
     Check if a JWT token is expired based on its 'exp' claim.
@@ -413,9 +445,8 @@ def is_token_expired(token: str, buffer_seconds: int = 0) -> bool:
 
     # This method is used for caching and/or extra validation purposes in addition to the main verification flow,
     # so we decode without signature verification here.
-    decoded_token = _decode_token_unverified(token)
-    expiration = decoded_token.get(Claims.EXPIRATION)
-    if not expiration:
+    expiration = resolve_jwt_expiration(token, raise_on_error=True)
+    if expiration is None:
         raise mlrun.errors.MLRunInvalidArgumentError(
             "Token is missing the 'exp' (expiration) claim"
         )

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -447,6 +447,10 @@ default_config = {
             "iguazio": {
                 "session_verification_endpoint": "data_sessions/verifications/app_service",
                 "authentication_endpoint": "api/v1/authentication/refresh-access-token",
+                "token_cache": {
+                    "max_size": 128,
+                    "ttl_seconds": 30,
+                },
             },
             "service_account": {
                 # the following are the default values for k8s service accounts, but may be changed per deployment

--- a/server/py/framework/tests/unit/utils/__init__.py
+++ b/server/py/framework/tests/unit/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/server/py/framework/tests/unit/utils/auth/__init__.py
+++ b/server/py/framework/tests/unit/utils/auth/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -298,139 +298,61 @@ async def test_concurrent_requests_share_single_backend_call(
     mock_instance.verify_request_session.assert_awaited_once()
 
 
-# --- Heap expiry paths ---
+# --- Stale callback regression ---
 
 
 @pytest.mark.asyncio
-async def test_rebuild_path_expires_valid_token(
+async def test_stale_done_callback_doesnt_evict_refreshed_task(
     verifier: framework.utils.auth.verifier.AuthVerifier,
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
-    monkeypatch: pytest.MonkeyPatch,
 ):
     """
-    The rebuild path (heap > 2*cache) is triggered through _authenticate_iguazio_v4
-    and correctly expires a token that is still in cache but past its TTL.
+    When a cached task's TTL expires and is lazily replaced by a new task,
+    the old task's done callback must not evict the new task from the cache.
 
-    Setup with max_size=1:
-      t=0: A cached → B cached (evicts A) → A re-cached (evicts B)
-      Result: heap has 3 entries [A_v1, B, A_v2], cache has 1 entry {A: A_v2}
-
-    At t=TTL+1, adding C triggers _expire_tokens with heap=3 > cache=1*2:
-      - A_v1: stale (different task)  → skip
-      - B:    stale (not in cache)    → skip
-      - A_v2: valid but expired       → deleted  ← the branch under test
+    1. Token A is cached (task_v1 starts but does not complete yet).
+    2. At t=TTL+1, token A is requested again; lazy expiry replaces task_v1 with task_v2.
+    3. task_v1 fails; its done callback fires.
+    4. task_v2 must still be in cache.
     """
-    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 1)
     client, _ = mock_client
-
     base_time = time.time()
-    token_a = _make_jwt(exp=base_time + 3600)
-    token_b = _make_jwt(exp=base_time + 3601)
-    token_c = _make_jwt(exp=base_time + 3602)
+    token = _make_jwt(exp=base_time + 3600)
 
+    backend_proceed = asyncio.Event()
+    call_count = 0
+
+    async def controlled_verify(_request):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            await backend_proceed.wait()
+            raise Exception("old task failed")
+        return schemas.AuthInfo(username="new-user")
+
+    client.verify_request_session.side_effect = controlled_verify
+
+    # Start first request at t=0; task_v1 blocks waiting on backend_proceed
     with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
         mock_time.time.return_value = base_time
-        await verifier._authenticate_iguazio_v4(_make_request(token_a))
-        await verifier._authenticate_iguazio_v4(_make_request(token_b))
-        await verifier._authenticate_iguazio_v4(_make_request(token_a))
+        task_outer = asyncio.create_task(
+            verifier._authenticate_iguazio_v4(_make_request(token))
+        )
+        await asyncio.sleep(0)  # yield to let task_v1 start
 
-    # Adding token_c at TTL+1 triggers the rebuild; token_a_v2 is expired and deleted
+    # At t=TTL+1, lazy expiry fires; task_v2 is created and returned
     with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
         mock_time.time.return_value = base_time + TOKEN_CACHE_MAX_TTL + 1
-        await verifier._authenticate_iguazio_v4(_make_request(token_c))
+        result = await verifier._authenticate_iguazio_v4(_make_request(token))
 
-    # a_v1, b, a_v2 at t=0, then c at t=TTL+1
-    assert client.verify_request_session.call_count == 4
-    assert token_c in verifier._token_cache
-    assert token_a not in verifier._token_cache
+    assert result.username == "new-user"
 
+    # Release task_v1 to fail; its done callback must not evict task_v2
+    backend_proceed.set()
+    with pytest.raises(Exception, match="old task failed"):
+        await task_outer
+    await asyncio.sleep(0)  # let the done callback run
 
-@pytest.mark.asyncio
-async def test_fast_path_skips_stale_heap_entry(
-    verifier: framework.utils.auth.verifier.AuthVerifier,
-    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """
-    In the fast path (heap <= 2*cache), an expired heap entry whose token has
-    already been LRU-evicted is silently skipped rather than causing an error.
-
-    Setup with max_size=1:
-      t=0: A cached → B cached (evicts A)
-      Result: heap=[A(TTL), B(TTL)], cache={B: task_b}; heap=2, cache=1 → 2 <= 2, fast path
-
-    At t=TTL+1, requesting A again triggers fast path expiry:
-      - A's entry: `cache.get(A) is task_a` → False (A was evicted) → no-op  ← the branch under test
-      - B's entry: `cache.get(B) is task_b` → True                → evicted
-    """
-    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 1)
-    client, _ = mock_client
-
-    base_time = time.time()
-    token_a = _make_jwt(exp=base_time + 3600)
-    token_b = _make_jwt(exp=base_time + 3601)
-
-    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
-        mock_time.time.return_value = base_time
-        await verifier._authenticate_iguazio_v4(_make_request(token_a))
-        await verifier._authenticate_iguazio_v4(_make_request(token_b))
-
-    # At TTL+1, re-requesting A triggers fast path; A's stale entry is skipped,
-    # B is evicted, and A gets a fresh backend call
-    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
-        mock_time.time.return_value = base_time + TOKEN_CACHE_MAX_TTL + 1
-        await verifier._authenticate_iguazio_v4(_make_request(token_a))
-
-    # a (t=0), b (t=0), a_v2 (t=TTL+1)
-    assert client.verify_request_session.call_count == 3
-    assert token_a in verifier._token_cache
-    assert token_b not in verifier._token_cache
-
-
-# --- Stale heap entry regression ---
-
-
-@pytest.mark.asyncio
-async def test_stale_heap_entry_doesnt_evict_recached_token(
-    verifier: framework.utils.auth.verifier.AuthVerifier,
-    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """
-    Regression test for the double-heap-entry bug:
-
-    1. Token A is cached (heap entry 1 with task_a_v1, expires at base+TTL).
-    2. Token B is cached, LRU-evicting token A. Heap entry 1 is now stale.
-    3. Token A is re-cached (heap entry 2 with task_a_v2, expires at base+5+TTL).
-    4. At base+TTL+1, heap entry 1 fires. It must NOT evict task_a_v2 from cache.
-    """
-    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 1)
-
-    base_time = time.time()
-    token_a = _make_jwt(exp=base_time + 3600)
-    token_b = _make_jwt(exp=base_time + 3601)
-
-    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
-        # t=0: cache token_a → heap entry 1 (expires at base_time + TTL)
-        mock_time.time.return_value = base_time
-        await verifier._authenticate_iguazio_v4(_make_request(token_a))
-        task_a_v1 = verifier._token_cache[token_a]
-
-        # t=0: cache token_b → LRU-evicts token_a; heap entry 1 becomes stale
-        await verifier._authenticate_iguazio_v4(_make_request(token_b))
-        assert token_a not in verifier._token_cache
-
-        # t=5: re-cache token_a → heap entry 2 (expires at base_time+5+TTL)
-        mock_time.time.return_value = base_time + 5
-        await verifier._authenticate_iguazio_v4(_make_request(token_a))
-        task_a_v2 = verifier._token_cache[token_a]
-        assert task_a_v2 is not task_a_v1
-
-    # t=TTL+1: heap entry 1 (base_time+TTL) fires but entry 2 (base_time+5+TTL)
-    # is still valid. The stale entry must not evict task_a_v2.
-    verifier._expire_tokens(base_time + TOKEN_CACHE_MAX_TTL + 1)
-
-    assert token_a in verifier._token_cache, (
-        "task_a_v2 should still be cached after stale heap entry fires"
+    assert token in verifier._token_cache, (
+        "task_v2 should still be cached after stale task_v1 callback fires"
     )
-    assert verifier._token_cache[token_a] is task_a_v2

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import asyncio
+import time
 import unittest.mock
 from collections.abc import Generator
 
 import fastapi
+import jwt
 import pytest
 import starlette.datastructures
 
@@ -53,7 +55,7 @@ async def test_cache_miss_calls_backend(
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
     client, auth_info = mock_client
-    token = "token"
+    token = _make_jwt(exp=time.time() + 3600)
 
     result = await verifier._authenticate_iguazio_v4(_make_request(token))
 
@@ -68,7 +70,7 @@ async def test_cache_hit_reuses_result(
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
     client, auth_info = mock_client
-    token = "token"
+    token = _make_jwt(exp=time.time() + 3600)
     request = _make_request(token)
 
     result1 = await verifier._authenticate_iguazio_v4(request)
@@ -91,7 +93,7 @@ async def test_cached_auth_info_has_no_token(
     The backend returns an AuthInfo that includes the token so there is
     actually something to strip and the assertion is meaningful.
     """
-    token = "token"
+    token = _make_jwt(exp=time.time() + 3600)
     mock_instance = unittest.mock.AsyncMock()
     mock_instance.verify_request_session.return_value = schemas.AuthInfo(
         username="test-user", token=token
@@ -129,13 +131,59 @@ async def test_non_bearer_scheme_skips_cache(
 
 
 @pytest.mark.asyncio
+async def test_non_jwt_token_skips_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    """A bearer token that is not a valid JWT bypasses the cache."""
+    client, _ = mock_client
+
+    await verifier._authenticate_iguazio_v4(_make_request("not-a-jwt"))
+    await verifier._authenticate_iguazio_v4(_make_request("not-a-jwt"))
+
+    assert len(verifier._token_cache) == 0
+    assert client.verify_request_session.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_jwt_without_exp_skips_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    """A JWT without an exp claim bypasses the cache."""
+    client, _ = mock_client
+    token = jwt.encode({"sub": "test-user"}, key="secret", algorithm="HS256")
+
+    await verifier._authenticate_iguazio_v4(_make_request(token))
+    await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    assert len(verifier._token_cache) == 0
+    assert client.verify_request_session.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_expired_token_raises_without_backend_call(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    """An expired JWT is rejected immediately without calling the backend."""
+    client, _ = mock_client
+    token = _make_jwt(exp=time.time() - 1)
+
+    with pytest.raises(mlrun.errors.MLRunUnauthorizedError):
+        await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    client.verify_request_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_backend_failure_evicts_task(
     verifier: framework.utils.auth.verifier.AuthVerifier,
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
     client, _ = mock_client
     client.verify_request_session.side_effect = Exception("backend unavailable")
-    token = "token"
+    token = _make_jwt(exp=time.time() + 3600)
     request = _make_request(token)
 
     with pytest.raises(Exception, match="backend unavailable"):
@@ -163,7 +211,7 @@ async def test_lru_eviction(
         mlrun.mlconf.httpdb.authentication.iguazio.token_cache, "max_size", 2
     )
 
-    tokens = ["token_0", "token_1", "token_2"]
+    tokens = [_make_jwt(exp=time.time() + 3600, sub=f"user_{i}") for i in range(3)]
 
     for token in tokens:
         await verifier._authenticate_iguazio_v4(_make_request(token))
@@ -181,7 +229,7 @@ async def test_ttl_expiry(
     client, _ = mock_client
     base_time = 0
     ttl: int = mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
-    token = "token"
+    token = _make_jwt(exp=base_time + ttl * 10)
     request = _make_request(token)
 
     with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
@@ -207,10 +255,34 @@ async def test_ttl_expiry(
 
 
 @pytest.mark.asyncio
+async def test_ttl_capped_at_token_expiry(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The cache entry expires at the token's own expiry when that is sooner than the TTL."""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication.iguazio.token_cache, "ttl_seconds", 300
+    )
+    curr_time = 0
+    token_expires_at = 100  # expires before the 300s TTL
+    token = _make_jwt(exp=token_expires_at)
+
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        mock_time.time.return_value = curr_time
+        await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    _, cached_expires_at = verifier._token_cache[
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)
+    ]
+    assert cached_expires_at == token_expires_at
+
+
+@pytest.mark.asyncio
 async def test_concurrent_requests_share_single_backend_call(
     verifier: framework.utils.auth.verifier.AuthVerifier,
 ):
-    token = "token"
+    token = _make_jwt(exp=time.time() + 3600)
     auth_info = schemas.AuthInfo(username="test-user")
 
     backend_started = asyncio.Event()
@@ -265,7 +337,8 @@ async def test_stale_done_callback_doesnt_evict_refreshed_task(
     """
     client, _ = mock_client
     base_time = 0
-    token = "token"
+    ttl = mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
+    token = _make_jwt(exp=base_time + ttl * 10)
 
     backend_proceed = asyncio.Event()
     call_count = 0
@@ -384,7 +457,7 @@ async def test_authenticate_iguazio_v4_case_insensitive_scheme_uses_cache(
 ):
     """Any capitalisation of 'Bearer' should be accepted and cached."""
     client, auth_info = mock_client
-    token = "mytoken"
+    token = _make_jwt(exp=time.time() + 3600)
 
     request = fastapi.Request({"type": "http"})
     request._headers = _make_headers(f"{scheme} {token}")
@@ -398,6 +471,11 @@ async def test_authenticate_iguazio_v4_case_insensitive_scheme_uses_cache(
     assert result2.token == token
     # Both requests must share the single cached backend call
     client.verify_request_session.assert_awaited_once()
+
+
+def _make_jwt(exp: float, sub: str = "test-user") -> str:
+    """Create a minimal JWT with the given expiry timestamp."""
+    return jwt.encode({"exp": int(exp), "sub": sub}, key="secret", algorithm="HS256")
 
 
 def _make_headers(authorization: str | None) -> starlette.datastructures.Headers:

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -60,7 +60,6 @@ async def test_cache_miss_calls_backend(
     result = await verifier._authenticate_iguazio_v4(_make_request(token))
 
     assert result.username == auth_info.username
-    assert result.token == token
     client.verify_request_session.assert_awaited_once()
 
 
@@ -78,38 +77,40 @@ async def test_cache_hit_reuses_result(
 
     assert result1.username == auth_info.username
     assert result2.username == auth_info.username
-    assert result1.token == token
-    assert result2.token == token
     # Backend should only be called once despite two requests
     client.verify_request_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_cached_auth_info_has_no_token(
+async def test_returned_auth_info_is_isolated_from_cache(
     verifier: framework.utils.auth.verifier.AuthVerifier,
 ):
-    """The auth_info stored in the cache must not contain the token.
+    """Mutations to the returned auth_info must not affect the cached copy.
 
-    The backend returns an AuthInfo that includes the token so there is
-    actually something to strip and the assertion is meaningful.
+    authenticate_request mutates the returned auth_info after the fact
+    (e.g. sets request_headers). The cache must be shielded from those changes
+    so that subsequent callers always get a clean copy.
     """
     token = _make_jwt(exp=time.time() + 3600)
     mock_instance = unittest.mock.AsyncMock()
     mock_instance.verify_request_session.return_value = schemas.AuthInfo(
-        username="test-user", token=token
+        username="test-user"
     )
 
     with unittest.mock.patch(
         "framework.utils.clients.iguazio.v4.AsyncClient",
         return_value=mock_instance,
     ):
-        await verifier._authenticate_iguazio_v4(_make_request(token))
+        result = await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    # Simulate what authenticate_request does: mutate the returned auth_info
+    result.request_headers = {"Authorization": f"Bearer {token}"}
 
     cached_task, _ = verifier._token_cache[
         framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)
     ]
     cached_auth_info = await cached_task
-    assert cached_auth_info.token is None
+    assert cached_auth_info.request_headers is None
 
 
 @pytest.mark.asyncio
@@ -335,8 +336,6 @@ async def test_concurrent_requests_share_single_backend_call(
 
     assert result1.username == auth_info.username
     assert result2.username == auth_info.username
-    assert result1.token == token
-    assert result2.token == token
     mock_instance.verify_request_session.assert_awaited_once()
 
 
@@ -487,8 +486,6 @@ async def test_authenticate_iguazio_v4_case_insensitive_scheme_uses_cache(
 
     assert result1.username == auth_info.username
     assert result2.username == auth_info.username
-    assert result1.token == token
-    assert result2.token == token
     # Both requests must share the single cached backend call
     client.verify_request_session.assert_awaited_once()
 

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -1,0 +1,436 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import time
+import unittest.mock
+from collections.abc import Generator
+
+import fastapi
+import jwt
+import pytest
+import starlette.datastructures
+
+import mlrun
+import mlrun.common.schemas as schemas
+import mlrun.utils.singleton
+
+import framework.utils.auth.verifier
+import framework.utils.clients.iguazio.v4
+from framework.utils.auth.verifier import TOKEN_CACHE_MAX_TTL
+
+# --- Helpers ---
+
+
+def _make_jwt(exp: float | None = None) -> str:
+    payload = {}
+    if exp is not None:
+        payload["exp"] = int(exp)
+    return jwt.encode(payload, key="test-secret", algorithm="HS256")
+
+
+def _make_request(token: str | None, scheme: str = "Bearer") -> fastapi.Request:
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"{scheme} {token}"
+    request = fastapi.Request({"type": "http"})
+    request._headers = starlette.datastructures.Headers(headers)
+    return request
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture(autouse=True)
+def reset_verifier() -> Generator[None, None, None]:
+    """Reset the AuthVerifier singleton before and after each test."""
+    original_mode = mlrun.mlconf.httpdb.authorization.mode
+    mlrun.mlconf.httpdb.authorization.mode = "none"
+    mlrun.utils.singleton.Singleton._instances.pop(
+        framework.utils.auth.verifier.AuthVerifier, None
+    )
+    yield
+    mlrun.mlconf.httpdb.authorization.mode = original_mode
+    mlrun.utils.singleton.Singleton._instances.pop(
+        framework.utils.auth.verifier.AuthVerifier, None
+    )
+
+
+@pytest.fixture
+def verifier() -> framework.utils.auth.verifier.AuthVerifier:
+    return framework.utils.auth.verifier.AuthVerifier()
+
+
+@pytest.fixture
+def mock_client() -> Generator[
+    tuple[unittest.mock.AsyncMock, schemas.AuthInfo], None, None
+]:
+    """Patches AsyncClient and returns (mock_instance, default_auth_info)."""
+    auth_info = schemas.AuthInfo(username="test-user")
+    mock_instance = unittest.mock.AsyncMock()
+    mock_instance.verify_request_session.return_value = auth_info
+    with unittest.mock.patch(
+        "framework.utils.clients.iguazio.v4.AsyncClient",
+        return_value=mock_instance,
+    ):
+        yield mock_instance, auth_info
+
+
+# --- Cache miss / hit ---
+
+
+@pytest.mark.asyncio
+async def test_cache_miss_calls_backend(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    client, auth_info = mock_client
+    token = _make_jwt(exp=time.time() + 3600)
+
+    result = await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    assert result == auth_info
+    client.verify_request_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_reuses_result(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    client, auth_info = mock_client
+    token = _make_jwt(exp=time.time() + 3600)
+    request = _make_request(token)
+
+    result1 = await verifier._authenticate_iguazio_v4(request)
+    result2 = await verifier._authenticate_iguazio_v4(request)
+
+    assert result1 == auth_info
+    assert result2 == auth_info
+    # Backend should only be called once despite two requests
+    client.verify_request_session.assert_awaited_once()
+
+
+# --- Scenarios that skip the cache ---
+
+
+@pytest.mark.asyncio
+async def test_no_auth_header_skips_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    await verifier._authenticate_iguazio_v4(_make_request(None))
+
+    assert len(verifier._token_cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_non_bearer_scheme_skips_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    token = _make_jwt(exp=time.time() + 3600)
+
+    await verifier._authenticate_iguazio_v4(_make_request(token, scheme="Basic"))
+
+    assert len(verifier._token_cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_non_jwt_bearer_skips_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    await verifier._authenticate_iguazio_v4(_make_request("not-a-jwt-token"))
+
+    assert len(verifier._token_cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_jwt_without_exp_skips_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    token = _make_jwt(exp=None)
+
+    await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    assert len(verifier._token_cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_expired_jwt_skips_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    token = _make_jwt(exp=time.time() - 1)
+
+    await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    assert len(verifier._token_cache) == 0
+
+
+# --- Failure and eviction ---
+
+
+@pytest.mark.asyncio
+async def test_backend_failure_evicts_task(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    client, _ = mock_client
+    client.verify_request_session.side_effect = Exception("backend unavailable")
+    token = _make_jwt(exp=time.time() + 3600)
+    request = _make_request(token)
+
+    with pytest.raises(Exception, match="backend unavailable"):
+        await verifier._authenticate_iguazio_v4(request)
+
+    # Done callbacks are scheduled via call_soon; yield to let them run
+    await asyncio.sleep(0)
+
+    assert token not in verifier._token_cache
+
+    # The next request should retry rather than returning the failed task
+    client.verify_request_session.side_effect = None
+    client.verify_request_session.return_value = schemas.AuthInfo(username="retry-user")
+    await verifier._authenticate_iguazio_v4(request)
+    assert client.verify_request_session.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_lru_eviction(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 2)
+
+    exp = time.time() + 3600
+    # Three distinct tokens (different exp → different JWT payloads)
+    tokens = [_make_jwt(exp=exp + i) for i in range(3)]
+
+    for token in tokens:
+        await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    assert tokens[0] not in verifier._token_cache
+    assert tokens[1] in verifier._token_cache
+    assert tokens[2] in verifier._token_cache
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+):
+    client, _ = mock_client
+    base_time = time.time()
+    token = _make_jwt(exp=base_time + 3600)
+    request = _make_request(token)
+
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        mock_time.time.return_value = base_time
+        await verifier._authenticate_iguazio_v4(request)
+
+    assert token in verifier._token_cache
+
+    # Advance time past TTL; _authenticate_iguazio_v4 should expire the token
+    # internally and call the backend again
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        mock_time.time.return_value = base_time + TOKEN_CACHE_MAX_TTL + 1
+        await verifier._authenticate_iguazio_v4(request)
+
+    assert client.verify_request_session.call_count == 2
+
+
+# --- Concurrency ---
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_share_single_backend_call(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+):
+    token = _make_jwt(exp=time.time() + 3600)
+    auth_info = schemas.AuthInfo(username="test-user")
+
+    backend_started = asyncio.Event()
+    backend_proceed = asyncio.Event()
+
+    async def slow_verify(_request):
+        backend_started.set()
+        await backend_proceed.wait()
+        return auth_info
+
+    mock_instance = unittest.mock.AsyncMock()
+    mock_instance.verify_request_session.side_effect = slow_verify
+
+    with unittest.mock.patch(
+        "framework.utils.clients.iguazio.v4.AsyncClient",
+        return_value=mock_instance,
+    ):
+        # Start first request and wait until the backend call is in-flight
+        task1 = asyncio.create_task(
+            verifier._authenticate_iguazio_v4(_make_request(token))
+        )
+        await backend_started.wait()
+
+        # Start second request while the first is still waiting on the backend
+        task2 = asyncio.create_task(
+            verifier._authenticate_iguazio_v4(_make_request(token))
+        )
+        backend_proceed.set()
+
+        result1, result2 = await asyncio.gather(task1, task2)
+
+    assert result1 == auth_info
+    assert result2 == auth_info
+    mock_instance.verify_request_session.assert_awaited_once()
+
+
+# --- Heap expiry paths ---
+
+
+@pytest.mark.asyncio
+async def test_rebuild_path_expires_valid_token(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    The rebuild path (heap > 2*cache) is triggered through _authenticate_iguazio_v4
+    and correctly expires a token that is still in cache but past its TTL.
+
+    Setup with max_size=1:
+      t=0: A cached → B cached (evicts A) → A re-cached (evicts B)
+      Result: heap has 3 entries [A_v1, B, A_v2], cache has 1 entry {A: A_v2}
+
+    At t=TTL+1, adding C triggers _expire_tokens with heap=3 > cache=1*2:
+      - A_v1: stale (different task)  → skip
+      - B:    stale (not in cache)    → skip
+      - A_v2: valid but expired       → deleted  ← the branch under test
+    """
+    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 1)
+    client, _ = mock_client
+
+    base_time = time.time()
+    token_a = _make_jwt(exp=base_time + 3600)
+    token_b = _make_jwt(exp=base_time + 3601)
+    token_c = _make_jwt(exp=base_time + 3602)
+
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        mock_time.time.return_value = base_time
+        await verifier._authenticate_iguazio_v4(_make_request(token_a))
+        await verifier._authenticate_iguazio_v4(_make_request(token_b))
+        await verifier._authenticate_iguazio_v4(_make_request(token_a))
+
+    # Adding token_c at TTL+1 triggers the rebuild; token_a_v2 is expired and deleted
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        mock_time.time.return_value = base_time + TOKEN_CACHE_MAX_TTL + 1
+        await verifier._authenticate_iguazio_v4(_make_request(token_c))
+
+    # a_v1, b, a_v2 at t=0, then c at t=TTL+1
+    assert client.verify_request_session.call_count == 4
+    assert token_c in verifier._token_cache
+    assert token_a not in verifier._token_cache
+
+
+@pytest.mark.asyncio
+async def test_fast_path_skips_stale_heap_entry(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    In the fast path (heap <= 2*cache), an expired heap entry whose token has
+    already been LRU-evicted is silently skipped rather than causing an error.
+
+    Setup with max_size=1:
+      t=0: A cached → B cached (evicts A)
+      Result: heap=[A(TTL), B(TTL)], cache={B: task_b}; heap=2, cache=1 → 2 <= 2, fast path
+
+    At t=TTL+1, requesting A again triggers fast path expiry:
+      - A's entry: `cache.get(A) is task_a` → False (A was evicted) → no-op  ← the branch under test
+      - B's entry: `cache.get(B) is task_b` → True                → evicted
+    """
+    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 1)
+    client, _ = mock_client
+
+    base_time = time.time()
+    token_a = _make_jwt(exp=base_time + 3600)
+    token_b = _make_jwt(exp=base_time + 3601)
+
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        mock_time.time.return_value = base_time
+        await verifier._authenticate_iguazio_v4(_make_request(token_a))
+        await verifier._authenticate_iguazio_v4(_make_request(token_b))
+
+    # At TTL+1, re-requesting A triggers fast path; A's stale entry is skipped,
+    # B is evicted, and A gets a fresh backend call
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        mock_time.time.return_value = base_time + TOKEN_CACHE_MAX_TTL + 1
+        await verifier._authenticate_iguazio_v4(_make_request(token_a))
+
+    # a (t=0), b (t=0), a_v2 (t=TTL+1)
+    assert client.verify_request_session.call_count == 3
+    assert token_a in verifier._token_cache
+    assert token_b not in verifier._token_cache
+
+
+# --- Stale heap entry regression ---
+
+
+@pytest.mark.asyncio
+async def test_stale_heap_entry_doesnt_evict_recached_token(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Regression test for the double-heap-entry bug:
+
+    1. Token A is cached (heap entry 1 with task_a_v1, expires at base+TTL).
+    2. Token B is cached, LRU-evicting token A. Heap entry 1 is now stale.
+    3. Token A is re-cached (heap entry 2 with task_a_v2, expires at base+5+TTL).
+    4. At base+TTL+1, heap entry 1 fires. It must NOT evict task_a_v2 from cache.
+    """
+    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 1)
+
+    base_time = time.time()
+    token_a = _make_jwt(exp=base_time + 3600)
+    token_b = _make_jwt(exp=base_time + 3601)
+
+    with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
+        # t=0: cache token_a → heap entry 1 (expires at base_time + TTL)
+        mock_time.time.return_value = base_time
+        await verifier._authenticate_iguazio_v4(_make_request(token_a))
+        task_a_v1 = verifier._token_cache[token_a]
+
+        # t=0: cache token_b → LRU-evicts token_a; heap entry 1 becomes stale
+        await verifier._authenticate_iguazio_v4(_make_request(token_b))
+        assert token_a not in verifier._token_cache
+
+        # t=5: re-cache token_a → heap entry 2 (expires at base_time+5+TTL)
+        mock_time.time.return_value = base_time + 5
+        await verifier._authenticate_iguazio_v4(_make_request(token_a))
+        task_a_v2 = verifier._token_cache[token_a]
+        assert task_a_v2 is not task_a_v1
+
+    # t=TTL+1: heap entry 1 (base_time+TTL) fires but entry 2 (base_time+5+TTL)
+    # is still valid. The stale entry must not evict task_a_v2.
+    verifier._expire_tokens(base_time + TOKEN_CACHE_MAX_TTL + 1)
+
+    assert token_a in verifier._token_cache, (
+        "task_a_v2 should still be cached after stale heap entry fires"
+    )
+    assert verifier._token_cache[token_a] is task_a_v2

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -22,7 +22,6 @@ import starlette.datastructures
 
 import mlrun
 import mlrun.common.schemas as schemas
-import mlrun.utils.singleton
 
 import framework.utils.auth.verifier
 import framework.utils.clients.iguazio.v4
@@ -31,37 +30,15 @@ import framework.utils.clients.iguazio.v4
 
 
 def _make_headers(authorization: str | None) -> starlette.datastructures.Headers:
-    headers = {}
+    headers: dict[str, str] = {}
     if authorization is not None:
         headers["Authorization"] = authorization
     return starlette.datastructures.Headers(headers)
 
 
 def _make_request(token: str | None, scheme: str = "Bearer") -> fastapi.Request:
-    headers = {}
-    if token is not None:
-        headers["Authorization"] = f"{scheme} {token}"
-    request = fastapi.Request({"type": "http"})
-    request._headers = starlette.datastructures.Headers(headers)
-    return request
-
-
-# --- Fixtures ---
-
-
-@pytest.fixture(autouse=True)
-def reset_verifier() -> Generator[None, None, None]:
-    """Reset the AuthVerifier singleton before and after each test."""
-    original_mode = mlrun.mlconf.httpdb.authorization.mode
-    mlrun.mlconf.httpdb.authorization.mode = "none"
-    mlrun.utils.singleton.Singleton._instances.pop(
-        framework.utils.auth.verifier.AuthVerifier, None
-    )
-    yield
-    mlrun.mlconf.httpdb.authorization.mode = original_mode
-    mlrun.utils.singleton.Singleton._instances.pop(
-        framework.utils.auth.verifier.AuthVerifier, None
-    )
+    headers = _make_headers(None if token is None else f"{scheme} {token}")
+    return fastapi.Request({"type": "http", "headers": headers.raw})
 
 
 @pytest.fixture
@@ -82,9 +59,6 @@ def mock_client() -> Generator[
         return_value=mock_instance,
     ):
         yield mock_instance, auth_info
-
-
-# --- Cache miss / hit ---
 
 
 @pytest.mark.asyncio
@@ -119,9 +93,6 @@ async def test_cache_hit_reuses_result(
     client.verify_request_session.assert_awaited_once()
 
 
-# --- Scenarios that skip the cache ---
-
-
 @pytest.mark.asyncio
 async def test_no_auth_header_skips_cache(
     verifier: framework.utils.auth.verifier.AuthVerifier,
@@ -140,9 +111,6 @@ async def test_non_bearer_scheme_skips_cache(
     await verifier._authenticate_iguazio_v4(_make_request("token", scheme="Basic"))
 
     assert len(verifier._token_cache) == 0
-
-
-# --- Failure and eviction ---
 
 
 @pytest.mark.asyncio
@@ -197,6 +165,7 @@ async def test_ttl_expiry(
 ):
     client, _ = mock_client
     base_time = 0
+    ttl: int = mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
     token = "token"
     request = _make_request(token)
 
@@ -204,22 +173,22 @@ async def test_ttl_expiry(
         mock_time.time.return_value = base_time
         await verifier._authenticate_iguazio_v4(request)
 
-    assert token in verifier._token_cache
+    assert client.verify_request_session.call_count == 1
+    init_task, init_expires_at = verifier._token_cache[token]
+    assert init_expires_at == base_time + ttl
 
     # Advance time past TTL; _authenticate_iguazio_v4 should expire the token
     # internally and call the backend again
+    refresh_time = init_expires_at + 1
+
     with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
-        mock_time.time.return_value = (
-            base_time
-            + mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
-            + 1
-        )
+        mock_time.time.return_value = refresh_time
         await verifier._authenticate_iguazio_v4(request)
 
     assert client.verify_request_session.call_count == 2
-
-
-# --- Concurrency ---
+    refresh_task, refresh_expires_at = verifier._token_cache[token]
+    assert refresh_task is not init_task
+    assert refresh_expires_at == refresh_time + ttl
 
 
 @pytest.mark.asyncio
@@ -261,9 +230,6 @@ async def test_concurrent_requests_share_single_backend_call(
     assert result1 == auth_info
     assert result2 == auth_info
     mock_instance.verify_request_session.assert_awaited_once()
-
-
-# --- Stale callback regression ---
 
 
 @pytest.mark.asyncio
@@ -327,9 +293,6 @@ async def test_stale_done_callback_doesnt_evict_refreshed_task(
     )
 
 
-# --- _parse_auth_header ---
-
-
 @pytest.mark.parametrize(
     "authorization, prefix, expected",
     [
@@ -362,9 +325,6 @@ def test_parse_auth_header(
     assert verifier._parse_auth_header(headers, prefix) == expected
 
 
-# --- _authenticate_basic case-insensitivity ---
-
-
 @pytest.mark.parametrize("scheme", ["Basic", "basic", "BASIC", "bAsIc"])
 def test_authenticate_basic_case_insensitive_scheme(
     verifier: framework.utils.auth.verifier.AuthVerifier,
@@ -384,9 +344,6 @@ def test_authenticate_basic_case_insensitive_scheme(
     assert auth_info.password == "pass"
 
 
-# --- _authenticate_bearer case-insensitivity ---
-
-
 @pytest.mark.parametrize("scheme", ["Bearer", "bearer", "BEARER", "bEaReR"])
 def test_authenticate_bearer_case_insensitive_scheme(
     verifier: framework.utils.auth.verifier.AuthVerifier,
@@ -399,9 +356,6 @@ def test_authenticate_bearer_case_insensitive_scheme(
 
     auth_info = verifier._authenticate_bearer(headers)
     assert auth_info.token == "secret"
-
-
-# --- _authenticate_iguazio_v4 case-insensitivity ---
 
 
 @pytest.mark.asyncio

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -26,20 +26,6 @@ import mlrun.common.schemas as schemas
 import framework.utils.auth.verifier
 import framework.utils.clients.iguazio.v4
 
-# --- Helpers ---
-
-
-def _make_headers(authorization: str | None) -> starlette.datastructures.Headers:
-    headers: dict[str, str] = {}
-    if authorization is not None:
-        headers["Authorization"] = authorization
-    return starlette.datastructures.Headers(headers)
-
-
-def _make_request(token: str | None, scheme: str = "Bearer") -> fastapi.Request:
-    headers = _make_headers(None if token is None else f"{scheme} {token}")
-    return fastapi.Request({"type": "http", "headers": headers.raw})
-
 
 @pytest.fixture
 def verifier() -> framework.utils.auth.verifier.AuthVerifier:
@@ -379,3 +365,15 @@ async def test_authenticate_iguazio_v4_case_insensitive_scheme_uses_cache(
     assert result2 == auth_info
     # Both requests must share the single cached backend call
     client.verify_request_session.assert_awaited_once()
+
+
+def _make_headers(authorization: str | None) -> starlette.datastructures.Headers:
+    headers: dict[str, str] = {}
+    if authorization is not None:
+        headers["Authorization"] = authorization
+    return starlette.datastructures.Headers(headers)
+
+
+def _make_request(token: str | None, scheme: str = "Bearer") -> fastapi.Request:
+    headers = _make_headers(None if token is None else f"{scheme} {token}")
+    return fastapi.Request({"type": "http", "headers": headers.raw})

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -57,7 +57,8 @@ async def test_cache_miss_calls_backend(
 
     result = await verifier._authenticate_iguazio_v4(_make_request(token))
 
-    assert result == auth_info
+    assert result.username == auth_info.username
+    assert result.token == token
     client.verify_request_session.assert_awaited_once()
 
 
@@ -73,10 +74,38 @@ async def test_cache_hit_reuses_result(
     result1 = await verifier._authenticate_iguazio_v4(request)
     result2 = await verifier._authenticate_iguazio_v4(request)
 
-    assert result1 == auth_info
-    assert result2 == auth_info
+    assert result1.username == auth_info.username
+    assert result2.username == auth_info.username
+    assert result1.token == token
+    assert result2.token == token
     # Backend should only be called once despite two requests
     client.verify_request_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cached_auth_info_has_no_token(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+):
+    """The auth_info stored in the cache must not contain the token.
+
+    The backend returns an AuthInfo that includes the token so there is
+    actually something to strip and the assertion is meaningful.
+    """
+    token = "token"
+    mock_instance = unittest.mock.AsyncMock()
+    mock_instance.verify_request_session.return_value = schemas.AuthInfo(
+        username="test-user", token=token
+    )
+
+    with unittest.mock.patch(
+        "framework.utils.clients.iguazio.v4.AsyncClient",
+        return_value=mock_instance,
+    ):
+        await verifier._authenticate_iguazio_v4(_make_request(token))
+
+    cached_task, _ = verifier._token_cache[framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)]
+    cached_auth_info = await cached_task
+    assert cached_auth_info.token is None
 
 
 @pytest.mark.asyncio
@@ -115,7 +144,7 @@ async def test_backend_failure_evicts_task(
     # Done callbacks are scheduled via call_soon; yield to let them run
     await asyncio.sleep(0)
 
-    assert token not in verifier._token_cache
+    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(token) not in verifier._token_cache
 
     # The next request should retry rather than returning the failed task
     client.verify_request_session.side_effect = None
@@ -139,9 +168,9 @@ async def test_lru_eviction(
     for token in tokens:
         await verifier._authenticate_iguazio_v4(_make_request(token))
 
-    assert tokens[0] not in verifier._token_cache
-    assert tokens[1] in verifier._token_cache
-    assert tokens[2] in verifier._token_cache
+    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[0]) not in verifier._token_cache
+    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[1]) in verifier._token_cache
+    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[2]) in verifier._token_cache
 
 
 @pytest.mark.asyncio
@@ -160,7 +189,7 @@ async def test_ttl_expiry(
         await verifier._authenticate_iguazio_v4(request)
 
     assert client.verify_request_session.call_count == 1
-    init_task, init_expires_at = verifier._token_cache[token]
+    init_task, init_expires_at = verifier._token_cache[framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)]
     assert init_expires_at == base_time + ttl
 
     # Advance time past TTL; _authenticate_iguazio_v4 should expire the token
@@ -172,7 +201,7 @@ async def test_ttl_expiry(
         await verifier._authenticate_iguazio_v4(request)
 
     assert client.verify_request_session.call_count == 2
-    refresh_task, refresh_expires_at = verifier._token_cache[token]
+    refresh_task, refresh_expires_at = verifier._token_cache[framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)]
     assert refresh_task is not init_task
     assert refresh_expires_at == refresh_time + ttl
 
@@ -213,8 +242,10 @@ async def test_concurrent_requests_share_single_backend_call(
 
         result1, result2 = await asyncio.gather(task1, task2)
 
-    assert result1 == auth_info
-    assert result2 == auth_info
+    assert result1.username == auth_info.username
+    assert result2.username == auth_info.username
+    assert result1.token == token
+    assert result2.token == token
     mock_instance.verify_request_session.assert_awaited_once()
 
 
@@ -274,7 +305,7 @@ async def test_stale_done_callback_doesnt_evict_refreshed_task(
         await task_outer
     await asyncio.sleep(0)  # let the done callback run
 
-    assert token in verifier._token_cache, (
+    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(token) in verifier._token_cache, (
         "task_v2 should still be cached after stale task_v1 callback fires"
     )
 
@@ -361,8 +392,10 @@ async def test_authenticate_iguazio_v4_case_insensitive_scheme_uses_cache(
     result1 = await verifier._authenticate_iguazio_v4(request)
     result2 = await verifier._authenticate_iguazio_v4(request)
 
-    assert result1 == auth_info
-    assert result2 == auth_info
+    assert result1.username == auth_info.username
+    assert result2.username == auth_info.username
+    assert result1.token == token
+    assert result2.token == token
     # Both requests must share the single cached backend call
     client.verify_request_session.assert_awaited_once()
 

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -26,7 +26,6 @@ import mlrun.utils.singleton
 
 import framework.utils.auth.verifier
 import framework.utils.clients.iguazio.v4
-from framework.utils.auth.verifier import TOKEN_CACHE_MAX_TTL
 
 # --- Helpers ---
 
@@ -170,7 +169,9 @@ async def test_lru_eviction(
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 2)
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication.iguazio.token_cache, "max_size", 2
+    )
 
     tokens = ["token_0", "token_1", "token_2"]
 
@@ -201,7 +202,11 @@ async def test_ttl_expiry(
     # Advance time past TTL; _authenticate_iguazio_v4 should expire the token
     # internally and call the backend again
     with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
-        mock_time.time.return_value = base_time + TOKEN_CACHE_MAX_TTL + 1
+        mock_time.time.return_value = (
+            base_time
+            + mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
+            + 1
+        )
         await verifier._authenticate_iguazio_v4(request)
 
     assert client.verify_request_session.call_count == 2
@@ -295,7 +300,11 @@ async def test_stale_done_callback_doesnt_evict_refreshed_task(
 
     # At t=TTL+1, lazy expiry fires; task_v2 is created and returned
     with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
-        mock_time.time.return_value = base_time + TOKEN_CACHE_MAX_TTL + 1
+        mock_time.time.return_value = (
+            base_time
+            + mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
+            + 1
+        )
         result = await verifier._authenticate_iguazio_v4(_make_request(token))
 
     assert result.username == "new-user"

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -30,6 +30,13 @@ import framework.utils.clients.iguazio.v4
 # --- Helpers ---
 
 
+def _make_headers(authorization: str | None) -> starlette.datastructures.Headers:
+    headers = {}
+    if authorization is not None:
+        headers["Authorization"] = authorization
+    return starlette.datastructures.Headers(headers)
+
+
 def _make_request(token: str | None, scheme: str = "Bearer") -> fastapi.Request:
     headers = {}
     if token is not None:
@@ -318,3 +325,103 @@ async def test_stale_done_callback_doesnt_evict_refreshed_task(
     assert token in verifier._token_cache, (
         "task_v2 should still be cached after stale task_v1 callback fires"
     )
+
+
+# --- _parse_auth_header ---
+
+
+@pytest.mark.parametrize(
+    "authorization, prefix, expected",
+    [
+        # Exact match returns the value after the prefix
+        ("Basic dXNlcjpwYXNz", "Basic ", "dXNlcjpwYXNz"),
+        ("Bearer mytoken", "Bearer ", "mytoken"),
+        # Wrong scheme returns None
+        ("Bearer mytoken", "Basic ", None),
+        ("Basic dXNlcjpwYXNz", "Bearer ", None),
+        # Missing header returns None
+        (None, "Bearer ", None),
+        # Case-insensitive scheme: lowercase
+        ("basic dXNlcjpwYXNz", "Basic ", "dXNlcjpwYXNz"),
+        ("bearer mytoken", "Bearer ", "mytoken"),
+        # Case-insensitive scheme: uppercase
+        ("BASIC dXNlcjpwYXNz", "Basic ", "dXNlcjpwYXNz"),
+        ("BEARER mytoken", "Bearer ", "mytoken"),
+        # Case-insensitive scheme: mixed case
+        ("bAsIc dXNlcjpwYXNz", "Basic ", "dXNlcjpwYXNz"),
+        ("BeArEr mytoken", "Bearer ", "mytoken"),
+    ],
+)
+def test_parse_auth_header(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    authorization: str | None,
+    prefix: str,
+    expected: str | None,
+):
+    headers = _make_headers(authorization)
+    assert verifier._parse_auth_header(headers, prefix) == expected
+
+
+# --- _authenticate_basic case-insensitivity ---
+
+
+@pytest.mark.parametrize("scheme", ["Basic", "basic", "BASIC", "bAsIc"])
+def test_authenticate_basic_case_insensitive_scheme(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    scheme: str,
+):
+    import base64
+
+    mlrun.mlconf.httpdb.authentication.mode = "basic"
+    mlrun.mlconf.httpdb.authentication.basic.username = "user"
+    mlrun.mlconf.httpdb.authentication.basic.password = "pass"
+
+    encoded = base64.b64encode(b"user:pass").decode()
+    headers = _make_headers(f"{scheme} {encoded}")
+
+    auth_info = verifier._authenticate_basic(headers)
+    assert auth_info.username == "user"
+    assert auth_info.password == "pass"
+
+
+# --- _authenticate_bearer case-insensitivity ---
+
+
+@pytest.mark.parametrize("scheme", ["Bearer", "bearer", "BEARER", "bEaReR"])
+def test_authenticate_bearer_case_insensitive_scheme(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    scheme: str,
+):
+    mlrun.mlconf.httpdb.authentication.mode = "bearer"
+    mlrun.mlconf.httpdb.authentication.bearer.token = "secret"
+
+    headers = _make_headers(f"{scheme} secret")
+
+    auth_info = verifier._authenticate_bearer(headers)
+    assert auth_info.token == "secret"
+
+
+# --- _authenticate_iguazio_v4 case-insensitivity ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scheme", ["Bearer", "bearer", "BEARER", "bEaReR"])
+async def test_authenticate_iguazio_v4_case_insensitive_scheme_uses_cache(
+    verifier: framework.utils.auth.verifier.AuthVerifier,
+    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
+    scheme: str,
+):
+    """Any capitalisation of 'Bearer' should be accepted and cached."""
+    client, auth_info = mock_client
+    token = "mytoken"
+
+    request = fastapi.Request({"type": "http"})
+    request._headers = _make_headers(f"{scheme} {token}")
+
+    result1 = await verifier._authenticate_iguazio_v4(request)
+    result2 = await verifier._authenticate_iguazio_v4(request)
+
+    assert result1 == auth_info
+    assert result2 == auth_info
+    # Both requests must share the single cached backend call
+    client.verify_request_session.assert_awaited_once()

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 import asyncio
-import time
 import unittest.mock
 from collections.abc import Generator
 
 import fastapi
-import jwt
 import pytest
 import starlette.datastructures
 
@@ -31,13 +29,6 @@ import framework.utils.clients.iguazio.v4
 from framework.utils.auth.verifier import TOKEN_CACHE_MAX_TTL
 
 # --- Helpers ---
-
-
-def _make_jwt(exp: float | None = None) -> str:
-    payload = {}
-    if exp is not None:
-        payload["exp"] = int(exp)
-    return jwt.encode(payload, key="test-secret", algorithm="HS256")
 
 
 def _make_request(token: str | None, scheme: str = "Bearer") -> fastapi.Request:
@@ -96,7 +87,7 @@ async def test_cache_miss_calls_backend(
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
     client, auth_info = mock_client
-    token = _make_jwt(exp=time.time() + 3600)
+    token = "token"
 
     result = await verifier._authenticate_iguazio_v4(_make_request(token))
 
@@ -110,7 +101,7 @@ async def test_cache_hit_reuses_result(
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
     client, auth_info = mock_client
-    token = _make_jwt(exp=time.time() + 3600)
+    token = "token"
     request = _make_request(token)
 
     result1 = await verifier._authenticate_iguazio_v4(request)
@@ -140,43 +131,7 @@ async def test_non_bearer_scheme_skips_cache(
     verifier: framework.utils.auth.verifier.AuthVerifier,
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
-    token = _make_jwt(exp=time.time() + 3600)
-
-    await verifier._authenticate_iguazio_v4(_make_request(token, scheme="Basic"))
-
-    assert len(verifier._token_cache) == 0
-
-
-@pytest.mark.asyncio
-async def test_non_jwt_bearer_skips_cache(
-    verifier: framework.utils.auth.verifier.AuthVerifier,
-    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
-):
-    await verifier._authenticate_iguazio_v4(_make_request("not-a-jwt-token"))
-
-    assert len(verifier._token_cache) == 0
-
-
-@pytest.mark.asyncio
-async def test_jwt_without_exp_skips_cache(
-    verifier: framework.utils.auth.verifier.AuthVerifier,
-    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
-):
-    token = _make_jwt(exp=None)
-
-    await verifier._authenticate_iguazio_v4(_make_request(token))
-
-    assert len(verifier._token_cache) == 0
-
-
-@pytest.mark.asyncio
-async def test_expired_jwt_skips_cache(
-    verifier: framework.utils.auth.verifier.AuthVerifier,
-    mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
-):
-    token = _make_jwt(exp=time.time() - 1)
-
-    await verifier._authenticate_iguazio_v4(_make_request(token))
+    await verifier._authenticate_iguazio_v4(_make_request("token", scheme="Basic"))
 
     assert len(verifier._token_cache) == 0
 
@@ -191,7 +146,7 @@ async def test_backend_failure_evicts_task(
 ):
     client, _ = mock_client
     client.verify_request_session.side_effect = Exception("backend unavailable")
-    token = _make_jwt(exp=time.time() + 3600)
+    token = "token"
     request = _make_request(token)
 
     with pytest.raises(Exception, match="backend unavailable"):
@@ -217,9 +172,7 @@ async def test_lru_eviction(
 ):
     monkeypatch.setattr(framework.utils.auth.verifier, "TOKEN_CACHE_MAX_SIZE", 2)
 
-    exp = time.time() + 3600
-    # Three distinct tokens (different exp → different JWT payloads)
-    tokens = [_make_jwt(exp=exp + i) for i in range(3)]
+    tokens = ["token_0", "token_1", "token_2"]
 
     for token in tokens:
         await verifier._authenticate_iguazio_v4(_make_request(token))
@@ -235,8 +188,8 @@ async def test_ttl_expiry(
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
     client, _ = mock_client
-    base_time = time.time()
-    token = _make_jwt(exp=base_time + 3600)
+    base_time = 0
+    token = "token"
     request = _make_request(token)
 
     with unittest.mock.patch("framework.utils.auth.verifier.time") as mock_time:
@@ -261,7 +214,7 @@ async def test_ttl_expiry(
 async def test_concurrent_requests_share_single_backend_call(
     verifier: framework.utils.auth.verifier.AuthVerifier,
 ):
-    token = _make_jwt(exp=time.time() + 3600)
+    token = "token"
     auth_info = schemas.AuthInfo(username="test-user")
 
     backend_started = asyncio.Event()
@@ -316,8 +269,8 @@ async def test_stale_done_callback_doesnt_evict_refreshed_task(
     4. task_v2 must still be in cache.
     """
     client, _ = mock_client
-    base_time = time.time()
-    token = _make_jwt(exp=base_time + 3600)
+    base_time = 0
+    token = "token"
 
     backend_proceed = asyncio.Event()
     call_count = 0

--- a/server/py/framework/tests/unit/utils/auth/test_verifier.py
+++ b/server/py/framework/tests/unit/utils/auth/test_verifier.py
@@ -105,7 +105,9 @@ async def test_cached_auth_info_has_no_token(
     ):
         await verifier._authenticate_iguazio_v4(_make_request(token))
 
-    cached_task, _ = verifier._token_cache[framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)]
+    cached_task, _ = verifier._token_cache[
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)
+    ]
     cached_auth_info = await cached_task
     assert cached_auth_info.token is None
 
@@ -162,18 +164,19 @@ async def test_jwt_without_exp_skips_cache(
 
 
 @pytest.mark.asyncio
-async def test_expired_token_raises_without_backend_call(
+async def test_expired_token_raises_skips_cache(
     verifier: framework.utils.auth.verifier.AuthVerifier,
     mock_client: tuple[unittest.mock.AsyncMock, schemas.AuthInfo],
 ):
-    """An expired JWT is rejected immediately without calling the backend."""
+    """An expired JWT bypassts the cache."""
     client, _ = mock_client
     token = _make_jwt(exp=time.time() - 1)
 
-    with pytest.raises(mlrun.errors.MLRunUnauthorizedError):
-        await verifier._authenticate_iguazio_v4(_make_request(token))
+    await verifier._authenticate_iguazio_v4(_make_request(token))
+    await verifier._authenticate_iguazio_v4(_make_request(token))
 
-    client.verify_request_session.assert_not_awaited()
+    assert len(verifier._token_cache) == 0
+    assert client.verify_request_session.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -192,7 +195,10 @@ async def test_backend_failure_evicts_task(
     # Done callbacks are scheduled via call_soon; yield to let them run
     await asyncio.sleep(0)
 
-    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(token) not in verifier._token_cache
+    assert (
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)
+        not in verifier._token_cache
+    )
 
     # The next request should retry rather than returning the failed task
     client.verify_request_session.side_effect = None
@@ -216,9 +222,18 @@ async def test_lru_eviction(
     for token in tokens:
         await verifier._authenticate_iguazio_v4(_make_request(token))
 
-    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[0]) not in verifier._token_cache
-    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[1]) in verifier._token_cache
-    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[2]) in verifier._token_cache
+    assert (
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[0])
+        not in verifier._token_cache
+    )
+    assert (
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[1])
+        in verifier._token_cache
+    )
+    assert (
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(tokens[2])
+        in verifier._token_cache
+    )
 
 
 @pytest.mark.asyncio
@@ -237,7 +252,9 @@ async def test_ttl_expiry(
         await verifier._authenticate_iguazio_v4(request)
 
     assert client.verify_request_session.call_count == 1
-    init_task, init_expires_at = verifier._token_cache[framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)]
+    init_task, init_expires_at = verifier._token_cache[
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)
+    ]
     assert init_expires_at == base_time + ttl
 
     # Advance time past TTL; _authenticate_iguazio_v4 should expire the token
@@ -249,7 +266,9 @@ async def test_ttl_expiry(
         await verifier._authenticate_iguazio_v4(request)
 
     assert client.verify_request_session.call_count == 2
-    refresh_task, refresh_expires_at = verifier._token_cache[framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)]
+    refresh_task, refresh_expires_at = verifier._token_cache[
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)
+    ]
     assert refresh_task is not init_task
     assert refresh_expires_at == refresh_time + ttl
 
@@ -378,9 +397,10 @@ async def test_stale_done_callback_doesnt_evict_refreshed_task(
         await task_outer
     await asyncio.sleep(0)  # let the done callback run
 
-    assert framework.utils.auth.verifier.AuthVerifier._token_cache_key(token) in verifier._token_cache, (
-        "task_v2 should still be cached after stale task_v1 callback fires"
-    )
+    assert (
+        framework.utils.auth.verifier.AuthVerifier._token_cache_key(token)
+        in verifier._token_cache
+    ), "task_v2 should still be cached after stale task_v1 callback fires"
 
 
 @pytest.mark.parametrize(

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import base64
+import hashlib
 import time
 import typing
 from collections import OrderedDict
@@ -35,7 +36,7 @@ import framework.utils.clients.iguazio.v4
 
 
 class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
-    _token_cache: OrderedDict[str, tuple[asyncio.Task[schemas.AuthInfo], float]]
+    _token_cache: OrderedDict[bytes, tuple[asyncio.Task[schemas.AuthInfo], float]]
 
     def __init__(self) -> None:
         super().__init__()
@@ -463,21 +464,23 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             return await iguazio_client.verify_request_session(request)
 
-        task_with_expiry = self._token_cache.get(token)
+        key = self._token_cache_key(token)
+        task_with_expiry = self._token_cache.get(key)
         curr_time = time.time()
 
         if task_with_expiry is None or task_with_expiry[1] <= curr_time:
             # No task or an expired task means we have to create a new task
             is_existing_key = task_with_expiry is not None
 
-            iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
-            task = asyncio.create_task(iguazio_client.verify_request_session(request))
-            task.add_done_callback(partial(self._on_verify_complete, token))
+            task = asyncio.create_task(
+                self._authenticate_iguazio_v4_without_token(request)
+            )
+            task.add_done_callback(partial(self._on_verify_complete, key))
 
             task_expires_at = curr_time + self._token_cache_ttl_seconds
 
             task_with_expiry = task, task_expires_at
-            self._token_cache[token] = task_with_expiry
+            self._token_cache[key] = task_with_expiry
         else:
             # We can reuse the old task
             is_existing_key = True
@@ -485,7 +488,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         if is_existing_key:
             # If the token was already in the cache the cache size did not
             # change. We just need to mark the token as the most recently used
-            self._token_cache.move_to_end(token)
+            self._token_cache.move_to_end(key)
 
         elif len(self._token_cache) > self._token_cache_max_size:
             # If the cache grew beyond the max size with the new item we pop
@@ -494,7 +497,28 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
 
         # We shield the task since it can be shared between multiple
         # verifications and cancellation could have unexpected side effects
-        return await asyncio.shield(task_with_expiry[0])
+        auth_info = await asyncio.shield(task_with_expiry[0])
+
+        # We have to reinsert the token since it was stripped before
+        auth_info = auth_info.copy()
+        auth_info.token = token
+        return auth_info
+
+    @staticmethod
+    async def _authenticate_iguazio_v4_without_token(
+        request: fastapi.Request,
+    ) -> schemas.AuthInfo:
+        iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
+        auth_info = await iguazio_client.verify_request_session(request)
+
+        # We strip the token from auth info to not keep it in memory
+        auth_info = auth_info.copy()
+        auth_info.token = None
+        return auth_info
+
+    @staticmethod
+    def _token_cache_key(token: str) -> bytes:
+        return hashlib.sha256(token.encode()).digest()
 
     @property
     def _token_cache_max_size(self) -> int:
@@ -505,13 +529,13 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         return mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
 
     def _on_verify_complete(
-        self, token: str, task: asyncio.Task[schemas.AuthInfo]
+        self, key: bytes, task: asyncio.Task[schemas.AuthInfo]
     ) -> None:
         # We evict from the cache on failure to make sure we dont block tokens
         # on things like temporary connectivity issues
         if not task.cancelled() and task.exception() is None:
             return
 
-        task_with_expiry = self._token_cache.get(token)
+        task_with_expiry = self._token_cache.get(key)
         if task_with_expiry is not None and task_with_expiry[0] is task:
-            del self._token_cache[token]
+            del self._token_cache[key]

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -396,8 +396,8 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
     @staticmethod
     def _parse_basic_auth(b64value: str) -> tuple[str, str]:
         """
-        parse_basic_auth('Basic YnVnczpidW5ueQ==')
-        ['bugs', 'bunny']
+        parse_basic_auth('YnVnczpidW5ueQ==')
+        ('bugs', 'bunny')
         """
         value = base64.b64decode(b64value).decode()
         username, password = value.split(":", 1)
@@ -468,7 +468,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
 
         if task_with_expiry is None or task_with_expiry[1] <= curr_time:
             # No task or an expired task means we have to create a new task
-            is_cached = task_with_expiry is not None
+            is_existing_key = task_with_expiry is not None
 
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             task = asyncio.create_task(iguazio_client.verify_request_session(request))
@@ -480,11 +480,11 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             self._token_cache[token] = task_with_expiry
         else:
             # We can reuse the old task
-            is_cached = True
+            is_existing_key = True
 
-        if is_cached:
-            # If the token was already cached the cache size did not change
-            # We just need to mark the token as the most recently used
+        if is_existing_key:
+            # If the token was already in the cache the cache size did not
+            # change. We just need to mark the token as the most recently used
             self._token_cache.move_to_end(token)
 
         elif len(self._token_cache) > self._token_cache_max_size:
@@ -509,7 +509,6 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
     ) -> None:
         # We evict from the cache on failure to make sure we dont block tokens
         # on things like temporary connectivity issues
-        # TODO: should we whitelist certain exceptions to be kept? e.g. invalid token
         if not task.cancelled() and task.exception() is None:
             return
 

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -21,13 +21,12 @@ from collections import OrderedDict
 from functools import partial
 
 import fastapi
-import jwt
 
 import mlrun
-from mlrun.auth.utils import resolve_jwt_expiration
 import mlrun.common.schemas as schemas
 import mlrun.utils.helpers
 import mlrun.utils.singleton
+from mlrun.auth.utils import resolve_jwt_expiration
 from mlrun.common.types import AuthenticationMode
 from mlrun.utils import logger
 

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -382,23 +382,37 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         return mlrun.mlconf.is_iguazio_v4_mode()
 
     @staticmethod
-    def _parse_basic_auth(header):
+    def _parse_auth_header(
+        headers: typing.Mapping[str, str], prefix: str
+    ) -> str | None:
+        header = headers.get(schemas.HeaderNames.authorization, "")
+
+        # Authorization schemes are case insensitive
+        if header.lower().startswith(prefix.lower()):
+            return header[len(prefix) :]
+        else:
+            return None
+
+    @staticmethod
+    def _parse_basic_auth(b64value: str) -> tuple[str, str]:
         """
         parse_basic_auth('Basic YnVnczpidW5ueQ==')
         ['bugs', 'bunny']
         """
-        b64value = header[len(schemas.AuthorizationHeaderPrefixes.basic) :]
         value = base64.b64decode(b64value).decode()
-        return value.split(":", 1)
+        username, password = value.split(":", 1)
+        return username, password
 
     def _authenticate_basic(
         self, headers: typing.Mapping[str, str]
     ) -> schemas.AuthInfo:
-        header = headers.get(schemas.HeaderNames.authorization, "")
-        if not header.startswith(schemas.AuthorizationHeaderPrefixes.basic):
+        basic_auth = self._parse_auth_header(
+            headers, schemas.AuthorizationHeaderPrefixes.basic
+        )
+        if basic_auth is None:
             raise mlrun.errors.MLRunUnauthorizedError("Missing basic auth header")
 
-        username, password = self._parse_basic_auth(header)
+        username, password = self._parse_basic_auth(basic_auth)
         if (
             username != mlrun.mlconf.httpdb.authentication.basic.username
             or password != mlrun.mlconf.httpdb.authentication.basic.password
@@ -412,11 +426,13 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
     def _authenticate_bearer(
         self, headers: typing.Mapping[str, str]
     ) -> schemas.AuthInfo:
-        header = headers.get(schemas.HeaderNames.authorization, "")
-        if not header.startswith(schemas.AuthorizationHeaderPrefixes.bearer):
+        token = self._parse_auth_header(
+            headers, schemas.AuthorizationHeaderPrefixes.bearer
+        )
+
+        if token is None:
             raise mlrun.errors.MLRunUnauthorizedError("Missing bearer auth header")
 
-        token = header[len(schemas.AuthorizationHeaderPrefixes.bearer) :]
         if token != mlrun.mlconf.httpdb.authentication.bearer.token:
             raise mlrun.errors.MLRunUnauthorizedError("Token did not match")
 
@@ -438,7 +454,9 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         self,
         request: fastapi.Request,
     ) -> schemas.AuthInfo:
-        token = self._extract_token(request)
+        token = self._parse_auth_header(
+            request.headers, schemas.AuthorizationHeaderPrefixes.bearer
+        )
 
         if token is None:
             # No token means no caching
@@ -485,18 +503,6 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
     @property
     def _token_cache_ttl_seconds(self) -> float:
         return mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
-
-    @staticmethod
-    def _extract_token(request: fastapi.Request) -> str | None:
-        header_value = request.headers.get("Authorization")
-        if header_value is None:
-            return None
-
-        scheme, _, token = header_value.partition(" ")
-        if scheme.lower() != "bearer":  # scheme is case insensitive
-            return None
-
-        return token
 
     def _on_verify_complete(
         self, token: str, task: asyncio.Task[schemas.AuthInfo]

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -18,6 +18,7 @@ import hashlib
 import time
 import typing
 from collections import OrderedDict
+from copy import deepcopy
 from functools import partial
 
 import fastapi
@@ -477,9 +478,8 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             # No task or an expired task means we have to create a new task
             is_existing_key = task_with_expiry is not None
 
-            task = asyncio.create_task(
-                self._authenticate_iguazio_v4_without_token(request)
-            )
+            iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
+            task = asyncio.create_task(iguazio_client.verify_request_session(request))
             task.add_done_callback(partial(self._on_verify_complete, key))
 
             task_expires_at = min(
@@ -507,22 +507,11 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         # verifications and cancellation could have unexpected side effects
         auth_info = await asyncio.shield(task_with_expiry[0])
 
-        # We have to reinsert the token since it was stripped before
-        auth_info = auth_info.copy()
-        auth_info.token = token
-        return auth_info
-
-    @staticmethod
-    async def _authenticate_iguazio_v4_without_token(
-        request: fastapi.Request,
-    ) -> schemas.AuthInfo:
-        iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
-        auth_info = await iguazio_client.verify_request_session(request)
-
-        # We strip the token from auth info to not keep it in memory
-        auth_info = auth_info.copy()
-        auth_info.token = None
-        return auth_info
+        # We dont want the auth info in the cache to ever be modified,
+        # especially since later calls are known to add sensitive data to the
+        # auth info that we do not want in the cache like the original request
+        # headers.
+        return deepcopy(auth_info)
 
     @staticmethod
     def _token_cache_key(token: str) -> bytes:

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -24,6 +24,7 @@ import fastapi
 import jwt
 
 import mlrun
+from mlrun.auth.utils import resolve_jwt_expiration
 import mlrun.common.schemas as schemas
 import mlrun.utils.helpers
 import mlrun.utils.singleton
@@ -459,20 +460,20 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         token = self._parse_auth_header(
             request.headers, schemas.AuthorizationHeaderPrefixes.bearer
         )
-        token_expires_at = self._extract_expires_at(token)
 
-        if token is None or token_expires_at is None:
-            # No token or expiry means no caching
+        if token is None:
+            iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
+            return await iguazio_client.verify_request_session(request)
+
+        token_expires_at = resolve_jwt_expiration(token)
+        curr_time = time.time()
+
+        if token_expires_at is None or token_expires_at <= curr_time:
+            # No expiry or an expired token means no caching
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             return await iguazio_client.verify_request_session(request)
 
         key = self._token_cache_key(token)
-        curr_time = time.time()
-
-        if token_expires_at <= curr_time:
-            self._token_cache.pop(key, None)
-            raise mlrun.errors.MLRunUnauthorizedError("Expired token")
-
         task_with_expiry = self._token_cache.get(key)
 
         if task_with_expiry is None or task_with_expiry[1] <= curr_time:
@@ -513,24 +514,6 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         auth_info = auth_info.copy()
         auth_info.token = token
         return auth_info
-
-    @staticmethod
-    def _extract_expires_at(token: str | None) -> float | None:
-        if token is None:
-            return None
-
-        # Signature verification happens on the backend
-        try:
-            decoded = jwt.decode(token, options={"verify_signature": False})
-        except jwt.DecodeError:
-            return None
-
-        expires_at = decoded.get("exp")
-
-        if not isinstance(expires_at, (int, float)):
-            return None
-
-        return expires_at
 
     @staticmethod
     async def _authenticate_iguazio_v4_without_token(

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -456,17 +456,17 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         self,
         request: fastapi.Request,
     ) -> schemas.AuthInfo:
-        token = self._extract_token(request)
+        token_with_expiry = self._extract_token(request)
         curr_time = time.time()
 
-        if token is None or token[1] <= curr_time:
+        if token_with_expiry is None or token_with_expiry[1] <= curr_time:
             # No token or an expired token means no caching
             # TODO: should we immediately throw an error instead of trying to
             # verify it?
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             return await iguazio_client.verify_request_session(request)
 
-        token, expires_at = token
+        token, expires_at = token_with_expiry
 
         self._expire_tokens(curr_time)
         task = self._token_cache.get(token)

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -33,9 +33,6 @@ import framework.utils.auth.providers.opa
 import framework.utils.clients.iguazio.v3
 import framework.utils.clients.iguazio.v4
 
-TOKEN_CACHE_MAX_SIZE = 128
-TOKEN_CACHE_MAX_TTL = 30  # seconds
-
 
 class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
     _token_cache: OrderedDict[str, tuple[asyncio.Task[schemas.AuthInfo], float]]
@@ -459,7 +456,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             task = asyncio.create_task(iguazio_client.verify_request_session(request))
             task.add_done_callback(partial(self._on_verify_complete, token))
 
-            task_expires_at = curr_time + TOKEN_CACHE_MAX_TTL
+            task_expires_at = curr_time + self._token_cache_ttl_seconds
 
             task_with_expiry = task, task_expires_at
             self._token_cache[token] = task_with_expiry
@@ -472,7 +469,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             # We just need to mark the token as the most recently used
             self._token_cache.move_to_end(token)
 
-        elif len(self._token_cache) > TOKEN_CACHE_MAX_SIZE:
+        elif len(self._token_cache) > self._token_cache_max_size:
             # If the cache grew beyond the max size with the new item we pop
             # the least recently used one
             self._token_cache.popitem(last=False)
@@ -480,6 +477,14 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         # We shield the task since it can be shared between multiple
         # verifications and cancellation could have unexpected side effects
         return await asyncio.shield(task_with_expiry[0])
+
+    @property
+    def _token_cache_max_size(self) -> int:
+        return mlrun.mlconf.httpdb.authentication.iguazio.token_cache.max_size
+
+    @property
+    def _token_cache_ttl_seconds(self) -> float:
+        return mlrun.mlconf.httpdb.authentication.iguazio.token_cache.ttl_seconds
 
     @staticmethod
     def _extract_token(request: fastapi.Request) -> str | None:

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from functools import partial
 
 import fastapi
+import jwt
 
 import mlrun
 import mlrun.common.schemas as schemas
@@ -458,15 +459,21 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         token = self._parse_auth_header(
             request.headers, schemas.AuthorizationHeaderPrefixes.bearer
         )
+        token_expires_at = self._extract_expires_at(token)
 
-        if token is None:
-            # No token means no caching
+        if token is None or token_expires_at is None:
+            # No token or expiry means no caching
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             return await iguazio_client.verify_request_session(request)
 
         key = self._token_cache_key(token)
-        task_with_expiry = self._token_cache.get(key)
         curr_time = time.time()
+
+        if token_expires_at <= curr_time:
+            self._token_cache.pop(key, None)
+            raise mlrun.errors.MLRunUnauthorizedError("Expired token")
+
+        task_with_expiry = self._token_cache.get(key)
 
         if task_with_expiry is None or task_with_expiry[1] <= curr_time:
             # No task or an expired task means we have to create a new task
@@ -477,7 +484,10 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             )
             task.add_done_callback(partial(self._on_verify_complete, key))
 
-            task_expires_at = curr_time + self._token_cache_ttl_seconds
+            task_expires_at = min(
+                curr_time + self._token_cache_ttl_seconds,
+                token_expires_at,
+            )
 
             task_with_expiry = task, task_expires_at
             self._token_cache[key] = task_with_expiry
@@ -503,6 +513,24 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         auth_info = auth_info.copy()
         auth_info.token = token
         return auth_info
+
+    @staticmethod
+    def _extract_expires_at(token: str | None) -> float | None:
+        if token is None:
+            return None
+
+        # Signature verification happens on the backend
+        try:
+            decoded = jwt.decode(token, options={"verify_signature": False})
+        except jwt.DecodeError:
+            return None
+
+        expires_at = decoded.get("exp")
+
+        if not isinstance(expires_at, (int, float)):
+            return None
+
+        return expires_at
 
     @staticmethod
     async def _authenticate_iguazio_v4_without_token(

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -392,8 +392,6 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         # Authorization schemes are case insensitive
         if header.lower().startswith(prefix.lower()):
             return header[len(prefix) :]
-        else:
-            return None
 
     @staticmethod
     def _parse_basic_auth(b64value: str) -> tuple[str, str]:

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -14,9 +14,15 @@
 
 import asyncio
 import base64
+import time
 import typing
+from collections import OrderedDict
+from dataclasses import dataclass
+from functools import partial
+from heapq import heapify, heappop, heappush
 
 import fastapi
+import jwt
 
 import mlrun
 import mlrun.common.schemas as schemas
@@ -30,8 +36,24 @@ import framework.utils.auth.providers.opa
 import framework.utils.clients.iguazio.v3
 import framework.utils.clients.iguazio.v4
 
+TOKEN_CACHE_MAX_SIZE = 128
+TOKEN_CACHE_MAX_TTL = 30  # seconds
+
+
+@dataclass(frozen=True)
+class TokenExpiryEntry:
+    token: str
+    task: asyncio.Task[schemas.AuthInfo]
+    expires_at: float
+
+    def __lt__(self, other: "TokenExpiryEntry") -> bool:
+        return self.expires_at < other.expires_at
+
 
 class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
+    _token_cache: OrderedDict[str, asyncio.Task[schemas.AuthInfo]]
+    _token_expiry_heap: list[TokenExpiryEntry]
+
     def __init__(self) -> None:
         super().__init__()
         self._resources_prefix = mlrun.mlconf.httpdb.authorization.namespaces.resources
@@ -46,6 +68,9 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             self._auth_provider = framework.utils.auth.providers.opa.Provider()
         else:
             raise NotImplementedError("Unsupported authorization mode")
+
+        self._token_cache = OrderedDict()
+        self._token_expiry_heap = []
 
     async def filter_project_resources_by_permissions(
         self,
@@ -427,9 +452,104 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             ]
         return auth_info
 
-    @staticmethod
     async def _authenticate_iguazio_v4(
+        self,
         request: fastapi.Request,
     ) -> schemas.AuthInfo:
-        iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
-        return await iguazio_client.verify_request_session(request)
+        token = self._extract_token(request)
+        curr_time = time.time()
+
+        if token is None or token[1] <= curr_time:
+            # No token or an expired token means no caching
+            # TODO: should we immediately throw an error instead of trying to
+            # verify it?
+            iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
+            return await iguazio_client.verify_request_session(request)
+
+        token, expires_at = token
+
+        self._expire_tokens(curr_time)
+        task = self._token_cache.get(token)
+
+        if task is None:
+            # No task means we have to create it and add it to the cache
+            iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
+            task = asyncio.create_task(iguazio_client.verify_request_session(request))
+            task.add_done_callback(partial(self._on_verify_complete, token))
+
+            self._token_cache[token] = task
+            if len(self._token_cache) > TOKEN_CACHE_MAX_SIZE:
+                self._token_cache.popitem(last=False)
+
+            expires_at = min(expires_at, curr_time + TOKEN_CACHE_MAX_TTL)
+            heappush(self._token_expiry_heap, TokenExpiryEntry(token, task, expires_at))
+        else:
+            # Move to end to mark it as the most recently used
+            self._token_cache.move_to_end(token)
+
+        # We shield the task since it can be shared between multiple
+        # verifications and cancellation could have unexpected side effects
+        return await asyncio.shield(task)
+
+    @staticmethod
+    def _extract_token(request: fastapi.Request) -> tuple[str, float] | None:
+        header_value = request.headers.get("Authorization")
+        if header_value is None:
+            return None
+
+        scheme, _, token = header_value.partition(" ")
+        if scheme.lower() != "bearer":  # scheme is case insensitive
+            return None
+
+        # We don't verify the signature here, this is handled by the endpoint
+        # called by the iguazio_client, we just want to extract the expiry time
+        try:
+            decoded = jwt.decode(token, options={"verify_signature": False})
+        except jwt.DecodeError:
+            return None
+
+        expires_at = decoded.get("exp")
+        if not isinstance(expires_at, (int, float)):
+            return None
+
+        return token, expires_at
+
+    def _expire_tokens(self, curr_time: float) -> None:
+        # The heap can have items that have been removed already, to keep this
+        # in bounds with the cache size we clean up the entire heap if it is
+        # more than double the cache size
+        if len(self._token_expiry_heap) > len(self._token_cache) * 2:
+            # In this case we filter the whole list while handling expiry and
+            # heapify it again
+            new_len = 0
+
+            for entry in self._token_expiry_heap:
+                if self._token_cache.get(entry.token) is not entry.task:
+                    pass  # already evicted
+                elif entry.expires_at <= curr_time:
+                    del self._token_cache[entry.token]  # expired
+                else:
+                    self._token_expiry_heap[new_len] = entry
+                    new_len += 1
+
+            del self._token_expiry_heap[new_len:]
+            heapify(self._token_expiry_heap)
+        else:
+            # We pop expired tokens from the heap to evict them from the cache
+            while (
+                self._token_expiry_heap
+                and self._token_expiry_heap[0].expires_at <= curr_time
+            ):
+                entry = heappop(self._token_expiry_heap)
+                if self._token_cache.get(entry.token) is entry.task:
+                    del self._token_cache[entry.token]
+
+    def _on_verify_complete(
+        self, token: str, task: asyncio.Task[schemas.AuthInfo]
+    ) -> None:
+        # We evict from the cache on failure to make sure we dont block tokens
+        # on things like temporary connectivity issues
+        # TODO: should we whitelist certain exceptions to be kept? e.g. invalid token
+        task_failed = task.cancelled() or task.exception() is not None
+        if task_failed and self._token_cache.get(token) is task:
+            del self._token_cache[token]

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -20,7 +20,6 @@ from collections import OrderedDict
 from functools import partial
 
 import fastapi
-import jwt
 
 import mlrun
 import mlrun.common.schemas as schemas
@@ -442,18 +441,15 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         self,
         request: fastapi.Request,
     ) -> schemas.AuthInfo:
-        token_with_expiry = self._extract_token(request)
-        curr_time = time.time()
+        token = self._extract_token(request)
 
-        if token_with_expiry is None or token_with_expiry[1] <= curr_time:
-            # No token or an expired token means no caching
-            # TODO: should we immediately throw an error instead of trying to
-            # verify it?
+        if token is None:
+            # No token means no caching
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             return await iguazio_client.verify_request_session(request)
 
-        token = token_with_expiry[0]
         task_with_expiry = self._token_cache.get(token)
+        curr_time = time.time()
 
         if task_with_expiry is None or task_with_expiry[1] <= curr_time:
             # No task or an expired task means we have to create a new task
@@ -486,7 +482,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         return await asyncio.shield(task_with_expiry[0])
 
     @staticmethod
-    def _extract_token(request: fastapi.Request) -> tuple[str, float] | None:
+    def _extract_token(request: fastapi.Request) -> str | None:
         header_value = request.headers.get("Authorization")
         if header_value is None:
             return None
@@ -495,18 +491,7 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
         if scheme.lower() != "bearer":  # scheme is case insensitive
             return None
 
-        # We don't verify the signature here, this is handled by the endpoint
-        # called by the iguazio_client, we just want to extract the expiry time
-        try:
-            decoded = jwt.decode(token, options={"verify_signature": False})
-        except jwt.DecodeError:
-            return None
-
-        expires_at = decoded.get("exp")
-        if not isinstance(expires_at, (int, float)):
-            return None
-
-        return token, expires_at
+        return token
 
     def _on_verify_complete(
         self, token: str, task: asyncio.Task[schemas.AuthInfo]

--- a/server/py/framework/utils/auth/verifier.py
+++ b/server/py/framework/utils/auth/verifier.py
@@ -17,9 +17,7 @@ import base64
 import time
 import typing
 from collections import OrderedDict
-from dataclasses import dataclass
 from functools import partial
-from heapq import heapify, heappop, heappush
 
 import fastapi
 import jwt
@@ -40,19 +38,8 @@ TOKEN_CACHE_MAX_SIZE = 128
 TOKEN_CACHE_MAX_TTL = 30  # seconds
 
 
-@dataclass(frozen=True)
-class TokenExpiryEntry:
-    token: str
-    task: asyncio.Task[schemas.AuthInfo]
-    expires_at: float
-
-    def __lt__(self, other: "TokenExpiryEntry") -> bool:
-        return self.expires_at < other.expires_at
-
-
 class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
-    _token_cache: OrderedDict[str, asyncio.Task[schemas.AuthInfo]]
-    _token_expiry_heap: list[TokenExpiryEntry]
+    _token_cache: OrderedDict[str, tuple[asyncio.Task[schemas.AuthInfo], float]]
 
     def __init__(self) -> None:
         super().__init__()
@@ -70,7 +57,6 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             raise NotImplementedError("Unsupported authorization mode")
 
         self._token_cache = OrderedDict()
-        self._token_expiry_heap = []
 
     async def filter_project_resources_by_permissions(
         self,
@@ -466,30 +452,38 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             return await iguazio_client.verify_request_session(request)
 
-        token, expires_at = token_with_expiry
+        token = token_with_expiry[0]
+        task_with_expiry = self._token_cache.get(token)
 
-        self._expire_tokens(curr_time)
-        task = self._token_cache.get(token)
+        if task_with_expiry is None or task_with_expiry[1] <= curr_time:
+            # No task or an expired task means we have to create a new task
+            is_cached = task_with_expiry is not None
 
-        if task is None:
-            # No task means we have to create it and add it to the cache
             iguazio_client = framework.utils.clients.iguazio.v4.AsyncClient()
             task = asyncio.create_task(iguazio_client.verify_request_session(request))
             task.add_done_callback(partial(self._on_verify_complete, token))
 
-            self._token_cache[token] = task
-            if len(self._token_cache) > TOKEN_CACHE_MAX_SIZE:
-                self._token_cache.popitem(last=False)
+            task_expires_at = curr_time + TOKEN_CACHE_MAX_TTL
 
-            expires_at = min(expires_at, curr_time + TOKEN_CACHE_MAX_TTL)
-            heappush(self._token_expiry_heap, TokenExpiryEntry(token, task, expires_at))
+            task_with_expiry = task, task_expires_at
+            self._token_cache[token] = task_with_expiry
         else:
-            # Move to end to mark it as the most recently used
+            # We can reuse the old task
+            is_cached = True
+
+        if is_cached:
+            # If the token was already cached the cache size did not change
+            # We just need to mark the token as the most recently used
             self._token_cache.move_to_end(token)
+
+        elif len(self._token_cache) > TOKEN_CACHE_MAX_SIZE:
+            # If the cache grew beyond the max size with the new item we pop
+            # the least recently used one
+            self._token_cache.popitem(last=False)
 
         # We shield the task since it can be shared between multiple
         # verifications and cancellation could have unexpected side effects
-        return await asyncio.shield(task)
+        return await asyncio.shield(task_with_expiry[0])
 
     @staticmethod
     def _extract_token(request: fastapi.Request) -> tuple[str, float] | None:
@@ -514,42 +508,15 @@ class AuthVerifier(metaclass=mlrun.utils.singleton.Singleton):
 
         return token, expires_at
 
-    def _expire_tokens(self, curr_time: float) -> None:
-        # The heap can have items that have been removed already, to keep this
-        # in bounds with the cache size we clean up the entire heap if it is
-        # more than double the cache size
-        if len(self._token_expiry_heap) > len(self._token_cache) * 2:
-            # In this case we filter the whole list while handling expiry and
-            # heapify it again
-            new_len = 0
-
-            for entry in self._token_expiry_heap:
-                if self._token_cache.get(entry.token) is not entry.task:
-                    pass  # already evicted
-                elif entry.expires_at <= curr_time:
-                    del self._token_cache[entry.token]  # expired
-                else:
-                    self._token_expiry_heap[new_len] = entry
-                    new_len += 1
-
-            del self._token_expiry_heap[new_len:]
-            heapify(self._token_expiry_heap)
-        else:
-            # We pop expired tokens from the heap to evict them from the cache
-            while (
-                self._token_expiry_heap
-                and self._token_expiry_heap[0].expires_at <= curr_time
-            ):
-                entry = heappop(self._token_expiry_heap)
-                if self._token_cache.get(entry.token) is entry.task:
-                    del self._token_cache[entry.token]
-
     def _on_verify_complete(
         self, token: str, task: asyncio.Task[schemas.AuthInfo]
     ) -> None:
         # We evict from the cache on failure to make sure we dont block tokens
         # on things like temporary connectivity issues
         # TODO: should we whitelist certain exceptions to be kept? e.g. invalid token
-        task_failed = task.cancelled() or task.exception() is not None
-        if task_failed and self._token_cache.get(token) is task:
+        if not task.cancelled() and task.exception() is None:
+            return
+
+        task_with_expiry = self._token_cache.get(token)
+        if task_with_expiry is not None and task_with_expiry[0] is task:
             del self._token_cache[token]


### PR DESCRIPTION
### 📝 Description
For IG4 authentication we cache the AuthInfo based on the JWT token, we do this to reduce the amount of requests to the auth backend.

---

### 🛠️ Changes Made
- Added a cache to the AuthVerifier-singleton. This cache combines LRU with a configurable max size and time based expiry based on the JWT token expiry with a configurable max TTL.
- This cache is used to cache the schemas.AuthInfo based on the JWT token for IG4 auth.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->
Added unittests including several tests for specific timing related edge cases.

Verified with a small helper script that when doing a lot of requests to an authenticated endpoint a request to the auth backend would show up for every request in the igz-api logs on an IG4 vm when running development.

Checked that with the same helper script we would max get one request per worker (cache is in memory and thus not shared between workers) every 30 seconds when running this PR.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-10417
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
The code currently assumes that if there is an Authorization header with a valid JWT token present that we can cache on it, however the underlying method forwards multiple headers that could be used for authentication to the backend. So if any of these other headers takes precedence over the JWT token our caching would not be correct, we should figure out if the JWT token always takes precedence, and if not if we can detect in which cases it will not.

There are 2 open points in the code currently that we could look into:
- What should we do when there is no token/an expired token? This is currently not cacheable (no key to cache or would immediately expire currently) so now auth just happens the same as before. We could look into if in some of these cases we could just immediately early return with a failure (I think expired token is a good candidate for this).
- What should we do when verifying the auth token fails? Currently this is explicitly not cached to avoid blocking tokens on things like temporary networking issues, however it could be worth it to maybe cache some failures like a token being invalid, this needs investigation on if we can differentiate/detect this however.

Some design decisions taken in the code:
- The codebase already contains a LRU cache, this one was now explicitly not used. This decision was made because the current LRU cache does not support wrapping asynchronous functions or time based expiry. Adding this would not be trivial. Both async and time based expiry can add tricky race conditions which are difficult to properly handle while abstracting the cache behaviour.
- The full JWT token was chosen as the cache key for now. The cached AuthInfo also contains the token so using the token as a key does not pose a security risk for memory dump attacks higher than we would have with another key. Caching based on the claimed user in the JWT could also be an option, but without properly verifying the signature of the JWT on the mlrun side this could lead to some potential attacks as well where an attacker would jam the authentication for a user with invalid keys to prevent authentication. Also the auth info contains the original token for inter service communication in name of the user, if we would cache based on user instead of token this would mean that inter service communication could happen with a different token than the original request which could mess up things like traceability in access logging.
