### PR TITLE
[Serving] Fix API handler system tests

### DIFF
--- a/tests/system/runtimes/assets/body_map_handler.py
+++ b/tests/system/runtimes/assets/body_map_handler.py
@@ -12,7 +12,9 @@
 # limitations under the License.
 
 
-def process_mapped_data(user_name: str, user_email: str, book_titles: list) -> dict:
+def process_mapped_data(
+    body, user_name: str, user_email: str, book_titles: list
+) -> dict:
     """Handler that receives mapped parameters from body_map."""
     return {
         "name": user_name,

--- a/tests/system/runtimes/assets/path_query_handler.py
+++ b/tests/system/runtimes/assets/path_query_handler.py
@@ -13,7 +13,11 @@
 
 
 def process_path_and_query_params(
-    category: str, item_id: str, tags: list | None = None, limit: str | None = None
+    body,
+    category: str,
+    item_id: str,
+    tags: list | None = None,
+    limit: str | None = None,
 ) -> dict:
     """Handler that receives path parameters and query parameters.
 

--- a/tests/system/runtimes/assets/wildcard_path_handler.py
+++ b/tests/system/runtimes/assets/wildcard_path_handler.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-def handle_wildcard(mlrun_request_path: str | None = None, **kwargs) -> dict:
+def handle_wildcard(body, mlrun_request_path: str | None = None, **kwargs) -> dict:
     """Handler that receives mlrun_request_path injected by the API handler.
 
     Used by system tests to verify that:


### PR DESCRIPTION
Following #9517.

The fix is to add the first positional argument `body` to all the handlers.

I ran all the API handler system tests
```
pytest -s "tests/system/runtimes/test_serving.py::TestServingAPIHandler"
```
And they passed: `6 passed in 632.42s (0:10:32)`.

Fixes [ML-12405](https://iguazio.atlassian.net/browse/ML-12405).

[ML-12405]: https://iguazio.atlassian.net/browse/ML-12405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