### PR TITLE
[Requirements] Bump storey version

### DIFF
--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -3590,8 +3590,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.0 \
-    --hash=sha256:51cad30e682b393cf76ec7137e1281c7312934b41757ba6c20cb118169d49080
+storey==1.12.1 \
+    --hash=sha256:2c2e0d516ffb916186261e546622f8d41ac041161a087cc9aae396560280526e
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -3337,8 +3337,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.0 \
-    --hash=sha256:51cad30e682b393cf76ec7137e1281c7312934b41757ba6c20cb118169d49080
+storey==1.12.1 \
+    --hash=sha256:2c2e0d516ffb916186261e546622f8d41ac041161a087cc9aae396560280526e
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -2977,8 +2977,8 @@ starlette==0.50.0 \
     --hash=sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca \
     --hash=sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca
     # via fastapi
-storey==1.12.0 \
-    --hash=sha256:51cad30e682b393cf76ec7137e1281c7312934b41757ba6c20cb118169d49080
+storey==1.12.1 \
+    --hash=sha256:2c2e0d516ffb916186261e546622f8d41ac041161a087cc9aae396560280526e
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -2796,8 +2796,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.0 \
-    --hash=sha256:51cad30e682b393cf76ec7137e1281c7312934b41757ba6c20cb118169d49080
+storey==1.12.1 \
+    --hash=sha256:2c2e0d516ffb916186261e546622f8d41ac041161a087cc9aae396560280526e
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -3590,8 +3590,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.0 \
-    --hash=sha256:51cad30e682b393cf76ec7137e1281c7312934b41757ba6c20cb118169d49080
+storey==1.12.1 \
+    --hash=sha256:2c2e0d516ffb916186261e546622f8d41ac041161a087cc9aae396560280526e
     # via -r requirements.txt
 tabulate==0.8.10 \
     --hash=sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc \

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -4601,8 +4601,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.12.0 \
-    --hash=sha256:51cad30e682b393cf76ec7137e1281c7312934b41757ba6c20cb118169d49080
+storey==1.12.1 \
+    --hash=sha256:2c2e0d516ffb916186261e546622f8d41ac041161a087cc9aae396560280526e
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -4705,8 +4705,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.12.0 \
-    --hash=sha256:51cad30e682b393cf76ec7137e1281c7312934b41757ba6c20cb118169d49080
+storey==1.12.1 \
+    --hash=sha256:2c2e0d516ffb916186261e546622f8d41ac041161a087cc9aae396560280526e
     # via -r requirements.txt
 strip-hints==0.1.13 \
     --hash=sha256:1feaebde61269ba0dea1e7f093df7ff9d4df4980cce7e3c22ed6d86ae43dbd06 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2025.5.1, <=2025.7.0
 v3iofs~=0.1.17
-storey~=1.12.0
+storey~=1.12.1
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,7 +128,7 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"~=1.12.0"},
+        "storey": {"~=1.12.1"},
         "pydantic": {">=1.10.15", ">=1,<2"},
         "nuclio-sdk": {">=0.5"},
         "scipy": {"~=1.16.3"},


### PR DESCRIPTION
### 📝 Description
Bump storey dependency to fix [ML-12406](https://iguazio.atlassian.net/browse/ML-12406).

---

### 🛠️ Changes Made
- Bumped storey version to 1.12.1

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Storey changes tested upstream: all parquet and queue tests pass (29 + 2).
- No MLRun-side code changes; this is a dependency bump only.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12406
- Storey PRs: https://github.com/mlrun/storey/pull/637, https://github.com/mlrun/storey/pull/640

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Storey changes included in this bump:
- **ParquetTarget**: `_emit()` now runs blocking I/O via `run_in_executor()` to avoid freezing the event loop.
- **SimpleAsyncQueue**: Added missing capacity enforcement on `put()`, FIFO fairness via `_size` counter to prevent putter starvation, and updated docstring explaining why this class exists (Python < 3.12 `asyncio.wait_for` bug).

[ML-12406]: https://iguazio.atlassian.net/browse/ML-12406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