### PR TITLE
[Invoke] Set verify to false when http verify is disabled

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1137,6 +1137,8 @@ class RemoteRuntime(KubeResource):
             logger.debug("Invoking function", method=method, path=path)
             if not getattr(self, "_http_session", None):
                 self._http_session = requests.Session()
+            if mlconf.httpdb.http.verify is False:
+                http_client_kwargs.setdefault("verify", False)
             resp = self._http_session.request(
                 method, path, headers=headers, **http_client_kwargs
             )


### PR DESCRIPTION
### 📝 Description
set verify=False when invoking functions when `mlconf.httpdb.http.verify` is False (for system tests mostly)

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<img width="1187" height="379" alt="image" src="https://github.com/user-attachments/assets/d969930b-c036-449b-845c-6bd62e57de56" />

---

### 🔗 References
- Ticket link:N/A
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
