### PR TITLE
[Serving] OpenAI rest api input conflicts

### DIFF
--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -1289,6 +1289,117 @@ class TestAPIHandlerMockServer:
         finally:
             server.wait_for_completion()
 
+    @pytest.mark.parametrize(
+        "bm_location",
+        [
+            pytest.param("star", id="bm_on_star_inherited"),
+            pytest.param("specific", id="bm_on_specific_endpoint"),
+        ],
+    )
+    def test_api_handler_body_param_conflicts_with_query_param(
+        self, bm_location: str
+    ) -> None:
+        """body_map destination 'limit' clashes with query param ?limit → 400.
+
+        The mapping is placed either on the star endpoint (inherited) or directly on
+        the specific endpoint — both must raise a conflict at request time.
+        """
+        conflict_bm = BodyMappings()
+        conflict_bm.add_mapping("$.batch_size", destination_path="limit")
+
+        non_conflict_bm = BodyMappings()
+        non_conflict_bm.add_mapping("$.model_name", destination_path="model")
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/v1/*",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            input_body_mappings=conflict_bm
+            if bm_location == "star"
+            else non_conflict_bm,
+        )
+        config.add_endpoint_handler(
+            "/v1/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            input_body_mappings=conflict_bm
+            if bm_location == "specific"
+            else non_conflict_bm,
+        )
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map-query-conflict", kind="serving"),
+        )
+        fn.set_api_handler_config(config)
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler="(event)").respond()
+
+        server = fn.to_mock_server()
+        try:
+            with pytest.raises(RuntimeError, match="400.*Parameter name conflict"):
+                server.test(
+                    "/v1/predict?limit=10",
+                    method="POST",
+                    body={"batch_size": 32, "model_name": "my-model"},
+                )
+        finally:
+            server.wait_for_completion()
+
+    @pytest.mark.parametrize(
+        "bm_location",
+        [
+            pytest.param("star", id="bm_on_star_inherited"),
+            pytest.param("specific", id="bm_on_specific_endpoint"),
+        ],
+    )
+    def test_api_handler_body_param_conflicts_with_path_param(
+        self, bm_location: str
+    ) -> None:
+        """body_map destination 'model' clashes with path param {model} → MLRunValueError at init.
+
+        The mapping is placed either on the star endpoint (inherited) or directly on
+        the specific endpoint — both must raise a conflict at config time.
+        """
+        conflict_bm = BodyMappings()
+        conflict_bm.add_mapping("$.batch_size", destination_path="model")
+
+        non_conflict_bm = BodyMappings()
+        non_conflict_bm.add_mapping("$.model_name", destination_path="name")
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/v1/*",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            input_body_mappings=conflict_bm
+            if bm_location == "star"
+            else non_conflict_bm,
+        )
+        config.add_endpoint_handler(
+            "/v1/{model}/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            input_body_mappings=conflict_bm
+            if bm_location == "specific"
+            else non_conflict_bm,
+        )
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map-path-conflict", kind="serving"),
+        )
+        fn.set_api_handler_config(config)
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler="(event)").respond()
+
+        with pytest.raises(
+            mlrun.errors.MLRunValueError,
+            match="Configuration conflict.*model.*overlap with path template",
+        ):
+            fn.to_mock_server()
+
     def test_api_handler_repeated_query_params(self) -> None:
         """Test that repeated query parameters are passed as lists"""
 


### PR DESCRIPTION
### 📝 Description
Adds parametrized tests for BodyMappings conflict detection in APIHandler, covering both query-param conflicts (caught at request time) and path-param conflicts (caught at config time), with inheritance via star endpoints.  

---

### 🛠️ Changes Made
- Added test_api_handler_body_param_conflicts_with_query_param — parametrized on bm_on_star_inherited / bm_on_specific_endpoint; asserts HTTP 400 "Parameter name conflict" at
request time when a body_map destination clashes with a query param.                                                                                                             
- Added `test_api_handler_body_param_conflicts_with_path_param` — same parametrization; asserts MLRunValueError "Configuration conflict…overlap with path template" at to_mock_server() when a body_map destination clashes with a path template param.                                                                                              

Both tests include a non-conflicting BodyMappings on the complementary endpoint to ensure the conflicting mapping triggers the error  

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: [ML-12515](https://ecliptos.atlassian.net/browse/ML-12515)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Depend and based on https://github.com/mlrun/mlrun/pull/9642


[ML-12515]: https://iguazio.atlassian.net/browse/ML-12515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