### PR TITLE
fix: replace bare except with except Exception (PEP 8 E722)

### DIFF
--- a/mlrun/datastore/model_provider/openai_provider.py
+++ b/mlrun/datastore/model_provider/openai_provider.py
@@ -332,7 +332,7 @@ class OpenAIProvider(ModelProvider):
         try:
             # gather() stops on first exception - fast fail
             return await asyncio.gather(*tasks)
-        except:
+        except Exception:
             # Cancel all remaining tasks
             for task in tasks:
                 task.cancel()


### PR DESCRIPTION
## Summary

Replace bare `except:` clause with `except Exception:` in `mlrun/datastore/model_provider/openai_provider.py` (line 335).

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which can mask critical errors and make debugging harder. Using `except Exception:` is the PEP 8 recommended practice (E722) and preserves the ability to interrupt the program.

**Change:**
```python
# Before
except:
    ...

# After
except Exception:
    ...
```

## Testing
No behavior change for normal exception handling — this is a correctness/style fix that only affects the handling of `BaseException` subclasses like `KeyboardInterrupt`.