### PR TITLE
[Model Monitoring/Test] Fix test_app_flow smoke test on open-source CE

### DIFF
--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -1077,7 +1077,7 @@ class RunDBInterface(ABC):
         self,
         project: str,
         base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
         fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4044,24 +4044,25 @@ class HTTPRunDB(RunDBInterface):
         self,
         project: str,
         base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        image: str | None = None,
     ) -> None:
         """
         Redeploy model monitoring application controller function.
 
-        :param project:                  Project name.
-        :param base_period:              The time period in minutes in which the model monitoring controller function
-                                         triggers. By default, the base period is 10 minutes.
-        :param image: The image of the model monitoring controller function.
-                                         By default, the image is mlrun/mlrun.
+        :param project:     Project name.
+        :param base_period: The time period in minutes in which the model monitoring controller function
+                            triggers. By default, the base period is 10 minutes.
+        :param image:       The image of the model monitoring controller function.
+                            Defaults to
+                            ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         """
+        params = {"base_period": base_period}
+        if image is not None:
+            params["image"] = image
         self.api_call(
             method=mlrun.common.types.HTTPMethod.PATCH,
             path=f"projects/{project}/model-monitoring/controller",
-            params={
-                "base_period": base_period,
-                "image": image,
-            },
+            params=params,
         )
 
     def enable_model_monitoring(

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4068,7 +4068,7 @@ class HTTPRunDB(RunDBInterface):
         self,
         project: str,
         base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
         fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,
@@ -4087,7 +4087,8 @@ class HTTPRunDB(RunDBInterface):
                                                   function triggers. By default, the base period is 10 minutes.
         :param image:                             The image of the model monitoring controller, writer & monitoring
                                                   stream functions, which are real time nuclio functions.
-                                                  By default, the image is mlrun/mlrun.
+                                                  Defaults to
+                                                  ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
         :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
         :param lag_threshold:                     Lag threshold in minutes for writer lag detection.
@@ -4098,11 +4099,14 @@ class HTTPRunDB(RunDBInterface):
 
         params = {
             "base_period": base_period,
-            "image": image,
             "deploy_histogram_data_drift_app": deploy_histogram_data_drift_app,
             "fetch_credentials_from_sys_config": fetch_credentials_from_sys_config,
             "auth_token_name": auth_token_name,
         }
+        # Only forward `image` when caller specified one — otherwise let the
+        # API server resolve it from `function_defaults.image_by_kind.nuclio`.
+        if image is not None:
+            params["image"] = image
         if lag_threshold is not None:
             params["lag_threshold"] = lag_threshold
         if lag_event_cooldown is not None:

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -858,7 +858,7 @@ class NopDB(RunDBInterface):
         self,
         project: str,
         base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
         fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2654,7 +2654,7 @@ class MlrunProject(ModelObj):
     def enable_model_monitoring(
         self,
         base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        image: str | None = None,
         *,
         deploy_histogram_data_drift_app: bool = True,
         wait_for_deployment: bool = False,
@@ -2675,7 +2675,8 @@ class MlrunProject(ModelObj):
                                                   (which is also the minimum value for production environments).
         :param image:                             The image of the model monitoring controller, writer, monitoring
                                                   stream & histogram data drift functions, which are real time nuclio
-                                                  functions. By default, the image is mlrun/mlrun.
+                                                  functions. Defaults to
+                                                  ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application:
             :py:class:`~mlrun.model_monitoring.applications.histogram_data_drift.HistogramDataDriftApplication`.
             If false, and you want to deploy the histogram data drift application

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2742,7 +2742,7 @@ class MlrunProject(ModelObj):
     def update_model_monitoring_controller(
         self,
         base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        image: str | None = None,
         *,
         wait_for_deployment: bool = False,
     ) -> None:
@@ -2753,7 +2753,8 @@ class MlrunProject(ModelObj):
                                     is triggered. By default, the base period is 10 minutes.
         :param image:               The image of the model monitoring controller, writer & monitoring
                                     stream functions, which are real time nuclio functions.
-                                    By default, the image is mlrun/mlrun.
+                                    Defaults to
+                                    ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param wait_for_deployment: If true, return only after the deployment is done on the backend.
                                     Otherwise, deploy the controller on the background.
         """

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -142,7 +142,7 @@ async def _common_parameters(
 def enable_model_monitoring(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     base_period: int = 10,
-    image: str = "mlrun/mlrun",
+    image: str | None = None,
     deploy_histogram_data_drift_app: bool = True,
     fetch_credentials_from_sys_config: bool = Query(
         False,
@@ -172,7 +172,8 @@ def enable_model_monitoring(
                                               function triggers. By default, the base period is 10 minutes.
     :param image:                             The image of the model monitoring controller, writer & monitoring
                                               stream functions, which are real time nuclio functions.
-                                              By default, the image is mlrun/mlrun.
+                                              Defaults to
+                                              ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
     :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
     :param fetch_credentials_from_sys_config: Deprecated. If true, fetch the credentials from the system configuration.
     :param lag_threshold:                     Lag threshold in minutes for writer lag detection.

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -194,7 +194,7 @@ def enable_model_monitoring(
 def update_model_monitoring_controller(
     commons: Annotated[_CommonParams, Depends(_common_parameters)],
     base_period: int = 10,
-    image: str = "mlrun/mlrun",
+    image: str | None = None,
 ):
     """
     Redeploy model monitoring application controller function.
@@ -203,9 +203,8 @@ def update_model_monitoring_controller(
     :param commons:     The common parameters of the request.
     :param base_period: The time period in minutes in which the model monitoring controller function
                         triggers. By default, the base period is 10 minutes.
-    :param image:       The default image of the model monitoring controller job. Note that the writer
-                        function, which is a real time nuclio functino, will be deployed with the same
-                        image. By default, the image is mlrun/mlrun.
+    :param image:       The image of the model monitoring controller function. Defaults to
+                        ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
     """
     try:
         # validate that the model monitoring stream has not yet been deployed

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -140,7 +140,7 @@ class MonitoringDeployment:
     def deploy_monitoring_functions(
         self,
         base_period: int = 10,
-        image: str = "mlrun/mlrun",
+        image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
         fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,
@@ -153,12 +153,14 @@ class MonitoringDeployment:
                                                   function triggers. By default, the base period is 10 minutes.
         :param image:                             The image of the model monitoring controller, writer & monitoring
                                                   stream functions, which are real time nuclio function.
-                                                  By default, the image is mlrun/mlrun.
+                                                  Defaults to ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
         :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
         :param lag_threshold:                     Lag threshold in minutes for writer lag detection.
         :param lag_event_cooldown:                Cooldown in minutes between consecutive lag events per worker.
         """
+        if image is None:
+            image = mlrun.mlconf.function_defaults.image_by_kind.nuclio
         # check if credentials should be fetched from the system configuration or if they are already been set.
         if fetch_credentials_from_sys_config:
             self.set_credentials()
@@ -206,7 +208,7 @@ class MonitoringDeployment:
             self.deploy_histogram_data_drift_app(image=image)
 
     def deploy_model_monitoring_stream_processing(
-        self, stream_image: str = "mlrun/mlrun", overwrite: bool = False
+        self, stream_image: str | None = None, overwrite: bool = False
     ) -> None:
         """
         Deploying model monitoring stream real time nuclio function. The goal of this real time function is
@@ -214,9 +216,11 @@ class MonitoringDeployment:
         It processes the new events into statistics that are then written to statistics databases.
 
         :param stream_image:                The image of the model monitoring stream function.
-                                            By default, the image is mlrun/mlrun.
+                                            Defaults to ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param overwrite:                   If true, overwrite the existing model monitoring stream. Default is False.
         """
+        if stream_image is None:
+            stream_image = mlrun.mlconf.function_defaults.image_by_kind.nuclio
 
         if overwrite or self._should_deploy_function(
             function_name=mm_constants.MonitoringFunctionNames.STREAM
@@ -254,7 +258,7 @@ class MonitoringDeployment:
     def deploy_model_monitoring_controller(
         self,
         base_period: int,
-        controller_image: str = "mlrun/mlrun",
+        controller_image: str | None = None,
         overwrite: bool = False,
     ) -> None:
         """
@@ -265,10 +269,12 @@ class MonitoringDeployment:
         :param base_period:                 The time period in minutes in which the model monitoring controller function
                                             triggers. By default, the base period is 10 minutes.
         :param controller_image:            The image of the model monitoring controller function.
-                                            By default, the image is mlrun/mlrun.
+                                            Defaults to ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param overwrite:                   If true, overwrite the existing model monitoring controller.
                                             By default, False.
         """
+        if controller_image is None:
+            controller_image = mlrun.mlconf.function_defaults.image_by_kind.nuclio
         if overwrite or self._should_deploy_function(
             function_name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER
         ):
@@ -316,7 +322,7 @@ class MonitoringDeployment:
 
     def deploy_model_monitoring_writer_application(
         self,
-        writer_image: str = "mlrun/mlrun",
+        writer_image: str | None = None,
         overwrite: bool = False,
         lag_threshold: int | None = None,
         lag_event_cooldown: int | None = None,
@@ -328,13 +334,15 @@ class MonitoringDeployment:
         It processes and writes the result to the databases.
 
         :param writer_image:                The image of the model monitoring writer function.
-                                            By default, the image is mlrun/mlrun.
+                                            Defaults to ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param overwrite:                   If true, overwrite the existing model monitoring writer. Default is False.
         :param lag_threshold:               Lag threshold in minutes for writer lag detection.
         :param lag_event_cooldown:          Cooldown in minutes between consecutive lag events per worker.
         :param base_period:                 The monitoring controller base period in minutes, used to
                                             compute default lag values.
         """
+        if writer_image is None:
+            writer_image = mlrun.mlconf.function_defaults.image_by_kind.nuclio
 
         if overwrite or self._should_deploy_function(
             function_name=mm_constants.MonitoringFunctionNames.WRITER

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import concurrent.futures
+import ipaddress
 import json
 import pickle
 import tempfile
@@ -566,7 +567,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
     def _workaround_ml_12522_force_http_for_nodeport(
         fn: mlrun.runtimes.nuclio.serving.ServingRuntime,
     ) -> None:
-        """Workaround for https://ecliptos.atlassian.net/browse/ML-12522.
+        """Workaround for ML-12522.
 
         Nuclio reports ``status.external_invocation_urls`` as scheme-less.
         Since mlrun #9578, ``_resolve_invocation_url`` prepends ``https://``
@@ -580,8 +581,6 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         invocations through ``APIGateway.invoke_url`` and
         ``_resolve_invocation_url`` defaults back to ``http://``.
         """
-        import ipaddress
-
         for i, url in enumerate(fn.status.external_invocation_urls or []):
             if "://" in url or "/" in url:
                 continue

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -559,7 +559,38 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
             serving_fn.spec.image = serving_fn.spec.build.image = cls.image
 
         serving_fn.deploy()
+        cls._workaround_ml_12522_force_http_for_nodeport(serving_fn)
         return serving_fn
+
+    @staticmethod
+    def _workaround_ml_12522_force_http_for_nodeport(
+        fn: mlrun.runtimes.nuclio.serving.ServingRuntime,
+    ) -> None:
+        """Workaround for https://ecliptos.atlassian.net/browse/ML-12522.
+
+        Nuclio reports ``status.external_invocation_urls`` as scheme-less.
+        Since mlrun #9578, ``_resolve_invocation_url`` prepends ``https://``
+        to scheme-less external URLs, which breaks plain-HTTP NodePort
+        setups (open-source CE / k3s) with ``SSL: WRONG_VERSION_NUMBER``.
+        Iguazio setups expose functions via TLS-terminated ingress
+        (hostname/path form) and must keep the ``https://`` default.
+
+        Only rewrite the NodePort form (IPv4 ``host:port`` with no path)
+        to ``http://`` here. Remove once ML-12522 routes API-gateway
+        invocations through ``APIGateway.invoke_url`` and
+        ``_resolve_invocation_url`` defaults back to ``http://``.
+        """
+        import ipaddress
+
+        for i, url in enumerate(fn.status.external_invocation_urls or []):
+            if "://" in url or "/" in url:
+                continue
+            host = url.split(":", 1)[0]
+            try:
+                ipaddress.ip_address(host)
+            except ValueError:
+                continue
+            fn.status.external_invocation_urls[i] = f"http://{url}"
 
     @classmethod
     def _infer(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -14,7 +14,6 @@
 
 import concurrent.futures
 import json
-import os
 import pickle
 import tempfile
 import time
@@ -431,9 +430,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
         )
 
     def _set_and_deploy_monitoring_apps(self) -> None:
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=1 if (os.cpu_count() or 1) <= 8 else None
-        ) as executor:
+        with concurrent.futures.ThreadPoolExecutor() as executor:
             for app_data in self.apps_data:
                 if app_data.deploy:
                     fn = self.project.set_model_monitoring_function(


### PR DESCRIPTION
### 📝 Description

`test_app_flow[True-True]` (the system smoke test for model monitoring) was failing for several independent reasons. This PR fixes them so the smoke gate passes against open-source CE on k3s. Each commit is a self-contained fix:

1. **Parallel app deploys** — `_set_and_deploy_monitoring_apps` had a `max_workers=1 if (os.cpu_count() or 1) <= 8 else None` guard that serialised monitoring-app deploys on small CPUs (the 8-CPU CI runner included). With ~13 min per kaniko build, `evidently-app-test` only began building at T+16 min and the test hit its 30-min `pytest-timeout` 2 min before it finished. The guard was originally there to avoid concurrent GitHub clones; that concern is moot now that the wheel is served from a local HTTP server.

2. **MM functions honour `function_defaults.image_by_kind.nuclio`** — `MonitoringDeployment.deploy_*` (controller / writer / stream / histogram-data-drift) hardcoded `image="mlrun/mlrun"` as the default, bypassing the configured nuclio default image. This meant an mlrun-ce deployment that pre-staged its base image into a local registry and configured `MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__NUCLIO` accordingly still saw MM infra functions cold-pull from `ghcr.io`. See https://github.com/mlrun/mlrun/pull/9644

3. **Plumb `None` default through the SDK→API chain** — the previous fix (commit 2) added a `None`-resolution at the API CRUD layer, but every layer above it (`Project.enable_model_monitoring`, `RunDBInterface`, `HTTPRunDB`, `NopDB`, FastAPI endpoint) had its own hardcoded `"mlrun/mlrun"` default that overrode it before the call ever reached the resolver. Switch all four call sites to `None` and have `HTTPRunDB` skip the `image` query param when the caller didn't specify one, so the server-side resolution actually fires.

4. **Test-side workaround for ML-12522** — `_resolve_invocation_url` was changed in #9578 to default scheme-less external URLs to `https://`, which broke NodePort/plain-HTTP setups (smoke runs on k3s via NodePort) with `SSL: WRONG_VERSION_NUMBER`. The proper fix lives in [ML-12522](https://ecliptos.atlassian.net/browse/ML-12522) — route API-gateway invocations through `APIGateway.invoke_url` so `_resolve_invocation_url` can default back to `http://`. Until that's resolved, `TestMonitoringAppFlow._deploy_model_serving` post-mutates `serving_fn.status.external_invocation_urls` to prefix `http://`, but only for IPv4 `host:port` form (NodePort) — iguazio's TLS-terminated ingress URLs (hostname/path form) keep the `https://` default.

---

### 🛠️ Changes Made

- `tests/system/model_monitoring/test_app.py`
  - `TestMonitoringAppFlow._set_and_deploy_monitoring_apps`: drop the CPU-count gate on `ThreadPoolExecutor`.
  - `TestMonitoringAppFlow._deploy_model_serving`: post-deploy, force `http://` on NodePort-form `external_invocation_urls` (IPv4 + port + no path). New helper `_workaround_ml_12522_force_http_for_nodeport`.
- `server/py/services/api/crud/model_monitoring/deployment.py`: change `image: str = "mlrun/mlrun"` defaults to `image: str | None = None` and resolve `None` to `mlrun.mlconf.function_defaults.image_by_kind.nuclio` in the four `deploy_*` methods.
- `server/py/services/api/api/endpoints/model_monitoring.py`: same `None` default for the `enable_model_monitoring` FastAPI endpoint.
- `mlrun/projects/project.py`, `mlrun/db/httpdb.py`, `mlrun/db/base.py`, `mlrun/db/nopdb.py`: same `None` default through the SDK→API chain. `HTTPRunDB.enable_model_monitoring` omits the `image` query param when `None`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

`test_app_flow[True-True]` smoke test passes end-to-end on open-source CE / k3s after these changes.

Reference smoke run on `feature/smoke` (with the equivalent commit set): https://github.com/mlrun/mlrun/actions/runs/25248470887 — `6 passed, 1 skipped, 736 deselected, 150 warnings in 762.09s (0:12:42)`.

---

### 🔗 References
- Ticket link: [ML-12522](https://ecliptos.atlassian.net/browse/ML-12522) — proper fix; test-side workaround in commit 4 will be removed once ML-12522 lands.
- Related: [#9578](https://github.com/mlrun/mlrun/pull/9578) — introduced the `https://` default that necessitated commit 4's workaround.

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

`enable_model_monitoring`'s default `image` value changes from the literal `"mlrun/mlrun"` to `None` (resolved server-side to `mlrun.mlconf.function_defaults.image_by_kind.nuclio`, whose default value is also `"mlrun/mlrun"`). Behavior is unchanged for callers passing an explicit `image` and for environments using the default `image_by_kind.nuclio` config.

---

### 🔍️ Additional Notes

Once ML-12522 lands and `_resolve_invocation_url` defaults back to `http://`, commit 4 (`deab343c3`) can be dropped — the test workaround becomes a harmless no-op (the `https://` default it bypasses no longer fires).
