### PR TITLE
[Projects] Download store:// function and workflow code during zip export

### DIFF
--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -188,6 +188,8 @@ def get_store_resource(
             tree=tree,
             uid=uid,
         )
+        if not resource:
+            return None
         if resource.get("kind", "") == "link":
             # todo: support other link types (not just iter, move this to the db/api layer
             link_iteration = resource["spec"].get("link_iteration", 0)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -3980,57 +3980,63 @@ class MlrunProject(ModelObj):
         project_dir = pathlib.Path(project_file_path).parent
         project_dir.mkdir(parents=True, exist_ok=True)
 
-        original_function_definitions = self.spec._function_definitions
-        original_workflows = self.spec._workflows
-        working_function_definitions = original_function_definitions
-        working_workflows = original_workflows
-        staged_downloads: list[tuple[pathlib.Path, str]] = []
+        # On-disk project.yaml always carries the ORIGINAL store:// URIs,
+        # which resolve at load time. Pre-zip-export PRs already wrote the
+        # yaml here; rewriting it would leave the user's context dir holding
+        # paths that only resolve inside the zip, breaking
+        # load_project(<context>) afterwards.
+        with open(project_file_path, "w") as fp:
+            fp.write(self.to_yaml())
 
-        with contextlib.ExitStack() as stack:
-            if archive_code:
-                staging_dir = stack.enter_context(
-                    tempfile.TemporaryDirectory(prefix="mlrun-export-")
-                )
-                (
-                    working_function_definitions,
-                    working_workflows,
-                    staged_downloads,
-                    download_failures,
-                ) = _stage_store_downloads_for_export(
-                    spec=self.spec,
-                    staging_dir=staging_dir,
-                    project_name=self.metadata.name,
-                )
-                if download_failures:
-                    # Fail-fast: a partially-rewritten YAML would silently
-                    # ship store:// URIs that won't resolve on the destination
-                    # cluster, defeating the point of a self-contained zip.
-                    # Per-URI warnings were already logged by the helper.
-                    raise mlrun.errors.MLRunRuntimeError(
-                        f"Failed to download {len(download_failures)} "
-                        f"store:// reference(s) during zip export: "
-                        f"{download_failures}. See per-URI warning logs for "
-                        f"the specific error of each."
-                    )
+        if not archive_code:
+            return
 
-            # Install rewritten copies for to_yaml(), restore originals so
-            # callers see no mutation. No-op when archive_code=False.
+        with tempfile.TemporaryDirectory(prefix="mlrun-export-") as staging_dir:
+            (
+                working_function_definitions,
+                working_workflows,
+                staged_downloads,
+                download_failures,
+            ) = _stage_store_downloads_for_export(
+                spec=self.spec,
+                staging_dir=staging_dir,
+                project_name=self.metadata.name,
+            )
+            if download_failures:
+                # Fail-fast: a partially-rewritten YAML would silently ship
+                # store:// URIs that won't resolve on the destination
+                # cluster, defeating the point of a self-contained zip.
+                # Per-URI warnings were already logged by the helper.
+                raise mlrun.errors.MLRunRuntimeError(
+                    f"Failed to download {len(download_failures)} "
+                    f"store:// reference(s) during zip export: "
+                    f"{download_failures}. See per-URI warning logs for "
+                    f"the specific error of each."
+                )
+
+            # Capture rewritten YAML as a string (NOT to disk under the
+            # user's context). Writing it to <context>/project.yaml would
+            # leave behind a YAML whose .mlrun/code/... paths resolve only
+            # inside the zip, breaking subsequent load_project(<context>).
+            # The rewritten YAML is added to the zip directly by
+            # _build_export_zip via writestr("project.yaml", ...).
+            original_function_definitions = self.spec._function_definitions
+            original_workflows = self.spec._workflows
             try:
                 self.spec._function_definitions = working_function_definitions
                 self.spec._workflows = working_workflows
-                with open(project_file_path, "w") as fp:
-                    fp.write(self.to_yaml())
+                rewritten_yaml = self.to_yaml()
             finally:
                 self.spec._function_definitions = original_function_definitions
                 self.spec._workflows = original_workflows
 
