### PR TITLE
[Projects Sync] Reroute all project crud to chief

### DIFF
--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -173,6 +173,20 @@ class Client(
             "POST", "build/function", request, json
         )
 
+    async def create_project(
+        self, request: fastapi.Request, api_version: str | None = None
+    ) -> fastapi.Response:
+        return await self._proxy_request_to_chief(
+            "POST", f"projects", request, version=api_version
+        )
+
+    async def store_project(
+        self, name, request: fastapi.Request, api_version: str | None = None
+    ) -> fastapi.Response:
+        return await self._proxy_request_to_chief(
+            "PUT", f"projects/{name}", request, version=api_version
+        )
+
     async def delete_project(
         self, name, request: fastapi.Request, api_version: str | None = None
     ) -> fastapi.Response:

--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -177,7 +177,7 @@ class Client(
         self, request: fastapi.Request, api_version: str | None = None
     ) -> fastapi.Response:
         return await self._proxy_request_to_chief(
-            "POST", f"projects", request, version=api_version
+            "POST", "projects", request, version=api_version
         )
 
     async def store_project(

--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -43,6 +43,7 @@ router = fastapi.APIRouter()
 )
 async def create_project(
     project: mlrun.common.schemas.Project,
+    request: fastapi.Request,
     response: fastapi.Response,
     # TODO: we're in a http request context here, therefore it doesn't make sense that by default it will hold the
     #  request until the process will be completed - after UI supports waiting - change default to False
@@ -60,6 +61,16 @@ async def create_project(
             mlrun.common.schemas.AuthorizationAction.create,
             auth_info,
         )
+
+    # we reroute to chief to ensure project sync is handled properly
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        != mlrun.common.schemas.ClusterizationRole.chief
+    ):
+        logger.info("Requesting to create project, re-routing to chief")
+        chief_client = framework.utils.clients.chief.Client()
+        return await chief_client.create_project(request=request)
+
     project, is_running_in_background = await run_in_threadpool(
         get_project_member().create_project,
         db_session,
@@ -89,6 +100,7 @@ async def create_project(
 async def store_project(
     project: mlrun.common.schemas.Project,
     name: str,
+    request: fastapi.Request,
     # TODO: we're in a http request context here, therefore it doesn't make sense that by default it will hold the
     #  request until the process will be completed - after UI supports waiting - change default to False
     wait_for_completion: bool = fastapi.Query(True, alias="wait-for-completion"),
@@ -100,6 +112,19 @@ async def store_project(
     ),
 ):
     await _ensure_project_create_or_update_permissions(db_session, name, auth_info)
+
+    # we reroute to chief to ensure project sync is handled properly
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        != mlrun.common.schemas.ClusterizationRole.chief
+    ):
+        logger.info(
+            "Requesting to store project, re-routing to chief",
+            project=name,
+        )
+        chief_client = framework.utils.clients.chief.Client()
+        return await chief_client.store_project(name=name, request=request)
+
     project, is_running_in_background = await run_in_threadpool(
         get_project_member().store_project,
         db_session,

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -498,9 +498,10 @@ def test_redirection_from_worker_to_chief_only_if_serving_function_with_track_mo
     httpserver,
     monkeypatch,
 ):
-    mlrun.mlconf.httpdb.clusterization.role = "worker"
     endpoint = "/build/function"
+    # create the project while still in chief role - project CRUD reroutes to chief on workers
     services.api.tests.unit.api.utils.create_project(client, PROJECT)
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
 
     function_name = "test-function"
     function = _generate_function(function_name)
@@ -532,9 +533,10 @@ def test_redirection_from_worker_to_chief_deploy_serving_function_with_track_mod
     client: fastapi.testclient.TestClient,
     httpserver,
 ):
-    mlrun.mlconf.httpdb.clusterization.role = "worker"
     endpoint = "/build/function"
+    # create the project while still in chief role - project CRUD reroutes to chief on workers
     services.api.tests.unit.api.utils.create_project(client, PROJECT)
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
 
     function_name = "test-function"
     function_with_track_models = _generate_function(function_name)

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -98,9 +98,10 @@ def project_member_mode(request, db: Session) -> str:
 def test_redirection_from_worker_to_chief_delete_project(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
 ):
-    mlrun.mlconf.httpdb.clusterization.role = "worker"
     project_name = "test-project"
+    # create the project while still in chief role - project CRUD reroutes to chief on workers
     _create_project(client, project_name)
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
 
     endpoint = f"projects/{project_name}"
     for strategy in mlrun.common.schemas.DeletionStrategy:
