### PR TITLE
[Automation] Add kubectl mode and DB migration trigger to patch_remote

### DIFF
--- a/automation/patch_igz/README.md
+++ b/automation/patch_igz/README.md
@@ -18,7 +18,7 @@ make install-automation-requirements
 * `ssh` (default): SSH into a data node and run kubectl there.
 * `kubectl`: Run kubectl locally against the cluster (no SSH credentials required).
 
-Select via `MODE` in the config file or `--mode {ssh,kubectl}`. In kubectl mode, point at a cluster via `KUBECONFIG` / `--kubeconfig`, or rely on the kubectl default.
+Mode is inferred from `KUBECONFIG` when unset — set `KUBECONFIG` (config field or `--kubeconfig`) and you get kubectl mode; leave it empty and you stay on ssh. To force a mode regardless, set `MODE` in the config or pass `--mode {ssh,kubectl}` (e.g. kubectl mode using the kubectl default `~/.kube/config`).
 
 WARNING: This may not persist after system restart
 

--- a/automation/patch_igz/README.md
+++ b/automation/patch_igz/README.md
@@ -13,6 +13,13 @@ make install-automation-requirements
 * From mlrun root dir run ./automation/patch_igz/patch_remote.py
 * If requesting to reset DB, DB_USER must be defined in patch_env.yml
 
+## Execution modes
+
+* `ssh` (default): SSH into a data node and run kubectl there.
+* `kubectl`: Run kubectl locally against the cluster (no SSH credentials required).
+
+Select via `MODE` in the config file or `--mode {ssh,kubectl}`. In kubectl mode, point at a cluster via `KUBECONFIG` / `--kubeconfig`, or rely on the kubectl default.
+
 WARNING: This may not persist after system restart
 
 Troubleshooting:

--- a/automation/patch_igz/patch_env_template.yml
+++ b/automation/patch_igz/patch_env_template.yml
@@ -16,12 +16,15 @@
 # this is a template file for the deploy env file
 
 
-# Execution mode (optional, default: ssh).
+# Execution mode (optional). Inferred from KUBECONFIG when unset:
+# kubectl mode if KUBECONFIG is set, otherwise ssh.
 # - ssh:     SSH into a data node and run kubectl there.
-# - kubectl: Run kubectl locally against the cluster (uses KUBECONFIG below).
+# - kubectl: Run kubectl locally against the cluster.
 MODE:
 
-# Path to a kubeconfig file (kubectl mode only). Falls back to the kubectl default.
+# Path to a kubeconfig file. Setting this implies MODE=kubectl unless MODE is
+# set explicitly. Leave unset for ssh mode or to use the kubectl default
+# (KUBECONFIG env var or ~/.kube/config) with an explicit MODE: kubectl.
 KUBECONFIG:
 
 # Data node IPs/hostnames (e.g. [1.1.1.1, 1.1.1.2, 1.1.1.3]).

--- a/automation/patch_igz/patch_env_template.yml
+++ b/automation/patch_igz/patch_env_template.yml
@@ -16,13 +16,23 @@
 # this is a template file for the deploy env file
 
 
-# Data node IPs/hostnames (required) (e.g. [1.1.1.1, 1.1.1.2, 1.1.1.3])
+# Execution mode (optional, default: ssh).
+# - ssh:     SSH into a data node and run kubectl there.
+# - kubectl: Run kubectl locally against the cluster (uses KUBECONFIG below).
+MODE:
+
+# Path to a kubeconfig file (kubectl mode only). Falls back to the kubectl default.
+KUBECONFIG:
+
+# Data node IPs/hostnames (e.g. [1.1.1.1, 1.1.1.2, 1.1.1.3]).
+# Required for MODE=ssh. In kubectl mode, only set when pushing to per-node
+# Iguazio datanode registries (multi-node image replication).
 DATA_NODES:
 
-# Username for ssh (required)
+# Username for ssh (required when MODE=ssh)
 SSH_USER:
 
-# Password for above user (required)
+# Password for above user (required when MODE=ssh)
 SSH_PASSWORD:
 
 # Docker registry you can push to. Make sure you are logged into it before running the script (required)

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -38,7 +38,11 @@ coloredlogs.install(level=log_level, logger=logger, fmt=fmt)
 
 
 class Constants:
