### PR TITLE
[Tests] Fix flaky TestMonitoringAppFlow::test_app_flow

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -856,16 +856,18 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         self._log_model(with_training_set)
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            executor.submit(
+            infra_future = executor.submit(
                 self._submit_controller_and_deploy_writer,
                 _DefaultDataDriftAppData in self.apps_data,
             )
-            executor.submit(self._set_and_deploy_monitoring_apps)
-            future = executor.submit(
+            monitoring_apps_future = executor.submit(self._set_and_deploy_monitoring_apps)
+            serving_future = executor.submit(
                 self._deploy_model_serving, with_training_set, with_model_runner
             )
 
-        serving_fn = future.result()
+        infra_future.result()
+        monitoring_apps_future.result()
+        serving_fn = serving_future.result()
         self._add_error_alert()
 
         time.sleep(5)

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -855,10 +855,11 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
 
         self._log_model(with_training_set)
 
-        self._submit_controller_and_deploy_writer(
-            deploy_histogram_data_drift_app=_DefaultDataDriftAppData in self.apps_data
-        )
         with concurrent.futures.ThreadPoolExecutor() as executor:
+            executor.submit(
+                self._submit_controller_and_deploy_writer,
+                _DefaultDataDriftAppData in self.apps_data,
+            )
             executor.submit(self._set_and_deploy_monitoring_apps)
             future = executor.submit(
                 self._deploy_model_serving, with_training_set, with_model_runner

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -426,6 +426,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
             base_period=self.app_interval,
             **({} if self.image is None else {"image": self.image}),
             deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
+            wait_for_deployment=True,
         )
 
     def _set_and_deploy_monitoring_apps(self) -> None:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -860,7 +860,9 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
                 self._submit_controller_and_deploy_writer,
                 _DefaultDataDriftAppData in self.apps_data,
             )
-            monitoring_apps_future = executor.submit(self._set_and_deploy_monitoring_apps)
+            monitoring_apps_future = executor.submit(
+                self._set_and_deploy_monitoring_apps
+            )
             serving_future = executor.submit(
                 self._deploy_model_serving, with_training_set, with_model_runner
             )


### PR DESCRIPTION
### 📝 Description
`test_app_flow[True-True]` intermittently fails with `AssertionError: last_request is None`
because monitoring infra functions (stream/controller/writer) were still being deployed in the background
while inference was already running, causing events to be silently dropped.

---

### 🛠️ Changes Made
- Add `wait_for_deployment=True` to `enable_model_monitoring` in `_submit_controller_and_deploy_writer`
  so MM infra is fully up before inference starts.
- Move `_submit_controller_and_deploy_writer` into the `ThreadPoolExecutor` alongside
  `_set_and_deploy_monitoring_apps` and `_deploy_model_serving`, so all three deploy
  concurrently instead of sequentially, keeping setup time low.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
Test-only change. The fix addresses a race condition observed in CI run
[24426761963](https://github.com/mlrun/mlrun/actions/runs/24426761963).

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?
- [x] No

---

### 🔍️ Additional Notes
Most other tests in the same file already pass `wait_for_deployment=True` — this aligns
`_submit_controller_and_deploy_writer` with that pattern.