### PR TITLE
[Testing] Fix smoke-tests timeout failures

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -685,8 +685,8 @@ jobs:
         # S3 credentials for client-side artifact uploads (SeaweedFS).
         # Read from the s3-credentials K8s secret created by the CE chart, but
         # replace the in-cluster DNS endpoint with a routable ClusterIP address.
-        export AWS_ACCESS_KEY_ID=$(kubectl get secret s3-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
-        export AWS_SECRET_ACCESS_KEY=$(kubectl get secret s3-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
+        export AWS_ACCESS_KEY_ID=$(kubectl get secret storage-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' | base64 -d)
+        export AWS_SECRET_ACCESS_KEY=$(kubectl get secret storage-credentials -n ${NAMESPACE} -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' | base64 -d)
         S3_CLUSTER_IP=$(kubectl get svc seaweedfs-s3 -n ${NAMESPACE} -o jsonpath='{.spec.clusterIP}')
         S3_PORT=$(kubectl get svc seaweedfs-s3 -n ${NAMESPACE} -o jsonpath='{.spec.ports[0].port}')
         export AWS_ENDPOINT_URL_S3="http://${S3_CLUSTER_IP}:${S3_PORT}"
@@ -808,7 +808,7 @@ jobs:
         echo "=== SEAWEEDFS S3 STATUS ==="
         echo "=================================="
         kubectl get svc seaweedfs-s3 -n ${NAMESPACE} -o wide 2>/dev/null || echo "seaweedfs-s3 service not found"
-        kubectl get secret s3-credentials -n ${NAMESPACE} 2>/dev/null || echo "s3-credentials secret not found"
+        kubectl get secret storage-credentials -n ${NAMESPACE} 2>/dev/null || echo "storage-credentials secret not found"
 
         set +x
 

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -505,7 +505,23 @@ jobs:
           --mlrun-dbpath "$MLRUN_DBPATH" \
           --github-access-token "${{ steps.github-app-token.outputs.token }}" \
           --openai-base-url "${{ secrets.OPENAI_BASE_URL }}" \
-          --openai-api-key "${{ secrets.OPENAI_API_KEY }}"  
+          --openai-api-key "${{ secrets.OPENAI_API_KEY }}"
+
+    - name: Build and serve MLRun wheel for kaniko builds
+      run: |
+        source venv/bin/activate
+        # Build a wheel from the already-rebased source tree so kaniko pods can
+        # pip-install mlrun from a local HTTP server instead of cloning from GitHub.
+        # This avoids GitHub rate-limiting when multiple kaniko builds run concurrently.
+        pip install build --quiet
+        python -m build --wheel --outdir /tmp/mlrun-wheels . --quiet
+        # Use a fixed name so the URL is predictable
+        mv /tmp/mlrun-wheels/*.whl /tmp/mlrun-wheels/mlrun-pr-rebased-development.whl
+        # Serve on the node IP so Kubernetes pods can reach it
+        NODE_IP=$(hostname -I | awk '{print $1}')
+        python3 -m http.server 9000 --directory /tmp/mlrun-wheels &
+        echo "MLRUN_WHEEL_NODE_IP=${NODE_IP}" >> $GITHUB_ENV
+        echo "MLRun wheel available at: http://${NODE_IP}:9000/mlrun-pr-rebased-development.whl"
 
     - name: Install MLRun CE helm chart
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -537,7 +553,7 @@ jobs:
               --helm-timeout=15m \
               --override-mlrun-api-image="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun-api:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
               --override-mlrun-log-collector-image="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/log-collector:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
-              --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ git+https://github.com/mlrun/mlrun@${{ needs.prepare-inputs.outputs.mlrun_version_specifier }}"' \
+              --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ http://${{ env.MLRUN_WHEEL_NODE_IP }}:9000/mlrun-pr-rebased-development.whl"' \
               --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}" \
               --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_TAG="${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
               --set mlrun.api.extraEnvKeyValue.MLRUN_DEFAULT_BASE_IMAGE="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -514,6 +514,7 @@ jobs:
         # pip-install mlrun from a local HTTP server instead of cloning from GitHub.
         # This avoids GitHub rate-limiting when multiple kaniko builds run concurrently.
         pip install build --quiet
+        rm -rf /tmp/mlrun-wheels && mkdir -p /tmp/mlrun-wheels
         python -m build --wheel --outdir /tmp/mlrun-wheels . --quiet
         # Use a fixed name so the URL is predictable
         mv /tmp/mlrun-wheels/*.whl /tmp/mlrun-wheels/mlrun-pr-rebased-development.whl

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -117,11 +117,6 @@ jobs:
           
           # if the action is running on a PR, we need to get the latest commit hash from the PR branch
           if [ -n "$PR_NUM" ]; then
-            # Include the PR HEAD SHA in the hash so each commit produces a unique
-            # docker tag. Without this, all commits to the same PR overwrite the
-            # `pr<NUM>` tag and cached images on self-hosted runners (or in
-            # Artifactory pull-through cache) can serve stale content under the
-            # same tag.
             PR_HEAD_SHA=$(curl -sS \
               -H "Authorization: token ${GH_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
@@ -131,6 +126,8 @@ jobs:
               echo "::error::Failed to resolve PR #${PR_NUM} HEAD SHA"
               exit 1
             fi
+            # Include the PR HEAD SHA in the mlrun hash so each commit produces a unique
+            # docker tag and wrong use of cached image is prevented
             PR_HEAD_SHORT=$(echo "$PR_HEAD_SHA" | cut -c1-8)
             echo "mlrun_hash=pr${PR_NUM}-${PR_HEAD_SHORT}" >> $GITHUB_OUTPUT
           else
@@ -560,26 +557,6 @@ jobs:
         echo "MLRUN_WHEEL_NODE_IP=${NODE_IP}" >> $GITHUB_ENV
         echo "MLRun wheel available at: http://${NODE_IP}:9000/mlrun-pr-rebased-development.whl"
 
-    - name: Wait for MLRun base image pre-stage
-      run: |
-        if [ -z "${MLRUN_PRESTAGE_PID}" ]; then
-          echo "No pre-stage PID found, skipping wait."
-          exit 0
-        fi
-        echo "Waiting for MLRun image pre-stage to finish (PID: ${MLRUN_PRESTAGE_PID})..."
-        while kill -0 "${MLRUN_PRESTAGE_PID}" 2>/dev/null; do
-          echo "  still running... ($(cat /tmp/mlrun-prestage.log 2>/dev/null | tail -1))"
-          sleep 15
-        done
-        echo "=== Pre-stage log ==="
-        cat /tmp/mlrun-prestage.log || true
-        if grep -q "\[prestage\] Done\." /tmp/mlrun-prestage.log 2>/dev/null; then
-          echo "✓ MLRun base image pre-staged successfully"
-        else
-          echo "✗ Pre-stage did not complete — helm install may fail if mlrun-api validates the base image"
-          exit 1
-        fi
-
     - name: Install MLRun CE helm chart
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
@@ -709,6 +686,29 @@ jobs:
           "mlrun,private-system-tests")
         echo "Token refresh daemon started (PID: ${DAEMON_PID})"
         echo "TOKEN_REFRESH_PID=${DAEMON_PID}" >> $GITHUB_ENV
+
+    - name: Wait for MLRun base image pre-stage
+      # The pre-stage's only consumer is kaniko (function builds in pytest).
+      # Helm install does not pull mlrun/mlrun so we let pre-stage run in
+      # parallel with helm install.
+      run: |
+        if [ -z "${MLRUN_PRESTAGE_PID}" ]; then
+          echo "No pre-stage PID found, skipping wait."
+          exit 0
+        fi
+        echo "Waiting for MLRun image pre-stage to finish (PID: ${MLRUN_PRESTAGE_PID})..."
+        while kill -0 "${MLRUN_PRESTAGE_PID}" 2>/dev/null; do
+          echo "  still running... ($(cat /tmp/mlrun-prestage.log 2>/dev/null | tail -1))"
+          sleep 15
+        done
+        echo "=== Pre-stage log ==="
+        cat /tmp/mlrun-prestage.log || true
+        if grep -q "\[prestage\] Done\." /tmp/mlrun-prestage.log 2>/dev/null; then
+          echo "✓ MLRun base image pre-staged successfully"
+        else
+          echo "✗ Pre-stage did not complete — kaniko builds in pytest will fail with image-not-found"
+          exit 1
+        fi
 
     - name: Run system tests
       id: system-tests

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -431,6 +431,26 @@ jobs:
         
         echo "✓ Registry configuration applied successfully"
 
+    - name: Pre-stage MLRun base image to local registry
+      run: |
+        MLRUN_IMAGE="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}"
+        LOCAL_IMAGE="localhost:32000/${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}"
+
+        echo "Starting background pre-stage: ${MLRUN_IMAGE} → local registry"
+        (
+          set -e
+          echo "[prestage] Pulling ${MLRUN_IMAGE} via crictl (Artifactory mirror)..."
+          sudo crictl pull "${MLRUN_IMAGE}"
+          echo "[prestage] Tagging as ${LOCAL_IMAGE}..."
+          sudo k3s ctr images tag "${MLRUN_IMAGE}" "${LOCAL_IMAGE}"
+          echo "[prestage] Pushing to local registry (plain HTTP)..."
+          sudo k3s ctr images push --plain-http "${LOCAL_IMAGE}"
+          echo "[prestage] Done."
+        ) > /tmp/mlrun-prestage.log 2>&1 &
+        PRESTAGE_PID=$!
+        echo "MLRUN_PRESTAGE_PID=${PRESTAGE_PID}" >> $GITHUB_ENV
+        echo "Pre-stage running in background (PID: ${PRESTAGE_PID})"
+
     - name: Setup K3S storage and check cluster health
       run: |
         echo "=== Checking K3S storage configuration ==="
@@ -524,6 +544,26 @@ jobs:
         echo "MLRUN_WHEEL_NODE_IP=${NODE_IP}" >> $GITHUB_ENV
         echo "MLRun wheel available at: http://${NODE_IP}:9000/mlrun-pr-rebased-development.whl"
 
+    - name: Wait for MLRun base image pre-stage
+      run: |
+        if [ -z "${MLRUN_PRESTAGE_PID}" ]; then
+          echo "No pre-stage PID found, skipping wait."
+          exit 0
+        fi
+        echo "Waiting for MLRun image pre-stage to finish (PID: ${MLRUN_PRESTAGE_PID})..."
+        while kill -0 "${MLRUN_PRESTAGE_PID}" 2>/dev/null; do
+          echo "  still running... ($(cat /tmp/mlrun-prestage.log 2>/dev/null | tail -1))"
+          sleep 15
+        done
+        echo "=== Pre-stage log ==="
+        cat /tmp/mlrun-prestage.log || true
+        if grep -q "\[prestage\] Done\." /tmp/mlrun-prestage.log 2>/dev/null; then
+          echo "✓ MLRun base image pre-staged successfully"
+        else
+          echo "✗ Pre-stage did not complete — helm install may fail if mlrun-api validates the base image"
+          exit 1
+        fi
+
     - name: Install MLRun CE helm chart
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
@@ -557,12 +597,12 @@ jobs:
               --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER="mlrun[complete] @ http://${{ env.MLRUN_WHEEL_NODE_IP }}:9000/mlrun-pr-rebased-development.whl"' \
               --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_REGISTRY="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}" \
               --set mlrun.api.extraEnvKeyValue.MLRUN_IMAGES_TAG="${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
-              --set mlrun.api.extraEnvKeyValue.MLRUN_DEFAULT_BASE_IMAGE="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
-              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__JOB="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
-              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__SERVING="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
-              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__NUCLIO="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
-              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__REMOTE="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
-              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__MPIJOB="${{ needs.prepare-inputs.outputs.mlrun_docker_registry }}${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
+              --set mlrun.api.extraEnvKeyValue.MLRUN_DEFAULT_BASE_IMAGE="registry.localhost/${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
+              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__JOB="registry.localhost/${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
+              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__SERVING="registry.localhost/${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
+              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__NUCLIO="registry.localhost/${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
+              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__REMOTE="registry.localhost/${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
+              --set mlrun.api.extraEnvKeyValue.MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__MPIJOB="registry.localhost/${{ needs.prepare-inputs.outputs.mlrun_docker_repo }}/mlrun:${{ needs.prepare-inputs.outputs.mlrun_docker_tag }}" \
               --set 'mlrun.api.extraEnvKeyValue.MLRUN_HTTPDB__SCHEDULING__MIN_ALLOWED_INTERVAL="0 seconds"' \
               --set mlrun.api.extraEnvKeyValue.MLRUN_MODEL_ENDPOINT_MONITORING__PARQUET_BATCHING_MAX_EVENTS="100" \
               --set jupyterNotebook.enabled=false \

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -117,7 +117,22 @@ jobs:
           
           # if the action is running on a PR, we need to get the latest commit hash from the PR branch
           if [ -n "$PR_NUM" ]; then
-            echo "mlrun_hash=pr$PR_NUM" >> $GITHUB_OUTPUT
+            # Include the PR HEAD SHA in the hash so each commit produces a unique
+            # docker tag. Without this, all commits to the same PR overwrite the
+            # `pr<NUM>` tag and cached images on self-hosted runners (or in
+            # Artifactory pull-through cache) can serve stale content under the
+            # same tag.
+            PR_HEAD_SHA=$(curl -sS \
+              -H "Authorization: token ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUM}" \
+              | jq -r '.head.sha')
+            if [ -z "$PR_HEAD_SHA" ] || [ "$PR_HEAD_SHA" = "null" ]; then
+              echo "::error::Failed to resolve PR #${PR_NUM} HEAD SHA"
+              exit 1
+            fi
+            PR_HEAD_SHORT=$(echo "$PR_HEAD_SHA" | cut -c1-8)
+            echo "mlrun_hash=pr${PR_NUM}-${PR_HEAD_SHORT}" >> $GITHUB_OUTPUT
           else
             echo "mlrun_hash=$( \
               cd /tmp && \
@@ -141,6 +156,7 @@ jobs:
           echo "unstable_version_prefix=$(cat automation/version/unstable_version_prefix)" >> $GITHUB_OUTPUT
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set computed versions params
         id: computed_params

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -386,10 +386,10 @@ jobs:
             - https://registry-1.docker.io
           ghcr.io:
             endpoint:
-            - https://${ARTIFACTORY_REGISTRY_URL}
+            - https://${ARTIFACTORY_REGISTRY_URL#https://}
           gcr.io:
             endpoint:
-            - https://${ARTIFACTORY_REGISTRY_URL}
+            - https://${ARTIFACTORY_REGISTRY_URL#https://}
         configs:
           "registry-1.docker.io":
             auth:


### PR DESCRIPTION
### 📝 Description

Set of fixes and improvements to `.github/workflows/system-tests-opensource.yml` (the open-source smoke-tests workflow). The cumulative effect is that smoke runs no longer time out at the 30-min `pytest-timeout` for `test_app_flow[True-True]`, helm install no longer cold-pulls the same image multiple times, and kaniko builds don't all race for the same upstream during 8-way concurrent monitoring-app deploys.

---

### 🛠️ Changes Made

1. **Fix S3 credentials secret name in system-tests workflow** (`b121d95c7`).
2. **Serve MLRun wheel locally to avoid GitHub rate-limiting in kaniko builds** (`ffd759680`) — start a Python HTTP server on the runner that hosts the rebased mlrun wheel and point `MLRUN_HTTPDB__BUILDER__MLRUN_VERSION_SPECIFIER` at it. Removes the GitHub clone-from-tar inside kaniko pods, which was rate-limited under 8× concurrent pulls.
3. **Fix double `https://` in Artifactory mirror URL for containerd registry** (`fa8376192`) — `ARTIFACTORY_DOCKER_REGISTRY_URL` already includes the scheme; strip with `${VAR#https://}` before re-prepending. Without this, k3s containerd silently fell back to direct `ghcr.io` / `gcr.io` pulls — bypassing the Artifactory cache.
4. **Pre-stage mlrun base image into local registry to fix kaniko build timeout** (`bf4d2afda`) — new background step that pulls `ghcr.io/mlrun/mlrun:${TAG}` via `crictl` (using the now-working Artifactory mirror), then pushes to the in-cluster registry at `localhost:32000`. Helm-install env vars `MLRUN_DEFAULT_BASE_IMAGE` and `MLRUN_FUNCTION_DEFAULTS__IMAGE_BY_KIND__*` switched to `registry.localhost/...`. The 8 concurrent kaniko builds now pull the base image from in-cluster network at near-disk speed instead of saturating the runner's NIC against ghcr.io.
Run pre-stage step in parallel with helm install
5. **Include PR HEAD SHA in docker tag to avoid stale-image cache hits** (`ec2f036f6`) — change image tag from `${unstable_prefix}-pr<N>` to `${unstable_prefix}-pr<N>-<sha8>` so each commit produces a unique tag. Without this, containerd's `IfNotPresent` pull policy on self-hosted runners would serve a cached image from a prior commit on the same PR, masking real changes.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

`feature/smoke` was used to run the smoke-tests workflow against PR #9643 repeatedly throughout development. Reference passing run with all commits in this set: https://github.com/mlrun/mlrun/actions/runs/25248470887 

Total wall-clock for a successful smoke run ranges from ~33 min (warm Artifactory cache on the chosen self-hosted runner) to ~64 min (cold), versus consistent timeouts (test_app_flow killed by `pytest-timeout` after 30 min, run total > 60 min) before this set of fixes.

---

### 🔗 References
- Ticket link:
- Related: PR #9643 — test- and server-side fixes that complete the smoke-test pass; depends on this workflow being able to run cleanly.
- Related: [ML-12522](https://ecliptos.atlassian.net/browse/ML-12522) — underlying URL-scheme bug that PR #9643's last commit works around at the test layer.

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

CI-only changes — no production code touched.

---

### 🔍️ Additional Notes
