### PR TITLE
[API] Add token issued at to secrets api

### DIFF
--- a/mlrun/auth/utils.py
+++ b/mlrun/auth/utils.py
@@ -36,6 +36,7 @@ class Claims:
     SUBJECT = "sub"
     EXPIRATION = "exp"
     PREFERRED_USERNAME = "preferred_username"
+    ISSUED_AT = "iat"
 
 
 def load_offline_token(
@@ -310,6 +311,11 @@ def extract_and_validate_tokens_info(
                     raise mlrun.errors.MLRunInvalidArgumentError(
                         f"Offline token '{token_name}' is missing the 'sub' (subject) claim"
                     )
+                # Validate token issued_at existence
+                if not decoded_token.get(Claims.ISSUED_AT):
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        f"Offline token '{token_name}' is missing the 'iat' (issued at) claim"
+                    )
 
                 # Validate token belongs to the authenticated user
                 token_sub = decoded_token.get(Claims.SUBJECT)
@@ -331,6 +337,7 @@ def extract_and_validate_tokens_info(
                 # Store token info
                 token_values[secret_token.name] = {
                     "token_exp": decoded_token.get(Claims.EXPIRATION),
+                    "token_iat": decoded_token.get(Claims.ISSUED_AT),
                     "token": secret_token.token,
                 }
             except mlrun.errors.MLRunInvalidArgumentError as exc:

--- a/mlrun/common/schemas/secret.py
+++ b/mlrun/common/schemas/secret.py
@@ -62,6 +62,7 @@ class StoreSecretTokensResponse(BaseModel):
 class SecretTokenInfo(BaseModel):
     name: str
     expiration: datetime
+    issued_at: datetime
     user_id: str
 
 

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from datetime import UTC, datetime
 import re
 from abc import ABC, abstractmethod
+from datetime import UTC, datetime
 
 import mlrun.common.schemas
 from mlrun.config import config as mlconf

--- a/mlrun/common/secrets.py
+++ b/mlrun/common/secrets.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from datetime import UTC, datetime
 import re
 from abc import ABC, abstractmethod
 
@@ -82,6 +83,7 @@ class SecretProviderInterface(ABC):
         token_name: str,
         token: str,
         expiration: int,
+        issued_at: int,
         force: bool = False,
         namespace: str | None = None,
     ) -> mlrun.common.schemas.SecretEventActions | None:
@@ -195,13 +197,15 @@ class InMemorySecretProvider(SecretProviderInterface):
         token_name: str,
         token: str,
         expiration: int,
+        issued_at: int,
         force: bool = False,
         namespace: str | None = None,
     ) -> mlrun.common.schemas.SecretEventActions | None:
         secret_name = self.resolve_auth_secret_name(auth_info.user_id, token_name)
         self.secrets_map[secret_name] = {
             "token": token,
-            "expiration": expiration,
+            "expiration": datetime.fromtimestamp(expiration, tz=UTC),
+            "issued_at": datetime.fromtimestamp(issued_at, tz=UTC),
             "user_id": auth_info.user_id,
             "token_name": token_name,
         }
@@ -226,6 +230,7 @@ class InMemorySecretProvider(SecretProviderInterface):
             mlrun.common.schemas.SecretTokenInfo(
                 name=self.secrets_map[secret_name]["token_name"],
                 expiration=self.secrets_map[secret_name]["expiration"],
+                issued_at=self.secrets_map[secret_name]["issued_at"],
             )
             for secret_name in secret_names
             if self.secrets_map[secret_name]["user_id"] == user_id

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1490,21 +1490,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         # Convert new_expiration to datetime for comparison
         new_exp_dt = datetime.fromtimestamp(new_expiration, tz=UTC)
-        if new_exp_dt > existing_exp:
-            return True
-
-        existing_iat = self._decode_secret_timestamp(k8s_secret, "tokenIssuedAt")
-
-        # If no isued at could be decoded, assume it needs an update
-        if existing_iat is None:
-            return True
-
-        # Convert new_issued_at to datetime for comparison
-        new_iat_dt = datetime.fromtimestamp(new_issued_at, tz=UTC)
-        if new_iat_dt > existing_iat:
-            return True
-
-        return False
+        return new_exp_dt > existing_exp
 
     def list_user_token_secrets(
         self,

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1391,6 +1391,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :param token_name: The logical name for the token.
         :param token: The offline token string (JWT).
         :param expiration: The token's expiration timestamp (int UNIX epoch).
+        :param issued_at: The token's issued at timestamp (int UNIX epoch).
         :param force: If True, forces an update of the secret even if the expiration
                       is not later than the existing one.
         :param namespace: Kubernetes namespace for the secret.

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1372,6 +1372,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         token_name: str,
         token: str,
         expiration: int,
+        issued_at: int,
         force: bool = False,
         namespace: str | None = None,
     ) -> mlrun.common.schemas.SecretEventActions | None:
@@ -1420,18 +1421,22 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 annotations=annotations,
                 namespace=namespace,
                 secret_name=self._resolve_auth_secret_name(user_id, token_name),
-                secrets=self._encode_user_token(token_name, token, expiration),
+                secrets=self._encode_user_token(
+                    token_name, token, expiration, issued_at
+                ),
                 encoded=True,
             )
             return mlrun.common.schemas.SecretEventActions.created
 
         # Update if force or if expiration is newer
-        if force or self._should_update_token_secret(k8s_secret, expiration):
+        if force or self._should_update_token_secret(k8s_secret, expiration, issued_at):
             self._update_secret(
                 k8s_secret=k8s_secret,
                 namespace=namespace,
                 secret_name=self._resolve_auth_secret_name(user_id, token_name),
-                secrets=self._encode_user_token(token_name, token, expiration),
+                secrets=self._encode_user_token(
+                    token_name, token, expiration, issued_at
+                ),
                 encoded=True,
             )
             return mlrun.common.schemas.SecretEventActions.updated
@@ -1446,7 +1451,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         )
 
     def _encode_user_token(
-        self, token_name: str, token: str, expiration: int
+        self, token_name: str, token: str, expiration: int, issued_at: int
     ) -> dict[str, str]:
         """
         Encode token and expiration into a dict suitable for Kubernetes Secret.data.
@@ -1457,13 +1462,18 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         )
         encoded_token_yaml = base64.b64encode(token_yaml.encode()).decode()
         encoded_expiration = base64.b64encode(str(expiration).encode()).decode()
+        encoded_issued_at = base64.b64encode(str(issued_at).encode()).decode()
         return {
             "tokensFile": encoded_token_yaml,
             "tokenExpiration": encoded_expiration,
+            "tokenIssuedAt": encoded_issued_at,
         }
 
     def _should_update_token_secret(
-        self, k8s_secret: client.V1Secret, new_expiration: int
+        self,
+        k8s_secret: client.V1Secret,
+        new_expiration: int,
+        new_issued_at: int,
     ) -> bool:
         """
         Determine if the secret should be updated based on tokenExpiration.
@@ -1472,7 +1482,7 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :param new_expiration: Expiration timestamp of the new token (Unix epoch).
         :return: True if the secret should be updated, False otherwise.
         """
-        existing_exp = self._decode_secret_expiration(k8s_secret)
+        existing_exp = self._decode_secret_timestamp(k8s_secret, "tokenExpiration")
 
         # If no expiration could be decoded, assume it needs an update
         if existing_exp is None:
@@ -1480,7 +1490,21 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
         # Convert new_expiration to datetime for comparison
         new_exp_dt = datetime.fromtimestamp(new_expiration, tz=UTC)
-        return new_exp_dt > existing_exp
+        if new_exp_dt > existing_exp:
+            return True
+
+        existing_iat = self._decode_secret_timestamp(k8s_secret, "tokenIssuedAt")
+
+        # If no isued at could be decoded, assume it needs an update
+        if existing_iat is None:
+            return True
+
+        # Convert new_issued_at to datetime for comparison
+        new_iat_dt = datetime.fromtimestamp(new_issued_at, tz=UTC)
+        if new_iat_dt > existing_iat:
+            return True
+
+        return False
 
     def list_user_token_secrets(
         self,
@@ -1579,24 +1603,27 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             mlrun_constants.MLRunInternalLabels.auth_token_name
         )
 
-        expiration = self._decode_secret_expiration(k8s_secret)
+        expiration = self._decode_secret_timestamp(k8s_secret, "tokenExpiration")
+        issued_at = self._decode_secret_timestamp(k8s_secret, "tokenIssuedAt")
         user_id = k8s_secret.metadata.labels.get(
             mlrun_constants.MLRunInternalLabels.auth_userid
         )
-        if expiration is None or user_id is None:
+        if expiration is None or issued_at is None or user_id is None:
             return None
 
         return mlrun.common.schemas.SecretTokenInfo(
             name=token_name,
             expiration=expiration,
+            issued_at=issued_at,
             user_id=user_id,
         )
 
-    def _decode_secret_expiration(self, k8s_secret) -> datetime | None:
-        """Decode the expiration timestamp from a Kubernetes secret.
+    def _decode_secret_timestamp(self, k8s_secret, field: str) -> datetime | None:
+        """Decode timestamp data from a Kubernetes secret.
 
-        :param k8s_secret: Kubernetes secret object containing tokenExpiration.
-        :return: Expiration as a timezone-aware datetime object, or None if decoding fails.
+        :param k8s_secret: Kubernetes secret object containing a timestamp in its data.
+        :param field: The field at which the timestamp is stored in the data.
+        :return: The timestamp as a timezone-aware datetime object, or None if decoding fails.
         """
         if not k8s_secret.data:
             logger.warning(
@@ -1605,20 +1632,20 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
             )
             return None
 
-        if "tokenExpiration" not in k8s_secret.data:
+        if field not in k8s_secret.data:
             logger.warning(
-                "Secret does not contain 'tokenExpiration', skipping expiration decode",
+                f"Secret does not contain {field!r}, skipping expiration decode",
                 secret_name=k8s_secret.metadata.name,
             )
             return None
 
         try:
-            expiration_b64 = k8s_secret.data["tokenExpiration"]
+            expiration_b64 = k8s_secret.data[field]
             expiration_str = base64.b64decode(expiration_b64).decode("utf-8")
             return datetime.fromtimestamp(int(expiration_str), tz=UTC)
         except Exception as exc:
             logger.warning(
-                "Failed to decode 'tokenExpiration' from secret",
+                f"Failed to decode {field!r} from secret",
                 secret_name=k8s_secret.metadata.name,
                 error=mlrun.errors.err_to_str(exc),
             )

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -468,12 +468,14 @@ class Secrets(
         for token_name, token_info in tokens_values.items():
             token = token_info["token"]
             expiration = token_info["token_exp"]
+            issued_at = token_info["token_iat"]
 
             action = self.secrets_provider.store_user_token_secret(
                 auth_info=auth_info,
                 token_name=token_name,
                 token=token,
                 expiration=expiration,
+                issued_at=issued_at,
                 force=force,
             )
             if action is not None:

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -723,7 +723,7 @@ def test_store_secret_tokens_missing_tokens(
 
 
 def test_store_secret_tokens_incorrect_user_id():
-    token_payload = {"exp": 9999999999, "sub": "user-id-123"}
+    token_payload = {"exp": 9999999999, "iat": 1, "sub": "user-id-123"}
     secret_tokens = [
         mlrun.common.schemas.SecretToken(
             name="token1", token=_generate_token(token_payload)
@@ -744,7 +744,7 @@ def test_store_secret_tokens_incorrect_user_id():
 
 
 def test_store_secret_tokens_duplicate_names():
-    token_payload = {"exp": 9999999999, "sub": "user-id-123"}
+    token_payload = {"exp": 9999999999, "iat": 1, "sub": "user-id-123"}
 
     secret_tokens = [
         mlrun.common.schemas.SecretToken(
@@ -784,24 +784,42 @@ def test_store_secret_tokens_invalid_offline_token_jwt_decode(mock_iguazio_clien
 @pytest.mark.parametrize(
     "payload, expected_err_msg",
     [
-        ({"sub": "user-id-123"}, r"missing the 'exp' \(expiration\) claim"),  # no exp
         (
-            {"sub": "user-id-123", "exp": None},
+            {"sub": "user-id-123", "iat": 1},
+            r"missing the 'exp' \(expiration\) claim",
+        ),  # no exp
+        (
+            {"sub": "user-id-123", "exp": None, "iat": 1},
             r"missing the 'exp' \(expiration\) claim",
         ),  # exp is None
         (
-            {"sub": "user-id-123", "exp": ""},
+            {"sub": "user-id-123", "exp": "", "iat": 1},
             r"missing the 'exp' \(expiration\) claim",
         ),  # exp is empty
-        ({"exp": 9999999999}, r"missing the 'sub' \(subject\) claim"),  # no sub
         (
-            {"sub": None, "exp": 9999999999},
+            {"exp": 9999999999, "iat": 1},
+            r"missing the 'sub' \(subject\) claim",
+        ),  # no sub
+        (
+            {"sub": None, "exp": 9999999999, "iat": 1},
             r"missing the 'sub' \(subject\) claim",
         ),  # sub is None
         (
-            {"sub": "", "exp": 9999999999},
+            {"sub": "", "exp": 9999999999, "iat": 1},
             r"missing the 'sub' \(subject\) claim",
         ),  # sub is empty
+        (
+            {"sub": "user-id-123", "exp": 9999999999},
+            r"missing the 'iat' \(issued at\) claim",
+        ),  # no iat
+        (
+            {"sub": "user-id-123", "exp": 9999999999, "iat": None},
+            r"missing the 'iat' \(issued at\) claim",
+        ),  # iat is None
+        (
+            {"sub": "user-id-123", "exp": 9999999999, "iat": ""},
+            r"missing the 'iat' \(issued at\) claim",
+        ),  # iat is empty
     ],
 )
 def test_store_secret_tokens_missing_required_claims_in_offline_token(
@@ -825,7 +843,7 @@ def test_store_secret_tokens_missing_required_claims_in_offline_token(
 
 
 def test_store_secret_tokens_return_values(mock_iguazio_client):
-    token_payload = {"sub": "user-id-123", "exp": 9999999999}
+    token_payload = {"sub": "user-id-123", "exp": 9999999999, "iat": 1}
     secret_tokens = [
         mlrun.common.schemas.SecretToken(
             name="token1", token=_generate_token(token_payload)
@@ -868,7 +886,7 @@ def test_store_secret_tokens_refresh_access_tokens_failure(mock_iguazio_client):
     secret_tokens = [
         mlrun.common.schemas.SecretToken(
             name="token1",
-            token=_generate_token({"sub": "user-id-123", "exp": 9999999999}),
+            token=_generate_token({"sub": "user-id-123", "exp": 9999999999, "iat": 1}),
         ),
     ]
 
@@ -887,14 +905,16 @@ def test_list_secret_tokens_returns_tokens():
     auth_info = mlrun.common.schemas.AuthInfo(
         username="dummy-user", user_id="user-id-123"
     )
+    iat1 = datetime.datetime(2025, 6, 26, 22, 6, 31, tzinfo=datetime.UTC)
     exp1 = datetime.datetime(2025, 6, 26, 23, 6, 31, tzinfo=datetime.UTC)
+    iat2 = datetime.datetime(2025, 9, 11, 11, 0, 0, tzinfo=datetime.UTC)
     exp2 = datetime.datetime(2025, 9, 11, 12, 0, 0, tzinfo=datetime.UTC)
     expected_tokens = [
         mlrun.common.schemas.SecretTokenInfo(
-            name="jupyter", expiration=exp1, user_id="user-id-123"
+            name="jupyter", expiration=exp1, issued_at=iat1, user_id="user-id-123"
         ),
         mlrun.common.schemas.SecretTokenInfo(
-            name="my-token", expiration=exp2, user_id="user-id-123"
+            name="my-token", expiration=exp2, issued_at=iat2, user_id="user-id-123"
         ),
     ]
 
@@ -910,9 +930,11 @@ def test_list_secret_tokens_returns_tokens():
     assert len(response.secret_tokens) == 2
     assert response.secret_tokens[0].name == "jupyter"
     assert response.secret_tokens[0].expiration == exp1
+    assert response.secret_tokens[0].issued_at == iat1
     assert response.secret_tokens[0].user_id == "user-id-123"
     assert response.secret_tokens[1].name == "my-token"
     assert response.secret_tokens[1].expiration == exp2
+    assert response.secret_tokens[1].issued_at == iat2
     assert response.secret_tokens[1].user_id == "user-id-123"
 
     mock_secrets_provider.list_user_token_secrets.assert_called_once_with(
@@ -1037,11 +1059,13 @@ async def test_delete_secret_tokens_success(mock_iguazio_client):
         mlrun.common.schemas.SecretTokenInfo(
             name="token-1",
             expiration=datetime.datetime.now(),
+            issued_at=datetime.datetime.now(),
             user_id=auth_info.user_id,
         ),
         mlrun.common.schemas.SecretTokenInfo(
             name="token-2",
             expiration=datetime.datetime.now(),
+            issued_at=datetime.datetime.now(),
             user_id=auth_info.user_id,
         ),
     ]
@@ -1087,16 +1111,19 @@ async def test_delete_secret_tokens_partial_failure(mock_iguazio_client):
         mlrun.common.schemas.SecretTokenInfo(
             name="token-1",
             expiration=datetime.datetime.now(),
+            issued_at=datetime.datetime.now(),
             user_id=auth_info.user_id,
         ),
         mlrun.common.schemas.SecretTokenInfo(
             name="token-2",
             expiration=datetime.datetime.now(),
+            issued_at=datetime.datetime.now(),
             user_id=auth_info.user_id,
         ),
         mlrun.common.schemas.SecretTokenInfo(
             name="token-3",
             expiration=datetime.datetime.now(),
+            issued_at=datetime.datetime.now(),
             user_id=auth_info.user_id,
         ),
     ]

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -494,12 +494,14 @@ def test_store_user_token_secret_created(k8s_helper):
     auth_info = mlrun.common.schemas.AuthInfo(user_id=user_id)
     token_name = "my-token"
     token_value = "abc123"
+    issued_at = 1
     expiration = 9999
 
     result = k8s_helper.store_user_token_secret(
         auth_info=auth_info,
         token_name=token_name,
         token=token_value,
+        issued_at=issued_at,
         expiration=expiration,
         namespace="default",
     )
@@ -530,6 +532,10 @@ def test_store_user_token_secret_created(k8s_helper):
     decoded_expiration = int(base64.b64decode(secrets_data["tokenExpiration"]).decode())
     assert decoded_expiration == expiration
 
+    # Decode and verify tokenIssuedAt
+    decoded_issued_at = int(base64.b64decode(secrets_data["tokenIssuedAt"]).decode())
+    assert decoded_issued_at == issued_at
+
 
 @pytest.mark.parametrize(
     "user_id",
@@ -552,6 +558,7 @@ def test_store_user_token_secret_stores_user_id_in_label(k8s_helper, user_id):
         auth_info=auth_info,
         token_name=token_name,
         token=token_value,
+        issued_at=1,
         expiration=expiration,
         namespace="default",
     )
@@ -605,12 +612,14 @@ def test_store_user_token_secret_username_annotation(
     auth_info = mlrun.common.schemas.AuthInfo(user_id=user_id, username=username)
     token_name = "my-token"
     token_value = "abc123"
+    issued_at = 1
     expiration = 9999
 
     result = k8s_helper.store_user_token_secret(
         auth_info=auth_info,
         token_name=token_name,
         token=token_value,
+        issued_at=issued_at,
         expiration=expiration,
         namespace="default",
     )
@@ -640,12 +649,14 @@ def test_store_user_token_secret_secret_naming(k8s_helper):
     auth_info = mlrun.common.schemas.AuthInfo(user_id=user_id)
     token_name = "my-token"
     token_value = "abc123"
+    issued_at = 1
     expiration = 9999
 
     result = k8s_helper.store_user_token_secret(
         auth_info=auth_info,
         token_name=token_name,
         token=token_value,
+        issued_at=issued_at,
         expiration=expiration,
         namespace="default",
     )
@@ -665,6 +676,7 @@ def test_store_user_token_secret_updated(k8s_helper):
     auth_info = mlrun.common.schemas.AuthInfo(user_id=user_id)
     token_name = "my-token"
     token_value = "abc123"
+    issued_at = 1
     new_expiration = 2000
     secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
@@ -673,6 +685,7 @@ def test_store_user_token_secret_updated(k8s_helper):
         secret_name,
         token_name=token_name,
         token_value=token_value,
+        issued_at=issued_at,
         expiration=1000,
         user_id=user_id,
     )
@@ -682,6 +695,7 @@ def test_store_user_token_secret_updated(k8s_helper):
         auth_info=auth_info,
         token_name=token_name,
         token=token_value,
+        issued_at=issued_at,
         expiration=new_expiration,
         namespace="default",
     )
@@ -695,6 +709,7 @@ def test_store_user_token_secret_updated(k8s_helper):
     secrets_data = k8s_helper._update_secret.call_args.kwargs["secrets"]
     assert "tokensFile" in secrets_data
     assert "tokenExpiration" in secrets_data
+    assert "tokenIssuedAt" in secrets_data
 
     # Decode and verify tokensFile
     decoded_tokens_yaml = base64.b64decode(secrets_data["tokensFile"]).decode()
@@ -706,6 +721,10 @@ def test_store_user_token_secret_updated(k8s_helper):
     # Decode and verify tokenExpiration
     decoded_expiration = int(base64.b64decode(secrets_data["tokenExpiration"]).decode())
     assert decoded_expiration == new_expiration
+
+    # Decode and verify tokenIssuedAt
+    decoded_issued_at = int(base64.b64decode(secrets_data["tokenIssuedAt"]).decode())
+    assert decoded_issued_at == issued_at
 
 
 @pytest.mark.parametrize(
@@ -728,12 +747,14 @@ def test_store_user_token_secret_skipped_and_force_update(
     auth_info = mlrun.common.schemas.AuthInfo(user_id=user_id)
     token_name = "my-token"
     token_value = "abc123"
+    issued_at = 1
     secret_name = k8s_helper._resolve_auth_secret_name(user_id, token_name)
 
     existing_secret = _make_user_token_secret(
         secret_name,
         token_name=token_name,
         token_value=token_value,
+        issued_at=issued_at,
         expiration=5000,
         user_id=user_id,
     )
@@ -743,6 +764,7 @@ def test_store_user_token_secret_skipped_and_force_update(
         auth_info=auth_info,
         token_name=token_name,
         token=token_value,
+        issued_at=issued_at,
         expiration=expiration,
         namespace="default",
         force=force,
@@ -837,15 +859,24 @@ def test_list_user_token_secrets_valid(k8s_helper):
     token1_name = "token1"
     token2_name = "token2"
     user_id = "test-user-id"
+    iat = 1
     exp1 = 1111
     exp2 = 2222
     secret1_name = k8s_helper._resolve_auth_secret_name(user_id, token1_name)
     secret2_name = k8s_helper._resolve_auth_secret_name(user_id, token2_name)
     secret1 = _make_user_token_secret(
-        secret1_name, token_name=token1_name, expiration=exp1, user_id=user_id
+        secret1_name,
+        token_name=token1_name,
+        issued_at=iat,
+        expiration=exp1,
+        user_id=user_id,
     )
     secret2 = _make_user_token_secret(
-        secret2_name, token_name=token2_name, expiration=exp2, user_id=user_id
+        secret2_name,
+        token_name=token2_name,
+        issued_at=iat,
+        expiration=exp2,
+        user_id=user_id,
     )
 
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
@@ -872,7 +903,26 @@ def test_list_user_token_secrets_invalid_expiration(k8s_helper):
     user_id = "test-user-id"
     secret_name = k8s_helper._resolve_auth_secret_name(user_id, "token1")
     bad_secret = _make_user_token_secret(
-        secret_name=secret_name, expiration=b"not-a-number", user_id=user_id
+        secret_name=secret_name,
+        issued_at=1,
+        expiration=b"not-a-number",
+        user_id=user_id,
+    )
+    k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[bad_secret])
+
+    result = k8s_helper.list_user_token_secrets(user_id=user_id, namespace="default")
+    assert len(result) == 0
+
+
+def test_list_user_token_secrets_invalid_issued_at(k8s_helper):
+    user_id = "test-user-id"
+    secret_name = k8s_helper._resolve_auth_secret_name(user_id, "token1")
+    bad_secret = _make_user_token_secret(
+        secret_name=secret_name,
+        issued_at=b"not-a-number",
+        expiration=1,
+        user_id=user_id,
     )
     k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
     k8s_helper.list_secrets = mock.MagicMock(return_value=[bad_secret])
@@ -892,6 +942,7 @@ def test_get_user_token_secret_value_valid(k8s_helper):
         secret_name,
         token_name=token_name,
         token_value=token_value,
+        issued_at=1,
         expiration=9999,
         user_id=user_id,
     )
@@ -1085,6 +1136,7 @@ def test_get_user_secret_tokens_as_igz_yml_data_single_token(k8s_helper):
         secret_name,
         token_name=token_name,
         token_value=token_value,
+        issued_at=1,
         expiration=9999,
         user_id=user_id,
     )
@@ -1124,6 +1176,7 @@ def test_list_user_token_secret_values(k8s_helper):
         secret1_name,
         token_name=token1_name,
         token_value=token1_value,
+        issued_at=1,
         expiration=1111,
         user_id=user_id,
     )
@@ -1131,6 +1184,7 @@ def test_list_user_token_secret_values(k8s_helper):
         secret2_name,
         token_name=token2_name,
         token_value=token2_value,
+        issued_at=1,
         expiration=2222,
         user_id=user_id,
     )
@@ -1162,6 +1216,7 @@ def test_list_user_token_secret_values_partial_failure(k8s_helper):
         secret1_name,
         token_name=token1_name,
         token_value=token1_value,
+        issued_at=1,
         expiration=1111,
         user_id=user_id,
     )
@@ -1169,6 +1224,7 @@ def test_list_user_token_secret_values_partial_failure(k8s_helper):
         secret2_name,
         token_name=token2_name,
         token_value="value2",
+        issued_at=1,
         expiration=2222,
         user_id=user_id,
     )
@@ -1228,6 +1284,7 @@ def test_get_user_secret_tokens_as_igz_yml_data_all_fail(k8s_helper):
         secret_name,
         token_name=token_name,
         token_value="value",
+        issued_at=1,
         expiration=1111,
         user_id=user_id,
     )
@@ -1249,6 +1306,7 @@ def _make_user_token_secret(
     token_name="my-token",
     token_value="abc123",
     expiration=None,
+    issued_at=None,
     labels=None,
     user_id="test-user-id",
 ):
@@ -1268,6 +1326,12 @@ def _make_user_token_secret(
     if expiration is not None:
         secret.data["tokenExpiration"] = base64.b64encode(
             str(expiration).encode()
+        ).decode()
+
+    # Encode tokenIssuedAt if provided
+    if issued_at is not None:
+        secret.data["tokenIssuedAt"] = base64.b64encode(
+            str(issued_at).encode()
         ).decode()
 
     return secret

--- a/tests/auth/test_auth_utils.py
+++ b/tests/auth/test_auth_utils.py
@@ -38,6 +38,8 @@ def _create_jwt_token(payload: dict, add_defaults: bool = True) -> str:
     if add_defaults:
         if "exp" not in payload:
             payload["exp"] = time.time() + 3600
+        if "iat" not in payload:
+            payload["iat"] = time.time() - 3600
         if "sub" not in payload:
             payload["sub"] = "test-user"
 
@@ -242,7 +244,7 @@ def test_load_and_prepare_secret_tokens_valid(
     # Generate valid JWT tokens with the specified user IDs
     tokens = []
     for idx, user_id in enumerate(token_user_ids):
-        jwt_token = _create_jwt_token({"sub": user_id, "exp": 9999999999})
+        jwt_token = _create_jwt_token({"sub": user_id, "iat": 1, "exp": 9999999999})
         tokens.append({"name": f"token{idx + 1}", "token": jwt_token})
 
     content = {"secretTokens": tokens}
@@ -289,7 +291,9 @@ def test_load_secret_tokens_from_file_invalid(tmp_path, content, monkeypatch):
             lambda: [
                 mlrun.common.schemas.SecretToken(
                     name="",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
             ],
             mlrun.errors.MLRunRuntimeError,
@@ -299,11 +303,15 @@ def test_load_secret_tokens_from_file_invalid(tmp_path, content, monkeypatch):
             lambda: [
                 mlrun.common.schemas.SecretToken(
                     name="dup",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
                 mlrun.common.schemas.SecretToken(
                     name="dup",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
             ],
             mlrun.errors.MLRunRuntimeError,
@@ -399,18 +407,18 @@ def _write_file(tmp_path, name: str, content) -> str:
         (
             {
                 "token_name": "token1",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             {
                 "token_name": "token2",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             None,
             None,
-            {"sub": "user-123", "exp": 9999999999},
-            {"sub": "user-123", "exp": 9999999999},
+            {"sub": "user-123", "iat": 1, "exp": 9999999999},
+            {"sub": "user-123", "iat": 1, "exp": 9999999999},
             "user-123",
         ),
         # Missing expiration claim
@@ -422,7 +430,7 @@ def _write_file(tmp_path, name: str, content) -> str:
             },
             {
                 "token_name": "token2",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             mlrun.errors.MLRunInvalidArgumentError,
@@ -435,12 +443,12 @@ def _write_file(tmp_path, name: str, content) -> str:
         (
             {
                 "token_name": "token1",
-                "token_payload": {"exp": 9999999999},
+                "token_payload": {"iat": 1, "exp": 9999999999},
                 "add_defaults": False,
             },
             {
                 "token_name": "token2",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             mlrun.errors.MLRunInvalidArgumentError,
@@ -453,12 +461,12 @@ def _write_file(tmp_path, name: str, content) -> str:
         (
             {
                 "token_name": "token1",
-                "token_payload": {"sub": "different-user", "exp": 9999999999},
+                "token_payload": {"sub": "different-user", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             {
                 "token_name": "token2",
-                "token_payload": {"sub": "different-user", "exp": 9999999999},
+                "token_payload": {"sub": "different-user", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             mlrun.errors.MLRunInvalidArgumentError,
@@ -472,12 +480,12 @@ def _write_file(tmp_path, name: str, content) -> str:
         (
             {
                 "token_name": "token1",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             {
                 "token_name": "token1",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             mlrun.errors.MLRunRuntimeError,
@@ -490,12 +498,12 @@ def _write_file(tmp_path, name: str, content) -> str:
         (
             {
                 "token_name": "",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             {
                 "token_name": "token2",
-                "token_payload": {"sub": "user-123", "exp": 9999999999},
+                "token_payload": {"sub": "user-123", "iat": 1, "exp": 9999999999},
                 "add_defaults": True,
             },
             mlrun.errors.MLRunRuntimeError,
@@ -679,7 +687,9 @@ def test_resolve_jwt_username_invalid_token():
             lambda: [
                 mlrun.common.schemas.SecretToken(
                     name="valid_token",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
                 mlrun.common.schemas.SecretToken(
                     name="invalid_token",
@@ -700,7 +710,9 @@ def test_resolve_jwt_username_invalid_token():
                 ),
                 mlrun.common.schemas.SecretToken(
                     name="good_token",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
             ],
             "user-123",
@@ -717,7 +729,9 @@ def test_resolve_jwt_username_invalid_token():
                 ),
                 mlrun.common.schemas.SecretToken(
                     name="good_token",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
             ],
             "user-123",
@@ -730,11 +744,15 @@ def test_resolve_jwt_username_invalid_token():
             lambda: [
                 mlrun.common.schemas.SecretToken(
                     name="no_sub",
-                    token=_create_jwt_token({"exp": 9999999999}, add_defaults=False),
+                    token=_create_jwt_token(
+                        {"iat": 1, "exp": 9999999999}, add_defaults=False
+                    ),
                 ),
                 mlrun.common.schemas.SecretToken(
                     name="good_token",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
             ],
             "user-123",
@@ -765,11 +783,15 @@ def test_resolve_jwt_username_invalid_token():
             lambda: [
                 mlrun.common.schemas.SecretToken(
                     name="wrong_user",
-                    token=_create_jwt_token({"sub": "other-user", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "other-user", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
                 mlrun.common.schemas.SecretToken(
                     name="good_token",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
             ],
             "user-123",
@@ -782,7 +804,9 @@ def test_resolve_jwt_username_invalid_token():
             lambda: [
                 mlrun.common.schemas.SecretToken(
                     name="valid_token",
-                    token=_create_jwt_token({"sub": "user-123", "exp": 9999999999}),
+                    token=_create_jwt_token(
+                        {"sub": "user-123", "iat": 1, "exp": 9999999999}
+                    ),
                 ),
                 mlrun.common.schemas.SecretToken(
                     name="invalid_token",
@@ -825,7 +849,7 @@ def test_extract_and_validate_tokens_info_skip_invalid(
 def test_load_and_prepare_secret_tokens_skips_invalid(tmp_path, monkeypatch):
     """Test that load_and_prepare_secret_tokens with raise_on_error=False skips
     invalid tokens and still returns the valid ones (simulates the import mlrun flow)."""
-    valid_jwt = _create_jwt_token({"sub": "user-123", "exp": 9999999999})
+    valid_jwt = _create_jwt_token({"sub": "user-123", "iat": 1, "exp": 9999999999})
     tokens = [
         {"name": "good_token", "token": valid_jwt},
         {"name": "bad_token", "token": "corrupted-jwt-data"},


### PR DESCRIPTION
### 📝 Description
Store issued_at in the secret token provider in the same way expiration is stored and make it available in the api.

---

### 🛠️ Changes Made
- Extract `iat` claim from offline token and store it with the token in the secret provider.
- Return the issued_at in the response from the secrets api.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-11637
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