-    mandatory_fields = {"DATA_NODES", "SSH_USER", "SSH_PASSWORD", "DOCKER_REGISTRY"}
+    mode_ssh = "ssh"
+    mode_kubectl = "kubectl"
+    valid_modes = {mode_ssh, mode_kubectl}
+    common_mandatory_fields = {"DOCKER_REGISTRY"}
+    ssh_mandatory_fields = {"DATA_NODES", "SSH_USER", "SSH_PASSWORD"}
     api_container = "mlrun-api"
     log_collector_container = "mlrun-log-collector"
     api = "api"
@@ -69,6 +73,9 @@ class MLRunPatcher:
         no_build: bool,
         no_push: bool,
         namespace: str,
+        mode: str = "",
+        kubeconfig: str = "",
+        migrate: bool = False,
     ):
         self._config = yaml.safe_load(conf_file)
         patch_yaml_data = yaml.safe_load(patch_file)
@@ -76,6 +83,11 @@ class MLRunPatcher:
         self._reset_db = reset_db
         self._image_tag = image_tag
         self._patch_log_collector_image = bool(patch_log_collector_image)
+        self._mode = self._resolve_mode(mode)
+        kubeconfig_value = kubeconfig or self._config.get("KUBECONFIG") or ""
+        self._kubeconfig = (
+            os.path.expanduser(kubeconfig_value) if kubeconfig_value else ""
+        )
         self._validate_config()
         self._patch_mlrun_image = patch_mlrun_image
         self._skip_patch_api = skip_patch_api
@@ -84,10 +96,16 @@ class MLRunPatcher:
         self._no_push = no_push
         self._namespace = self._resolve_namespace(namespace)
         self._docker_client = docker.from_env()
+        self._ssh_client: paramiko.SSHClient | None = None
+        self._migrate = migrate
         if self._skip_patch_api and self._patch_alerts:
             raise ValueError("Cannot skip api and patch alerts at the same time")
+        if self._migrate and self._skip_patch_api:
+            raise ValueError(
+                "--migrate requires the api to be patched (drop --skip-api)"
+            )
 
-        cluster_data_nodes = self._config["DATA_NODES"]
+        cluster_data_nodes = self._config.get("DATA_NODES") or []
         if not isinstance(cluster_data_nodes, list):
             cluster_data_nodes = [cluster_data_nodes]
         self._cluster_data_nodes = cluster_data_nodes
@@ -122,8 +140,7 @@ class MLRunPatcher:
             )
             self._push_docker_images(built_images)
 
-        # Connect to the first node and start deployment patching process
-        node = self._cluster_data_nodes[0]
+        node = self._cluster_data_nodes[0] if self._cluster_data_nodes else None
         self._connect_to_node(node)
 
         if self._patch_log_collector_image:
@@ -146,6 +163,9 @@ class MLRunPatcher:
                     self._rollout_deployment()
 
                 self._wait_deployment_ready()
+
+                if self._migrate:
+                    self._run_db_migrations()
 
             finally:
                 # Check status of pods after deployment
@@ -246,7 +266,10 @@ class MLRunPatcher:
                 fut.result()
 
     def _validate_config(self):
-        missing_fields = Constants.mandatory_fields - set(self._config.keys())
+        mandatory_fields = set(Constants.common_mandatory_fields)
+        if self._mode == Constants.mode_ssh:
+            mandatory_fields |= Constants.ssh_mandatory_fields
+        missing_fields = mandatory_fields - set(self._config.keys())
         if len(missing_fields) > 0:
             raise RuntimeError(f"Mandatory options not defined: {missing_fields}")
 
@@ -259,6 +282,17 @@ class MLRunPatcher:
 
         if self._reset_db and "DB_USER" not in self._config:
             raise RuntimeError("Must define DB_USER if requesting DB reset")
+
+        if self._kubeconfig and not os.path.isfile(self._kubeconfig):
+            raise RuntimeError(f"KUBECONFIG file not found: {self._kubeconfig}")
+
+    def _resolve_mode(self, mode: str) -> str:
+        resolved = (mode or self._config.get("MODE") or Constants.mode_ssh).lower()
+        if resolved not in Constants.valid_modes:
+            raise ValueError(
+                f"Invalid mode '{resolved}'. Valid modes: {sorted(Constants.valid_modes)}"
+            )
+        return resolved
 
     def _get_current_version(self) -> str:
         if "unstable" in self._image_tag:
@@ -326,6 +360,8 @@ class MLRunPatcher:
         return target_to_image
 
     def _connect_to_node(self, node):
+        if self._mode == Constants.mode_kubectl:
+            return
         logger.debug(f"Connecting to {node}")
 
         self._ssh_client = paramiko.SSHClient()
