### PR TITLE
[CI] Add optional repo secret for enterprise system tests docker registry

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -40,7 +40,7 @@ on:
   workflow_dispatch:
     inputs:
       docker_registry:
-        description: 'Docker registry to pull images from (default: ghcr.io/, use registry.hub.docker.com/ for docker hub)'
+        description: 'Docker registry to pull images from (e.g ghcr.io/, or registry.hub.docker.com/ for docker hub).'
         required: true
         default: 'ghcr.io/'
       clean_resources_in_teardown:
@@ -208,8 +208,8 @@ jobs:
           -o StrictHostKeyChecking=no system-tests-branches-list.txt \
           ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/
 
-      # checking out to base branch and not the target(resolved) branch, to be able to run the changed preparation code
-      # before merging the changes to upstream.
+    # checking out to base branch and not the target(resolved) branch, to be able to run the changed preparation code
+    # before merging the changes to upstream.
     - name: Checkout base branch
       uses: actions/checkout@v6
 
@@ -261,13 +261,14 @@ jobs:
         echo "mlrun_docker_tag=$(echo ${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$mlrun_hash)" >> $GITHUB_OUTPUT
         echo "mlrun_ui_version=${{ steps.git_upstream_info.outputs.unstable_version_prefix }}-$ui_hash" >> $GITHUB_OUTPUT
         echo "mlrun_docker_registry=$( \
-          input_docker_registry=$INPUT_DOCKER_REGISTRY && \
-          echo ${input_docker_registry:-ghcr.io/})" >> $GITHUB_OUTPUT
+          effective_docker_registry="${INPUT_DOCKER_REGISTRY:-$SECRET_DOCKER_REGISTRY}" && \
+          echo "${effective_docker_registry:-ghcr.io/}")" >> $GITHUB_OUTPUT
         echo "mlrun_system_tests_clean_resources=$( \
           input_system_tests_clean_resources=$INPUT_CLEAN_RESOURCES_IN_TEARDOWN && \
           echo ${input_system_tests_clean_resources:-true})" >> $GITHUB_OUTPUT
         echo "override_iguazio_version=$INPUT_OVERRIDE_IGUAZIO_VERSION" >> $GITHUB_OUTPUT
       env:
+        SECRET_DOCKER_REGISTRY: ${{ secrets.SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY }}
         INPUT_DOCKER_REGISTRY: ${{ github.event.inputs.docker_registry }}
         INPUT_OVERRIDE_IGUAZIO_VERSION: ${{ github.event.inputs.override_iguazio_version }}
         INPUT_CLEAN_RESOURCES_IN_TEARDOWN: ${{ github.event.inputs.clean_resources_in_teardown }}
@@ -275,7 +276,8 @@ jobs:
     - name: Prepare System Test Environment and Install MLRun
       env:
         IP_ADDR_PREFIX: ${{ secrets.IP_ADDR_PREFIX }}
-        # AWS credentials are automatically available from configure-aws-credentials action
+
+      # AWS credentials are automatically available from configure-aws-credentials action
       timeout-minutes: 50
       run: |
         . venv/bin/activate


### PR DESCRIPTION
### 📝 Description
Enterprise system tests workflow can now read an optional repository secret `SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY` so scheduled (and other non-dispatch) runs can pull images from a configured registry without changing workflow inputs. When `workflow_dispatch` is used, the `docker_registry` input still takes precedence; if both input and secret are empty, the registry defaults to `ghcr.io/`.

---

### 🛠️ Changes Made
- Pass `secrets.SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY` into the "Set computed versions params" step and resolve `mlrun_docker_registry` as: dispatch input, then secret, then `ghcr.io/`.
- Document the behavior on the `docker_registry` workflow input and add a short inline comment in the workflow.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
Not run (workflow YAML only). Validation is by inspection of the expression order and GitHub Actions semantics for empty vs. set inputs on `workflow_dispatch` vs. `schedule`/`push`.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Repository maintainers must create the optional secret `SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY` in **Settings → Secrets and variables → Actions** when a non-default registry is needed for scheduled runs.