@@ -145,6 +146,93 @@ def test_redirection_from_worker_to_chief_delete_project(
             except json.decoder.JSONDecodeError:
                 # NO_CONTENT response doesn't return json serializable response
                 assert response.text == expected_response
+
+
+def test_redirection_from_worker_to_chief_create_project(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
+):
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+    project_name = "test-project"
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(),
+    )
+
+    endpoint = "projects"
+    for test_case in [
+        # creating project accepted and is running in background
+        {
+            "expected_status": http.HTTPStatus.ACCEPTED.value,
+            "expected_body": {},
+        },
+        # project successfully created
+        {
+            "expected_status": http.HTTPStatus.CREATED.value,
+            "expected_body": project.dict(),
+        },
+        # creating project failed for unknown reason
+        {
+            "expected_status": http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "expected_body": {"detail": {"reason": "Unknown error"}},
+        },
+    ]:
+        expected_status = test_case.get("expected_status")
+        expected_response = test_case.get("expected_body")
+
+        httpserver.expect_ordered_request(
+            f"{ORIGINAL_VERSIONED_API_PREFIX}/{endpoint}", method="POST"
+        ).respond_with_json(expected_response, status=expected_status)
+        url = httpserver.url_for("")
+        mlrun.mlconf.httpdb.clusterization.chief.url = url
+        response = client.post(endpoint, json=project.dict())
+        assert response.status_code == expected_status
+        assert response.json() == expected_response
+
+
+def test_redirection_from_worker_to_chief_store_project(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
+):
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+    project_name = "test-project"
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(),
+    )
+
+    endpoint = f"projects/{project_name}"
+    for test_case in [
+        # storing project accepted and is running in background
+        {
+            "expected_status": http.HTTPStatus.ACCEPTED.value,
+            "expected_body": {},
+        },
+        # project successfully stored
+        {
+            "expected_status": http.HTTPStatus.OK.value,
+            "expected_body": project.dict(),
+        },
+        # project successfully created via store
+        {
+            "expected_status": http.HTTPStatus.CREATED.value,
+            "expected_body": project.dict(),
+        },
+        # storing project failed for unknown reason
+        {
+            "expected_status": http.HTTPStatus.INTERNAL_SERVER_ERROR.value,
+            "expected_body": {"detail": {"reason": "Unknown error"}},
+        },
+    ]:
+        expected_status = test_case.get("expected_status")
+        expected_response = test_case.get("expected_body")
+
+        httpserver.expect_ordered_request(
+            f"{ORIGINAL_VERSIONED_API_PREFIX}/{endpoint}", method="PUT"
+        ).respond_with_json(expected_response, status=expected_status)
+        url = httpserver.url_for("")
+        mlrun.mlconf.httpdb.clusterization.chief.url = url
+        response = client.put(endpoint, json=project.dict())
+        assert response.status_code == expected_status
+        assert response.json() == expected_response
 
 
 def test_create_project_failure_already_exists(

--- a/server/py/services/api/tests/unit/api/test_submit.py
+++ b/server/py/services/api/tests/unit/api/test_submit.py
@@ -434,13 +434,14 @@ def test_redirection_from_worker_to_chief_only_if_schedules_in_job(
     httpserver,
     monkeypatch,
 ):
-    mlrun.mlconf.httpdb.clusterization.role = "worker"
-
     project = "test-project"
     function_name = "test-function"
     function_tag = "latest"
 
+    # create the project while still in chief role - project CRUD reroutes to chief on workers
     services.api.tests.unit.api.utils.create_project(client, project)
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+
     function = mlrun.new_function(
         name=function_name,
         project=project,
@@ -476,7 +477,6 @@ def test_redirection_from_worker_to_chief_only_if_schedules_in_job(
 def test_redirection_from_worker_to_chief_submit_job_with_schedule(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient, httpserver
 ):
-    mlrun.mlconf.httpdb.clusterization.role = "worker"
     endpoint = "/submit_job"
     project = "test-project"
 
@@ -490,7 +490,10 @@ def test_redirection_from_worker_to_chief_submit_job_with_schedule(
         image="mlrun/mlrun",
     )
 
+    # create the project while still in chief role - project CRUD reroutes to chief on workers
     services.api.tests.unit.api.utils.create_project(client, project)
+    mlrun.mlconf.httpdb.clusterization.role = "worker"
+
     submit_job_body = _create_submit_job_body_with_schedule(function, project)
 
     for test_case in [


### PR DESCRIPTION
### 📝 Description
Makes sure all project crud happens on the chief.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
