### PR TITLE
[Code Artifacts] Body-backed source and multi-file archive support

### DIFF
--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -74,7 +74,7 @@ class CodeArtifact(Artifact):
     """Code Artifact
 
     Store source code for use as a function or workflow source. The artifact
-    payload is a Python file or an archive (``.zip`` / ``.tar.gz``) whose
+    payload is a source file or an archive (``.zip`` / ``.tar.gz``) whose
     members are extracted on resolution. The payload may be carried inline
     as ``body`` (subject to the inline-artifact size limit) or uploaded to
     ``target_path`` like any other artifact.

--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -73,8 +73,11 @@ class CodeArtifactSpec(ArtifactSpec):
 class CodeArtifact(Artifact):
     """Code Artifact
 
-    Store a code file or archive for use as a function or workflow source.
-    Supports a single code file or a single archive (.zip, .tar.gz).
+    Store source code for use as a function or workflow source. The artifact
+    payload is a Python file or an archive (``.zip`` / ``.tar.gz``) whose
+    members are extracted on resolution. The payload may be carried inline
+    as ``body`` (subject to the inline-artifact size limit) or uploaded to
+    ``target_path`` like any other artifact.
     """
 
     kind = "code"

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -187,13 +187,17 @@ def _validate_workflow_code_artifact(artifact, workflow_path: str) -> None:
     """Validate ``artifact`` is a code artifact with ``code_type='workflow'``.
 
     Pure validation — no I/O. ``code_type=None`` is accepted for backward
-    compatibility; only an *explicit* non-workflow value fails.
+    compatibility; only an *explicit* non-workflow value fails. Archive
+    payloads (``.zip`` / ``.tar.gz``) are rejected: the workflow runner
+    needs a single source-file path to submit to KFP, and archive code
+    artifacts resolve to ``(target_dir, None)`` from ``load_source_code``.
 
     :param artifact:      Resolved store-resource (or ``None``).
     :param workflow_path: Original ``store://`` URI, used in error messages.
     :raises MLRunNotFoundError: if ``artifact`` is ``None``.
-    :raises MLRunInvalidArgumentError: if not an Artifact, or if kind /
-                                       code_type mismatch.
+    :raises MLRunInvalidArgumentError: if not an Artifact, if kind /
+                                       code_type mismatch, or if payload is
+                                       an archive.
     """
     if artifact is None:
         raise mlrun.errors.MLRunNotFoundError(
@@ -224,6 +228,13 @@ def _validate_workflow_code_artifact(artifact, workflow_path: str) -> None:
             f"Workflow path {workflow_path!r} resolves to a code artifact "
             f"with code_type={code_type.value!r}; expected "
             f"{mlrun.artifacts.CodeArtifactCodeType.workflow.value!r}."
+        )
+    filename = mlrun.utils.clones.resolve_artifact_filename(artifact)
+    if filename.lower().endswith((".zip", ".tar.gz")):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Workflow path {workflow_path!r} resolves to an archive code "
+            f"artifact ({filename!r}); workflow code artifacts must be a "
+            f"single source file."
         )
 
 

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -187,17 +187,17 @@ def _validate_workflow_code_artifact(artifact, workflow_path: str) -> None:
     """Validate ``artifact`` is a code artifact with ``code_type='workflow'``.
 
     Pure validation — no I/O. ``code_type=None`` is accepted for backward
-    compatibility; only an *explicit* non-workflow value fails. Archive
-    payloads (``.zip`` / ``.tar.gz``) are rejected: the workflow runner
-    needs a single source-file path to submit to KFP, and archive code
-    artifacts resolve to ``(target_dir, None)`` from ``load_source_code``.
+    compatibility; only an *explicit* non-workflow value fails. The payload
+    must be a single ``.py`` file: KFP runs Python workflows, so a non-Python
+    file (or an archive, which resolves to ``(target_dir, None)`` from
+    ``load_source_code`` with no single entry file) cannot be submitted.
 
     :param artifact:      Resolved store-resource (or ``None``).
     :param workflow_path: Original ``store://`` URI, used in error messages.
     :raises MLRunNotFoundError: if ``artifact`` is ``None``.
     :raises MLRunInvalidArgumentError: if not an Artifact, if kind /
-                                       code_type mismatch, or if payload is
-                                       an archive.
+                                       code_type mismatch, or if the payload
+                                       is not a single ``.py`` file.
     """
     if artifact is None:
         raise mlrun.errors.MLRunNotFoundError(
@@ -230,11 +230,11 @@ def _validate_workflow_code_artifact(artifact, workflow_path: str) -> None:
             f"{mlrun.artifacts.CodeArtifactCodeType.workflow.value!r}."
         )
     filename = mlrun.utils.clones.resolve_artifact_filename(artifact)
-    if filename.lower().endswith((".zip", ".tar.gz")):
+    if not filename.lower().endswith(".py"):
         raise mlrun.errors.MLRunInvalidArgumentError(
-            f"Workflow path {workflow_path!r} resolves to an archive code "
-            f"artifact ({filename!r}); workflow code artifacts must be a "
-            f"single source file."
+            f"Workflow path {workflow_path!r} resolves to {filename!r}; "
+            f"workflow code artifacts must be a single Python (.py) file "
+            f"(KFP runs Python workflows)."
         )
 
 

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -276,14 +276,41 @@ def load_source_code(
     )
 
 
+def resolve_artifact_filename(artifact) -> str:
+    """Pick the on-disk filename for a resolved artifact.
+
+    Precedence: spec.src_path -> spec.target_path -> metadata.key.
+    Each candidate is passed through ``os.path.basename`` so a path-traversal
+    component sneaked into any field cannot escape the target directory.
+    Returns ``""`` if every candidate is empty or basename-empty (e.g. all
+    fields unset, or a trailing-slash path-only value); callers that need
+    a non-empty filename must check and raise.
+    """
+    for candidate in (
+        artifact.spec.src_path,
+        artifact.spec.target_path,
+        artifact.metadata.key,
+    ):
+        if candidate:
+            filename = os.path.basename(candidate)
+            if filename:
+                return filename
+    return ""
+
+
 def _load_store_artifact(
     source_uri: str,
     target_dir: str,
     project: str | None = None,
     secrets=None,
-) -> tuple[str, str]:
+) -> tuple[str, str | None]:
     """
-    Load a single-file artifact from the MLRun artifact store.
+    Load an artifact from the MLRun artifact store onto disk.
+
+    Code artifacts take a code-aware path: inline ``spec.body`` is preferred
+    over the target-path download, and ``.zip`` / ``.tar.gz`` payloads are
+    extracted in place. Other artifact kinds keep today's single-file
+    download behavior.
 
     :param source_uri: Artifact URI (store://artifacts/project/key)
     :param target_dir: Target directory where the file will be placed
@@ -293,12 +320,12 @@ def _load_store_artifact(
                        download for cases where the artifact target path lives
                        on a credential-protected store)
 
-    :returns: ``(target_dir, local_file_path)`` — the directory the file was
-              downloaded into and the resolved file path within it. Each call
-              re-downloads the artifact content, overwriting any previous local
-              copy at the same path.
+    :returns: ``(target_dir, local_file_path)`` — the directory the artifact
+              was materialized into and the resolved file path within it. For
+              archive code artifacts (.zip/.tar.gz) that are extracted in
+              place, ``local_file_path`` is ``None`` since the archive itself
+              is removed after extraction.
     """
-    # Resolve the artifact from the store
     artifact = mlrun.datastore.get_store_resource(
         source_uri,
         project=project,
@@ -306,34 +333,152 @@ def _load_store_artifact(
         data_store_secrets=secrets,
     )
 
-    # Get the target path where the artifact content is stored
+    if artifact.kind == mlrun.artifacts.CodeArtifact.kind:
+        return _load_code_artifact(artifact, target_dir, secrets=secrets)
+    return _download_artifact_to_dir(artifact, target_dir, secrets=secrets)
+
+
+def _download_artifact_to_dir(artifact, target_dir: str, secrets) -> tuple[str, str]:
+    """Download a resolved artifact's target_path into target_dir."""
     artifact_target_path = artifact.get_target_path()
     if not artifact_target_path:
-        raise ValueError(f"Artifact {source_uri} does not have a valid target path")
-
-    # Create target directory if it doesn't exist
-    os.makedirs(target_dir, exist_ok=True)
-
-    # Preserve the original filename uploaded
-    if artifact.spec.src_path:
-        filename = os.path.basename(artifact.spec.src_path)
-    else:
-        # src_path may be unset for artifacts created via API/DB directly or with inline body.
-        # Fall back to the artifact-store filename
-        filename = os.path.basename(artifact_target_path)
-    local_file_path = os.path.join(target_dir, filename)
-
-    # Download the artifact content to the target directory
-    try:
-        mlrun.get_dataitem(artifact_target_path, secrets=secrets).download(
-            local_file_path
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Artifact {artifact.uri} does not have a valid target path"
         )
-    except Exception as exc:
-        raise mlrun.errors.MLRunRuntimeError(
-            f"Failed to download artifact from {artifact_target_path} to {local_file_path}"
-        ) from exc
+
+    filename = resolve_artifact_filename(artifact)
+    if not filename:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Artifact {artifact.uri} has no resolvable filename "
+            "(src_path, target_path, and metadata.key are all empty or "
+            "basename-empty)"
+        )
+    os.makedirs(target_dir, exist_ok=True)
+    local_file_path = os.path.join(target_dir, filename)
+    _download_dataitem_to(local_file_path, artifact_target_path, secrets=secrets)
 
     return target_dir, local_file_path