@@ -339,7 +375,9 @@ class MLRunPatcher:
         )
 
     def _disconnect_from_node(self):
-        self._ssh_client.close()
+        if self._ssh_client is not None:
+            self._ssh_client.close()
+            self._ssh_client = None
 
     def _patch_deployment_from_file(self):
         for deployment in self._deployments:
@@ -448,6 +486,109 @@ class MLRunPatcher:
             except RuntimeError:
                 # Retry until timeout is reached
                 time.sleep(5)
+
+    def _run_db_migrations(self):
+        chief = "mlrun-api-chief"
+        self._ensure_backup_disabled_on_chief(chief)
+        self._trigger_migration_via_endpoint(chief)
+
+    def _ensure_backup_disabled_on_chief(self, deployment: str):
+        # Workaround: services/api/utils/db/backup.py runs mysqldump without a
+        # password flag and the api container has no MYSQL_PWD / .my.cnf, so
+        # the backup step in /operations/migrations fails when a migration is
+        # actually pending. Disable backup before triggering.
+        env_var = "MLRUN_HTTPDB__DB__BACKUP__MODE"
+        desired = "disabled"
+        current = self._exec_remote(
+            [
+                "kubectl",
+                "-n",
+                self._namespace,
+                "get",
+                "deployment",
+                deployment,
+                "-o",
+                (
+                    f"jsonpath={{.spec.template.spec.containers[?(@.name=='{Constants.api_container}')]"
+                    f".env[?(@.name=='{env_var}')].value}}"
+                ),
+            ]
+        ).strip()
+        if current == desired:
+            logger.info("DB backup already disabled on %s", deployment)
+            return
+
+        logger.info("Disabling DB backup on %s", deployment)
+        self._exec_remote(
+            [
+                "kubectl",
+                "-n",
+                self._namespace,
+                "set",
+                "env",
+                f"deployment/{deployment}",
+                "-c",
+                Constants.api_container,
+                f"{env_var}={desired}",
+            ]
+        )
+        self._exec_remote(
+            [
+                "kubectl",
+                "-n",
+                self._namespace,
+                "rollout",
+                "status",
+                "deployment",
+                deployment,
+                "--timeout=120s",
+            ],
+            live=True,
+        )
+
+    def _trigger_migration_via_endpoint(self, deployment: str):
+        # Bypass mlrun.get_run_db() — its connect() syncs client-spec which
+        # turns on auth_with_oauth_token, and IGTokenProvider's __init__
+        # eagerly fetches a token we don't have. Construct HTTPRunDB directly
+        # and inject the pod's k8s service-account token on the session so
+        # every api_call (POST + polling GETs) carries the SA bearer.
+        snippet = "\n".join(
+            [
+                "import sys, mlrun.db.httpdb as httpdb",
+                "db = httpdb.HTTPRunDB('http://localhost:8080')",
+                "db.token_provider = None",
+                "db.session = db._init_session(False, False)",
+                "with open('/var/run/secrets/kubernetes.io/serviceaccount/token') as f:",
+                "    token = f.read().strip()",
+                "db.session.headers.update({",
+                "    'Authorization': f'Bearer {token}',",
+                "    'x-igz-authenticator-kind': 'sa',",
+                "})",
+                "result = db.trigger_migrations()",
+                "if result is None:",
+                "    sys.exit(0)",
+                "state = result.status.state",
+                "print('migration finished:', state)",
+                "sys.exit(0 if state == 'succeeded' else 1)",
+            ]
+        )
+        logger.info("Triggering DB migration on %s", deployment)
+        self._exec_remote(
+            [
+                "kubectl",
+                "-n",
+                self._namespace,
+                "exec",
+                f"deployment/{deployment}",
+                "--container",
+                Constants.api_container,
+                "--",
+                "python",
+                "-c",
+                snippet,
+            ],
+            live=True,
+        )
 
     def _reset_mlrun_db(self):
         mlrun_api_services_deployment_selector = (
@@ -574,6 +715,9 @@ class MLRunPatcher:
         return output
 
     def _exec_remote(self, cmd: list[str], live=False) -> str:
+        if self._mode == Constants.mode_kubectl:
+            return self._exec_kubectl_local(cmd, live=live)
+
         cmd_str = shlex.join(cmd)
         logger.debug("Exec remote: %s", cmd_str)
         stdin_stream, stdout_stream, stderr_stream = self._ssh_client.exec_command(
@@ -601,6 +745,17 @@ class MLRunPatcher:
             )
 
         return stdout
+
+    def _exec_kubectl_local(self, cmd: list[str], live: bool = False) -> str:
+        cmd_str = shlex.join(cmd)
+        logger.debug("Exec kubectl: %s", cmd_str)
+        env = {"KUBECONFIG": self._kubeconfig} if self._kubeconfig else None
+        try:
+            return self._exec_local(cmd, live=live, env=env)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"Command '{cmd_str}' finished with failure ({exc.returncode})"
+            ) from exc
 
     def _resolve_overwrite_registry(self):
         docker_registry = self._config.get("DOCKER_REGISTRY")
