### PR TITLE
[Projects Sync] Extend follower interface for 2pc flow

### DIFF
--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -389,6 +389,47 @@ class Client(BaseClient, project_follower.Member):
     ) -> mlrun.common.schemas.ProjectSummary:
         raise NotImplementedError("Get project summary is not supported")
 
+    def prepare_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def commit_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def prepare_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def commit_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def update_project_follower(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
     def _project_policies_exist(
         self, project: str, auth_info: mlrun.common.schemas.AuthInfo
     ) -> bool:

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import tempfile
 import typing
+import uuid
 
 import httpx
 import iguazio
@@ -391,42 +392,37 @@ class Client(BaseClient, project_follower.Member):
 
     def prepare_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def commit_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def prepare_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def commit_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def update_project_follower(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 

--- a/server/py/framework/utils/clients/nuclio.py
+++ b/server/py/framework/utils/clients/nuclio.py
@@ -209,6 +209,47 @@ class Client(
         response_body = response.json()
         return response_body["dashboard"]["label"]
 
+    def prepare_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def commit_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def prepare_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def commit_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def update_project_follower(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
     def _get_project_from_nuclio(
         self, name, auth_info: mlrun.common.schemas.AuthInfo = None
     ):

--- a/server/py/framework/utils/clients/nuclio.py
+++ b/server/py/framework/utils/clients/nuclio.py
@@ -15,6 +15,7 @@
 import copy
 import enum
 import http
+import uuid
 
 import requests.adapters
 import requests.auth
@@ -211,42 +212,37 @@ class Client(
 
     def prepare_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def commit_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def prepare_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def commit_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def update_project_follower(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 

--- a/server/py/framework/utils/projects/remotes/follower.py
+++ b/server/py/framework/utils/projects/remotes/follower.py
@@ -105,3 +105,49 @@ class Member(abc.ABC):
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ) -> mlrun.common.schemas.ProjectSummary:
         pass
+
+    @abc.abstractmethod
+    def prepare_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    def commit_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    def prepare_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    def commit_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    def update_project_follower(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        pass

--- a/server/py/framework/utils/projects/remotes/follower.py
+++ b/server/py/framework/utils/projects/remotes/follower.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import abc
+import uuid
 
 import sqlalchemy.orm
 
@@ -106,48 +107,50 @@ class Member(abc.ABC):
     ) -> mlrun.common.schemas.ProjectSummary:
         pass
 
+    # ----- 2PC follower hooks ----------------------------------------------
+    # Invoked by the 2PC orchestrator on each remote follower as part of
+    # parallel fan-out. They take only data persisted on the project row, so
+    # request-driven and reconciliation-driven invocations are equivalent —
+    # no per-request session, no per-request auth_info. Concrete followers
+    # authenticate using their own service-account credentials.
+
     @abc.abstractmethod
     def prepare_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         pass
 
     @abc.abstractmethod
     def commit_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         pass
 
     @abc.abstractmethod
     def prepare_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         pass
 
     @abc.abstractmethod
     def commit_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         pass
 
     @abc.abstractmethod
     def update_project_follower(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         pass

--- a/server/py/framework/utils/projects/remotes/nop_follower.py
+++ b/server/py/framework/utils/projects/remotes/nop_follower.py
@@ -144,3 +144,44 @@ class Member(project_follower.Member):
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ) -> mlrun.common.schemas.ProjectSummary:
         raise NotImplementedError("Get project summary is not supported")
+
+    def prepare_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def commit_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def prepare_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def commit_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError
+
+    def update_project_follower(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError

--- a/server/py/framework/utils/projects/remotes/nop_follower.py
+++ b/server/py/framework/utils/projects/remotes/nop_follower.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import uuid
+
 import mergedeep
 import sqlalchemy.orm
 
@@ -147,41 +149,36 @@ class Member(project_follower.Member):
 
     def prepare_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def commit_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def prepare_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def commit_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError
 
     def update_project_follower(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -16,6 +16,7 @@ import asyncio
 import collections
 import datetime
 import typing
+import uuid
 
 import fastapi.concurrency
 import humanfriendly
@@ -798,9 +799,8 @@ class Projects(
 
     def prepare_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError(
             "MLRun is the leader of the 2PC project sync flow, not a follower; "
@@ -809,9 +809,8 @@ class Projects(
 
     def commit_create_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError(
             "MLRun is the leader of the 2PC project sync flow, not a follower; "
@@ -820,9 +819,8 @@ class Projects(
 
     def prepare_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError(
             "MLRun is the leader of the 2PC project sync flow, not a follower; "
@@ -831,9 +829,8 @@ class Projects(
 
     def commit_delete_project(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError(
             "MLRun is the leader of the 2PC project sync flow, not a follower; "
@@ -842,10 +839,9 @@ class Projects(
 
     def update_project_follower(
         self,
-        session: sqlalchemy.orm.Session,
         name: str,
         project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+        op_id: uuid.UUID,
     ) -> None:
         raise NotImplementedError(
             "MLRun is the leader of the 2PC project sync flow, not a follower; "

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -789,3 +789,65 @@ class Projects(
         framework.utils.singletons.db.get_db().patch_project(
             session, name, project_patch
         )
+
+    # ----- 2PC follower-interface stubs ------------------------------------
+    # mlrun is the 2PC leader, so these per-follower hooks (called by the
+    # orchestrator on every remote follower) must never run on mlrun itself.
+    # They are present only to satisfy the abstract follower interface and
+    # to fail loudly if the orchestrator ever fans out incorrectly.
+
+    def prepare_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError(
+            "MLRun is the leader of the 2PC project sync flow, not a follower; "
+            "this hook must not be invoked on the mlrun follower"
+        )
+
+    def commit_create_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError(
+            "MLRun is the leader of the 2PC project sync flow, not a follower; "
+            "this hook must not be invoked on the mlrun follower"
+        )
+
+    def prepare_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError(
+            "MLRun is the leader of the 2PC project sync flow, not a follower; "
+            "this hook must not be invoked on the mlrun follower"
+        )
+
+    def commit_delete_project(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError(
+            "MLRun is the leader of the 2PC project sync flow, not a follower; "
+            "this hook must not be invoked on the mlrun follower"
+        )
+
+    def update_project_follower(
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ) -> None:
+        raise NotImplementedError(
+            "MLRun is the leader of the 2PC project sync flow, not a follower; "
+            "this hook must not be invoked on the mlrun follower"
+        )


### PR DESCRIPTION
### 📝 Description
Update the follower interface with methods needed for the project sync flow.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12474
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
This PR only implements the interface mentioned in the ticket, the rest is done in https://github.com/mlrun/mlrun/pull/9667, reason for this separation is so that we can start implementing interfaces without having to depend on the full sync mechanism being merged.
