### PR TITLE
[Agents] Slim AGENTS.md to ~100 lines and reference existing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ MLRun is an open-source AI/ML orchestration platform. This repo contains the **S
 - **Units in numerics**: name size/time vars explicitly (`size_in_kb`, `timeout_seconds`) or add a unit comment.
 - **Commits**: `[<Scope>] Verb changes made` (imperative). Include `fix`/`bug` for bugfixes (auto-categorized in release notes).
 - **Principles**: DRY, KISS, YAGNI. No speculative abstractions.
-- **Full convention lists** (17+ rules, including docstring format and additional MLRun-specific rules): `CONTRIBUTING.md` §"Python Code Conventions" (L309) and §"MLRun Coding Conventions" (L376). Read before any non-trivial code authoring or review.
+- **Full convention lists** (17+ rules, including docstring format and additional MLRun-specific rules): [`CONTRIBUTING.md#python-code-conventions`](./CONTRIBUTING.md#python-code-conventions) and [`CONTRIBUTING.md#mlrun-coding-conventions`](./CONTRIBUTING.md#mlrun-coding-conventions). Read before any non-trivial code authoring or review.
 
 ## New FastAPI endpoints — security is mandatory
 
@@ -97,7 +97,7 @@ Schema changes, DB migrations, import-linter rule changes, and deprecations requ
 
 | Task | File |
 |---|---|
-| Writing or reviewing Python in `mlrun/` or `server/py/` (full convention list, docstring format) | `CONTRIBUTING.md` §L309 + §L376 |
+| Writing or reviewing Python in `mlrun/` or `server/py/` (full convention list, docstring format) | [`CONTRIBUTING.md#python-code-conventions`](./CONTRIBUTING.md#python-code-conventions) + [`#mlrun-coding-conventions`](./CONTRIBUTING.md#mlrun-coding-conventions) |
 | Dev env setup, ARM64, testing, PR process, lock-file updates, system tests | `CONTRIBUTING.md` |
 | Deprecating an API / parameter / endpoint | `DEPRECATION.md` |
 | Architecture, deployment, non-root user model | `docs/architecture.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,13 @@ import mlrun.common.schemas
 import framework.api.deps
 import framework.utils.auth.verifier
 
+
 @router.get("/projects/{project}/resource")
 async def my_endpoint(
     project: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(framework.api.deps.authenticate_request),
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(
+        framework.api.deps.authenticate_request
+    ),
 ):
     await framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,386 +1,108 @@
 <!-- This file provides guidance to AI agents. -->
 
-# Project Overview
-
-**MLRun** is an open-source AI orchestration platform for rapidly building and managing continuous (gen) AI and ML applications across their lifecycle. MLRun automates the delivery of production data pipelines, ML workflows, and online applications, significantly reducing engineering efforts, time to production, and computational resources. It integrates into development and CI/CD environments, breaks silos between data, ML, software, and DevOps/MLOps teams, and supports both community edition (CE) deployments and enterprise features when running in Iguazio systems.
-
-## Repository Structure
-
-This repository contains two major Python codebases plus Go services:
-
-- **`mlrun/`** – SDK and client library (what end-users import); includes projects, runtimes, feature store, model monitoring, data store, serving, launchers, and frameworks integrations.
-- **`server/py/`** – Python server components (FastAPI-based API service + alerts service); includes `services/api/` (main MLRun API), `services/alerts/` (events processing), and `framework/` (DB sessions, auth, utilities, rundb implementation).
-- **`server/go/`** – Go services; includes `services/logcollector/` (gRPC microservice for streaming logs from Kubernetes pods).
-- **`tests/`** – SDK unit tests, integration tests, and system tests (CE and enterprise-marked); uses pytest with shared fixtures in `tests/common_fixtures.py`.
-- **`server/py/services/api/tests/`** – Server-side unit tests (note: `pyproject.toml` configures pytest `pythonpath=./server/py` to enable running server tests from repo root).
-- **`docs/`** – Sphinx-based documentation (API reference, tutorials, guides, architecture); builds to ReadTheDocs.
-- **`pipeline-adapters/`** – Pipeline integration packages (mlrun-pipelines-kfp-common, kfp-v1-8, kfp-v2) with independent `pyproject.toml` files.
-- **`automation/`** – CI/CD automation scripts (deployment, system tests, release notes generation, version management).
-- **`dockerfiles/`** – Dockerfile definitions for mlrun, mlrun-api, mlrun-gpu, mlrun-kfp, jupyter, test, test-system images.
-- **`hack/`** – Local development environment configurations (.env files for various setups, local k8s manifests, benchmarks).
-- **`examples/`** – Jupyter notebooks and example scripts demonstrating MLRun features.
-- **`.github/`** – GitHub workflows (build, CI, system tests, security scans, release pipelines), issue templates, PR template, CODEOWNERS.
-
-
-## Build & Development Commands
-
-### Environment Setup
-
-Set up Python environment:
-
-```bash
-# Create virtual environment (using venv or uv)
-uv venv venv --python 3.11 --seed
-source venv/bin/activate
-
-# Install all dependencies
-export MLRUN_PYTHON_PACKAGE_INSTALLER=uv
-make install-requirements
-uv pip install -e '.[complete]'
-```
-
-**Configure PYTHONPATH:**
-
-```bash
-# Required for server-side development
-export PYTHONPATH="$(pwd):$(pwd)/server/py"
-```
-
-### Format & Lint
-
-```bash
-# Format code (Ruff formatter)
-make fmt
-
-# Lint code (Ruff linter)
-make lint
-```
-
-### Database Migrations
-
-```bash
-# Create a new database migration (MySQL)
-MLRUN_MIGRATION_MESSAGE="Add new column" make create-migration
-```
-
-### Documentation
-
-```bash
-# Install docs dependencies
-make install-docs-requirements
-
-# Build docs locally
-cd docs
-make html
-# Output in docs/_build/html/index.html
-```
-
-### Dependency Management
-
-```bash
-# Update Python lock files for mlrun-api image
-make upgrade-mlrun-api-deps-lock
-
-# Update specific package only
-MLRUN_UV_UPGRADE_FLAG="--upgrade-package <package-name>" make upgrade-mlrun-api-deps-lock
-```
-
-## Code Style & Conventions
-
-### Formatter & Linter
-
-- **Ruff** (v0.8.0+) for both formatting and linting (configured in `pyproject.toml`).
-- Run `make fmt` before every commit.
-- CI enforces linting via `make lint`.
-
-### Naming
-
-- **snake_case**: functions, variables, modules, parameters.
-- **CamelCase**: classes.
-- Prefer explicit, readable names; avoid unclear abbreviations.
-
-### Imports
-
-- **Internal (repo) imports**: **SHOULD** prefer module imports (`import pkg.mod`) or aliases (`import pkg.mod as mod`) to reduce circular-import risk and make boundaries explicit.
-  - Example (preferred): `import mlrun.utils`
-  - Example (avoid): `from mlrun.utils import logger`
-- **External packages**: `from X import Y` is acceptable when it improves readability.
-- **Import boundaries**: `mlrun.common` must NOT import higher-level `mlrun.*` modules (enforced by import-linter in `pyproject.toml`).
-- **Forbidden imports**:
-  - In `mlrun/`, do NOT import `kfp` directly; use `mlrun_pipelines` adapters instead.
-  - In `mlrun/`, do NOT import `server/py` (server-side code).
-
-### Type Hints & Docstrings
-
-- Use type hints for complex data structures and public APIs.
-- Public API functions/classes require docstrings (triple-quotes `""" """`).
-- Docstring format: brief description, `:param` tags for parameters, `:return` tag for return value.
-
-### Logging
-
-- Use **structured logging** (variables as fields, not f-strings):
-
-```python
-from mlrun.utils import logger
-
-# GOOD
-logger.debug("Storing function", project=project, name=name, tag=tag)
-
-# BAD: f-string in logs
-logger.debug(f"Storing function {project}/{name}:{tag}")
-```
-
-- **NEVER log credentials**: passwords, tokens, API keys, secret values, auth headers, session cookies.
-
-### Error Handling
-
-- Stringify exceptions using `mlrun.errors.err_to_str(exc)` instead of `str(exc)`.
-- Use `mlrun.errors.raise_for_status(...)` for HTTP response validation.
-
-### Async + Blocking I/O (CRITICAL)
-
-In `async def` contexts (server endpoints, async utilities):
-
-- **NEVER block the event loop with synchronous I/O**.
-- Run blocking I/O in a threadpool:
-
-```python
-import mlrun.utils
-
-
-async def handler():
-    # GOOD: run blocking work in threadpool
-    result = await mlrun.utils.run_in_threadpool(sync_db_call, "arg")
-    return result
-```
-
-### Commit Messages
-
-- Follow conventional commit format: `[<Scope>] Verb changes made` (e.g., `[API] Add endpoint to list runs`).
-- Use imperative verbs (Add, Fix, Update, Refactor).
-- Include `fix` or `bug` keywords for bugfix PRs (auto-categorized in release notes).
-
-## Architecture Notes
-
-### High-Level Component Flow
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        User / IDE / CI/CD                       │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │
-                            ▼
-        ┌───────────────────────────────────────────┐
-        │       MLRun SDK (mlrun/)                  │
-        │  - Projects, Runtimes, Feature Store      │
-        │  - Data Store, Model Monitoring           │
-        │  - Launchers (Local/Remote/Server)        │
-        └───────────────┬───────────────────────────┘
-                        │ HTTP (via mlrun.db.httpdb.HTTPRunDB)
-                        ▼
-        ┌───────────────────────────────────────────┐
-        │   MLRun API Server (server/py/services/   │
-        │              api/)                        │
-        │  - FastAPI endpoints (api/endpoints/)     │
-        │  - CRUD operations (crud/)                │
-        │  - ServerSideLauncher (launcher.py)       │
-        └───────────┬───────────────────────────────┘
-                    │\
-                    │ \ gRPC
-                    │  ▼
-                    │  ┌──────────────────┐
-                    │  │ Log Collector    │
-                    │  │ (Go service)     │
-                    │  │ (gRPC + K8s API) │
-                    │  └──────────────────┘
-                    │
-        ┌───────────┴────────────┬──────────────────┐
-        ▼                        ▼                  ▼
-┌──────────────┐      ┌──────────────────┐  ┌──────────────┐
-│ Database     │      │ Kubernetes API   │  │ Alerts       │
-│ (MySQL/      │      │ (Job/Pod/CRD     │  │ Service      │
-│  PostgreSQL) │      │  orchestration)  │  │ (alerts/)    │
-└──────────────┘      └──────────────────┘  └──────────────┘
-```
-
-### Key Architectural Patterns
-
-**1. SDK ↔ Server Boundary**
-
-- SDK communicates via `mlrun.db.httpdb.HTTPRunDB` (implements `mlrun.db.base.RunDBInterface`).
-- Project-scoped interface: `mlrun.projects.project.MlrunProject` (high-level wrapper with project context and enrichment).
-
-**2. Launcher Pattern**
-
-- **BaseLauncher** (`mlrun/launcher/base.py`): abstract interface for running functions.
-- **ClientLocalLauncher** (`mlrun/launcher/local.py`): runs locally (user machine or remote with local semantics).
-- **ClientRemoteLauncher** (`mlrun/launcher/remote.py`): submits jobs to API server/Kubernetes.
-- **ServerSideLauncher** (`server/py/services/api/launcher.py`): server-side run submission with auth context.
-- Launcher selection: automatic based on `mlrun.config.is_running_as_api()`, `runtime._is_remote`, and `local=` flag.
-
-**3. Shared Layer (`mlrun.common`)**
-
-- Foundation layer with minimal dependencies.
-- Must NOT import higher-level `mlrun.*` modules (enforced by import-linter).
-
-**4. Server Framework (`server/py/framework/`)**
-
-- DB sessions, middlewares, auth utilities, base services.
-- Should NOT import specific services (some exceptions exist, tracked in `pyproject.toml`).
-
-### Data Flow Examples
-
-**Function Execution (Remote):**
-
-1. User calls `function.run()` in SDK.
-2. `ClientRemoteLauncher` (or `ServerSideLauncher`) submits run via `HTTPRunDB.submit_run(...)`.
-3. Server endpoint (`/projects/{project}/functions/{name}`) receives request.
-4. Server launcher creates Kubernetes job/pod with runtime spec.
-5. Log collector gRPC service streams logs from pod to persistent storage.
-6. Run results/artifacts stored in DB and object storage.
-
-## Testing Strategy
-
-### Test Types & Tools
-
-- **Unit Tests**: pytest, mocks (`pytest-mock`), fixtures.
-- **Integration Tests**: pytest with Docker containers (MySQL, Postgres via `pytest-mock-resources`), K8s interactions (via test clusters).
-- **System Tests**: end-to-end tests against live MLRun CE or Iguazio system (marked with `@pytest.mark.enterprise` for enterprise-only features).
-- **Coverage**: tracked via `coverage.py` (configured in `pyproject.toml`).
-
-## Security & Compliance
-
-### Authentication & Authorization (Server APIs)
-
-**Every new FastAPI endpoint MUST:**
-
-1. **Authenticate requests** via `framework.api.deps.authenticate_request`:
+# MLRun — Agent Orientation
+
+MLRun is an open-source AI/ML orchestration platform. This repo contains the **SDK** users import (`mlrun/`), the **Python API server** (`server/py/`), and a **Go log collector** (`server/go/`). SDK ↔ server boundary: `mlrun/db/httpdb.py`.
+
+## Repo map (where to look)
+
+- `mlrun/` — SDK: projects, runtimes, feature store, data store, serving, launchers
+- `server/py/services/api/` — FastAPI API service; endpoints in `api/endpoints/`, CRUD in `crud/`
+- `server/py/services/alerts/` — alerts service
+- `server/py/framework/` — DB sessions, auth, middlewares (shared server infra)
+- `server/go/services/logcollector/` — gRPC log streaming from K8s pods
+- `tests/` — SDK unit + integration + system tests; fixtures in `tests/common_fixtures.py`
+- `server/py/services/api/tests/` — server-side tests (`pythonpath=./server/py` in `pyproject.toml`)
+- `pipeline-adapters/` — KFP adapter packages (separate `pyproject.toml` each)
+- `docs/`, `automation/`, `dockerfiles/`, `hack/` — docs, CI/release scripts, image defs, local-dev configs
+
+## Code conventions (apply on every edit)
+
+- **Format/lint**: `make fmt` and `make lint` (Ruff, configured in `pyproject.toml`). CI enforces lint.
+- **Naming**: `snake_case` functions/vars/modules; `CamelCase` classes.
+- **Internal imports**: prefer module form (`import mlrun.utils`) over `from mlrun.utils import logger` — reduces circular-import risk. External packages: `from X import Y` is fine.
+- **Import boundaries** (enforced by import-linter in `pyproject.toml`):
+  - `mlrun.common` must NOT import higher-level `mlrun.*`.
+  - In `mlrun/`: do NOT import `kfp` (use `mlrun_pipelines` adapters) and do NOT import `server/py`.
+- **Type hints + docstrings** required on public APIs. Docstring uses `:param`/`:return`.
+- **Structured logging** — variables as fields, never f-strings, and never log credentials/tokens/secrets:
+  ```python
+  logger.debug("Storing function", project=project, name=name, tag=tag)  # not f"..."
+  ```
+- **Errors**: stringify with `mlrun.errors.err_to_str(exc)`; validate HTTP via `mlrun.errors.raise_for_status(...)`.
+- **Async + blocking I/O**: never block the event loop. Wrap sync work:
+  ```python
+  result = await mlrun.utils.run_in_threadpool(sync_db_call, "arg")
+  ```
+- **In-file ordering**: public methods/functions above private (`_`-prefixed) ones; helpers declared below their caller.
+- **Call style**: prefer keyword arguments when calling multi-parameter functions.
+- **Config access**: use `mlrun.mlconf`, not `mlrun.config.config`.
+- **Units in numerics**: name size/time vars explicitly (`size_in_kb`, `timeout_seconds`) or add a unit comment.
+- **Commits**: `[<Scope>] Verb changes made` (imperative). Include `fix`/`bug` for bugfixes (auto-categorized in release notes).
+- **Principles**: DRY, KISS, YAGNI. No speculative abstractions.
+- **Full convention lists** (17+ rules, including docstring format and additional MLRun-specific rules): `CONTRIBUTING.md` §"Python Code Conventions" (L309) and §"MLRun Coding Conventions" (L376). Read before any non-trivial code authoring or review.
+
+## New FastAPI endpoints — security is mandatory
+
+Every endpoint MUST authenticate AND authorize:
 
 ```python
 from fastapi import Depends
 import mlrun.common.schemas
 import framework.api.deps
-
+import framework.utils.auth.verifier
 
 @router.get("/projects/{project}/resource")
 async def my_endpoint(
     project: str,
-    auth_info: mlrun.common.schemas.AuthInfo = Depends(
-        framework.api.deps.authenticate_request
-    ),
+    auth_info: mlrun.common.schemas.AuthInfo = Depends(framework.api.deps.authenticate_request),
 ):
-    # endpoint logic
-    pass
-```
-
-2. **Authorize access** via `framework.utils.auth.verifier.AuthVerifier`:
-
-```python
-import framework.utils.auth.verifier
-import mlrun.common.schemas
-
-
-async def verify_permissions(
-    project: str,
-    resource_name: str,
-    auth_info: mlrun.common.schemas.AuthInfo,
-):
-    # Project-level permission
-    await framework.utils.auth.verifier.AuthVerifier().query_project_permissions(
-        project_name=project,
-        action=mlrun.common.schemas.AuthorizationAction.read,
-        auth_info=auth_info,
-    )
-
-    # Resource-level permission
     await framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions(
         resource_type=mlrun.common.schemas.AuthorizationResourceTypes.function,
         project_name=project,
-        resource_name=resource_name,
-        action=mlrun.common.schemas.AuthorizationAction.update,
+        resource_name="...",
+        action=mlrun.common.schemas.AuthorizationAction.read,
         auth_info=auth_info,
     )
 ```
 
-### Secrets Handling
+## Guardrails — do NOT modify without team approval
 
-- **NEVER log credentials**: passwords, tokens, API keys, secret values, auth headers, session cookies.
-- Use `mlrun.secrets` module for secret management (integrates with Kubernetes secrets, Vault).
-- Sanitize request/response payloads before logging.
+- `mlrun/utils/version/version.json` — auto-generated by release automation
+- `server/py/services/api/migrations/versions/*.py` — never edit existing migrations; create new ones via `MLRUN_MIGRATION_MESSAGE="..." make create-migration`
+- `**/locked-requirements.txt` — regenerate via `make upgrade-mlrun-api-deps-lock`
+- `.github/workflows/*.yaml` — maintainer review required
 
-## Agent Guardrails
+Schema changes, DB migrations, import-linter rule changes, and deprecations require review. Deprecations follow `DEPRECATION.md`.
 
-### Files NEVER to Modify (Without Team Approval)
+## Critical environment
 
-- **`mlrun/utils/version/version.json`** – Auto-generated by release automation; manual edits will be overwritten.
-- **Database migration files** (`server/py/services/api/migrations/versions/*.py`) – Never edit existing migrations; create new ones via `make create-migration`.
-- **`**/locked-requirements.txt`** – Auto-generated by uv; use `make upgrade-mlrun-deps-lock` to update.
-- **`.github/workflows/*.yaml`** – CI/CD pipelines; changes require maintainer review.
+- `PYTHONPATH="$(pwd):$(pwd)/server/py"` for server-side dev
+- `MLRUN_PYTHON_PACKAGE_INSTALLER=uv` (preferred)
+- `MLRUN_DBPATH` — API server URL (e.g., `http://localhost:8080`)
 
-### Required Reviews
+## Code navigation
 
-- **API schema changes** (FastAPI endpoint modifications, new fields in schemas) – Require backward compatibility review.
-- **Database schema migrations** – Require DB team review.
-- **Import boundary changes** (`pyproject.toml` import-linter rules) – Require architecture review.
-- **Deprecations/removals** – Follow `DEPRECATION.md` process; update Jira ticket.
+- SDK↔server boundary: `mlrun/db/httpdb.py`, `mlrun/db/base.py`
+- Project layer: `mlrun/projects/project.py`, `mlrun/projects/pipelines.py`
+- Launcher selection: `mlrun/launcher/factory.py`, `mlrun/launcher/`, `server/py/services/api/launcher.py`
+- Server endpoints: `server/py/services/api/api/endpoints/`
+- Server DB/session: `server/py/framework/db/`, `server/py/framework/rundb/`
+- Go log collector: `server/go/services/logcollector/`
 
-### Programming Principles (MUST FOLLOW)
+## Load on demand — read when the task matches
 
-- **DRY**: Extract helpers instead of copy/pasting logic across modules.
-- **KISS**: Prefer straightforward solutions; minimize abstractions.
-- **YAGNI**: Don't add "future-proof" frameworks without concrete need.
-
-### Environment Variables
-
-Key configuration variables (see `mlrun/config.py` and `hack/*.env` for examples):
-
-- `MLRUN_PYTHON_PACKAGE_INSTALLER` - either `pip` or `uv`. prefer `uv`.
-- `MLRUN_DBPATH` – MLRun API server URL (e.g., `http://localhost:8080`).
-- `MLRUN_VERSION` – Version override for builds.
-- `MLRUN_DOCKER_REGISTRY` – Docker registry prefix (default: DockerHub).
-- `MLRUN_NO_CACHE` – Disable build/pip caching (set to any value).
-- `MLRUN_SKIP_COMPILE_SCHEMAS` – Skip protobuf schema compilation during build.
-- `MLRUN_SYSTEM_TESTS_COMPONENT` – Filter system tests by component (or prefix with `no_` to exclude).
-- `COVERAGE_FILE` – Coverage data file path (for `RUN_COVERAGE=true`).
-
-### Plugin Points
-
-- **Custom runtimes**: extend `mlrun.runtimes.base.BaseRuntime` and register in `mlrun.runtimes/__init__.py`.
-- **Data sources**: implement `mlrun.datastore.base.DataStore` interface for custom storage backends.
-- **Serving steps**: extend `mlrun.serving.server.GraphStep` for custom serving graph nodes.
-- **Model monitoring apps**: implement custom monitoring apps in `mlrun.model_monitoring.applications/`.
-
-### Feature Flags
-
-- **Import-time feature flags**: check `mlrun.mlconf.<feature>` (e.g., `mlrun.mlconf.igz_version` for Iguazio integration).
-- **Runtime feature flags**: controlled via `mlrun.common.schemas.FeatureFlags` (server-side).
-
-## Further Reading
-
-### Documentation
-
-- **Architecture**: `docs/architecture.md` – high-level system design.
-- **Contributing**: `CONTRIBUTING.md` – dev environment setup, coding conventions, PR guidelines.
-- **Deprecation process**: `DEPRECATION.md` – how to deprecate APIs/parameters/endpoints.
-- **Cheat sheet**: `docs/cheat-sheet.md` – quick reference for common SDK operations.
-
-### Code Navigation
-
-- **SDK ↔ server boundary**: `mlrun/db/httpdb.py`, `mlrun/db/base.py`.
-- **Project layer**: `mlrun/projects/project.py`, `mlrun/projects/pipelines.py`.
-- **Launcher selection**: `mlrun/launcher/factory.py`, `mlrun/launcher/`, `server/py/services/api/launcher.py`.
-- **Server endpoints**: `server/py/services/api/api/endpoints/`.
-- **Server DB/session infra**: `server/py/framework/db/`, `server/py/framework/rundb/`.
-- **Go log collector**: `server/go/services/logcollector/`.
-
-### External Resources
-
-- **MLRun Docs**: [docs.mlrun.org](https://docs.mlrun.org/) (stable version on ReadTheDocs).
-- **Tutorials**: [Tutorials](https://docs.mlrun.org/en/stable/tutorials/index.html) (Jupyter notebooks).
-- **API Reference**: [API Reference](https://docs.mlrun.org/en/stable/api/index.html) (auto-generated from docstrings).
-
-### Internal Docs
-
-- **Pipeline adapters**: `pipeline-adapters/README.md` (KFP integration details).
-- **Automation scripts**: `automation/` (release notes, version management, deployment).
-- **Local dev setup**: `hack/local/README.md` (running MLRun locally on Kubernetes).
+| Task | File |
+|---|---|
+| Writing or reviewing Python in `mlrun/` or `server/py/` (full convention list, docstring format) | `CONTRIBUTING.md` §L309 + §L376 |
+| Dev env setup, ARM64, testing, PR process, lock-file updates, system tests | `CONTRIBUTING.md` |
+| Deprecating an API / parameter / endpoint | `DEPRECATION.md` |
+| Architecture, deployment, non-root user model | `docs/architecture.md` |
+| SDK quick reference / usage examples | `docs/cheat-sheet.md` |
+| Writing or updating Sphinx documentation | `docs/CONTRIBUTING.md` |
+| Running MLRun locally on Docker / k8s | `hack/local/README.md` |
+| Building or modifying images | `dockerfiles/README.md` |
+| KFP pipeline integration changes | `pipeline-adapters/README.md`, `pipeline-adapters/CONTRIBUTING.md` |
+| Release notes, version bumps, deployment automation | `automation/deployment/README.md`, `automation/patch_igz/README.md` |
+| Opening a PR (description format, checklist) | `.github/pull_request_template.md` |
+| Config / env vars / feature flags reference | `mlrun/config.py`, `hack/*.env` |


### PR DESCRIPTION
### 📝 Description

Motivation: `AGENTS.md` is loaded into AI agent context on every conversation via `@AGENTS.md` in `CLAUDE.md`. Keeping it short and pointing at existing canonical docs reduces always-loaded token cost, avoids drift between AGENTS.md and the human-facing docs, and makes the file easier to maintain.

---

### 🛠️ Changes Made

- Trimmed `AGENTS.md` from 386 → 108 lines 
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

N/A for system tests — docs-only change to a non-shipped agent guidance file.

---

### 🧪 Testing



---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Affects only AI-agent guidance; no runtime, API, or build behavior changes.

---

### 🔍️ Additional Notes

- The line-number anchors (`§L309`, `§L376`) in the convention-trigger row are static and will drift if `CONTRIBUTING.md` is reorganized. The section names (in quotes) remain authoritative and let a reader re-locate them.
- Worktree copies under `.claude/worktrees/*/AGENTS.md` are intentionally left untouched.
- If reviewers feel additional rules from `CONTRIBUTING.md` should be inlined for visibility (e.g., "keep functions short", "avoid logging large objects"), that's an easy follow-up — current trade-off favors keeping the file under ~100 lines and trusting the on-demand trigger.
