### PR TITLE
[Local Dev] Fix pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ universal = true
 
 [tool.pytest]
 addopts = ["-v", "-rf", "--disable-warnings", "--import-mode=importlib"]
-pythonpath = ["./server/py"] # This allows running server side tests from the project root directory
+pythonpath = [".", "./server/py"] # This allows running server side tests from the project root directory
 python_files = [
     "tests/*/test_*.py",
     "tests/test_*.py",


### PR DESCRIPTION
### 📝 Description
Fixed a small bug in the pytest config that caused import errors when running the `pytest` cli directly.

---

### 🛠️ Changes Made
Updated the `pythonpath` setting of the pytest config to include the root directory.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Basically the setting to include `./server/py` when running from the root, excluded the root itself which is also needed because some test files import from `tests.*`. This issue was not as apparent because if you run pytest through python (`python -m pytest`) the root is already part of the pythonpath through the python invocation and wont get removed. This PR thus leaves the correct behaviour of `python -m pytest` intact while bringing `pytest` inline with it.