@@ -696,6 +851,25 @@ class MLRunPatcher:
     default="",
     help="Kubernetes namespace to deploy to. If not set, defaults to 'default-tenant'.",
 )
+@click.option(
+    "-m",
+    "--mode",
+    type=click.Choice([Constants.mode_ssh, Constants.mode_kubectl]),
+    default=None,
+    help="Execution mode: 'ssh' (default) or 'kubectl'. Overrides the 'MODE' config field.",
+)
+@click.option(
+    "--kubeconfig",
+    default="",
+    type=str,
+    help="Path to a kubeconfig file (kubectl mode only). Overrides the 'KUBECONFIG' config field.",
+)
+@click.option(
+    "-mig",
+    "--migrate",
+    is_flag=True,
+    help="After the api rollout, trigger DB migrations on mlrun-api-chief via /operations/migrations.",
+)
 def main(
     verbose: bool,
     config: str,
@@ -709,6 +883,9 @@ def main(
     no_build: bool,
     no_push: bool,
     namespace: str,
+    mode: str | None,
+    kubeconfig: str,
+    migrate: bool,
 ):
     if verbose:
         coloredlogs.set_level(logging.DEBUG)
@@ -725,6 +902,9 @@ def main(
         no_build=no_build,
         no_push=no_push,
         namespace=namespace,
+        mode=mode or "",
+        kubeconfig=kubeconfig,
+        migrate=migrate,
     ).patch()
 
 

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -269,7 +269,9 @@ class MLRunPatcher:
         mandatory_fields = set(Constants.common_mandatory_fields)
         if self._mode == Constants.mode_ssh:
             mandatory_fields |= Constants.ssh_mandatory_fields
-        missing_fields = mandatory_fields - set(self._config.keys())
+        missing_fields = {
+            field for field in mandatory_fields if not self._config.get(field)
+        }
         if len(missing_fields) > 0:
             raise RuntimeError(f"Mandatory options not defined: {missing_fields}")
 
@@ -711,12 +713,15 @@ class MLRunPatcher:
     ) -> str:
         logger.debug("Exec local: %s", " ".join(cmd))
         buf = io.StringIO()
-        for line in self._execute_local_proc_interactive(cmd, env):
-            buf.write(line)
-            if live:
-                print(line, end="")
-        output = buf.getvalue()
-        return output
+        try:
+            for line in self._execute_local_proc_interactive(cmd, env):
+                buf.write(line)
+                if live:
+                    print(line, end="")
+        except subprocess.CalledProcessError as exc:
+            exc.output = buf.getvalue()
+            raise
+        return buf.getvalue()
 
     def _exec_remote(self, cmd: list[str], live=False) -> str:
         if self._mode == Constants.mode_kubectl:
@@ -757,8 +762,9 @@ class MLRunPatcher:
         try:
             return self._exec_local(cmd, live=live, env=env)
         except subprocess.CalledProcessError as exc:
+            output = (exc.output or "").strip()
             raise RuntimeError(
-                f"Command '{cmd_str}' finished with failure ({exc.returncode})"
+                f"Command '{cmd_str}' finished with failure ({exc.returncode})\n{output}"
             ) from exc
 
     def _resolve_overwrite_registry(self):

--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -83,11 +83,11 @@ class MLRunPatcher:
         self._reset_db = reset_db
         self._image_tag = image_tag
         self._patch_log_collector_image = bool(patch_log_collector_image)
-        self._mode = self._resolve_mode(mode)
         kubeconfig_value = kubeconfig or self._config.get("KUBECONFIG") or ""
         self._kubeconfig = (
             os.path.expanduser(kubeconfig_value) if kubeconfig_value else ""
         )
+        self._mode = self._resolve_mode(mode)
         self._validate_config()
         self._patch_mlrun_image = patch_mlrun_image
         self._skip_patch_api = skip_patch_api
@@ -287,12 +287,16 @@ class MLRunPatcher:
             raise RuntimeError(f"KUBECONFIG file not found: {self._kubeconfig}")
 
     def _resolve_mode(self, mode: str) -> str:
