### PR TITLE
[Workflow] Skip running project_setup.py for remote workflows

### DIFF
--- a/mlrun/common/schemas/workflow.py
+++ b/mlrun/common/schemas/workflow.py
@@ -35,6 +35,7 @@ class WorkflowSpec(pydantic.v1.BaseModel):
     image: str | None = None
     workflow_runner_node_selector: dict[str, str] | None = None
     auth_token_name: str | None = None
+    run_setup: bool = False
 
 
 class WorkflowRequest(pydantic.v1.BaseModel):

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -1187,6 +1187,7 @@ def load_and_run_workflow(
     cleanup_ttl: int | None = None,
     wait_for_completion: bool = False,
     project_context: str | None = None,
+    run_setup: bool = False,
 ):
     """
     Auxiliary function that the RemoteRunner run once or run every schedule.
@@ -1215,6 +1216,7 @@ def load_and_run_workflow(
                                 workflow and all its resources are deleted)
     :param wait_for_completion: wait for workflow completion before returning
     :param project_context:     project context path (used for loading the project)
+    :param run_setup:           whether the setup script should be ran (default False)
     """
     project_context = project_context or f"./{project_name}"
 
@@ -1229,6 +1231,7 @@ def load_and_run_workflow(
         clone=clone,
         schedule=schedule,
         workflow_name=workflow_name,
+        run_setup=run_setup,
     )
 
     # Retrieve the project object:
@@ -1238,6 +1241,7 @@ def load_and_run_workflow(
         context=project_context or f"./{project_name}",
         name=project_name,
         allow_cross_project=True,
+        run_setup=run_setup,
     )
 
     # extract "start" notification if exists
@@ -1309,6 +1313,7 @@ def pull_remote_project_files(
     clone: bool,
     schedule: typing.Union[str, mlrun.common.schemas.ScheduleCronTrigger] | None,
     workflow_name: str | None,
+    run_setup: bool = True,
 ) -> None:
     """
     Load the project to clone remote files if they exist.
@@ -1323,6 +1328,7 @@ def pull_remote_project_files(
     :param clone:          Whether to clone the repository.
     :param schedule:       Schedule for running the workflow.
     :param workflow_name:  Name of the workflow to run.
+    :param run_setup:      whether the setup script should be ran (default True)
     """
     try:
         # Load the project to clone remote files if they exist.
@@ -1336,6 +1342,7 @@ def pull_remote_project_files(
             clone=clone,
             save=False,
             allow_cross_project=True,
+            run_setup=run_setup,
         )
     except Exception as error:
         notify_scheduled_workflow_failure(

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -88,6 +88,7 @@ class WorkflowSpec(mlrun.model.ModelObj):
         cleanup_ttl: int | None = None,
         image: str | None = None,
         workflow_runner_node_selector: dict[str, str] | None = None,
+        run_setup: bool = False,
     ):
         self.engine = engine
         self.code = code
@@ -102,6 +103,7 @@ class WorkflowSpec(mlrun.model.ModelObj):
         self.schedule = schedule
         self.image = image
         self.workflow_runner_node_selector = workflow_runner_node_selector
+        self.run_setup = run_setup
 
     def get_source_file(self, context=""):
         if not self.code and not self.path:
@@ -1216,7 +1218,7 @@ def load_and_run_workflow(
                                 workflow and all its resources are deleted)
     :param wait_for_completion: wait for workflow completion before returning
     :param project_context:     project context path (used for loading the project)
-    :param run_setup:           whether the setup script should be ran (default False)
+    :param run_setup:           whether the setup script should be run (default False)
     """
     project_context = project_context or f"./{project_name}"
 
@@ -1328,7 +1330,7 @@ def pull_remote_project_files(
     :param clone:          Whether to clone the repository.
     :param schedule:       Schedule for running the workflow.
     :param workflow_name:  Name of the workflow to run.
-    :param run_setup:      whether the setup script should be ran (default True)
+    :param run_setup:      whether the setup script should be run (default True)
     """
     try:
         # Load the project to clone remote files if they exist.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -232,7 +232,7 @@ def new_project(
                          if project with name exists
     :param parameters:   key/value pairs to add to the project.spec.params
     :param default_function_node_selector: defines the default node selector for scheduling functions within the project
-    :param run_setup:    whether the setup script should be ran (default True)
+    :param run_setup:    whether the setup script should be run (default True)
 
     :returns: project object
     """
@@ -387,7 +387,7 @@ def load_project(
     :param parameters:      key/value pairs to add to the project.spec.params
     :param allow_cross_project: if True, override the loaded project name. This flag ensures awareness of
                                 loading an existing project yaml as a baseline for a new project with a different name
-    :param run_setup:       whether the setup script should be ran (default True)
+    :param run_setup:       whether the setup script should be run (default True)
 
     :returns: project object
     """
