### PR TITLE
[Model Monitoring] Pin serving stream HPA to a single replica

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -628,7 +628,7 @@ default_config = {
                 "num_workers": 2,
                 # TODO(ML-12430): pinned to a single replica to avoid rebalance-induced
                 # event replay under load. Revert to min_replicas=1 / max_replicas=4 once
-                # ML-11979 and NUC-756 (tracked in ML-12316) are resolved.
+                # NUC-756/ML-12316 is resolved.
                 "min_replicas": 1,
                 "max_replicas": 1,
                 "target_cpu": "400m",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -626,8 +626,11 @@ default_config = {
                 "partition_count": 8,
                 "replication_factor": 1,
                 "num_workers": 2,
+                # TODO(ML-12430): pinned to a single replica to avoid rebalance-induced
+                # event replay under load. Revert to min_replicas=1 / max_replicas=4 once
+                # ML-11979 and NUC-756 (tracked in ML-12316) are resolved.
                 "min_replicas": 1,
-                "max_replicas": 4,
+                "max_replicas": 1,
                 "target_cpu": "400m",
             },
         },


### PR DESCRIPTION
## 📝 Description

Pin the model monitoring serving stream (Kafka) to `min_replicas=1` /
`max_replicas=1`

With `max_replicas=4` the HPA reacts to transient CPU spikes, and
each scale event triggers a Kafka consumer-group rebalance. Because
the stream consumer uses `explicitOnly` acks, every rebalance causes
in-flight offsets to be replayed, producing bursts of duplicate
events into the writer graph and visible writer lag (see ML-12430
investigation).

A TODO comment in `mlrun/config.py` points to the two upstream
tickets that must be resolved before horizontal scaling can be
safely re-enabled.

## 🛠️ Changes Made

- `mlrun/config.py`: `model_endpoint_monitoring.serving_stream.kafka`
  `max_replicas` changed from `4` to `1`.
- Added a TODO referencing ML-11979 and NUC-756 (tracked in ML-12316)
  describing when to revert to `min_replicas=1` / `max_replicas=4`.

## ✅ Checklist

- [x] Code formatted (`make fmt`)
- [x] Linter passes (`make lint`)
- [x] No functional / schema changes
- [x] TODO added for revert condition



## 🔗 References

- Jira: [ML-12430]
- Related: ML-11979, NUC-756 (tracked in ML-12316)

## 🚨 Breaking Changes

No. This only narrows the HPA range for the model monitoring serving
stream; the stream continues to run with a single consumer replica,
which already matched the default `min_replicas=1`.

[ML-12430]: https://iguazio.atlassian.net/browse/ML-12430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