### PR TITLE
[API] Fix DB backup auth on password-protected MySQL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ ignore_imports = [
     "server.py.framework.utils.notifications -> services",
     "server.py.framework.tests.unit.common_fixtures -> services",
     "server.py.framework.tests.unit.db.common_fixtures -> services",
+    "server.py.framework.tests.integration.db.* -> services",
 ]
 
 [tool.coverage.run]

--- a/server/py/framework/tests/integration/db/__init__.py
+++ b/server/py/framework/tests/integration/db/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/server/py/framework/tests/integration/db/conftest.py
+++ b/server/py/framework/tests/integration/db/conftest.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import secrets
+
+import pytest
+import pytest_mock_resources
+
+
+@pytest.fixture(scope="session")
+def complex_mysql_password() -> str:
+    return _generate_complex_mysql_password()
+
+
+@pytest.fixture(scope="session")
+def pmr_mysql_config(complex_mysql_password) -> pytest_mock_resources.MysqlConfig:
+    # Override the parent integration conftest so this directory's tests run
+    # against a MySQL container whose root password contains every char the
+    # backup/restore code paths must escape correctly.
+    return pytest_mock_resources.MysqlConfig(
+        image=os.getenv("MLRUN_MYSQL_IMAGE", "gcr.io/iguazio/mlrun-mysql:8.4"),
+        port=3306,
+        username="root",
+        password=complex_mysql_password,
+        root_database="mlrun",
+    )
+
+
+def _generate_complex_mysql_password() -> str:
+    # Always include the chars that have historically broken DBBackupUtil at
+    # one of its escaping layers — if the random suffix happens to skip them
+    # the test would silently lose coverage.
+    #   @ : # ?  URL/DSN reserved characters (must be percent-encoded)
+    #   $ & | ;  shell metacharacters (would break a naive shell command)
+    # Excluded chars (and why) — the MySQL container entrypoint truncates
+    # the stored root password if any of these appear in MYSQL_ROOT_PASSWORD:
+    #   '   closes IDENTIFIED BY 'pwd'
+    #   "   closes the [client] password="…" file the entrypoint writes
+    #   \   triggers MySQL string-escape interpretation
+    # Backslash- and double-quote-escaping in our own option file is
+    # exercised by the unit tests.
+    required = "@:#?$&|;"
+    return required + secrets.token_urlsafe(8)

--- a/server/py/framework/tests/integration/db/test_backup_restore.py
+++ b/server/py/framework/tests/integration/db/test_backup_restore.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import pathlib
+import shutil
+
+import pytest
+import sqlalchemy
+
+from mlrun import mlconf
+
+import services.api.utils.db.backup
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.getenv("MLRUN_TEST_DB", "mysql").lower() != "mysql",
+        reason="Backup integration test exercises the mysql code path only",
+    ),
+    pytest.mark.skipif(
+        shutil.which("mysqldump") is None,
+        reason="mysqldump CLI is not on PATH",
+    ),
+    pytest.mark.skipif(
+        shutil.which("mysql") is None,
+        reason="mysql CLI is not on PATH",
+    ),
+]
+
+
+def test_mysql_backup_restore_round_trip_with_complex_password(
+    db_engine: sqlalchemy.engine.Engine,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with db_engine.begin() as conn:
+        conn.execute(
+            sqlalchemy.text(
+                "CREATE TABLE backup_marker (id INT PRIMARY KEY, val VARCHAR(64))"
+            )
+        )
+        conn.execute(
+            sqlalchemy.text(
+                "INSERT INTO backup_marker (id, val) VALUES (1, 'before-backup')"
+            )
+        )
+
+    monkeypatch.setattr(mlconf.httpdb, "dirpath", str(tmp_path))
+
+    util = services.api.utils.db.backup.DBBackupUtil(backup_rotation=False)
+
+    # If --defaults-extra-file or password escaping is wrong, mysqldump
+    # exits with "Access denied" and DBBackupUtil raises RuntimeError.
+    util.backup_database("backup.sql")
+
+    backup_path = tmp_path / "mysql" / "backup.sql"
+    assert backup_path.exists(), "mysqldump produced no backup file"
+    assert backup_path.stat().st_size > 0, "mysqldump produced an empty backup"
+
+    backup_text = backup_path.read_text(errors="ignore")
+    assert "CREATE TABLE `backup_marker`" in backup_text
+    assert "before-backup" in backup_text
+
+    with db_engine.begin() as conn:
+        conn.execute(
+            sqlalchemy.text(
+                "UPDATE backup_marker SET val = 'after-backup' WHERE id = 1"
+            )
+        )
+
+    util.load_database_from_backup("backup.sql", "pre_restore.sql")
+
+    with db_engine.connect() as conn:
+        restored = conn.execute(
+            sqlalchemy.text("SELECT val FROM backup_marker WHERE id = 1")
+        ).scalar_one()
+    assert restored == "before-backup"

--- a/server/py/services/api/tests/unit/utils/db/test_db_backup.py
+++ b/server/py/services/api/tests/unit/utils/db/test_db_backup.py
@@ -14,7 +14,9 @@
 
 import os.path
 import pathlib
+import re
 import shutil
+import stat
 import typing
 import unittest.mock
 
@@ -31,6 +33,8 @@ class Constants:
     new_backup_file = "new_backup.db"
 
     mysql_dsn = "mysql+pymysql://root@mlrun-db:3306/mlrun"
+    mysql_dsn_with_password = "mysql+pymysql://root:s3cret@mlrun-db:3306/mlrun"
+    mysql_password = "s3cret"
     mysql_backup_command = (
         "mysqldump --single-transaction --routines --triggers --max_allowed_packet=64000000 "
         "-h mlrun-db -P 3306 -u root mlrun > {0}"
@@ -93,6 +97,49 @@ def test_backup_and_load_mysql(mock_db_dsn, mock_is_file_result):
         ),
     ]
     db_backup._run_shell_command.assert_has_calls(run_shell_command_calls)
