### PR TITLE
[CI] Fix GitHub App token script with timeout settings 

### DIFF
--- a/.github/scripts/github-app-token.sh
+++ b/.github/scripts/github-app-token.sh
@@ -35,7 +35,7 @@ generate_installation_token() {
   local repos="${2:-}"
 
   local jwt=$(generate_jwt)
-  local installation_id=$(curl -sf \
+  local installation_id=$(curl -sf --connect-timeout 10 --max-time 30 \
     -H "Authorization: Bearer ${jwt}" \
     -H "Accept: application/vnd.github+json" \
     "https://api.github.com/app/installations" \
@@ -51,7 +51,7 @@ generate_installation_token() {
     data=$(echo "${repos}" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$";"")) | {"repositories": .}')
   fi
 
-  local token=$(curl -sf -X POST \
+  local token=$(curl -sf --connect-timeout 10 --max-time 30 -X POST \
     -H "Authorization: Bearer ${jwt}" \
     -H "Accept: application/vnd.github+json" \
     "https://api.github.com/app/installations/${installation_id}/access_tokens" \
@@ -95,6 +95,10 @@ start_token_refresh_daemon() {
   fi
 
   (
+    # Detach from the parent's stdout/stderr so that the command substitution
+    # used by callers (DAEMON_PID=$(start_token_refresh_daemon ...)) is not
+    # kept open by this infinite loop, which would cause the step to hang.
+    exec </dev/null >>"${token_file}.log" 2>&1
     while true; do
       sleep "${refresh_interval}"
       local new_token=$(generate_installation_token "${owner}" "${repos}" 2>/dev/null)
@@ -103,9 +107,9 @@ start_token_refresh_daemon() {
         if [ -n "${env_yml_file}" ] && [ -f "${env_yml_file}" ]; then
           _update_env_yml "${env_yml_file}" "${env_var_name}" "${new_token}"
         fi
-        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Token refreshed" >&2
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Token refreshed"
       else
-        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WARNING: Token refresh failed, will retry" >&2
+        echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WARNING: Token refresh failed, will retry"
       fi
     done
   ) &

--- a/.github/scripts/github-app-token.sh
+++ b/.github/scripts/github-app-token.sh
@@ -87,7 +87,19 @@ start_token_refresh_daemon() {
   local owner="${5:-${GITHUB_REPOSITORY_OWNER}}"
   local repos="${6:-}"
 
-  local initial_token=$(generate_installation_token "${owner}" "${repos}")
+  for cmd in openssl curl jq; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+      echo "ERROR: Required command '${cmd}' not found" >&2
+      return 1
+    fi
+  done
+
+  local initial_token
+  initial_token=$(generate_installation_token "${owner}" "${repos}")
+  if [ $? -ne 0 ] || [ -z "${initial_token}" ]; then
+    echo "ERROR: Failed to generate initial token" >&2
+    return 1
+  fi
   echo "${initial_token}" > "${token_file}"
 
   if [ -n "${env_yml_file}" ] && [ -f "${env_yml_file}" ]; then
@@ -101,8 +113,9 @@ start_token_refresh_daemon() {
     exec </dev/null >>"${token_file}.log" 2>&1
     while true; do
       sleep "${refresh_interval}"
-      local new_token=$(generate_installation_token "${owner}" "${repos}" 2>/dev/null)
-      if [ -n "${new_token}" ] && [ "${new_token}" != "null" ]; then
+      local new_token
+      new_token=$(generate_installation_token "${owner}" "${repos}" 2>&1)
+      if [ $? -eq 0 ] && [ -n "${new_token}" ] && [ "${new_token}" != "null" ]; then
         echo "${new_token}" > "${token_file}"
         if [ -n "${env_yml_file}" ] && [ -f "${env_yml_file}" ]; then
           _update_env_yml "${env_yml_file}" "${env_var_name}" "${new_token}"

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -452,6 +452,7 @@ jobs:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
     - name: Start GitHub App token refresh daemon
+      shell: bash
       env:
         GH_APP_ID: ${{ secrets.GH_APP_ID }}
         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -621,6 +621,7 @@ jobs:
             done
 
     - name: Start GitHub App token refresh daemon
+      shell: bash
       env:
         GH_APP_ID: ${{ secrets.GH_APP_ID }}
         GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This pull request improves the reliability and behavior of the GitHub App token management script by adding network request timeouts, properly detaching the token refresh daemon's output, and redirecting log messages. These changes help prevent the script from hanging and make log management easier.

**Daemon process and logging improvements:**

* Modified `start_token_refresh_daemon()` to detach the daemon's stdout and stderr from the parent process, redirecting all output to a log file. This prevents the parent process from hanging due to open file descriptors.
* Changed log messages in the daemon to write to standard output (now redirected to a log file) instead of standard error, ensuring all logs are captured in one place.