### PR TITLE
[API] Publish DB connections faile events

### DIFF
--- a/mlrun/common/schemas/__init__.py
+++ b/mlrun/common/schemas/__init__.py
@@ -82,6 +82,7 @@ from .constants import (
 from .datastore_profile import DatastoreProfile
 from .events import (
     AuthSecretEventActions,
+    DBConnectionEventActions,
     EventClientKinds,
     EventsModes,
     MigrationEventActions,

--- a/mlrun/common/schemas/events.py
+++ b/mlrun/common/schemas/events.py
@@ -42,3 +42,7 @@ class MigrationEventActions(mlrun.common.types.StrEnum):
     started = "started"
     completed = "completed"
     failed = "failed"
+
+
+class DBConnectionEventActions(mlrun.common.types.StrEnum):
+    failed = "failed"

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -904,6 +904,13 @@ default_config = {
         "verbose": False,
         # used for igz client when emitting events
         "access_key": "",
+        "db_connection": {
+            # Per-process throttle: at most one Platform.MLRun.DB.Connection.Failed
+            # event every N seconds. Iguazio's event service has its own
+            # throttling; this is a local cap so a sustained outage doesn't emit
+            # one event per failed query.
+            "min_emit_interval_seconds": 60,
+        },
     },
     "grafana_url": "",
     "alerts": {

--- a/server/py/framework/tests/integration/db/test_db_connection_event.py
+++ b/server/py/framework/tests/integration/db/test_db_connection_event.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Integration tests for ``Platform.MLRun.DB.ConnectionFailed`` against a real
+Integration tests for ``Platform.MLRun.DB.Connection.Failed`` against a real
 MySQL or PostgreSQL container. Selected via ``MLRUN_TEST_DB={mysql,postgres}``.
 
 The mapping is intentionally conservative — only true "cannot connect"
@@ -130,7 +130,7 @@ def test_lock_wait_timeout_does_not_emit_event(
             conn.execute(sqlalchemy.text("DROP TABLE conn_event_lock_test"))
 
     assert stub_events_client == [], (
-        "lock wait timeout must not trigger ConnectionFailed (false-positive risk)"
+        "lock wait timeout must not trigger Connection.Failed (false-positive risk)"
     )
 
 

--- a/server/py/framework/tests/integration/db/test_db_connection_event.py
+++ b/server/py/framework/tests/integration/db/test_db_connection_event.py
@@ -15,15 +15,15 @@
 Integration tests for ``Platform.MLRun.DB.Connection.Failed`` against a real
 MySQL or PostgreSQL container. Selected via ``MLRUN_TEST_DB={mysql,postgres}``.
 
-The mapping is intentionally conservative — only true "cannot connect"
+The mapping is intentionally conservative: only true "cannot connect"
 failures (driver-level disconnects, ``too_many_connections``, pool checkout
 timeout) emit the event. Everything else, including lock waits, deadlocks,
 query timeouts, and integrity violations, must NOT trigger it.
 
 These tests exercise the wiring against a real driver and verify the
 no-false-positive contract for the most plausible noise sources:
-  * Lock wait timeout — common under contention; must NOT emit.
-  * Integrity violation — user error; must NOT emit.
+  * Lock wait timeout: common under contention; must NOT emit.
+  * Integrity violation: user error; must NOT emit.
 
 True-positive disconnect detection is covered by the unit tests
 (test_db_errors.py) and was verified end-to-end on the lab during PR review.
@@ -78,7 +78,7 @@ def test_lock_wait_timeout_does_not_emit_event(
     stub_events_client: list,
 ) -> None:
     """
-    Lock wait timeouts are NOT a connection failure — the connection is fine,
+    Lock wait timeouts are NOT a connection failure: the connection is fine,
     another transaction held a row lock too long. Must NOT emit the event.
     """
     if _is_mysql(registered_engine):

--- a/server/py/framework/tests/integration/db/test_db_connection_event.py
+++ b/server/py/framework/tests/integration/db/test_db_connection_event.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Integration tests for ``Platform.MLRun.DB.ConnectionFailed`` against a real
+MySQL or PostgreSQL container. Selected via ``MLRUN_TEST_DB={mysql,postgres}``.
+
+The mapping is intentionally conservative — only true "cannot connect"
+failures (driver-level disconnects, ``too_many_connections``, pool checkout
+timeout) emit the event. Everything else, including lock waits, deadlocks,
+query timeouts, and integrity violations, must NOT trigger it.
+
+These tests exercise the wiring against a real driver and verify the
+no-false-positive contract for the most plausible noise sources:
+  * Lock wait timeout — common under contention; must NOT emit.
+  * Integrity violation — user error; must NOT emit.
+
+True-positive disconnect detection is covered by the unit tests
+(test_db_errors.py) and was verified end-to-end on the lab during PR review.
+Reproducing a real disconnect deterministically in a container fixture is
+brittle (it usually means killing the container mid-test).
+"""
+
+import threading
+import unittest.mock
+
+import pytest
+import sqlalchemy
+import sqlalchemy.exc
+
+import mlrun.common.db.dialects
+import mlrun.common.schemas
+
+import services.api.utils.events.db_errors as db_errors
+
+
+@pytest.fixture
+def stub_events_client(monkeypatch):
+    """Replace the events factory with a stub that records emitted specs."""
+    emitted: list = []
+    spec_marker = object()
+
+    client = unittest.mock.MagicMock()
+    client.generate_db_connection_event.return_value = spec_marker
+    client.emit.side_effect = lambda spec: emitted.append(
+        client.generate_db_connection_event.call_args.kwargs
+    )
+
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(return_value=client),
+    )
+    monkeypatch.setattr(db_errors, "_last_emit_monotonic", 0.0)
+    db_errors._registered_engines.clear()
+    yield emitted
+    db_errors._registered_engines.clear()
+
+
+@pytest.fixture
+def registered_engine(db_engine, stub_events_client):
+    db_errors.register(db_engine)
+    return db_engine
+
+
+def test_lock_wait_timeout_does_not_emit_event(
+    registered_engine: sqlalchemy.engine.Engine,
+    stub_events_client: list,
+) -> None:
+    """
+    Lock wait timeouts are NOT a connection failure — the connection is fine,
+    another transaction held a row lock too long. Must NOT emit the event.
+    """
+    if _is_mysql(registered_engine):
+        sql_lock_timeout_setup = "SET SESSION innodb_lock_wait_timeout = 1"
+    elif _is_postgres(registered_engine):
+        sql_lock_timeout_setup = "SET lock_timeout = '500ms'"
+    else:
+        pytest.skip("Unsupported dialect")
+
+    with registered_engine.begin() as conn:
+        conn.execute(
+            sqlalchemy.text(
+                "CREATE TABLE conn_event_lock_test (id INT PRIMARY KEY, v INT)"
+            )
+        )
+        conn.execute(sqlalchemy.text("INSERT INTO conn_event_lock_test VALUES (1, 1)"))
+
+    blocker_holding = threading.Event()
+    release_blocker = threading.Event()
+
+    def _blocker():
+        with registered_engine.begin() as bconn:
+            bconn.execute(
+                sqlalchemy.text(
+                    "SELECT * FROM conn_event_lock_test WHERE id = 1 FOR UPDATE"
+                )
+            )
+            blocker_holding.set()
+            release_blocker.wait(timeout=10)
+
+    blocker_thread = threading.Thread(target=_blocker)
+    blocker_thread.start()
+    try:
+        assert blocker_holding.wait(timeout=10), "blocker never acquired the lock"
+
+        with pytest.raises(sqlalchemy.exc.DBAPIError):
+            with registered_engine.connect() as conn:
+                conn.execute(sqlalchemy.text(sql_lock_timeout_setup))
+                conn.execute(sqlalchemy.text("BEGIN"))
+                conn.execute(
+                    sqlalchemy.text(
+                        "SELECT * FROM conn_event_lock_test WHERE id = 1 FOR UPDATE"
+                    )
+                )
+    finally:
+        release_blocker.set()
+        blocker_thread.join(timeout=10)
+        with registered_engine.begin() as conn:
+            conn.execute(sqlalchemy.text("DROP TABLE conn_event_lock_test"))
+
+    assert stub_events_client == [], (
+        "lock wait timeout must not trigger ConnectionFailed (false-positive risk)"
+    )
+
+
+def test_integrity_violation_does_not_emit_event(
+    registered_engine: sqlalchemy.engine.Engine,
+    stub_events_client: list,
+) -> None:
+    """A duplicate-key integrity error is a user error, not a connection failure."""
+    with registered_engine.begin() as conn:
+        conn.execute(
+            sqlalchemy.text(
+                "CREATE TABLE conn_event_integrity_test (id INT PRIMARY KEY)"
+            )
+        )
+        conn.execute(
+            sqlalchemy.text("INSERT INTO conn_event_integrity_test VALUES (1)")
+        )
+
+    try:
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            with registered_engine.begin() as conn:
+                conn.execute(
+                    sqlalchemy.text("INSERT INTO conn_event_integrity_test VALUES (1)")
+                )
+    finally:
+        with registered_engine.begin() as conn:
+            conn.execute(sqlalchemy.text("DROP TABLE conn_event_integrity_test"))
+
+    assert stub_events_client == [], "integrity violation must not trigger an event"
+
+
+def _is_postgres(engine: sqlalchemy.engine.Engine) -> bool:
+    return engine.dialect.name.startswith(mlrun.common.db.dialects.Dialects.POSTGRESQL)
+
+
+def _is_mysql(engine: sqlalchemy.engine.Engine) -> bool:
+    return engine.dialect.name.startswith(mlrun.common.db.dialects.Dialects.MYSQL)

--- a/server/py/services/api/main.py
+++ b/server/py/services/api/main.py
@@ -52,6 +52,7 @@ import services.api.crud
 import services.api.initial_data
 import services.api.runtime_handlers
 import services.api.utils.db.partitioner
+import services.api.utils.events.db_errors
 from framework.db.session import close_session, create_session
 from framework.utils.periodic import (
     run_function_periodically,
@@ -142,6 +143,9 @@ class Service(framework.service.Service):
 
     async def _custom_setup_service(self):
         initialize_logs_dir()
+        # Attach the DB connection-failed event listener before any DB work so
+        # we capture connection issues that surface during initial migrations.
+        services.api.utils.events.db_errors.register_for_default_engine()
         await mlrun.utils.run_in_threadpool(self._initialize_data)
 
     async def _custom_teardown_service(self):

--- a/server/py/services/api/tests/unit/utils/events/test_db_errors.py
+++ b/server/py/services/api/tests/unit/utils/events/test_db_errors.py
@@ -270,6 +270,71 @@ def test_publish_no_event_from_nop_client_does_not_consume_throttle(monkeypatch)
     real_client.emit.assert_called_once()
 
 
+def test_publish_releases_slot_when_emit_raises(monkeypatch):
+    """
+    If ``client.emit`` raises (e.g. events service unreachable), no event was
+    delivered, so the throttle slot must be released so the next DB error
+    within the window can retry.
+    """
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_connection_event.return_value = object()
+    fake_client.emit.side_effect = [
+        RuntimeError("events service unreachable"),
+        None,
+    ]
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(return_value=fake_client),
+    )
+    monkeypatch.setattr(
+        mlrun.mlconf.events.db_connection, "min_emit_interval_seconds", 60
+    )
+    fake_now = {"value": 1000.0}
+    monkeypatch.setattr(db_errors.time, "monotonic", lambda: fake_now["value"])
+
+    err = pymysql.err.OperationalError(2013, "Lost connection")
+    # First emit fails; slot must be released so we are not locked out.
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is False
+    )
+    # Same instant: a slot was released, so the next attempt can claim & emit.
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is True
+    )
+    assert fake_client.emit.call_count == 2
+
+
+def test_publish_keeps_slot_after_success(monkeypatch):
+    """A successful emit must keep the slot consumed (otherwise no throttle)."""
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_connection_event.return_value = object()
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(return_value=fake_client),
+    )
+    monkeypatch.setattr(
+        mlrun.mlconf.events.db_connection, "min_emit_interval_seconds", 60
+    )
+    fake_now = {"value": 1000.0}
+    monkeypatch.setattr(db_errors.time, "monotonic", lambda: fake_now["value"])
+
+    err = pymysql.err.OperationalError(2013, "Lost connection")
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is True
+    )
+    fake_now["value"] += 30
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is False
+    )
+    assert fake_client.emit.call_count == 1
+
+
 def test_publish_swallows_factory_exception(monkeypatch):
     monkeypatch.setattr(
         db_errors.events_factory.EventsFactory,

--- a/server/py/services/api/tests/unit/utils/events/test_db_errors.py
+++ b/server/py/services/api/tests/unit/utils/events/test_db_errors.py
@@ -60,6 +60,24 @@ def mysql_engine(monkeypatch):
             db_errors.CATEGORY_TOO_MANY_CONNECTIONS,
             1040,
         ),
+        (
+            pymysql.err.OperationalError(1045, "Access denied for user"),
+            False,
+            db_errors.CATEGORY_AUTH_FAILED,
+            1045,
+        ),
+        (
+            pymysql.err.OperationalError(1044, "Access denied for user to db"),
+            False,
+            db_errors.CATEGORY_AUTH_FAILED,
+            1044,
+        ),
+        (
+            pymysql.err.OperationalError(1698, "Access denied (no password)"),
+            False,
+            db_errors.CATEGORY_AUTH_FAILED,
+            1698,
+        ),
     ],
 )
 def test_classify_mysql_codes(exc, is_disconnect, expected_category, expected_code):
@@ -109,6 +127,11 @@ class _PsycopgLikeError(Exception):
         ("57P03", db_errors.CATEGORY_DISCONNECT),  # cannot_connect_now
         ("57P01", db_errors.CATEGORY_DISCONNECT),  # admin_shutdown
         ("53300", db_errors.CATEGORY_TOO_MANY_CONNECTIONS),
+        (
+            "28000",
+            db_errors.CATEGORY_AUTH_FAILED,
+        ),  # invalid_authorization_specification
+        ("28P01", db_errors.CATEGORY_AUTH_FAILED),  # invalid_password
     ],
 )
 def test_classify_postgres_sqlstates(sqlstate, expected_category):

--- a/server/py/services/api/tests/unit/utils/events/test_db_errors.py
+++ b/server/py/services/api/tests/unit/utils/events/test_db_errors.py
@@ -89,8 +89,8 @@ def test_classify_mysql_codes(exc, is_disconnect, expected_category, expected_co
 @pytest.mark.parametrize(
     "exc",
     [
-        # Lock waits, deadlocks, and query timeouts are query-level — must NOT
-        # trigger a connection-failed event (the spec is "cannot connect").
+        # Lock waits, deadlocks, and query timeouts are query-level. They
+        # must NOT trigger a connection-failed event.
         pymysql.err.OperationalError(1205, "Lock wait timeout exceeded"),
         pymysql.err.OperationalError(1213, "Deadlock found"),
         pymysql.err.OperationalError(3024, "Query execution was interrupted"),
@@ -171,7 +171,7 @@ def test_classify_postgres_disconnect_prefers_sqlstate_over_stray_int_arg():
     """
     On a PG disconnect, ``args[0]`` may be an OS errno (e.g. 110 from a
     network-level OSError wrapped by SQLAlchemy). The reported error_code
-    must be the SQLSTATE — the stray int must not leak through.
+    must be the SQLSTATE; the stray int must not leak through.
     """
 
     class _MixedError(Exception):
@@ -189,7 +189,7 @@ def test_classify_postgres_disconnect_prefers_sqlstate_over_stray_int_arg():
 
 
 def test_classify_postgres_unknown_sqlstate_returns_none():
-    """Non-fatal SQLSTATE (e.g. 23505 unique violation) — must not trigger event."""
+    """Non-fatal SQLSTATE (e.g. 23505 unique violation) must not trigger event."""
     exc = _PsycopgLikeError("23505", "unique_violation")
     category, code = db_errors.classify(_ctx(exc, dialect_name="postgresql"))
     assert category is None
@@ -239,7 +239,7 @@ def test_publish_emits_event_via_factory(monkeypatch):
 
 
 def test_publish_no_event_from_nop_client_does_not_consume_throttle(monkeypatch):
-    """A NopClient returns None — emit is skipped AND the throttle slot stays free."""
+    """A NopClient returns None: emit is skipped AND the throttle slot stays free."""
     nop_client = unittest.mock.MagicMock()
     nop_client.generate_db_connection_event.return_value = None
     real_client = unittest.mock.MagicMock()

--- a/server/py/services/api/tests/unit/utils/events/test_db_errors.py
+++ b/server/py/services/api/tests/unit/utils/events/test_db_errors.py
@@ -97,7 +97,7 @@ def test_classify_mysql_codes(exc, is_disconnect, expected_category, expected_co
     ],
 )
 def test_classify_mysql_query_level_errors_skipped(exc):
-    """Conservative mapping: query-level errors don't fire ConnectionFailed."""
+    """Conservative mapping: query-level errors don't fire Connection.Failed."""
     category, code = db_errors.classify(_ctx(exc))
     assert category is None
     assert code is None
@@ -150,7 +150,7 @@ def test_classify_postgres_sqlstates(sqlstate, expected_category):
     ],
 )
 def test_classify_postgres_query_level_sqlstates_skipped(sqlstate):
-    """Conservative mapping: query-level SQLSTATEs don't fire ConnectionFailed."""
+    """Conservative mapping: query-level SQLSTATEs don't fire Connection.Failed."""
     exc = _PsycopgLikeError(sqlstate)
     category, code = db_errors.classify(_ctx(exc, dialect_name="postgresql"))
     assert category is None

--- a/server/py/services/api/tests/unit/utils/events/test_db_errors.py
+++ b/server/py/services/api/tests/unit/utils/events/test_db_errors.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest.mock
+
+import pymysql.err
+import pytest
+import sqlalchemy
+import sqlalchemy.exc
+
+import mlrun
+import mlrun.common.schemas
+
+import framework.db.sqldb.sql_session
+import services.api.utils.events.db_errors as db_errors
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    monkeypatch.setattr(db_errors, "_last_emit_monotonic", 0.0)
+    db_errors._registered_engines.clear()
+    yield
+    db_errors._registered_engines.clear()
+
+
+@pytest.fixture
+def mysql_engine(monkeypatch):
+    """In-memory engine masquerading as MySQL so register() attaches a listener."""
+    return _engine_with_dialect(monkeypatch, "mysql")
+
+
+@pytest.mark.parametrize(
+    "exc,is_disconnect,expected_category,expected_code",
+    [
+        (
+            pymysql.err.OperationalError(2013, "Lost connection to MySQL server"),
+            True,
+            db_errors.CATEGORY_DISCONNECT,
+            2013,
+        ),
+        (
+            pymysql.err.OperationalError(2003, "Can't connect to MySQL server"),
+            False,
+            db_errors.CATEGORY_DISCONNECT,
+            2003,
+        ),
+        (
+            pymysql.err.OperationalError(1040, "Too many connections"),
+            False,
+            db_errors.CATEGORY_TOO_MANY_CONNECTIONS,
+            1040,
+        ),
+    ],
+)
+def test_classify_mysql_codes(exc, is_disconnect, expected_category, expected_code):
+    category, code = db_errors.classify(_ctx(exc, is_disconnect=is_disconnect))
+    assert category == expected_category
+    assert code == expected_code
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # Lock waits, deadlocks, and query timeouts are query-level — must NOT
+        # trigger a connection-failed event (the spec is "cannot connect").
+        pymysql.err.OperationalError(1205, "Lock wait timeout exceeded"),
+        pymysql.err.OperationalError(1213, "Deadlock found"),
+        pymysql.err.OperationalError(3024, "Query execution was interrupted"),
+    ],
+)
+def test_classify_mysql_query_level_errors_skipped(exc):
+    """Conservative mapping: query-level errors don't fire ConnectionFailed."""
+    category, code = db_errors.classify(_ctx(exc))
+    assert category is None
+    assert code is None
+
+
+def test_classify_pool_timeout():
+    pool_timeout = sqlalchemy.exc.TimeoutError("QueuePool checkout timed out")
+    category, code = db_errors.classify(_ctx(pool_timeout))
+    assert category == db_errors.CATEGORY_POOL_TIMEOUT
+    assert code is None
+
+
+class _PsycopgLikeError(Exception):
+    """Stand-in for psycopg2/3 errors: carries a SQLSTATE on .pgcode/.sqlstate."""
+
+    def __init__(self, sqlstate: str, msg: str = ""):
+        super().__init__(msg or sqlstate)
+        self.pgcode = sqlstate
+        self.sqlstate = sqlstate
+
+
+@pytest.mark.parametrize(
+    "sqlstate,expected_category",
+    [
+        ("08006", db_errors.CATEGORY_DISCONNECT),  # connection_failure
+        ("08001", db_errors.CATEGORY_DISCONNECT),
+        ("57P03", db_errors.CATEGORY_DISCONNECT),  # cannot_connect_now
+        ("57P01", db_errors.CATEGORY_DISCONNECT),  # admin_shutdown
+        ("53300", db_errors.CATEGORY_TOO_MANY_CONNECTIONS),
+    ],
+)
+def test_classify_postgres_sqlstates(sqlstate, expected_category):
+    exc = _PsycopgLikeError(sqlstate)
+    category, code = db_errors.classify(_ctx(exc, dialect_name="postgresql"))
+    assert category == expected_category
+    assert code == sqlstate
+
+
+@pytest.mark.parametrize(
+    "sqlstate",
+    [
+        "55P03",  # lock_not_available
+        "40P01",  # deadlock_detected
+        "57014",  # query_canceled (statement_timeout)
+    ],
+)
+def test_classify_postgres_query_level_sqlstates_skipped(sqlstate):
+    """Conservative mapping: query-level SQLSTATEs don't fire ConnectionFailed."""
+    exc = _PsycopgLikeError(sqlstate)
+    category, code = db_errors.classify(_ctx(exc, dialect_name="postgresql"))
+    assert category is None
+    assert code is None
+
+
+def test_classify_postgres_disconnect_via_is_disconnect_flag():
+    """SQLAlchemy may set is_disconnect=True without an obvious SQLSTATE."""
+    exc = _PsycopgLikeError("08006", "server closed the connection unexpectedly")
+    category, code = db_errors.classify(
+        _ctx(exc, is_disconnect=True, dialect_name="postgresql")
+    )
+    assert category == db_errors.CATEGORY_DISCONNECT
+    assert code == "08006"
+
+
+def test_classify_postgres_disconnect_prefers_sqlstate_over_stray_int_arg():
+    """
+    On a PG disconnect, ``args[0]`` may be an OS errno (e.g. 110 from a
+    network-level OSError wrapped by SQLAlchemy). The reported error_code
+    must be the SQLSTATE — the stray int must not leak through.
+    """
+
+    class _MixedError(Exception):
+        def __init__(self):
+            super().__init__(110, "Connection timed out")
+            self.pgcode = "08006"
+            self.sqlstate = "08006"
+
+    exc = _MixedError()
+    category, code = db_errors.classify(
+        _ctx(exc, is_disconnect=True, dialect_name="postgresql")
+    )
+    assert category == db_errors.CATEGORY_DISCONNECT
+    assert code == "08006"
+
+
+def test_classify_postgres_unknown_sqlstate_returns_none():
+    """Non-fatal SQLSTATE (e.g. 23505 unique violation) — must not trigger event."""
+    exc = _PsycopgLikeError("23505", "unique_violation")
+    category, code = db_errors.classify(_ctx(exc, dialect_name="postgresql"))
+    assert category is None
+    assert code is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pymysql.err.IntegrityError(1062, "Duplicate entry"),
+        pymysql.err.ProgrammingError(1064, "SQL syntax error"),
+        ValueError("not a db error"),
+    ],
+)
+def test_classify_skips_non_fatal_errors(exc):
+    category, code = db_errors.classify(_ctx(exc))
+    assert category is None
+    assert code is None
+
+
+def test_publish_emits_event_via_factory(monkeypatch):
+    fake_event = object()
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_connection_event.return_value = fake_event
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(return_value=fake_client),
+    )
+
+    err = pymysql.err.OperationalError(2013, "Lost connection to MySQL server")
+    emitted = db_errors.publish_connection_failed(
+        error=err,
+        dialect="mysql",
+        category=db_errors.CATEGORY_DISCONNECT,
+        error_code=2013,
+    )
+    assert emitted is True
+    fake_client.generate_db_connection_event.assert_called_once()
+    call_kwargs = fake_client.generate_db_connection_event.call_args.kwargs
+    assert call_kwargs["action"] == mlrun.common.schemas.DBConnectionEventActions.failed
+    assert call_kwargs["error"] is err
+    assert call_kwargs["error_category"] == db_errors.CATEGORY_DISCONNECT
+    assert call_kwargs["error_code"] == 2013
+    assert call_kwargs["dialect"] == "mysql"
+    fake_client.emit.assert_called_once_with(fake_event)
+
+
+def test_publish_no_event_from_nop_client_does_not_consume_throttle(monkeypatch):
+    """A NopClient returns None — emit is skipped AND the throttle slot stays free."""
+    nop_client = unittest.mock.MagicMock()
+    nop_client.generate_db_connection_event.return_value = None
+    real_client = unittest.mock.MagicMock()
+    real_client.generate_db_connection_event.return_value = object()
+
+    # First call returns nop, second call returns a real client; if the nop call
+    # had consumed the slot, the second emit would be throttled.
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(side_effect=[nop_client, real_client]),
+    )
+
+    assert (
+        db_errors.publish_connection_failed(
+            RuntimeError("boom"), "mysql", db_errors.CATEGORY_DISCONNECT
+        )
+        is False
+    )
+    nop_client.emit.assert_not_called()
+
+    assert (
+        db_errors.publish_connection_failed(
+            RuntimeError("boom"), "mysql", db_errors.CATEGORY_DISCONNECT
+        )
+        is True
+    )
+    real_client.emit.assert_called_once()
+
+
+def test_publish_swallows_factory_exception(monkeypatch):
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(side_effect=RuntimeError("network down")),
+    )
+    emitted = db_errors.publish_connection_failed(
+        error=RuntimeError("boom"),
+        dialect="mysql",
+        category=db_errors.CATEGORY_DISCONNECT,
+    )
+    assert emitted is False
+
+
+def test_publish_throttles_within_interval(monkeypatch):
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_connection_event.return_value = object()
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(return_value=fake_client),
+    )
+    monkeypatch.setattr(
+        mlrun.mlconf.events.db_connection, "min_emit_interval_seconds", 60
+    )
+    fake_now = {"value": 1000.0}
+    monkeypatch.setattr(db_errors.time, "monotonic", lambda: fake_now["value"])
+
+    err = pymysql.err.OperationalError(2013, "Lost connection")
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is True
+    )
+
+    fake_now["value"] += 30
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is False
+    )
+
+    fake_now["value"] += 60
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is True
+    )
+    assert fake_client.emit.call_count == 2
+
+
+def test_publish_throttle_interval_is_configurable(monkeypatch):
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_connection_event.return_value = object()
+    monkeypatch.setattr(
+        db_errors.events_factory.EventsFactory,
+        "get_events_client",
+        unittest.mock.MagicMock(return_value=fake_client),
+    )
+    # Tighten the throttle to 5 seconds
+    monkeypatch.setattr(
+        mlrun.mlconf.events.db_connection, "min_emit_interval_seconds", 5
+    )
+    fake_now = {"value": 1000.0}
+    monkeypatch.setattr(db_errors.time, "monotonic", lambda: fake_now["value"])
+
+    err = pymysql.err.OperationalError(2013, "Lost connection")
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is True
+    )
+    fake_now["value"] += 6  # past the 5s window
+    assert (
+        db_errors.publish_connection_failed(err, "mysql", db_errors.CATEGORY_DISCONNECT)
+        is True
+    )
+    assert fake_client.emit.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "dialect,expected_attached",
+    [
+        ("mysql", True),
+        ("postgresql", True),
+        ("sqlite", False),
+    ],
+)
+def test_register_attaches_listener_per_dialect(
+    monkeypatch, dialect, expected_attached
+):
+    """Listener attaches for supported dialects (mysql, postgresql) and skips others."""
+    engine = _engine_with_dialect(monkeypatch, dialect)
+    db_errors.register(engine)
+    assert (
+        sqlalchemy.event.contains(engine, "handle_error", db_errors._on_dbapi_error)
+        is expected_attached
+    )
+    assert (id(engine) in db_errors._registered_engines) is expected_attached
+
+
+def test_register_is_idempotent_per_engine(mysql_engine, monkeypatch):
+    listen_spy = unittest.mock.MagicMock(wraps=sqlalchemy.event.listen)
+    monkeypatch.setattr(sqlalchemy.event, "listen", listen_spy)
+
+    db_errors.register(mysql_engine)
+    db_errors.register(mysql_engine)
+    assert listen_spy.call_count == 1
+
+
+def test_listener_publishes_on_fatal_error(monkeypatch):
+    publish_calls: list[dict] = []
+    monkeypatch.setattr(
+        db_errors,
+        "publish_connection_failed",
+        lambda **kw: publish_calls.append(kw) or True,
+    )
+    ctx = _ctx(pymysql.err.OperationalError(2013, "Lost connection"))
+    db_errors._on_dbapi_error(ctx)
+
+    assert len(publish_calls) == 1
+    assert publish_calls[0]["category"] == db_errors.CATEGORY_DISCONNECT
+    assert publish_calls[0]["error_code"] == 2013
+    assert publish_calls[0]["dialect"] == "mysql"
+
+
+def test_listener_skips_non_fatal_error(monkeypatch):
+    publish_calls: list = []
+    monkeypatch.setattr(
+        db_errors,
+        "publish_connection_failed",
+        lambda **kw: publish_calls.append(kw) or True,
+    )
+    ctx = _ctx(pymysql.err.IntegrityError(1062, "Duplicate"))
+    db_errors._on_dbapi_error(ctx)
+    assert publish_calls == []
+
+
+def test_listener_skips_pool_pre_ping(monkeypatch):
+    """Pre-ping (``ctx.engine is None``) must not emit an event."""
+    publish_calls: list = []
+    monkeypatch.setattr(
+        db_errors,
+        "publish_connection_failed",
+        lambda **kw: publish_calls.append(kw) or True,
+    )
+    classify_spy = unittest.mock.MagicMock()
+    monkeypatch.setattr(db_errors, "classify", classify_spy)
+
+    ctx = _ctx(
+        pymysql.err.OperationalError(2013, "Lost connection during pre-ping"),
+        is_disconnect=True,
+    )
+    ctx.engine = None
+
+    db_errors._on_dbapi_error(ctx)
+
+    assert publish_calls == []
+    classify_spy.assert_not_called()
+
+
+def test_listener_swallows_internal_errors(monkeypatch):
+    """If classify or publish raises, the listener must not propagate."""
+    monkeypatch.setattr(
+        db_errors,
+        "classify",
+        unittest.mock.MagicMock(side_effect=RuntimeError("classifier broke")),
+    )
+    ctx = _ctx(pymysql.err.OperationalError(2013, "lost"), is_disconnect=True)
+    # Must not raise
+    db_errors._on_dbapi_error(ctx)
+
+
+def test_register_for_default_engine_uses_session_engine(monkeypatch):
+    fake_engine = unittest.mock.MagicMock()
+    fake_engine.dialect.name = "mysql"
+    monkeypatch.setattr(
+        framework.db.sqldb.sql_session, "get_engine", lambda: fake_engine
+    )
+    listen_spy = unittest.mock.MagicMock()
+    monkeypatch.setattr(sqlalchemy.event, "listen", listen_spy)
+
+    db_errors.register_for_default_engine()
+
+    listen_spy.assert_called_once()
+    args = listen_spy.call_args.args
+    assert args[0] is fake_engine
+    assert args[1] == "handle_error"
+
+
+def test_register_for_default_engine_swallows_engine_lookup_failure(monkeypatch):
+    monkeypatch.setattr(
+        framework.db.sqldb.sql_session,
+        "get_engine",
+        unittest.mock.MagicMock(side_effect=RuntimeError("no DSN")),
+    )
+    # Must not raise
+    db_errors.register_for_default_engine()
+
+
+def _ctx(exception, is_disconnect=False, dialect_name="mysql"):
+    """Build a minimal stand-in for sqlalchemy.engine.ExceptionContext.
+
+    ``ExceptionContext.engine`` is None during pool pre-ping (the listener uses
+    that as a signal to skip emitting the event); set ``ctx.engine = None``
+    explicitly on a returned ctx to simulate that path.
+    """
+    ctx = unittest.mock.MagicMock()
+    ctx.original_exception = exception
+    ctx.is_disconnect = is_disconnect
+    ctx.engine.dialect.name = dialect_name
+    ctx.dialect.name = dialect_name
+    return ctx
+
+
+def _engine_with_dialect(
+    monkeypatch: pytest.MonkeyPatch, dialect_name: str
+) -> sqlalchemy.engine.Engine:
+    """In-memory SQLite engine with its dialect name patched to ``dialect_name``."""
+    engine = sqlalchemy.create_engine("sqlite:///:memory:")
+    monkeypatch.setattr(engine.dialect, "name", dialect_name)
+    return engine

