### PR TITLE
[API] Publish DB migration lifecycle events to Iguazio v4

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -84,6 +84,7 @@ from .events import (
     AuthSecretEventActions,
     EventClientKinds,
     EventsModes,
+    MigrationEventActions,
     SecretEventActions,
 )
 from .feature_store import (

--- a/mlrun/common/schemas/events.py
+++ b/mlrun/common/schemas/events.py
@@ -22,6 +22,7 @@ class EventsModes(mlrun.common.types.StrEnum):
 
 class EventClientKinds(mlrun.common.types.StrEnum):
     iguazio = "iguazio"
+    iguazio_v4 = "iguazio-v4"
     nop = "nop"
 
 
@@ -34,3 +35,10 @@ class SecretEventActions(mlrun.common.types.StrEnum):
 class AuthSecretEventActions(mlrun.common.types.StrEnum):
     created = "created"
     updated = "updated"
+
+
+class MigrationEventActions(mlrun.common.types.StrEnum):
+    required = "required"
+    started = "started"
+    completed = "completed"
+    failed = "failed"

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -152,19 +152,21 @@ def _migrate_existing_data(
     db_util = DBUtil()
     db_util.wait_for_db_liveness()
     db_util.set_configurations()
-    migration_scope: list[str] = []
-    migration_versions: dict = {}
+    migration_operations: dict[str, tuple] = {}
     if engine.name != mlrun.common.db.dialects.Dialects.SQLITE:
         (
             is_migration_needed,
             is_backup_needed,
-            migration_scope,
-            migration_versions,
+            migration_operations,
         ) = _resolve_needed_operations(alembic_util)
     else:
         # ON SQLite, we don't have schema migrations, so we don't need to check for them
         is_migration_needed = False
         is_backup_needed = False
+
+    migration_scope, migration_versions = _operations_to_scope_and_versions(
+        migration_operations
+    )
 
     if not perform_migrations_if_needed and is_migration_needed:
         state = mlrun.common.schemas.APIStates.waiting_for_migrations
@@ -179,18 +181,16 @@ def _migrate_existing_data(
 
     mlrun.utils.logger.info("Creating initial data")
     mlrun.mlconf.httpdb.state = mlrun.common.schemas.APIStates.migrations_in_progress
-    migration_start_monotonic: float | None = None
-    if is_migration_needed:
-        migration_start_monotonic = time.monotonic()
-        _publish_db_migration_event(
-            mlrun.common.schemas.MigrationEventActions.started,
-            scope=migration_scope,
-            versions=migration_versions,
-        )
 
     db_session = framework.db.session.create_session()
     try:
         if is_migration_needed:
+            migration_start_monotonic = time.monotonic()
+            _publish_db_migration_event(
+                mlrun.common.schemas.MigrationEventActions.started,
+                scope=migration_scope,
+                versions=migration_versions,
+            )
             try:
                 # DB backup runs inside the migration try/except so a backup
                 # failure transitions the API to migrations_failed and emits
@@ -217,16 +217,14 @@ def _migrate_existing_data(
                     versions=migration_versions,
                 )
                 raise
+            _publish_db_migration_event(
+                mlrun.common.schemas.MigrationEventActions.completed,
+                duration_seconds=_elapsed_since(migration_start_monotonic),
+                scope=migration_scope,
+                versions=migration_versions,
+            )
     finally:
         framework.db.session.close_session(db_session)
-
-    if is_migration_needed:
-        _publish_db_migration_event(
-            mlrun.common.schemas.MigrationEventActions.completed,
-            duration_seconds=_elapsed_since(migration_start_monotonic),
-            scope=migration_scope,
-            versions=migration_versions,
-        )
 
     # if the above process actually ran a migration - initializations that were skipped on the API initialization
     # should happen - we can't do it here because it requires an asyncio loop which can't be accessible here
@@ -263,7 +261,7 @@ def update_default_configuration_data():
 
 def _resolve_needed_operations(
     alembic_util: services.api.utils.db.alembic.AlembicUtil,
-) -> tuple[bool, bool, list[str], dict]:
+) -> tuple[bool, bool, dict[str, tuple]]:
     is_schema_migration_needed = alembic_util.is_schema_migration_needed()
     is_data_migration_needed = (
         not _is_latest_data_version()
@@ -274,16 +272,17 @@ def _resolve_needed_operations(
         mlrun.mlconf.httpdb.db.backup.mode == "enabled" and is_migration_needed
     )
 
-    scope: list[str] = []
-    versions: dict = {}
+    operations: dict[str, tuple] = {}
     if is_schema_migration_needed:
-        scope.append("schema")
-        versions["current_schema_revision"] = alembic_util.get_current_revision()
-        versions["target_schema_revision"] = alembic_util.latest_revision
+        operations["schema"] = (
+            alembic_util.get_current_revision(),
+            alembic_util.latest_revision,
+        )
     if is_data_migration_needed:
-        scope.append("data")
-        versions["current_data_version"] = _get_current_data_version()
-        versions["target_data_version"] = latest_data_version
+        operations["data"] = (
+            _get_current_data_version(),
+            latest_data_version,
+        )
 
     mlrun.utils.logger.info(
         "Checking if migration is needed",
@@ -293,7 +292,7 @@ def _resolve_needed_operations(
         is_migration_needed=is_migration_needed,
     )
 
-    return is_migration_needed, is_backup_needed, scope, versions
+    return is_migration_needed, is_backup_needed, operations
 
 
 def _get_current_data_version() -> int | None:
@@ -370,6 +369,21 @@ def _elapsed_since(start_monotonic: float | None) -> float | None:
     if start_monotonic is None:
         return None
     return time.monotonic() - start_monotonic
+
+
+def _operations_to_scope_and_versions(
+    operations: dict[str, tuple],
+) -> tuple[list[str], dict]:
+    versions: dict = {}
+    if "schema" in operations:
+        current, target = operations["schema"]
+        versions["current_schema_revision"] = current
+        versions["target_schema_revision"] = target
+    if "data" in operations:
+        current, target = operations["data"]
+        versions["current_data_version"] = current
+        versions["target_data_version"] = target
+    return list(operations.keys()), versions
 
 
 def _is_latest_data_version():

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -18,6 +18,7 @@ import os
 import pathlib
 import random
 import string
+import time
 import typing
 
 import alembic
@@ -51,6 +52,7 @@ import framework.db.sqldb.sql_session
 import framework.utils.pagination_cache
 import services.api.utils.db.alembic
 import services.api.utils.db.backup
+import services.api.utils.events.events_factory
 import services.api.utils.scheduler
 from framework.utils.db.utils import DBUtil
 
@@ -150,10 +152,14 @@ def _migrate_existing_data(
     db_util = DBUtil()
     db_util.wait_for_db_liveness()
     db_util.set_configurations()
+    migration_scope: list[str] = []
+    migration_versions: dict = {}
     if engine.name != mlrun.common.db.dialects.Dialects.SQLITE:
         (
             is_migration_needed,
             is_backup_needed,
+            migration_scope,
+            migration_versions,
         ) = _resolve_needed_operations(alembic_util)
     else:
         # ON SQLite, we don't have schema migrations, so we don't need to check for them
@@ -164,32 +170,63 @@ def _migrate_existing_data(
         state = mlrun.common.schemas.APIStates.waiting_for_migrations
         mlrun.utils.logger.info("Migration is needed, changing API state", state=state)
         mlrun.mlconf.httpdb.state = state
+        _publish_db_migration_event(
+            mlrun.common.schemas.MigrationEventActions.required,
+            scope=migration_scope,
+            versions=migration_versions,
+        )
         return
-
-    if is_backup_needed:
-        mlrun.utils.logger.info("DB Backup is needed, backing up...")
-        db_backup = services.api.utils.db.backup.DBBackupUtil()
-        db_backup.backup_database()
 
     mlrun.utils.logger.info("Creating initial data")
     mlrun.mlconf.httpdb.state = mlrun.common.schemas.APIStates.migrations_in_progress
+    migration_start_monotonic: float | None = None
+    if is_migration_needed:
+        migration_start_monotonic = time.monotonic()
+        _publish_db_migration_event(
+            mlrun.common.schemas.MigrationEventActions.started,
+            scope=migration_scope,
+            versions=migration_versions,
+        )
 
     db_session = framework.db.session.create_session()
     try:
         if is_migration_needed:
             try:
+                # DB backup runs inside the migration try/except so a backup
+                # failure transitions the API to migrations_failed and emits
+                # the Failed event — it's part of the migration window from
+                # an operator's perspective.
+                if is_backup_needed:
+                    mlrun.utils.logger.info("DB Backup is needed, backing up...")
+                    db_backup = services.api.utils.db.backup.DBBackupUtil()
+                    db_backup.backup_database()
                 _perform_schema_migrations(alembic_util)
                 _add_initial_data(db_session)
                 _perform_data_migrations(db_session)
-            except Exception:
+            except Exception as exc:
                 state = mlrun.common.schemas.APIStates.migrations_failed
                 mlrun.utils.logger.warning(
                     "Migrations failed, changing API state", state=state
                 )
                 mlrun.mlconf.httpdb.state = state
+                _publish_db_migration_event(
+                    mlrun.common.schemas.MigrationEventActions.failed,
+                    error=exc,
+                    duration_seconds=_elapsed_since(migration_start_monotonic),
+                    scope=migration_scope,
+                    versions=migration_versions,
+                )
                 raise
     finally:
         framework.db.session.close_session(db_session)
+
+    if is_migration_needed:
+        _publish_db_migration_event(
+            mlrun.common.schemas.MigrationEventActions.completed,
+            duration_seconds=_elapsed_since(migration_start_monotonic),
+            scope=migration_scope,
+            versions=migration_versions,
+        )
 
     # if the above process actually ran a migration - initializations that were skipped on the API initialization
     # should happen - we can't do it here because it requires an asyncio loop which can't be accessible here
@@ -226,7 +263,7 @@ def update_default_configuration_data():
 
 def _resolve_needed_operations(
     alembic_util: services.api.utils.db.alembic.AlembicUtil,
-) -> tuple[bool, bool]:
+) -> tuple[bool, bool, list[str], dict]:
     is_schema_migration_needed = alembic_util.is_schema_migration_needed()
     is_data_migration_needed = (
         not _is_latest_data_version()
@@ -236,6 +273,18 @@ def _resolve_needed_operations(
     is_backup_needed = (
         mlrun.mlconf.httpdb.db.backup.mode == "enabled" and is_migration_needed
     )
+
+    scope: list[str] = []
+    versions: dict = {}
+    if is_schema_migration_needed:
+        scope.append("schema")
+        versions["current_schema_revision"] = alembic_util.get_current_revision()
+        versions["target_schema_revision"] = alembic_util.latest_revision
+    if is_data_migration_needed:
+        scope.append("data")
+        versions["current_data_version"] = _get_current_data_version()
+        versions["target_data_version"] = latest_data_version
+
     mlrun.utils.logger.info(
         "Checking if migration is needed",
         is_schema_migration_needed=is_schema_migration_needed,
@@ -244,7 +293,27 @@ def _resolve_needed_operations(
         is_migration_needed=is_migration_needed,
     )
 
-    return is_migration_needed, is_backup_needed
+    return is_migration_needed, is_backup_needed, scope, versions
+
+
+def _get_current_data_version() -> int | None:
+    db_session = framework.db.session.create_session()
+    db = framework.db.sqldb.db.SQLDB()
+    try:
+        version = _resolve_current_data_version(db, db_session)
+    finally:
+        framework.db.session.close_session(db_session)
+    if version is None:
+        return None
+    try:
+        return int(version)
+    except (TypeError, ValueError) as exc:
+        mlrun.utils.logger.warning(
+            "Could not parse current data version, treating as unknown",
+            version=version,
+            exc=mlrun.errors.err_to_str(exc),
+        )
+        return None
 
 
 def _create_alembic_util() -> services.api.utils.db.alembic.AlembicUtil:
@@ -262,6 +331,45 @@ def _perform_schema_migrations(alembic_util: services.api.utils.db.alembic.Alemb
     if alembic_util:
         mlrun.utils.logger.info("Performing schema migration")
         alembic_util.init_alembic()
+
+
+def _publish_db_migration_event(
+    action: mlrun.common.schemas.MigrationEventActions,
+    error: BaseException | None = None,
+    duration_seconds: float | None = None,
+    scope: list[str] | None = None,
+    versions: dict | None = None,
+) -> None:
+    """
+    Best-effort publish of a DB migration lifecycle event.
+    Failures must not break startup or the migration flow.
+    """
+    try:
+        events_client = (
+            services.api.utils.events.events_factory.EventsFactory.get_events_client()
+        )
+        event = events_client.generate_db_migration_event(
+            action,
+            error=error,
+            duration_seconds=duration_seconds,
+            scope=scope,
+            versions=versions,
+        )
+        if event is None:
+            return
+        events_client.emit(event)
+    except Exception as publish_exc:
+        mlrun.utils.logger.warning(
+            "Failed to publish DB migration event",
+            action=action,
+            exc=mlrun.errors.err_to_str(publish_exc),
+        )
+
+
+def _elapsed_since(start_monotonic: float | None) -> float | None:
+    if start_monotonic is None:
+        return None
+    return time.monotonic() - start_monotonic
 
 
 def _is_latest_data_version():

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -739,6 +739,63 @@ def test_migrate_monitoring_functions_labels():
             assert key not in func_labels, f"{func_name} has an unexpected label"
 
 
+def test_publish_db_migration_event_emits(monkeypatch: pytest.MonkeyPatch):
+    fake_event = object()
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_migration_event.return_value = fake_event
+    monkeypatch.setattr(
+        "services.api.utils.events.events_factory.EventsFactory.get_events_client",
+        lambda *a, **kw: fake_client,
+    )
+    services.api.initial_data._publish_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.completed,
+        duration_seconds=2.5,
+        scope=["schema", "data"],
+        versions={"current_schema_revision": "abc", "target_schema_revision": "def"},
+    )
+    fake_client.generate_db_migration_event.assert_called_once_with(
+        mlrun.common.schemas.MigrationEventActions.completed,
+        error=None,
+        duration_seconds=2.5,
+        scope=["schema", "data"],
+        versions={"current_schema_revision": "abc", "target_schema_revision": "def"},
+    )
+    fake_client.emit.assert_called_once_with(fake_event)
+
+
+def test_publish_db_migration_event_skips_when_event_is_none(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # default base client returns None -> emit must not be called
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_migration_event.return_value = None
+    monkeypatch.setattr(
+        "services.api.utils.events.events_factory.EventsFactory.get_events_client",
+        lambda *a, **kw: fake_client,
+    )
+    services.api.initial_data._publish_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.required
+    )
+    fake_client.emit.assert_not_called()
+
+
+def test_publish_db_migration_event_swallows_factory_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _boom(*_a, **_kw):
+        raise RuntimeError("factory broken")
+
+    monkeypatch.setattr(
+        "services.api.utils.events.events_factory.EventsFactory.get_events_client",
+        _boom,
+    )
+    # must not raise
+    services.api.initial_data._publish_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.failed,
+        error=RuntimeError("boom"),
+    )
+
+
 def _initialize_db_without_schema() -> tuple[
     framework.db.sqldb.db.SQLDB, sqlalchemy.orm.Session
 ]:

--- a/server/py/services/api/tests/unit/utils/events/test_events_factory.py
+++ b/server/py/services/api/tests/unit/utils/events/test_events_factory.py
@@ -15,18 +15,21 @@
 import pytest
 
 import mlrun.common.schemas
+import mlrun.common.types
 
 import services.api.utils.events.base
 import services.api.utils.events.events_factory
 import services.api.utils.events.iguazio
+import services.api.utils.events.iguazio_v4
 import services.api.utils.events.nop
 
 
 @pytest.mark.parametrize(
-    "events_mode,kind,igz_version,expected_error,expected_instance",
+    "events_mode,kind,igz_version,auth_mode,expected_error,expected_instance",
     [
         (
             mlrun.common.schemas.EventsModes.disabled,
+            None,
             None,
             None,
             None,
@@ -34,6 +37,7 @@ import services.api.utils.events.nop
         ),
         (
             mlrun.common.schemas.EventsModes.enabled,
+            None,
             None,
             None,
             None,
@@ -42,6 +46,7 @@ import services.api.utils.events.nop
         (
             mlrun.common.schemas.EventsModes.enabled,
             mlrun.common.schemas.EventClientKinds.iguazio,
+            None,
             None,
             mlrun.errors.MLRunInvalidArgumentError,
             None,
@@ -51,7 +56,26 @@ import services.api.utils.events.nop
             mlrun.common.schemas.EventClientKinds.iguazio,
             "3.5.3",
             None,
+            None,
             services.api.utils.events.iguazio.Client,
+        ),
+        # v4 mode auto-selected when auth mode is iguazio-v4
+        (
+            mlrun.common.schemas.EventsModes.enabled,
+            None,
+            "4.0.0",
+            mlrun.common.types.AuthenticationMode.IGUAZIO_V4,
+            None,
+            services.api.utils.events.iguazio_v4.Client,
+        ),
+        # explicit v4 kind without v4 auth mode -> error
+        (
+            mlrun.common.schemas.EventsModes.enabled,
+            mlrun.common.schemas.EventClientKinds.iguazio_v4,
+            "3.5.3",
+            None,
+            mlrun.errors.MLRunInvalidArgumentError,
+            None,
         ),
     ],
 )
@@ -59,11 +83,17 @@ def test_get_events_client(
     events_mode: mlrun.common.schemas.EventsModes,
     kind: mlrun.common.schemas.EventClientKinds,
     igz_version: str,
+    auth_mode: mlrun.common.types.AuthenticationMode,
     expected_error: mlrun.errors.MLRunBaseError,
     expected_instance: services.api.utils.events.base.BaseEventClient,
 ):
     mlrun.mlconf.events.mode = events_mode.value
     mlrun.mlconf.igz_version = igz_version
+    mlrun.mlconf.httpdb.authentication.mode = (
+        auth_mode.value
+        if auth_mode
+        else mlrun.common.types.AuthenticationMode.NONE.value
+    )
     if expected_error:
         with pytest.raises(expected_error):
             services.api.utils.events.events_factory.EventsFactory.get_events_client(

--- a/server/py/services/api/tests/unit/utils/events/test_events_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/events/test_events_iguazio_v4.py
@@ -1,0 +1,259 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock
+
+import iguazio
+import iguazio.schemas
+import pytest
+
+import mlrun.common.schemas
+
+import services.api.utils.events.iguazio_v4 as iguazio_v4_events
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(iguazio, "Client", unittest.mock.MagicMock())
+    monkeypatch.setattr(
+        "framework.utils.clients.service_account_token.Client",
+        unittest.mock.MagicMock(),
+    )
+    mlrun.mlconf.services.service_name = "api"
+    mlrun.mlconf.httpdb.clusterization.role = "chief"
+    return iguazio_v4_events.Client()
+
+
+@pytest.mark.parametrize(
+    "action,expected_config_name,expected_severity",
+    [
+        (
+            mlrun.common.schemas.MigrationEventActions.required,
+            iguazio_v4_events.DB_MIGRATION_REQUIRED,
+            iguazio.schemas.Severity.CRITICAL,
+        ),
+        (
+            mlrun.common.schemas.MigrationEventActions.started,
+            iguazio_v4_events.DB_MIGRATION_STARTED,
+            iguazio.schemas.Severity.INFO,
+        ),
+        (
+            mlrun.common.schemas.MigrationEventActions.completed,
+            iguazio_v4_events.DB_MIGRATION_COMPLETED,
+            iguazio.schemas.Severity.INFO,
+        ),
+        (
+            mlrun.common.schemas.MigrationEventActions.failed,
+            iguazio_v4_events.DB_MIGRATION_FAILED,
+            iguazio.schemas.Severity.CRITICAL,
+        ),
+    ],
+)
+def test_generate_db_migration_event_basic(
+    client, action, expected_config_name, expected_severity
+):
+    event = client.generate_db_migration_event(action)
+    assert event.config_name == expected_config_name
+    assert event.kind == "system"
+    assert event.class_ == "Platform"
+    assert event.severity == expected_severity
+    assert event.entity_name == "MLRun"
+    assert event.source == "mlrun-api-chief"
+    # description is the catalog default for non-failed actions
+    if action != mlrun.common.schemas.MigrationEventActions.failed:
+        assert event.description and "MLRun database migration" in event.description
+    # error/duration are only populated when supplied
+    assert "error" not in event.details
+    assert "duration_seconds" not in event.details
+
+
+@pytest.mark.parametrize(
+    "service_name,role,expected_source",
+    [
+        ("api", "chief", "mlrun-api-chief"),
+        ("api", "worker", "mlrun-api-worker"),
+        ("alerts", "chief", "mlrun-alerts"),
+    ],
+)
+def test_source_reflects_deployment(monkeypatch, service_name, role, expected_source):
+    monkeypatch.setattr(iguazio, "Client", unittest.mock.MagicMock())
+    monkeypatch.setattr(
+        "framework.utils.clients.service_account_token.Client",
+        unittest.mock.MagicMock(),
+    )
+    mlrun.mlconf.services.service_name = service_name
+    mlrun.mlconf.httpdb.clusterization.role = role
+    c = iguazio_v4_events.Client()
+    event = c.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.started
+    )
+    assert event.source == expected_source
+
+
+def test_completed_event_carries_duration(client):
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.completed,
+        duration_seconds=12.3456,
+    )
+    assert event.details == {"duration_seconds": 12.346}
+    assert event.severity == iguazio.schemas.Severity.INFO
+
+
+@pytest.mark.parametrize(
+    "scope,expected",
+    [
+        (["schema"], ["schema"]),
+        (["data"], ["data"]),
+        (["schema", "data"], ["data", "schema"]),
+        (["data", "schema"], ["data", "schema"]),
+        (None, None),
+        ([], None),
+    ],
+)
+def test_scope_in_details(client, scope, expected):
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.started,
+        scope=scope,
+    )
+    if expected is None:
+        assert "scope" not in event.details
+    else:
+        assert event.details["scope"] == expected
+
+
+def test_versions_merged_into_details(client):
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.required,
+        scope=["schema", "data"],
+        versions={
+            "current_schema_revision": "abc123",
+            "target_schema_revision": "def456",
+            "current_data_version": 9,
+            "target_data_version": 10,
+        },
+    )
+    assert event.details["current_schema_revision"] == "abc123"
+    assert event.details["target_schema_revision"] == "def456"
+    assert event.details["current_data_version"] == 9
+    assert event.details["target_data_version"] == 10
+    assert event.details["scope"] == ["data", "schema"]
+
+
+def test_versions_drops_none_values(client):
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.required,
+        versions={
+            "current_schema_revision": "abc123",
+            "target_schema_revision": "def456",
+            "current_data_version": None,
+            "target_data_version": None,
+        },
+    )
+    assert event.details == {
+        "current_schema_revision": "abc123",
+        "target_schema_revision": "def456",
+    }
+
+
+def test_versions_empty_or_none(client):
+    e1 = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.started, versions=None
+    )
+    e2 = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.started, versions={}
+    )
+    assert e1.details == {} == e2.details
+
+
+def test_failed_event_with_exception_includes_summary_and_duration(client):
+    err = RuntimeError("schema head mismatch")
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.failed,
+        error=err,
+        duration_seconds=4.0,
+    )
+    assert event.config_name == iguazio_v4_events.DB_MIGRATION_FAILED
+    assert event.details["error"] == "schema head mismatch"
+    assert event.details["error_type"] == "RuntimeError"
+    assert event.details["duration_seconds"] == 4.0
+    assert "schema head mismatch" in event.description
+    # description still contains the catalog wording
+    assert "MLRun database migration failed" in event.description
+
+
+def test_failed_event_with_string_error(client):
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.failed,
+        error="boom",
+    )
+    assert event.details["error"] == "boom"
+    # error_type is only set for exceptions, not raw strings
+    assert "error_type" not in event.details
+    assert "boom" in event.description
+
+
+def test_failed_event_truncates_long_error(client):
+    long_err = "x" * 4096
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.failed,
+        error=long_err,
+    )
+    assert event.details["error"].endswith("...[truncated]")
+    # Truncation budget is hard — output must not exceed the documented limit
+    assert len(event.details["error"]) <= iguazio_v4_events.ERROR_DETAIL_LIMIT
+    # description summary is truncated more aggressively
+    assert event.description.endswith("...[truncated]")
+    assert len(event.description) < 350
+
+
+@pytest.mark.parametrize("falsy_error", ["", None])
+def test_failed_event_with_falsy_error_uses_catalog_description(client, falsy_error):
+    event = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.failed,
+        error=falsy_error,
+    )
+    # No error context appended; description stays as the catalog default,
+    # and details contain neither error nor error_type.
+    assert event.description == (
+        "MLRun database migration failed, functionality may be impaired"
+    )
+    assert "error" not in event.details
+    assert "error_type" not in event.details
+
+
+def test_emit_calls_publish_event(client):
+    spec = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.started
+    )
+    client.emit(spec)
+    client._client.with_headers.assert_called_once()
+    client._client.publish_event.assert_called_once_with(spec)
+
+
+def test_emit_swallows_exceptions(client):
+    spec = client.generate_db_migration_event(
+        mlrun.common.schemas.MigrationEventActions.required
+    )
+    client._client.publish_event.side_effect = RuntimeError("network down")
+    client.emit(spec)
+
+
+def test_emit_none_event_is_noop(client):
+    client.emit(None)
+    client._client.publish_event.assert_not_called()
+
+
+def test_unsupported_action_raises(client):
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        client.generate_db_migration_event("bogus")  # type: ignore[arg-type]

