### PR TITLE
[CI] Add missing jq and openssl to enterprise test dependencies

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -383,6 +383,7 @@ jobs:
         # graphviz      for generating graphs (feature store tests)
         # git-core      for cloning repos and etc, required by many suites
         # gcc, make     for installing python packages
+        # jq, openssl   for github-app-token.sh (token refresh daemon)
         apt-get update -qqy && \
           apt-get install -y \
             curl \
@@ -391,7 +392,9 @@ jobs:
             graphviz \
             git-core \
             gcc \
-            make
+            make \
+            jq \
+            openssl
 
     - name: Install aws-iam-authenticator
       # Required when kubeconfig uses exec auth with `command: aws-iam-authenticator`


### PR DESCRIPTION
## Summary
- Adds `jq` and `openssl` to the `Install Dependencies` step in the enterprise system test job (`run-system-tests-enterprise-ci`)
- The token refresh daemon (`github-app-token.sh`) requires both tools, but the `gcr.io/iguazio/python:3.11` container doesn't include them
- This caused all enterprise test matrix jobs to fail with `ERROR: Required command 'jq' not found`

## Related
- #9659 (backport script to 1.11.x)
- #9660 (backport script to 1.10.x)

## Test plan
- [ ] Enterprise system tests pass the "Start GitHub App token refresh daemon" step on next scheduled run

Made with [Cursor](https://cursor.com)