--- a/server/py/services/api/tests/unit/utils/events/test_events_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/events/test_events_iguazio_v4.py
@@ -66,10 +66,11 @@ def test_generate_db_migration_event_basic(
     event = client.generate_db_migration_event(action)
     assert event.config_name == expected_config_name
     assert event.kind == "system"
-    assert event.class_ == "Platform"
+    assert event.class_ == "Application.Core"
     assert event.severity == expected_severity
-    assert event.entity_name == "MLRun"
-    assert event.source == "mlrun-api-chief"
+    assert event.entity_name == "mlrun-api-chief"
+    # source is left empty so the orca backend can derive it
+    assert event.source == ""
     # description is the catalog default for non-failed actions
     if action != mlrun.common.schemas.MigrationEventActions.failed:
         assert event.description and "MLRun database migration" in event.description
@@ -79,14 +80,16 @@ def test_generate_db_migration_event_basic(
 
 
 @pytest.mark.parametrize(
-    "service_name,role,expected_source",
+    "service_name,role,expected_entity_name",
     [
         ("api", "chief", "mlrun-api-chief"),
         ("api", "worker", "mlrun-api-worker"),
         ("alerts", "chief", "mlrun-alerts"),
     ],
 )
-def test_source_reflects_deployment(monkeypatch, service_name, role, expected_source):
+def test_entity_name_reflects_deployment(
+    monkeypatch, service_name, role, expected_entity_name
+):
     monkeypatch.setattr(iguazio, "Client", unittest.mock.MagicMock())
     monkeypatch.setattr(
         "framework.utils.clients.service_account_token.Client",
@@ -98,7 +101,8 @@ def test_source_reflects_deployment(monkeypatch, service_name, role, expected_so
     event = c.generate_db_migration_event(
         mlrun.common.schemas.MigrationEventActions.started
     )
-    assert event.source == expected_source
+    assert event.entity_name == expected_entity_name
+    assert event.source == ""
 
 
 def test_completed_event_carries_duration(client):
@@ -257,3 +261,90 @@ def test_emit_none_event_is_noop(client):
 def test_unsupported_action_raises(client):
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
         client.generate_db_migration_event("bogus")  # type: ignore[arg-type]
+
+
+def test_generate_db_connection_event_basic(client):
+    event = client.generate_db_connection_event(
+        mlrun.common.schemas.DBConnectionEventActions.failed,
+    )
+    assert event.config_name == iguazio_v4_events.DB_CONNECTION_FAILED
+    assert event.kind == "system"
+    assert event.class_ == "Application.Core"
+    assert event.severity == iguazio.schemas.Severity.CRITICAL
+    assert event.entity_name == "mlrun-api-chief"
+    # source is left empty so the orca backend can derive it
+    assert event.source == ""
+    assert event.description == "MLRun cannot connect to its database"
+    assert event.details == {}
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # falsy error — None
+        {"error": None},
+        # all metadata fields explicitly None
+        {"error_category": None, "error_code": None, "dialect": None},
+    ],
+    ids=["none_error", "none_metadata"],
+)
+def test_db_connection_event_no_context_uses_catalog_description(client, kwargs):
+    """Empty/None inputs → details stay empty and description is the catalog wording."""
+    event = client.generate_db_connection_event(
+        mlrun.common.schemas.DBConnectionEventActions.failed,
+        **kwargs,
+    )
+    assert event.description == "MLRun cannot connect to its database"
+    assert event.details == {}
+
+
+@pytest.mark.parametrize(
+    "error,expected_error_substring,expected_error_type",
+    [
+        # Exception → carries error_type
+        (
+            TimeoutError("Lock wait timeout exceeded; try restarting transaction"),
+            "Lock wait timeout",
+            "TimeoutError",
+        ),
+        # Raw string → no error_type
+        ("connection lost", "connection lost", None),
+    ],
+    ids=["exception", "string"],
+)
+def test_db_connection_event_renders_error(
+    client, error, expected_error_substring, expected_error_type
+):
+    event = client.generate_db_connection_event(
+        mlrun.common.schemas.DBConnectionEventActions.failed,
+        error=error,
+        error_category="lock_wait_timeout",
+        error_code=1205,
+        dialect="mysql",
+    )
+    assert event.details["error_category"] == "lock_wait_timeout"
+    assert event.details["error_code"] == 1205
+    assert event.details["dialect"] == "mysql"
+    assert expected_error_substring in event.details["error"]
+    assert expected_error_substring in event.description
+    assert "MLRun cannot connect to its database" in event.description
+    if expected_error_type is None:
+        assert "error_type" not in event.details
+    else:
+        assert event.details["error_type"] == expected_error_type
+
+
+def test_db_connection_event_truncates_long_error(client):
+    long_err = "x" * 4096
+    event = client.generate_db_connection_event(
+        mlrun.common.schemas.DBConnectionEventActions.failed,
+        error=long_err,
+    )
+    assert event.details["error"].endswith("...[truncated]")
+    assert len(event.details["error"]) <= iguazio_v4_events.ERROR_DETAIL_LIMIT
+    assert event.description.endswith("...[truncated]")
+
+
+def test_db_connection_unsupported_action_raises(client):
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        client.generate_db_connection_event("bogus")  # type: ignore[arg-type]

--- a/server/py/services/api/utils/events/base.py
+++ b/server/py/services/api/utils/events/base.py
@@ -78,3 +78,25 @@ class BaseEventClient:
         :return: event object to emit, or None if the client doesn't support this event
         """
         return None
+
+    def generate_db_connection_event(
+        self,
+        action: mlrun.common.schemas.DBConnectionEventActions,
+        error: BaseException | str | None = None,
+        error_category: str | None = None,
+        error_code: int | str | None = None,
+        dialect: str | None = None,
+    ) -> typing.Any | None:
+        """
+        Generate a DB connection lifecycle event
+        :param action: ``failed``
+        :param error: optional underlying exception or string
+        :param error_category: short label classifying the failure (e.g.
+            ``disconnect``, ``lock_wait_timeout``, ``deadlock``, ``query_timeout``,
+            ``too_many_connections``, ``pool_timeout``)
+        :param error_code: optional driver error code — pymysql int errno or
+            PostgreSQL SQLSTATE string (e.g. ``1205`` or ``"40P01"``)
+        :param dialect: SQLAlchemy dialect name (e.g. ``mysql``, ``postgresql``)
+        :return: event object to emit, or None if the client doesn't support this event
+        """
+        return None

--- a/server/py/services/api/utils/events/base.py
+++ b/server/py/services/api/utils/events/base.py
@@ -94,7 +94,7 @@ class BaseEventClient:
         :param error_category: short label classifying the failure (e.g.
             ``disconnect``, ``lock_wait_timeout``, ``deadlock``, ``query_timeout``,
             ``too_many_connections``, ``pool_timeout``)
-        :param error_code: optional driver error code — pymysql int errno or
+        :param error_code: optional driver error code: pymysql int errno or
             PostgreSQL SQLSTATE string (e.g. ``1205`` or ``"40P01"``)
         :param dialect: SQLAlchemy dialect name (e.g. ``mysql``, ``postgresql``)
         :return: event object to emit, or None if the client doesn't support this event

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -63,7 +63,7 @@ PG_CATEGORIES: dict[str, str] = {
     "08006": CATEGORY_DISCONNECT,  # connection_failure
     # 08007 (transaction_resolution_unknown) is intentionally NOT mapped:
     # it fires when the COMMIT ack is lost, which means the txn may actually
-    # have committed. Reporting it as ConnectionFailed would be misleading.
+    # have committed. Reporting it as Connection.Failed would be misleading.
     "57P01": CATEGORY_DISCONNECT,  # admin_shutdown
     "57P02": CATEGORY_DISCONNECT,  # crash_shutdown
     "57P03": CATEGORY_DISCONNECT,  # cannot_connect_now

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -1,0 +1,259 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+
+import sqlalchemy
+import sqlalchemy.engine
+import sqlalchemy.event
+import sqlalchemy.exc
+
+import mlrun.common.db.dialects
+import mlrun.common.schemas
+import mlrun.config
+import mlrun.errors
+from mlrun.utils import logger
+
+import framework.db.sqldb.sql_session
+import services.api.utils.events.events_factory as events_factory
+
+CATEGORY_DISCONNECT = "disconnect"
+CATEGORY_TOO_MANY_CONNECTIONS = "too_many_connections"
+CATEGORY_POOL_TIMEOUT = "pool_timeout"
+
+# Conservative mapping — each entry must be unambiguously a "cannot connect"
+# failure. Lock waits, deadlocks, and query timeouts are query-level and stay
+# off the map to keep the false-positive rate at zero.
+_MYSQL_CATEGORIES: dict[int, str] = {
+    2002: CATEGORY_DISCONNECT,  # CR_CONNECTION_ERROR — can't connect via socket
+    2003: CATEGORY_DISCONNECT,  # CR_CONN_HOST_ERROR — can't connect via TCP
+    2005: CATEGORY_DISCONNECT,  # CR_UNKNOWN_HOST
+    2006: CATEGORY_DISCONNECT,  # CR_SERVER_GONE_ERROR
+    2013: CATEGORY_DISCONNECT,  # CR_SERVER_LOST
+    1040: CATEGORY_TOO_MANY_CONNECTIONS,  # ER_CON_COUNT_ERROR
+}
+
+# PostgreSQL SQLSTATEs surfaced via psycopg2 ``pgcode`` / psycopg3 ``sqlstate``.
+# See https://www.postgresql.org/docs/current/errcodes-appendix.html.
+_PG_CATEGORIES: dict[str, str] = {
+    # Class 08 — Connection Exception
+    "08000": CATEGORY_DISCONNECT,
+    "08001": CATEGORY_DISCONNECT,  # sqlclient_unable_to_establish_sqlconnection
+    "08003": CATEGORY_DISCONNECT,  # connection_does_not_exist
+    "08004": CATEGORY_DISCONNECT,  # sqlserver_rejected_establishment_of_sqlconnection
+    "08006": CATEGORY_DISCONNECT,  # connection_failure
+    # 08007 (transaction_resolution_unknown) is intentionally NOT mapped:
+    # it fires when the COMMIT ack is lost, which means the txn may actually
+    # have committed. Reporting it as ConnectionFailed would be misleading.
+    "57P01": CATEGORY_DISCONNECT,  # admin_shutdown
+    "57P02": CATEGORY_DISCONNECT,  # crash_shutdown
+    "57P03": CATEGORY_DISCONNECT,  # cannot_connect_now
+    "53300": CATEGORY_TOO_MANY_CONNECTIONS,  # too_many_connections
+}
+
+_SUPPORTED_DIALECTS: frozenset[str] = frozenset(
+    {
+        mlrun.common.db.dialects.Dialects.MYSQL,
+        mlrun.common.db.dialects.Dialects.POSTGRESQL,
+    }
+)
+
+_throttle_lock = threading.Lock()
+_last_emit_monotonic: float = 0.0
+
+_registered_engines: set[int] = set()
+
+
+def classify(
+    ctx: sqlalchemy.engine.ExceptionContext,
+) -> tuple[str | None, int | str | None]:
+    """
+    Classify a DBAPI error into ``(category, driver_code)``.
+
+    Returns ``(None, None)`` for errors we don't consider connection-level
+    (integrity violations, programming errors, etc.).
+
+    ``driver_code`` is an int for pymysql errors and a SQLSTATE string for
+    psycopg2/3 errors.
+    """
+    original = ctx.original_exception
+
+    if getattr(ctx, "is_disconnect", False):
+        # SQLSTATE first — it's a 5-char string from psycopg2/3, far more
+        # specific than a stray ``args[0]`` int (which can be an OS errno on
+        # a wrapped network exception, not a pymysql errno).
+        code = _extract_pg_sqlstate(original) or _extract_mysql_code(original)
+        return CATEGORY_DISCONNECT, code
+
+    if isinstance(original, sqlalchemy.exc.TimeoutError):
+        return CATEGORY_POOL_TIMEOUT, None
+
+    mysql_code = _extract_mysql_code(original)
+    if mysql_code is not None:
+        category = _MYSQL_CATEGORIES.get(mysql_code)
+        if category is not None:
+            return category, mysql_code
+
+    pg_code = _extract_pg_sqlstate(original)
+    if pg_code is not None:
+        category = _PG_CATEGORIES.get(pg_code)
+        if category is not None:
+            return category, pg_code
+
+    return None, None
+
+
+def publish_connection_failed(
+    error: BaseException,
+    dialect: str | None,
+    category: str,
+    error_code: int | str | None = None,
+) -> bool:
+    """
+    Best-effort publish of a ``Platform.MLRun.DB.Connection.Failed`` event.
+
+    Throttled to one emission per process per
+    ``mlconf.events.db_connection.min_emit_interval_seconds``. The throttle
+    slot is only consumed when an event is actually emitted, so a no-op client
+    (e.g. ``NopClient``) does not burn the window. Never raises.
+
+    :return: True if an event was emitted, False if throttled or unsupported.
+    """
+    try:
+        client = events_factory.EventsFactory.get_events_client()
+        event = client.generate_db_connection_event(
+            action=mlrun.common.schemas.DBConnectionEventActions.failed,
+            error=error,
+            error_category=category,
+            error_code=error_code,
+            dialect=dialect,
+        )
+        if event is None:
+            return False
+        if not _claim_emit_slot():
+            return False
+        client.emit(event)
+        return True
+    except Exception as publish_exc:
+        logger.warning(
+            "Failed to publish DB connection event",
+            category=category,
+            error_code=error_code,
+            exc_info=publish_exc,
+        )
+        return False
+
+
+def register(engine: sqlalchemy.engine.Engine) -> None:
+    """
+    Attach the ``handle_error`` listener to ``engine``. The listener never
+    interferes with the original exception flow. Only MySQL and PostgreSQL
+    engines are wired up; SQLite and any other dialect are skipped because
+    we have no driver-code mapping for them.
+    """
+    if engine.dialect.name not in _SUPPORTED_DIALECTS:
+        return
+    if id(engine) in _registered_engines:
+        return
+    _registered_engines.add(id(engine))
+    sqlalchemy.event.listen(engine, "handle_error", _on_dbapi_error)
+
+
+def register_for_default_engine() -> None:
+    """
+    Attach the connection-failed listener to the runtime MLRun engine.
+    Safe to call multiple times — the engine is a process-wide singleton.
+    """
+    try:
+        engine = framework.db.sqldb.sql_session.get_engine()
+    except (RuntimeError, AttributeError) as exc:
+        logger.warning(
+            "Failed to resolve DB engine — skipping connection event listener",
+            exc_info=exc,
+        )
+        return
+    register(engine)
+
+
+def _on_dbapi_error(ctx: sqlalchemy.engine.ExceptionContext) -> None:
+    """``handle_error`` listener — never raises."""
+    try:
+        # ``ctx.engine`` is None exactly during the pool's pre-ping probe.
+        # Pre-ping is self-healing (discards stale connections, opens fresh
+        # ones), so we suppress the event there. A real outage will still
+        # surface — the fresh-connect attempt that follows fires
+        # ``handle_error`` again with the engine set, and that path emits.
+        if ctx.engine is None:
+            return
+        category, code = classify(ctx)
+        if category is None:
+            return
+        publish_connection_failed(
+            error=ctx.original_exception,
+            dialect=ctx.engine.dialect.name,
+            category=category,
+            error_code=code,
+        )
+    except Exception as exc:
+        logger.warning(
+            "DB error event listener raised — swallowing",
+            exc_info=exc,
+        )
+
+
+def _extract_mysql_code(exc: BaseException | None) -> int | None:
+    """
+    pymysql exposes ``args == (errno, message)``. Returns the int errno or
+    None if ``exc`` is not a pymysql exception.
+
+    The module check guards against unrelated exceptions whose first arg
+    happens to be an int (e.g. ``OSError(110, "Connection timed out")``
+    propagated through psycopg) — without it those would be reported as
+    a MySQL errno on a PG disconnect, masking the SQLSTATE.
+    """
+    if exc is None:
+        return None
+    if not type(exc).__module__.startswith(("pymysql", "MySQLdb")):
+        return None
+    args = exc.args
+    if args and isinstance(args[0], int):
+        return args[0]
+    return None
+
+
+def _extract_pg_sqlstate(exc: BaseException | None) -> str | None:
+    """
+    psycopg2 exposes the SQLSTATE on ``.pgcode``; psycopg3 on ``.sqlstate``.
+    SQLAlchemy preserves these on the original DBAPI exception. Returns the
+    5-char SQLSTATE string or None.
+    """
+    if exc is None:
+        return None
+    code = getattr(exc, "pgcode", None) or getattr(exc, "sqlstate", None)
+    if isinstance(code, str) and code:
+        return code
+    return None
+
+
+def _claim_emit_slot() -> bool:
+    """Return True at most once per the configured throttle interval per process."""
+    global _last_emit_monotonic
+    min_interval = float(mlrun.mlconf.events.db_connection.min_emit_interval_seconds)
+    now = time.monotonic()
+    with _throttle_lock:
+        if now - _last_emit_monotonic < min_interval:
+            return False
+        _last_emit_monotonic = now
+        return True

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -36,7 +36,7 @@ CATEGORY_POOL_TIMEOUT = "pool_timeout"
 # Conservative mapping — each entry must be unambiguously a "cannot connect"
 # failure. Lock waits, deadlocks, and query timeouts are query-level and stay
 # off the map to keep the false-positive rate at zero.
-_MYSQL_CATEGORIES: dict[int, str] = {
+MYSQL_CATEGORIES: dict[int, str] = {
     2002: CATEGORY_DISCONNECT,  # CR_CONNECTION_ERROR — can't connect via socket
     2003: CATEGORY_DISCONNECT,  # CR_CONN_HOST_ERROR — can't connect via TCP
     2005: CATEGORY_DISCONNECT,  # CR_UNKNOWN_HOST
@@ -47,7 +47,7 @@ _MYSQL_CATEGORIES: dict[int, str] = {
 
 # PostgreSQL SQLSTATEs surfaced via psycopg2 ``pgcode`` / psycopg3 ``sqlstate``.
 # See https://www.postgresql.org/docs/current/errcodes-appendix.html.
-_PG_CATEGORIES: dict[str, str] = {
+PG_CATEGORIES: dict[str, str] = {
     # Class 08 — Connection Exception
     "08000": CATEGORY_DISCONNECT,
     "08001": CATEGORY_DISCONNECT,  # sqlclient_unable_to_establish_sqlconnection
@@ -63,7 +63,7 @@ _PG_CATEGORIES: dict[str, str] = {
     "53300": CATEGORY_TOO_MANY_CONNECTIONS,  # too_many_connections
 }
 
-_SUPPORTED_DIALECTS: frozenset[str] = frozenset(
+SUPPORTED_DIALECTS: frozenset[str] = frozenset(
     {
         mlrun.common.db.dialects.Dialects.MYSQL,
         mlrun.common.db.dialects.Dialects.POSTGRESQL,
@@ -102,13 +102,13 @@ def classify(
 
     mysql_code = _extract_mysql_code(original)
     if mysql_code is not None:
-        category = _MYSQL_CATEGORIES.get(mysql_code)
+        category = MYSQL_CATEGORIES.get(mysql_code)
         if category is not None:
             return category, mysql_code
 
     pg_code = _extract_pg_sqlstate(original)
     if pg_code is not None:
-        category = _PG_CATEGORIES.get(pg_code)
+        category = PG_CATEGORIES.get(pg_code)
         if category is not None:
             return category, pg_code
 
@@ -163,7 +163,7 @@ def register(engine: sqlalchemy.engine.Engine) -> None:
     engines are wired up; SQLite and any other dialect are skipped because
     we have no driver-code mapping for them.
     """
-    if engine.dialect.name not in _SUPPORTED_DIALECTS:
+    if engine.dialect.name not in SUPPORTED_DIALECTS:
         return
     if id(engine) in _registered_engines:
         return

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -34,19 +34,17 @@ CATEGORY_TOO_MANY_CONNECTIONS = "too_many_connections"
 CATEGORY_POOL_TIMEOUT = "pool_timeout"
 CATEGORY_AUTH_FAILED = "auth_failed"
 
-# Conservative mapping — each entry must be unambiguously a "cannot connect"
-# failure. Lock waits, deadlocks, and query timeouts are query-level and stay
-# off the map to keep the false-positive rate at zero.
+# Each entry must be unambiguously a "cannot connect" failure. Query-level
+# errors (lock waits, deadlocks, query timeouts) stay off the map.
+# CATEGORY_AUTH_FAILED covers credential-rotation cases where the API cannot
+# open a session at all, e.g. RDS password rotation not yet propagated.
 MYSQL_CATEGORIES: dict[int, str] = {
-    2002: CATEGORY_DISCONNECT,  # CR_CONNECTION_ERROR — can't connect via socket
-    2003: CATEGORY_DISCONNECT,  # CR_CONN_HOST_ERROR — can't connect via TCP
+    2002: CATEGORY_DISCONNECT,  # CR_CONNECTION_ERROR (socket)
+    2003: CATEGORY_DISCONNECT,  # CR_CONN_HOST_ERROR (TCP)
     2005: CATEGORY_DISCONNECT,  # CR_UNKNOWN_HOST
     2006: CATEGORY_DISCONNECT,  # CR_SERVER_GONE_ERROR
     2013: CATEGORY_DISCONNECT,  # CR_SERVER_LOST
     1040: CATEGORY_TOO_MANY_CONNECTIONS,  # ER_CON_COUNT_ERROR
-    # Class 28 equivalents — auth blocks the API from establishing a session.
-    # Realistic trigger: RDS/managed-DB password rotation that hasn't propagated
-    # to the API's secret yet.
     1044: CATEGORY_AUTH_FAILED,  # ER_DBACCESS_DENIED_ERROR
     1045: CATEGORY_AUTH_FAILED,  # ER_ACCESS_DENIED_ERROR
     1698: CATEGORY_AUTH_FAILED,  # ER_ACCESS_DENIED_NO_PASSWORD_ERROR
@@ -55,23 +53,21 @@ MYSQL_CATEGORIES: dict[int, str] = {
 # PostgreSQL SQLSTATEs surfaced via psycopg2 ``pgcode`` / psycopg3 ``sqlstate``.
 # See https://www.postgresql.org/docs/current/errcodes-appendix.html.
 PG_CATEGORIES: dict[str, str] = {
-    # Class 08 — Connection Exception
+    # Class 08 (connection_exception)
     "08000": CATEGORY_DISCONNECT,
     "08001": CATEGORY_DISCONNECT,  # sqlclient_unable_to_establish_sqlconnection
     "08003": CATEGORY_DISCONNECT,  # connection_does_not_exist
     "08004": CATEGORY_DISCONNECT,  # sqlserver_rejected_establishment_of_sqlconnection
     "08006": CATEGORY_DISCONNECT,  # connection_failure
     # 08007 (transaction_resolution_unknown) is intentionally NOT mapped:
-    # it fires when the COMMIT ack is lost, which means the txn may actually
-    # have committed. Reporting it as Connection.Failed would be misleading.
+    # it fires when the COMMIT ack is lost, so the txn may have actually
+    # committed; reporting it as Connection.Failed would be misleading.
     "57P01": CATEGORY_DISCONNECT,  # admin_shutdown
     "57P02": CATEGORY_DISCONNECT,  # crash_shutdown
     "57P03": CATEGORY_DISCONNECT,  # cannot_connect_now
     "53300": CATEGORY_TOO_MANY_CONNECTIONS,  # too_many_connections
-    # Class 28 — Invalid Authorization Specification. Auth blocks the API from
-    # establishing a session; realistic trigger is RDS/managed-DB password
-    # rotation that hasn't propagated to the API's secret yet.
-    "28000": CATEGORY_AUTH_FAILED,  # invalid_authorization_specification
+    # Class 28 (invalid_authorization_specification)
+    "28000": CATEGORY_AUTH_FAILED,
     "28P01": CATEGORY_AUTH_FAILED,  # invalid_password
 }
 
@@ -103,9 +99,8 @@ def classify(
     original = ctx.original_exception
 
     if getattr(ctx, "is_disconnect", False):
-        # SQLSTATE first — it's a 5-char string from psycopg2/3, far more
-        # specific than a stray ``args[0]`` int (which can be an OS errno on
-        # a wrapped network exception, not a pymysql errno).
+        # Prefer SQLSTATE: ``args[0]`` may be an OS errno on a wrapped network
+        # exception, not a pymysql errno.
         code = _extract_pg_sqlstate(original) or _extract_mysql_code(original)
         return CATEGORY_DISCONNECT, code
 
@@ -138,8 +133,8 @@ def publish_connection_failed(
 
     Throttled to one emission per process per
     ``mlconf.events.db_connection.min_emit_interval_seconds``. The throttle
-    slot is only consumed when an event is actually emitted, so a no-op client
-    (e.g. ``NopClient``) does not burn the window. Never raises.
+    slot is consumed only on successful delivery; a no-op client or a
+    raising ``emit`` leave the slot free so the next DB error can retry.
 
     :return: True if an event was emitted, False if throttled or unsupported.
     """
@@ -170,10 +165,9 @@ def publish_connection_failed(
 
 def register(engine: sqlalchemy.engine.Engine) -> None:
     """
-    Attach the ``handle_error`` listener to ``engine``. The listener never
-    interferes with the original exception flow. Only MySQL and PostgreSQL
-    engines are wired up; SQLite and any other dialect are skipped because
-    we have no driver-code mapping for them.
+    Attach the ``handle_error`` listener to ``engine``. Only MySQL and
+    PostgreSQL are wired up; other dialects are skipped (no driver-code
+    mapping). The listener never alters exception flow.
     """
     if engine.dialect.name not in SUPPORTED_DIALECTS:
         return
@@ -186,13 +180,13 @@ def register(engine: sqlalchemy.engine.Engine) -> None:
 def register_for_default_engine() -> None:
     """
     Attach the connection-failed listener to the runtime MLRun engine.
-    Safe to call multiple times — the engine is a process-wide singleton.
+    Safe to call multiple times (the engine is a process-wide singleton).
     """
     try:
         engine = framework.db.sqldb.sql_session.get_engine()
     except (RuntimeError, AttributeError) as exc:
         logger.warning(
-            "Failed to resolve DB engine — skipping connection event listener",
+            "Failed to resolve DB engine, skipping connection event listener",
             exc_info=exc,
         )
         return
@@ -200,13 +194,11 @@ def register_for_default_engine() -> None:
 
 
 def _on_dbapi_error(ctx: sqlalchemy.engine.ExceptionContext) -> None:
-    """``handle_error`` listener — never raises."""
+    """``handle_error`` listener; never raises."""
     try:
-        # ``ctx.engine`` is None exactly during the pool's pre-ping probe.
-        # Pre-ping is self-healing (discards stale connections, opens fresh
-        # ones), so we suppress the event there. A real outage will still
-        # surface — the fresh-connect attempt that follows fires
-        # ``handle_error`` again with the engine set, and that path emits.
+        # ``ctx.engine`` is None during the pool's pre-ping probe, which is
+        # self-healing. A real outage surfaces on the fresh-connect attempt
+        # that follows, where ``ctx.engine`` is set and we emit.
         if ctx.engine is None:
             return
         category, code = classify(ctx)
@@ -227,13 +219,9 @@ def _on_dbapi_error(ctx: sqlalchemy.engine.ExceptionContext) -> None:
 
 def _extract_mysql_code(exc: BaseException | None) -> int | None:
     """
-    pymysql exposes ``args == (errno, message)``. Returns the int errno or
-    None if ``exc`` is not a pymysql exception.
-
-    The module check guards against unrelated exceptions whose first arg
-    happens to be an int (e.g. ``OSError(110, "Connection timed out")``
-    propagated through psycopg) — without it those would be reported as
-    a MySQL errno on a PG disconnect, masking the SQLSTATE.
+    Return the pymysql errno (``exc.args[0]``), or None if ``exc`` is not a
+    pymysql exception. The module check prevents misreporting an unrelated
+    int arg (e.g. an OSError errno on a PG disconnect) as a MySQL errno.
     """
     if exc is None:
         return None
@@ -247,9 +235,8 @@ def _extract_mysql_code(exc: BaseException | None) -> int | None:
 
 def _extract_pg_sqlstate(exc: BaseException | None) -> str | None:
     """
-    psycopg2 exposes the SQLSTATE on ``.pgcode``; psycopg3 on ``.sqlstate``.
-    SQLAlchemy preserves these on the original DBAPI exception. Returns the
-    5-char SQLSTATE string or None.
+    Return the psycopg SQLSTATE (``.pgcode`` for psycopg2, ``.sqlstate`` for
+    psycopg3), or None if ``exc`` carries neither.
     """
     if exc is None:
         return None

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -32,6 +32,7 @@ import services.api.utils.events.events_factory as events_factory
 CATEGORY_DISCONNECT = "disconnect"
 CATEGORY_TOO_MANY_CONNECTIONS = "too_many_connections"
 CATEGORY_POOL_TIMEOUT = "pool_timeout"
+CATEGORY_AUTH_FAILED = "auth_failed"
 
 # Conservative mapping — each entry must be unambiguously a "cannot connect"
 # failure. Lock waits, deadlocks, and query timeouts are query-level and stay
@@ -43,6 +44,12 @@ MYSQL_CATEGORIES: dict[int, str] = {
     2006: CATEGORY_DISCONNECT,  # CR_SERVER_GONE_ERROR
     2013: CATEGORY_DISCONNECT,  # CR_SERVER_LOST
     1040: CATEGORY_TOO_MANY_CONNECTIONS,  # ER_CON_COUNT_ERROR
+    # Class 28 equivalents — auth blocks the API from establishing a session.
+    # Realistic trigger: RDS/managed-DB password rotation that hasn't propagated
+    # to the API's secret yet.
+    1044: CATEGORY_AUTH_FAILED,  # ER_DBACCESS_DENIED_ERROR
+    1045: CATEGORY_AUTH_FAILED,  # ER_ACCESS_DENIED_ERROR
+    1698: CATEGORY_AUTH_FAILED,  # ER_ACCESS_DENIED_NO_PASSWORD_ERROR
 }
 
 # PostgreSQL SQLSTATEs surfaced via psycopg2 ``pgcode`` / psycopg3 ``sqlstate``.
@@ -61,6 +68,11 @@ PG_CATEGORIES: dict[str, str] = {
     "57P02": CATEGORY_DISCONNECT,  # crash_shutdown
     "57P03": CATEGORY_DISCONNECT,  # cannot_connect_now
     "53300": CATEGORY_TOO_MANY_CONNECTIONS,  # too_many_connections
+    # Class 28 — Invalid Authorization Specification. Auth blocks the API from
+    # establishing a session; realistic trigger is RDS/managed-DB password
+    # rotation that hasn't propagated to the API's secret yet.
+    "28000": CATEGORY_AUTH_FAILED,  # invalid_authorization_specification
+    "28P01": CATEGORY_AUTH_FAILED,  # invalid_password
 }
 
 SUPPORTED_DIALECTS: frozenset[str] = frozenset(
@@ -208,7 +220,7 @@ def _on_dbapi_error(ctx: sqlalchemy.engine.ExceptionContext) -> None:
         )
     except Exception as exc:
         logger.warning(
-            "DB error event listener raised — swallowing",
+            "Failed to handle DB error event, ignoring",
             exc_info=exc,
         )
 

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -149,9 +149,14 @@ def publish_connection_failed(
         )
         if event is None:
             return False
-        if not _claim_emit_slot():
+        previous_slot = _try_claim_emit_slot()
+        if previous_slot is None:
             return False
-        client.emit(event)
+        try:
+            client.emit(event)
+        except Exception:
+            _release_emit_slot(previous_slot)
+            raise
         return True
     except Exception as publish_exc:
         logger.warning(
@@ -246,13 +251,25 @@ def _extract_pg_sqlstate(exc: BaseException | None) -> str | None:
     return None
 
 
-def _claim_emit_slot() -> bool:
-    """Return True at most once per the configured throttle interval per process."""
+def _try_claim_emit_slot() -> float | None:
+    """
+    Try to claim the throttle slot. On success returns the previous
+    ``_last_emit_monotonic`` value (pass to :func:`_release_emit_slot` to
+    undo on delivery failure); returns None if throttled.
+    """
     global _last_emit_monotonic
     min_interval = float(mlrun.mlconf.events.db_connection.min_emit_interval_seconds)
     now = time.monotonic()
     with _throttle_lock:
         if now - _last_emit_monotonic < min_interval:
-            return False
+            return None
+        previous = _last_emit_monotonic
         _last_emit_monotonic = now
-        return True
+        return previous
+
+
+def _release_emit_slot(previous: float) -> None:
+    """Restore the slot to ``previous`` so the next DB error can retry emit."""
+    global _last_emit_monotonic
+    with _throttle_lock:
+        _last_emit_monotonic = previous

--- a/server/py/services/api/utils/events/iguazio_v4.py
+++ b/server/py/services/api/utils/events/iguazio_v4.py
@@ -24,21 +24,18 @@ import framework.utils.clients.helpers as clients_helpers
 import framework.utils.clients.service_account_token as service_account_token
 import services.api.utils.events.base as base_events
 
-DB_MIGRATION_REQUIRED = "Platform.MLRun.DB.MigrationRequired"
-DB_MIGRATION_STARTED = "Platform.MLRun.DB.MigrationStarted"
-DB_MIGRATION_COMPLETED = "Platform.MLRun.DB.MigrationCompleted"
-DB_MIGRATION_FAILED = "Platform.MLRun.DB.MigrationFailed"
+DB_MIGRATION_REQUIRED = "Platform.MLRun.DB.Migration.Required"
+DB_MIGRATION_STARTED = "Platform.MLRun.DB.Migration.Started"
+DB_MIGRATION_COMPLETED = "Platform.MLRun.DB.Migration.Completed"
+DB_MIGRATION_FAILED = "Platform.MLRun.DB.Migration.Failed"
+DB_CONNECTION_FAILED = "Platform.MLRun.DB.Connection.Failed"
 
-ENTITY_NAME = "MLRun"
 EVENT_KIND = "system"
-EVENT_CLASS = "Platform"
+EVENT_CLASS = "Application.Core"
 ERROR_DETAIL_LIMIT = 1024
 ERROR_DESCRIPTION_LIMIT = 200
 TRUNCATION_SUFFIX = "...[truncated]"
 
-# Per IG4 System Events Spec — Phase 2.
-# class is "Platform", kind is "system" for all DB lifecycle events.
-# Severity follows the spec: Required/Failed are Critical, Started/Completed are Info.
 DB_MIGRATION_EVENTS: dict[
     mlrun.common.schemas.MigrationEventActions,
     tuple[str, iguazio.schemas.Severity, str],
@@ -65,6 +62,17 @@ DB_MIGRATION_EVENTS: dict[
     ),
 }
 
+DB_CONNECTION_EVENTS: dict[
+    mlrun.common.schemas.DBConnectionEventActions,
+    tuple[str, iguazio.schemas.Severity, str],
+] = {
+    mlrun.common.schemas.DBConnectionEventActions.failed: (
+        DB_CONNECTION_FAILED,
+        iguazio.schemas.Severity.CRITICAL,
+        "MLRun cannot connect to its database",
+    ),
+}
+
 
 class Client(base_events.BaseEventClient):
     """
@@ -80,7 +88,7 @@ class Client(base_events.BaseEventClient):
             verify_ssl=mlrun.mlconf.iguazio_api_ssl_verify,
         )
         self._service_account_token_client = service_account_token.Client()
-        self._source = self._resolve_source()
+        self._entity_name = self._resolve_entity_name()
 
     def emit(self, event):
         if event is None:
@@ -89,7 +97,7 @@ class Client(base_events.BaseEventClient):
             logger.debug(
                 "Emitting event",
                 config_name=event.config_name,
-                source=event.source,
+                entity_name=event.entity_name,
             )
             with self._client.with_headers(
                 clients_helpers.enrich_headers(
@@ -129,24 +137,52 @@ class Client(base_events.BaseEventClient):
         if duration_seconds is not None:
             details["duration_seconds"] = round(float(duration_seconds), 3)
 
-        if action == mlrun.common.schemas.MigrationEventActions.failed and error:
-            error_str = (
-                error if isinstance(error, str) else mlrun.errors.err_to_str(error)
-            )
-            details["error"] = self._truncate(error_str, ERROR_DETAIL_LIMIT)
-            if not isinstance(error, str):
-                details["error_type"] = type(error).__name__
-            description = (
-                f"{description}: {self._truncate(error_str, ERROR_DESCRIPTION_LIMIT)}"
-            )
+        if action == mlrun.common.schemas.MigrationEventActions.failed:
+            description = self._apply_error(details, description, error)
 
         return iguazio.schemas.EventActivationSpec(
             config_name=config_name,
-            source=self._source,
+            source="",
             kind=EVENT_KIND,
             severity=severity,
             class_=EVENT_CLASS,
-            entity_name=ENTITY_NAME,
+            entity_name=self._entity_name,
+            description=description,
+            details=details,
+        )
+
+    def generate_db_connection_event(
+        self,
+        action: mlrun.common.schemas.DBConnectionEventActions,
+        error: BaseException | str | None = None,
+        error_category: str | None = None,
+        error_code: int | str | None = None,
+        dialect: str | None = None,
+    ) -> iguazio.schemas.EventActivationSpec:
+        try:
+            config_name, severity, description = DB_CONNECTION_EVENTS[action]
+        except KeyError as exc:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Unsupported DB connection action {action}"
+            ) from exc
+
+        details: dict = {}
+        if error_category:
+            details["error_category"] = error_category
+        if error_code is not None:
+            details["error_code"] = error_code
+        if dialect:
+            details["dialect"] = dialect
+
+        description = self._apply_error(details, description, error)
+
+        return iguazio.schemas.EventActivationSpec(
+            config_name=config_name,
+            source="",
+            kind=EVENT_KIND,
+            severity=severity,
+            class_=EVENT_CLASS,
+            entity_name=self._entity_name,
             description=description,
             details=details,
         )
@@ -175,14 +211,8 @@ class Client(base_events.BaseEventClient):
         )
 
     @staticmethod
-    def _resolve_source() -> str:
-        """
-        Use the K8s deployment name as the event source so consumers can tell which
-        component emitted the event:
-        * the api service runs as `mlrun-api-chief` or `mlrun-api-worker`
-          (role is set in mlconf.httpdb.clusterization.role)
-        * other services (currently just alerts) deploy as `mlrun-<service_name>`
-        """
+    def _resolve_entity_name() -> str:
+        """K8s deployment name: ``mlrun-api-{role}`` for api, ``mlrun-{name}`` otherwise."""
         service_name = mlrun.mlconf.services.service_name or "api"
         if service_name == "api":
             role = mlrun.mlconf.httpdb.clusterization.role or "chief"
@@ -197,3 +227,22 @@ class Client(base_events.BaseEventClient):
         if limit <= len(TRUNCATION_SUFFIX):
             return value[:limit]
         return value[: limit - len(TRUNCATION_SUFFIX)] + TRUNCATION_SUFFIX
+
+    @classmethod
+    def _apply_error(
+        cls,
+        details: dict,
+        description: str,
+        error: BaseException | str | None,
+    ) -> str:
+        """
+        Append truncated error context to ``details`` and ``description``.
+        Returns the (possibly extended) description.
+        """
+        if not error:
+            return description
+        error_str = error if isinstance(error, str) else mlrun.errors.err_to_str(error)
+        details["error"] = cls._truncate(error_str, ERROR_DETAIL_LIMIT)
+        if not isinstance(error, str):
+            details["error_type"] = type(error).__name__
+        return f"{description}: {cls._truncate(error_str, ERROR_DESCRIPTION_LIMIT)}"

--- a/server/py/services/api/utils/events/iguazio_v4.py
+++ b/server/py/services/api/utils/events/iguazio_v4.py
@@ -76,8 +76,8 @@ DB_CONNECTION_EVENTS: dict[
 
 class Client(base_events.BaseEventClient):
     """
-    Events client for Iguazio v4 — publishes events through the Iguazio (orca) SDK
-    using catalog event configs.
+    Events client for Iguazio v4. Publishes events through the Iguazio (orca)
+    SDK using catalog event configs.
     """
 
     def __init__(self, **_kwargs):
@@ -221,7 +221,6 @@ class Client(base_events.BaseEventClient):
 
     @staticmethod
     def _truncate(value: str, limit: int) -> str:
-        """Trim ``value`` so the returned string is at most ``limit`` characters."""
         if len(value) <= limit:
             return value
         if limit <= len(TRUNCATION_SUFFIX):


### PR DESCRIPTION
### 📝 Description

Wires up the second the DB system event after the migration set in #9618: `Platform.MLRun.DB.Connection.Failed` (Critical, `class=Application.Core`). Fires on unambiguously connection-level DBAPI errors only - disconnects, `too_many_connections`, and pool-checkout timeouts. The mapping is intentionally conservative (zero false positives by design): lock waits, deadlocks, query timeouts, integrity violations, and SQLAlchemy pool pre-ping probes are deliberately not mapped.

Also renames the existing migration events to dotted form (`Platform.MLRun.DB.Migration.{Required,Started,Completed,Failed}`) and migrates both groups to the new envelope: `class=Application.Core`, `entity_name=mlrun-api-{chief,worker}` / `mlrun-alerts`, `source=""`.


The whole feature in five nodes:
  1. MLRun service hits the DB.
  2. Listener intercepts errors without altering the flow - original exception always reaches the caller.
  3. Two filters: pre-ping is silently dropped (pool self-heals); only true cannot-connect errors continue.
  4. Throttle: at most one event per 60 s per process.
  5. Enterprise backend receives a Critical event when something operationally meaningful happens.

---

### 🛠️ Changes Made

- New listener in `server/py/services/api/utils/events/db_errors.py`: classifier + configurable throttled best-effort publisher + idempotent per-engine `register()`. Attaches as a SQLAlchemy `handle_error` event listener at API startup via `services.api.main._custom_setup_service`.
- Pre-ping suppression: when `ctx.engine is None` (SQLAlchemy's pool pre-ping path), the listener short-circuits and emits nothing. Pre-ping is self-healing; a real outage still surfaces on the fresh-connect attempt that follows with the engine populated.
- Throttle: `mlconf.events.db_connection.min_emit_interval_seconds` (default 60s) caps emissions to one per process per window. The slot is only consumed when an event is actually emitted, so a `NopClient` (non-v4 deployments) does not burn the window.
- `iguazio_v4.Client.generate_db_connection_event(...)` builds the spec with `class=Application.Core`, `kind=system`, `entity_name` from `_resolve_entity_name()`, `source=""`. Truncation logic for `error` / `description` is shared with `generate_db_migration_event` via a new `_apply_error` helper.
- `BaseEventClient.generate_db_connection_event` returns `None` so non-v4 clients are silent automatically.
- `mlrun.common.schemas.events`: adds `DBConnectionEventActions.failed`.
- `mlrun/config.py`: adds `events.db_connection.min_emit_interval_seconds` (default 60).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable) — N/A, no user-facing docs touched
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing
- **Unit** — `pytest server/py/services/api/tests/unit/utils/events/`
- **Integration** — `MLRUN_TEST_DB={mysql,postgres} pytest server/py/framework/tests/integration/db/test_db_connection_event.py` (CI matrix runs both): asserts that lock-wait timeout and integrity violation against real MySQL + Postgres containers do **not** trigger the event.

---

### 🔗 References
- Ticket link: IG4-2137

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- **Throttling rationale.** The 60s per-process cap is a local guard so a sustained outage doesn't emit one event per failed query. Consume-on-success ensures a transient events-service failure doesn't silently burn the window.