-        resolved = (mode or self._config.get("MODE") or Constants.mode_ssh).lower()
-        if resolved not in Constants.valid_modes:
-            raise ValueError(
-                f"Invalid mode '{resolved}'. Valid modes: {sorted(Constants.valid_modes)}"
-            )
-        return resolved
+        explicit = mode or self._config.get("MODE")
+        if explicit:
+            resolved = explicit.lower()
+            if resolved not in Constants.valid_modes:
+                raise ValueError(
+                    f"Invalid mode '{resolved}'. Valid modes: {sorted(Constants.valid_modes)}"
+                )
+            return resolved
+        # Infer: kubeconfig present => kubectl; else legacy ssh.
+        return Constants.mode_kubectl if self._kubeconfig else Constants.mode_ssh
 
     def _get_current_version(self) -> str:
         if "unstable" in self._image_tag:
@@ -856,13 +860,13 @@ class MLRunPatcher:
     "--mode",
     type=click.Choice([Constants.mode_ssh, Constants.mode_kubectl]),
     default=None,
-    help="Execution mode: 'ssh' (default) or 'kubectl'. Overrides the 'MODE' config field.",
+    help="Force execution mode. Defaults to ssh, or kubectl when --kubeconfig/KUBECONFIG is set.",
 )
 @click.option(
     "--kubeconfig",
     default="",
     type=str,
-    help="Path to a kubeconfig file (kubectl mode only). Overrides the 'KUBECONFIG' config field.",
+    help="Path to a kubeconfig file. Setting this implies kubectl mode unless --mode is given.",
 )
 @click.option(
     "-mig",


### PR DESCRIPTION
### 📝 Description

Adds two opt-in capabilities to `automation/patch_igz/patch_remote.py` to make patching faster and friendlier when working from a workstation that already has cluster access via `kubectl`, without changing the existing SSH-based flow.

The existing `ssh` mode remains the default and is unchanged.

Usage example

```sh
./automation/patch_igz/patch_remote.py \
    -c automation/patch_igz/patch_env.yml \
    --kubeconfig ~/.kube/mydev.yaml
```

or, with migration

```sh
./automation/patch_igz/patch_remote.py \
    -c automation/patch_igz/patch_env.yml \
    --kubeconfig ~/.kube/mydev.yaml \
    --migrate
```

---

### 🛠️ Changes Made

- **`MODE=kubectl` / `--mode kubectl`**: run `kubectl` locally against the target cluster instead of SSH-ing into a data node. `KUBECONFIG` (config field) or `--kubeconfig` points at the right cluster.
  - `SSH_USER` / `SSH_PASSWORD` are no longer required in this mode.
  - `DATA_NODES` is optional unless pushing to per-node Iguazio datanode registries (multi-node image replication).
- **Mode inference**: when `MODE` is unset, kubectl mode is inferred if `KUBECONFIG` is provided (config field or `--kubeconfig` flag); otherwise the legacy `ssh` default is used. Explicit `MODE` always wins, so kubectl mode against the kubectl default (`KUBECONFIG` env / `~/.kube/config`) still works via `MODE: kubectl` with no `KUBECONFIG` field.
- **`--migrate` / `-mig`**: after the api rollout, trigger DB migrations on `mlrun-api-chief` via the official `/operations/migrations` endpoint.
  - Authenticates with the pod's k8s service-account token + `x-igz-authenticator-kind: sa` header (Iguazio v4 verifies it as an SA session).
  - Disables the chief deployment's DB backup mode first (idempotent) to work around the api container's missing `mysqldump` credentials when a migration is actually pending.
  - Refuses to run together with `--skip-api`.
- **Config/CLI/docs updates**: `patch_env_template.yml` now documents `MODE` and `KUBECONFIG` and clarifies which fields are required per mode; `README.md` describes the two execution modes and inference rules.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Manually patched a remote Iguazio lab system

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Existing SSH flow is unchanged. New behavior is opt-in via `MODE` / `KUBECONFIG` / `--migrate`.

---

### 🔍️ Additional Notes

- The migration trigger intentionally bypasses `mlrun.get_run_db()`: its `connect()` syncs client-spec which enables `auth_with_oauth_token`, and `IGTokenProvider.__init__` eagerly fetches a token that isn't available inside the api pod. The snippet constructs `HTTPRunDB` directly and injects the SA bearer onto the session so both the trigger `POST` and the polling `GET`s carry it.

