### PR TITLE
[CI] Add code owner for application runtime changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,6 +97,8 @@ mlrun/common/formatters/** @quaark @mlrun/platform-owners
 # server clients, server side runtimes and run monitoring are owned by alonmr
 server/py/framework/utils/clients/** @alonmr @mlrun/platform-owners
 server/py/framework/utils/runtimes/** @alonmr @mlrun/platform-owners
+
+server/py/services/api/crud/runtimes/nuclio/** @Yacouby @mlrun/platform-owners
 server/py/services/api/common/runtime_handlers.py @alonmr @mlrun/platform-owners
 server/py/services/api/runtime_handlers/** @alonmr @mlrun/platform-owners
 
@@ -169,9 +171,9 @@ mlrun/runtimes/sparkjob/** @mlrun/data-flows-owners
 # api gateway runtime is owned by rokatyy
 mlrun/runtimes/nuclio/api_gateway.py @rokatyy @mlrun/platform-owners
 
-# application runtime is owned by TomerShor
-mlrun/runtimes/nuclio/application/** @TomerShor @mlrun/platform-owners
-mlrun/runtimes/nuclio/function.py @TomerShor @mlrun/platform-owners
+# application runtime is owned by TomerShor and Yacouby
+mlrun/runtimes/nuclio/application/** @TomerShor @Yacouby @mlrun/platform-owners
+mlrun/runtimes/nuclio/function.py @TomerShor @Yacouby @mlrun/platform-owners
 
 ### End of Runtimes ###
 


### PR DESCRIPTION
### 📝 Description
Update `CODEOWNERS` to add ownership for the application runtime and server-side nuclio runtime CRUD paths.

---

### 🛠️ Changes Made
Added `@Yacouby` as co-owner for:
`mlrun/runtimes/nuclio/application/**`
`mlrun/runtimes/nuclio/function.py`
`server/py/services/api/crud/runtimes/nuclio/**`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