@@ -534,7 +534,7 @@ def get_or_create_project(
     :param parameters:   key/value pairs to add to the project.spec.params
     :param allow_cross_project: if True, override the loaded project name. This flag ensures awareness of
                                 loading an existing project yaml as a baseline for a new project with a different name
-    :param run_setup:    whether the setup script should be ran (default True)
+    :param run_setup:    whether the setup script should be run (default True)
 
     :returns: project object
     """
@@ -1403,6 +1403,7 @@ class MlrunProject(ModelObj):
         schedule: typing.Union[str, mlrun.common.schemas.ScheduleCronTrigger] = None,
         ttl: int | None = None,
         image: str | None = None,
+        run_setup: bool = False,
         **args,
     ):
         """Add or update a workflow, specify a name and the code path
@@ -1424,6 +1425,9 @@ class MlrunProject(ModelObj):
                               The image must have mlrun[kfp] installed which requires python 3.9.
                               Therefore, the project default image will not be used for the workflow,
                               and the image must be specified explicitly.
+        :param run_setup:     Whether the project setup script should be run on the remote workflow runner pod.
+                              Only relevant for remote/scheduled workflows; the runner loads the project from
+                              the DB (the source of truth), so setup is skipped by default (default False).
         :param args:          Argument values (key=value, ..)
         """
 
@@ -1469,6 +1473,8 @@ class MlrunProject(ModelObj):
             workflow["ttl"] = ttl
         if image:
             workflow["image"] = image
+        if run_setup:
+            workflow["run_setup"] = run_setup
         self.spec.set_workflow(name, workflow)
 
     def set_artifact(
@@ -3750,6 +3756,7 @@ class MlrunProject(ModelObj):
         cleanup_ttl: int | None = None,
         notifications: list[mlrun.model.Notification] | None = None,
         workflow_runner_node_selector: dict[str, str] | None = None,
+        run_setup: bool | None = None,
         context: mlrun.execution.MLClientCtx | None = None,
     ) -> _PipelineRunStatus:
         """Run a workflow using kubeflow pipelines
@@ -3793,6 +3800,10 @@ class MlrunProject(ModelObj):
                           This allows you to control and specify where the workflow runner pod will be scheduled.
                           This setting is only relevant when the engine is set to 'remote' or for scheduled workflows,
                           and it will be ignored if the workflow is not run on a remote engine.
+        :param run_setup:           Whether the project setup script should be run on the remote workflow runner pod.
+                          Only relevant for remote/scheduled workflows; the runner loads the project from the DB
+                          (the source of truth), so setup is skipped by default. When not specified, the value set
+                          via `set_workflow(..., run_setup=...)` is used (default False).
         :param context:             mlrun context.
         :returns: ~py:class:`~mlrun.projects.pipelines._PipelineRunStatus` instance
         """
@@ -3833,6 +3844,8 @@ class MlrunProject(ModelObj):
             workflow_spec.merge_args(arguments)
         workflow_spec.cleanup_ttl = cleanup_ttl or workflow_spec.cleanup_ttl
         workflow_spec.run_local = local
+        if run_setup is not None:
+            workflow_spec.run_setup = run_setup
 
         name = f"{self.metadata.name}-{name}" if name else self.metadata.name
         artifact_path = artifact_path or self._enrich_artifact_path_with_workflow_uid()

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -163,6 +163,7 @@ def new_project(
     overwrite: bool = False,
     parameters: dict | None = None,
     default_function_node_selector: dict | None = None,
+    run_setup: bool = True,
 ) -> "MlrunProject":
     """Create a new MLRun project, optionally load it from a yaml/zip/git template.
     The project will become the active project for the current session.
@@ -231,6 +232,7 @@ def new_project(
                          if project with name exists
     :param parameters:   key/value pairs to add to the project.spec.params
     :param default_function_node_selector: defines the default node selector for scheduling functions within the project
+    :param run_setup:    whether the setup script should be ran (default True)
 
     :returns: project object
     """
@@ -316,7 +318,8 @@ def new_project(
         )
 
     # Hook for initializing the project using a project_setup script
-    project = project.setup(save and mlrun.mlconf.dbpath)
+    if run_setup:
+        project = project.setup(save and mlrun.mlconf.dbpath)
 
     return project
 
@@ -334,6 +337,7 @@ def load_project(
     sync_functions: bool = False,
     parameters: dict | None = None,
     allow_cross_project: bool | None = None,
+    run_setup: bool = True,
 ) -> "MlrunProject":
     """Load an MLRun project from git or tar or dir. The project will become the active project for
     the current session.
@@ -383,6 +387,7 @@ def load_project(
     :param parameters:      key/value pairs to add to the project.spec.params
     :param allow_cross_project: if True, override the loaded project name. This flag ensures awareness of
                                 loading an existing project yaml as a baseline for a new project with a different name
+    :param run_setup:       whether the setup script should be ran (default True)
 
     :returns: project object
     """
@@ -454,7 +459,8 @@ def load_project(
         project.save()
 
     # Hook for initializing the project using a project_setup script
-    project = project.setup(to_save)
+    if run_setup:
+        project = project.setup(to_save)
 
     if to_save:
         project.register_artifacts()
@@ -480,6 +486,7 @@ def get_or_create_project(
     save: bool = True,
     parameters: dict | None = None,
     allow_cross_project: bool | None = None,
+    run_setup: bool = True,
 ) -> "MlrunProject":
     """Load a project from MLRun DB, or create/import if it does not exist.
     The project will become the active project for the current session.
@@ -527,6 +534,7 @@ def get_or_create_project(
     :param parameters:   key/value pairs to add to the project.spec.params
     :param allow_cross_project: if True, override the loaded project name. This flag ensures awareness of
                                 loading an existing project yaml as a baseline for a new project with a different name
+    :param run_setup:    whether the setup script should be ran (default True)
 
     :returns: project object
     """
@@ -547,6 +555,7 @@ def get_or_create_project(
             save=False,
             parameters=parameters,
             allow_cross_project=allow_cross_project,
+            run_setup=run_setup,
         )
         logger.info("Project loaded successfully", project_name=project.name)
         return project
@@ -578,6 +587,7 @@ def get_or_create_project(
             save=save,
             parameters=parameters,
             allow_cross_project=allow_cross_project,
+            run_setup=run_setup,
         )
 
         logger.info(
@@ -599,6 +609,7 @@ def get_or_create_project(
         subpath=subpath,
         save=save,
         parameters=parameters,
+        run_setup=run_setup,
     )
     logger.info(
         "Project created successfully", project_name=project.name, stored_in_db=save

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -571,6 +571,7 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
             local=workflow_request.spec.run_local,
             subpath=project.spec.subpath,
             url=source,
+            run_setup=workflow_request.spec.run_setup,
         )
 
         run_object = self._create_run_object(

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -75,6 +75,56 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             ].startswith("mlrun.notifications.")
 
     @pytest.mark.parametrize(
+        "run_setup_kwargs, expected_run_setup",
+        [
+            # default: setup is skipped on the runner pod (DB is the source of truth)
+            ({}, False),
+            ({"run_setup": False}, False),
+            # users can opt-in to running the setup script on the runner pod
+            ({"run_setup": True}, True),
+        ],
+    )
+    def test_run_workflow_run_setup_flag(
+        self,
+        db: sqlalchemy.orm.Session,
+        k8s_secrets_mock,
+        run_setup_kwargs: dict,
+        expected_run_setup: bool,
+    ):
+        project = mlrun.common.schemas.ProjectOut(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+            spec=mlrun.common.schemas.ProjectSpecOut(),
+        )
+        services.api.crud.Projects().create_project(db, project)
+
+        run_name = "run-name"
+        runner = services.api.crud.WorkflowRunners().create_runner(
+            run_name=run_name,
+            project=project.metadata.name,
+            db_session=db,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+            image="mlrun/mlrun",
+        )
+
+        run = services.api.crud.WorkflowRunners().run(
+            runner=runner,
+            project=project,
+            workflow_request=mlrun.common.schemas.WorkflowRequest(
+                spec=mlrun.common.schemas.WorkflowSpec(
+                    name=run_name,
+                    engine="remote",
+                    image="mlrun/mlrun",
+                    **run_setup_kwargs,
+                ),
+                source="/home/mlrun/project-name/",
+                artifact_path="/home/mlrun/artifacts",
+            ),
+            auth_info=mlrun.common.schemas.AuthInfo(username="test-user"),
+        )
+
+        assert run.spec.parameters["run_setup"] == expected_run_setup
+
+    @pytest.mark.parametrize(
         "source_code_target_dir",
         [
             "/home/mlrun_code",

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -538,6 +538,53 @@ def test_project_with_setup(context, op):
         assert project.spec.params == {"p1": "xyz", "p2": "123", "test123": "456"}
 
 
+@pytest.mark.parametrize("run_setup", [True, False])
+def test_load_project_run_setup_flag(context, run_setup):
+    # load_project should run the setup script only when run_setup is True, while the
+    # save/register_artifacts side effects (DB is the source of truth) always happen.
+    project_path = (
+        pathlib.Path(tests.conftest.tests_root_directory)
+        / "projects"
+        / "assets"
+        / "load_setup_test"
+    )
+    mlrun_project_cls = mlrun.projects.project.MlrunProject
+
+    # to_save = save and mlconf.dbpath, so a dbpath is required to exercise the save path
+    original_dbpath = mlrun.mlconf.dbpath
+    mlrun.mlconf.dbpath = "http://localhost:12345"
+    try:
+        with (
+            unittest.mock.patch.object(
+                mlrun_project_cls,
+                "setup",
+                autospec=True,
+                side_effect=lambda self, save=True: self,
+            ) as setup_mock,
+            unittest.mock.patch.object(
+                mlrun_project_cls, "save", autospec=True
+            ) as save_mock,
+            unittest.mock.patch.object(
+                mlrun_project_cls, "register_artifacts", autospec=True
+            ) as register_artifacts_mock,
+        ):
+            mlrun.load_project(
+                context=project_path,
+                name="projset-runsetup",
+                save=True,
+                parameters={"p2": "123"},
+                run_setup=run_setup,
+            )
+    finally:
+        mlrun.mlconf.dbpath = original_dbpath
+
+    # setup runs only when explicitly opted in
+    assert setup_mock.called is run_setup
+    # the project is still saved and its artifacts registered regardless of run_setup
+    save_mock.assert_called_once()
+    register_artifacts_mock.assert_called_once()
+
+
 @pytest.mark.parametrize(
     "setup_file_contents, exception",
     [


### PR DESCRIPTION
### 📝 Description
For projects loaded from a git source, the workflow-runner pod re-executes `project_setup.py` after loading the project from the MLRun DB. The setup script is intended for the local create/load flow only — re-running it on the runner overwrites authoritative DB state (env vars, params set via `get_or_create_project(parameters=...)`), causing inconsistencies between the user's view of the project and what the workflow actually runs against.

This PR threads a `run_setup` flag through `new_project` / `load_project` / `get_or_create_project` / `pull_remote_project_files`, and passes `run_setup=False` from `load_and_run_workflow` so the workflow-runner skips the setup hook. Default behaviour for direct SDK callers is unchanged.

---

### 🛠️ Changes Made
- `mlrun/projects/project.py`: added `run_setup: bool = True` to `new_project`, `load_project`, `get_or_create_project`; gates the `project.setup(...)` hook.
- `mlrun/projects/pipelines.py`: added `run_setup: bool = True` to `pull_remote_project_files`, `run_setup: bool = False` to `load_and_run_workflow`, and threaded the flag into both `pull_remote_project_files` and `mlrun.load_project` calls inside the workflow runner.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
End-to-end verification on lab `vmdev122ig4` (mlrun 1.12.0-rc2 baseline):
- Built `mlrun-kfp:unstable` from this branch, pushed to `ig4-user-registry.../mlrun-kfp:unstable`, pinned the workflow-runner image via `set_workflow(..., image=...)`.
- Repro project with `project_setup.py` that prints a sentinel and mutates `spec.params`: https://github.com/daanvdk-mck/ml-12102-verify
- **Patched runner pod**: workflow loaded successfully end-to-end, sentinel string absent from logs → `project_setup.py` was not executed in the runner.
- **Stock control pod** (same workflow, `mlrun-kfp:1.12.0-rc2`): sentinel string appears twice in logs (once during `pull_remote_project_files`, once during `load_project`) → reproduces ML-12102.
- Client-side `mlrun.load_project(...)` still runs setup locally on both runs — `run_setup=True` default preserved for the user-facing path.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12102

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Defaults preserve existing behaviour for direct SDK callers. Only `load_and_run_workflow` opts out of setup, and that function is only invoked from inside the workflow-runner pod.

---

### 🔍️ Additional Notes
- Fix is purely SDK-side — no api / db / migration changes. The mlrun-api image does not need to be rebuilt; workflow-runner pods pick up the new behaviour from the next `mlrun` / `mlrun-kfp` image.
- No system tests today cover a remote workflow over a git source with a `project_setup.py`. Worth adding one under `tests/system/projects/` to lock this in.