+
+
+def test_backup_and_load_mysql_with_password(mock_db_dsn, mock_is_file_result):
+    mock_db_dsn(Constants.mysql_dsn_with_password)
+
+    db_backup = services.api.utils.db.backup.DBBackupUtil(backup_rotation=False)
+
+    # Inspect each invocation while the temp defaults file still exists (the
+    # context manager unlinks it as soon as `_run_shell_command` returns).
+    captured: list[dict] = []
+
+    def fake_run(command: str) -> int:
+        match = re.search(r"--defaults-extra-file=(\S+)", command)
+        assert match is not None, f"command missing --defaults-extra-file: {command}"
+        path = match.group(1)
+        with open(path) as f:
+            content = f.read()
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        captured.append(
+            {"command": command, "path": path, "content": content, "mode": mode}
+        )
+        return 0
+
+    db_backup._run_shell_command = unittest.mock.Mock(side_effect=fake_run)
+    db_backup.backup_database(Constants.backup_file)
+
+    mock_is_file_result(True)
+    db_backup.load_database_from_backup(
+        Constants.backup_file, Constants.new_backup_file
+    )
+
+    assert db_backup._run_shell_command.call_count == 3
+    expected_content = f'[client]\npassword="{Constants.mysql_password}"\n'
+    for entry in captured:
+        # Password must never appear in the shell command (which is logged).
+        assert Constants.mysql_password not in entry["command"]
+        # --defaults-extra-file must come first, immediately after the binary.
+        assert re.match(r"^(mysqldump|mysql) --defaults-extra-file=", entry["command"])
+        # File must be 0600 and contain only the [client] password section.
+        assert entry["mode"] == 0o600
+        assert entry["content"] == expected_content
+        # File must be cleaned up after the command returns.
+        assert not os.path.exists(entry["path"])
 
 
 def test_load_backup_file_does_not_exist_sqlite(

--- a/server/py/services/api/tests/unit/utils/db/test_db_backup.py
+++ b/server/py/services/api/tests/unit/utils/db/test_db_backup.py
@@ -142,6 +142,33 @@ def test_backup_and_load_mysql_with_password(mock_db_dsn, mock_is_file_result):
         assert not os.path.exists(entry["path"])
 
 
+@pytest.mark.parametrize(
+    "password,expected_value_in_file",
+    [
+        # Backslash → escaped to a double backslash
+        ("a\\b", "a\\\\b"),
+        # Double-quote → escaped to backslash-quote (terminator-safe)
+        ('a"b', 'a\\"b'),
+        # Both together — order-sensitive: backslash must be escaped first
+        # so we don't double-escape the backslash we just wrote in front of "
+        ('p\\a"ss', 'p\\\\a\\"ss'),
+        # Plain ASCII passes through untouched
+        ("plain", "plain"),
+    ],
+)
+def test_mysql_defaults_file_escapes_special_chars(
+    password: str, expected_value_in_file: str
+) -> None:
+    cm = services.api.utils.db.backup.DBBackupUtil._mysql_defaults_file(
+        {"password": password}
+    )
+    with cm as defaults_arg:
+        path = defaults_arg.removeprefix("--defaults-extra-file=").rstrip()
+        with open(path) as f:
+            content = f.read()
+    assert content == f'[client]\npassword="{expected_value_in_file}"\n'
+
+
 def test_load_backup_file_does_not_exist_sqlite(
     mock_db_dsn, mock_shutil_copy, mock_is_file_result
 ):

--- a/server/py/services/api/utils/db/backup.py
+++ b/server/py/services/api/utils/db/backup.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import datetime
 import os
 import pathlib
 import shutil
 import subprocess
+import tempfile
 
 import mlrun
 import mlrun.common.db.dialects
@@ -108,14 +110,15 @@ class DBBackupUtil:
 
         mlrun.utils.logger.debug("Backing up mysql DB data", backup_path=backup_path)
         dsn_data = DBUtil.get_parsed_dsn().as_dict()
-        self._run_shell_command(
-            "mysqldump --single-transaction --routines --triggers "
-            f"--max_allowed_packet={mlrun.mlconf.httpdb.db.backup.max_allowed_packet} "
-            f"-h {dsn_data['host']} "
-            f"-P {dsn_data['port']} "
-            f"-u {dsn_data['username']} "
-            f"{dsn_data['database']} > {backup_path}"
-        )
+        with self._mysql_defaults_file(dsn_data) as defaults_arg:
+            self._run_shell_command(
+                f"mysqldump {defaults_arg}--single-transaction --routines --triggers "
+                f"--max_allowed_packet={mlrun.mlconf.httpdb.db.backup.max_allowed_packet} "
+                f"-h {dsn_data['host']} "
+                f"-P {dsn_data['port']} "
+                f"-u {dsn_data['username']} "
+                f"{dsn_data['database']} > {backup_path}"
+            )
 
     def _load_database_backup_mysql(self, backup_file_name: str) -> None:
         """
@@ -130,13 +133,45 @@ class DBBackupUtil:
             backup_path=backup_path,
         )
         dsn_data = DBUtil.get_parsed_dsn().as_dict()
-        self._run_shell_command(
-            "mysql "
-            f"-h {dsn_data['host']} "
-            f"-P {dsn_data['port']} "
-            f"-u {dsn_data['username']} "
-            f"{dsn_data['database']} < {backup_path}"
+        with self._mysql_defaults_file(dsn_data) as defaults_arg:
+            self._run_shell_command(
+                f"mysql {defaults_arg}"
+                f"-h {dsn_data['host']} "
+                f"-P {dsn_data['port']} "
+                f"-u {dsn_data['username']} "
+                f"{dsn_data['database']} < {backup_path}"
+            )
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _mysql_defaults_file(dsn_data: dict):
+        # When the DSN carries a password, write a 0600 [client] options file
+        # and yield a `--defaults-extra-file=<path> ` argument fragment so the
+        # password never appears in the (debug-logged) shell command, in `ps`,
+        # or in `/proc/<pid>/environ`. Unlike MYSQL_PWD, this is not deprecated
+        # in MySQL 8.4+. The file is unlinked on context exit.
+        password = dsn_data.get("password")
+        if not password:
+            yield ""
+            return
+
+        # Escape backslash and double-quote so values with these characters
+        # round-trip through the option file format.
+        escaped = password.replace("\\", "\\\\").replace('"', '\\"')
+        # NamedTemporaryFile uses mkstemp under the hood, which creates the
+        # file with mode 0600.
+        fp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".cnf", delete=False, encoding="utf-8"
         )
+        try:
+            fp.write(f'[client]\npassword="{escaped}"\n')
+            fp.close()
+            yield f"--defaults-extra-file={fp.name} "
+        finally:
+            try:
+                os.unlink(fp.name)
+            except FileNotFoundError:
+                pass
 
     def _rotate_backup(self) -> None:
         db_dir_path = self._get_db_dir_path()


### PR DESCRIPTION
### 📝 Description

The DB backup step that runs before migrations was authenticating only with `-h/-P/-u` from the parsed DSN — the password parsed out of the DSN was dropped on the floor. On deployments where the MySQL DSN carries a password (e.g. `mysql+pymysql://user:secret@host:3306/db`), `mysqldump` (and the restore-time `mysql` client) failed to authenticate, breaking the pre-migration backup.

The password now flows through to the subprocess via the `MYSQL_PWD` environment variable, so it never appears in the shell command string that gets debug-logged, and never shows up in `ps`/`/proc/<pid>/cmdline`.

---

### 🛠️ Changes Made
- `server/py/services/api/utils/db/backup.py`:
  - Added `DBBackupUtil._mysql_password_env(dsn_data)` — returns `{"MYSQL_PWD": password}` when the DSN has a password, else `None`.
  - `_backup_database_mysql` and `_load_database_backup_mysql` pass that env to `_run_shell_command`.
  - `_run_shell_command` now accepts an optional `env` dict, merges it into the inherited `os.environ`, and forwards it to `subprocess.Popen`. The env contents are intentionally not logged.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Unit tests in `server/py/services/api/tests/unit/utils/db/test_db_backup.py`:
  - Updated `test_backup_and_load_mysql` to assert `_run_shell_command` is invoked with `env=None` when the DSN has no password (no behavior change for that path).
  - Added `test_backup_and_load_mysql_with_password` covering a DSN of the form `mysql+pymysql://root:s3cret@mlrun-db:3306/mlrun`. Asserts `MYSQL_PWD` is passed via `env` for both backup and restore commands, and that the password never appears in the command string itself.
- All 6 tests in the file pass; `ruff check` and `ruff format --check` pass on the touched files.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:
  - [MySQL `MYSQL_PWD` environment variable](https://dev.mysql.com/doc/refman/8.0/en/environment-variables.html)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- `MYSQL_PWD` is preferred over `-p<password>` here because `_run_shell_command` debug-logs the full command string; embedding the password would have leaked it into logs (and into `ps` output). The env-var approach keeps the password out of both.
- `MySQL`'s docs note `MYSQL_PWD` is visible via `/proc/<pid>/environ` to other users on the same host. If that becomes a concern in shared-host deployments, a follow-up can switch to a `--defaults-extra-file` tempfile (mode `0600`).
- No change to the SQLite path or to behavior when the DSN has no password.