-            if archive_code:
-                _build_export_zip(
-                    filepath=filepath,
-                    project_dir=project_dir,
-                    files_filter=include_files or "**",
-                    staged_downloads=staged_downloads,
-                )
+            _build_export_zip(
+                filepath=filepath,
+                project_dir=project_dir,
+                files_filter=include_files or "**",
+                staged_downloads=staged_downloads,
+                rewritten_yaml=rewritten_yaml,
+            )
 
     def set_model_monitoring_credentials(
         self,
@@ -6133,31 +6139,16 @@ def _download_store_artifact_for_export(
               inside ``staging_dir``; ``zip_arcname`` is the POSIX-style
               relative path that the caller embeds in the exported
               ``project.yaml`` AND uses as the arcname when adding the file
-              to the zip. Returns ``None`` on recoverable failure (artifact
-              missing, network/IO error).
-    :raises:  MLRunInvalidArgumentError if the resolved store:// URI does not
-              point to a code-bearing artifact (e.g., user passed a feature-
-              set URI as a function source).
+              to the zip. Returns ``None`` on any recoverable failure:
+              artifact missing, wrong artifact kind (not a CodeArtifact),
+              empty download body, or network/IO error. The caller logs the
+              specific error per-URI and aggregates all failures into a
+              single ``MLRunRuntimeError`` at end of the walk.
     """
     # Do not log target_path: for some datastores it may be a presigned URL
     # carrying credentials. store_uri is the public handle and is safe.
     try:
-        try:
-            artifact = mlrun.datastore.get_store_resource(
-                store_uri, project=project_name
-            )
-        except AttributeError as exc:
-            # Upstream get_store_resource calls .get(...) on the read_artifact
-            # result before its own None-check (store_resources.py:191), so a
-            # missing artifact surfaces as `'NoneType' object has no attribute
-            # 'get'`. Translate that one specific case to MLRunNotFoundError;
-            # any other AttributeError is a real bug or unrelated upstream
-            # failure — propagate so it's visible.
-            if "NoneType" not in str(exc):
-                raise
-            raise mlrun.errors.MLRunNotFoundError(
-                f"store:// artifact not found: {store_uri}"
-            ) from exc
+        artifact = mlrun.datastore.get_store_resource(store_uri, project=project_name)
         if artifact is None:
             raise mlrun.errors.MLRunNotFoundError(
                 f"store:// artifact not found: {store_uri}"
@@ -6173,6 +6164,17 @@ def _download_store_artifact_for_export(
                 f"code artifact)"
             )
         target_path = artifact.get_target_path()
+        if not target_path:
+            # Artifact exists in the DB but has no backing target_path
+            # (e.g., inline-body artifact registered without a stored file).
+            # Mirror the wrong-kind branch above: the URI resolves to
+            # something structurally unusable as a code source, so it's an
+            # invalid argument rather than a not-found. Caught by the
+            # aggregate handler below.
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"store:// artifact has no target path (cannot be used as a "
+                f"code source): {store_uri}"
+            )
         filename = os.path.basename(target_path)
         # Hash on target_path (not store_uri) so different URIs that resolve
         # to the same backing file produce the same local filename — and so
@@ -6183,16 +6185,28 @@ def _download_store_artifact_for_export(
         unique_filename = f"{basename}_{path_hash}{ext}"
         real_path = pathlib.Path(staging_dir) / unique_filename
         mlrun.get_dataitem(target_path).download(str(real_path))
+        if not real_path.exists() or real_path.stat().st_size == 0:
+            # Some backends return HTTP 200 with an empty body on transient
+            # failure. Shipping a zero-byte file would silently produce a
+            # broken zip; treat the backing bytes as missing so the caller
+            # aggregates it with the other download failures.
+            raise mlrun.errors.MLRunNotFoundError(
+                f"downloaded code artifact is empty: {store_uri}"
+            )
         # POSIX-style separators in the YAML so the zip unpacks correctly
         # on any OS the recipient uses.
         arcname = f".mlrun/code/{unique_filename}"
         return real_path, arcname
-    except mlrun.errors.MLRunInvalidArgumentError:
-        raise
-    except (mlrun.errors.MLRunNotFoundError, OSError, ConnectionError) as exc:
-        # Best-effort: a single broken artifact must not abort the entire
-        # export. Caller logs an aggregate summary; YAML keeps the original
-        # store:// URI for the broken function.
+    except (
+        mlrun.errors.MLRunNotFoundError,
+        mlrun.errors.MLRunInvalidArgumentError,
+        OSError,
+        ConnectionError,
+    ) as exc:
+        # Aggregate all per-URI failures uniformly: missing artifact, wrong
+        # artifact kind, and IO errors all become "this URI failed" so the
+        # caller can raise a single MLRunRuntimeError listing every failure
+        # rather than aborting mid-walk on the first wrong-kind URI.
         logger.warning(
             "Failed to download code artifact for export",
             store_uri=store_uri,
@@ -6203,16 +6217,15 @@ def _download_store_artifact_for_export(
 
 
 def _stage_store_downloads_for_export(
-    spec,
+    spec: "ProjectSpec",
     staging_dir: str,
     project_name: str,
-) -> tuple[dict, dict, list[tuple[pathlib.Path, str]], list[str]]:
+) -> tuple[dict, dict, dict[str, pathlib.Path], list[str]]:
     """Walk function and workflow definitions, download store:// sources into
     ``staging_dir``, and return rewritten copies of the spec dicts plus the
     bookkeeping the caller needs to finish the export.
 
-    Source-bearing fields handled (Pre-submit audit #1 — polymorphic-branch
-    parity): dict-form ``func_def["url"]``, BaseRuntime
+    Source-bearing fields handled: dict-form ``func_def["url"]``, BaseRuntime
     ``func_def.spec.build.source``, ``WorkflowSpec.path``. Other BaseRuntime
     fields (``spec.command``, ``spec.image``) are cmd/container values, never
     store:// URIs.
@@ -6221,13 +6234,14 @@ def _stage_store_downloads_for_export(
               staged_downloads, failures)`` where the first two are deepcopies
               of ``spec._function_definitions`` and ``spec._workflows`` with
               ``store://`` URIs rewritten to local arcnames; ``staged_downloads``
-              is a list of ``(real_path_in_staging, zip_arcname)`` pairs to
-              write into the zip; ``failures`` lists names whose download
-              returned ``None`` (best-effort skip).
+              is a ``{zip_arcname: real_path_in_staging}`` map (dict so
+              multiple functions sharing the same store:// URI don't add
+              duplicate zip entries); ``failures`` lists names whose download
+              returned ``None``.
     """
     working_function_definitions = deepcopy(spec._function_definitions)
     working_workflows = deepcopy(spec._workflows)
-    staged_downloads: list[tuple[pathlib.Path, str]] = []
+    staged_downloads: dict[str, pathlib.Path] = {}
     failures: list[str] = []
 
     for name, func_def in working_function_definitions.items():
@@ -6249,7 +6263,7 @@ def _stage_store_downloads_for_export(
             )
             if result is not None:
                 real_path, arcname = result
-                staged_downloads.append((real_path, arcname))
+                staged_downloads[arcname] = real_path
                 if isinstance(func_def, dict):
                     func_def["url"] = arcname
                 elif hasattr(func_def, "spec"):
@@ -6267,7 +6281,7 @@ def _stage_store_downloads_for_export(
             )
             if result is not None:
                 real_path, arcname = result
-                staged_downloads.append((real_path, arcname))
+                staged_downloads[arcname] = real_path
                 workflow_spec.path = arcname
             else:
                 failures.append(name)
@@ -6279,25 +6293,42 @@ def _build_export_zip(
     filepath: str,
     project_dir: pathlib.Path,
     files_filter: str,
-    staged_downloads: list[tuple[pathlib.Path, str]],
+    staged_downloads: dict[str, pathlib.Path],
+    rewritten_yaml: str,
 ) -> None:
     """Build the project export zip and (if ``filepath`` is a remote URL)
     upload it via mlrun.get_dataitem.
 
-    The zip combines two sources: regular project files under ``project_dir``
-    walked with the user's ``files_filter`` glob, and files staged in a
-    tmpdir during the download phase added with explicit ``arcname``s.
+    The zip combines three sources: the rewritten ``project.yaml`` (with
+    ``store://`` URIs replaced by local arcnames), regular project files
+    under ``project_dir`` walked with the user's ``files_filter`` glob, and
+    files staged in a tmpdir during the download phase added with explicit
+    arcnames.
+
+    The rewritten yaml is written ONLY into the zip — never to disk under
+    ``project_dir`` — so a subsequent ``load_project(project_dir)`` still
+    sees the original ``store://`` URIs and resolves them at load time.
+    Any ``project.yaml`` already present under ``project_dir`` is skipped
+    during the glob so we don't ship two copies (the rewritten one wins).
     """
     with tempfile.NamedTemporaryFile(suffix=".zip") as f:
         remote_file = "://" in filepath
         fpath = f.name if remote_file else filepath
         with zipfile.ZipFile(fpath, "w") as zipf:
+            zipf.writestr("project.yaml", rewritten_yaml)
             for file_path in glob.iglob(
                 f"{project_dir}/{files_filter}", recursive=True
             ):
                 write_path = pathlib.Path(file_path)
-                zipf.write(write_path, arcname=write_path.relative_to(project_dir))
-            for real_path, arcname in staged_downloads:
+                arcname = write_path.relative_to(project_dir)
+                if str(arcname) == "project.yaml":
+                    # Already written from rewritten_yaml above. Skipping
+                    # avoids a duplicate-entry warning from zipfile and
+                    # guarantees the rewritten copy is the one that lands
+                    # in the zip.
+                    continue
+                zipf.write(write_path, arcname=arcname)
+            for arcname, real_path in staged_downloads.items():
                 zipf.write(real_path, arcname=arcname)
         if remote_file:
             mlrun.get_dataitem(filepath).upload(zipf.filename)

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -16,6 +16,7 @@ import contextlib
 import datetime
 import getpass
 import glob
+import hashlib
 import http
 import importlib.util as imputil
 import json
@@ -3978,24 +3979,58 @@ class MlrunProject(ModelObj):
 
         project_dir = pathlib.Path(project_file_path).parent
         project_dir.mkdir(parents=True, exist_ok=True)
-        with open(project_file_path, "w") as fp:
-            fp.write(self.to_yaml())
 
-        if archive_code:
-            files_filter = include_files or "**"
-            with tempfile.NamedTemporaryFile(suffix=".zip") as f:
-                remote_file = "://" in filepath
-                fpath = f.name if remote_file else filepath
-                with zipfile.ZipFile(fpath, "w") as zipf:
-                    for file_path in glob.iglob(
-                        f"{project_dir}/{files_filter}", recursive=True
-                    ):
-                        write_path = pathlib.Path(file_path)
-                        zipf.write(
-                            write_path, arcname=write_path.relative_to(project_dir)
-                        )
-                if remote_file:
-                    mlrun.get_dataitem(filepath).upload(zipf.filename)
+        original_function_definitions = self.spec._function_definitions
+        original_workflows = self.spec._workflows
+        working_function_definitions = original_function_definitions
+        working_workflows = original_workflows
+        staged_downloads: list[tuple[pathlib.Path, str]] = []
+
+        with contextlib.ExitStack() as stack:
+            if archive_code:
+                staging_dir = stack.enter_context(
+                    tempfile.TemporaryDirectory(prefix="mlrun-export-")
+                )
+                (
+                    working_function_definitions,
+                    working_workflows,
+                    staged_downloads,
+                    download_failures,
+                ) = _stage_store_downloads_for_export(
+                    spec=self.spec,
+                    staging_dir=staging_dir,
+                    project_name=self.metadata.name,
+                )
+                if download_failures:
+                    # Fail-fast: a partially-rewritten YAML would silently
+                    # ship store:// URIs that won't resolve on the destination
+                    # cluster, defeating the point of a self-contained zip.
+                    # Per-URI warnings were already logged by the helper.
+                    raise mlrun.errors.MLRunRuntimeError(
+                        f"Failed to download {len(download_failures)} "
+                        f"store:// reference(s) during zip export: "
+                        f"{download_failures}. See per-URI warning logs for "
+                        f"the specific error of each."
+                    )
+
+            # Install rewritten copies for to_yaml(), restore originals so
+            # callers see no mutation. No-op when archive_code=False.
+            try:
+                self.spec._function_definitions = working_function_definitions
+                self.spec._workflows = working_workflows
+                with open(project_file_path, "w") as fp:
+                    fp.write(self.to_yaml())
+            finally:
+                self.spec._function_definitions = original_function_definitions
+                self.spec._workflows = original_workflows
+
+            if archive_code:
+                _build_export_zip(
+                    filepath=filepath,
+                    project_dir=project_dir,
+                    files_filter=include_files or "**",
+                    staged_downloads=staged_downloads,
+                )
 
     def set_model_monitoring_credentials(
         self,
@@ -6080,6 +6115,192 @@ class MlrunProject(ModelObj):
 def _set_as_current_active_project(project: MlrunProject):
     mlrun.mlconf.active_project = project.metadata.name
     pipeline_context.set(project)
+
+
+def _download_store_artifact_for_export(
+    staging_dir: str,
+    store_uri: str,
+    project_name: str,
+) -> tuple[pathlib.Path, str] | None:
+    """Download a store:// artifact's content into a staging dir for zip export.
+
+    :param staging_dir:  Temporary directory where bytes are written (caller-owned;
+                         normally a `tempfile.TemporaryDirectory`).
+    :param store_uri:    The store:// URI.
+    :param project_name: Project name.
+    :returns: ``(real_local_path, zip_arcname)`` on success.
+              ``real_local_path`` is the absolute path of the downloaded file
+              inside ``staging_dir``; ``zip_arcname`` is the POSIX-style
+              relative path that the caller embeds in the exported
+              ``project.yaml`` AND uses as the arcname when adding the file
+              to the zip. Returns ``None`` on recoverable failure (artifact
+              missing, network/IO error).
+    :raises:  MLRunInvalidArgumentError if the resolved store:// URI does not
+              point to a code-bearing artifact (e.g., user passed a feature-
+              set URI as a function source).
+    """
+    # Do not log target_path: for some datastores it may be a presigned URL
+    # carrying credentials. store_uri is the public handle and is safe.
+    try:
+        try:
+            artifact = mlrun.datastore.get_store_resource(
+                store_uri, project=project_name
+            )
+        except AttributeError as exc:
+            # Upstream get_store_resource calls .get(...) on the read_artifact
+            # result before its own None-check (store_resources.py:191), so a
+            # missing artifact surfaces as `'NoneType' object has no attribute
+            # 'get'`. Translate that one specific case to MLRunNotFoundError;
+            # any other AttributeError is a real bug or unrelated upstream
+            # failure — propagate so it's visible.
+            if "NoneType" not in str(exc):
+                raise
+            raise mlrun.errors.MLRunNotFoundError(
+                f"store:// artifact not found: {store_uri}"
+            ) from exc
+        if artifact is None:
+            raise mlrun.errors.MLRunNotFoundError(
+                f"store:// artifact not found: {store_uri}"
+            )
+        if not isinstance(artifact, mlrun.artifacts.CodeArtifact):
+            # ModelArtifact, DatasetArtifact, FeatureSet, FeatureVector — all
+            # have store:// URIs but none should be used as a function or
+            # workflow source. Surface a typed error rather than silently
+            # download bytes that won't execute as Python.
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"store:// URI {store_uri!r} resolved to {type(artifact).__name__}, "
+                f"expected CodeArtifact (function/workflow source must be a "
+                f"code artifact)"
+            )
+        target_path = artifact.get_target_path()
+        filename = os.path.basename(target_path)
+        # Hash on target_path (not store_uri) so different URIs that resolve
+        # to the same backing file produce the same local filename — and so
+        # different files with the same basename get distinct names.
+        # 16 hex = 64 bits, birthday-safe up to ~4 billion artifacts.
+        path_hash = hashlib.sha256(target_path.encode()).hexdigest()[:16]
+        basename, ext = os.path.splitext(filename)
+        unique_filename = f"{basename}_{path_hash}{ext}"
+        real_path = pathlib.Path(staging_dir) / unique_filename
+        mlrun.get_dataitem(target_path).download(str(real_path))
+        # POSIX-style separators in the YAML so the zip unpacks correctly
+        # on any OS the recipient uses.
+        arcname = f".mlrun/code/{unique_filename}"
+        return real_path, arcname
+    except mlrun.errors.MLRunInvalidArgumentError:
+        raise
+    except (mlrun.errors.MLRunNotFoundError, OSError, ConnectionError) as exc:
+        # Best-effort: a single broken artifact must not abort the entire
+        # export. Caller logs an aggregate summary; YAML keeps the original
+        # store:// URI for the broken function.
+        logger.warning(
+            "Failed to download code artifact for export",
+            store_uri=store_uri,
+            project=project_name,
+            error=mlrun.errors.err_to_str(exc),
+        )
+        return None
+
+
+def _stage_store_downloads_for_export(
+    spec,
+    staging_dir: str,
+    project_name: str,
+) -> tuple[dict, dict, list[tuple[pathlib.Path, str]], list[str]]:
+    """Walk function and workflow definitions, download store:// sources into
+    ``staging_dir``, and return rewritten copies of the spec dicts plus the
+    bookkeeping the caller needs to finish the export.
+
+    Source-bearing fields handled (Pre-submit audit #1 — polymorphic-branch
+    parity): dict-form ``func_def["url"]``, BaseRuntime
+    ``func_def.spec.build.source``, ``WorkflowSpec.path``. Other BaseRuntime
+    fields (``spec.command``, ``spec.image``) are cmd/container values, never
+    store:// URIs.
+
+    :returns: ``(working_function_definitions, working_workflows,
+              staged_downloads, failures)`` where the first two are deepcopies
+              of ``spec._function_definitions`` and ``spec._workflows`` with
+              ``store://`` URIs rewritten to local arcnames; ``staged_downloads``
+              is a list of ``(real_path_in_staging, zip_arcname)`` pairs to
+              write into the zip; ``failures`` lists names whose download
+              returned ``None`` (best-effort skip).
+    """
+    working_function_definitions = deepcopy(spec._function_definitions)
+    working_workflows = deepcopy(spec._workflows)
+    staged_downloads: list[tuple[pathlib.Path, str]] = []
+    failures: list[str] = []
+
+    for name, func_def in working_function_definitions.items():
+        store_uri = None
+        if isinstance(func_def, dict):
+            source = func_def.get("url", "")
+            if source and mlrun.datastore.is_store_uri(source):
+                store_uri = source
+        elif hasattr(func_def, "spec") and hasattr(func_def.spec, "build"):
+            source = getattr(func_def.spec.build, "source", "")
+            if source and mlrun.datastore.is_store_uri(source):
+                store_uri = source
+
+        if store_uri:
+            result = _download_store_artifact_for_export(
+                staging_dir=staging_dir,
+                store_uri=store_uri,
+                project_name=project_name,
+            )
+            if result is not None:
+                real_path, arcname = result
+                staged_downloads.append((real_path, arcname))
+                if isinstance(func_def, dict):
+                    func_def["url"] = arcname
+                elif hasattr(func_def, "spec"):
+                    func_def.spec.build.source = arcname
+            else:
+                failures.append(name)
+
+    for name, workflow_spec in working_workflows.items():
+        workflow_path = getattr(workflow_spec, "path", "") or ""
+        if workflow_path and mlrun.datastore.is_store_uri(workflow_path):
+            result = _download_store_artifact_for_export(
+                staging_dir=staging_dir,
+                store_uri=workflow_path,
+                project_name=project_name,
+            )
+            if result is not None:
+                real_path, arcname = result
+                staged_downloads.append((real_path, arcname))
+                workflow_spec.path = arcname
+            else:
+                failures.append(name)
+
+    return working_function_definitions, working_workflows, staged_downloads, failures
+
+
+def _build_export_zip(
+    filepath: str,
+    project_dir: pathlib.Path,
+    files_filter: str,
+    staged_downloads: list[tuple[pathlib.Path, str]],
+) -> None:
+    """Build the project export zip and (if ``filepath`` is a remote URL)
+    upload it via mlrun.get_dataitem.
+
+    The zip combines two sources: regular project files under ``project_dir``
+    walked with the user's ``files_filter`` glob, and files staged in a
+    tmpdir during the download phase added with explicit ``arcname``s.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".zip") as f:
+        remote_file = "://" in filepath
+        fpath = f.name if remote_file else filepath
+        with zipfile.ZipFile(fpath, "w") as zipf:
+            for file_path in glob.iglob(
+                f"{project_dir}/{files_filter}", recursive=True
+            ):
+                write_path = pathlib.Path(file_path)
+                zipf.write(write_path, arcname=write_path.relative_to(project_dir))
+            for real_path, arcname in staged_downloads:
+                zipf.write(real_path, arcname=arcname)
+        if remote_file:
+            mlrun.get_dataitem(filepath).upload(zipf.filename)
 
 
 def _init_function_from_dict(

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -936,11 +936,16 @@ class ProjectSpec(ModelObj):
     def functions(self) -> list:
         """list of function object/specs used in this project"""
         functions = []
+        source_repo = self._source_repo()
         for name, function in self._function_definitions.items():
             if hasattr(function, "to_dict"):
                 spec = function.to_dict(strip=True)
-                if function.spec.build.source and function.spec.build.source.startswith(
-                    self._source_repo()
+                # Empty source_repo would make every path "start with" "",
+                # silently clobbering valid build.source values.
+                if (
+                    source_repo
+                    and function.spec.build.source
+                    and function.spec.build.source.startswith(source_repo)
                 ):
                     update_in(spec, "spec.build.source", "./")
                 functions.append({"name": name, "spec": spec})
@@ -6217,7 +6222,7 @@ def _download_store_artifact_for_export(
 
 
 def _stage_store_downloads_for_export(
-    spec: "ProjectSpec",
+    spec: ProjectSpec,
     staging_dir: str,
     project_name: str,
 ) -> tuple[dict, dict, dict[str, pathlib.Path], list[str]]:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1549,6 +1549,69 @@ def test_export_to_zip_downloads_store_workflow_code(rundb_mock, tmp_path):
     )
 
 
+def test_export_to_zip_downloads_store_function_code_for_runtime_object(
+    rundb_mock, tmp_path
+):
+    """Runtime-object branch of the export walker: function assigned via
+    `project.spec.functions = [runtime_obj]` stores a BaseRuntime whose
+    source lives at `spec.build.source` (separate code path from the
+    dict-form `set_function(func=store_uri)`).
+    """
+    project_dir = tmp_path / "store-zip-runtime"
+    project_dir.mkdir(parents=True)
+
+    handler_path = project_dir / "handler_source.py"
+    handler_path.write_text("def my_func(context):\n    return 1\n")
+
+    project = mlrun.new_project(
+        "toziprt", context=str(project_dir / "code"), save=False
+    )
+    code_artifact = project.log_code_file(
+        key="rt_handler", local_path=str(handler_path)
+    )
+    store_uri = code_artifact.uri
+
+    rt = mlrun.code_to_function(
+        name="rt-fn",
+        kind="job",
+        filename=str(handler_path),
+        handler="my_func",
+        image="mlrun/mlrun",
+    )
+    rt.spec.build.source = store_uri
+    project.spec.functions = [rt]
+
+    zip_path = str(project_dir / "proj.zip")
+    project.export(zip_path)
+
+    extract_dir = project_dir / "extracted"
+    extract_dir.mkdir()
+    with zipfile.ZipFile(zip_path, "r") as zipf:
+        zipf.extractall(extract_dir)
+
+    code_files = list((extract_dir / ".mlrun" / "code").glob("rt_handler*.py"))
+    assert len(code_files) == 1, (
+        f"expected exactly one downloaded code file, got {code_files}"
+    )
+
+    project_data = yaml.safe_load((extract_dir / "project.yaml").read_text())
+    function_entries = [
+        f for f in project_data["spec"]["functions"] if f["name"] == "rt-fn"
+    ]
+    assert len(function_entries) == 1
+    rewritten_source = function_entries[0]["spec"]["spec"]["build"]["source"]
+    assert rewritten_source == f".mlrun/code/{code_files[0].name}", (
+        f"runtime function spec.build.source must be rewritten to local "
+        f"arcname, got {rewritten_source!r}"
+    )
+
+    restored_rt = project.spec._function_definitions["rt-fn"]
+    assert restored_rt.spec.build.source == store_uri, (
+        f"in-memory runtime source must be restored after export, "
+        f"got {restored_rt.spec.build.source!r}"
+    )
+
+
 def test_export_to_zip_keeps_context_yaml_loadable(rundb_mock, tmp_path):
     """After `export("proj.zip")`, the on-disk `<context>/project.yaml`
     must still carry the ORIGINAL store:// URIs, not the .mlrun/code/...

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -1317,9 +1317,7 @@ def test_export_to_zip_downloads_store_function_code(rundb_mock, tmp_path):
 
     # Log the code file so rundb_mock has a real artifact backing the
     # store:// URI we hand to set_function. Use the artifact's canonical
-    # uri rather than reconstructing one with an f-string template
-    # (TESTING_STANDARDS principle 7 — canonical fields over reconstructed
-    # values).
+    # uri rather than reconstructing one with an f-string template.
     code_artifact = project.log_code_file(
         key="my_handler", local_path=str(handler_path)
     )
@@ -1548,6 +1546,73 @@ def test_export_to_zip_downloads_store_workflow_code(rundb_mock, tmp_path):
     assert project.spec._workflows["main"].path == workflow_store_uri, (
         f"in-memory workflow path must be restored after export, "
         f"got {project.spec._workflows['main'].path!r}"
+    )
+
+
+def test_export_to_zip_keeps_context_yaml_loadable(rundb_mock, tmp_path):
+    """After `export("proj.zip")`, the on-disk `<context>/project.yaml`
+    must still carry the ORIGINAL store:// URIs, not the .mlrun/code/...
+    arcnames that only resolve inside the zip. Otherwise
+    `load_project(<context>)` after the export would fail because those
+    local paths don't exist outside the zip.
+
+    Regression guard for: zip export rewriting the on-disk yaml in place.
+    """
+    project_dir = tmp_path / "store-zip-keepyaml"
+    project_dir.mkdir(parents=True)
+
+    handler_path = project_dir / "handler_source.py"
+    handler_path.write_text("def my_func(context):\n    return 1\n")
+
+    context_dir = project_dir / "code"
+    project = mlrun.new_project("tozipkeep", context=str(context_dir), save=False)
+    code_artifact = project.log_code_file(
+        key="my_handler", local_path=str(handler_path)
+    )
+    store_uri = code_artifact.uri
+    project.set_function(
+        func=store_uri, name="my-func", kind="job", handler="handler_source:my_func"
+    )
+
+    zip_path = str(project_dir / "proj.zip")
+    project.export(zip_path)
+
+    # Post-condition 1: on-disk project.yaml exists and preserves the
+    # original store:// URI.
+    on_disk_yaml = context_dir / "project.yaml"
+    assert on_disk_yaml.exists(), "on-disk project.yaml must be written"
+    on_disk_data = yaml.safe_load(on_disk_yaml.read_text())
+    on_disk_funcs = [
+        f for f in on_disk_data["spec"]["functions"] if f["name"] == "my-func"
+    ]
+    assert len(on_disk_funcs) == 1
+    assert on_disk_funcs[0]["url"] == store_uri, (
+        f"on-disk yaml must keep the original store:// URI so "
+        f"load_project(<context>) resolves it, got {on_disk_funcs[0]['url']!r}"
+    )
+
+    # Post-condition 2: zip's embedded project.yaml has the REWRITTEN path
+    # (so the zip is self-contained). Same export call, divergent content.
+    extract_dir = project_dir / "extracted"
+    extract_dir.mkdir()
+    with zipfile.ZipFile(zip_path, "r") as zipf:
+        zipf.extractall(extract_dir)
+    in_zip_data = yaml.safe_load((extract_dir / "project.yaml").read_text())
+    in_zip_funcs = [
+        f for f in in_zip_data["spec"]["functions"] if f["name"] == "my-func"
+    ]
+    assert in_zip_funcs[0]["url"].startswith(".mlrun/code/"), (
+        f"zip-embedded yaml must use the rewritten local arcname, "
+        f"got {in_zip_funcs[0]['url']!r}"
+    )
+
+    # Post-condition 3: load_project(<context>) still works after export.
+    reloaded = mlrun.load_project(str(context_dir), save=False)
+    reloaded_funcs = [f for f in reloaded.spec.functions if f["name"] == "my-func"]
+    assert len(reloaded_funcs) == 1
+    assert reloaded_funcs[0]["url"] == store_uri, (
+        f"load_project(<context>) after export must still see the original "
+        f"store:// URI, got {reloaded_funcs[0]['url']!r}"
     )
 
 

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -24,6 +24,7 @@ from contextlib import nullcontext as does_not_raise
 import deepdiff
 import inflection
 import pytest
+import yaml
 
 import mlrun
 import mlrun.alerts.alert
@@ -1296,6 +1297,258 @@ def test_export_to_zip(rundb_mock):
     # check upload to (remote) DataItem
     project.export("memory://x.zip")
     assert mlrun.get_dataitem("memory://x.zip").stat().size
+
+
+def test_export_to_zip_downloads_store_function_code(rundb_mock, tmp_path):
+    """Zip-export: store:// function source is downloaded into the project
+    context and project.yaml is rewritten to a local relative path inside
+    the zip."""
+    project_dir = tmp_path / "store-zip-project"
+    project_dir.mkdir(parents=True)
+
+    # Local source file that will be uploaded as a CodeArtifact.
+    handler_path = project_dir / "handler_source.py"
+    handler_body = "def my_func(context, p1=1):\n    return {'echo': p1}\n"
+    handler_path.write_text(handler_body)
+
+    project = mlrun.new_project(
+        "tozipstore", context=str(project_dir / "code"), save=False
+    )
+
+    # Log the code file so rundb_mock has a real artifact backing the
+    # store:// URI we hand to set_function. Use the artifact's canonical
+    # uri rather than reconstructing one with an f-string template
+    # (TESTING_STANDARDS principle 7 — canonical fields over reconstructed
+    # values).
+    code_artifact = project.log_code_file(
+        key="my_handler", local_path=str(handler_path)
+    )
+    store_uri = code_artifact.uri
+
+    project.set_function(
+        func=store_uri, name="my-func", kind="job", handler="handler_source:my_func"
+    )
+
+    zip_path = str(project_dir / "proj.zip")
+    project.export(zip_path)
+
+    # Unzip and inspect contents.
+    extract_dir = project_dir / "extracted"
+    extract_dir.mkdir()
+    with zipfile.ZipFile(zip_path, "r") as zipf:
+        zipf.extractall(extract_dir)
+
+    # The downloaded code file lives under .mlrun/code/<basename>_<hash16>.py.
+    code_files = list((extract_dir / ".mlrun" / "code").glob("*.py"))
+    assert len(code_files) == 1, (
+        f"expected exactly one downloaded code file, got {code_files}"
+    )
+    assert code_files[0].read_text() == handler_body, (
+        "downloaded file content must match original"
+    )
+
+    # Embedded project.yaml: function entry's url is rewritten to the
+    # local relative path, NOT the original store:// URI.
+    project_data = yaml.safe_load((extract_dir / "project.yaml").read_text())
+    function_entries = [
+        f for f in project_data["spec"]["functions"] if f["name"] == "my-func"
+    ]
+    assert len(function_entries) == 1
+    rewritten_url = function_entries[0]["url"]
+    assert not rewritten_url.startswith("store://"), (
+        f"function url must not be a store:// URI after rewrite, got {rewritten_url!r}"
+    )
+    assert rewritten_url.startswith(".mlrun/code/"), (
+        f"function url must point at the downloaded local path, got {rewritten_url!r}"
+    )
+    assert rewritten_url == f".mlrun/code/{code_files[0].name}", (
+        "function url must reference the actual downloaded file"
+    )
+
+
+def test_export_to_yaml_keeps_store_uri(rundb_mock, tmp_path):
+    """YAML-only export does NOT download or rewrite — store:// URIs are
+    preserved verbatim because same-cluster round-trip resolves them at
+    load time via _init_function_from_dict."""
+    project_dir = tmp_path / "store-yaml-project"
+    project_dir.mkdir(parents=True)
+
+    handler_path = project_dir / "handler_source.py"
+    handler_path.write_text("def my_func(context, p1=1):\n    return p1\n")
+
+    project = mlrun.new_project(
+        "toyamlstore", context=str(project_dir / "code"), save=False
+    )
+    code_artifact = project.log_code_file(
+        key="my_handler", local_path=str(handler_path)
+    )
+    store_uri = code_artifact.uri
+
+    project.set_function(
+        func=store_uri, name="my-func", kind="job", handler="handler_source:my_func"
+    )
+
+    yaml_path = str(project_dir / "project.yaml")
+    project.export(yaml_path)
+
+    yaml_content = pathlib.Path(yaml_path).read_text()
+    assert store_uri in yaml_content, (
+        "YAML-only export must preserve store:// URI verbatim (no download, no rewrite)"
+    )
+    # No .mlrun/code/ directory should be created for YAML-only exports.
+    # (export() would create it relative to the YAML file's parent if the
+    # zip branch were taken in error.)
+    assert not (project_dir / ".mlrun" / "code").exists(), (
+        "YAML-only export must not create .mlrun/code/ download directory"
+    )
+
+
+def test_export_to_zip_raises_on_unresolvable_store_uri(rundb_mock, tmp_path):
+    """Fail-fast: a store:// URI with no backing artifact aborts the export
+    with MLRunRuntimeError; the partial zip is not produced and the user's
+    in-memory project state is unchanged."""
+    project_dir = tmp_path / "store-zip-broken-project"
+    project_dir.mkdir(parents=True)
+
+    project = mlrun.new_project(
+        "tozipstorebroken", context=str(project_dir / "code"), save=False
+    )
+    # No log_code_file — the store:// URI below points at nothing.
+    broken_uri = f"store://artifacts/{project.metadata.name}/missing_handler"
+    project.set_function(
+        func=broken_uri, name="my-func", kind="job", handler="missing:fn"
+    )
+
+    zip_path = str(project_dir / "proj.zip")
+    with pytest.raises(mlrun.errors.MLRunRuntimeError, match="my-func"):
+        project.export(zip_path)
+
+    # In-memory state is unchanged after the failed export.
+    func_def = project.spec._function_definitions["my-func"]
+    assert func_def["url"] == broken_uri, (
+        f"in-memory function source must be unchanged after failed export, "
+        f"got {func_def.get('url')!r}"
+    )
+    # No partial zip should be produced when the export aborts.
+    assert not pathlib.Path(zip_path).exists(), (
+        "fail-fast export must not leave a partial zip on disk"
+    )
+
+
+def test_export_to_zip_raises_on_download_failure(rundb_mock, tmp_path, monkeypatch):
+    """Different failure path from unresolvable-artifact: the artifact IS
+    resolvable but `mlrun.get_dataitem(target_path).download(...)` raises
+    OSError (network/permission failure). Same fail-fast contract —
+    MLRunRuntimeError aborts the export, in-memory state untouched."""
+    project_dir = tmp_path / "store-zip-download-failure"
+    project_dir.mkdir(parents=True)
+
+    handler_path = project_dir / "handler_source.py"
+    handler_path.write_text("def my_func(context):\n    return 1\n")
+
+    project = mlrun.new_project(
+        "tozipdlfail", context=str(project_dir / "code"), save=False
+    )
+    code_artifact = project.log_code_file(
+        key="my_handler", local_path=str(handler_path)
+    )
+    store_uri = code_artifact.uri
+    project.set_function(
+        func=store_uri, name="my-func", kind="job", handler="handler_source:my_func"
+    )
+
+    # Patch get_dataitem so its returned object's .download() raises.
+    # monkeypatch auto-restores after the test.
+    class _BoomDataItem:
+        def download(self, target):
+            raise OSError("simulated network or permission failure")
+
+    monkeypatch.setattr(
+        mlrun,
+        "get_dataitem",
+        lambda *args, **kwargs: _BoomDataItem(),
+    )
+
+    zip_path = str(project_dir / "proj.zip")
+    with pytest.raises(mlrun.errors.MLRunRuntimeError, match="my-func"):
+        project.export(zip_path)
+
+    # In-memory state unchanged.
+    func_def = project.spec._function_definitions["my-func"]
+    assert func_def["url"] == store_uri
+    assert not pathlib.Path(zip_path).exists(), (
+        "fail-fast export must not leave a partial zip on disk"
+    )
+
+
+def test_export_to_zip_downloads_store_workflow_code(rundb_mock, tmp_path):
+    """Zip-export: store:// workflow source is downloaded into the project
+    context and the embedded project.yaml's workflow path is rewritten to a
+    local relative path. Same behavior as functions, but on `_workflows`.
+
+    Note: `set_workflow(store://...)` requires a file suffix on the URI
+    (e.g. `.py`) — `_validate_file_path` rejects suffix-less remote URLs.
+    Tests that the export rewrite restores in-memory state on success.
+    """
+    project_dir = tmp_path / "store-zip-workflow-project"
+    project_dir.mkdir(parents=True)
+
+    workflow_source = project_dir / "workflow_source.py"
+    workflow_body = (
+        "from kfp import dsl\n\n@dsl.pipeline(name='p')\ndef pipeline():\n    pass\n"
+    )
+    workflow_source.write_text(workflow_body)
+
+    project = mlrun.new_project(
+        "tozipstoreworkflow", context=str(project_dir / "code"), save=False
+    )
+
+    # Log the workflow as a code artifact, then reference it with the
+    # artifact's canonical uri. The key includes a .py suffix so
+    # _validate_file_path inside set_workflow accepts the URI (it requires
+    # any remote URL to have a file suffix).
+    workflow_artifact = project.log_code_file(
+        key="my_workflow.py", local_path=str(workflow_source)
+    )
+    workflow_store_uri = workflow_artifact.uri
+    project.set_workflow("main", workflow_store_uri)
+
+    zip_path = str(project_dir / "proj.zip")
+    project.export(zip_path)
+
+    # Unzip and confirm the workflow source landed under .mlrun/code/.
+    extract_dir = project_dir / "extracted"
+    extract_dir.mkdir()
+    with zipfile.ZipFile(zip_path, "r") as zipf:
+        zipf.extractall(extract_dir)
+
+    code_files = list((extract_dir / ".mlrun" / "code").glob("my_workflow*.py"))
+    assert len(code_files) == 1, (
+        f"expected exactly one downloaded workflow file, got {code_files}"
+    )
+    assert code_files[0].read_text() == workflow_body, (
+        "downloaded workflow content must match original"
+    )
+
+    # Embedded project.yaml: workflow entry's path is rewritten to the actual
+    # downloaded local path, NOT the original store:// URI.
+    project_data = yaml.safe_load((extract_dir / "project.yaml").read_text())
+    workflow_entries = [
+        w for w in project_data["spec"]["workflows"] if w["name"] == "main"
+    ]
+    assert len(workflow_entries) == 1
+    rewritten_path = workflow_entries[0]["path"]
+    assert rewritten_path == f".mlrun/code/{code_files[0].name}", (
+        f"workflow path must reference the downloaded local file, "
+        f"got {rewritten_path!r}"
+    )
+
+    # In-memory state restored on success — workflow_spec.path is back to
+    # the original store:// URI.
+    assert project.spec._workflows["main"].path == workflow_store_uri, (
+        f"in-memory workflow path must be restored after export, "
+        f"got {project.spec._workflows['main'].path!r}"
+    )
 
 
 def test_function_receives_project_artifact_path(rundb_mock):


### PR DESCRIPTION
 ### 📝 Description                                                                                                                                                                                         
                                                                                                                                                                                                             
  When `MlrunProject.export()` produces a zip archive, functions and workflows whose source is a `store://` CodeArtifact URI currently end up referenced verbatim in the embedded `project.yaml`. The zip is
  therefore not self-contained — it cannot be unpacked on a different cluster (or after the source DB is gone), because the `store://` URI is only meaningful relative to the cluster it was created against.
                                                                                                                                                                                                             
  This PR makes zip-export self-contained: when `archive_code=True`, each `store://` function/workflow source is resolved to its target, downloaded into a temporary staging directory, and the zip is built 
  with the bytes included plus `project.yaml` rewritten to reference local paths inside the zip (`.mlrun/code/<basename>_<sha256(target_path)[:16]><ext>`). YAML-only export keeps `store://` URIs verbatim —
   same-cluster round-trip already resolves them via pr-a/pr-b's `_init_function_from_dict` `store://` branch.                                                                                               
                                                                                                                                                                                                             
  ### 🛠️  Changes Made                    
                                                                                                                                                                                                             
  `mlrun/projects/project.py`:                                                                         
  - New module-level helper `_download_store_artifact_for_export(staging_dir, store_uri, project_name)` resolves the URI via `mlrun.datastore.get_store_resource`, downloads the bytes into the caller's
  staging directory, and returns `(real_path, zip_arcname)`. Returns `None` on recoverable failures (artifact missing, network/IO); raises `MLRunInvalidArgumentError` for non-`CodeArtifact` resolutions
  (e.g., user passed a model or feature-set URI as a function source).
  - New module-level helper `_stage_store_downloads_for_export(spec, staging_dir, project_name)` walks `_function_definitions` and `_workflows`, calls the download helper for each `store://` URI it finds,
  and returns deepcopied dicts with paths rewritten plus `(staged_downloads, failures)` bookkeeping. Pure — no side effects on `self.spec`.                                                                  
  - New module-level helper `_build_export_zip(filepath, project_dir, files_filter, staged_downloads)` owns the `tempfile.NamedTemporaryFile` + `zipfile.ZipFile` + remote-upload step.
  - `MlrunProject.export()` itself shrinks to ~70 LOC: a `contextlib.ExitStack` manages the staging tmpdir, the deepcopy/swap pattern keeps the live spec invariant across the YAML write, and any download  
  failures abort the export with `MLRunRuntimeError` (fail-fast — a partial zip silently shipping `store://` URIs would defeat the purpose of a self-contained archive).                                     
                                          
  `tests/projects/test_project.py`:                                                                                                                                                                          
  - 5 mock-free integration tests using the existing `rundb_mock` fixture, all `tmp_path`-isolated:                                                                                                          
    - `test_export_to_zip_downloads_store_function_code`                                                                                                                                                     
    - `test_export_to_yaml_keeps_store_uri`                                                                                                                                                                  
    - `test_export_to_zip_raises_on_unresolvable_store_uri`                                            
    - `test_export_to_zip_raises_on_download_failure`                                                                                                                                                        
    - `test_export_to_zip_downloads_store_workflow_code`                                                                                                                                                     
                                                                                                                                                                                                             
  ### ✅ Checklist                                                                                                                                                                                           
                                                                                                       
  - [x] I updated the documentation (if applicable) — N/A, internal SDK path                                                                                                                                 
  - [x] I have tested the changes in this PR                                                           
  - [x] I confirmed whether my changes are covered by system tests                                                                                                                                           
    - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR — N/A; covered by mock-free integration tests against real `mlrun.datastore` resolution                  
    - [x] I updated existing system tests and/or added new ones if needed to cover my changes — see above
                                                                                                                                                                                                             
  ### 🧪 Testing                                                                                       
                                                                                                                                                                                                             
  - 5 mock-free integration tests exercise the real `mlrun.datastore` `store:// → file://` resolution path via the in-memory `rundb_mock` fixture (no patching of the helper itself).                        
  - Why no system tests: the export-side logic is pure SDK; the load-side is unchanged from pr-a/b/c (`_init_function_from_dict`'s `store://` branch). A real-cluster round-trip would mostly verify         
  v3io/cluster infrastructure that this PR does not touch.                                                                                                                                                   
                                                                                                                                                                                                             
  ### 🔗 References                      
                                                                                                                                                                                                             
  - Ticket link: ML-11980                                                                              
                                                                                                                                                                                                             
  ### 🚨 Breaking Changes?                                                                             
                                          
  - [ ] Yes                                   
  - [x] No 