### PR TITLE
[CI] Speed up provctl patch with higher docker pull concurrency

### DIFF
--- a/automation/system_test/prepare.py
+++ b/automation/system_test/prepare.py
@@ -639,6 +639,7 @@ class SystemTestPreparer:
                 # we force because by default provctl doesn't allow downgrading between version but due to system tests
                 # running on multiple branches this might occur.
                 "--force",
+                "--docker-pull-push-concurrency=8",
                 f"--override-mlrun-ui-version={self._mlrun_ui_version}"
                 if self._mlrun_ui_version
                 else "",


### PR DESCRIPTION
### 📝 Description
Enterprise system test preparation patches MLRun via `provctl patch appservice`. Image pulls were serialized by default; this change passes `--docker-pull-push-concurrency=8` so provctl can pull images in parallel and shorten patch time.

---

### 🛠️ Changes Made
- Added `--docker-pull-push-concurrency=8` to the `provctl patch appservice` argument list in `automation/system_test/prepare.py` (after `--force`, as an appservice subcommand flag).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Not run locally; change is a single provctl CLI flag addition on the system test automation path.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Requires a provctl build that supports `--docker-pull-push-concurrency` on `patch appservice` (aligned with the version used in enterprise system tests).

