### PR TITLE
[API] Fix OPA race on datastore_profile endpoints

### DIFF
--- a/server/py/services/api/api/endpoints/datastore_profile.py
+++ b/server/py/services/api/api/endpoints/datastore_profile.py
@@ -44,10 +44,10 @@ async def store_datastore_profile(
     ),
 ):
     await run_in_threadpool(
-        framework.utils.singletons.project_member.get_project_member().get_project,
+        framework.utils.singletons.project_member.get_project_member().ensure_project,
         db_session,
         project_name,
-        auth_info,
+        auth_info=auth_info,
     )
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
@@ -116,10 +116,10 @@ async def list_datastore_profiles(
     ),
 ):
     await run_in_threadpool(
-        framework.utils.singletons.project_member.get_project_member().get_project,
+        framework.utils.singletons.project_member.get_project_member().ensure_project,
         db_session,
         project_name,
-        auth_info,
+        auth_info=auth_info,
     )
     await framework.utils.auth.verifier.AuthVerifier().query_project_permissions(
         project_name,
@@ -154,10 +154,10 @@ async def get_datastore_profile(
     ),
 ):
     await run_in_threadpool(
-        framework.utils.singletons.project_member.get_project_member().get_project,
+        framework.utils.singletons.project_member.get_project_member().ensure_project,
         db_session,
         project_name,
-        auth_info,
+        auth_info=auth_info,
     )
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
@@ -188,10 +188,10 @@ async def delete_datastore_profile(
     ),
 ):
     await run_in_threadpool(
-        framework.utils.singletons.project_member.get_project_member().get_project,
+        framework.utils.singletons.project_member.get_project_member().ensure_project,
         db_session,
         project_name,
-        auth_info,
+        auth_info=auth_info,
     )
     await (
         framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(


### PR DESCRIPTION
## 📝 Description

When MLRun runs as project-leader on multi-pod deployments, calls to `register_datastore_profile` (and the sibling list/get/delete endpoints) issued immediately after `create_project()` can fail with a transient 403:

```
MLRunAccessDeniedError: Not allowed to create resource /resources/projects/<project>/datastore_profiles
```

Same race already fixed in #9432 for `project_secrets`: the request is load-balanced to a pod whose OPA sidecar has not yet received the manifest for the freshly created project, so the permission check rejects the owner.

`ensure_project` was extended in #9432 to populate `_allowed_project_owners_cache` from the shared DB whenever the requester is the project owner, allowing OPA-not-yet-synced pods to authorize via cache (30s TTL). The `datastore_profile` endpoints were missed in that PR — they still call `get_project`, which does not populate the cache.

## 🛠️ Changes Made

- `server/py/services/api/api/endpoints/datastore_profile.py`: replace `get_project` with `ensure_project` in all four endpoints (`store`, `list`, `get`, `delete`), matching the pattern in `project_secrets.py`.

## ✅ Checklist
- [x] I have tested the changes in this PR
- [x] My changes are covered by existing system tests
- [ ] I updated the documentation (N/A)
- [ ] I introduced a deprecation (N/A)

## 🧪 Testing

- `pytest server/py/services/api/tests/unit/api/test_datastore_profiles.py` — 8 passed
- `pytest server/py/services/api/tests/unit/api/test_projects.py server/py/services/api/tests/unit/utils/projects/test_leader_member.py` — 76 passed
- `make fmt` & `make lint` — clean

## 🔗 References
- Ticket: https://iguazio.atlassian.net/browse/ML-12527
- Prior fix (project_secrets): #9432 / ML-11996

## 🚨 Breaking Changes?
- [x] No