### PR TITLE
[Comments] Drop references to old JIRA sites

### DIFF
--- a/dockerfiles/mlrun/Dockerfile
+++ b/dockerfiles/mlrun/Dockerfile
@@ -65,7 +65,7 @@ ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 # Install MLRun:
 # no-deps to ignore existing dependencies, just add the locked requirements
 # mainly because of how the image is built with conda.
-# see https://iguazio.atlassian.net/browse/ML-8712 for example
+# see ML-8712 for example
 # where 'tqdm' is given by conda env but will get remove if we omit the `--no-deps`.
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1767,8 +1767,7 @@ def format_run(run: PipelineRun, with_project=False) -> dict:
         ):
             run[key] = None
 
-    # pipelines are yet to populate the status or workflow has failed
-    # as observed https://jira.iguazeng.com/browse/ML-5195
+    # pipelines are yet to populate the status or workflow has failed as observed (ML-5195)
     # set to unknown to ensure a status is returned
     if run.get("status", None) is None:
         run["status"] = inflection.titleize(

--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -352,7 +352,7 @@ with warnings.catch_warnings():
         __tablename__ = "artifacts_v2"
         __table_args__ = (
             UniqueConstraint("uid", "project", "key", name="_artifacts_v2_uc"),
-            # Used when enriching workflow status with run artifacts. See https://iguazio.atlassian.net/browse/ML-6770
+            # Used when enriching workflow status with run artifacts. See ML-6770.
             Index(
                 "idx_artifacts_producer_id_best_iteration_and_project",
                 "project",
@@ -360,17 +360,17 @@ with warnings.catch_warnings():
                 "best_iteration",
             ),
             # Used to speed up querying artifact tags which is frequently done by UI with project and category.
-            # See https://iguazio.atlassian.net/browse/ML-7266
+            # See ML-7266.
             Index(
                 "idx_project_kind",
                 "project",
                 "kind",
             ),
             # Used for calculating the project counters more efficiently.
-            # See https://iguazio.atlassian.net/browse/ML-8556
+            # See ML-8556.
             Index("idx_project_kind_key", "project", "kind", "key"),
             # Used explicitly in list_artifacts, as most of the queries request best_iteration, and all always sort by
-            # updated. See https://iguazio.atlassian.net/browse/ML-9189
+            # updated. See ML-9189.
             Index(
                 "idx_project_bi_updated", "project", "best_iteration", "kind", "updated"
             ),

--- a/server/py/framework/utils/projects/follower.py
+++ b/server/py/framework/utils/projects/follower.py
@@ -122,8 +122,7 @@ class Member(
             created_project = None
             if not is_running_in_background:
                 # not running in background means long-project creation operation might stale
-                # its db session, so we need to create a new one
-                # https://jira.iguazeng.com/browse/ML-5764
+                # its db session, so we need to create a new one (ML-5764)
                 created_project = framework.db.session.run_function_with_new_db_session(
                     self.get_project, project.metadata.name, auth_info
                 )

--- a/server/py/services/api/utils/helpers.py
+++ b/server/py/services/api/utils/helpers.py
@@ -51,8 +51,7 @@ def resolve_client_default_kfp_image(
             image = mlrun.mlconf.default_base_image
             if ":" not in image:
                 # enrich the image with the client version to ensure that
-                # client < 1.8 will use the correct mlrun image and version.
-                # https://iguazio.atlassian.net/browse/ML-9292
+                # client < 1.8 will use the correct mlrun image and version (ML-9292)
                 enriched_image = mlrun.utils.enrich_image_url(
                     image, client_version=client_version
                 )


### PR DESCRIPTION
### 📝 Description
Not replacing with new site because:
1. this is by and large the convention in the code base
2. this is open source code
3. users with access know where to find it
4. in case the domain changes again in the future

---

### 🛠️ Changes Made
Removed references to old JIRA sites.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
None.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