+
+
+def _load_code_artifact(artifact, target_dir: str, secrets) -> tuple[str, str | None]:
+    """Materialize a CodeArtifact onto disk in target_dir.
+
+    Body-backed code artifacts are written directly. Target-path-backed
+    artifacts are downloaded. In both cases, .zip/.tar.gz archives are
+    extracted in place after landing — the original archive file is then
+    removed and the returned file path is ``None``.
+    """
+    body = artifact.spec.get_body()
+
+    artifact_target_path = None
+    if body is None:
+        artifact_target_path = artifact.get_target_path()
+        if not artifact_target_path:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Code artifact {artifact.uri} has neither inline body nor a "
+                "target_path"
+            )
+
+    filename = resolve_artifact_filename(artifact)
+    if not filename:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Code artifact {artifact.uri} has no resolvable filename "
+            "(src_path, target_path, and metadata.key are all empty or "
+            "basename-empty)"
+        )
+    os.makedirs(target_dir, exist_ok=True)
+    local_file_path = os.path.join(target_dir, filename)
+
+    if body is None:
+        _download_dataitem_to(local_file_path, artifact_target_path, secrets=secrets)
+    else:
+        _write_body_to_path(body, local_file_path)
+
+    extracted = _maybe_extract_archive(local_file_path, target_dir)
+    return target_dir, (None if extracted else local_file_path)
+
+
+def _download_dataitem_to(local_file_path: str, source_path: str, secrets) -> None:
+    """Download a data item from ``source_path`` into ``local_file_path``.
+
+    Wraps any failure as ``MLRunRuntimeError`` so callers can fail loudly
+    without leaking internals from the underlying datastore implementation.
+    """
+    try:
+        mlrun.get_dataitem(source_path, secrets=secrets).download(local_file_path)
+    except Exception as exc:
+        raise mlrun.errors.MLRunRuntimeError(
+            f"Failed to download artifact from {source_path} to {local_file_path}"
+        ) from exc
+
+
+def _write_body_to_path(body, dest_path: str) -> None:
+    """Write an artifact body to disk in binary mode.
+
+    ``body`` shape matches what ``Artifact._upload_body`` writes today:
+    either ``bytes`` (e.g. .zip / .tar.gz archives) or ``str`` (e.g. .py
+    source). String bodies are encoded as UTF-8 so the bytes on disk are
+    independent of host locale and so no newline translation happens.
+    Archive payloads round-trip byte-for-byte.
+    """
+    data = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    with open(dest_path, "wb") as fh:
+        fh.write(data)
+
+
+def _maybe_extract_archive(local_file_path: str, target_dir: str) -> bool:
+    """Extract a .zip / .tar.gz in place and remove the archive.
+
+    No-op for non-archive payloads (the single file stays on disk).
+
+    :returns: ``True`` if the file was an archive that was extracted (and the
+              original archive removed); ``False`` for non-archive payloads
+              that stay on disk untouched.
+    """
+    lower = local_file_path.lower()
+    if lower.endswith(".zip"):
+        with zipfile.ZipFile(local_file_path, "r") as zf:
+            _safe_extract_zip(zf, target_dir)
+    elif lower.endswith(".tar.gz"):
+        with tarfile.TarFile.open(local_file_path, "r:*") as tf:
+            _safe_extract_tar(tf, target_dir)
+    else:
+        return False
+    os.remove(local_file_path)
+    return True
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, target_dir: str) -> None:
+    """Extract a zip into target_dir, rejecting any member that escapes it."""
+    for member in zf.namelist():
+        member_path = os.path.join(target_dir, member)
+        if not _is_path_under(member_path, target_dir):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Refusing to extract zip member {member!r}: resolved path "
+                f"escapes target directory"
+            )
+    zf.extractall(target_dir)
+
+
+def _safe_extract_tar(tf: tarfile.TarFile, target_dir: str) -> None:
+    """Extract a tar into target_dir, rejecting any member that escapes it."""
+    for member in tf.getmembers():
+        member_path = os.path.join(target_dir, member.name)
+        if not _is_path_under(member_path, target_dir):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"Refusing to extract tar member {member.name!r}: resolved "
+                f"path escapes target directory"
+            )
+    # PEP 706 data filter: defense-in-depth — also rejects link members
+    # whose linkname escapes target_dir (the pre-flight only inspects
+    # member.name, not member.linkname).
+    tf.extractall(path=target_dir, filter="data")
+
+
+def _is_path_under(child: str, parent: str) -> bool:
+    parent_real = os.path.realpath(parent)
+    child_real = os.path.realpath(child)
+    return child_real == parent_real or child_real.startswith(parent_real + os.sep)
 
 
 def _load_git_source(source_uri: str, target_dir: str) -> str:

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -307,10 +307,10 @@ def _load_store_artifact(
     """
     Load an artifact from the MLRun artifact store onto disk.
 
-    Code artifacts take a code-aware path: inline ``spec.body`` is preferred
-    over the target-path download, and ``.zip`` / ``.tar.gz`` payloads are
-    extracted in place. Other artifact kinds keep today's single-file
-    download behavior.
+    Code artifacts take a code-aware path: inline ``spec.body`` (plain source)
+    is written directly when set, otherwise the target_path is downloaded and
+    an archive payload (zip or tar, detected by content) is extracted in
+    place. Other artifact kinds keep today's single-file download behavior.
 
     :param source_uri: Artifact URI (store://artifacts/project/key)
     :param target_dir: Target directory where the file will be placed
@@ -322,9 +322,9 @@ def _load_store_artifact(
 
     :returns: ``(target_dir, local_file_path)`` — the directory the artifact
               was materialized into and the resolved file path within it. For
-              archive code artifacts (.zip/.tar.gz) that are extracted in
-              place, ``local_file_path`` is ``None`` since the archive itself
-              is removed after extraction.
+              archive code artifacts that are extracted in place,
+              ``local_file_path`` is ``None`` since the archive itself is
+              removed after extraction.
     """
     artifact = mlrun.datastore.get_store_resource(
         source_uri,
@@ -332,6 +332,20 @@ def _load_store_artifact(
         secrets=secrets,
         data_store_secrets=secrets,
     )
+
+    if artifact is None:
+        raise mlrun.errors.MLRunNotFoundError(
+            f"Source {source_uri!r} did not resolve to an artifact "
+            "(the store returned no resource; the URI may be malformed or "
+            "point at a missing link target)."
+        )
+    if not isinstance(artifact, mlrun.artifacts.Artifact):
+        # get_store_resource can also return FeatureSet / FeatureVector /
+        # DataItem for non-artifact store URIs (e.g. store://feature-sets/...).
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Source {source_uri!r} resolves to a {type(artifact).__name__}; "
+            "expected an artifact."
+        )
 
     if artifact.kind == mlrun.artifacts.CodeArtifact.kind:
         return _load_code_artifact(artifact, target_dir, secrets=secrets)
@@ -363,22 +377,11 @@ def _download_artifact_to_dir(artifact, target_dir: str, secrets) -> tuple[str, 
 def _load_code_artifact(artifact, target_dir: str, secrets) -> tuple[str, str | None]:
     """Materialize a CodeArtifact onto disk in target_dir.
 
-    Body-backed code artifacts are written directly. Target-path-backed
-    artifacts are downloaded. In both cases, .zip/.tar.gz archives are
-    extracted in place after landing — the original archive file is then
-    removed and the returned file path is ``None``.
+    Inline ``body`` is plain source written directly as a single file. A
+    target-path-backed artifact is downloaded; if it is an archive (zip or
+    tar, detected by content) it is extracted in place, the original archive
+    is removed, and the returned file path is ``None``.
     """
-    body = artifact.spec.get_body()
-
-    artifact_target_path = None
-    if body is None:
-        artifact_target_path = artifact.get_target_path()
-        if not artifact_target_path:
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Code artifact {artifact.uri} has neither inline body nor a "
-                "target_path"
-            )
-
     filename = resolve_artifact_filename(artifact)
     if not filename:
         raise mlrun.errors.MLRunInvalidArgumentError(
@@ -389,90 +392,107 @@ def _load_code_artifact(artifact, target_dir: str, secrets) -> tuple[str, str | 
     os.makedirs(target_dir, exist_ok=True)
     local_file_path = os.path.join(target_dir, filename)
 
-    if body is None:
-        _download_dataitem_to(local_file_path, artifact_target_path, secrets=secrets)
-    else:
+    body = artifact.spec.get_body()
+    if body is not None:
         _write_body_to_path(body, local_file_path)
+        return target_dir, local_file_path
 
-    extracted = _maybe_extract_archive(local_file_path, target_dir)
-    return target_dir, (None if extracted else local_file_path)
+    artifact_target_path = artifact.get_target_path()
+    if not artifact_target_path:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Code artifact {artifact.uri} has neither inline body nor a target_path"
+        )
+    _download_dataitem_to(local_file_path, artifact_target_path, secrets=secrets)
+
+    if _maybe_extract_archive(local_file_path, target_dir):
+        os.remove(local_file_path)
+        return target_dir, None
+    return target_dir, local_file_path
 
 
 def _download_dataitem_to(local_file_path: str, source_path: str, secrets) -> None:
     """Download a data item from ``source_path`` into ``local_file_path``.
 
-    Wraps any failure as ``MLRunRuntimeError`` so callers can fail loudly
-    without leaking internals from the underlying datastore implementation.
+    Wraps any failure as ``MLRunRuntimeError`` for a consistent error type,
+    surfacing the underlying cause in the message so a log-only context still
+    shows why the download failed.
     """
     try:
         mlrun.get_dataitem(source_path, secrets=secrets).download(local_file_path)
     except Exception as exc:
         raise mlrun.errors.MLRunRuntimeError(
-            f"Failed to download artifact from {source_path} to {local_file_path}"
+            f"Failed to download artifact from {source_path} to {local_file_path}: "
+            f"{mlrun.errors.err_to_str(exc)}"
         ) from exc
 
 
 def _write_body_to_path(body, dest_path: str) -> None:
-    """Write an artifact body to disk in binary mode.
+    """Write an inline artifact body (plain source) to disk in binary mode.
 
-    ``body`` shape matches what ``Artifact._upload_body`` writes today:
-    either ``bytes`` (e.g. .zip / .tar.gz archives) or ``str`` (e.g. .py
-    source). String bodies are encoded as UTF-8 so the bytes on disk are
-    independent of host locale and so no newline translation happens.
-    Archive payloads round-trip byte-for-byte.
+    ``body`` is the inline source — typically ``str`` (e.g. .py source),
+    optionally ``bytes``. String bodies are encoded as UTF-8 so the bytes on
+    disk are independent of host locale and no newline translation happens.
     """
-    data = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    if isinstance(body, str):
+        data = body.encode("utf-8")
+    elif isinstance(body, (bytes, bytearray, memoryview)):
+        data = bytes(body)
+    else:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Unsupported artifact body type {type(body).__name__}; "
+            "expected str or bytes"
+        )
     with open(dest_path, "wb") as fh:
         fh.write(data)
 
 
 def _maybe_extract_archive(local_file_path: str, target_dir: str) -> bool:
-    """Extract a .zip / .tar.gz in place and remove the archive.
+    """Extract an archive into target_dir; no-op for a single file.
 
-    No-op for non-archive payloads (the single file stays on disk).
+    Archive type is detected by content, not filename suffix, so any
+    extension (or none) works: ``zipfile`` for zip, and ``tarfile`` for the
+    whole tar family (gzip/.tgz, bzip2, xz, uncompressed). The archive file
+    itself is left on disk for the caller to remove.
 
-    :returns: ``True`` if the file was an archive that was extracted (and the
-              original archive removed); ``False`` for non-archive payloads
-              that stay on disk untouched.
+    :returns: ``True`` if the file was an archive and was extracted; ``False``
+              for a single-file payload that stays on disk untouched.
     """
-    lower = local_file_path.lower()
-    if lower.endswith(".zip"):
+    if zipfile.is_zipfile(local_file_path):
         with zipfile.ZipFile(local_file_path, "r") as zf:
             _safe_extract_zip(zf, target_dir)
-    elif lower.endswith(".tar.gz"):
+    elif tarfile.is_tarfile(local_file_path):
         with tarfile.TarFile.open(local_file_path, "r:*") as tf:
             _safe_extract_tar(tf, target_dir)
     else:
         return False
-    os.remove(local_file_path)
     return True
 
 
 def _safe_extract_zip(zf: zipfile.ZipFile, target_dir: str) -> None:
     """Extract a zip into target_dir, rejecting any member that escapes it."""
     for member in zf.namelist():
-        member_path = os.path.join(target_dir, member)
-        if not _is_path_under(member_path, target_dir):
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Refusing to extract zip member {member!r}: resolved path "
-                f"escapes target directory"
-            )
+        _reject_member_escaping_target(member, target_dir)
     zf.extractall(target_dir)
 
 
 def _safe_extract_tar(tf: tarfile.TarFile, target_dir: str) -> None:
     """Extract a tar into target_dir, rejecting any member that escapes it."""
     for member in tf.getmembers():
-        member_path = os.path.join(target_dir, member.name)
-        if not _is_path_under(member_path, target_dir):
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                f"Refusing to extract tar member {member.name!r}: resolved "
-                f"path escapes target directory"
-            )
+        _reject_member_escaping_target(member.name, target_dir)
     # PEP 706 data filter: defense-in-depth — also rejects link members
     # whose linkname escapes target_dir (the pre-flight only inspects
     # member.name, not member.linkname).
     tf.extractall(path=target_dir, filter="data")
