### PR TITLE
[DB] Add name column to runs composite index

### DIFF
--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -470,6 +470,7 @@ with warnings.catch_warnings():
                 "project",
                 "iteration",
                 "start_time",
+                "name",
             ),
         )
 

--- a/server/py/services/api/migrations/versions/8712e85b0281_index_runs_project_iteration_start_time.py
+++ b/server/py/services/api/migrations/versions/8712e85b0281_index_runs_project_iteration_start_time.py
@@ -37,11 +37,11 @@ def upgrade():
     inspector = sa.inspect(op.get_bind())
     existing = {idx["name"] for idx in inspector.get_indexes(_table_name)}
     if _index_name in existing:
-        return
+        op.drop_index(_index_name, table_name=_table_name)
     op.create_index(
         _index_name,
         _table_name,
-        ["project", "iteration", "start_time"],
+        ["project", "iteration", "start_time", "name"],
         unique=False,
     )
     # ### end Alembic commands ###

--- a/server/py/services/api/migrations/versions/8712e85b0281_index_runs_project_iteration_start_time.py
+++ b/server/py/services/api/migrations/versions/8712e85b0281_index_runs_project_iteration_start_time.py
@@ -37,7 +37,7 @@ def upgrade():
     inspector = sa.inspect(op.get_bind())
     existing = {idx["name"] for idx in inspector.get_indexes(_table_name)}
     if _index_name in existing:
-        op.drop_index(_index_name, table_name=_table_name)
+        return
     op.create_index(
         _index_name,
         _table_name,


### PR DESCRIPTION
### 📝 Description
Follow-up to #9580. Adds the `name` column to the `idx_runs_project_iter_start` composite index so that the `ROW_NUMBER() OVER (PARTITION BY runs.project, runs.name ...)` window function in the list-runs query can be fully satisfied from the index.

---

### 🛠️ Changes Made
- Updated migration  to create the index on `(project, iteration, start_time, name)` instead of `(project, iteration, start_time)`
- Updated the SQLAlchemy model to match

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Covered by existing `pytest-alembic` migration tests (test_model_definitions_match_ddl, test_upgrade, test_up_down_consistency)

---

### 🔗 References
- Ticket link: ML-12431
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
