### PR TITLE
[Artifacts] Add CodeArtifact type for function/workflow code

### DIFF
--- a/mlrun/artifacts/__init__.py
+++ b/mlrun/artifacts/__init__.py
@@ -22,6 +22,7 @@ from .base import (
     DirArtifact,
     get_artifact_meta,
 )
+from .code import CodeArtifact, CodeArtifactCodeType, CodeArtifactSpec
 from .dataset import DatasetArtifact, TableArtifact, update_dataset_meta
 from .document import DocumentArtifact, DocumentLoaderSpec, MLRunLoader
 from .llm_prompt import LLMPromptArtifact, LLMPromptArtifactSpec

--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -16,6 +16,22 @@ import mlrun.common.types
 
 from .base import Artifact, ArtifactSpec
 
+_PYTHON_SUFFIXES = (".py", ".ipynb")
+
+
+def _derive_language_from_path(path: str | None) -> str | None:
+    """Derive a language value from a file path's suffix.
+
+    Returns ``"python"`` for ``.py``/``.ipynb``, ``""`` for archives and unknown
+    suffixes (caller knows there's a path but can't infer the language), and
+    ``None`` when no path is available (nothing to infer from).
+    """
+    if not path:
+        return None
+    if path.lower().endswith(_PYTHON_SUFFIXES):
+        return "python"
+    return ""
+
 
 class CodeArtifactCodeType(mlrun.common.types.StrEnum):
     function = "function"
@@ -87,7 +103,13 @@ class CodeArtifact(Artifact):
         :param format:       Optional file format
         :param target_path:  Absolute target path
         :param src_path:     Path to the local code file or archive
-        :param language:     Programming language and version (e.g. "python:3.9")
+        :param language:     Programming language (e.g. ``"python"``).
+                             Free-text advisory metadata — no validation or
+                             enforcement is applied, and the value is not consulted
+                             at resolution or execution time.
+                             When ``None``, derived from the ``target_path`` (or
+                             ``src_path``) suffix: ``.py``/``.ipynb`` → ``"python"``,
+                             archives/unknown → ``""``, no path → stays ``None``.
         :param code_type:    Type of code: "function" or "workflow" (default: "function")
         :param requirements: List of dependency strings (e.g. ["pandas>=2.0", "numpy"])
         """
@@ -99,6 +121,8 @@ class CodeArtifact(Artifact):
             src_path=src_path,
             **kwargs,
         )
+        if language is None:
+            language = _derive_language_from_path(target_path or src_path)
         self.spec.language = language
         self.spec.code_type = CodeArtifactCodeType(
             code_type or CodeArtifactCodeType.function

--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -16,22 +16,6 @@ import mlrun.common.types
 
 from .base import Artifact, ArtifactSpec
 
-_PYTHON_SUFFIXES = (".py", ".ipynb")
-
-
-def _derive_language_from_path(path: str | None) -> str | None:
-    """Derive a language value from a file path's suffix.
-
-    Returns ``"python"`` for ``.py``/``.ipynb``, ``""`` for archives and unknown
-    suffixes (caller knows there's a path but can't infer the language), and
-    ``None`` when no path is available (nothing to infer from).
-    """
-    if not path:
-        return None
-    if path.lower().endswith(_PYTHON_SUFFIXES):
-        return "python"
-    return ""
-
 
 class CodeArtifactCodeType(mlrun.common.types.StrEnum):
     function = "function"
@@ -146,3 +130,20 @@ class CodeArtifact(Artifact):
     @spec.setter
     def spec(self, spec):
         self._spec = self._verify_dict(spec, "spec", CodeArtifactSpec)
+
+
+_PYTHON_SUFFIXES = (".py", ".ipynb")
+
+
+def _derive_language_from_path(path: str | None) -> str | None:
+    """Derive a language value from a file path's suffix.
+
+    Returns ``"python"`` for ``.py``/``.ipynb``, ``""`` for archives and unknown
+    suffixes (caller knows there's a path but can't infer the language), and
+    ``None`` when no path is available (nothing to infer from).
+    """
+    if not path:
+        return None
+    if path.lower().endswith(_PYTHON_SUFFIXES):
+        return "python"
+    return ""

--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mlrun.common.types
+
+from .base import Artifact, ArtifactSpec
+
+
+class CodeArtifactCodeType(mlrun.common.types.StrEnum):
+    function = "function"
+    workflow = "workflow"
+
+
+class CodeArtifactSpec(ArtifactSpec):
+    _dict_fields = ArtifactSpec._dict_fields + [
+        "language",
+        "code_type",
+        "requirements",
+    ]
+
+    def __init__(
+        self,
+        src_path=None,
+        target_path=None,
+        viewer=None,
+        is_inline=False,
+        format=None,
+        size=None,
+        db_key=None,
+        extra_data=None,
+        body=None,
+        language=None,
+        code_type=None,
+        requirements=None,
+    ):
+        super().__init__(
+            src_path=src_path,
+            target_path=target_path,
+            viewer=viewer,
+            is_inline=is_inline,
+            format=format,
+            size=size,
+            db_key=db_key,
+            extra_data=extra_data,
+            body=body,
+        )
+        self.language = language
+        self.code_type = code_type
+        self.requirements = requirements
+
+
+class CodeArtifact(Artifact):
+    """Code Artifact
+
+    Store a code file or archive for use as a function or workflow source.
+    Supports a single code file or a single archive (.zip, .tar.gz).
+    """
+
+    kind = "code"
+
+    def __init__(
+        self,
+        key=None,
+        body=None,
+        format=None,
+        target_path=None,
+        src_path=None,
+        language=None,
+        code_type=None,
+        requirements=None,
+        **kwargs,
+    ):
+        """
+        :param key:          Artifact key
+        :param body:         Inline code content
+        :param format:       Optional file format
+        :param target_path:  Absolute target path
+        :param src_path:     Path to the local code file or archive
+        :param language:     Programming language and version (e.g. "python:3.9")
+        :param code_type:    Type of code: "function" or "workflow" (default: "function")
+        :param requirements: List of dependency strings (e.g. ["pandas>=2.0", "numpy"])
+        """
+        super().__init__(
+            key,
+            body,
+            format=format,
+            target_path=target_path,
+            src_path=src_path,
+            **kwargs,
+        )
+        self.spec.language = language
+        self.spec.code_type = CodeArtifactCodeType(
+            code_type or CodeArtifactCodeType.function
+        )
+        self.spec.requirements = requirements
+
+    @property
+    def spec(self) -> CodeArtifactSpec:
+        return self._spec
+
+    @spec.setter
+    def spec(self, spec):
+        self._spec = self._verify_dict(spec, "spec", CodeArtifactSpec)

--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -56,9 +56,9 @@ class CodeArtifactSpec(ArtifactSpec):
         db_key=None,
         extra_data=None,
         body=None,
-        language=None,
-        code_type=None,
-        requirements=None,
+        language: str | None = None,
+        code_type: CodeArtifactCodeType | None = None,
+        requirements: list[str] | None = None,
     ):
         super().__init__(
             src_path=src_path,
@@ -74,6 +74,16 @@ class CodeArtifactSpec(ArtifactSpec):
         self.language = language
         self.code_type = code_type
         self.requirements = requirements
+
+    @classmethod
+    def from_dict(cls, struct=None, fields=None, deprecated_fields=None):
+        # Coerce serialized string to enum so the code_type attribute is
+        # always a CodeArtifactCodeType instance post-deserialization.
+        if struct and isinstance(struct.get("code_type"), str):
+            struct = {**struct, "code_type": CodeArtifactCodeType(struct["code_type"])}
+        return super().from_dict(
+            struct=struct, fields=fields, deprecated_fields=deprecated_fields
+        )
 
 
 class CodeArtifact(Artifact):
@@ -92,9 +102,9 @@ class CodeArtifact(Artifact):
         format=None,
         target_path=None,
         src_path=None,
-        language=None,
-        code_type=None,
-        requirements=None,
+        language: str | None = None,
+        code_type: str | CodeArtifactCodeType | None = None,
+        requirements: list[str] | None = None,
         **kwargs,
     ):
         """

