### PR TITLE
[Bugfix] Fix 4 logic bugs: reversed checks, wrong attribute refs, operator precedence

### DIFF
--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -311,9 +311,12 @@ class DatasetArtifact(Artifact):
         if stats or (
             stats is None
             and (
-                artifact.spec.length < max_csv and len(df.columns) < max_preview_columns
+                (
+                    artifact.spec.length < max_csv
+                    and len(df.columns) < max_preview_columns
+                )
+                or ignore_preview_limits
             )
-            or ignore_preview_limits
         ):
             artifact.status.stats = get_df_stats(df)
 

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1021,11 +1021,11 @@ class Config:
 
     def keys(self):
         if isinstance(self._cfg, Mapping):
-            return iter(self.data.keys())
+            return iter(self._cfg.keys())
 
     def values(self):
         if isinstance(self._cfg, Mapping):
-            return iter(self.data.values())
+            return iter(self._cfg.values())
 
     def update(self, cfg, skip_errors=False):
         for key, value in cfg.items():

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -2251,7 +2251,7 @@ def warn_on_deprecated_image(image: str | None):
     """
     deprecated_images = ["mlrun/ml-base"]
     if image and any(
-        image in deprecated_image for deprecated_image in deprecated_images
+        deprecated_image in image for deprecated_image in deprecated_images
     ):
         warnings.warn(
             "'mlrun/ml-base' image is deprecated in 1.10.0 and will be replaced by 'mlrun/mlrun'. "

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -389,7 +389,7 @@ def remove_image_protocol_prefix(image: str) -> str:
     if not image:
         return image
 
-    prefixes = ["https://", "https://"]
+    prefixes = ["https://", "http://"]
     if any(prefix in image for prefix in prefixes):
         image = image.removeprefix("https://").removeprefix("http://")
         logger.warning(

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -211,6 +211,51 @@ def test_dataset_stats():
             assert dataset_artifact.status.stats is not None
 
 
+def test_dataset_stats_with_ignore_preview_limits():
+    """Test that stats=False is respected even when ignore_preview_limits=True.
+
+    Before the fix, an operator precedence bug caused `or ignore_preview_limits`
+    to be evaluated outside of the `stats is None and (...)` group, meaning
+    stats were computed even when the user explicitly disabled them with
+    stats=False.
+    """
+    raw_data = {
+        "first_name": ["Jason", "Molly", "Tina", "Jake", "Amy"],
+        "last_name": ["Miller", "Jacobson", "Ali", "Milner", "Cooze"],
+        "age": [42, 52, 36, 24, 73],
+        "testScore": [25, 94, 57, 62, 70],
+    }
+    df = pandas.DataFrame(
+        raw_data, columns=["first_name", "last_name", "age", "testScore"]
+    )
+
+    # stats=False with ignore_preview_limits=True should NOT compute stats
+    artifact = mlrun.artifacts.dataset.DatasetArtifact(
+        df=df, stats=False, ignore_preview_limits=True
+    )
+    assert artifact.status.stats is None, (
+        "stats should be None when user explicitly sets stats=False, "
+        "even with ignore_preview_limits=True"
+    )
+
+    # stats=None (auto) with ignore_preview_limits=True should compute stats
+    artifact = mlrun.artifacts.dataset.DatasetArtifact(
+        df=df, stats=None, ignore_preview_limits=True
+    )
+    assert artifact.status.stats is not None, (
+        "stats should be computed when stats=None (auto mode) "
+        "and ignore_preview_limits=True"
+    )
+
+    # stats=True with ignore_preview_limits=True should compute stats
+    artifact = mlrun.artifacts.dataset.DatasetArtifact(
+        df=df, stats=True, ignore_preview_limits=True
+    )
+    assert artifact.status.stats is not None, (
+        "stats should be computed when stats=True, regardless of ignore_preview_limits"
+    )
+
+
 def test_get_log_dataset_dont_duplicate_index_column(ensure_project):
     source_url = mlrun.get_sample_path("data/iris/iris.data.raw.csv")
     df = mlrun.get_dataitem(source_url).as_df()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -786,6 +786,31 @@ def test_default_forbidden_service_account_config(
     )
 
 
+def test_config_keys_and_values():
+    """Test that Config.keys() and Config.values() return the correct data.
+
+    Regression test for a bug where keys() and values() referenced self.data
+    (which doesn't exist) instead of self._cfg, causing AttributeError.
+    """
+    cfg = mlrun.config.Config({"a": 1, "b": 2, "nested": {"x": 10}})
+
+    # keys() should return all top-level keys
+    keys = list(cfg.keys())
+    assert sorted(keys) == ["a", "b", "nested"]
+
+    # values() should return all top-level values
+    values = list(cfg.values())
+    assert sorted(values, key=str) == sorted([1, 2, {"x": 10}], key=str)
+
+    # items() should match keys and values
+    items = list(cfg.items())
+    assert sorted(items) == sorted([("a", 1), ("b", 2), ("nested", {"x": 10})])
+
+    # __iter__ should yield the same keys
+    iter_keys = list(cfg)
+    assert sorted(iter_keys) == ["a", "b", "nested"]
+
+
 def _exec_mlrun(cmd, cwd=None):
     cmd = [sys.executable, "-m", "mlrun"] + cmd.split()
     out = subprocess.run(cmd, capture_output=True, cwd=cwd)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -60,6 +60,7 @@ from mlrun.utils.helpers import (
     validate_v3io_stream_consumer_group,
     verify_field_regex,
     verify_list_items_type,
+    warn_on_deprecated_image,
 )
 
 STORE_PREFIX = "store://{kind}/dummy-project/dummy-db-key"
@@ -2169,3 +2170,41 @@ def test_set_auth_user_id_works_with_run_spec():
     spec = mlrun.model.RunSpec()
     set_auth_user_id(spec, "user-123")
     assert spec.auth["user_id"] == "user-123"
+
+
+import warnings
+
+
+@pytest.mark.parametrize(
+    "image,should_warn",
+    [
+        # Exact deprecated image name
+        ("mlrun/ml-base", True),
+        # Tagged deprecated image (the core bug scenario)
+        ("mlrun/ml-base:v1.11.0", True),
+        ("mlrun/ml-base:latest", True),
+        # Registry-prefixed deprecated image
+        ("registry.example.com/mlrun/ml-base:latest", True),
+        # Non-deprecated images should NOT warn
+        ("mlrun/mlrun:latest", False),
+        ("mlrun/mlrun", False),
+        ("my-custom-image:v1", False),
+        # None and empty string should NOT warn
+        (None, False),
+        ("", False),
+    ],
+)
+def test_warn_on_deprecated_image(image, should_warn):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        warn_on_deprecated_image(image)
+        if should_warn:
+            assert len(w) == 1, (
+                f"Expected 1 FutureWarning for image '{image}', got {len(w)}"
+            )
+            assert issubclass(w[0].category, FutureWarning)
+        else:
+            assert len(w) == 0, (
+                f"Expected no warnings for image '{image}', got {len(w)}"
+            )
+

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -45,6 +45,7 @@ from mlrun.utils.helpers import (
     lock_hub_uri_version,
     merge_requirements,
     parse_artifact_uri,
+    remove_image_protocol_prefix,
     remove_tag_from_artifact_uri,
     resolve_image_tag_suffix,
     set_auth_token_name,
@@ -2208,3 +2209,22 @@ def test_warn_on_deprecated_image(image, should_warn):
                 f"Expected no warnings for image '{image}', got {len(w)}"
             )
 
+
+@pytest.mark.parametrize(
+    "image, expected",
+    [
+        # http:// prefix should be stripped
+        ("http://my-registry.com/my-image:latest", "my-registry.com/my-image:latest"),
+        # https:// prefix should be stripped
+        ("https://my-registry.com/my-image:latest", "my-registry.com/my-image:latest"),
+        # no prefix should remain unchanged
+        ("my-registry.com/my-image:latest", "my-registry.com/my-image:latest"),
+        # empty string should remain empty
+        ("", ""),
+    ],
+)
+def test_remove_image_protocol_prefix(image, expected):
+    result = remove_image_protocol_prefix(image)
+    assert result == expected, (
+        f"Expected '{expected}' for image '{image}', got '{result}'"
+    )

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import re
 import unittest.mock
+import warnings
 from contextlib import nullcontext as does_not_raise
 from datetime import UTC, datetime, timedelta, timezone
 
@@ -2171,9 +2172,6 @@ def test_set_auth_user_id_works_with_run_spec():
     spec = mlrun.model.RunSpec()
     set_auth_user_id(spec, "user-123")
     assert spec.auth["user_id"] == "user-123"
-
-
-import warnings
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description

Fix 4 independent bugs across the MLRun codebase - reversed checks, duplicate entries, wrong attribute references, and operator precedence issues. Each fix includes a dedicated unit test that verifies the bug existed and is now resolved.

---

### 🛠️ Changes Made

- **[Utils]** Fixed reversed substring check in `warn_on_deprecated_image` — `image in deprecated_image` was backwards, so tagged/registry-prefixed images (e.g. `mlrun/ml-base:v1.11.0`) silently skipped the deprecation warning.
- **[Utils]** Fixed duplicate `"https://"` entry in `remove_image_protocol_prefix` prefixes list — `"http://"` was missing, so `http://`-prefixed images were never cleaned.
- **[Config]** Fixed `Config.keys()` and `Config.values()` referencing `self.data` (nonexistent) instead of `self._cfg`, causing `AttributeError` on every call.
- **[Artifacts]** Fixed operator precedence bug in `DatasetArtifact.update_preview_fields_from_df` where `ignore_preview_limits=True` could override an explicit `stats=False`, computing statistics despite the user's opt-out.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Added unit tests for all 4 bug fixes:
  - `tests/utils/test_helpers.py` — 9 parametrized cases for `warn_on_deprecated_image`, 4 cases for `remove_image_protocol_prefix`
  - `tests/test_config.py` — `test_config_keys_and_values` verifying `keys()`, `values()`, `items()`, and `__iter__` consistency
  - `tests/artifacts/test_dataset.py` — `test_dataset_stats_with_ignore_preview_limits` covering `stats=False`/`None`/`True` with `ignore_preview_limits`
- Each regression test was verified to fail with the old code and pass with the fix.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

All fixes are minimal and isolated — each is a 1-3 line code change targeting a specific logic error. No behavioral changes beyond correcting the bugs.
