### PR TITLE
[Runtimes] Make job + module:func handlers work for runtime-loaded source

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -438,8 +438,14 @@ def run(
     set_item(runobj.spec, scrape_metrics, "scrape_metrics")
     update_in(runtime, "metadata.name", name, replace=False)
     update_in(runtime, "metadata.project", project, replace=False)
-    if not kind and "." in handler:
-        # handle the case of module.submodule.handler
+    if not kind and isinstance(handler, str) and ("." in handler or ":" in handler):
+        # Handle module-prefixed handler forms: dotted ("pkg.mod.handler") or
+        # canonical mlrun ("mod:func"). Force "local" runtime — among the
+        # kinds new_function() will pick from {"", "local"} when no command is
+        # set, only LocalRuntime's _pre_run runs extract_source and sets
+        # spec.command + strips the handler prefix for runtime-loaded source
+        # (store:// CodeArtifact, git, archive). Without this, kind="" routes
+        # to HandlerRuntime which has no _pre_run override.
         update_in(runtime, "kind", "local")
 
     if kfp or runobj.spec.verbose or verbose:

--- a/mlrun/launcher/base.py
+++ b/mlrun/launcher/base.py
@@ -293,7 +293,12 @@ class BaseLauncher(abc.ABC):
         def_name = runtime.metadata.name
         if run.spec.handler_name:
             short_name = run.spec.handler_name
-            for separator in ["#", "::", "."]:
+            # Strip every recognized handler separator from the short name —
+            # `:` is required for the canonical mlrun "module:function" form
+            # (auto-name must be DNS-1123 valid; K8s rejects `:`). Ordered
+            # longest-match-first as a defensive convention; `split(...)[-1]`
+            # makes the end result invariant to this ordering today.
+            for separator in ["#", "::", ":", "."]:
                 # drop paths, module or class name from short name
                 if separator in short_name:
                     short_name = short_name.split(separator)[-1]

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -239,8 +239,16 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
             meta.name = function_name or meta.name
             meta.project = project or meta.project
 
-        # if the handler has module prefix force "local" (vs "handler") runtime
-        kind = "local" if isinstance(handler, str) and "." in handler else ""
+        # if the handler has module prefix (dotted "pkg.mod.fn" OR canonical
+        # "mod:fn") force "local" runtime — among the kinds new_function()
+        # will pick here (HandlerRuntime for "", LocalRuntime for "local"),
+        # only LocalRuntime's _pre_run runs extract_source and adds the
+        # workdir to sys.path.
+        kind = (
+            "local"
+            if isinstance(handler, str) and ("." in handler or ":" in handler)
+            else ""
+        )
 
         # Create temporary local function for execution
         fn = mlrun.new_function(meta.name, command=command, args=args, kind=kind)

--- a/mlrun/run.py
+++ b/mlrun/run.py
@@ -868,8 +868,9 @@ def code_to_function(
     if not name:
         raise ValueError("name must be specified")
 
-    h = get_in(spec, "spec.handler", "").split(":")
-    runtime.handler = h[0] if len(h) <= 1 else h[1]
+    _, runtime.handler = mlrun.utils.helpers.split_handler_module_and_function(
+        get_in(spec, "spec.handler", "")
+    )
     runtime.metadata = get_in(spec, "spec.metadata")
     runtime.metadata.name = name
     build = runtime.spec.build

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -285,6 +285,20 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
                 if os.path.isfile(candidate):
                     self.spec.command = candidate
                     runobj.spec.handler = func_name
+                else:
+                    # Surface the missing-file case with a useful breadcrumb
+                    # — without this log, a typo in the handler module name
+                    # falls through to a cryptic ImportError downstream when
+                    # _get_handler tries to load an empty spec.command.
+                    logger.warning(
+                        "module:func handler refers to a module that wasn't "
+                        "found in the extracted source directory; the run "
+                        "will likely fail to load the handler",
+                        handler=runobj.spec.handler or self.spec.default_handler,
+                        module_name=module_name,
+                        candidate=candidate,
+                        target_dir=target_dir,
+                    )
 
         if execution._current_workdir:
             execution._old_workdir = os.getcwd()

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -39,6 +39,7 @@ from nuclio import Event
 
 import mlrun
 import mlrun.common.constants as mlrun_constants
+import mlrun.utils.helpers
 from mlrun.lists import RunList
 from mlrun.package import handler as mlrun_handler_decorator
 
@@ -265,6 +266,25 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
                 execution._current_workdir = os.path.join(target_dir, workdir)
             else:
                 execution._current_workdir = workdir or target_dir
+
+            # When the source was extracted (e.g. from a store:// CodeArtifact)
+            # rather than baked into the function image, spec.command is empty -
+            # _get_handler / load_module would then have no file to import, and
+            # a `module:func` handler can't be resolved. Mirror the convention
+            # used by mlrun.code_to_function: spec.command holds the file,
+            # spec.handler holds just the function name; load_module loads the
+            # file, _search_in_namespaces finds the function in the loaded
+            # module.
+            module_name, func_name = (
+                mlrun.utils.helpers.split_handler_module_and_function(
+                    runobj.spec.handler or self.spec.default_handler or ""
+                )
+            )
+            if not self.spec.command and module_name:
+                candidate = os.path.join(target_dir, f"{module_name}.py")
+                if os.path.isfile(candidate):
+                    self.spec.command = candidate
+                    runobj.spec.handler = func_name
 
         if execution._current_workdir:
             execution._old_workdir = os.getcwd()

--- a/mlrun/runtimes/local.py
+++ b/mlrun/runtimes/local.py
@@ -267,14 +267,9 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
             else:
                 execution._current_workdir = workdir or target_dir
 
-            # When the source was extracted (e.g. from a store:// CodeArtifact)
-            # rather than baked into the function image, spec.command is empty -
-            # _get_handler / load_module would then have no file to import, and
-            # a `module:func` handler can't be resolved. Mirror the convention
-            # used by mlrun.code_to_function: spec.command holds the file,
-            # spec.handler holds just the function name; load_module loads the
-            # file, _search_in_namespaces finds the function in the loaded
-            # module.
+            # Source extracted at runtime (store:// CodeArtifact, git, archive)
+            # leaves spec.command empty, so a "module:func" handler can't resolve.
+            # Mirror code_to_function: command -> file, handler -> bare function.
             module_name, func_name = (
                 mlrun.utils.helpers.split_handler_module_and_function(
                     runobj.spec.handler or self.spec.default_handler or ""
@@ -286,10 +281,8 @@ class LocalRuntime(BaseRuntime, ParallelRunner):
                     self.spec.command = candidate
                     runobj.spec.handler = func_name
                 else:
-                    # Surface the missing-file case with a useful breadcrumb
-                    # — without this log, a typo in the handler module name
-                    # falls through to a cryptic ImportError downstream when
-                    # _get_handler tries to load an empty spec.command.
+                    # Warn so a handler-module typo doesn't end in a cryptic
+                    # ImportError downstream from an empty spec.command.
                     logger.warning(
                         "module:func handler refers to a module that wasn't "
                         "found in the extracted source directory; the run "

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1485,6 +1485,28 @@ def get_class(class_name, namespace=None):
     return class_object
 
 
+def split_handler_module_and_function(handler: str) -> tuple[str, str]:
+    """Split mlrun's ``"module:function"`` handler form into ``(module, function)``.
+
+    mlrun's canonical handler format on the wire is ``"<module>:<function>"`` —
+    e.g. ``"trainer:train_model"``. Internally on the runtime spec, however,
+    ``spec.handler`` typically holds JUST the function name (the module is
+    implicit in ``spec.command`` or in the loaded source file). This helper
+    bridges the two: callers split once and decide what to do with each part.
+
+    Bare function names (no colon) are returned with an empty module:
+    ``"my_func"`` -> ``("", "my_func")``.
+
+    :param handler: Handler string in either ``"module:function"`` or bare
+                    ``"function"`` form. Falsy values return ``("", "")``.
+    :returns: ``(module_name, function_name)``.
+    """
+    if not handler or ":" not in handler:
+        return "", handler or ""
+    module, _, function = handler.partition(":")
+    return module, function
+
+
 def get_function(function, namespaces, reload_modules: bool = False):
     """Return function callable object from function name string
 

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1485,7 +1485,7 @@ def get_class(class_name, namespace=None):
     return class_object
 
 
-def split_handler_module_and_function(handler: str) -> tuple[str, str]:
+def split_handler_module_and_function(handler: str | None) -> tuple[str, str]:
     """Split mlrun's ``"module:function"`` handler form into ``(module, function)``.
 
     mlrun's canonical handler format on the wire is ``"<module>:<function>"`` —

--- a/tests/launcher/test_local.py
+++ b/tests/launcher/test_local.py
@@ -107,8 +107,10 @@ def test_create_local_function_for_execution_with_enrichment():
 @pytest.mark.parametrize(
     "module_qualified_handler",
     [
-        "module.submodule.fn",  # dotted form (already works)
-        "handler:my_func",  # canonical mlrun module:func form (the new case)
+        # dotted form — already works
+        "module.submodule.fn",
+        # canonical mlrun module:func form — the new case
+        "handler:my_func",
     ],
 )
 def test_create_local_function_for_execution_picks_local_for_module_qualified_handler(
@@ -378,9 +380,10 @@ def test_enrich_run_name_strips_handler_module_prefix(handler_value, expected_su
     Order matters: the `::` separator (class-method) must split BEFORE `:`
     so MyClass::run_method becomes 'run_method', not 'method'."""
     launcher = mlrun.launcher.local.ClientLocalLauncher(local=False)
-    runtime = mlrun.code_to_function(
-        name="my-fn", kind="job", filename=str(func_path), handler=handler
-    )
+    # Build the runtime with NO default handler so the parametrized
+    # `handler_value` is the only handler input — keeps the data flow
+    # unambiguous when reading the test cold.
+    runtime = mlrun.code_to_function(name="my-fn", kind="job", filename=str(func_path))
     run = mlrun.run.RunObject()
     launcher._enrich_run(
         runtime=runtime,

--- a/tests/launcher/test_local.py
+++ b/tests/launcher/test_local.py
@@ -104,6 +104,43 @@ def test_create_local_function_for_execution_with_enrichment():
     assert runtime.spec.allow_empty_resources
 
 
+@pytest.mark.parametrize(
+    "module_qualified_handler",
+    [
+        "module.submodule.fn",  # dotted form (already works)
+        "handler:my_func",  # canonical mlrun module:func form (the new case)
+    ],
+)
+def test_create_local_function_for_execution_picks_local_for_module_qualified_handler(
+    module_qualified_handler,
+):
+    """Both dotted (`pkg.mod.fn`) and canonical (`mod:fn`) handler forms must
+    cause _create_local_function_for_execution to pick LocalRuntime — only
+    LocalRuntime has a _pre_run override that runs extract_source and puts
+    the workdir on sys.path. HandlerRuntime would silently starve.
+
+    The bug surfaces when the runtime has no embedded source code and no
+    inline command (source is fetched at runtime via git://, archive, or
+    store:// CodeArtifact) — in that case ``mlrun.new_function`` falls back
+    to ``HandlerRuntime`` unless the launcher passes ``kind="local"``.
+    """
+    launcher = mlrun.launcher.local.ClientLocalLauncher(local=False)
+    # simulate a job runtime whose source is loaded at runtime
+    # (git/archive/store) — no embedded source, no inline command. This is
+    # what makes the kind selector matter; otherwise the command path makes
+    # ``mlrun.new_function`` produce a LocalRuntime regardless.
+    runtime = mlrun.new_function(name="test", kind="job")
+    runtime.spec.build.source = "git://github.com/example/repo.git"
+    run = mlrun.run.RunObject()
+    fn = launcher._create_local_function_for_execution(
+        runtime=runtime,
+        run=run,
+        project="some-project",
+        handler=module_qualified_handler,
+    )
+    assert fn.kind == "local"
+
+
 def test_validate_inputs():
     launcher = mlrun.launcher.local.ClientLocalLauncher(local=False)
     runtime = mlrun.code_to_function(
@@ -323,3 +360,34 @@ def test_validate_run_retries_invalid_runtime():
         launcher._validate_run(runtime, run)
 
     assert "Retry is not supported for dask runtime" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "handler_value,expected_suffix",
+    [
+        ("handler:my_func", "my-func"),
+        ("MyClass::run_method", "run-method"),
+        ("pkg.mod.entrypoint", "entrypoint"),
+        ("hello_world", "hello-world"),
+    ],
+)
+def test_enrich_run_name_strips_handler_module_prefix(handler_value, expected_suffix):
+    """The auto-generated run.metadata.name must strip the module prefix from
+    every handler form mlrun accepts. Critically, the result must be a valid
+    DNS-1123 name - no `:` allowed - or the run will be rejected by K8s.
+    Order matters: the `::` separator (class-method) must split BEFORE `:`
+    so MyClass::run_method becomes 'run_method', not 'method'."""
+    launcher = mlrun.launcher.local.ClientLocalLauncher(local=False)
+    runtime = mlrun.code_to_function(
+        name="my-fn", kind="job", filename=str(func_path), handler=handler
+    )
+    run = mlrun.run.RunObject()
+    launcher._enrich_run(
+        runtime=runtime,
+        run=run,
+        handler=handler_value,
+        project_name="some-project",
+        name=None,
+    )
+    assert ":" not in run.metadata.name
+    assert run.metadata.name == f"my-fn-{expected_suffix}"

--- a/tests/runtimes/test_local.py
+++ b/tests/runtimes/test_local.py
@@ -15,6 +15,8 @@ import pathlib
 
 import pytest
 
+import mlrun
+import mlrun.runtimes.local
 from mlrun.runtimes.local import run_exec
 
 
@@ -47,9 +49,6 @@ def test_pre_run_points_command_at_extracted_module(tmp_path, monkeypatch):
     handler="module:func", ...), produce no module, and fail downstream
     with ModuleNotFoundError.
     """
-    import mlrun
-    import mlrun.runtimes.local
-
     # Pre-create the module file the helper will look for.
     target_dir = tmp_path / "extracted"
     target_dir.mkdir()
@@ -73,17 +72,12 @@ def test_pre_run_points_command_at_extracted_module(tmp_path, monkeypatch):
     assert run.spec.handler == "my_func"
 
 
-def test_pre_run_warns_when_module_not_in_extracted_dir(tmp_path, monkeypatch, caplog):
+def test_pre_run_warns_when_module_not_in_extracted_dir(tmp_path, monkeypatch):
     """When `module:func` is given but `<module>.py` doesn't exist in the
     extracted source dir, _pre_run logs a warning instead of silently
     falling through. Pinning this prevents the regression where a handler
     typo produces a cryptic ImportError far from the entry point.
     """
-    import logging
-
-    import mlrun
-    import mlrun.runtimes.local
-
     target_dir = tmp_path / "extracted"
     target_dir.mkdir()
     # Note: NO handler.py — the helper should warn about the missing file.
@@ -93,19 +87,27 @@ def test_pre_run_warns_when_module_not_in_extracted_dir(tmp_path, monkeypatch, c
         lambda *args, **kwargs: str(target_dir),
     )
 
+    # Capture logger.warning directly. caplog can miss records when the mlrun
+    # logger's propagate flag is toggled by other test setup, so observe the
+    # call site instead of relying on stdlib logging propagation.
+    warn_calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        mlrun.runtimes.local.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warn_calls.append((msg, kwargs)),
+    )
+
     runtime = mlrun.runtimes.local.LocalRuntime()
     runtime.spec.build.source = "store://artifacts/proj/missing_code"
     run = mlrun.run.RunObject()
     run.spec.handler = "missing_module:my_func"
     execution = mlrun.run.MLClientCtx.from_dict(run.to_dict(), autocommit=False)
 
-    with caplog.at_level(logging.WARNING, logger="mlrun"):
-        runtime._pre_run(run, execution)
+    runtime._pre_run(run, execution)
 
     assert any(
-        "module:func handler refers to a module that wasn't found"
-        in record.getMessage()
-        for record in caplog.records
+        "module:func handler refers to a module that wasn't found" in msg
+        for msg, _ in warn_calls
     )
     # spec.command stays unset; downstream handler logic raises with a less
     # cryptic error after the warning has been logged.

--- a/tests/runtimes/test_local.py
+++ b/tests/runtimes/test_local.py
@@ -36,3 +36,78 @@ def test_run_exec_verbose_stderr(return_code):
     assert out == "some output\n"
     expected_err_length = 100000 if return_code else 0
     assert len(err) == expected_err_length
+
+
+def test_pre_run_points_command_at_extracted_module(tmp_path, monkeypatch):
+    """`LocalRuntime._pre_run` points spec.command at the extracted module
+    file and strips the module prefix from the run handler when the source
+    is loaded at runtime (e.g. store:// CodeArtifact, git, archive).
+
+    Without this, _get_handler would call load_module(file_name="",
+    handler="module:func", ...), produce no module, and fail downstream
+    with ModuleNotFoundError.
+    """
+    import mlrun
+    import mlrun.runtimes.local
+
+    # Pre-create the module file the helper will look for.
+    target_dir = tmp_path / "extracted"
+    target_dir.mkdir()
+    handler_path = target_dir / "handler.py"
+    handler_path.write_text("def my_func(context):\n    return 42\n")
+
+    monkeypatch.setattr(
+        "mlrun.runtimes.local.extract_source",
+        lambda *args, **kwargs: str(target_dir),
+    )
+
+    runtime = mlrun.runtimes.local.LocalRuntime()
+    runtime.spec.build.source = "store://artifacts/proj/handler_code"
+    run = mlrun.run.RunObject()
+    run.spec.handler = "handler:my_func"
+    execution = mlrun.run.MLClientCtx.from_dict(run.to_dict(), autocommit=False)
+
+    runtime._pre_run(run, execution)
+
+    assert runtime.spec.command == str(handler_path)
+    assert run.spec.handler == "my_func"
+
+
+def test_pre_run_warns_when_module_not_in_extracted_dir(tmp_path, monkeypatch, caplog):
+    """When `module:func` is given but `<module>.py` doesn't exist in the
+    extracted source dir, _pre_run logs a warning instead of silently
+    falling through. Pinning this prevents the regression where a handler
+    typo produces a cryptic ImportError far from the entry point.
+    """
+    import logging
+
+    import mlrun
+    import mlrun.runtimes.local
+
+    target_dir = tmp_path / "extracted"
+    target_dir.mkdir()
+    # Note: NO handler.py — the helper should warn about the missing file.
+
+    monkeypatch.setattr(
+        "mlrun.runtimes.local.extract_source",
+        lambda *args, **kwargs: str(target_dir),
+    )
+
+    runtime = mlrun.runtimes.local.LocalRuntime()
+    runtime.spec.build.source = "store://artifacts/proj/missing_code"
+    run = mlrun.run.RunObject()
+    run.spec.handler = "missing_module:my_func"
+    execution = mlrun.run.MLClientCtx.from_dict(run.to_dict(), autocommit=False)
+
+    with caplog.at_level(logging.WARNING, logger="mlrun"):
+        runtime._pre_run(run, execution)
+
+    assert any(
+        "module:func handler refers to a module that wasn't found"
+        in record.getMessage()
+        for record in caplog.records
+    )
+    # spec.command stays unset; downstream handler logic raises with a less
+    # cryptic error after the warning has been logged.
+    assert not runtime.spec.command
+    assert run.spec.handler == "missing_module:my_func"

--- a/tests/system/runtimes/test_applications_store_uri.py
+++ b/tests/system/runtimes/test_applications_store_uri.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import mlrun.common.constants
+import tests.system.base
+
+
+@tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
+class TestApplicationStoreUri(tests.system.base.TestMLRunSystem):
+    """End-to-end coverage for kind=application functions whose source is an
+    explicit store:// CodeArtifact URI.
+
+    The application runtime supports store:// via a server-installed init
+    container ('mlrun load-source') that downloads code into a shared volume
+    before the user's sidecar container starts. This is pre-existing
+    infrastructure - already in development - that pr-b shipped without an
+    end-to-end test using an explicit store:// URI. (The auto-upload path is
+    covered by test_deploy_application_with_source_reload; this test covers
+    the explicit-URI path users hit when integrating with external code
+    artifact systems like Vera.)
+    """
+
+    project_name = "application-store-uri-system-test"
+
+    def custom_setup(self):
+        super().custom_setup()
+        self._app_filename = "simple_flask_app.py"
+        self._function_image = os.environ.get("MLRUN_TEST_IMAGE", "mlrun/mlrun")
+
+    def _log_code_artifact(self, key: str) -> str:
+        """Log the assets/simple_flask_app.py file as a CodeArtifact and
+        return its store:// URI."""
+        local_path = os.path.join(self.assets_path, self._app_filename)
+        self.project.log_code_file(key=key, local_path=local_path)
+        return f"store://artifacts/{self.project_name}/{key}"
+
+    def _assert_init_container_present(self, function):
+        """Assert the source-loader init container is wired correctly."""
+        init_containers = function.spec.config.get("spec.initContainers") or []
+        loader_containers = [
+            c
+            for c in init_containers
+            if c.get("name") == mlrun.common.constants.SOURCE_LOADER_INIT_CONTAINER_NAME
+        ]
+        assert len(loader_containers) == 1, (
+            f"Expected exactly one source-loader init container, got "
+            f"{len(loader_containers)} (all init containers: {init_containers})"
+        )
+        assert loader_containers[0]["command"] == ["mlrun", "load-source"]
+
+    def test_e2e_application_function_from_store_artifact(self):
+        """Application kind + explicit store:// URI.
+
+        Flow:
+          1. log_code_file uploads simple_flask_app.py as a CodeArtifact.
+          2. set_function with kind="application" and func=<store-uri>.
+          3. deploy_function - server installs the source-loader init
+             container; the init container downloads the code at pod start.
+          4. Asserts the init container is wired and the application
+             responds.
+        """
+        store_uri = self._log_code_artifact("app_code")
+
+        function = self.project.set_function(
+            func=store_uri,
+            name="app-from-store",
+            kind="application",
+            requirements=["Flask==3.0.0"],
+            image=self._function_image,
+        )
+        function.set_internal_application_port(5000)
+        function.spec.command = "python"
+        function.spec.args = [
+            "-m",
+            "flask",
+            f"--app={os.path.splitext(self._app_filename)[0]}",
+            "run",
+            "--host=0.0.0.0",
+            "--port=5000",
+        ]
+        function.set_probe(type="readiness", http_path="/", period_seconds=2)
+
+        function.deploy(with_mlrun=False)
+
+        # store:// must remain in the function spec after deploy.
+        db_function = self.project.get_function("app-from-store")
+        assert db_function.spec.build.source == store_uri, (
+            f"Expected store:// URI preserved in DB, got "
+            f"{db_function.spec.build.source!r}"
+        )
+
+        self._assert_init_container_present(db_function)
+
+        # Functional check: the app is reachable AND the init container
+        # actually downloaded the right code. simple_flask_app.py returns
+        # "version-1" from /; if the init container failed to download, the
+        # sidecar wouldn't have the module and Flask would 500.
+        response = function.invoke("/", verify=False)
+        assert response.content.decode("utf-8") == "version-1"

--- a/tests/system/runtimes/test_applications_store_uri.py
+++ b/tests/system/runtimes/test_applications_store_uri.py
@@ -42,10 +42,21 @@ class TestApplicationStoreUri(tests.system.base.TestMLRunSystem):
 
     def _log_code_artifact(self, key: str) -> str:
         """Log the assets/simple_flask_app.py file as a CodeArtifact and
-        return its store:// URI."""
+        return its canonical store:// URI.
+
+        The asset (``tests/system/runtimes/assets/simple_flask_app.py``)
+        is the existing Flask app used by other system tests in this
+        directory — it returns ``"version-1"`` from ``/`` which the
+        invocation assertion below pins.
+
+        Uses the artifact's own ``.uri`` rather than rebuilding
+        ``f"store://artifacts/<project>/<key>"`` from a template — the
+        reconstructed value can drift from what the system actually
+        stored. See TESTING_STANDARDS §7.
+        """
         local_path = os.path.join(self.assets_path, self._app_filename)
-        self.project.log_code_file(key=key, local_path=local_path)
-        return f"store://artifacts/{self.project_name}/{key}"
+        artifact = self.project.log_code_file(key=key, local_path=local_path)
+        return artifact.uri
 
     def _assert_init_container_present(self, function):
         """Assert the source-loader init container is wired correctly."""

--- a/tests/system/runtimes/test_jobs_store_uri.py
+++ b/tests/system/runtimes/test_jobs_store_uri.py
@@ -38,10 +38,20 @@ class TestJobStoreUri(tests.system.base.TestMLRunSystem):
 
     def _log_code_artifact(self, key: str) -> str:
         """Log the assets/handler.py file as a CodeArtifact and return its
-        store:// URI."""
+        canonical store:// URI.
+
+        The asset (``tests/system/runtimes/assets/handler.py``) is the
+        existing handler used by other system tests in this directory —
+        its ``my_func`` callable returns deterministic outputs we assert on.
+
+        Uses the artifact's own ``.uri`` rather than rebuilding
+        ``f"store://artifacts/<project>/<key>"`` from a template — the
+        reconstructed value can drift from what the system actually stored
+        (tag suffixes, scheme changes). See TESTING_STANDARDS §7.
+        """
         local_path = os.path.join(self.assets_path, self._handler_filename)
-        self.project.log_code_file(key=key, local_path=local_path)
-        return f"store://artifacts/{self.project_name}/{key}"
+        artifact = self.project.log_code_file(key=key, local_path=local_path)
+        return artifact.uri
 
     def test_e2e_job_function_from_store_artifact(self):
         """Job kind + store:// + canonical ``module:function`` handler form.

--- a/tests/system/runtimes/test_jobs_store_uri.py
+++ b/tests/system/runtimes/test_jobs_store_uri.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import tests.system.base
+
+
+@tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
+class TestJobStoreUri(tests.system.base.TestMLRunSystem):
+    """End-to-end coverage for kind=job functions whose source is a store://
+    CodeArtifact URI.
+
+    pr-b (#9609) shipped the SDK + server-side enrich pieces for this flow
+    but had no end-to-end test. This file fills that gap and verifies the
+    three colon-handler fixes that landed alongside it (launcher kind
+    selector, LocalRuntime._pre_run command-pointing, auto-name separator)
+    by using the canonical ``module:function`` handler form.
+    """
+
+    project_name = "job-store-uri-system-test"
+
+    def custom_setup(self):
+        super().custom_setup()
+        self._handler_filename = "handler.py"
+        self._function_image = os.environ.get("MLRUN_TEST_IMAGE", "mlrun/mlrun")
+
+    def _log_code_artifact(self, key: str) -> str:
+        """Log the assets/handler.py file as a CodeArtifact and return its
+        store:// URI."""
+        local_path = os.path.join(self.assets_path, self._handler_filename)
+        self.project.log_code_file(key=key, local_path=local_path)
+        return f"store://artifacts/{self.project_name}/{key}"
+
+    def test_e2e_job_function_from_store_artifact(self):
+        """Job kind + store:// + canonical ``module:function`` handler form.
+
+        Flow:
+          1. log_code_file uploads handler.py as a CodeArtifact and returns
+             its store:// URI.
+          2. set_function with kind="job", handler="handler:my_func".
+          3. function.run(params={"p1": 5}) — the pod downloads the artifact
+             at startup, _pre_run points spec.command at the extracted
+             handler.py, and my_func runs.
+          4. Asserts state=completed and accuracy=10 (my_func sets
+             accuracy = p1 * 2).
+        """
+        store_uri = self._log_code_artifact("job_code")
+
+        function = self.project.set_function(
+            func=store_uri,
+            name="job-from-store",
+            kind="job",
+            handler="handler:my_func",
+            image=self._function_image,
+        )
+
+        run = function.run(params={"p1": 5})
+
+        assert run.status.state == "completed", (
+            f"Run did not complete: state={run.status.state}, error={run.status.error}"
+        )
+        assert run.status.results["accuracy"] == 10, (
+            f"Expected accuracy=10, got {run.status.results.get('accuracy')!r}"
+        )
+
+        # store:// must remain in the function spec after run - server must
+        # never resolve it back to s3:// in the DB.
+        db_function = self.project.get_function("job-from-store")
+        assert db_function.spec.build.source == store_uri, (
+            f"Expected store:// URI preserved in DB, got "
+            f"{db_function.spec.build.source!r}"
+        )

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -2346,3 +2346,21 @@ def test_remove_image_protocol_prefix(image, expected):
     assert result == expected, (
         f"Expected '{expected}' for image '{image}', got '{result}'"
     )
+
+
+@pytest.mark.parametrize(
+    "handler,expected",
+    [
+        ("trainer:train_model", ("trainer", "train_model")),
+        ("my_func", ("", "my_func")),
+        ("", ("", "")),
+        (None, ("", "")),
+        # leading/trailing whitespace is preserved by partition (caller's
+        # responsibility) — this is just documenting current behavior:
+        ("a:b:c", ("a", "b:c")),  # only the FIRST colon splits
+    ],
+)
+def test_split_handler_module_and_function(handler, expected):
+    from mlrun.utils.helpers import split_handler_module_and_function
+
+    assert split_handler_module_and_function(handler) == expected

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -2355,9 +2355,9 @@ def test_remove_image_protocol_prefix(image, expected):
         ("my_func", ("", "my_func")),
         ("", ("", "")),
         (None, ("", "")),
-        # leading/trailing whitespace is preserved by partition (caller's
-        # responsibility) — this is just documenting current behavior:
-        ("a:b:c", ("a", "b:c")),  # only the FIRST colon splits
+        # only the FIRST colon splits — partition() returns
+        # ("a", ":", "b:c"), not split's ["a", "b", "c"]
+        ("a:b:c", ("a", "b:c")),
     ],
 )
 def test_split_handler_module_and_function(handler, expected):


### PR DESCRIPTION
## 📝 Description

PR #9609 (ML-11980 / pr-b) shipped `store://` CodeArtifact support for jobs but the canonical `module:function` handler form was broken end-to-end whenever the source had to be loaded at runtime (`store://`, `git://`, archive). Three separate mlrun code paths each accepted `.` as a module-prefix separator but missed `:`. Cluster validation on vmdev76 surfaced a fourth site in `mlrun/__main__.py` that the launcher-side fix doesn't cover.

This PR also fills the system-test coverage gap pr-b shipped without — `kind=job` + `store://` and `kind=application` + `store://` end-to-end flows now have dedicated tests.

## 🛠️ Changes Made

**Code fixes (4 line-level + 1 small refactor)**

- `mlrun/launcher/local.py` — kind selector in `ClientLocalLauncher._create_local_function_for_execution` accepts `:` (covers `function.run(local=True)` path)
- `mlrun/__main__.py` — parallel kind selector in the `mlrun run` CLI accepts `:` (covers the K8s job pod path: `mlrun run --from-env --handler mod:func --source store://...`)
- `mlrun/runtimes/local.py` — `LocalRuntime._pre_run` points `spec.command` at the extracted `<module>.py` and strips the module prefix from `runobj.spec.handler` when source is loaded at runtime
- `mlrun/launcher/base.py` — auto-name separator list adds `:` so `run.metadata.name` stays DNS-1123 valid for `module:func` handlers
- `mlrun/utils/helpers.py` + `mlrun/run.py` — extracted `split_handler_module_and_function` helper, reused from `code_to_function` and the new `_pre_run` logic

**Tests**

- 3 new parametrized unit tests in `tests/utils/test_helpers.py` and `tests/launcher/test_local.py` (helper round-trip, kind-selector branch, run-name stripping)
- 2 new system tests: `tests/system/runtimes/test_jobs_store_uri.py` and `tests/system/runtimes/test_applications_store_uri.py` — both passed on vmdev76
- System tests default image to `mlrun/mlrun` (matching `test_archives.py` / `test_kubejob.py`); `MLRUN_TEST_IMAGE` env var overrides

## ✅ Checklist

- [x] Format/lint clean (`ruff format`, `ruff check`)
- [x] Unit tests pass locally (557 in launcher / runtimes / utils sweep)
- [x] System tests pass on vmdev76 (job + application)
- [x] No public API docs needed updating (handler form already documented; helper is internal)
- [x] No secrets in diff
- [x] Independent of pr-c (ML-12480 Nuclio init container) — neither test uses pr-c-only symbols

## 🧪 Testing

**Unit (local)**
```
pytest tests/utils/test_helpers.py tests/launcher/ \
       tests/runtimes/test_local.py tests/runtimes/test_function.py
# 557 passed
```

**System (vmdev76)**
```
pytest tests/system/runtimes/test_jobs_store_uri.py \
       tests/system/runtimes/test_applications_store_uri.py
# 2 passed in 4:17
```

## 🔗 References

- Jira: [ML-11980](https://iguazio.atlassian.net/browse/ML-11980) (parent feature: load functions from artifact)
- Jira: [ML-12479](https://iguazio.atlassian.net/browse/ML-12479) (pr-b deficiency)
- Builds on: #9609 (pr-b — already merged)

## 🚨 Breaking Changes

**No.** All changes are gated behind conditions that don't trigger for existing flows:
- New colon-handler paths only activate when handler contains `:`
- `_pre_run` command-pointing only activates when `spec.command` is empty AND module name is set AND the file exists in `target_dir`
- Refactored `split(":")` in `code_to_function` produces identical results for all bare and single-colon inputs (multi-colon `"a:b:c"` now yields `"b:c"` instead of `"b"` — pinned by the new helper test; this form is exotic and undocumented)

[ML-11980]: https://iguazio.atlassian.net/browse/ML-11980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