+
+
+def _reject_member_escaping_target(member_name: str, target_dir: str) -> None:
+    """Raise if extracting ``member_name`` would resolve outside target_dir."""
+    member_path = os.path.join(target_dir, member_name)
+    if not _is_path_under(member_path, target_dir):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Refusing to extract archive member {member_name!r}: resolved "
+            f"path escapes target directory"
+        )
 
 
 def _is_path_under(child: str, parent: str) -> bool:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2135,12 +2135,13 @@ def test_validate_workflow_code_artifact_pure():
     # accepted: kind='code' + code_type='workflow'
     ok = mlrun.artifacts.CodeArtifact(
         key="ok",
+        src_path="ok.py",
         code_type=mlrun.artifacts.CodeArtifactCodeType.workflow,
     )
     validate(ok, "store://artifacts/p/ok")
 
     # accepted: kind='code' + code_type=None (older clients, backward compat)
-    legacy = mlrun.artifacts.CodeArtifact(key="legacy")
+    legacy = mlrun.artifacts.CodeArtifact(key="legacy", src_path="legacy.py")
     legacy.spec.code_type = None
     validate(legacy, "store://artifacts/p/legacy")
 
@@ -2239,25 +2240,27 @@ def test_validate_workflow_code_artifact_rejects_non_artifact():
 @pytest.mark.parametrize(
     "src_path, target_path, key",
     [
-        # rejected via src_path
+        # archive suffixes are not .py
         ("workflow.zip", None, "k"),
         ("workflow.tar.gz", None, "k"),
-        # case-insensitive suffix match
-        ("workflow.ZIP", None, "k"),
+        # .tgz (the suffix a blacklist would miss) is rejected for free
+        ("workflow.tgz", None, "k"),
+        # non-python single file
+        ("workflow.sh", None, "k"),
         # rejected via target_path fallback (src_path unset)
         (None, "s3://b/archive.zip", "k"),
         # rejected via metadata.key fallback (src_path + target_path unset)
         (None, None, "archive.tar.gz"),
+        # no resolvable filename at all -> "" -> not .py -> rejected
+        (None, None, None),
     ],
 )