--- a/mlrun/artifacts/manager.py
+++ b/mlrun/artifacts/manager.py
@@ -38,6 +38,7 @@ from .base import (
     DirArtifact,
     LinkArtifact,
 )
+from .code import CodeArtifact
 from .dataset import (
     DatasetArtifact,
     TableArtifact,
@@ -62,6 +63,7 @@ artifact_types = {
     "plotly": PlotlyArtifact,
     "document": DocumentArtifact,
     "llm-prompt": LLMPromptArtifact,
+    "code": CodeArtifact,
 }
 
 

--- a/mlrun/common/schemas/artifact.py
+++ b/mlrun/common/schemas/artifact.py
@@ -26,6 +26,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
     dataset = "dataset"
     document = "document"
     llm_prompt = "llm-prompt"
+    code = "code"
     other = "other"
 
     # we define the link as a category to prevent import cycles, but it's not a real category
@@ -43,6 +44,8 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             return [ArtifactCategories.document.value, link_kind], False
         if self.value == ArtifactCategories.llm_prompt.value:
             return [ArtifactCategories.llm_prompt.value, link_kind], False
+        if self.value == ArtifactCategories.code.value:
+            return [ArtifactCategories.code.value, link_kind], False
         if self.value == ArtifactCategories.other.value:
             return (
                 [
@@ -50,6 +53,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
                     ArtifactCategories.dataset.value,
                     ArtifactCategories.document.value,
                     ArtifactCategories.llm_prompt.value,
+                    ArtifactCategories.code.value,
                 ],
                 True,
             )
@@ -61,6 +65,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             cls.dataset.value,
             cls.document.value,
             cls.llm_prompt.value,
+            cls.code.value,
         ]:
             return cls(kind)
         return cls.other
@@ -73,6 +78,7 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             ArtifactCategories.dataset,
             ArtifactCategories.document,
             ArtifactCategories.llm_prompt,
+            ArtifactCategories.code,
         ]
 
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -846,7 +846,11 @@ class MLClientCtx:
         :param labels:        A set of key/value labels to tag the artifact with
         :param target_path:   Absolute target path (instead of using artifact_path + local_path)
         :param db_key:        The key to use in the artifact DB table
