### PR TITLE
[CI] Fix S3 credentials secret name in open-source workflow

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -685,8 +685,8 @@ jobs:
         # S3 credentials for client-side artifact uploads (SeaweedFS).
         # Read from the s3-credentials K8s secret created by the CE chart, but
         # replace the in-cluster DNS endpoint with a routable ClusterIP address.
-        export AWS_ACCESS_KEY_ID=$(kubectl get secret s3-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
-        export AWS_SECRET_ACCESS_KEY=$(kubectl get secret s3-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
+        export AWS_ACCESS_KEY_ID=$(kubectl get secret storage-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
+        export AWS_SECRET_ACCESS_KEY=$(kubectl get secret storage-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
         S3_CLUSTER_IP=$(kubectl get svc seaweedfs-s3 -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
         S3_PORT=$(kubectl get svc seaweedfs-s3 -n ${NAMESPACE} -o jsonpath='{.spec.ports[0].port}')
         export AWS_ENDPOINT_URL_S3="http://${S3_CLUSTER_IP}:${S3_PORT}"
@@ -808,7 +808,7 @@ jobs:
         echo "=== SEAWEEDFS S3 STATUS ==="
         echo "=================================="
         kubectl get svc seaweedfs-s3 -n ${NAMESPACE} -o wide 2>/dev/null || echo "seaweedfs-s3 service not found"
-        kubectl get secret s3-credentials -n ${NAMESPACE} 2>/dev/null || echo "s3-credentials secret not found"
+        kubectl get secret storage-credentials -n ${NAMESPACE} 2>/dev/null || echo "storage-credentials secret not found"
 
         set +x
 


### PR DESCRIPTION
CE chart creates 'storage-credentials' secret, not 's3-credentials'. Using the wrong name caused empty AWS credentials, boto3 falling through to EC2 IMDS, and ultimately AccessDenied from SeaweedFS.

### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

Fetch the SeaweedFS creds from  'storage-credentials' secret

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