-def test_validate_workflow_code_artifact_rejects_archive_payloads(
+def test_validate_workflow_code_artifact_rejects_non_python_payloads(
     src_path, target_path, key
 ):
-    """Archive code artifacts cannot back a workflow: the runner needs a
-    single .py path to import (KFP submits one source file, not a tree),
-    and _load_code_artifact extracts archives in place and returns
-    (target_dir, None). Pre-CodeArtifact, set_workflow only ever accepted
-    a single Python file; this validator preserves that contract.
+    """KFP runs Python workflows, so a workflow code artifact must resolve
+    to a single .py file. The validator whitelists .py — archives (incl.
+    .tgz), other languages, and unresolvable filenames are all rejected.
     """
     artifact = mlrun.artifacts.CodeArtifact(
         key=key,
@@ -2268,19 +2271,20 @@ def test_validate_workflow_code_artifact_rejects_archive_payloads(
     validate = mlrun.projects.pipelines._validate_workflow_code_artifact
     with pytest.raises(
         mlrun.errors.MLRunInvalidArgumentError,
-        match="archive code artifact",
+        match="must be a single Python",
     ):
         validate(artifact, "store://artifacts/p/k")
 
 
-def test_validate_workflow_code_artifact_accepts_python_payload():
-    """A workflow code artifact with a .py src_path passes the archive
-    rejection — pins that the new check doesn't over-match.
+@pytest.mark.parametrize("src_path", ["workflow.py", "workflow.PY", "./sub/wf.py"])
+def test_validate_workflow_code_artifact_accepts_python_payload(src_path):
+    """A workflow code artifact resolving to a .py file passes (case-
+    insensitive) — pins that the whitelist doesn't over-reject.
     """
     artifact = mlrun.artifacts.CodeArtifact(
         key="k",
         code_type=mlrun.artifacts.CodeArtifactCodeType.workflow,
-        src_path="workflow.py",
+        src_path=src_path,
     )
     mlrun.projects.pipelines._validate_workflow_code_artifact(
         artifact, "store://artifacts/p/k"

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -2236,6 +2236,57 @@ def test_validate_workflow_code_artifact_rejects_non_artifact():
         validate(_NotAnArtifact(), "store://feature-sets/p/x")
 
 
+@pytest.mark.parametrize(
+    "src_path, target_path, key",
+    [
+        # rejected via src_path
+        ("workflow.zip", None, "k"),
+        ("workflow.tar.gz", None, "k"),
+        # case-insensitive suffix match
+        ("workflow.ZIP", None, "k"),
+        # rejected via target_path fallback (src_path unset)
+        (None, "s3://b/archive.zip", "k"),
+        # rejected via metadata.key fallback (src_path + target_path unset)
+        (None, None, "archive.tar.gz"),
+    ],
+)
+def test_validate_workflow_code_artifact_rejects_archive_payloads(
+    src_path, target_path, key
+):
+    """Archive code artifacts cannot back a workflow: the runner needs a
+    single .py path to import (KFP submits one source file, not a tree),
+    and _load_code_artifact extracts archives in place and returns
+    (target_dir, None). Pre-CodeArtifact, set_workflow only ever accepted
+    a single Python file; this validator preserves that contract.
+    """
+    artifact = mlrun.artifacts.CodeArtifact(
+        key=key,
+        code_type=mlrun.artifacts.CodeArtifactCodeType.workflow,
+        src_path=src_path,
+        target_path=target_path,
+    )
+    validate = mlrun.projects.pipelines._validate_workflow_code_artifact
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="archive code artifact",
+    ):
+        validate(artifact, "store://artifacts/p/k")
+
+
+def test_validate_workflow_code_artifact_accepts_python_payload():
+    """A workflow code artifact with a .py src_path passes the archive
+    rejection — pins that the new check doesn't over-match.
+    """
+    artifact = mlrun.artifacts.CodeArtifact(
+        key="k",
+        code_type=mlrun.artifacts.CodeArtifactCodeType.workflow,
+        src_path="workflow.py",
+    )
+    mlrun.projects.pipelines._validate_workflow_code_artifact(
+        artifact, "store://artifacts/p/k"
+    )
+
+
 def test_remote_runner_run_relativizes_workflow_path(monkeypatch, tmp_path):
     """_RemoteRunner.run must rewrite an absolute workflow_path under the
     project code-path into a relative form before submitting it to the API.

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -80,7 +80,8 @@ def test_load_artifact_success(tmp_path, project):
     target_dir = str(tmp_path / "target")
     artifact_target_path = "s3://bucket/artifacts/handler.py"
 
-    mock_artifact = unittest.mock.MagicMock()
+    mock_artifact = unittest.mock.MagicMock(spec=mlrun.artifacts.Artifact)
+    mock_artifact.kind = "artifact"
     mock_artifact.get_target_path.return_value = artifact_target_path
     mock_artifact.spec.src_path = "handler.py"
     mock_dataitem = unittest.mock.MagicMock()
@@ -132,7 +133,8 @@ def test_load_artifact_forwards_secrets(tmp_path):
     artifact_target_path = "s3://bucket/artifacts/handler.py"
     secrets = {"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s"}
 
-    mock_artifact = unittest.mock.MagicMock()
+    mock_artifact = unittest.mock.MagicMock(spec=mlrun.artifacts.Artifact)
+    mock_artifact.kind = "artifact"
     mock_artifact.get_target_path.return_value = artifact_target_path
     mock_artifact.spec.src_path = "handler.py"
     mock_dataitem = unittest.mock.MagicMock()
@@ -215,7 +217,8 @@ def test_load_source_code_failures(
     source_uri, target_dir, is_store_uri_return, artifact_target_path, error_match
 ):
     # Test various failure scenarios for load_source_code
-    mock_artifact = unittest.mock.MagicMock()
+    mock_artifact = unittest.mock.MagicMock(spec=mlrun.artifacts.Artifact)
+    mock_artifact.kind = "artifact"
     mock_artifact.get_target_path.return_value = artifact_target_path
 
     with (
@@ -413,6 +416,15 @@ def test_write_body_to_path(tmp_path, body, expected_bytes):
     assert target.read_bytes() == expected_bytes
 
 
+def test_write_body_to_path_rejects_non_str_bytes(tmp_path):
+    """A body that is neither str nor bytes must raise rather than silently
+    writing a corrupted file (e.g. bytes(int) producing a zero buffer)."""
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="Unsupported artifact body type"
+    ):
+        mlrun.utils.clones._write_body_to_path(123, str(tmp_path / "out.bin"))
+
+
 # ---------------------------------------------------------------------------
 # Archive builder helpers
 # ---------------------------------------------------------------------------
@@ -477,7 +489,7 @@ def _mock_code_artifact(
     uri="store://artifacts/proj/key",
 ):
     """Build a MagicMock standing in for a resolved code artifact."""
-    artifact = unittest.mock.MagicMock()
+    artifact = unittest.mock.MagicMock(spec=mlrun.artifacts.CodeArtifact)
     artifact.kind = mlrun.artifacts.CodeArtifact.kind if kind is None else kind
     artifact.spec.get_body.return_value = body
     artifact.spec.src_path = src_path
@@ -563,9 +575,24 @@ def test_maybe_extract_archive(
     archive = tmp_path / f"src{suffix}"
     archive.write_bytes(make_archive(members))
 
-    mlrun.utils.clones._maybe_extract_archive(str(archive), str(tmp_path))
+    extracted = mlrun.utils.clones._maybe_extract_archive(str(archive), str(tmp_path))
 
-    assert not archive.exists()
+    assert extracted is True
+    # Removal is the caller's responsibility; the archive stays on disk here.
+    assert archive.exists()
+    assert (tmp_path / "a.py").read_bytes() == members["a.py"]
+    assert (tmp_path / "b.py").read_bytes() == members["b.py"]
+
+
+def test_maybe_extract_archive_tgz_suffix(tmp_path):
+    """`.tgz` is gzipped tar and must be extracted like `.tar.gz`."""
+    members = {"a.py": b"a", "b.py": b"b"}
+    archive = tmp_path / "src.tgz"
+    archive.write_bytes(_make_tgz_bytes(members))
+
+    extracted = mlrun.utils.clones._maybe_extract_archive(str(archive), str(tmp_path))
+
+    assert extracted is True
     assert (tmp_path / "a.py").read_bytes() == members["a.py"]
     assert (tmp_path / "b.py").read_bytes() == members["b.py"]
 
@@ -607,7 +634,12 @@ def test_load_code_artifact_target_path_single_file(tmp_path):
     artifact.get_target_path.return_value = "s3://bucket/abc/handler.py"
     target_dir = str(tmp_path)
 
+    def fake_download(dest_path):
+        with open(dest_path, "wb") as fh:
+            fh.write(b"print('handler')\n")
+
     mock_dataitem = unittest.mock.MagicMock()
+    mock_dataitem.download.side_effect = fake_download
     with unittest.mock.patch(
         "mlrun.get_dataitem", return_value=mock_dataitem
     ) as mock_get_dataitem:
@@ -615,34 +647,15 @@ def test_load_code_artifact_target_path_single_file(tmp_path):
             artifact, target_dir, secrets=None
         )
 
+    # A plain source file is content-detected as a non-archive and left as-is.
     assert result == (target_dir, os.path.join(target_dir, "handler.py"))
+    assert (tmp_path / "handler.py").read_bytes() == b"print('handler')\n"
     mock_get_dataitem.assert_called_once_with(
         "s3://bucket/abc/handler.py", secrets=None
     )
     mock_dataitem.download.assert_called_once_with(
         os.path.join(target_dir, "handler.py")
     )
-
-
-@pytest.mark.parametrize(
-    "make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc",
-    ARCHIVE_FORMATS,
-)
-def test_load_code_artifact_body_archive_extracted(
-    tmp_path, make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc
-):
-    members = {"a.py": b"print('a')\n", "pkg/b.py": b"print('b')\n"}
-    artifact = _mock_code_artifact(
-        body=make_archive(members), src_path=f"src{suffix}", key="src"
-    )
-    target_dir = str(tmp_path)
-
-    result = mlrun.utils.clones._load_code_artifact(artifact, target_dir, secrets=None)
-
-    assert result == (target_dir, None)
-    assert not (tmp_path / f"src{suffix}").exists()
-    assert (tmp_path / "a.py").read_bytes() == members["a.py"]
-    assert (tmp_path / "pkg" / "b.py").read_bytes() == members["pkg/b.py"]
 
 
 @pytest.mark.parametrize(
@@ -677,7 +690,7 @@ def test_load_code_artifact_target_path_archive_extracted(
 
 
 def test_load_code_artifact_no_body_no_target_path_raises(tmp_path):
-    artifact = _mock_code_artifact()
+    artifact = _mock_code_artifact(src_path="handler.py")
     artifact.get_target_path.return_value = ""
 
     with pytest.raises(
@@ -703,47 +716,69 @@ def test_load_code_artifact_body_with_unresolvable_filename_raises(tmp_path):
         mlrun.utils.clones._load_code_artifact(artifact, str(tmp_path), secrets=None)
 
 
-def test_load_code_artifact_body_zip_slip_rejected(tmp_path):
-    artifact = _mock_code_artifact(
-        body=_make_zip_bytes({"../escape.py": b"print('escape')\n"}),
-        src_path="evil.zip",
-        key="evil",
-    )
-    target_dir = tmp_path / "target"
-    target_dir.mkdir()
-
-    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="escape"):
-        mlrun.utils.clones._load_code_artifact(artifact, str(target_dir), secrets=None)
-
-    # Nothing leaked outside target_dir
-    assert not (tmp_path / "escape.py").exists()
-
-
-@pytest.mark.parametrize(
-    "_make_archive, suffix, _opener, _extract_fn_name, bad_archive_exc",
-    ARCHIVE_FORMATS,
-)
-def test_load_code_artifact_body_corrupted_archive_propagates(
-    tmp_path, _make_archive, suffix, _opener, _extract_fn_name, bad_archive_exc
-):
-    """Corrupted archive body must surface the stdlib decoder error uncaught.
-
-    Pins the spec contract: extraction errors fail loudly so the runner
-    init container does not silently start from a half-extracted dir.
+def test_load_code_artifact_target_path_archive_extension_not_an_archive(tmp_path):
+    """Archive detection is by content, not suffix: a payload named like an
+    archive but whose bytes are not a valid zip/tar is left as a single file
+    (not extracted), and the returned path is the file itself.
     """
-    artifact = _mock_code_artifact(
-        body=b"not actually an archive",
-        src_path=f"broken{suffix}",
-        key="broken",
-    )
+    artifact = _mock_code_artifact(src_path="broken.zip")
+    artifact.get_target_path.return_value = "s3://bucket/abc/broken.zip"
+    target_dir = str(tmp_path)
 
-    with pytest.raises(bad_archive_exc):
-        mlrun.utils.clones._load_code_artifact(artifact, str(tmp_path), secrets=None)
+    def fake_download(dest_path):
+        with open(dest_path, "wb") as fh:
+            fh.write(b"not actually an archive")
+
+    mock_dataitem = unittest.mock.MagicMock()
+    mock_dataitem.download.side_effect = fake_download
+
+    with unittest.mock.patch("mlrun.get_dataitem", return_value=mock_dataitem):
+        result = mlrun.utils.clones._load_code_artifact(
+            artifact, target_dir, secrets=None
+        )
+
+    assert result == (target_dir, os.path.join(target_dir, "broken.zip"))
+    assert (tmp_path / "broken.zip").read_bytes() == b"not actually an archive"
 
 
 # ---------------------------------------------------------------------------
 # Kind switch in _load_store_artifact
 # ---------------------------------------------------------------------------
+
+
+def test_load_store_artifact_none_resolution_raises(tmp_path):
+    """get_store_resource can return None (e.g. a link artifact whose target
+    re-read is falsy); the resolver must surface a typed NotFound rather than
+    an AttributeError on None.kind."""
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=None
+        ),
+        pytest.raises(
+            mlrun.errors.MLRunNotFoundError, match="did not resolve to an artifact"
+        ),
+    ):
+        mlrun.utils.clones._load_store_artifact(
+            "store://artifacts/proj/missing", str(tmp_path)
+        )
+
+
+def test_load_store_artifact_non_artifact_resolution_raises(tmp_path):
+    """get_store_resource can return FeatureSet / DataItem for non-artifact
+    store URIs; the resolver must reject those before touching .kind."""
+    not_an_artifact = unittest.mock.MagicMock()
+
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=not_an_artifact
+        ),
+        pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError, match="expected an artifact"
+        ),
+    ):
+        mlrun.utils.clones._load_store_artifact(
+            "store://feature-sets/proj/x", str(tmp_path)
+        )
 
 
 def test_load_store_artifact_code_kind_uses_body(tmp_path):

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
+import tarfile
 import unittest.mock