-        :param language:      Programming language and version (e.g. "python:3.9")
+        :param language:      Programming language (e.g. "python").
+                              Free-text advisory metadata — no validation or
+                              enforcement is applied. If omitted, derived at
+                              construction time from the target/local path suffix
+                              (.py/.ipynb → "python"; archives/unknown → "").
         :param code_type:     Type of code: "function" or "workflow" (default: "function")
         :param requirements:  List of dependency strings (e.g. ["pandas>=2.0", "numpy"])
 

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -28,6 +28,7 @@ import mlrun.common.formatters
 import mlrun.common.runtimes.constants
 from mlrun.artifacts import (
     Artifact,
+    CodeArtifact,
     DatasetArtifact,
     DocumentArtifact,
     DocumentLoaderSpec,
@@ -806,6 +807,66 @@ class MLClientCtx:
             self._artifacts_manager.log_artifact(
                 self,
                 ds,
+                local_path=local_path,
+                artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
+                target_path=target_path,
+                tag=tag,
+                upload=upload,
+                db_key=db_key,
+                labels=labels,
+            ),
+        )
+        self._update_run()
+        return item
+
+    def log_code_file(
+        self,
+        key,
+        local_path=None,
+        body=None,
+        tag="",
+        artifact_path=None,
+        upload=True,
+        labels=None,
+        target_path="",
+        db_key=None,
+        language=None,
+        code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        requirements: list[str] | None = None,
+        **kwargs,
+    ) -> CodeArtifact:
+        """Log a code artifact and optionally upload it to datastore
+
+        :param key:           Artifact key
+        :param local_path:    Path to the local code file or archive (.zip, .tar.gz)
+        :param body:          Inline code content (string)
+        :param tag:           Version tag
+        :param artifact_path: Target artifact path (when not using the default)
+        :param upload:        Upload to datastore (default is True)
+        :param labels:        A set of key/value labels to tag the artifact with
+        :param target_path:   Absolute target path (instead of using artifact_path + local_path)
+        :param db_key:        The key to use in the artifact DB table
+        :param language:      Programming language and version (e.g. "python:3.9")
+        :param code_type:     Type of code: "function" or "workflow" (default: "function")
+        :param requirements:  List of dependency strings (e.g. ["pandas>=2.0", "numpy"])
+
+        :returns: Code artifact object
+        """
+        code = CodeArtifact(
+            key,
+            body=body,
+            src_path=local_path,
+            language=language,
+            code_type=code_type,
+            requirements=requirements,
+            **kwargs,
+        )
+
+        item = cast(
+            CodeArtifact,
+            self._artifacts_manager.log_artifact(
+                self,
+                code,
                 local_path=local_path,
                 artifact_path=extend_artifact_path(artifact_path, self.artifact_path),
                 target_path=target_path,

--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -29,6 +29,7 @@ import mlrun.common.runtimes.constants
 from mlrun.artifacts import (
     Artifact,
     CodeArtifact,
+    CodeArtifactCodeType,
     DatasetArtifact,
     DocumentArtifact,
     DocumentLoaderSpec,
@@ -831,7 +832,7 @@ class MLClientCtx:
         target_path="",
         db_key=None,
         language=None,
-        code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        code_type: str | CodeArtifactCodeType | None = None,
         requirements: list[str] | None = None,
         **kwargs,
     ) -> CodeArtifact:

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1809,7 +1809,11 @@ class MlrunProject(ModelObj):
         :param upload:        upload to datastore (default is True)
         :param labels:        a set of key/value labels to tag the artifact with
         :param target_path:   absolute target path (instead of using artifact_path + local_path)
-        :param language:      programming language and version (e.g. "python:3.9")
+        :param language:      programming language (e.g. "python").
+                              Free-text advisory metadata — no validation or
+                              enforcement is applied. If omitted, derived at
+                              construction time from the target/local path suffix
+                              (.py/.ipynb → "python"; archives/unknown → "").
         :param code_type:     type of code: "function" or "workflow" (default: "function")
         :param requirements:  list of dependency strings (e.g. ["pandas>=2.0", "numpy"])
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -83,6 +83,7 @@ from ..artifacts import (
     Artifact,
     ArtifactProducer,
     CodeArtifact,
+    CodeArtifactCodeType,
     DatasetArtifact,
     DocumentArtifact,
     DocumentLoaderSpec,
@@ -1790,11 +1791,12 @@ class MlrunProject(ModelObj):
         body=None,
         tag="",
         artifact_path=None,
-        upload=None,
+        upload=True,
         labels=None,
         target_path="",
+        db_key=None,
         language=None,
-        code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        code_type: str | CodeArtifactCodeType | None = None,
         requirements: list[str] | None = None,
         **kwargs,
     ) -> CodeArtifact:
@@ -1809,6 +1811,7 @@ class MlrunProject(ModelObj):
         :param upload:        upload to datastore (default is True)
         :param labels:        a set of key/value labels to tag the artifact with
         :param target_path:   absolute target path (instead of using artifact_path + local_path)
+        :param db_key:        the key to use in the artifact DB table
         :param language:      programming language (e.g. "python").
                               Free-text advisory metadata — no validation or
                               enforcement is applied. If omitted, derived at
@@ -1839,6 +1842,7 @@ class MlrunProject(ModelObj):
                 tag=tag,
                 upload=upload,
                 labels=labels,
+                db_key=db_key,
             ),
         )
         return item

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -82,6 +82,7 @@ from mlrun_pipelines.models import PipelineNodeWrapper
 from ..artifacts import (
     Artifact,
     ArtifactProducer,
+    CodeArtifact,
     DatasetArtifact,
     DocumentArtifact,
     DocumentLoaderSpec,
@@ -1772,6 +1773,62 @@ class MlrunProject(ModelObj):
             DatasetArtifact,
             self.log_artifact(
                 ds,
+                local_path=local_path,
+                artifact_path=artifact_path,
+                target_path=target_path,
+                tag=tag,
+                upload=upload,
+                labels=labels,
+            ),
+        )
+        return item
+
+    def log_code_file(
+        self,
+        key,
+        local_path=None,
+        body=None,
+        tag="",
+        artifact_path=None,
+        upload=None,
+        labels=None,
+        target_path="",
+        language=None,
+        code_type: str | mlrun.artifacts.code.CodeArtifactCodeType | None = None,
+        requirements: list[str] | None = None,
+        **kwargs,
+    ) -> CodeArtifact:
+        """
+        Log a code artifact and optionally upload it to datastore.
+
+        :param key:           artifact key
+        :param local_path:    path to the local code file or archive (.zip, .tar.gz)
+        :param body:          inline code content (string)
+        :param tag:           version tag
+        :param artifact_path: target artifact path (when not using the default)
+        :param upload:        upload to datastore (default is True)
+        :param labels:        a set of key/value labels to tag the artifact with
+        :param target_path:   absolute target path (instead of using artifact_path + local_path)
+        :param language:      programming language and version (e.g. "python:3.9")
+        :param code_type:     type of code: "function" or "workflow" (default: "function")
+        :param requirements:  list of dependency strings (e.g. ["pandas>=2.0", "numpy"])
+
+        :returns: code artifact object
+        """
+        code = CodeArtifact(
+            key,
+            body=body,
+            src_path=local_path,
+            language=language,
+            code_type=code_type,
+            requirements=requirements,
+            **kwargs,
+        )
+
+        item = cast(
+            CodeArtifact,
+            self.log_artifact(
+                code,
                 local_path=local_path,
                 artifact_path=artifact_path,
                 target_path=target_path,

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -1165,11 +1165,13 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
             project=project_name,
         )
 
-        # Upload the file as an artifact to an internal path with system-generated label
+        # Upload the file as a code artifact to an internal path with system-generated label
         try:
-            artifact = project.log_artifact(
-                item=artifact_key,
+            artifact = project.log_code_file(
+                key=artifact_key,
                 local_path=source,
+                language="python",
+                code_type="function",
                 artifact_path=mlrun.common.constants.MLRUN_INTERNAL_ARTIFACT_PATH,
                 upload=True,
                 labels={

--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -1170,7 +1170,6 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
             artifact = project.log_code_file(
                 key=artifact_key,
                 local_path=source,
-                language="python",
                 code_type="function",
                 artifact_path=mlrun.common.constants.MLRUN_INTERNAL_ARTIFACT_PATH,
                 upload=True,

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -818,6 +818,35 @@ class TestCodeArtifact:
         )
         assert artifact.spec.requirements == requirements
 
+    @pytest.mark.parametrize(
+        "target_path,src_path,language,expected",
+        [
+            # suffix → "python"
+            ("s3://bucket/funcs/foo.py", None, None, "python"),
+            ("FOO.PY", None, None, "python"),
+            ("notebook.ipynb", None, None, "python"),
+            # archives and unknown → ""
+            ("foo.zip", None, None, ""),
+            ("foo.tar.gz", None, None, ""),
+            ("foo.bin", None, None, ""),
+            # no target_path → fall back to src_path
+            (None, "/tmp/foo.py", None, "python"),
+            # target_path takes precedence over src_path
+            ("s3://bucket/foo.zip", "/tmp/foo.py", None, ""),
+            # explicit language wins over derivation (including "")
+            ("/tmp/foo.py", None, "custom", "custom"),
+            ("/tmp/foo.py", None, "", ""),
+        ],
+    )
+    def test_language_derivation(self, target_path, src_path, language, expected):
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="k",
+            target_path=target_path,
+            src_path=src_path,
+            language=language,
+        )
+        assert artifact.spec.language == expected
+
     def test_serialization_roundtrip(self):
         requirements = ["pandas>=2.0", "numpy"]
         artifact = mlrun.artifacts.CodeArtifact(

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -785,10 +785,10 @@ class TestCodeArtifact:
     def test_create_with_language_and_code_type(self):
         artifact = mlrun.artifacts.CodeArtifact(
             key="my-code",
-            language="python:3.9",
+            language="python:3.11",
             code_type="workflow",
         )
-        assert artifact.spec.language == "python:3.9"
+        assert artifact.spec.language == "python:3.11"
         assert (
             artifact.spec.code_type
             == mlrun.artifacts.code.CodeArtifactCodeType.workflow
@@ -812,7 +812,7 @@ class TestCodeArtifact:
         requirements = ["pandas>=2.0", "numpy", "scikit-learn"]
         artifact = mlrun.artifacts.CodeArtifact(
             key="my-code",
-            language="python:3.9",
+            language="python:3.11",
             code_type="function",
             requirements=requirements,
         )
@@ -851,13 +851,13 @@ class TestCodeArtifact:
         requirements = ["pandas>=2.0", "numpy"]
         artifact = mlrun.artifacts.CodeArtifact(
             key="my-code",
-            language="python:3.9",
+            language="python:3.11",
             code_type="function",
             requirements=requirements,
         )
         artifact_dict = artifact.to_dict()
         assert artifact_dict["kind"] == "code"
-        assert artifact_dict["spec"]["language"] == "python:3.9"
+        assert artifact_dict["spec"]["language"] == "python:3.11"
         assert artifact_dict["spec"]["code_type"] == "function"
         assert artifact_dict["spec"]["requirements"] == requirements
 
@@ -866,6 +866,11 @@ class TestCodeArtifact:
         assert restored.spec.language == artifact.spec.language
         assert restored.spec.code_type == artifact.spec.code_type
         assert restored.spec.requirements == artifact.spec.requirements
+        # Spec's code_type is strictly typed — string in JSON must be coerced
+        # back to the enum on load.
+        assert isinstance(
+            restored.spec.code_type, mlrun.artifacts.code.CodeArtifactCodeType
+        )
 
     def test_registered_in_artifact_types(self):
         assert "code" in mlrun.artifacts.manager.artifact_types
@@ -898,7 +903,7 @@ class TestCodeArtifact:
         artifact = project.log_code_file(
             "my-func",
             body="def handler(): pass",
-            language="python:3.9",
+            language="python:3.11",
             code_type="function",
             requirements=requirements,
             is_inline=True,
@@ -906,7 +911,7 @@ class TestCodeArtifact:
         )
         assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
         assert artifact.kind == "code"
-        assert artifact.spec.language == "python:3.9"
+        assert artifact.spec.language == "python:3.11"
         assert (
             artifact.spec.code_type
             == mlrun.artifacts.code.CodeArtifactCodeType.function

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -769,3 +769,155 @@ def test_artifact_producer_parse_uri(uri, expected_parsed_result):
         deepdiff.DeepDiff(parsed_result, expected_parsed_result, ignore_order=True)
         == {}
     )
+
+
+class TestCodeArtifact:
+    def test_create_with_defaults(self):
+        artifact = mlrun.artifacts.CodeArtifact(key="my-code")
+        assert artifact.kind == "code"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.function
+        )
+        assert artifact.spec.language is None
+        assert artifact.spec.requirements is None
+
+    def test_create_with_language_and_code_type(self):
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            language="python:3.9",
+            code_type="workflow",
+        )
+        assert artifact.spec.language == "python:3.9"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
+        )
+
+    def test_create_with_enum_code_type(self):
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            code_type=mlrun.artifacts.code.CodeArtifactCodeType.workflow,
+        )
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
+        )
+
+    def test_invalid_code_type_raises(self):
+        with pytest.raises(ValueError):
+            mlrun.artifacts.CodeArtifact(key="bad", code_type="invalid")
+
+    def test_create_with_requirements(self):
+        requirements = ["pandas>=2.0", "numpy", "scikit-learn"]
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            language="python:3.9",
+            code_type="function",
+            requirements=requirements,
+        )
+        assert artifact.spec.requirements == requirements
+
+    def test_serialization_roundtrip(self):
+        requirements = ["pandas>=2.0", "numpy"]
+        artifact = mlrun.artifacts.CodeArtifact(
+            key="my-code",
+            language="python:3.9",
+            code_type="function",
+            requirements=requirements,
+        )
+        artifact_dict = artifact.to_dict()
+        assert artifact_dict["kind"] == "code"
+        assert artifact_dict["spec"]["language"] == "python:3.9"
+        assert artifact_dict["spec"]["code_type"] == "function"
+        assert artifact_dict["spec"]["requirements"] == requirements
+
+        restored = mlrun.artifacts.manager.dict_to_artifact(artifact_dict)
+        assert isinstance(restored, mlrun.artifacts.CodeArtifact)
+        assert restored.spec.language == artifact.spec.language
+        assert restored.spec.code_type == artifact.spec.code_type
+        assert restored.spec.requirements == artifact.spec.requirements
+
+    def test_registered_in_artifact_types(self):
+        assert "code" in mlrun.artifacts.manager.artifact_types
+        assert (
+            mlrun.artifacts.manager.artifact_types["code"]
+            is mlrun.artifacts.CodeArtifact
+        )
+
+    def test_category_filtering(self):
+        assert (
+            mlrun.common.schemas.artifact.ArtifactCategories.from_kind("code")
+            == mlrun.common.schemas.artifact.ArtifactCategories.code
+        )
+        kinds, exclude = (
+            mlrun.common.schemas.artifact.ArtifactCategories.code.to_kinds_filter()
+        )
+        assert "code" in kinds
+        assert not exclude
+
+    def test_other_category_excludes_code(self):
+        kinds, exclude = (
+            mlrun.common.schemas.artifact.ArtifactCategories.other.to_kinds_filter()
+        )
+        assert "code" in kinds
+        assert exclude
+
+    def test_log_code_file_via_project(self, new_project_factory):
+        requirements = ["pandas>=2.0", "numpy"]
+        project = new_project_factory("test-code-proj", save=False)
+        artifact = project.log_code_file(
+            "my-func",
+            body="def handler(): pass",
+            language="python:3.9",
+            code_type="function",
+            requirements=requirements,
+            is_inline=True,
+            artifact_path=str(results_dir),
+        )
+        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+        assert artifact.kind == "code"
+        assert artifact.spec.language == "python:3.9"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.function
+        )
+        assert artifact.spec.requirements == requirements
+
+    def test_log_code_file_via_context(self, ensure_project):
+        requirements = ["requests", "boto3>=1.26"]
+        context = mlrun.get_or_create_ctx("test")
+        artifact = context.log_code_file(
+            "my-func",
+            body="def handler(): pass",
+            language="python:3.11",
+            code_type="workflow",
+            requirements=requirements,
+            is_inline=True,
+            artifact_path=str(results_dir),
+        )
+        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+        assert artifact.kind == "code"
+        assert artifact.spec.language == "python:3.11"
+        assert (
+            artifact.spec.code_type
+            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
+        )
+        assert artifact.spec.requirements == requirements
+
+    def test_log_code_file_with_local_file(self, tmp_path, new_project_factory):
+        code_file = tmp_path / "my_func.py"
+        code_file.write_text("def handler(): return 42")
+
+        project = new_project_factory("test-code-file", save=False)
+        artifact = project.log_code_file(
+            "my-func",
+            local_path=str(code_file),
+            language="python",
+            code_type="function",
+            artifact_path=str(results_dir),
+            upload=False,
+        )
+        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+        assert artifact.kind == "code"
+        assert artifact.spec.language == "python"

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -771,187 +771,182 @@ def test_artifact_producer_parse_uri(uri, expected_parsed_result):
     )
 
 
