### PR TITLE
[Mounts] Explicit auto_mount_type config takes precedence over MLRUN_PVC_MOUNT env var [1.11.x]

### DIFF
--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -382,19 +382,25 @@ def auto_mount(
             volume_mount_path=volume_mount_path,
             volume_name=volume_name or "shared-persistency",
         )
+    # When auto_mount_type is explicitly configured (not the default "auto"),
+    # honour it regardless of env variables like MLRUN_PVC_MOUNT.  This ensures
+    # that an admin-configured S3 or secret_env mount type takes precedence over
+    # a PVC env var that may be set on the client machine (e.g., external Jupyter).
+    # Lazy import to avoid circular dependency (pod.py imports mounts.py at module level).
+    from mlrun.runtimes.pod import AutoMountType, _filter_modifier_params
+
+    auto_mount_type = AutoMountType(config.storage.auto_mount_type)
+    if auto_mount_type != AutoMountType.auto:
+        modifier = auto_mount_type.get_modifier()
+        if modifier:
+            params = _filter_modifier_params(
+                modifier, config.get_storage_auto_mount_params()
+            )
+            return modifier(**params)
     if "MLRUN_PVC_MOUNT" in os.environ:
         return mount_pvc(
             volume_name=volume_name or "shared-persistency",
         )
-    # In the case of CE when working remotely, no env variables will be defined but auto-mount
-    # parameters may still be declared - use them in that case.
-    # Lazy import to avoid circular dependency (pod.py imports mounts.py at module level).
-    from mlrun.runtimes.pod import AutoMountType
-
-    auto_mount_type = AutoMountType(config.storage.auto_mount_type)
-    modifier = auto_mount_type.get_modifier()
-    if modifier and auto_mount_type != AutoMountType.auto:
-        return modifier(**config.get_storage_auto_mount_params())
     if "V3IO_ACCESS_KEY" in os.environ:
         return mount_v3io(name=volume_name or "v3io")
 

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -378,6 +378,33 @@ def test_auto_mount_secret_env():
     assert env_from[0].secret_ref.name == "s3-credentials"
 
 
+def test_auto_mount_s3_takes_precedence_over_pvc_env():
+    """Test that auto_mount_type=s3 takes precedence over MLRUN_PVC_MOUNT env var.
+
+    When the server sets auto_mount_type=s3, it should be honoured even if
+    MLRUN_PVC_MOUNT is set on the client (e.g., external Jupyter). See ML-12370.
+    """
+    mlrun.mlconf.storage.auto_mount_type = "s3"
+    mlrun.mlconf.storage.auto_mount_params = (
+        "endpoint_url=https://minio-lab.example.com,secret_name=minio-credentials"
+    )
+    os.environ["MLRUN_PVC_MOUNT"] = "some-pvc:/home/jovyan/"
+    try:
+        function = mlrun.new_function(
+            "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+        )
+        function.apply(mlrun.runtimes.mounts.auto_mount())
+
+        env_dict = {
+            var["name"]: var.get("value", var.get("valueFrom"))
+            for var in function.spec.env
+        }
+        assert "AWS_ACCESS_KEY_ID" in env_dict
+        assert env_dict["AWS_ENDPOINT_URL_S3"] == "https://minio-lab.example.com"
+    finally:
+        os.environ.pop("MLRUN_PVC_MOUNT", None)
+
+
 def test_auto_mount_raises_without_config():
     """Test that auto_mount() raises ValueError when no mount type is configured."""
     mlrun.mlconf.storage.auto_mount_type = ""


### PR DESCRIPTION


When the server sets auto_mount_type to a non-auto value (e.g., s3), auto_mount() now honours it regardless of the MLRUN_PVC_MOUNT env var on the client. Previously, MLRUN_PVC_MOUNT was checked first, causing S3 credentials to be replaced by a PVC mount on external Jupyter environments where both are present.

Reference: ML-12370

### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