+import zipfile
 
 import pytest
 
+import mlrun
+import mlrun.artifacts
 import mlrun.datastore
 import mlrun.errors
 import mlrun.utils.clones
@@ -356,3 +361,527 @@ def test_load_source_code_archive_failure(tmp_path):
                 source_uri=source_uri,
                 target_dir=target_dir,
             )
+
+
+@pytest.mark.parametrize(
+    "src_path, target_path, key, expected",
+    [
+        # src_path wins when set
+        ("foo.py", "s3://bucket/abcdef", "my-key", "foo.py"),
+        # src_path wins even when it's a relative path with ./
+        ("./sub/foo.py", "s3://bucket/abcdef", "my-key", "foo.py"),
+        # src_path with parent traversal -> basename strips it
+        ("../escape.py", "s3://bucket/abcdef", "my-key", "escape.py"),
+        # src_path empty -> fall back to target_path
+        ("", "s3://bucket/handler.py", "my-key", "handler.py"),
+        # both empty -> fall back to key
+        ("", "", "my-key", "my-key"),
+        # src_path None -> fall back chain
+        (None, None, "key/with/slashes", "slashes"),
+        # all three fields empty / None -> ""
+        ("", "", "", ""),
+        (None, None, None, ""),
+        # all three basename to empty (path-only) -> ""
+        ("dir/", "s3://bucket/", "key/", ""),
+    ],
+)
+def test_resolve_artifact_filename(src_path, target_path, key, expected):
+    artifact = unittest.mock.MagicMock()
+    artifact.spec.src_path = src_path
+    artifact.spec.target_path = target_path
+    artifact.metadata.key = key
+
+    result = mlrun.utils.clones.resolve_artifact_filename(artifact)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "body, expected_bytes",
+    [
+        (b"binary content\n", b"binary content\n"),
+        ("text content\n", b"text content\n"),
+        (b"", b""),
+        ("", b""),
+    ],
+)
+def test_write_body_to_path(tmp_path, body, expected_bytes):
+    target = tmp_path / "out.bin"
+
+    mlrun.utils.clones._write_body_to_path(body, str(target))
+
+    assert target.read_bytes() == expected_bytes
+
+
+# ---------------------------------------------------------------------------
+# Archive builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_zip_bytes(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def _make_tgz_bytes(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _open_zip(path):
+    return zipfile.ZipFile(path)
+
+
+def _open_tar(path):
+    return tarfile.open(path, "r:gz")
+
+
+# Per-format parameter bundles reused across the archive tests below.
+# Each tuple supplies everything that varies between zip and tar.gz so the
+# tests themselves only express the behavior under test.
+ARCHIVE_FORMATS = [
+    pytest.param(
+        _make_zip_bytes,
+        ".zip",
+        _open_zip,
+        "_safe_extract_zip",
+        zipfile.BadZipFile,
+        id="zip",
+    ),
+    pytest.param(
+        _make_tgz_bytes,
+        ".tar.gz",
+        _open_tar,
+        "_safe_extract_tar",
+        tarfile.ReadError,
+        id="tgz",
+    ),
+]
+
+
+def _mock_code_artifact(
+    *,
+    body=None,
+    src_path="",
+    target_path="",
+    key="",
+    kind=None,
+    uri="store://artifacts/proj/key",
+):
+    """Build a MagicMock standing in for a resolved code artifact."""
+    artifact = unittest.mock.MagicMock()
+    artifact.kind = mlrun.artifacts.CodeArtifact.kind if kind is None else kind
+    artifact.spec.get_body.return_value = body
+    artifact.spec.src_path = src_path
+    artifact.spec.target_path = target_path
+    artifact.metadata.key = key
+    artifact.uri = uri
+    return artifact
+
+
+# ---------------------------------------------------------------------------
+# Zip-slip-safe extractor tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "make_archive, suffix, opener, extract_fn_name, _bad_archive_exc", ARCHIVE_FORMATS
+)
+def test_safe_extract_archive_extracts_safe_members(
+    tmp_path, make_archive, suffix, opener, extract_fn_name, _bad_archive_exc
+):
+    members = {"a.py": b"print('a')\n", "pkg/b.py": b"print('b')\n"}
+    archive_path = tmp_path / f"good{suffix}"
+    archive_path.write_bytes(make_archive(members))
+    extract_fn = getattr(mlrun.utils.clones, extract_fn_name)
+
+    with opener(str(archive_path)) as archive:
+        extract_fn(archive, str(tmp_path))
+
+    assert (tmp_path / "a.py").read_bytes() == members["a.py"]
+    assert (tmp_path / "pkg" / "b.py").read_bytes() == members["pkg/b.py"]
+
+
+@pytest.mark.parametrize(
+    "make_archive, suffix, opener, extract_fn_name, _bad_archive_exc", ARCHIVE_FORMATS
+)
+def test_safe_extract_archive_rejects_path_traversal(
+    tmp_path, make_archive, suffix, opener, extract_fn_name, _bad_archive_exc
+):
+    archive_path = tmp_path / f"evil{suffix}"
+    archive_path.write_bytes(make_archive({"../escape.py": b"print('escape')\n"}))
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    extract_fn = getattr(mlrun.utils.clones, extract_fn_name)
+
+    with opener(str(archive_path)) as archive:
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="escape"):
+            extract_fn(archive, str(target_dir))
+
+    # No file leaked outside target_dir
+    assert not (tmp_path / "escape.py").exists()
+
+
+def test_safe_extract_tar_rejects_linkname_traversal(tmp_path):
+    """A symlink whose linkname escapes target_dir must not be extracted."""
+    archive_path = tmp_path / "evil_link.tar.gz"
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+
+    with tarfile.open(archive_path, "w:gz") as tf:
+        info = tarfile.TarInfo(name="benign-link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../etc/passwd"
+        tf.addfile(info)
+
+    # tarfile's PEP 706 data filter raises LinkOutsideDestinationError
+    # for symlinks whose linkname escapes the destination.
+    with tarfile.open(archive_path, "r:gz") as tf:
+        with pytest.raises(tarfile.LinkOutsideDestinationError):
+            mlrun.utils.clones._safe_extract_tar(tf, str(target_dir))
+
+    # Nothing landed on disk under target_dir.
+    assert list(target_dir.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc",
+    ARCHIVE_FORMATS,
+)
+def test_maybe_extract_archive(
+    tmp_path, make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc
+):
+    members = {"a.py": b"a", "b.py": b"b"}
+    archive = tmp_path / f"src{suffix}"
+    archive.write_bytes(make_archive(members))
+
+    mlrun.utils.clones._maybe_extract_archive(str(archive), str(tmp_path))
+
+    assert not archive.exists()
+    assert (tmp_path / "a.py").read_bytes() == members["a.py"]
+    assert (tmp_path / "b.py").read_bytes() == members["b.py"]
+
+
+def test_maybe_extract_archive_non_archive_is_noop(tmp_path):
+    payload = b"print('hello')\n"
+    file_path = tmp_path / "hello.py"
+    file_path.write_bytes(payload)
+
+    mlrun.utils.clones._maybe_extract_archive(str(file_path), str(tmp_path))
+    assert file_path.read_bytes() == payload
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(b"print('inline body')\n", id="non-empty"),
+        # Pins that None vs b"" is the discriminator on the body branch,
+        # not a generic truthiness check.
+        pytest.param(b"", id="empty"),
+    ],
+)
+def test_load_code_artifact_body_only_single_file(tmp_path, body):
+    artifact = _mock_code_artifact(body=body, src_path="hello.py", key="hello")
+    target_dir = str(tmp_path)
+
+    with unittest.mock.patch("mlrun.get_dataitem") as mock_get_dataitem:
+        result = mlrun.utils.clones._load_code_artifact(
+            artifact, target_dir, secrets=None
+        )
+
+    assert result == (target_dir, os.path.join(target_dir, "hello.py"))
+    assert (tmp_path / "hello.py").read_bytes() == body
+    mock_get_dataitem.assert_not_called()
+
+
+def test_load_code_artifact_target_path_single_file(tmp_path):
+    artifact = _mock_code_artifact(src_path="handler.py")
+    artifact.get_target_path.return_value = "s3://bucket/abc/handler.py"
+    target_dir = str(tmp_path)
+
+    mock_dataitem = unittest.mock.MagicMock()
+    with unittest.mock.patch(
+        "mlrun.get_dataitem", return_value=mock_dataitem
+    ) as mock_get_dataitem:
+        result = mlrun.utils.clones._load_code_artifact(
+            artifact, target_dir, secrets=None
+        )
+
+    assert result == (target_dir, os.path.join(target_dir, "handler.py"))
+    mock_get_dataitem.assert_called_once_with(
+        "s3://bucket/abc/handler.py", secrets=None
+    )
+    mock_dataitem.download.assert_called_once_with(
+        os.path.join(target_dir, "handler.py")
+    )
+
+
+@pytest.mark.parametrize(
+    "make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc",
+    ARCHIVE_FORMATS,
+)
+def test_load_code_artifact_body_archive_extracted(
+    tmp_path, make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc
+):
+    members = {"a.py": b"print('a')\n", "pkg/b.py": b"print('b')\n"}
+    artifact = _mock_code_artifact(
+        body=make_archive(members), src_path=f"src{suffix}", key="src"
+    )
+    target_dir = str(tmp_path)
+
+    result = mlrun.utils.clones._load_code_artifact(artifact, target_dir, secrets=None)
+
+    assert result == (target_dir, None)
+    assert not (tmp_path / f"src{suffix}").exists()
+    assert (tmp_path / "a.py").read_bytes() == members["a.py"]
+    assert (tmp_path / "pkg" / "b.py").read_bytes() == members["pkg/b.py"]
+
+
+@pytest.mark.parametrize(
+    "make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc",
+    ARCHIVE_FORMATS,
+)
+def test_load_code_artifact_target_path_archive_extracted(
+    tmp_path, make_archive, suffix, _opener, _extract_fn_name, _bad_archive_exc
+):
+    members = {"a.py": b"print('a')\n", "b.py": b"print('b')\n"}
+    archive_bytes = make_archive(members)
+    artifact = _mock_code_artifact(src_path=f"src{suffix}")
+    artifact.get_target_path.return_value = f"s3://bucket/abc/src{suffix}"
+    target_dir = str(tmp_path)
+
+    def fake_download(dest_path):
+        with open(dest_path, "wb") as fh:
+            fh.write(archive_bytes)
+
+    mock_dataitem = unittest.mock.MagicMock()
+    mock_dataitem.download.side_effect = fake_download
+
+    with unittest.mock.patch("mlrun.get_dataitem", return_value=mock_dataitem):
+        result = mlrun.utils.clones._load_code_artifact(
+            artifact, target_dir, secrets=None
+        )
+
+    assert result == (target_dir, None)
+    assert not (tmp_path / f"src{suffix}").exists()
+    assert (tmp_path / "a.py").read_bytes() == members["a.py"]
+    assert (tmp_path / "b.py").read_bytes() == members["b.py"]
+
+
+def test_load_code_artifact_no_body_no_target_path_raises(tmp_path):
+    artifact = _mock_code_artifact()
+    artifact.get_target_path.return_value = ""
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="neither inline body nor a target_path",
+    ):
+        mlrun.utils.clones._load_code_artifact(artifact, str(tmp_path), secrets=None)
+
+
+def test_load_code_artifact_body_with_unresolvable_filename_raises(tmp_path):
+    """Body-backed code artifact with no resolvable filename anywhere
+    (src_path / target_path / metadata.key all empty or basename-empty)
+    must raise typed MLRunInvalidArgumentError. Without this guard, the
+    join produces target_dir itself, and the body write crashes with
+    IsADirectoryError instead of a typed error.
+    """
+    artifact = _mock_code_artifact(body=b"hi", src_path="", target_path="", key="")
+
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="has no resolvable filename",
+    ):
+        mlrun.utils.clones._load_code_artifact(artifact, str(tmp_path), secrets=None)
+
+
+def test_load_code_artifact_body_zip_slip_rejected(tmp_path):
+    artifact = _mock_code_artifact(
+        body=_make_zip_bytes({"../escape.py": b"print('escape')\n"}),
+        src_path="evil.zip",
+        key="evil",
+    )
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="escape"):
+        mlrun.utils.clones._load_code_artifact(artifact, str(target_dir), secrets=None)
+
+    # Nothing leaked outside target_dir
+    assert not (tmp_path / "escape.py").exists()
+
+
+@pytest.mark.parametrize(
+    "_make_archive, suffix, _opener, _extract_fn_name, bad_archive_exc",
+    ARCHIVE_FORMATS,
+)
+def test_load_code_artifact_body_corrupted_archive_propagates(
+    tmp_path, _make_archive, suffix, _opener, _extract_fn_name, bad_archive_exc
+):
+    """Corrupted archive body must surface the stdlib decoder error uncaught.
+
+    Pins the spec contract: extraction errors fail loudly so the runner
+    init container does not silently start from a half-extracted dir.
+    """
+    artifact = _mock_code_artifact(
+        body=b"not actually an archive",
+        src_path=f"broken{suffix}",
+        key="broken",
+    )
+
+    with pytest.raises(bad_archive_exc):
+        mlrun.utils.clones._load_code_artifact(artifact, str(tmp_path), secrets=None)
+
+
+# ---------------------------------------------------------------------------
+# Kind switch in _load_store_artifact
+# ---------------------------------------------------------------------------
+
+
+def test_load_store_artifact_code_kind_uses_body(tmp_path):
+    body = b"print('code artifact')\n"
+    artifact = _mock_code_artifact(body=body, src_path="code.py", key="code")
+    target_dir = str(tmp_path)
+
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=artifact
+        ),
+        unittest.mock.patch("mlrun.get_dataitem") as mock_get_dataitem,
+    ):
+        result = mlrun.utils.clones._load_store_artifact(
+            "store://artifacts/proj/code", target_dir
+        )
+
+    assert result == (target_dir, os.path.join(target_dir, "code.py"))
+    assert (tmp_path / "code.py").read_bytes() == body
+    mock_get_dataitem.assert_not_called()
+
+
+def test_load_store_artifact_non_code_kind_skips_body(tmp_path):
+    """A non-code artifact with body present must NOT be read; today's
+    target-path download is the only path."""
+    # Body present but should be ignored by the non-code branch.
+    artifact = _mock_code_artifact(
+        body=b"would-be-body", src_path="model.bin", kind="model"
+    )
+    artifact.get_target_path.return_value = "s3://bucket/model.bin"
+    target_dir = str(tmp_path)
+
+    mock_dataitem = unittest.mock.MagicMock()
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=artifact
+        ),
+        unittest.mock.patch(
+            "mlrun.get_dataitem", return_value=mock_dataitem
+        ) as mock_get_dataitem,
+    ):
+        result = mlrun.utils.clones._load_store_artifact(
+            "store://artifacts/proj/model", target_dir
+        )
+
+    assert result == (target_dir, os.path.join(target_dir, "model.bin"))
+    mock_get_dataitem.assert_called_once_with("s3://bucket/model.bin", secrets=None)
+    mock_dataitem.download.assert_called_once()
+    # Body was NOT consulted (the spec's get_body mock would still be
+    # callable, but the production path must not have called it).
+    artifact.spec.get_body.assert_not_called()
+
+
+def test_load_store_artifact_non_code_zip_not_extracted(tmp_path):
+    """A non-code artifact whose target is a .zip must NOT be extracted;
+    extraction is a code-artifact-only behavior."""
+    archive_bytes = _make_zip_bytes({"a.py": b"a"})
+
+    artifact = _mock_code_artifact(src_path="bundle.zip", kind="model")
+    artifact.get_target_path.return_value = "s3://bucket/bundle.zip"
+    target_dir = str(tmp_path)
+
+    def fake_download(dest_path):
+        with open(dest_path, "wb") as fh:
+            fh.write(archive_bytes)
+
+    mock_dataitem = unittest.mock.MagicMock()
+    mock_dataitem.download.side_effect = fake_download
+
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=artifact
+        ),
+        unittest.mock.patch("mlrun.get_dataitem", return_value=mock_dataitem),
+    ):
+        mlrun.utils.clones._load_store_artifact(
+            "store://artifacts/proj/bundle", target_dir
+        )
+
+    # The archive is still on disk, NOT extracted.
+    assert (tmp_path / "bundle.zip").read_bytes() == archive_bytes
+    assert not (tmp_path / "a.py").exists()
+
+
+def test_load_store_artifact_non_code_empty_src_path_falls_back_to_target_basename(
+    tmp_path,
+):
+    """When src_path is unset, the on-disk filename falls back to the
+    target_path basename. Pins the historical _load_store_artifact
+    behavior now relocated into _download_artifact_to_dir.
+    """
+    artifact = _mock_code_artifact(
+        src_path="", target_path="s3://bucket/dir/payload.bin", kind="model"
+    )
+    artifact.get_target_path.return_value = "s3://bucket/dir/payload.bin"
+    target_dir = str(tmp_path)
+
+    mock_dataitem = unittest.mock.MagicMock()
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=artifact
+        ),
+        unittest.mock.patch(
+            "mlrun.get_dataitem", return_value=mock_dataitem
+        ) as mock_get_dataitem,
+    ):
+        result = mlrun.utils.clones._load_store_artifact(
+            "store://artifacts/proj/payload", target_dir
+        )
+
+    assert result == (target_dir, os.path.join(target_dir, "payload.bin"))
+    mock_get_dataitem.assert_called_once_with(
+        "s3://bucket/dir/payload.bin", secrets=None
+    )
+
+
+def test_download_artifact_to_dir_unresolvable_filename_raises(tmp_path):
+    """target_path is truthy (passes the early check) but its basename is
+    empty and no other field provides a filename; the explicit
+    ``has no resolvable filename`` raise must fire before any download.
+    """
+    artifact = _mock_code_artifact(
+        src_path="", target_path="s3://bucket/", key="", kind="model"
+    )
+    artifact.get_target_path.return_value = "s3://bucket/"
+
+    with (
+        unittest.mock.patch.object(
+            mlrun.datastore, "get_store_resource", return_value=artifact
+        ),
+        unittest.mock.patch("mlrun.get_dataitem") as mock_get_dataitem,
+        pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="has no resolvable filename",
+        ),
+    ):
+        mlrun.utils.clones._load_store_artifact(
+            "store://artifacts/proj/no-name", str(tmp_path)
+        )
+
+    mock_get_dataitem.assert_not_called()


