### PR TITLE
[Pipelines] Fix step-to-run correlation for long pipeline names

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -294,8 +294,11 @@ def run(
 
     if workflow:
         runobj.metadata.labels[mlrun_constants.MLRunInternalLabels.workflow] = workflow
+        # Use the full pod name (via MLRUN_POD_NAME downward API env var) for
+        # unambiguous step-to-run correlation. socket.gethostname() is truncated
+        # to 63 chars by the kubelet, which can cause lookup mismatches.
         runobj.metadata.labels[mlrun_constants.MLRunInternalLabels.runner_pod] = (
-            socket.gethostname()
+            environ.get("MLRUN_POD_NAME", socket.gethostname())
         )
 
     if db:

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-common"
-version = "0.6.4"
+version = "0.7.0"
 description = "MLRun Pipelines adapter package for providing KFP common functionality"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.6.4"
+version = "0.7.0"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py
@@ -186,6 +186,17 @@ def add_default_env(k8s_client, cop):
             ),
         )
     )
+    # Inject the full pod name (metadata.name) for runner_pod annotation.
+    # socket.gethostname() is truncated to 63 chars by the kubelet,
+    # but the full pod name is needed for unambiguous step correlation.
+    cop.container.add_env_variable(
+        k8s_client.V1EnvVar(
+            "MLRUN_POD_NAME",
+            value_from=k8s_client.V1EnvVarSource(
+                field_ref=k8s_client.V1ObjectFieldSelector(field_path="metadata.name")
+            ),
+        )
+    )
 
     if config.httpdb.api_url:
         cop.container.add_env_variable(

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v2"
-version = "0.6.0"
+version = "0.7.0"
 description = "MLRun Pipelines adapter package for providing KFP 2.* compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
@@ -213,6 +213,8 @@ def add_labels(task, function, scrape_metrics=False):
 def add_default_env(task):
     if hasattr(kfp_k8s, "use_field_path_as_env"):
         kfp_k8s.use_field_path_as_env(task, "MLRUN_NAMESPACE", "metadata.namespace")
+        # Inject the full pod name for runner_pod annotation.
+        kfp_k8s.use_field_path_as_env(task, "MLRUN_POD_NAME", "metadata.name")
     else:
         # TODO: remove this warning as soon as "use_field_path_as_env" is available for MLRun SDK
         logger.warning(

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -88,7 +88,7 @@ class TestMLRunSystem:
 
         cls.uploaded_code = False
 
-        if "MLRUN_IGUAZIO_API_URL" in env:
+        if "MLRUN_IGUAZIO_API_URL" in env and "V3IO_ACCESS_KEY" in env:
             cls._igz_mgmt_client = igz_mgmt.Client(
                 endpoint=env["MLRUN_IGUAZIO_API_URL"],
                 access_key=env["V3IO_ACCESS_KEY"],

--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -226,3 +226,57 @@ class TestKFP(tests.system.base.TestMLRunSystem):
         record = db.get_pipeline(run_id, project=self.project_name)
         err = record["run"].get("status", "")
         assert "failed" in err.lower(), f"expected failed error, got: {err}"
+
+    def test_kfp_long_pipeline_name_steps_have_run_uid(self):
+        """Verify that pipeline steps are correctly matched to MLRun runs
+        even when the pipeline + step names produce pod hostnames exceeding
+        the 63-char kubelet truncation limit."""
+        code_path = str(self.assets_path / "my_func.py")
+        func = mlrun.code_to_function(
+            name="func",
+            kind="job",
+            filename=code_path,
+            project=self.project_name,
+            image="mlrun/mlrun",
+        )
+        self.project.set_function(func)
+
+        # Use a long pipeline name so that pipeline-name + step-name + node-id > 63 chars
+        long_pipeline_name = "long-pipeline-name-with-many-characters"
+
+        @dsl.pipeline(name=long_pipeline_name)
+        def long_name_pipeline():
+            mlrun.run_function(
+                "func",
+                name="data-preprocessing-and-validation",
+                handler="handler",
+                params={"p1": 1},
+            )
+            mlrun.run_function(
+                "func",
+                name="model-training-and-evaluation",
+                handler="handler",
+                params={"p1": 2},
+            )
+
+        run_id = self.project.run(
+            workflow_handler=long_name_pipeline,
+            name="long-name-test",
+            watch=True,
+        )
+
+        mlrun.wait_for_pipeline_completion(run_id, project=self.project_name)
+
+        db = mlrun.get_run_db()
+        pipeline = db.get_pipeline(run_id, project=self.project_name)
+        graph = pipeline.get("graph", {})
+
+        steps_with_run_uid = [
+            step_name
+            for step_name, step_info in graph.items()
+            if step_info.get("run_uid")
+        ]
+        assert len(steps_with_run_uid) == 2, (
+            f"Expected 2 steps with run_uid, got {len(steps_with_run_uid)}. "
+            f"Graph: {graph}"
+        )


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

Fix step-to-run correlation failure when pipeline + step names produce pod hostnames exceeding the 63-character kubelet truncation limit.

When KFP pipeline names are long, the kubelet truncates the pod hostname to 63 characters. The `runner_pod` label was set using `socket.gethostname()`, which returns this truncated value, causing the API server to fail matching pipeline steps to their MLRun runs (missing `run_uid` in the pipeline graph).

The fix injects `MLRUN_POD_NAME` via the Kubernetes downward API (`metadata.name`) into pipeline step pods, and uses it (with `socket.gethostname()` as fallback) when setting the `runner_pod` label.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

- **`mlrun/__main__.py`**: Use `MLRUN_POD_NAME` env var (falling back to `socket.gethostname()`) for the `runner_pod` label
- **`pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py`**: Inject `MLRUN_POD_NAME` env var from Kubernetes downward API (`metadata.name`) into pipeline step containers
- **`pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py`**: Same injection for KFP v2 adapter using `kfp_k8s.use_field_path_as_env`
- **`pipeline-adapters/*/pyproject.toml`**: Version bump to 0.7.0 for all three pipeline adapter packages
- **`tests/system/runtimes/test_kfp.py`**: Add system test `test_kfp_long_pipeline_name_steps_have_run_uid` that runs a pipeline with long names and asserts both steps have `run_uid`
- **`tests/system/base.py`**: Skip `igz_mgmt.Client` initialization when `V3IO_ACCESS_KEY` is not configured (supports igz4 systems)

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

- Ran `test_kfp_long_pipeline_name_steps_have_run_uid` system test against vmdev103ig4 lab — pipeline completed successfully with both steps having `run_uid` populated
- The test uses a pipeline name of 39 chars + step names of 35/30 chars, ensuring the combined pod hostname exceeds 63 chars

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12372
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->

- The `MLRUN_POD_NAME` env var is only injected into KFP pipeline step pods (not regular MLRun jobs), and the fallback to `socket.gethostname()` ensures backward compatibility for environments where the env var is not set.
- The `tests/system/base.py` change is a minor fix to support running system tests against igz4 systems where `V3IO_ACCESS_KEY` is not needed.
