### PR TITLE
[Nuclio] Extend init container to vanilla Nuclio/Serving for store:// sources

### DIFF
--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -23,6 +23,19 @@ MLRUN_SERVING_SPEC_PATH = (
 DEFAULT_SOURCE_CODE_TARGET_DIR = "/home/mlrun_code"
 SOURCE_LOADER_INIT_CONTAINER_NAME = "mlrun-source-loader"
 SOURCE_CODE_VOLUME_NAME = "mlrun-source-code"
+# Module name for a generated stub that re-exports the user's real handler
+# under a fixed name. The dedicated namespaced name avoids the sys.path[0]
+# (=/opt/nuclio) shadow that would otherwise hide the real handler module
+# loaded into the source-loader init container's output directory.
+STORE_URI_HANDLER_LOADER_MODULE = "_mlrun_store_uri_loader"
+# BUMP THIS WHENEVER THE LOADER STUB BODY CHANGES.
+# The version marker is baked as the first line of the loader stub
+# (`# stub_version=<N>`); on (re)deploy, an existing stub whose marker
+# doesn't match the current value is re-baked, so a stub-body fix in
+# mlrun reaches existing functions on their next deploy. If you forget
+# to bump this when changing the stub, deployed functions stay on the
+# old bytes forever.
+STORE_URI_LOADER_STUB_VERSION = "1"
 MLRUN_FUNCTIONS_ANNOTATION = "mlrun/mlrun-functions"
 MYSQL_MEDIUMBLOB_SIZE_BYTES = 16 * 1024 * 1024
 MLRUN_LABEL_PREFIX = "mlrun/"

--- a/mlrun/common/constants.py
+++ b/mlrun/common/constants.py
@@ -23,18 +23,9 @@ MLRUN_SERVING_SPEC_PATH = (
 DEFAULT_SOURCE_CODE_TARGET_DIR = "/home/mlrun_code"
 SOURCE_LOADER_INIT_CONTAINER_NAME = "mlrun-source-loader"
 SOURCE_CODE_VOLUME_NAME = "mlrun-source-code"
-# Module name for a generated stub that re-exports the user's real handler
-# under a fixed name. The dedicated namespaced name avoids the sys.path[0]
-# (=/opt/nuclio) shadow that would otherwise hide the real handler module
-# loaded into the source-loader init container's output directory.
 STORE_URI_HANDLER_LOADER_MODULE = "_mlrun_store_uri_loader"
-# BUMP THIS WHENEVER THE LOADER STUB BODY CHANGES.
-# The version marker is baked as the first line of the loader stub
-# (`# stub_version=<N>`); on (re)deploy, an existing stub whose marker
-# doesn't match the current value is re-baked, so a stub-body fix in
-# mlrun reaches existing functions on their next deploy. If you forget
-# to bump this when changing the stub, deployed functions stay on the
-# old bytes forever.
+# Bump when the loader stub body changes — existing functions re-bake on
+# next deploy via the `# stub_version=<N>` marker.
 STORE_URI_LOADER_STUB_VERSION = "1"
 MLRUN_FUNCTIONS_ANNOTATION = "mlrun/mlrun-functions"
 MYSQL_MEDIUMBLOB_SIZE_BYTES = 16 * 1024 * 1024

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2997,7 +2997,12 @@ class MlrunProject(ModelObj):
                           - handler: execute a python handler (used automatically in notebooks or for debug)
 
         :param image:               Docker image to be used, can also be specified in the function object/yaml
-        :param handler:             Default function handler to invoke (can only be set with .py/.ipynb files)
+        :param handler:             Default function handler to invoke. Format ``module:function`` (e.g.
+                                    ``"my_app:predict"``) or just ``function`` for the canonical
+                                    ``main:handler`` form. Valid for ``.py``/``.ipynb`` files, ``store://``
+                                    CodeArtifact URIs, ``db://`` function references, and ``hub://`` items.
+                                    When omitted with ``store://`` source, falls back to mlrun's
+                                    convention default ``main:handler``.
         :param with_repo:           Add (clone) the current repo to the build source - use when the function code is in
                                     the project repo (project.spec.source).
         :param tag:                 Function version tag to set (none for current or 'latest')

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -271,6 +271,8 @@ class NuclioStatus(FunctionStatus):
         external_invocation_urls=None,
         build_pod=None,
         container_image=None,
+        application_source=None,
+        original_handler=None,
     ):
         super().__init__(state, build_pod)
 
@@ -287,6 +289,21 @@ class NuclioStatus(FunctionStatus):
 
         # the name of the image that was built and pushed to the registry, and used by the nuclio function
         self.container_image = container_image
+
+        # Stash for the original spec.build.source — used when the deploy path
+        # clears spec.build.source mid-deploy (Application from_image; vanilla
+        # Nuclio store:// gate). Lets _should_fetch_source_code recover the URI
+        # on redeploys after spec.build.source has been cleared.
+        self.application_source = application_source
+
+        # User-provided handler for store:// CodeArtifact deploys. The deployed
+        # CRD's spec.handler points at a generated loader module (so Nuclio's
+        # bake doesn't shadow the user's handler module via /opt/nuclio); the
+        # loader reads the real handler from the MLRUN_REAL_HANDLER env var,
+        # which is sourced from this field. Persisting it lets us recover the
+        # original on redeploys (when spec.function_handler already shows the
+        # loader handler).
+        self.original_handler = original_handler
 
 
 class RemoteRuntime(KubeResource):

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -277,53 +277,13 @@ def _compile_function_config(
             "Ensure the application image is set via 'spec.image' or 'with_sidecar()'."
         )
 
-    # Configure init container when source needs runtime loading.
-    if _should_fetch_source_code(function):
-        if function.kind == mlrun.runtimes.RuntimeKinds.application:
-            # Gate the project-secret envFrom mount on source type, not runtime
-            # kind: store:// sources may resolve through DataStore profiles
-            # whose private members live in mlrun-project-secrets-<project>;
-            # git/archive sources don't need that resolution.
-            application_source = function.spec.build.source or getattr(
-                function.status, "application_source", ""
-            )
-            _configure_source_loader_init_container(
-                function,
-                # Application runtime has exactly one sidecar (the user's application container)
-                sidecar=sidecars[0],
-                client_version=client_version,
-                client_python_version=client_python_version,
-                add_project_secrets=mlrun.datastore.is_store_uri(application_source),
-            )
-        else:
-            # Vanilla Nuclio/Serving. Nuclio's native builder resolves git://
-            # and archive sources directly (codeEntryType="git"/"archive");
-            # only store:// is unsupported and gets routed through the init
-            # container path. Anything else with load_source_on_run=True is
-            # an unsupported combination and raises.
-            source = function.spec.build.source or getattr(
-                function.status, "application_source", ""
-            )
-            if mlrun.datastore.is_store_uri(source):
-                _install_store_uri_loader(
-                    function,
-                    project=project,
-                    client_version=client_version,
-                    client_python_version=client_python_version,
-                )
-            else:
-                # _should_fetch_source_code returned True, source is not
-                # store:// — must be git/archive + load_source_on_run on a
-                # non-Application kind. The init-container redirect was only
-                # designed for store://; other source types belong on
-                # Application kind (where the sidecar handles them).
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    f"Function '{function.metadata.name}' (kind="
-                    f"{function.kind!r}) has source={source!r} with "
-                    "load_source_on_run=True, which is supported on "
-                    "Application kind only. Either set kind='application' "
-                    "or use a store:// CodeArtifact source."
-                )
+    _configure_source_code_loading(
+        function,
+        sidecars=sidecars,
+        project=project,
+        client_version=client_version,
+        client_python_version=client_python_version,
+    )
 
     nuclio_spec = nuclio.ConfigSpec(
         env=env_dict,
@@ -815,24 +775,17 @@ def _should_fetch_source_code(
     - Source is a store artifact URI (store://)
     - Source is Git or archive with pull_at_runtime=True
 
-    Reads ``function.spec.build.source`` first, then falls back to
-    ``function.status.application_source``. The fallback covers the redeploy
-    case where ``_install_store_uri_loader`` cleared ``spec.build.source``
-    and stashed the original URI on the status field so Nuclio's builder
-    wouldn't see a URI it can't resolve.
-
     :param function: The function object
     :return: True if init container is needed, False otherwise
     """
-    # build.source may be empty after from_image() clears it on redeploy.
-    # fall back to status.application_source which preserves the original source URI.
+    # On redeploy build.source has been cleared; the original URI lives on
+    # status.application_source.
     source = function.spec.build.source or getattr(
         function.status, "application_source", None
     )
     if not source:
         return False
 
-    # Store artifact URIs always need init container
     if mlrun.datastore.is_store_uri(source):
         return True
 
@@ -843,6 +796,63 @@ def _should_fetch_source_code(
     return (is_git_source or is_archive_source) and pull_at_runtime
 
 
+def _configure_source_code_loading(
+    function: mlrun.runtimes.nuclio.function.RemoteRuntime,
+    sidecars: list,
+    project: str,
+    client_version: str | None = None,
+    client_python_version: str | None = None,
+):
+    """Route runtime source-code loading to the right init-container path.
+
+    Three cases:
+    - Application kind: configure the loader against the user's sidecar.
+      Project-secret envFrom is mounted only for `store://` sources, which
+      may resolve through DataStore profiles whose private members live in
+      `mlrun-project-secrets-<project>`.
+    - Vanilla Nuclio/Serving + `store://`: install the loader stub and init
+      container; Nuclio's native builder cannot resolve `store://` URIs.
+    - Anything else with `load_source_on_run=True` on a non-Application
+      kind: unsupported, raise.
+
+    No-op when no source needs runtime loading.
+    """
+    if not _should_fetch_source_code(function):
+        return
+
+    if function.kind == mlrun.runtimes.RuntimeKinds.application:
+        application_source = function.spec.build.source or getattr(
+            function.status, "application_source", ""
+        )
+        _configure_source_loader_init_container(
+            function,
+            sidecar=sidecars[0],
+            client_version=client_version,
+            client_python_version=client_python_version,
+            add_project_secrets=mlrun.datastore.is_store_uri(application_source),
+        )
+        return
+
+    source = function.spec.build.source or getattr(
+        function.status, "application_source", ""
+    )
+    if mlrun.datastore.is_store_uri(source):
+        _install_store_uri_loader(
+            function,
+            project=project,
+            client_version=client_version,
+            client_python_version=client_python_version,
+        )
+        return
+
+    raise mlrun.errors.MLRunInvalidArgumentError(
+        f"Function '{function.metadata.name}' (kind={function.kind!r}) has "
+        f"source={source!r} with load_source_on_run=True, which is supported "
+        "on Application kind only. Either set kind='application' or use a "
+        "store:// CodeArtifact source."
+    )
+
+
 def _install_store_uri_loader(
     function: mlrun.runtimes.nuclio.function.RemoteRuntime,
     project: str,
@@ -851,57 +861,32 @@ def _install_store_uri_loader(
 ):
     """Install the store:// loader stub on a vanilla Nuclio/Serving function.
 
-    For non-Application Nuclio/Serving kinds with a ``store://`` source,
-    Nuclio's native builder cannot resolve the URI. This helper:
+    Nuclio's native builder cannot resolve `store://` URIs. The helper
+    stashes the URI on `status.application_source`, bakes a generated
+    loader stub as `functionSourceCode` (under a fixed module name to
+    avoid the `/opt/nuclio` sys.path[0] shadow), routes `function_handler`
+    to the loader, and configures the source-loader init container.
 
-    1. Resolves the store URI and validates that the artifact is a
-       CodeArtifact (``kind == "code"``); fails fast on a wrong-kind
-       artifact rather than producing a cryptic ImportError in the pod.
-    2. Stashes the URI to ``status.application_source`` and clears
-       ``spec.build.source`` so Nuclio's builder doesn't see it.
-    3. Bakes a generated loader stub as ``functionSourceCode`` under a
-       fixed module name (avoids the ``sys.path[0]`` (= ``/opt/nuclio``)
-       shadow over the user's real module).
-    4. Stashes the user's real handler in ``status.original_handler`` and
-       injects ``MLRUN_REAL_HANDLER`` into ``spec.config["spec.env"]``
-       (deduped in both ``spec.config`` and ``spec.base_spec``).
-    5. Overrides ``spec.function_handler`` to point at the loader.
-    6. Configures the source-loader init container.
-
-    Mutates ``function.spec`` and ``function.status``. Idempotent — safe to
-    call on redeploys, which re-use the stashed values.
-
-    :param function: The function to install the loader on.
-    :param project:  Project name for artifact resolution.
-    :param client_version: Forwarded to the init container builder.
-    :param client_python_version: Forwarded to the init container builder.
+    Idempotent on redeploy — re-uses the stashed values. Mutates
+    `function.spec` and `function.status`.
     """
     source = function.spec.build.source or getattr(
         function.status, "application_source", ""
     )
-    # Defensive guard: production callers (`_compile_function_config`) already
-    # gate on `is_store_uri(source)`, but keep the no-op return so the helper
-    # is safe to call from tests / future entry points without re-checking.
+    # Safe to call directly (e.g. from tests); production callers pre-gate.
     if not mlrun.datastore.is_store_uri(source):
         return
 
-    # Boundary validation: confirm the resolved artifact is a CodeArtifact.
-    # Without this, a wrong-kind artifact (model, dataset) silently flows
-    # through to the loader and fails with a cryptic ImportError at runtime.
+    # Fail fast on wrong-kind artifact; otherwise we'd get a cryptic
+    # ImportError in the pod at runtime.
     try:
         artifact = mlrun.datastore.get_store_resource(source, project=project)
     except mlrun.errors.MLRunBaseError:
-        # Preserve typed MLRun errors so callers (and HTTP-status mapping)
-        # can pattern-match on them; only the generic-Exception branch wraps.
         raise
     except Exception as exc:
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"Cannot resolve code artifact {source}: {mlrun.errors.err_to_str(exc)}"
         ) from exc
-    # `get_store_resource` returns None when the resolver can't find the
-    # artifact (deleted between deploys, empty resource, ...). Surface that
-    # as a typed MLRunNotFoundError instead of the AttributeError that the
-    # next `artifact.kind` access would otherwise raise.
     if artifact is None:
         raise mlrun.errors.MLRunNotFoundError(f"Code artifact not found at {source}")
     if artifact.kind != "code":
@@ -925,12 +910,10 @@ def _install_store_uri_loader(
         or mlrun.common.constants.DEFAULT_SOURCE_CODE_TARGET_DIR
     )
 
-    # Serving with no explicit handler uses mlrun's serving wrapper (wired
-    # later by `_set_source_code_and_handler`). The loader stub would
-    # override that and break the topology graph. Install the init container
-    # + PYTHONPATH only; let `_set_source_code_and_handler` set the wrapper
-    # handler. Serving WITH an explicit handler still goes through the
-    # loader-stub path, same as nuclio.
+    # Serving without an explicit handler is topology-driven; the wrapper
+    # handler is wired later by `_set_source_code_and_handler`, so the
+    # loader stub would override it. Skip the stub for this case; the init
+    # container + PYTHONPATH still need to be set up.
     is_serving_topology = (
         function.kind == mlrun.runtimes.RuntimeKinds.serving
         and not function.spec.function_handler
@@ -938,18 +921,15 @@ def _install_store_uri_loader(
     loader_module = mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE
     loader_handler = f"{loader_module}:handler"
 
+    stub_version_marker = (
+        f"# stub_version={mlrun.common.constants.STORE_URI_LOADER_STUB_VERSION}"
+    )
+
     if is_serving_topology:
-        # If the function was previously deployed with an explicit handler
-        # (loader stub baked, MLRUN_REAL_HANDLER env injected) and the user
-        # is now switching to topology, clear the loader-shaped state so
-        # the spec doesn't carry dead bytes. The serving wrapper handler
-        # is wired downstream by `_set_source_code_and_handler`.
-        if function.spec.function_handler == loader_handler:
-            function.spec.function_handler = ""
+        # Clear loader-shaped state left from a prior explicit-handler deploy
+        # so the serving wrapper can take over cleanly downstream.
         env_list = function.spec.config.get("spec.env") or []
         env_list[:] = [e for e in env_list if e.get("name") != "MLRUN_REAL_HANDLER"]
-        # Same dedupe in base_spec as `_set_unique_env` does for the
-        # explicit-handler path.
         base_spec = function.spec.base_spec or {}
         base_env = mlrun.utils.get_in(base_spec, "spec.env", []) or []
         if base_env:
@@ -958,8 +938,6 @@ def _install_store_uri_loader(
                 "spec.env",
                 [e for e in base_env if e.get("name") != "MLRUN_REAL_HANDLER"],
             )
-        # If the previously-baked stub is loader-shaped, drop it so Nuclio
-        # rebuilds with the wrapper wiring.
         if function.spec.build.functionSourceCode:
             try:
                 decoded = base64.b64decode(
@@ -967,7 +945,7 @@ def _install_store_uri_loader(
                 ).decode("utf-8")
             except Exception:
                 decoded = ""
-            if "MLRUN_REAL_HANDLER" in decoded:
+            if "# stub_version=" in decoded:
                 function.spec.build.functionSourceCode = ""
 
         logger.debug(
@@ -985,15 +963,10 @@ def _install_store_uri_loader(
         )
         return
 
-    # Stub-bytes layout: a version marker on the first line lets future
-    # mlrun releases re-bake an existing function's loader when stub
-    # semantics change. Without the marker, the `if not functionSourceCode`
-    # short-circuit below would keep stale bytes from the first deploy
-    # forever. Marker version lives in `mlrun.common.constants` —
-    # bump it whenever the stub body changes.
-    stub_version_marker = (
-        f"# stub_version={mlrun.common.constants.STORE_URI_LOADER_STUB_VERSION}"
-    )
+    # Stub-bytes layout: a version marker on the first line gates re-baking
+    # so a future mlrun release that changes stub semantics can invalidate
+    # existing functions. Bump `STORE_URI_LOADER_STUB_VERSION` when the
+    # stub body changes.
     existing_stub = ""
     if function.spec.build.functionSourceCode:
         try:
@@ -1002,8 +975,6 @@ def _install_store_uri_loader(
             ).decode("utf-8")
         except Exception:
             existing_stub = ""
-    # Substring check (not splitlines) so the marker is robust to line-ending
-    # mutations if the bytes were ever round-tripped through a Windows tool.
     if stub_version_marker not in existing_stub:
         loader_source = (
             f"{stub_version_marker}\n"
@@ -1024,7 +995,7 @@ def _install_store_uri_loader(
             '        "MLRUN_REAL_HANDLER env var not set; cannot resolve "\n'
             '        "user handler for store:// Nuclio function."\n'
             "    )\n"
-            '_module_name, _, _func_name = _real.rpartition(":")\n'
+            '_module_name, _, _func_name = _real.partition(":")\n'
             "if not _module_name or not _func_name:\n"
             "    raise RuntimeError(\n"
             "        f\"MLRUN_REAL_HANDLER must be in 'module:function' \"\n"
@@ -1045,25 +1016,16 @@ def _install_store_uri_loader(
             loader_source.encode("utf-8")
         ).decode("utf-8")
 
-    # Resolve the user's "real" handler. The spec is the source of truth:
-    # if the user updates `function.spec.function_handler` between deploys,
-    # the new value wins. status.original_handler is only consulted as a
-    # fallback for the redeploy case where spec.function_handler has
-    # already been overwritten with the loader handler from a prior deploy.
-    # When neither is set (first deploy with no handler= passed), fall back
-    # to mlrun's existing convention default — the same `"main:handler"`
-    # used elsewhere in this file for non-store:// nuclio functions.
+    # Spec wins over status: a user-updated `function_handler` on redeploy
+    # replaces the stashed value. Default to `main:handler` matching the
+    # non-store:// convention when neither is set.
     spec_handler = function.spec.function_handler
     if spec_handler and spec_handler != loader_handler:
-        # User-provided value (first deploy or explicit redeploy update).
         function.status.original_handler = spec_handler
     elif not function.status.original_handler:
         function.status.original_handler = "main:handler"
 
     _set_unique_env(function, "MLRUN_REAL_HANDLER", function.status.original_handler)
-
-    # Override function_handler so Nuclio's CRD spec.handler points at the
-    # loader.
     function.spec.function_handler = loader_handler
 
     logger.debug(
@@ -1193,10 +1155,8 @@ def _configure_source_loader_init_container(
             workdir=workdir,
         )
     else:
-        # Vanilla Nuclio/serving: inject PYTHONPATH on the main function
-        # container so the runtime can import the loaded source. Volume
-        # mounts are already wired via function.spec.with_volume_mounts()
-        # above.
+        # No sidecar (vanilla Nuclio/serving): patch PYTHONPATH on the main
+        # container; volume mounts are already on function.spec.
         _inject_main_container_pythonpath(
             function=function,
             target_dir=target_dir,
@@ -1231,15 +1191,10 @@ def _build_source_loader_init_container(
     :param volume_mount: Volume mount configuration
     :param client_version: Client version for image resolution
     :param client_python_version: Client Python version for image resolution
-    :param add_project_secrets: When True, mount the project's K8s secret
-                                via envFrom so the loader process can use
-                                project-secret-based credentials (e.g., AWS_*,
-                                GOOGLE_APPLICATION_CREDENTIALS) AND resolve
-                                DataStore profiles with private members
-                                (which are stored in the same K8s secret).
-                                Off for non-store:// sources, where the
-                                loader has no datastore-profile resolution
-                                to do.
+    :param add_project_secrets: Mount `mlrun-project-secrets-<project>` via
+                                envFrom so the loader can authenticate to
+                                credential-protected datastores and resolve
+                                DataStore profiles with private members.
     :return: Init container specification dict
     """
     project = function.metadata.project
@@ -1302,18 +1257,12 @@ def _ensure_source_loader_init_container(
     if not init_container_name:
         raise mlrun.errors.MLRunInvalidArgumentError("Init container name is required")
 
-    # Dedupe in function.spec.config first.
     init_containers = function.spec.config.setdefault("spec.initContainers", [])
     init_containers[:] = [
         c for c in init_containers if c.get("name") != init_container_name
     ]
     init_containers.append(init_container)
 
-    # Also dedupe in function.spec.base_spec — on redeploys the persisted
-    # base_spec carries over the previous deploy's init container at
-    # spec.initContainers, and extend_config later merges base_spec with
-    # function.spec.config, producing a duplicate. Nuclio rejects the
-    # resulting K8s Deployment with "Duplicate value".
     base_spec = function.spec.base_spec or {}
     base_spec_init_containers = mlrun.utils.get_in(base_spec, "spec.initContainers", [])
     if base_spec_init_containers:
@@ -1411,20 +1360,22 @@ def _inject_main_container_pythonpath(
     :param workdir: Working directory relative to target_dir or absolute path on
                     the container filesystem
     """
-    _add_pythonpath_to_env_list(
-        function.spec.config.setdefault("spec.env", []),
-        _resolve_workdir(target_dir, workdir),
-    )
+    spec_env = function.spec.config.setdefault("spec.env", [])
 
-    # Mirror the dedupe in spec.base_spec — extend_config merges
-    # base_spec["spec"]["env"] into spec.config["spec.env"] on deploy, and
-    # without removing the stale PYTHONPATH from base_spec a redeploy
-    # accumulates a duplicate entry alongside the freshly-set one.
+    # Merge user-set paths from base_spec into spec.config first, then prepend
+    # the managed workdir so it wins module-resolution races. extend_config
+    # later append-merges base_spec env into spec.config — drop PYTHONPATH
+    # from base_spec to prevent a duplicate at deploy time.
     base_spec = function.spec.base_spec or {}
     base_env = mlrun.utils.get_in(base_spec, "spec.env", []) or []
-    if base_env:
+    base_pythonpath = next((e for e in base_env if e.get("name") == "PYTHONPATH"), None)
+    if base_pythonpath:
+        for path in reversed((base_pythonpath.get("value") or "").split(":")):
+            if path:
+                _add_pythonpath_to_env_list(spec_env, path)
         mlrun.utils.update_in(
             base_spec,
             "spec.env",
             [e for e in base_env if e.get("name") != "PYTHONPATH"],
         )
+    _add_pythonpath_to_env_list(spec_env, _resolve_workdir(target_dir, workdir))

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -847,9 +847,9 @@ def _configure_source_code_loading(
 
     raise mlrun.errors.MLRunInvalidArgumentError(
         f"Function '{function.metadata.name}' (kind={function.kind!r}) has "
-        f"source={source!r} with load_source_on_run=True, which is supported "
-        "on Application kind only. Either set kind='application' or use a "
-        "store:// CodeArtifact source."
+        f"source={source!r} with load_source_on_run=True. Git/archive "
+        "sources with load_source_on_run are supported on Application kind "
+        "only; for Nuclio/Serving use a store:// CodeArtifact source instead."
     )
 
 

--- a/server/py/services/api/crud/runtimes/nuclio/function.py
+++ b/server/py/services/api/crud/runtimes/nuclio/function.py
@@ -269,22 +269,61 @@ def _compile_function_config(
                 )
             )
 
-    # Configure init container for Application runtime when source needs runtime loading
-    if function.kind == mlrun.runtimes.RuntimeKinds.application:
-        if not sidecars:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"No sidecar found for Application runtime '{function.metadata.name}'. "
-                "Application runtime requires a sidecar container to run the user's application. "
-                "Ensure the application image is set via 'spec.image' or 'with_sidecar()'."
+    # Application runtime always requires a sidecar (the user's app container).
+    if function.kind == mlrun.runtimes.RuntimeKinds.application and not sidecars:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"No sidecar found for Application runtime '{function.metadata.name}'. "
+            "Application runtime requires a sidecar container to run the user's application. "
+            "Ensure the application image is set via 'spec.image' or 'with_sidecar()'."
+        )
+
+    # Configure init container when source needs runtime loading.
+    if _should_fetch_source_code(function):
+        if function.kind == mlrun.runtimes.RuntimeKinds.application:
+            # Gate the project-secret envFrom mount on source type, not runtime
+            # kind: store:// sources may resolve through DataStore profiles
+            # whose private members live in mlrun-project-secrets-<project>;
+            # git/archive sources don't need that resolution.
+            application_source = function.spec.build.source or getattr(
+                function.status, "application_source", ""
             )
-        if _should_fetch_source_code(function):
             _configure_source_loader_init_container(
                 function,
                 # Application runtime has exactly one sidecar (the user's application container)
                 sidecar=sidecars[0],
                 client_version=client_version,
                 client_python_version=client_python_version,
+                add_project_secrets=mlrun.datastore.is_store_uri(application_source),
             )
+        else:
+            # Vanilla Nuclio/Serving. Nuclio's native builder resolves git://
+            # and archive sources directly (codeEntryType="git"/"archive");
+            # only store:// is unsupported and gets routed through the init
+            # container path. Anything else with load_source_on_run=True is
+            # an unsupported combination and raises.
+            source = function.spec.build.source or getattr(
+                function.status, "application_source", ""
+            )
+            if mlrun.datastore.is_store_uri(source):
+                _install_store_uri_loader(
+                    function,
+                    project=project,
+                    client_version=client_version,
+                    client_python_version=client_python_version,
+                )
+            else:
+                # _should_fetch_source_code returned True, source is not
+                # store:// — must be git/archive + load_source_on_run on a
+                # non-Application kind. The init-container redirect was only
+                # designed for store://; other source types belong on
+                # Application kind (where the sidecar handles them).
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Function '{function.metadata.name}' (kind="
+                    f"{function.kind!r}) has source={source!r} with "
+                    "load_source_on_run=True, which is supported on "
+                    "Application kind only. Either set kind='application' "
+                    "or use a store:// CodeArtifact source."
+                )
 
     nuclio_spec = nuclio.ConfigSpec(
         env=env_dict,
@@ -776,6 +815,12 @@ def _should_fetch_source_code(
     - Source is a store artifact URI (store://)
     - Source is Git or archive with pull_at_runtime=True
 
+    Reads ``function.spec.build.source`` first, then falls back to
+    ``function.status.application_source``. The fallback covers the redeploy
+    case where ``_install_store_uri_loader`` cleared ``spec.build.source``
+    and stashed the original URI on the status field so Nuclio's builder
+    wouldn't see a URI it can't resolve.
+
     :param function: The function object
     :return: True if init container is needed, False otherwise
     """
@@ -798,30 +843,314 @@ def _should_fetch_source_code(
     return (is_git_source or is_archive_source) and pull_at_runtime
 
 
-def _configure_source_loader_init_container(
+def _install_store_uri_loader(
     function: mlrun.runtimes.nuclio.function.RemoteRuntime,
-    sidecar: dict,
+    project: str,
     client_version: str | None = None,
     client_python_version: str | None = None,
 ):
-    """
-    Configure an init container for Application runtime to load source code at runtime.
+    """Install the store:// loader stub on a vanilla Nuclio/Serving function.
 
-    This function sets up a Kubernetes init container that runs before the main sidecar
-    container starts. The init container is responsible for fetching source code from
-    remote locations (store:// URIs, git repos, archives) and extracting it to a shared
-    volume that the sidecar can access.
+    For non-Application Nuclio/Serving kinds with a ``store://`` source,
+    Nuclio's native builder cannot resolve the URI. This helper:
+
+    1. Resolves the store URI and validates that the artifact is a
+       CodeArtifact (``kind == "code"``); fails fast on a wrong-kind
+       artifact rather than producing a cryptic ImportError in the pod.
+    2. Stashes the URI to ``status.application_source`` and clears
+       ``spec.build.source`` so Nuclio's builder doesn't see it.
+    3. Bakes a generated loader stub as ``functionSourceCode`` under a
+       fixed module name (avoids the ``sys.path[0]`` (= ``/opt/nuclio``)
+       shadow over the user's real module).
+    4. Stashes the user's real handler in ``status.original_handler`` and
+       injects ``MLRUN_REAL_HANDLER`` into ``spec.config["spec.env"]``
+       (deduped in both ``spec.config`` and ``spec.base_spec``).
+    5. Overrides ``spec.function_handler`` to point at the loader.
+    6. Configures the source-loader init container.
+
+    Mutates ``function.spec`` and ``function.status``. Idempotent — safe to
+    call on redeploys, which re-use the stashed values.
+
+    :param function: The function to install the loader on.
+    :param project:  Project name for artifact resolution.
+    :param client_version: Forwarded to the init container builder.
+    :param client_python_version: Forwarded to the init container builder.
+    """
+    source = function.spec.build.source or getattr(
+        function.status, "application_source", ""
+    )
+    # Defensive guard: production callers (`_compile_function_config`) already
+    # gate on `is_store_uri(source)`, but keep the no-op return so the helper
+    # is safe to call from tests / future entry points without re-checking.
+    if not mlrun.datastore.is_store_uri(source):
+        return
+
+    # Boundary validation: confirm the resolved artifact is a CodeArtifact.
+    # Without this, a wrong-kind artifact (model, dataset) silently flows
+    # through to the loader and fails with a cryptic ImportError at runtime.
+    try:
+        artifact = mlrun.datastore.get_store_resource(source, project=project)
+    except mlrun.errors.MLRunBaseError:
+        # Preserve typed MLRun errors so callers (and HTTP-status mapping)
+        # can pattern-match on them; only the generic-Exception branch wraps.
+        raise
+    except Exception as exc:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Cannot resolve code artifact {source}: {mlrun.errors.err_to_str(exc)}"
+        ) from exc
+    # `get_store_resource` returns None when the resolver can't find the
+    # artifact (deleted between deploys, empty resource, ...). Surface that
+    # as a typed MLRunNotFoundError instead of the AttributeError that the
+    # next `artifact.kind` access would otherwise raise.
+    if artifact is None:
+        raise mlrun.errors.MLRunNotFoundError(f"Code artifact not found at {source}")
+    if artifact.kind != "code":
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Source {source} resolves to a {artifact.kind!r} artifact; "
+            "expected a code artifact (kind='code')."
+        )
+
+    # Stash the URI so subsequent (re)deploys can re-resolve it after
+    # spec.build.source is cleared for the Nuclio builder.
+    if function.spec.build.source:
+        function.status.application_source = function.spec.build.source
+        function.spec.build.source = ""
+    # base_spec must be set so _compile_function_config takes the config
+    # branch; without it an empty source falls through to nuclio.build_file().
+    if not function.spec.base_spec:
+        function.spec.base_spec = nuclio.config.new_config()
+
+    target_dir = (
+        function.spec.build.source_code_target_dir
+        or mlrun.common.constants.DEFAULT_SOURCE_CODE_TARGET_DIR
+    )
+
+    # Serving with no explicit handler uses mlrun's serving wrapper (wired
+    # later by `_set_source_code_and_handler`). The loader stub would
+    # override that and break the topology graph. Install the init container
+    # + PYTHONPATH only; let `_set_source_code_and_handler` set the wrapper
+    # handler. Serving WITH an explicit handler still goes through the
+    # loader-stub path, same as nuclio.
+    is_serving_topology = (
+        function.kind == mlrun.runtimes.RuntimeKinds.serving
+        and not function.spec.function_handler
+    )
+    loader_module = mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE
+    loader_handler = f"{loader_module}:handler"
+
+    if is_serving_topology:
+        # If the function was previously deployed with an explicit handler
+        # (loader stub baked, MLRUN_REAL_HANDLER env injected) and the user
+        # is now switching to topology, clear the loader-shaped state so
+        # the spec doesn't carry dead bytes. The serving wrapper handler
+        # is wired downstream by `_set_source_code_and_handler`.
+        if function.spec.function_handler == loader_handler:
+            function.spec.function_handler = ""
+        env_list = function.spec.config.get("spec.env") or []
+        env_list[:] = [e for e in env_list if e.get("name") != "MLRUN_REAL_HANDLER"]
+        # Same dedupe in base_spec as `_set_unique_env` does for the
+        # explicit-handler path.
+        base_spec = function.spec.base_spec or {}
+        base_env = mlrun.utils.get_in(base_spec, "spec.env", []) or []
+        if base_env:
+            mlrun.utils.update_in(
+                base_spec,
+                "spec.env",
+                [e for e in base_env if e.get("name") != "MLRUN_REAL_HANDLER"],
+            )
+        # If the previously-baked stub is loader-shaped, drop it so Nuclio
+        # rebuilds with the wrapper wiring.
+        if function.spec.build.functionSourceCode:
+            try:
+                decoded = base64.b64decode(
+                    function.spec.build.functionSourceCode
+                ).decode("utf-8")
+            except Exception:
+                decoded = ""
+            if "MLRUN_REAL_HANDLER" in decoded:
+                function.spec.build.functionSourceCode = ""
+
+        logger.debug(
+            "Installing source-loader init container for serving topology",
+            project=function.metadata.project,
+            function=function.metadata.name,
+            source=source,
+        )
+        _configure_source_loader_init_container(
+            function,
+            sidecar=None,
+            client_version=client_version,
+            client_python_version=client_python_version,
+            add_project_secrets=True,
+        )
+        return
+
+    # Stub-bytes layout: a version marker on the first line lets future
+    # mlrun releases re-bake an existing function's loader when stub
+    # semantics change. Without the marker, the `if not functionSourceCode`
+    # short-circuit below would keep stale bytes from the first deploy
+    # forever. Marker version lives in `mlrun.common.constants` —
+    # bump it whenever the stub body changes.
+    stub_version_marker = (
+        f"# stub_version={mlrun.common.constants.STORE_URI_LOADER_STUB_VERSION}"
+    )
+    existing_stub = ""
+    if function.spec.build.functionSourceCode:
+        try:
+            existing_stub = base64.b64decode(
+                function.spec.build.functionSourceCode
+            ).decode("utf-8")
+        except Exception:
+            existing_stub = ""
+    # Substring check (not splitlines) so the marker is robust to line-ending
+    # mutations if the bytes were ever round-tripped through a Windows tool.
+    if stub_version_marker not in existing_stub:
+        loader_source = (
+            f"{stub_version_marker}\n"
+            "# Generated by mlrun for store:// Nuclio functions.\n"
+            "# Loads the user's real handler from the source-loader\n"
+            "# init container's output directory.\n"
+            "import importlib\n"
+            "import os\n"
+            "import sys\n"
+            "\n"
+            f"_CODE_DIR = {target_dir!r}\n"
+            "if _CODE_DIR not in sys.path:\n"
+            "    sys.path.insert(0, _CODE_DIR)\n"
+            "\n"
+            '_real = os.environ.get("MLRUN_REAL_HANDLER", "")\n'
+            "if not _real:\n"
+            "    raise RuntimeError(\n"
+            '        "MLRUN_REAL_HANDLER env var not set; cannot resolve "\n'
+            '        "user handler for store:// Nuclio function."\n'
+            "    )\n"
+            '_module_name, _, _func_name = _real.rpartition(":")\n'
+            "if not _module_name or not _func_name:\n"
+            "    raise RuntimeError(\n"
+            "        f\"MLRUN_REAL_HANDLER must be in 'module:function' \"\n"
+            '        f"format, got {_real!r}."\n'
+            "    )\n"
+            "\n"
+            "# Drop any cached _module_name from a prior pod-warm-start so a\n"
+            "# redeploy that re-uses the worker picks up the new bytes the\n"
+            "# init container fetched into _CODE_DIR.\n"
+            "importlib.invalidate_caches()\n"
+            "if _module_name in sys.modules:\n"
+            "    del sys.modules[_module_name]\n"
+            "\n"
+            "_user_module = importlib.import_module(_module_name)\n"
+            "handler = getattr(_user_module, _func_name)\n"
+        )
+        function.spec.build.functionSourceCode = base64.b64encode(
+            loader_source.encode("utf-8")
+        ).decode("utf-8")
+
+    # Resolve the user's "real" handler. The spec is the source of truth:
+    # if the user updates `function.spec.function_handler` between deploys,
+    # the new value wins. status.original_handler is only consulted as a
+    # fallback for the redeploy case where spec.function_handler has
+    # already been overwritten with the loader handler from a prior deploy.
+    # When neither is set (first deploy with no handler= passed), fall back
+    # to mlrun's existing convention default — the same `"main:handler"`
+    # used elsewhere in this file for non-store:// nuclio functions.
+    spec_handler = function.spec.function_handler
+    if spec_handler and spec_handler != loader_handler:
+        # User-provided value (first deploy or explicit redeploy update).
+        function.status.original_handler = spec_handler
+    elif not function.status.original_handler:
+        function.status.original_handler = "main:handler"
+
+    _set_unique_env(function, "MLRUN_REAL_HANDLER", function.status.original_handler)
+
+    # Override function_handler so Nuclio's CRD spec.handler points at the
+    # loader.
+    function.spec.function_handler = loader_handler
+
+    logger.debug(
+        "Installed store:// loader stub on Nuclio function",
+        project=function.metadata.project,
+        function=function.metadata.name,
+        source=source,
+        original_handler=function.status.original_handler,
+    )
+
+    _configure_source_loader_init_container(
+        function,
+        sidecar=None,
+        client_version=client_version,
+        client_python_version=client_python_version,
+        add_project_secrets=True,
+    )
+
+
+def _set_unique_env(
+    function: mlrun.runtimes.nuclio.function.RemoteRuntime,
+    name: str,
+    value: str,
+):
+    """Set an env var on the function, deduping in both ``spec.config`` and
+    ``spec.base_spec``.
+
+    K8s tolerates duplicate env names (last wins), but
+    ``nuclio.config.extend_config`` later appends ``spec.config["spec.env"]``
+    onto whatever's in ``spec.base_spec["spec"]["env"]``, which on a
+    redeploy can produce two entries for the same name. Mirror the dedupe
+    pattern used for init containers: clear from both, then append fresh
+    to ``spec.config`` only.
+    """
+    env_list = function.spec.config.setdefault("spec.env", [])
+    env_list[:] = [e for e in env_list if e.get("name") != name]
+    env_list.append({"name": name, "value": value})
+
+    base_spec = function.spec.base_spec or {}
+    base_env = mlrun.utils.get_in(base_spec, "spec.env", []) or []
+    if base_env:
+        mlrun.utils.update_in(
+            base_spec,
+            "spec.env",
+            [e for e in base_env if e.get("name") != name],
+        )
+
+
+def _configure_source_loader_init_container(
+    function: mlrun.runtimes.nuclio.function.RemoteRuntime,
+    sidecar: dict | None = None,
+    client_version: str | None = None,
+    client_python_version: str | None = None,
+    add_project_secrets: bool = False,
+):
+    """
+    Configure an init container to load source code at runtime.
+
+    This function sets up a Kubernetes init container that runs before the main
+    container starts. The init container is responsible for fetching source code
+    from remote locations (store:// URIs, git repos, archives) and extracting it
+    to a shared volume that the runtime container can access.
+
+    For Application runtime the runtime container is the user-provided sidecar
+    (passed in ``sidecar``). For vanilla Nuclio/Serving there is no sidecar, and
+    the runtime container is the main function container itself — pass
+    ``sidecar=None`` and the main container is patched via ``function.spec.config``.
 
     The setup involves:
-    1. Creating an emptyDir volume shared between init container and sidecar
+    1. Creating an emptyDir volume shared between init container and runtime container
     2. Building an init container spec that runs `mlrun load-source` command
     3. Adding the init container to the function's Nuclio spec
-    4. Patching the sidecar to mount the shared volume and set PYTHONPATH
+    4. Patching the runtime container to mount the shared volume and set PYTHONPATH
 
     :param function: The function object to configure
     :param sidecar: The sidecar container dict (the user's application container)
+                    when patching an Application sidecar; ``None`` to patch the
+                    main Nuclio function container instead.
     :param client_version: Client version for resolving the init container image
     :param client_python_version: Client Python version for resolving the init container image
+    :param add_project_secrets: Forwarded to _build_source_loader_init_container.
+                                When True, mounts the project's K8s secret via
+                                envFrom on the init container so the loader can
+                                authenticate to credential-protected datastores
+                                and resolve DataStore profiles with private
+                                members. Off for non-store:// sources, whose
+                                loaders read no project secrets.
     """
     source = function.spec.build.source or getattr(
         function.status, "application_source", None
@@ -837,7 +1166,7 @@ def _configure_source_loader_init_container(
     volume = {"name": volume_name, "emptyDir": {}}
     volume_mount = {"name": volume_name, "mountPath": target_dir}
 
-    # Add volume to function spec so both init container and sidecar can access it
+    # Add volume to function spec so both init container and runtime container can access it
     function.spec.with_volumes(volume)
     function.spec.with_volume_mounts(volume_mount)
 
@@ -849,18 +1178,30 @@ def _configure_source_loader_init_container(
         volume_mount=volume_mount,
         client_version=client_version,
         client_python_version=client_python_version,
+        add_project_secrets=add_project_secrets,
     )
 
     # Add init container to function spec (idempotently - replaces if exists)
     _ensure_source_loader_init_container(function, init_container)
 
-    _patch_sidecar_for_source(
-        sidecar=sidecar,
-        volume_name=volume_name,
-        volume_mount=volume_mount,
-        target_dir=target_dir,
-        workdir=workdir,
-    )
+    if sidecar is not None:
+        _patch_sidecar_for_source(
+            sidecar=sidecar,
+            volume_name=volume_name,
+            volume_mount=volume_mount,
+            target_dir=target_dir,
+            workdir=workdir,
+        )
+    else:
+        # Vanilla Nuclio/serving: inject PYTHONPATH on the main function
+        # container so the runtime can import the loaded source. Volume
+        # mounts are already wired via function.spec.with_volume_mounts()
+        # above.
+        _inject_main_container_pythonpath(
+            function=function,
+            target_dir=target_dir,
+            workdir=workdir,
+        )
 
     logger.debug(
         "Configured source loader init container",
@@ -879,6 +1220,7 @@ def _build_source_loader_init_container(
     volume_mount: dict,
     client_version: str | None = None,
     client_python_version: str | None = None,
+    add_project_secrets: bool = False,
 ) -> dict:
     """
     Build the init container spec for loading source code.
@@ -889,6 +1231,15 @@ def _build_source_loader_init_container(
     :param volume_mount: Volume mount configuration
     :param client_version: Client version for image resolution
     :param client_python_version: Client Python version for image resolution
+    :param add_project_secrets: When True, mount the project's K8s secret
+                                via envFrom so the loader process can use
+                                project-secret-based credentials (e.g., AWS_*,
+                                GOOGLE_APPLICATION_CREDENTIALS) AND resolve
+                                DataStore profiles with private members
+                                (which are stored in the same K8s secret).
+                                Off for non-store:// sources, where the
+                                loader has no datastore-profile resolution
+                                to do.
     :return: Init container specification dict
     """
     project = function.metadata.project
@@ -899,7 +1250,7 @@ def _build_source_loader_init_container(
         client_python_version=client_python_version,
     )
 
-    return {
+    init_container = {
         "name": mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME,
         "image": init_container_image,
         "command": ["mlrun", "load-source"],
@@ -911,6 +1262,22 @@ def _build_source_loader_init_container(
         "volumeMounts": [volume_mount],
     }
 
+    if add_project_secrets:
+        # `optional: true` keeps deploys working when a project has no secrets
+        # set yet — set_secrets({}) creates the K8s Secret lazily.
+        init_container["envFrom"] = [
+            {
+                "secretRef": {
+                    "name": framework.utils.singletons.k8s.get_k8s_helper(
+                        silent=True
+                    ).get_project_secret_name(project),
+                    "optional": True,
+                }
+            }
+        ]
+
+    return init_container
+
 
 def _ensure_source_loader_init_container(
     function: mlrun.runtimes.nuclio.function.RemoteRuntime,
@@ -919,10 +1286,14 @@ def _ensure_source_loader_init_container(
     """
     Add the source loader init container to the function spec idempotently.
 
-    This function ensures the source loader init container is present in the Nuclio
-    function spec. If an init container with the same name already exists, it will
-    be replaced with the new configuration. This enables safe re-deployment without
-    duplicating init containers.
+    If an init container with the same name already exists, it is filtered
+    out and replaced with the new configuration. The dedupe runs against
+    BOTH ``function.spec.config["spec.initContainers"]`` AND the matching
+    list inside ``function.spec.base_spec``: on a redeploy the persisted
+    base_spec carries over the previous deploy's init container, and
+    ``nuclio.config.extend_config`` later merges base_spec into config —
+    without the base_spec dedupe, that merge produces a duplicate and
+    Nuclio rejects the resulting K8s Deployment with "Duplicate value".
 
     :param function: The function object to configure
     :param init_container: Init container specification
@@ -930,14 +1301,61 @@ def _ensure_source_loader_init_container(
     init_container_name = init_container.get("name")
     if not init_container_name:
         raise mlrun.errors.MLRunInvalidArgumentError("Init container name is required")
-    init_containers = function.spec.config.setdefault("spec.initContainers", [])
 
-    for index, container in enumerate(init_containers):
-        if container.get("name") == init_container_name:
-            init_containers[index] = init_container
-            break
-    else:
-        init_containers.append(init_container)
+    # Dedupe in function.spec.config first.
+    init_containers = function.spec.config.setdefault("spec.initContainers", [])
+    init_containers[:] = [
+        c for c in init_containers if c.get("name") != init_container_name
+    ]
+    init_containers.append(init_container)
+
+    # Also dedupe in function.spec.base_spec — on redeploys the persisted
+    # base_spec carries over the previous deploy's init container at
+    # spec.initContainers, and extend_config later merges base_spec with
+    # function.spec.config, producing a duplicate. Nuclio rejects the
+    # resulting K8s Deployment with "Duplicate value".
+    base_spec = function.spec.base_spec or {}
+    base_spec_init_containers = mlrun.utils.get_in(base_spec, "spec.initContainers", [])
+    if base_spec_init_containers:
+        mlrun.utils.update_in(
+            base_spec,
+            "spec.initContainers",
+            [
+                c
+                for c in base_spec_init_containers
+                if c.get("name") != init_container_name
+            ],
+        )
+
+
+def _resolve_workdir(target_dir: str, workdir: str | None) -> str:
+    """Resolve a workdir against the source-loader target dir.
+
+    Absolute workdirs are used as-is; relative workdirs are joined onto
+    target_dir. Falls back to target_dir when workdir is empty.
+    """
+    if not workdir:
+        return target_dir
+    return workdir if os.path.isabs(workdir) else os.path.join(target_dir, workdir)
+
+
+def _add_pythonpath_to_env_list(env_list: list[dict], resolved_workdir: str):
+    """Idempotently prepend resolved_workdir to a PYTHONPATH entry in env_list.
+
+    If PYTHONPATH is missing, append a fresh entry. If present and already
+    contains resolved_workdir (as a colon-separated entry), leave it alone.
+    Otherwise prepend, preserving any user-defined paths.
+    """
+    pythonpath_env = next((e for e in env_list if e.get("name") == "PYTHONPATH"), None)
+    if pythonpath_env is None:
+        env_list.append({"name": "PYTHONPATH", "value": resolved_workdir})
+        return
+    existing_path = pythonpath_env.get("value", "")
+    if resolved_workdir in existing_path.split(":"):
+        return
+    pythonpath_env["value"] = (
+        f"{resolved_workdir}:{existing_path}" if existing_path else resolved_workdir
+    )
 
 
 def _patch_sidecar_for_source(
@@ -963,31 +1381,50 @@ def _patch_sidecar_for_source(
     if not any(vm.get("name") == volume_name for vm in sidecar_mounts):
         sidecar_mounts.append(volume_mount)
 
-    # Resolve the effective working directory for the sidecar.
-    # workdir can be relative (joined with target_dir) or absolute (used as-is).
-    if workdir:
-        if os.path.isabs(workdir):
-            resolved_workdir = workdir
-        else:
-            resolved_workdir = os.path.join(target_dir, workdir)
-    else:
-        resolved_workdir = target_dir
-
+    resolved_workdir = _resolve_workdir(target_dir, workdir)
     sidecar["workingDir"] = resolved_workdir
 
-    # Set PYTHONPATH so the sidecar can import modules from the source directory.
-    # If PYTHONPATH already exists (user-defined), prepend our path to preserve theirs.
-    sidecar_env = sidecar.setdefault("env", [])
-    pythonpath_env = next(
-        (e for e in sidecar_env if e.get("name") == "PYTHONPATH"), None
+    _add_pythonpath_to_env_list(sidecar.setdefault("env", []), resolved_workdir)
+
+
+def _inject_main_container_pythonpath(
+    function: mlrun.runtimes.nuclio.function.RemoteRuntime,
+    target_dir: str,
+    workdir: str | None = None,
+):
+    """
+    Inject PYTHONPATH into ``function.spec.config["spec.env"]`` so Nuclio
+    applies it to the main function container at deploy time.
+
+    Unlike sidecars (which are dicts directly mutable in
+    ``function.spec.config["spec.sidecars"]``), the main container is
+    constructed by Nuclio's controller from the function CRD's ``spec.env``.
+    We append to that env list here because ``_resolve_env_vars()`` — which
+    would otherwise have picked up ``function.spec.env`` — has already run
+    by the time this function is called.
+
+    Volume mounts for the main container are wired by the caller via
+    ``function.spec.with_volume_mounts()``.
+
+    :param function: The function object
+    :param target_dir: Target directory where source code is extracted
+    :param workdir: Working directory relative to target_dir or absolute path on
+                    the container filesystem
+    """
+    _add_pythonpath_to_env_list(
+        function.spec.config.setdefault("spec.env", []),
+        _resolve_workdir(target_dir, workdir),
     )
-    if pythonpath_env:
-        existing_path = pythonpath_env.get("value", "")
-        if resolved_workdir not in existing_path.split(":"):
-            pythonpath_env["value"] = (
-                f"{resolved_workdir}:{existing_path}"
-                if existing_path
-                else resolved_workdir
-            )
-    else:
-        sidecar_env.append({"name": "PYTHONPATH", "value": resolved_workdir})
+
+    # Mirror the dedupe in spec.base_spec — extend_config merges
+    # base_spec["spec"]["env"] into spec.config["spec.env"] on deploy, and
+    # without removing the stale PYTHONPATH from base_spec a redeploy
+    # accumulates a duplicate entry alongside the freshly-set one.
+    base_spec = function.spec.base_spec or {}
+    base_env = mlrun.utils.get_in(base_spec, "spec.env", []) or []
+    if base_env:
+        mlrun.utils.update_in(
+            base_spec,
+            "spec.env",
+            [e for e in base_env if e.get("name") != "PYTHONPATH"],
+        )

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import unittest.mock
+
 import pytest
 
 import mlrun
@@ -19,6 +22,24 @@ import mlrun
 import services.api.crud.runtimes.nuclio.function
 import services.api.crud.runtimes.nuclio.helpers
 from services.api.tests.unit.conftest import assets_path
+
+
+@pytest.fixture(autouse=True)
+def _mock_code_artifact_resolution(monkeypatch):
+    """Stub `mlrun.datastore.get_store_resource` for unit tests.
+
+    `_install_store_uri_loader` resolves the store URI to validate that the
+    artifact's `kind == "code"`. Unit tests don't have a real artifact DB,
+    so return a fake CodeArtifact-shaped object whose `kind` attribute is
+    `"code"`. Tests that need to exercise the validation failure path can
+    override via their own `monkeypatch.setattr`.
+    """
+    fake_artifact = unittest.mock.MagicMock()
+    fake_artifact.kind = "code"
+    monkeypatch.setattr(
+        "mlrun.datastore.get_store_resource",
+        lambda *args, **kwargs: fake_artifact,
+    )
 
 
 def test_compiled_function_config_nuclio_golang():
@@ -161,4 +182,742 @@ def test_resolve_nuclio_runtime_python_image(
         == services.api.crud.runtimes.nuclio.helpers.resolve_nuclio_runtime_python_image(
             mlrun_client_version, python_version
         )
+    )
+
+
+def test_should_fetch_source_code_for_nuclio_with_store_uri():
+    """_should_fetch_source_code returns True for vanilla nuclio with store:// source."""
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.spec.build.source = "store://artifacts/test-proj/my_code"
+
+    assert (
+        services.api.crud.runtimes.nuclio.function._should_fetch_source_code(func)
+        is True
+    )
+    assert func.kind == mlrun.runtimes.RuntimeKinds.remote
+
+
+@pytest.mark.parametrize("kind", ["nuclio", "serving"])
+def test_compile_nuclio_function_with_store_source_has_init_container(
+    kind, tmp_path, monkeypatch
+):
+    """_compile_function_config sets up an init container for vanilla
+    Nuclio AND Serving when source is a store:// CodeArtifact URI.
+
+    Both kinds share the same store:// gate in the new code path; only
+    Application is special-cased ahead of it. Parametrizing here pins
+    that contract.
+    """
+    # Isolate cwd so the project save-on-load side-effect doesn't write a
+    # project.yaml into the repo root and pollute sibling tests.
+    monkeypatch.chdir(tmp_path)
+
+    source_uri = "store://artifacts/test-proj/my_code"
+    func = mlrun.new_function("test-func", kind=kind)
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = source_uri
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    init_containers = func.spec.config.get("spec.initContainers") or []
+    assert len(init_containers) == 1
+    assert (
+        init_containers[0]["name"]
+        == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+    )
+    assert init_containers[0]["command"] == ["mlrun", "load-source"]
+    assert source_uri in init_containers[0]["args"]
+
+    # Original store:// URI is stashed so it survives Nuclio builder seeing an empty source.
+    assert func.status.application_source == source_uri
+
+    # Nuclio's build phase needs *some* baked code (otherwise it rejects the
+    # CRD with "Function must have either spec.build.path,
+    # spec.build.functionSourceCode, spec.build.image or spec.image"). We
+    # bake a dedicated loader module that resolves the user's real handler
+    # at runtime via the MLRUN_REAL_HANDLER env var. spec.handler is
+    # rewritten to point at the loader; the original is preserved in
+    # status.original_handler.
+    assert func.spec.build.functionSourceCode
+    decoded_loader = base64.b64decode(func.spec.build.functionSourceCode).decode(
+        "utf-8"
+    )
+    assert "MLRUN_REAL_HANDLER" in decoded_loader
+    assert "import importlib" in decoded_loader
+    assert mlrun.common.constants.DEFAULT_SOURCE_CODE_TARGET_DIR in decoded_loader
+
+    # Handler rewritten to the loader.
+    loader_module = mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE
+    assert func.spec.function_handler == f"{loader_module}:handler"
+    # Original handler stashed for redeploy recovery.
+    assert func.status.original_handler == "main:handler"
+    # Loader reads user's handler from env var.
+    env_list = func.spec.config.get("spec.env", [])
+    real_handler_env = next(
+        (e for e in env_list if e.get("name") == "MLRUN_REAL_HANDLER"), None
+    )
+    assert real_handler_env is not None
+    assert real_handler_env["value"] == "main:handler"
+
+
+@pytest.mark.parametrize("kind", ["nuclio", "serving", "application"])
+def test_compile_nuclio_function_with_store_source_mounts_project_secrets_on_init_container(
+    kind, tmp_path, monkeypatch
+):
+    """Init container for a store:// source mounts the project's K8s secret
+    via envFrom, so the source-loader process can authenticate to
+    credential-protected datastores (S3, GCS, Azure) and resolve DataStore
+    profiles whose private members live in mlrun-project-secrets-<project>.
+
+    All three Nuclio-derived kinds (vanilla nuclio, serving, application)
+    use the same source-loader init container for store:// sources, and
+    all three need the project-secret envFrom mount when the artifact's
+    target_path resolves through a DataStore profile.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    source_uri = "store://artifacts/test-proj/my_code"
+    func = mlrun.new_function("test-func", kind=kind)
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = source_uri
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+    if kind == "application":
+        # Application requires a sidecar (the user's app container).
+        func.spec.config["spec.sidecars"] = [
+            {"name": "user-app", "image": "python:3.11"}
+        ]
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    init_containers = func.spec.config.get("spec.initContainers") or []
+    assert len(init_containers) == 1
+    init_container = init_containers[0]
+    env_from = init_container.get("envFrom") or []
+    project_secret_refs = [
+        e
+        for e in env_from
+        if e.get("secretRef", {}).get("name") == "mlrun-project-secrets-test-proj"
+    ]
+    assert len(project_secret_refs) == 1, (
+        f"Expected exactly one project-secrets envFrom entry, got {env_from}"
+    )
+    # `optional: true` so the deploy doesn't fail when a project has no
+    # secrets at all (the K8s secret is created lazily by set_secrets).
+    assert project_secret_refs[0]["secretRef"].get("optional") is True
+
+
+def test_nuclio_store_source_preserved_on_redeploy():
+    """status.application_source preserves store:// URI across re-deploys.
+
+    Simulates the post-deploy state where spec.build.source has been cleared
+    (Nuclio builder must not see store://) and the original is held in
+    status.application_source. _should_fetch_source_code must still detect
+    it so a redeploy reconfigures the init container.
+    """
+    source_uri = "store://artifacts/test-proj/my_code"
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.status.application_source = source_uri
+    func.spec.build.source = ""
+
+    assert (
+        services.api.crud.runtimes.nuclio.function._should_fetch_source_code(func)
+        is True
+    )
+
+
+def test_compile_nuclio_function_with_store_source_redeploy_is_idempotent(
+    tmp_path, monkeypatch
+):
+    """Recompile after a deploy must not duplicate init containers, env vars,
+    loader source, or overwrite original_handler.
+
+    Simulates the persisted state of a function that has already been deployed
+    once with a store:// source: spec.build.source has been cleared,
+    status.application_source / status.original_handler hold the originals,
+    spec.build.functionSourceCode is the loader stub, spec.handler points at
+    the loader, and both spec.config and spec.base_spec already carry an
+    init-container entry (the latter is what triggered the "Duplicate value"
+    K8s error before the base_spec dedupe fix).
+    """
+    monkeypatch.chdir(tmp_path)
+
+    source_uri = "store://artifacts/test-proj/my_code"
+    loader_module = mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE
+    loader_handler = f"{loader_module}:handler"
+    init_container_name = mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+    # Seed with bytes carrying the current stub version marker so the
+    # re-bake guard treats them as up-to-date and short-circuits — pins
+    # the cache-preservation behavior for current-version stubs.
+    original_loader_source = base64.b64encode(
+        b"# stub_version=1\n# original loader bytes"
+    ).decode("utf-8")
+
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.image = "python:3.11"
+
+    # Post-first-deploy state.
+    func.spec.build.source = ""
+    func.status.application_source = source_uri
+    func.status.original_handler = "main:handler"
+    func.spec.function_handler = loader_handler
+    func.spec.build.functionSourceCode = original_loader_source
+    func.spec.config["spec.env"] = [
+        {"name": "MLRUN_REAL_HANDLER", "value": "main:handler"}
+    ]
+    func.spec.config["spec.initContainers"] = [
+        {
+            "name": init_container_name,
+            "command": ["mlrun", "load-source"],
+            "envFrom": [
+                {
+                    "secretRef": {
+                        "name": "mlrun-project-secrets-test-proj",
+                        "optional": True,
+                    }
+                }
+            ],
+        }
+    ]
+    func.spec.base_spec = {
+        "spec": {
+            "initContainers": [
+                {"name": init_container_name, "command": ["mlrun", "load-source"]}
+            ],
+            # base_spec also carries over the prior deploy's env. Without a
+            # base_spec env dedupe these would survive into extend_config's
+            # merge and produce a duplicate alongside the freshly-set entries
+            # in spec.config — same class of bug as the init-container
+            # duplication, just on env vars.
+            "env": [
+                {"name": "MLRUN_REAL_HANDLER", "value": "stale:handler"},
+                {
+                    "name": "PYTHONPATH",
+                    "value": "/stale/path",
+                },
+                {"name": "USER_VAR", "value": "keep_me"},
+            ],
+        }
+    }
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    # Exactly one init container in spec.config (no duplication on rebuild).
+    init_containers = func.spec.config.get("spec.initContainers") or []
+    loader_init = [c for c in init_containers if c.get("name") == init_container_name]
+    assert len(loader_init) == 1
+
+    # envFrom is set on the freshly-compiled init container — assert it's
+    # exactly one entry (no duplication when the dedupe-replace runs over
+    # an init container that already had the same envFrom from a prior deploy).
+    env_from = loader_init[0].get("envFrom") or []
+    project_secret_refs = [
+        e
+        for e in env_from
+        if e.get("secretRef", {}).get("name") == "mlrun-project-secrets-test-proj"
+    ]
+    assert len(project_secret_refs) == 1
+
+    # extend_config later merges nuclio_spec into base_spec; without the dedupe
+    # we'd see two entries with the same name here and Nuclio would reject
+    # the K8s Deployment with "Duplicate value".
+    base_spec_init = mlrun.utils.get_in(func.spec.base_spec, "spec.initContainers", [])
+    base_loader_count = sum(
+        1 for c in base_spec_init if c.get("name") == init_container_name
+    )
+    assert base_loader_count == 1
+
+    # Exactly one MLRUN_REAL_HANDLER env var with the user's original handler.
+    env_list = func.spec.config.get("spec.env", [])
+    real_handler_envs = [e for e in env_list if e.get("name") == "MLRUN_REAL_HANDLER"]
+    assert len(real_handler_envs) == 1
+    assert real_handler_envs[0]["value"] == "main:handler"
+
+    # base_spec env dedupe: the stale MLRUN_REAL_HANDLER and PYTHONPATH that
+    # carried over from the prior deploy are removed BEFORE extend_config
+    # merges spec.config's freshly-set values in. Net result: exactly one
+    # entry per loader-managed name (the freshly-set value), plus the
+    # user-set entry untouched. Without the base_spec dedupe, extend_config's
+    # append-merge would produce two entries per name and Nuclio would
+    # reject the K8s Deployment with "Duplicate value".
+    base_env = mlrun.utils.get_in(func.spec.base_spec, "spec.env", []) or []
+    base_real_handlers = [e for e in base_env if e.get("name") == "MLRUN_REAL_HANDLER"]
+    assert len(base_real_handlers) == 1
+    assert base_real_handlers[0]["value"] == "main:handler"
+    base_pythonpaths = [e for e in base_env if e.get("name") == "PYTHONPATH"]
+    assert len(base_pythonpaths) == 1
+    assert base_pythonpaths[0]["value"] != "/stale/path"
+    base_user_vars = [e for e in base_env if e.get("name") == "USER_VAR"]
+    assert len(base_user_vars) == 1
+    assert base_user_vars[0]["value"] == "keep_me"
+
+    # Recovery: original_handler stays anchored to the user's value, not the
+    # loader handler that's now in spec.function_handler.
+    assert func.status.original_handler == "main:handler"
+    assert func.spec.function_handler == loader_handler
+
+    # Loader stub is short-circuited when functionSourceCode is already set —
+    # we keep the bytes from the prior deploy so Nuclio's build cache sees an
+    # unchanged source and can skip rebuild.
+    assert func.spec.build.functionSourceCode == original_loader_source
+
+
+def test_compile_nuclio_function_with_store_source_defaults_to_main_handler(
+    tmp_path, monkeypatch
+):
+    """Vanilla Nuclio + store:// source without an explicit handler falls
+    back to mlrun's existing ``main:handler`` convention.
+
+    Matches the same fallback applied to non-store:// nuclio functions when
+    ``handler=`` isn't passed: defer to Nuclio's standard module:function
+    default rather than failing at compile. Users who follow the convention
+    (a ``main.py`` with a ``handler`` function in their CodeArtifact) get a
+    successful deploy without specifying a handler explicitly.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = "store://artifacts/test-proj/my_code"
+    func.spec.image = "python:3.11"
+    # No handler set.
+    func.spec.function_handler = None
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    # The default flows through to status.original_handler (preserved across
+    # redeploys) and to the MLRUN_REAL_HANDLER env var the loader stub reads.
+    assert func.status.original_handler == "main:handler"
+    env_list = func.spec.config.get("spec.env") or []
+    real_handler_env = next(
+        (e for e in env_list if e.get("name") == "MLRUN_REAL_HANDLER"), None
+    )
+    assert real_handler_env is not None
+    assert real_handler_env["value"] == "main:handler"
+
+
+def test_compile_nuclio_function_with_custom_source_code_target_dir(
+    tmp_path, monkeypatch
+):
+    """source_code_target_dir override flows through to the loader stub and volume mount.
+
+    Users overriding the default /home/mlrun_code (e.g., to layer on top of a
+    base image whose user lacks write access to /home) must see the custom
+    path embedded in both the generated loader's sys.path insert and the
+    init-container's output directory.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    custom_dir = "/opt/user_code"
+    source_uri = "store://artifacts/test-proj/my_code"
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = source_uri
+    func.spec.build.source_code_target_dir = custom_dir
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    # Loader stub embeds the custom path.
+    decoded_loader = base64.b64decode(func.spec.build.functionSourceCode).decode(
+        "utf-8"
+    )
+    assert custom_dir in decoded_loader
+    # And the default isn't accidentally also present.
+    assert mlrun.common.constants.DEFAULT_SOURCE_CODE_TARGET_DIR not in decoded_loader
+
+
+def test_compile_nuclio_function_with_git_source_skips_loader_branch(
+    tmp_path, monkeypatch
+):
+    """Git sources stay on Nuclio's native code-entry-type path.
+
+    Nuclio's builder resolves git:// directly (codeEntryType="git"); the
+    store:// init-container redirect only applies to URIs Nuclio cannot
+    resolve. Verify a git source doesn't accidentally trigger the loader
+    stub or the source-loader init container.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = "git://github.com/example/repo.git#main"
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(
+        func, builder_env={}
+    )
+
+    # No source-loader init container — Nuclio's native git pull handles this.
+    init_containers = func.spec.config.get("spec.initContainers") or []
+    assert all(
+        c.get("name") != mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+        for c in init_containers
+    )
+    # Handler stays as the user's value (no loader substitution).
+    assert func.spec.function_handler == "main:handler"
+    # No store:// URI stash since the source isn't store://.
+    assert not func.status.application_source
+    assert not func.status.original_handler
+
+
+@pytest.mark.parametrize(
+    "existing_pythonpath, expected",
+    [
+        # No PYTHONPATH set yet.
+        (None, "/work"),
+        # PYTHONPATH already set, target_dir not in it — prepend.
+        ("/other/path", "/work:/other/path"),
+        # PYTHONPATH already set, target_dir already in it — leave unchanged.
+        ("/work", "/work"),
+        # PYTHONPATH set with target_dir as one of multiple entries — leave unchanged.
+        ("/before:/work:/after", "/before:/work:/after"),
+    ],
+)
+def test_inject_main_container_pythonpath_merge_logic(existing_pythonpath, expected):
+    """_inject_main_container_pythonpath must idempotently maintain PYTHONPATH.
+
+    Repeated deploys must not produce ``/work:/work`` or accumulate stale
+    entries; absent PYTHONPATH must produce a single fresh entry.
+    """
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    if existing_pythonpath is not None:
+        func.spec.config["spec.env"] = [
+            {"name": "PYTHONPATH", "value": existing_pythonpath}
+        ]
+
+    services.api.crud.runtimes.nuclio.function._inject_main_container_pythonpath(
+        function=func, target_dir="/work"
+    )
+
+    env_list = func.spec.config.get("spec.env", [])
+    pythonpath_envs = [e for e in env_list if e.get("name") == "PYTHONPATH"]
+    assert len(pythonpath_envs) == 1
+    assert pythonpath_envs[0]["value"] == expected
+
+
+def test_compile_application_function_with_git_source_does_not_mount_project_secrets(
+    tmp_path, monkeypatch
+):
+    """Application git+pull_at_runtime DOES use the source-loader init
+    container, but the gating is store:// only — assert that branch does
+    NOT pick up the project-secrets envFrom mount, preventing a behavior
+    shift for existing Application git/archive deploys.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    func = mlrun.new_function("test-func", kind="application")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = "git://github.com/example/repo.git#main"
+    func.spec.build.load_source_on_run = True
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+    # Application requires a sidecar.
+    func.spec.config["spec.sidecars"] = [{"name": "user-app", "image": "python:3.11"}]
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(
+        func, builder_env={}
+    )
+
+    init_containers = func.spec.config.get("spec.initContainers") or []
+    loader_init = [
+        c
+        for c in init_containers
+        if c.get("name") == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+    ]
+    assert len(loader_init) == 1, (
+        f"Expected source-loader init container for git+pull_at_runtime, got {init_containers}"
+    )
+    # Critical: git/archive init containers must NOT mount project secrets —
+    # this is what keeps the change from being a behavior shift for existing
+    # Application git/archive deploys.
+    # Pin schema: the key is absent (None) rather than an empty list — that
+    # way a future code path that adds an empty `envFrom: []` placeholder
+    # surfaces here as a regression instead of passing vacuously.
+    assert loader_init[0].get("envFrom") is None, (
+        f"git source init container should not have envFrom (got {loader_init[0].get('envFrom')!r})"
+    )
+
+
+@pytest.mark.parametrize("kind", ["nuclio", "serving"])
+def test_compile_nuclio_function_with_git_pull_at_runtime_raises_for_non_application(
+    kind, tmp_path, monkeypatch
+):
+    """Vanilla Nuclio/Serving + git source + load_source_on_run is unsupported.
+
+    The init-container redirect was designed for store:// URIs only;
+    git/archive sources with pull_at_runtime belong on Application kind
+    (where the sidecar handles them) or on the native Nuclio path with
+    pull_at_runtime=False (so Nuclio's own builder fetches the source).
+    Compile-time raise makes the unsupported combination explicit instead
+    of silently producing a no-init-container deploy that fails later.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    func = mlrun.new_function("test-func", kind=kind)
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = "git://github.com/example/repo.git#main"
+    func.spec.build.load_source_on_run = True
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="supported on Application kind only",
+    ):
+        services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+
+def test_compile_nuclio_function_with_non_code_artifact_raises(tmp_path, monkeypatch):
+    """The store URI must resolve to a CodeArtifact (kind == 'code').
+
+    Without this boundary check, a wrong-kind artifact (model, dataset, ...)
+    silently flows through to the loader and fails with a cryptic
+    ``ImportError`` in the pod. Failing fast at compile time gives the user
+    a message that names the actual problem.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    fake_model = unittest.mock.MagicMock()
+    fake_model.kind = "model"
+    monkeypatch.setattr(
+        "mlrun.datastore.get_store_resource",
+        lambda *args, **kwargs: fake_model,
+    )
+
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = "store://artifacts/test-proj/some_model"
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="expected a code artifact",
+    ):
+        services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+
+def test_compile_serving_function_with_topology_skips_loader_stub(
+    tmp_path, monkeypatch
+):
+    """Serving + store:// + no explicit handler must not install the loader
+    stub.
+
+    A serving function with `set_topology()` doesn't set
+    `function.spec.function_handler` — the serving wrapper handler is wired
+    later by `_set_source_code_and_handler`. Installing the loader stub
+    would override the wrapper and break the topology graph. The init
+    container + PYTHONPATH still need to be present so the user's serving
+    code is loadable.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    func = mlrun.new_function("test-serving", kind="serving")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = "store://artifacts/test-proj/my_code"
+    # No explicit function_handler — _set_source_code_and_handler will fill
+    # in the serving wrapper later.
+    func.spec.image = "python:3.11"
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    # Init container present (the user's source still needs to be loaded).
+    init_containers = func.spec.config.get("spec.initContainers") or []
+    loader_inits = [
+        c
+        for c in init_containers
+        if c.get("name") == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+    ]
+    assert len(loader_inits) == 1
+
+    # No loader stub baked, no handler override.
+    assert not func.spec.build.functionSourceCode
+    loader_handler = f"{mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE}:handler"
+    assert func.spec.function_handler != loader_handler
+    # No MLRUN_REAL_HANDLER env injection — the wrapper doesn't read it.
+    env_list = func.spec.config.get("spec.env", [])
+    assert not any(e.get("name") == "MLRUN_REAL_HANDLER" for e in env_list)
+
+
+def test_compile_nuclio_function_with_store_source_redeploy_honors_handler_update(
+    tmp_path, monkeypatch
+):
+    """A redeploy must honor an explicit handler change in spec.
+
+    On the first deploy `function.status.original_handler` is stashed.
+    If the user later updates `function.spec.function_handler` (e.g. from
+    "v1:handler" to "v2:handler") and redeploys, the new value must win
+    over the stashed status.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.image = "python:3.11"
+
+    # Post-first-deploy state with stashed original_handler == "v1:handler".
+    func.spec.build.source = ""
+    func.status.application_source = "store://artifacts/test-proj/my_code"
+    func.status.original_handler = "v1:handler"
+    # User updates spec.function_handler between deploys to a fresh value.
+    func.spec.function_handler = "v2:handler"
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    # status.original_handler now reflects the spec update.
+    assert func.status.original_handler == "v2:handler"
+    # MLRUN_REAL_HANDLER env follows the new value.
+    env_list = func.spec.config.get("spec.env", [])
+    real_handler_envs = [e for e in env_list if e.get("name") == "MLRUN_REAL_HANDLER"]
+    assert len(real_handler_envs) == 1
+    assert real_handler_envs[0]["value"] == "v2:handler"
+
+
+def test_compile_nuclio_function_rebakes_loader_stub_when_version_marker_missing(
+    tmp_path, monkeypatch
+):
+    """Stub bytes from before the version marker was introduced must be
+    re-baked on next compile. Without this, an mlrun upgrade that fixes a
+    stub bug would never reach existing functions whose
+    ``functionSourceCode`` was set on a prior deploy.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    pre_marker_bytes = base64.b64encode(b"# pre-marker stub bytes\n").decode("utf-8")
+
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.image = "python:3.11"
+    func.spec.build.source = ""
+    func.status.application_source = "store://artifacts/test-proj/my_code"
+    func.status.original_handler = "main:handler"
+    func.spec.function_handler = (
+        f"{mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE}:handler"
+    )
+    func.spec.build.functionSourceCode = pre_marker_bytes
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    # Stub re-baked: bytes changed AND now carry the version marker.
+    assert func.spec.build.functionSourceCode != pre_marker_bytes
+    rebaked = base64.b64decode(func.spec.build.functionSourceCode).decode("utf-8")
+    assert rebaked.startswith("# stub_version=1")
+
+
+def test_compile_nuclio_function_with_missing_artifact_raises_typed_error(
+    tmp_path, monkeypatch
+):
+    """get_store_resource returning None must surface as MLRunNotFoundError,
+    not the AttributeError that an unguarded `artifact.kind` access would
+    raise.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "mlrun.datastore.get_store_resource",
+        lambda *args, **kwargs: None,
+    )
+
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.build.source = "store://artifacts/test-proj/missing"
+    func.spec.function_handler = "main:handler"
+    func.spec.image = "python:3.11"
+
+    with pytest.raises(
+        mlrun.errors.MLRunNotFoundError,
+        match="Code artifact not found",
+    ):
+        services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+
+def test_compile_serving_function_topology_clears_loader_shaped_state_on_toggle(
+    tmp_path, monkeypatch
+):
+    """When a serving function previously deployed with an explicit handler
+    (loader stub baked, MLRUN_REAL_HANDLER env, function_handler pointing at
+    the loader) is redeployed without an explicit handler, the loader-shaped
+    state must be cleared so the serving wrapper can take over cleanly.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    loader_handler = f"{mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE}:handler"
+    stub_with_marker = base64.b64encode(
+        f"# stub_version={mlrun.common.constants.STORE_URI_LOADER_STUB_VERSION}\n"
+        "# loader stub\n"
+        "MLRUN_REAL_HANDLER = '...'\n".encode()
+    ).decode("utf-8")
+
+    func = mlrun.new_function("test-serving", kind="serving")
+    func.metadata.project = "test-proj"
+    func.metadata.tag = "latest"
+    func.spec.image = "python:3.11"
+
+    # Post-explicit-handler-deploy state.
+    func.spec.build.source = ""
+    func.status.application_source = "store://artifacts/test-proj/my_code"
+    func.status.original_handler = "old:handler"
+    # User has now removed function_handler to switch to topology — but
+    # spec.function_handler is still the loader handler from the prior deploy.
+    func.spec.function_handler = loader_handler
+    func.spec.build.functionSourceCode = stub_with_marker
+    func.spec.config["spec.env"] = [
+        {"name": "MLRUN_REAL_HANDLER", "value": "old:handler"},
+        {"name": "USER_VAR", "value": "keep_me"},
+    ]
+    func.spec.base_spec = {
+        "spec": {
+            "env": [
+                {"name": "MLRUN_REAL_HANDLER", "value": "old:handler"},
+                {"name": "USER_VAR", "value": "keep_me"},
+            ]
+        }
+    }
+
+    # Simulate the user removing the explicit handler. This is the "toggle
+    # handler -> topology" scenario: the helper sees `spec.function_handler`
+    # as the loader handler (from a prior deploy), but the user's intent
+    # for the upcoming deploy is topology — so the loader-shaped state
+    # gets cleared.
+    func.spec.function_handler = ""
+
+    services.api.crud.runtimes.nuclio.function._compile_function_config(func)
+
+    # Loader-shaped state cleared.
+    assert not func.spec.build.functionSourceCode
+    env_list = func.spec.config.get("spec.env", [])
+    assert not any(e.get("name") == "MLRUN_REAL_HANDLER" for e in env_list)
+    base_env = mlrun.utils.get_in(func.spec.base_spec, "spec.env", []) or []
+    assert not any(e.get("name") == "MLRUN_REAL_HANDLER" for e in base_env)
+
+    # User-set env survives.
+    assert any(e.get("name") == "USER_VAR" for e in env_list)
+    assert any(e.get("name") == "USER_VAR" for e in base_env)
+
+    # Init container still present (source still needs loading).
+    init_containers = func.spec.config.get("spec.initContainers") or []
+    assert any(
+        c.get("name") == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+        for c in init_containers
     )

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -610,6 +610,34 @@ def test_inject_main_container_pythonpath_merge_logic(existing_pythonpath, expec
     assert pythonpath_envs[0]["value"] == expected
 
 
+def test_inject_main_container_pythonpath_preserves_user_base_spec_value():
+    """A PYTHONPATH set by the user directly in base_spec must be merged
+    into spec.config and dropped from base_spec, not silently lost."""
+    func = mlrun.new_function("test-func", kind="nuclio")
+    func.metadata.project = "test-proj"
+    func.spec.base_spec = {
+        "spec": {"env": [{"name": "PYTHONPATH", "value": "/opt/user_lib:/opt/extras"}]}
+    }
+
+    services.api.crud.runtimes.nuclio.function._inject_main_container_pythonpath(
+        function=func, target_dir="/work"
+    )
+
+    spec_pythonpaths = [
+        e for e in func.spec.config.get("spec.env", []) if e.get("name") == "PYTHONPATH"
+    ]
+    assert len(spec_pythonpaths) == 1
+    # Managed workdir first; user-set paths follow in original order.
+    assert spec_pythonpaths[0]["value"] == "/work:/opt/user_lib:/opt/extras"
+
+    base_pythonpaths = [
+        e
+        for e in mlrun.utils.get_in(func.spec.base_spec, "spec.env", []) or []
+        if e.get("name") == "PYTHONPATH"
+    ]
+    assert base_pythonpaths == []
+
+
 def test_compile_application_function_with_git_source_does_not_mount_project_secrets(
     tmp_path, monkeypatch
 ):

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -21,7 +21,9 @@ import tempfile
 import pytest
 from nuclio.auth import AuthInfo as NuclioAuthInfo
 
+import mlrun.common.constants
 import mlrun.common.schemas
+import mlrun.datastore.datastore_profile as datastore_profile
 import mlrun.runtimes
 import mlrun.runtimes.utils
 import tests.system.base
@@ -451,6 +453,93 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         )
         function.with_source_archive(source=delay_healthcheck_source)
         return function
+
+    def test_deploy_application_with_store_uri_via_datastore_profile(self):
+        """End-to-end: an Application function whose store:// CodeArtifact
+        target_path resolves through a DataStore profile with private members
+        deploys successfully.
+
+        Verifies that the source-loader init container can resolve the profile
+        at fetch time — which requires the profile's private body to be readable
+        from env via the project-secret envFrom mount on the init container.
+
+        Without the envFrom mount on Application's init container, the deploy
+        would fail with MLRunNotFoundError during artifact resolution (the
+        profile's private body would be absent from the init container's env).
+        """
+        access_key = os.environ.get("V3IO_ACCESS_KEY")
+        assert access_key, "V3IO_ACCESS_KEY required for this system test"
+
+        profile_name = "application-store-test-v3io-profile"
+        profile = datastore_profile.DatastoreProfileV3io(
+            name=profile_name,
+            v3io_access_key=access_key,
+        )
+        self.project.register_datastore_profile(profile)
+        # Also register client-side so log_code_file can resolve the ds:// URL.
+        datastore_profile.register_temporary_client_datastore_profile(profile)
+
+        # Log the simple flask app as a CodeArtifact whose target_path lives
+        # on the ds:// profile — the init container will resolve the profile
+        # at fetch time, which requires the project-secret envFrom mount.
+        artifact_key = "simple_flask_app_via_profile"
+        local_path = os.path.join(self.assets_path, self._simple_flask_app)
+        artifact_target_path = (
+            f"ds://{profile_name}"
+            f"/projects/{self.project_name}/code/{self._simple_flask_app}"
+        )
+        artifact = self.project.log_code_file(
+            key=artifact_key,
+            local_path=local_path,
+            target_path=artifact_target_path,
+        )
+        # Use the artifact's canonical URI — see TESTING_STANDARDS.md §7.
+        store_uri = artifact.uri
+
+        function = self.project.set_function(
+            func=store_uri,
+            name="store-app-via-profile",
+            kind="application",
+            requirements=["Flask==3.0.0"],
+        )
+        function.set_internal_application_port(5000)
+        function.spec.command = "python"
+        function.spec.args = [
+            "-m",
+            "flask",
+            "--app=simple_flask_app",
+            "run",
+            "--host=0.0.0.0",
+            "--port=5000",
+        ]
+
+        self._logger.debug(
+            "Deploying Application with store:// + DataStore profile source"
+        )
+        function.deploy(with_mlrun=False)
+        assert function.status.state == "ready"
+
+        # The source-loader init container must have the project-secret envFrom
+        # mount, otherwise the deploy would have failed at profile resolution.
+        # Asserting the spec wiring catches future regressions of the gating.
+        init_containers = function.spec.config.get("spec.initContainers") or []
+        loader = next(
+            c
+            for c in init_containers
+            if c.get("name") == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+        )
+        env_from = loader.get("envFrom") or []
+        expected_secret = f"mlrun-project-secrets-{self.project_name}"
+        assert any(
+            e.get("secretRef", {}).get("name") == expected_secret for e in env_from
+        ), (
+            f"Init container missing envFrom secretRef to {expected_secret}; "
+            f"got envFrom={env_from}"
+        )
+
+        # Functional check — the deployed flask app responds.
+        response = function.invoke("/", verify=False)
+        assert response.content.decode("utf-8") == "version-1"
 
     def _create_simple_flask_application(self, name="simple-flask-app", source=None):
         """Create a simple Flask application for testing source reload."""

--- a/tests/system/runtimes/test_nuclio_store_uri.py
+++ b/tests/system/runtimes/test_nuclio_store_uri.py
@@ -1,0 +1,260 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+import mlrun.common.constants
+import mlrun.datastore.datastore_profile as datastore_profile
+import tests.system.base
+
+
+@tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
+class TestNuclioStoreUri(tests.system.base.TestMLRunSystem):
+    """End-to-end coverage for vanilla Nuclio with store:// CodeArtifact sources.
+
+    These tests validate the init-container path the server installs when a
+    Nuclio function's source is a store:// CodeArtifact URI:
+
+      1. Source URI is stashed to status.application_source so the Nuclio
+         builder doesn't see store:// (which it cannot resolve).
+      2. An init container runs `mlrun load-source` and writes code into a
+         shared volume.
+      3. The main function container picks up the code via PYTHONPATH.
+    """
+
+    project_name = "nuclio-store-uri-system-test"
+
+    def custom_setup(self):
+        super().custom_setup()
+        self._handler_filename = "echo_handler.py"
+        self._function_handler = "echo_handler:handler"
+        self._function_image = os.environ.get("MLRUN_TEST_IMAGE")
+
+    def _log_code_artifact(self, key: str, src_path: str | None = None) -> str:
+        """Log a CodeArtifact and return its canonical store:// URI.
+
+        :param key:      Artifact key (must be unique per test).
+        :param src_path: Path to the source file. Defaults to the test's
+                         echo_handler asset.
+        :returns: The artifact's own ``.uri`` (whatever the system stored,
+                  including any tag suffix). Avoids reconstructing the URI
+                  from a string template — see TESTING_STANDARDS.md §7.
+        """
+        local_path = src_path or os.path.join(self.assets_path, self._handler_filename)
+        artifact = self.project.log_code_file(key=key, local_path=local_path)
+        return artifact.uri
+
+    def _assert_init_container_present(self, function):
+        """Assert the source-loader init container is wired correctly."""
+        init_containers = function.spec.config.get("spec.initContainers") or []
+        loader_containers = [
+            c
+            for c in init_containers
+            if c.get("name") == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+        ]
+        assert len(loader_containers) == 1, (
+            f"Expected exactly one source-loader init container, got "
+            f"{len(loader_containers)} (all init containers: {init_containers})"
+        )
+        assert loader_containers[0]["command"] == ["mlrun", "load-source"]
+
+    @staticmethod
+    def _versioned_handler_body(version: str) -> str:
+        """Return a Nuclio handler that responds with its module VERSION."""
+        return (
+            "import json\n"
+            "from http import HTTPStatus\n\n"
+            "import nuclio_sdk\n\n"
+            f"VERSION = {version!r}\n\n"
+            "def handler(context, event):\n"
+            "    return context.Response(\n"
+            "        body=json.dumps({'version': VERSION}),\n"
+            "        headers={},\n"
+            "        content_type='application/json',\n"
+            "        status_code=HTTPStatus.OK,\n"
+            "    )\n"
+        )
+
+    def test_deploy_and_artifact_update(self):
+        """End-to-end deploy + artifact-update redeploy via a DataStore profile.
+
+        Combines three concerns into a single deploy/redeploy cycle:
+
+        1. Artifact-update redeploy semantics — the init container fetches the
+           *current* artifact target on each deploy, not a cached copy
+           (log_code_file v1 → deploy → re-log v2 under same key+tag →
+           redeploy → handler returns v2).
+
+        2. Init container envFrom mount — asserts the deployed init container
+           references mlrun-project-secrets-<project> via envFrom. Verified on
+           the v1 deploy that's already happening (no extra wall time).
+
+        3. DataStore profile with private members — the artifact target is a
+           ds:// URL backed by a v3io profile carrying a private access key.
+           The v1/v2 deploys both require the init container to resolve the
+           profile (read its private body from env via the envFrom mount) and
+           use the resolved key to authenticate to v3io.
+        """
+        access_key = os.environ.get("V3IO_ACCESS_KEY")
+        assert access_key, "V3IO_ACCESS_KEY required for this system test"
+
+        profile_name = "nuclio-store-test-v3io-profile"
+        profile = datastore_profile.DatastoreProfileV3io(
+            name=profile_name,
+            v3io_access_key=access_key,
+        )
+        self.project.register_datastore_profile(profile)
+        # Also register client-side so log_code_file can resolve ds:// URLs.
+        datastore_profile.register_temporary_client_datastore_profile(profile)
+
+        # Note: we write to .py files (not log_code_file(body=...)) so the
+        # artifact's target_path keeps the .py extension — the loader does
+        # importlib.import_module(<key>), which requires a matching .py file
+        # in the source-loader output directory.
+        artifact_key = "artifact_update_handler"
+        artifact_target_path = (
+            f"ds://{profile_name}/projects/{self.project_name}/code/{artifact_key}.py"
+        )
+
+        with tempfile.TemporaryDirectory(
+            prefix="nuclio_store_artifact_update_"
+        ) as temp_dir:
+            handler_path = os.path.join(temp_dir, f"{artifact_key}.py")
+
+            # Use an explicit tag so each re-log under the same key+tag updates
+            # the tag's pointer to the new tree (instead of accumulating
+            # untagged versions, which makes the store:// URI ambiguous and
+            # breaks the server-side resolver with "Multiple rows found").
+            tag = "current"
+
+            with open(handler_path, "w") as f:
+                f.write(self._versioned_handler_body("v1"))
+            artifact_v1 = self.project.log_code_file(
+                key=artifact_key,
+                local_path=handler_path,
+                tag=tag,
+                target_path=artifact_target_path,
+            )
+            # Use the artifact's canonical URI rather than reconstructing it
+            # — the stored format may evolve (e.g. tree-ref encoding) and
+            # the test should follow whatever the system actually wrote.
+            store_uri = artifact_v1.uri
+
+            function = self.project.set_function(
+                func=store_uri,
+                name="nuclio-update-app",
+                kind="nuclio",
+                handler=f"{artifact_key}:handler",
+                image=self._function_image,
+            )
+
+            self._logger.debug("First deploy with v1 source")
+            function.deploy()
+            assert function.status.state == "ready"
+            self._assert_init_container_present(function)
+
+            # The source-loader init container for store:// sources mounts
+            # mlrun-project-secrets-<project> via envFrom, so the loader can
+            # resolve DataStore profiles with private members and authenticate
+            # to credential-protected datastores. Asserted on this deploy
+            # (already being done) to avoid an extra wall-time test.
+            init_containers = function.spec.config.get("spec.initContainers") or []
+            loader = next(
+                c
+                for c in init_containers
+                if c.get("name")
+                == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+            )
+            env_from = loader.get("envFrom") or []
+            expected_secret = f"mlrun-project-secrets-{self.project_name}"
+            assert any(
+                e.get("secretRef", {}).get("name") == expected_secret for e in env_from
+            ), (
+                f"Init container missing envFrom secretRef to {expected_secret}; "
+                f"got envFrom={env_from}"
+            )
+
+            v1_response = function.invoke("/")
+            assert v1_response == {"version": "v1"}
+
+            # Re-log under the same key+tag with v2 body — the tag pointer
+            # moves to the new tree, store:// URI resolves to v2.
+            with open(handler_path, "w") as f:
+                f.write(self._versioned_handler_body("v2"))
+            self.project.log_code_file(
+                key=artifact_key,
+                local_path=handler_path,
+                tag=tag,
+                target_path=artifact_target_path,
+            )
+            # The deploy clears spec.build.source server-side and stashes the
+            # original URI in status.application_source so subsequent
+            # (re)deploys can re-resolve it.
+            assert function.status.application_source == store_uri
+
+            self._logger.debug("Redeploying with v2 source")
+            function.deploy()
+            assert function.status.state == "ready"
+
+            v2_response = function.invoke("/")
+            assert v2_response == {"version": "v2"}
+
+    def test_cross_runtime_same_artifact(self):
+        """
+        Same store:// CodeArtifact used by both job and nuclio runtimes:
+        1. log_code_file → store://
+        2. Job runtime: set_function(kind="job"), run_function() succeeds.
+        3. Nuclio runtime: set_function(kind="nuclio"), deploy succeeds.
+
+        Confirms the same artifact URI is consumable by both runtime paths
+        and is preserved verbatim in spec.build.source for both.
+        """
+        # Use the job-style handler.py for the job side, echo handler for nuclio.
+        # We cannot share one handler signature across job + nuclio (the call
+        # contracts differ); the test asserts the *artifact URI* is consumable,
+        # not that one Python file works in both runtimes.
+        nuclio_uri = self._log_code_artifact("cross_runtime_nuclio_code")
+        job_uri = self._log_code_artifact(
+            "cross_runtime_job_code",
+            src_path=os.path.join(self.assets_path, "handler.py"),
+        )
+
+        nuclio_fn = self.project.set_function(
+            func=nuclio_uri,
+            name="cross-runtime-nuclio",
+            kind="nuclio",
+            handler=self._function_handler,
+            image=self._function_image,
+        )
+        assert nuclio_fn.spec.build.source == nuclio_uri
+
+        job_fn = self.project.set_function(
+            func=job_uri,
+            name="cross-runtime-job",
+            kind="job",
+            handler="handler.my_func",
+            image=self._function_image,
+        )
+        assert job_fn.spec.build.source == job_uri
+
+        self._logger.debug("Deploying nuclio side of cross-runtime test")
+        nuclio_fn.deploy()
+        assert nuclio_fn.status.state == "ready"
+        self._assert_init_container_present(nuclio_fn)
+
+        self._logger.debug("Running job side of cross-runtime test")
+        run = job_fn.run(params={"p1": 7})
+        assert run.state() == "completed"
+        assert run.outputs["accuracy"] == 14


### PR DESCRIPTION
### 📝 Description

Vanilla Nuclio and Serving functions cannot be deployed from a `store://`
CodeArtifact source today — Nuclio's native builder errors out with
"Couldn't resolve code entry type from source" because store:// is not a
type Nuclio knows. Until now the source-loader init-container path that
solves this was gated to Application runtime only.

This PR removes that gate for store:// sources on vanilla Nuclio and
Serving runtimes: the existing `mlrun load-source` init container is
re-used to fetch the artifact at deploy time, and a small generated
loader stub re-exports the user's real handler at runtime.

---

### 🛠️ Changes Made

- `services/api/crud/runtimes/nuclio/function.py::_compile_function_config`:
  for non-Application kinds with a store:// source, stash the URI to
  `status.application_source`, clear `spec.build.source` so the Nuclio
  builder doesn't see it, generate a dedicated loader stub as
  `functionSourceCode`, override `spec.handler` to point at the loader,
  and configure the source-loader init container.
- `_configure_source_loader_init_container`: `sidecar` parameter is now
  optional. When `None` (vanilla Nuclio/Serving), patches the main
  function container via the new `_patch_main_function_container` helper.
- `_patch_main_function_container`: injects PYTHONPATH into
  `function.spec.config["spec.env"]` (volumes are wired by the parent).
- `_ensure_source_loader_init_container`: dedupes init containers in BOTH
  `function.spec.config` and `function.spec.base_spec` — without the
  `base_spec` dedupe, redeploys hit "Duplicate value" because
  `extend_config` later merges `base_spec` with `config` and produces a
  duplicate.
- `NuclioStatus` gains `application_source` (URI stash for redeploy) and
  `original_handler` (handler stash for redeploy).
- `mlrun.common.constants.STORE_URI_HANDLER_LOADER_MODULE`: name of the
  generated loader module. A dedicated module name avoids the
  `/opt/nuclio` `sys.path[0]` shadow that would otherwise hide the
  user's real handler module loaded by the init container.

Git/archive sources with `pull_at_runtime` stay on the native Nuclio
path (`codeEntryType="git"/"archive"`) — only `store://` is redirected,
since Nuclio handles git/archive natively but not store://.

---

### ✅ Checklist

- [x] I updated the documentation (if applicable) — N/A, internal compile path
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes

---

### 🧪 Testing

**Unit tests** (`server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py`):

- `test_should_fetch_source_code_for_nuclio_with_store_uri`
- `test_compile_nuclio_function_with_store_source_has_init_container[nuclio|serving]`
- `test_nuclio_store_source_preserved_on_redeploy`
- `test_compile_nuclio_function_with_store_source_redeploy_is_idempotent` —
  pins the "Duplicate value" regression: init-container, MLRUN_REAL_HANDLER
  env, functionSourceCode, original_handler all stay single/stable on rebuild.
- `test_compile_nuclio_function_with_store_source_requires_handler` —
  fail-fast at compile time if no handler is provided.
- `test_compile_nuclio_function_with_custom_source_code_target_dir` —
  override flows through to the loader stub embedded path.
- `test_compile_nuclio_function_with_git_source_skips_loader_branch` —
  negative test: git sources don't accidentally pick up the loader.
- `test_patch_main_function_container_pythonpath_merge_logic` (4
  parametrized cases): empty / prepend / already-present / multi-entry.

**System tests** (`tests/system/runtimes/test_nuclio_store_uri.py` — new):

- `test_deploy_and_artifact_update`: log_code_file v1 → deploy → invoke
  (asserts init container + status.application_source preserved + v1
  response). Re-log v2 under same key+tag → redeploy → invoke (asserts
  v2 response). Proves the init container fetches the *current* artifact
  on each deploy, not a cached copy.
- `test_cross_runtime_same_artifact`: same store:// CodeArtifact consumed
  by both job and nuclio runtimes (different handler files per runtime).

Both system tests run end-to-end on vmdev76 with `MLRUN_TEST_IMAGE` set
to a runnable mlrun image.

---

### 🔗 References

Jira (this PR): ML-12480
Parent feature: ML-11980


---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---