### PR DESCRIPTION
### 📝 Description

Make `_load_store_artifact` (the `mlrun-load-src` resolver) read inline `body` from code artifacts and extract `.zip` / `.tar.gz` payloads in place. Gated on `artifact.kind == "code"` so non-code kinds keep today's behavior unchanged.

Two complementary changes:

- **Body-backed code** — when a code artifact has a body set, the resolver writes that body to disk instead of downloading from `target_path`. Closes the gap where inline-body code artifacts (which generic `Artifact` already supports via `is_inline=True`) were unusable end-to-end because the resolver always went through `target_path`.
- **Multi-file archives** — when the resolved code artifact is a `.zip` / `.tar.gz`, extract it in place. Zip-slip-safe via `os.path.realpath` pre-flight on every member, plus PEP 706 `tarfile` data filter to reject link members whose `linkname` escapes `target_dir`. Today such archives land as `target_dir/<hash>.zip` and are unusable by the runner.

This is the third PR in the ML-11980 chain (after [#9568] CodeArtifact type and [#9609] run jobs from `store://`). Stacks on top of `feature/ML-12358-pr-b` (still open) — diff against `development` will include those parent commits until pr-b merges.

---

### 🛠️ Changes Made

**`mlrun/utils/clones.py` — resolver internals:**
- `_load_store_artifact` now switches on `artifact.kind`: code artifacts go through `_load_code_artifact`, others fall through to existing target-path download.
- New `_load_code_artifact(artifact, target_dir, secrets)` — body-aware materialization. Reads `spec.get_body()` and writes directly when set; otherwise downloads from `target_path`. Both branches feed into `_maybe_extract_archive`. Raises `MLRunInvalidArgumentError` for malformed code artifacts (no body, no target_path).
- New `_resolve_artifact_filename(artifact)` — filename precedence `src_path` → `target_path` → `metadata.key`, each through `os.path.basename` (defense against path-traversal in `src_path`).
- New `_write_body_to_path(body, path)` — symmetric read-side counterpart of `Artifact._upload_body`. Picks `wb`/`w` open mode by body type.
- New `_maybe_extract_archive(local_file_path, target_dir)` — suffix-dispatched extraction over `.zip` / `.tar.gz`; returns `bool` so callers can distinguish single-file payloads from multi-file archives.
- New `_safe_extract_zip` / `_safe_extract_tar` — pre-flight every member's resolved path against `target_dir` (`os.path.realpath` + `parent + os.sep` boundary check). Tar additionally uses `extractall(filter="data")` for linkname escape defense.
- Extracted `_download_artifact_to_dir` from the previous body of `_load_store_artifact` — today's behavior, unchanged. Used by the non-code branch.

**`mlrun/artifacts/code.py` — docstring update:**
- Drop the now-stale "single code file or a single archive" line; describe the actual contract (file or archive whose members are extracted on resolution; payload may be inline body or `target_path`).

**`tests/utils/test_clones.py` — 28 new tests (52 total in the file):**
- `_resolve_artifact_filename`: 6 parametrized cases (precedence, traversal sanitization, fallback to key).
- `_write_body_to_path`: 4 cases (bytes/str × empty/non-empty).
- `_safe_extract_zip` / `_safe_extract_tar`: happy path + zip-slip rejection (both formats).
- `_safe_extract_tar` linkname escape (PEP 706 data filter pins `LinkOutsideDestinationError`).
- `_maybe_extract_archive`: zip / tgz / non-archive no-op.
- `_load_code_artifact`: body-only single file, target-path single file, body zip/tgz extracted, target-path zip extracted, missing-payload error, zip-slip integration.
- `_load_store_artifact` kind switch: code kind uses body, non-code kind skips body, non-code zip not extracted (pins kind-gating contract).

---

### ✅ Checklist

- [x] I updated the documentation (if applicable) — N/A, internal SDK code path
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR — covered transitively by existing `store://`-source system tests in pr-b/c
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes — see Testing section

---

### 🧪 Testing

**Unit tests (`tests/utils/test_clones.py`):** 52 passed (24 pre-existing + 28 new).

**Broader smoke (`tests/utils/` + `tests/artifacts/`):** 859 passed, no regressions.

**Coverage on new code:** ~98% — only the `MLRunRuntimeError` branch in `_load_code_artifact`'s target-path download (lines 371-372) is uncovered, symmetric with the equivalent uncovered path in `_download_artifact_to_dir`.

**Quality gate:** `make fmt` and `make lint` clean (0 ruff errors, 0 broken import-linter contracts).

---

### 🔗 References

- Ticket: ML-11980
- Builds on: #9568 (CodeArtifact type) and #9609 (run jobs from store://) — both merged
- Stacks on: feature/ML-12358-pr-b (open) — pr-b's commits will appear in this PR's diff until pr-b merges
- Sibling open PRs in the same chain: #9651 (module:func handlers), #9655 (set_workflow), #9649 (vanilla Nuclio init container), #9656 (zip-export `store://` download)

---

### 🚨 Breaking Changes?

- [ ] Yes
- [x] No

The kind-switch is additive: code artifacts get a new code-aware path, every other kind takes the same target-path download as today (extracted to a private helper but functionally identical, including the legacy `ValueError` for missing-target_path).

One observable behavior change for **code-artifact** consumers: a `.zip` / `.tar.gz` code artifact previously landed as `target_dir/<file>.zip` (un-extracted, unusable). Now the archive is extracted in place. We classify this as a fix, not a breaking change — the prior behavior was unusable, no caller could have depended on it.

---

### 🔍️ Additional Notes

- Spec and implementation plan are saved at `docs/superpowers/specs/2026-05-10-code-artifact-body-design.md` and `docs/superpowers/plans/2026-05-10-code-artifact-body.md` (kept untracked locally; happy to attach if useful).
- **Coupling with #9655** (set_workflow): both PRs edit `_load_store_artifact`. 9655 changes the return shape to `(target_dir, file_path | None)`. Whichever lands second does a small rebase: the multi-file archive case needs to return `(target_dir, None)` (matching 9655's existing convention for git/archive sources). Workflow callers should reject multi-file archives early — that's a one-line guard in 9655's `_download_store_workflow_artifact`.
- The deferred `import mlrun.artifacts` workaround used during development (to satisfy Pre-Submit Audit §9 "compare against the enum constant") was removed by `make fmt`'s `PLC0415` autofix; the comparison is now `if artifact.kind == "code"` to match the literal already used in `enrich_function_from_code_artifact`. Existing MLRun convention prevailed.