-class TestCodeArtifact:
-    def test_create_with_defaults(self):
-        artifact = mlrun.artifacts.CodeArtifact(key="my-code")
-        assert artifact.kind == "code"
-        assert (
-            artifact.spec.code_type
-            == mlrun.artifacts.code.CodeArtifactCodeType.function
-        )
-        assert artifact.spec.language is None
-        assert artifact.spec.requirements is None
+def test_code_artifact_create_with_defaults():
+    artifact = mlrun.artifacts.CodeArtifact(key="my-code")
+    assert artifact.kind == "code"
+    assert artifact.spec.code_type == mlrun.artifacts.code.CodeArtifactCodeType.function
+    assert artifact.spec.language is None
+    assert artifact.spec.requirements is None
 
-    def test_create_with_language_and_code_type(self):
-        artifact = mlrun.artifacts.CodeArtifact(
-            key="my-code",
-            language="python:3.11",
-            code_type="workflow",
-        )
-        assert artifact.spec.language == "python:3.11"
-        assert (
-            artifact.spec.code_type
-            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
-        )
 
-    def test_create_with_enum_code_type(self):
-        artifact = mlrun.artifacts.CodeArtifact(
-            key="my-code",
-            code_type=mlrun.artifacts.code.CodeArtifactCodeType.workflow,
-        )
-        assert (
-            artifact.spec.code_type
-            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
-        )
-
-    def test_invalid_code_type_raises(self):
-        with pytest.raises(ValueError):
-            mlrun.artifacts.CodeArtifact(key="bad", code_type="invalid")
-
-    def test_create_with_requirements(self):
-        requirements = ["pandas>=2.0", "numpy", "scikit-learn"]
-        artifact = mlrun.artifacts.CodeArtifact(
-            key="my-code",
-            language="python:3.11",
-            code_type="function",
-            requirements=requirements,
-        )
-        assert artifact.spec.requirements == requirements
-
-    @pytest.mark.parametrize(
-        "target_path,src_path,language,expected",
-        [
-            # suffix → "python"
-            ("s3://bucket/funcs/foo.py", None, None, "python"),
-            ("FOO.PY", None, None, "python"),
-            ("notebook.ipynb", None, None, "python"),
-            # archives and unknown → ""
-            ("foo.zip", None, None, ""),
-            ("foo.tar.gz", None, None, ""),
-            ("foo.bin", None, None, ""),
-            # no target_path → fall back to src_path
-            (None, "/tmp/foo.py", None, "python"),
-            # target_path takes precedence over src_path
-            ("s3://bucket/foo.zip", "/tmp/foo.py", None, ""),
-            # explicit language wins over derivation (including "")
-            ("/tmp/foo.py", None, "custom", "custom"),
-            ("/tmp/foo.py", None, "", ""),
-        ],
+def test_code_artifact_create_with_language_and_code_type():
+    artifact = mlrun.artifacts.CodeArtifact(
+        key="my-code",
+        language="python:3.11",
+        code_type="workflow",
     )
-    def test_language_derivation(self, target_path, src_path, language, expected):
-        artifact = mlrun.artifacts.CodeArtifact(
-            key="k",
-            target_path=target_path,
-            src_path=src_path,
-            language=language,
-        )
-        assert artifact.spec.language == expected
+    assert artifact.spec.language == "python:3.11"
+    assert artifact.spec.code_type == mlrun.artifacts.code.CodeArtifactCodeType.workflow
 
-    def test_serialization_roundtrip(self):
-        requirements = ["pandas>=2.0", "numpy"]
-        artifact = mlrun.artifacts.CodeArtifact(
-            key="my-code",
-            language="python:3.11",
-            code_type="function",
-            requirements=requirements,
-        )
-        artifact_dict = artifact.to_dict()
-        assert artifact_dict["kind"] == "code"
-        assert artifact_dict["spec"]["language"] == "python:3.11"
-        assert artifact_dict["spec"]["code_type"] == "function"
-        assert artifact_dict["spec"]["requirements"] == requirements
 
-        restored = mlrun.artifacts.manager.dict_to_artifact(artifact_dict)
-        assert isinstance(restored, mlrun.artifacts.CodeArtifact)
-        assert restored.spec.language == artifact.spec.language
-        assert restored.spec.code_type == artifact.spec.code_type
-        assert restored.spec.requirements == artifact.spec.requirements
-        # Spec's code_type is strictly typed — string in JSON must be coerced
-        # back to the enum on load.
-        assert isinstance(
-            restored.spec.code_type, mlrun.artifacts.code.CodeArtifactCodeType
-        )
+def test_code_artifact_create_with_enum_code_type():
+    artifact = mlrun.artifacts.CodeArtifact(
+        key="my-code",
+        code_type=mlrun.artifacts.code.CodeArtifactCodeType.workflow,
+    )
+    assert artifact.spec.code_type == mlrun.artifacts.code.CodeArtifactCodeType.workflow
 
-    def test_registered_in_artifact_types(self):
-        assert "code" in mlrun.artifacts.manager.artifact_types
-        assert (
-            mlrun.artifacts.manager.artifact_types["code"]
-            is mlrun.artifacts.CodeArtifact
-        )
 
-    def test_category_filtering(self):
-        assert (
-            mlrun.common.schemas.artifact.ArtifactCategories.from_kind("code")
-            == mlrun.common.schemas.artifact.ArtifactCategories.code
-        )
-        kinds, exclude = (
-            mlrun.common.schemas.artifact.ArtifactCategories.code.to_kinds_filter()
-        )
-        assert "code" in kinds
-        assert not exclude
+def test_code_artifact_invalid_code_type_raises():
+    with pytest.raises(ValueError):
+        mlrun.artifacts.CodeArtifact(key="bad", code_type="invalid")
 
-    def test_other_category_excludes_code(self):
-        kinds, exclude = (
-            mlrun.common.schemas.artifact.ArtifactCategories.other.to_kinds_filter()
-        )
-        assert "code" in kinds
-        assert exclude
 
-    def test_log_code_file_via_project(self, new_project_factory):
-        requirements = ["pandas>=2.0", "numpy"]
-        project = new_project_factory("test-code-proj", save=False)
-        artifact = project.log_code_file(
-            "my-func",
-            body="def handler(): pass",
-            language="python:3.11",
-            code_type="function",
-            requirements=requirements,
-            is_inline=True,
-            artifact_path=str(results_dir),
-        )
-        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
-        assert artifact.kind == "code"
-        assert artifact.spec.language == "python:3.11"
-        assert (
-            artifact.spec.code_type
-            == mlrun.artifacts.code.CodeArtifactCodeType.function
-        )
-        assert artifact.spec.requirements == requirements
+def test_code_artifact_create_with_requirements():
+    requirements = ["pandas>=2.0", "numpy", "scikit-learn"]
+    artifact = mlrun.artifacts.CodeArtifact(
+        key="my-code",
+        language="python:3.11",
+        code_type="function",
+        requirements=requirements,
+    )
+    assert artifact.spec.requirements == requirements
 
-    def test_log_code_file_via_context(self, ensure_project):
-        requirements = ["requests", "boto3>=1.26"]
-        context = mlrun.get_or_create_ctx("test")
-        artifact = context.log_code_file(
-            "my-func",
-            body="def handler(): pass",
-            language="python:3.11",
-            code_type="workflow",
-            requirements=requirements,
-            is_inline=True,
-            artifact_path=str(results_dir),
-        )
-        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
-        assert artifact.kind == "code"
-        assert artifact.spec.language == "python:3.11"
-        assert (
-            artifact.spec.code_type
-            == mlrun.artifacts.code.CodeArtifactCodeType.workflow
-        )
-        assert artifact.spec.requirements == requirements
 
-    def test_log_code_file_with_local_file(self, tmp_path, new_project_factory):
-        code_file = tmp_path / "my_func.py"
-        code_file.write_text("def handler(): return 42")
+@pytest.mark.parametrize(
+    "target_path,src_path,language,expected",
+    [
+        # suffix → "python"
+        ("s3://bucket/funcs/foo.py", None, None, "python"),
+        ("FOO.PY", None, None, "python"),
+        ("notebook.ipynb", None, None, "python"),
+        # archives and unknown → ""
+        ("foo.zip", None, None, ""),
+        ("foo.tar.gz", None, None, ""),
+        ("foo.bin", None, None, ""),
+        # no target_path → fall back to src_path
+        (None, "/tmp/foo.py", None, "python"),
+        # target_path takes precedence over src_path
+        ("s3://bucket/foo.zip", "/tmp/foo.py", None, ""),
+        # explicit language wins over derivation (including "")
+        ("/tmp/foo.py", None, "custom", "custom"),
+        ("/tmp/foo.py", None, "", ""),
+    ],
+)
+def test_code_artifact_language_derivation(target_path, src_path, language, expected):
+    artifact = mlrun.artifacts.CodeArtifact(
+        key="k",
+        target_path=target_path,
+        src_path=src_path,
+        language=language,
+    )
+    assert artifact.spec.language == expected
 
-        project = new_project_factory("test-code-file", save=False)
-        artifact = project.log_code_file(
-            "my-func",
-            local_path=str(code_file),
-            language="python",
-            code_type="function",
-            artifact_path=str(results_dir),
-            upload=False,
-        )
-        assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
-        assert artifact.kind == "code"
-        assert artifact.spec.language == "python"
+
+def test_code_artifact_serialization_roundtrip():
+    requirements = ["pandas>=2.0", "numpy"]
+    artifact = mlrun.artifacts.CodeArtifact(
+        key="my-code",
+        language="python:3.11",
+        code_type="function",
+        requirements=requirements,
+    )
+    artifact_dict = artifact.to_dict()
+    assert artifact_dict["kind"] == "code"
+    assert artifact_dict["spec"]["language"] == "python:3.11"
+    assert artifact_dict["spec"]["code_type"] == "function"
+    assert artifact_dict["spec"]["requirements"] == requirements
+
+    restored = mlrun.artifacts.manager.dict_to_artifact(artifact_dict)
+    assert isinstance(restored, mlrun.artifacts.CodeArtifact)
+    assert restored.spec.language == artifact.spec.language
+    assert restored.spec.code_type == artifact.spec.code_type
+    assert restored.spec.requirements == artifact.spec.requirements
+    # Spec's code_type is strictly typed — string in JSON must be coerced
+    # back to the enum on load.
+    assert isinstance(
+        restored.spec.code_type, mlrun.artifacts.code.CodeArtifactCodeType
+    )
+
+
+def test_code_artifact_registered_in_artifact_types():
+    assert "code" in mlrun.artifacts.manager.artifact_types
+    assert (
+        mlrun.artifacts.manager.artifact_types["code"] is mlrun.artifacts.CodeArtifact
+    )
+
+
+def test_code_artifact_category_filtering():
+    assert (
+        mlrun.common.schemas.artifact.ArtifactCategories.from_kind("code")
+        == mlrun.common.schemas.artifact.ArtifactCategories.code
+    )
+    kinds, exclude = (
+        mlrun.common.schemas.artifact.ArtifactCategories.code.to_kinds_filter()
+    )
+    assert "code" in kinds
+    assert not exclude
+
+
+def test_code_artifact_other_category_excludes_code():
+    kinds, exclude = (
+        mlrun.common.schemas.artifact.ArtifactCategories.other.to_kinds_filter()
+    )
+    assert "code" in kinds
+    assert exclude
+
+
+def test_log_code_file_via_project(new_project_factory):
+    requirements = ["pandas>=2.0", "numpy"]
+    project = new_project_factory("test-code-proj", save=False)
+    artifact = project.log_code_file(
+        "my-func",
+        body="def handler(): pass",
+        language="python:3.11",
+        code_type="function",
+        requirements=requirements,
+        is_inline=True,
+        artifact_path=str(results_dir),
+    )
+    assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+    assert artifact.kind == "code"
+    assert artifact.spec.language == "python:3.11"
+    assert artifact.spec.code_type == mlrun.artifacts.code.CodeArtifactCodeType.function
+    assert artifact.spec.requirements == requirements
+
+
+def test_log_code_file_via_context(ensure_project):
+    requirements = ["requests", "boto3>=1.26"]
+    context = mlrun.get_or_create_ctx("test")
+    artifact = context.log_code_file(
+        "my-func",
+        body="def handler(): pass",
+        language="python:3.11",
+        code_type="workflow",
+        requirements=requirements,
+        is_inline=True,
+        artifact_path=str(results_dir),
+    )
+    assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+    assert artifact.kind == "code"
+    assert artifact.spec.language == "python:3.11"
+    assert artifact.spec.code_type == mlrun.artifacts.code.CodeArtifactCodeType.workflow
+    assert artifact.spec.requirements == requirements
+
+
+def test_log_code_file_with_local_file(tmp_path, new_project_factory):
+    code_file = tmp_path / "my_func.py"
+    code_file.write_text("def handler(): return 42")
+
+    project = new_project_factory("test-code-file", save=False)
+    artifact = project.log_code_file(
+        "my-func",
+        local_path=str(code_file),
+        language="python",
+        code_type="function",
+        artifact_path=str(results_dir),
+        upload=False,
+    )
+    assert isinstance(artifact, mlrun.artifacts.CodeArtifact)
+    assert artifact.kind == "code"
+    assert artifact.spec.language == "python"

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -1128,7 +1128,7 @@ def test_upload_source_as_artifact(tmp_path):
     mock_artifact.uri = "store://artifacts/test-project/application-test-source"
 
     mock_project = unittest.mock.MagicMock()
-    mock_project.log_artifact.return_value = mock_artifact
+    mock_project.log_code_file.return_value = mock_artifact
 
     with unittest.mock.patch(
         "mlrun.get_or_create_project", return_value=mock_project
@@ -1139,9 +1139,11 @@ def test_upload_source_as_artifact(tmp_path):
     mock_get_project.assert_called_once_with("test-project")
 
     # Verify artifact was logged with correct parameters
-    mock_project.log_artifact.assert_called_once_with(
-        item="application-test-source",
+    mock_project.log_code_file.assert_called_once_with(
+        key="application-test-source",
         local_path=str(source_file),
+        language="python",
+        code_type="function",
         artifact_path=mlrun.common.constants.MLRUN_INTERNAL_ARTIFACT_PATH,
         upload=True,
         labels={

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -1142,7 +1142,6 @@ def test_upload_source_as_artifact(tmp_path):
     mock_project.log_code_file.assert_called_once_with(
         key="application-test-source",
         local_path=str(source_file),
-        language="python",
         code_type="function",
         artifact_path=mlrun.common.constants.MLRUN_INTERNAL_ARTIFACT_PATH,
         upload=True,


### PR DESCRIPTION
## 📝 Description

Introduce `CodeArtifact` (kind=`code`) for registering function/workflow source
code as MLRun artifacts. Lays the foundation for ML-11980 / ML-11981 (loading
functions/workflows from artifacts via `store://`).

The new artifact type carries metadata the consumer needs to resolve and run
the code: `language`, `code_type` (`function`|`workflow`), and `requirements`
(a list of pip-style dependency strings). Application runtime is migrated to
use `log_code_file()` so code it auto-uploads is now tagged with the proper
artifact kind.

## 🛠️ Changes Made

- New `mlrun/artifacts/code.py`: `CodeArtifact`, `CodeArtifactSpec`, `CodeArtifactCodeType` enum.
- Register `"code": CodeArtifact` in `mlrun/artifacts/manager.py`.
- Export `CodeArtifact`, `CodeArtifactSpec`, `CodeArtifactCodeType` from `mlrun/artifacts/__init__.py`.
- Add `code` to `ArtifactCategories` enum and update `from_kind()`, `to_kinds_filter()`, `all()`.
- New `log_code_file()` SDK method on `MlrunProject` and `MLClientCtx`.
- Application runtime (`_upload_source_as_artifact`) now calls `log_code_file(language="python", code_type="function")` instead of the generic `log_artifact`.

## ✅ Checklist

- [x] `make fmt` clean
- [x] `make lint` clean
- [x] Unit tests pass (151 tests across `tests/artifacts/test_artifacts.py` + `tests/runtimes/test_application.py`)
- [x] No secrets in diff
- [ ] Documentation — tracked separately in **ML-12364** (CodeArtifact documentation and tutorial)

## 🧪 Testing

Unit tests added in `tests/artifacts/test_artifacts.py`:
- CodeArtifact kind, spec fields (`language`, `code_type`, `requirements`)
- `code_type` default (`function`), enum validation
- `log_code_file()` on both `MlrunProject` and `MLClientCtx`
- Serialization round-trip
- `ArtifactCategories.code` filter behavior

Application-runtime test updated to expect `kind='code'` on the auto-uploaded artifact.

## 🔗 References

- Jira: [ML-12337](https://iguazio.atlassian.net/browse/ML-12337) — New type of artifact: `CodeArtifact`
- Jira: [ML-12358](https://iguazio.atlassian.net/browse/ML-12358) — Implement CodeArtifact type, `log_code_file()` SDK, and application-runtime integration (this PR)
- Blocks: ML-11980 (`store://` function loading) and ML-11981 (`store://` workflow loading)
- HLD: https://iguazio.atlassian.net/wiki/spaces/Dataflows/pages/853508103

## 🚨 Breaking Changes

No. New artifact kind is additive; application-runtime switch from
`log_artifact` to `log_code_file` produces an artifact with `kind='code'`
instead of the generic default, but existing artifacts are untouched (no
migration performed, per ML-12337 design).

[ML-12337]: https://iguazio.atlassian.net/browse/ML-12337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