### PR TITLE
[Serving] Block incoming events during drain

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -1013,7 +1013,11 @@ def _set_callbacks(server, context):
             "Setting drain callback to terminate and restart the graph on a drain event (such as rebalancing)"
         )
 
+        context.drain_complete = asyncio.Event()
+        context.drain_complete.set()
+
         async def drain_callback():
+            context.drain_complete.clear()
             context.logger.info("Drain callback called")
             maybe_coroutine = server.wait_for_completion()
             if asyncio.iscoroutine(maybe_coroutine):
@@ -1021,9 +1025,9 @@ def _set_callbacks(server, context):
             context.logger.info(
                 "Termination of async flow is completed. Rerunning async flow."
             )
-            # Rerun the flow without reconstructing it
             server.graph._run_async_flow()
             context.logger.info("Async flow restarted")
+            context.drain_complete.set()
 
         context.platform.set_drain_callback(drain_callback)
 
@@ -1213,6 +1217,7 @@ class GraphContext:
         self.stream = None
         self.root = None
         self.executor: storey.flow.RunnableExecutor | None = None
+        self.drain_complete: asyncio.Event | None = None
 
         if nuclio_context:
             self.logger: NuclioLogger = nuclio_context.logger

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -3156,6 +3156,17 @@ class FlowStep(BaseStep):
         await awaitable
         return {"id": event.id}
 
+    async def _await_drain_and_return_id(self, awaitable, event):
+        drain_complete = self.context.drain_complete
+        if drain_complete is not None and not drain_complete.is_set():
+            self.context.logger.warning(
+                "Event received during drain, waiting for flow restart"
+            )
+            await drain_complete.wait()
+            awaitable = self._controller.emit(event)
+        await awaitable
+        return {"id": event.id}
+
     def run(self, event, *args, **kwargs):
         if self._controller:
             # async flow (using storey)
@@ -3172,7 +3183,7 @@ class FlowStep(BaseStep):
                 )
                 if self._wait_for_result:
                     return resp_awaitable
-                return self._await_and_return_id(resp_awaitable, event)
+                return self._await_drain_and_return_id(resp_awaitable, event)
             event = copy(event)
             event.body = {"id": event.id}
             return event

--- a/tests/serving/test_async_flow.py
+++ b/tests/serving/test_async_flow.py
@@ -1778,3 +1778,115 @@ async def test_async_graph_no_responder_json_serializable():
         assert "id" in response, f"Expected 'id' key in response: {response}"
     finally:
         server.wait_for_completion()
+
+
+class _SlowTerminationStep(storey.Flow):
+    """A Storey step that takes a configurable time to terminate.
+
+    Used to simulate slow ParquetTarget flushes during drain.
+    """
+
+    def __init__(self, termination_delay: float = 0, **kwargs):
+        super().__init__(**kwargs)
+        self._termination_delay = termination_delay
+
+    async def _do(self, event):
+        if event is storey.flow._termination_obj:
+            await asyncio.sleep(self._termination_delay)
+            return await self._do_downstream(event)
+        return await self._do_downstream(event)
+
+
+@pytest.mark.asyncio
+async def test_event_during_drain_waits_for_flow_restart():
+    """Test that events arriving during drain block until the flow restarts.
+
+    Regression test for ML-12406: When Nuclio triggers a drain (e.g. Kafka
+    rebalance), the Go processor's workerTerminationTimeout can expire before
+    the Python drain callback finishes. Go reconnects and sends new events, but
+    the Storey flow is still terminated, causing ValueError("Cannot emit to a
+    terminated flow"). Events should block until the drain completes and the
+    flow restarts.
+    """
+    from mlrun.serving.server import _set_callbacks
+
+    function = mlrun.new_function("test-drain-gate", kind="serving")
+    graph = function.set_topology("flow", engine="async")
+    graph.to(name="step1", class_name="Echo")
+
+    server = GraphServer.from_dict(function.spec.to_dict())
+    server.init_states(context=None, namespace=globals(), is_mock=False)
+    server.init_object(globals())
+
+    drain_cb = None
+
+    class MockPlatform:
+        def set_drain_callback(self, cb):
+            nonlocal drain_cb
+            drain_cb = cb
+
+        def set_termination_callback(self, cb):
+            pass
+
+    server.context.platform = MockPlatform()
+    _set_callbacks(server, server.context)
+    assert drain_cb is not None, (
+        "_set_callbacks should have registered a drain callback"
+    )
+
+    event = storey.Event(body={"before_drain": True})
+    response = server.run(event)
+    if asyncio.iscoroutine(response):
+        response = await response
+    assert isinstance(response, dict)
+
+    # Wrap drain_cb with a delay to simulate slow ParquetTarget flush
+    drain_delay = asyncio.Event()
+
+    async def slow_drain():
+        server.context.drain_complete.clear()
+        server.context.logger.info("Drain callback called")
+        maybe_coroutine = server.wait_for_completion()
+        if asyncio.iscoroutine(maybe_coroutine):
+            await maybe_coroutine
+        # Simulate slow flush (e.g. ParquetTarget writing to remote storage)
+        await drain_delay.wait()
+        server.graph._run_async_flow()
+        server.context.logger.info("Async flow restarted")
+        server.context.drain_complete.set()
+
+    drain_task = asyncio.create_task(slow_drain())
+
+    # Give the drain a moment to terminate the flow
+    await asyncio.sleep(0.05)
+
+    # Now emit an event while drain is still in progress
+    event_during_drain = storey.Event(body={"during_drain": True})
+    event_task = asyncio.create_task(
+        _run_event_through_server(server, event_during_drain)
+    )
+
+    # The event should be blocked — drain hasn't completed yet
+    done, _ = await asyncio.wait({event_task}, timeout=0.1)
+    assert not done, "Event should be blocked waiting for drain to complete"
+
+    # Release the slow flush
+    drain_delay.set()
+    await drain_task
+
+    # Now the event should complete successfully
+    response = await asyncio.wait_for(event_task, timeout=5.0)
+    assert isinstance(response, dict), f"Expected dict, got {type(response)}"
+    assert "id" in response
+
+    maybe_coroutine = server.wait_for_completion()
+    if asyncio.iscoroutine(maybe_coroutine):
+        await maybe_coroutine
+
+
+async def _run_event_through_server(server, event):
+    """Helper to run an event through a server, awaiting if async."""
+    response = server.run(event)
+    if asyncio.iscoroutine(response):
+        response = await response
+    return response


### PR DESCRIPTION
[ML-12406](https://iguazio.atlassian.net/browse/ML-12406)

### 📝 Description

During a Kafka rebalance, Nuclio triggers a drain that terminates and restarts the Storey async flow. If the Go processor's `workerTerminationTimeout` expires before the Python drain callback finishes (e.g. due to a slow `ParquetTarget` flush), Go reconnects and sends new events while the flow is still terminated. This causes `ValueError("Cannot emit to a terminated flow")` and silently stalls the pipeline.

This PR adds an `asyncio.Event` drain gate to the serving layer that blocks incoming events during drain and re-emits them once the flow restarts.

---

### 🛠️ Changes Made

- **`mlrun/serving/server.py`**: Add a `drain_complete` attribute (`asyncio.Event`) to `GraphContext`. In `_set_callbacks`, clear it when drain starts and set it after the flow restarts.
- **`mlrun/serving/states.py`**: Add `_await_drain_and_return_id` to `RootFlowStep` — if a drain is in progress, log a warning and wait for `drain_complete` before re-emitting the event to the new flow. Replace `_await_and_return_id` in the non-mock `run()` path.
- **`tests/serving/test_async_flow.py`**: Add `test_event_during_drain_waits_for_flow_restart` — simulates a slow drain, verifies that an event arriving mid-drain blocks until the flow restarts, then succeeds.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Unit test `test_event_during_drain_waits_for_flow_restart` simulates the race condition: starts a slow drain, emits an event mid-drain, asserts the event blocks, releases the drain, and verifies the event completes successfully.
- Full `test_async_flow.py` suite passes (pre-existing unrelated failure in `test_configure_model_runner_step_max_threads_processes` excluded).

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12406
- Design docs links:
- External links: https://iguazio.atlassian.net/browse/NUC-756 (related Nuclio drain signaling story)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The gate only applies to the drain path (rebalance). The termination path (worker shutdown) intentionally does not gate — events arriving after termination should fail, ideally with a clear error from Storey (separate follow-up).
- The Go processor's `eventTimeout` is unset (0 = infinite) for MM stream functions, so blocking during drain does not risk a Go-side timeout. Functions that explicitly set `eventTimeout` would already face the same tension between timeouts and slow drains regardless of this change.

[ML-12406]: https://iguazio.atlassian.net/browse/ML-12406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