### PR TITLE
[Feature store] Add context manager support to `RemoteVectorResponse`

### DIFF
--- a/mlrun/feature_store/retrieval/job.py
+++ b/mlrun/feature_store/retrieval/job.py
@@ -197,6 +197,16 @@ class RemoteVectorResponse:
         self._is_ready()
         return self.run.output("target")["path"]
 
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
 
 _default_merger_handler = """
 import mlrun


### PR DESCRIPTION
### 📝 Description

Fix breakage following #9507.

Fixes `TestFeatureStore::test_parquet_filters[passthrough=False]`.

`get_offline_features()` returns `RemoteVectorResponse` when `passthrough=False`, but #9507 wrapped `get_offline_features()` calls in `with` blocks without adding context manager support to `RemoteVectorResponse`. This caused `test_parquet_filters[passthrough=False-*]` variants to fail with `TypeError: 'RemoteVectorResponse' object does not support the context manager protocol`.

---

### 🛠️ Changes Made

- Added no-op `close()`, `__enter__`, and `__exit__` to `RemoteVectorResponse` so it supports the context manager protocol, matching `OfflineVectorResponse`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Ran `test_parquet_filters` (all non-skipped variants) — passed.

---

### 🔗 References
- Ticket link: ML-11973
- Design docs links:
- External links: #9507

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

None.