--- a/server/py/services/api/utils/db/alembic.py
+++ b/server/py/services/api/utils/db/alembic.py
@@ -36,6 +36,13 @@ class AlembicUtil:
         logger.debug("Performing alembic schema migrations")
         alembic.command.upgrade(self._alembic_config, "head")
 
+    @property
+    def latest_revision(self) -> str:
+        return self._latest_revision
+
+    def get_current_revision(self) -> str | None:
+        return self._get_current_revision()
+
     def is_schema_migration_needed(self):
         current_revision = self._get_current_revision()
         logger.debug(

--- a/server/py/services/api/utils/events/base.py
+++ b/server/py/services/api/utils/events/base.py
@@ -54,3 +54,26 @@ class BaseEventClient:
         :return: event object to emit
         """
         pass
+
+    def generate_db_migration_event(
+        self,
+        action: mlrun.common.schemas.MigrationEventActions,
+        error: BaseException | str | None = None,
+        duration_seconds: float | None = None,
+        scope: list[str] | None = None,
+        versions: dict | None = None,
+    ):
+        """
+        Generate a DB migration lifecycle event
+        :param action: required, started, completed or failed
+        :param error: optional error (only used for failed)
+        :param duration_seconds: optional elapsed time since started; reported
+            on completed and failed events
+        :param scope: which migration kinds are involved (e.g. ["schema"], ["data"],
+            or ["schema", "data"])
+        :param versions: schema/data version context, e.g.
+            {"current_schema_revision": "...", "target_schema_revision": "...",
+             "current_data_version": 9, "target_data_version": 10}
+        :return: event object to emit, or None if the client doesn't support this event
+        """
+        return None

--- a/server/py/services/api/utils/events/base.py
+++ b/server/py/services/api/utils/events/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import typing
 
 import mlrun.common.schemas
 
@@ -62,7 +63,7 @@ class BaseEventClient:
         duration_seconds: float | None = None,
         scope: list[str] | None = None,
         versions: dict | None = None,
-    ):
+    ) -> typing.Any | None:
         """
         Generate a DB migration lifecycle event
         :param action: required, started, completed or failed

--- a/server/py/services/api/utils/events/events_factory.py
+++ b/server/py/services/api/utils/events/events_factory.py
@@ -17,6 +17,7 @@ import mlrun.utils.singleton
 
 import services.api.utils.events.base
 import services.api.utils.events.iguazio
+import services.api.utils.events.iguazio_v4
 import services.api.utils.events.nop
 
 
@@ -29,8 +30,17 @@ class EventsFactory:
             return services.api.utils.events.nop.NopClient()
 
         if not kind:
-            if mlrun.mlconf.get_parsed_igz_version():
+            if mlrun.mlconf.is_iguazio_v4_mode():
+                kind = mlrun.common.schemas.EventClientKinds.iguazio_v4
+            elif mlrun.mlconf.get_parsed_igz_version():
                 kind = mlrun.common.schemas.EventClientKinds.iguazio
+
+        if kind == mlrun.common.schemas.EventClientKinds.iguazio_v4:
+            if not mlrun.mlconf.is_iguazio_v4_mode():
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "Iguazio v4 events client can only be used in Iguazio v4 environment"
+                )
+            return services.api.utils.events.iguazio_v4.Client(**kwargs)
 
         if kind == mlrun.common.schemas.EventClientKinds.iguazio:
             if not mlrun.mlconf.get_parsed_igz_version():

--- a/server/py/services/api/utils/events/iguazio_v4.py
+++ b/server/py/services/api/utils/events/iguazio_v4.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import iguazio
+import iguazio.schemas
+
+import mlrun.common.schemas
+import mlrun.errors
+from mlrun.utils import logger
+
+import framework.utils.clients.helpers as clients_helpers
+import framework.utils.clients.service_account_token as service_account_token
+import services.api.utils.events.base as base_events
+
+DB_MIGRATION_REQUIRED = "Platform.MLRun.DB.MigrationRequired"
+DB_MIGRATION_STARTED = "Platform.MLRun.DB.MigrationStarted"
+DB_MIGRATION_COMPLETED = "Platform.MLRun.DB.MigrationCompleted"
+DB_MIGRATION_FAILED = "Platform.MLRun.DB.MigrationFailed"
+
+ENTITY_NAME = "MLRun"
+EVENT_KIND = "system"
+EVENT_CLASS = "Platform"
+ERROR_DETAIL_LIMIT = 1024
+ERROR_DESCRIPTION_LIMIT = 200
+TRUNCATION_SUFFIX = "...[truncated]"
+
+# Per IG4 System Events Spec — Phase 2.
+# class is "Platform", kind is "system" for all DB lifecycle events.
+# Severity follows the spec: Required/Failed are Critical, Started/Completed are Info.
+DB_MIGRATION_EVENTS: dict[
+    mlrun.common.schemas.MigrationEventActions,
+    tuple[str, iguazio.schemas.Severity, str],
+] = {
+    mlrun.common.schemas.MigrationEventActions.required: (
+        DB_MIGRATION_REQUIRED,
+        iguazio.schemas.Severity.CRITICAL,
+        "MLRun database migration required, functionality may be impaired",
+    ),
+    mlrun.common.schemas.MigrationEventActions.started: (
+        DB_MIGRATION_STARTED,
+        iguazio.schemas.Severity.INFO,
+        "MLRun database migration started",
+    ),
+    mlrun.common.schemas.MigrationEventActions.completed: (
+        DB_MIGRATION_COMPLETED,
+        iguazio.schemas.Severity.INFO,
+        "MLRun database migration completed successfully",
+    ),
+    mlrun.common.schemas.MigrationEventActions.failed: (
+        DB_MIGRATION_FAILED,
+        iguazio.schemas.Severity.CRITICAL,
+        "MLRun database migration failed, functionality may be impaired",
+    ),
+}
+
+
+class Client(base_events.BaseEventClient):
+    """
+    Events client for Iguazio v4 — publishes events through the Iguazio (orca) SDK
+    using catalog event configs.
+    """
+
+    def __init__(self, **_kwargs):
+        self._client = iguazio.Client(
+            api_url=mlrun.mlconf.iguazio_api_url,
+            auto_login=False,
+            use_token_file=False,
+            verify_ssl=mlrun.mlconf.iguazio_api_ssl_verify,
+        )
+        self._service_account_token_client = service_account_token.Client()
+        self._source = self._resolve_source()
+
+    def emit(self, event):
+        if event is None:
+            return
+        try:
+            logger.debug(
+                "Emitting event",
+                config_name=event.config_name,
+                source=event.source,
+            )
+            with self._client.with_headers(
+                clients_helpers.enrich_headers(
+                    headers=self._service_account_token_client.auth_headers,
+                )
+            ):
+                self._client.publish_event(event)
+        except Exception as exc:
+            logger.warning(
+                "Failed to emit event",
+                config_name=getattr(event, "config_name", None),
+                exc=mlrun.errors.err_to_str(exc),
+            )
+
+    def generate_db_migration_event(
+        self,
+        action: mlrun.common.schemas.MigrationEventActions,
+        error: BaseException | str | None = None,
+        duration_seconds: float | None = None,
+        scope: list[str] | None = None,
+        versions: dict | None = None,
+    ) -> iguazio.schemas.EventActivationSpec:
+        try:
+            config_name, severity, description = DB_MIGRATION_EVENTS[action]
+        except KeyError as exc:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Unsupported DB migration action {action}"
+            ) from exc
+
+        details: dict = {}
+        if scope:
+            details["scope"] = sorted(scope)
+        if versions:
+            for key, value in versions.items():
+                if value is not None:
+                    details[key] = value
+        if duration_seconds is not None:
+            details["duration_seconds"] = round(float(duration_seconds), 3)
+
+        if action == mlrun.common.schemas.MigrationEventActions.failed and error:
+            error_str = (
+                error if isinstance(error, str) else mlrun.errors.err_to_str(error)
+            )
+            details["error"] = self._truncate(error_str, ERROR_DETAIL_LIMIT)
+            if not isinstance(error, str):
+                details["error_type"] = type(error).__name__
+            description = (
+                f"{description}: {self._truncate(error_str, ERROR_DESCRIPTION_LIMIT)}"
+            )
+
+        return iguazio.schemas.EventActivationSpec(
+            config_name=config_name,
+            source=self._source,
+            kind=EVENT_KIND,
+            severity=severity,
+            class_=EVENT_CLASS,
+            entity_name=ENTITY_NAME,
+            description=description,
+            details=details,
+        )
+
+    def generate_auth_secret_event(
+        self,
+        username: str,
+        secret_name: str,
+        action: mlrun.common.schemas.AuthSecretEventActions,
+    ):
+        # TODO: map v3 auth-secret events onto the v4 catalog (separate change).
+        raise NotImplementedError(
+            "Auth secret events are not yet supported on Iguazio v4"
+        )
+
+    def generate_project_secret_event(
+        self,
+        project: str,
+        secret_name: str,
+        secret_keys: list[str] | None = None,
+        action: mlrun.common.schemas.SecretEventActions = mlrun.common.schemas.SecretEventActions.created,
+    ):
+        # TODO: map v3 project-secret events onto the v4 catalog (separate change).
+        raise NotImplementedError(
+            "Project secret events are not yet supported on Iguazio v4"
+        )
+
+    @staticmethod
+    def _resolve_source() -> str:
+        """
+        Use the K8s deployment name as the event source so consumers can tell which
+        component emitted the event:
+        * the api service runs as `mlrun-api-chief` or `mlrun-api-worker`
+          (role is set in mlconf.httpdb.clusterization.role)
+        * other services (currently just alerts) deploy as `mlrun-<service_name>`
+        """
+        service_name = mlrun.mlconf.services.service_name or "api"
+        if service_name == "api":
+            role = mlrun.mlconf.httpdb.clusterization.role or "chief"
+            return f"mlrun-api-{role}"
+        return f"mlrun-{service_name}"
+
+    @staticmethod
+    def _truncate(value: str, limit: int) -> str:
+        """Trim ``value`` so the returned string is at most ``limit`` characters."""
+        if len(value) <= limit:
+            return value
+        if limit <= len(TRUNCATION_SUFFIX):
+            return value[:limit]
+        return value[: limit - len(TRUNCATION_SUFFIX)] + TRUNCATION_SUFFIX


### PR DESCRIPTION
### 📝 Description

Add an Iguazio v4 events client that publishes
`Platform.MLRun.DB.Migration{Required,Started,Completed,Failed}` via the
orca SDK's `publish_event` endpoint

Bonus fix: the DB backup step is now wrapped inside the same try/except as schema and data migrations, so a backup failure correctly transitions the API to `migrations_failed` and emits the `Failed` event (previously the exception bubbled out without state transition).

---

### 🛠️ Changes Made
- Added `services/api/utils/events/iguazio_v4.py` — events client built on the iguazio (orca) Python SDK with auth via the in-cluster service-account token.
- Extended `BaseEventClient` with a default-no-op `generate_db_migration_event(action, error, duration_seconds, scope, versions)`.
- Updated `EventsFactory` to select the v4 client when `is_iguazio_v4_mode()`, with the existing v3 path preserved for non-v4 environments.
- Wired `_migrate_existing_data` in `initial_data.py` to publish Required/Started/Completed/Failed at the right transitions, capturing duration via `time.monotonic()` and version context via `_resolve_needed_operations`.
- Exposed `latest_revision` and `get_current_revision()` on `AlembicUtil` so the publish helper can include alembic source/target revisions in event details.
- Added `MigrationEventActions` enum (`required`/`started`/`completed`/`failed`) and `EventClientKinds.iguazio_v4 = "iguazio-v4"` to `mlrun.common.schemas.events`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

Unit tests
Lab verification
- Real migration cycle (introduced a temporary alembic head) emitted `Required → Started → Completed` with correct schema revisions, scope, and duration in iguazio's events store.
- Verified events are persisted via `iguazio.Client.list_event_activations` from the SDK.

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/IG4-2137
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No



---

### 🔍️ Additional Notes

