### PR TITLE
[Artifacts] Fix dataframe hash collisions

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -1654,8 +1654,83 @@ def calculate_local_file_hash(filename):
 
 
 def calculate_dataframe_hash(dataframe: pandas.DataFrame):
-    # https://stackoverflow.com/questions/49883236/how-to-generate-a-hash-or-checksum-value-on-python-dataframe-created-from-a-fix/62754084#62754084
-    return hashlib.sha1(pandas.util.hash_pandas_object(dataframe).values).hexdigest()
+    dataframe_hash = hashlib.sha256()
+    dataframe_hash.update(_get_dataframe_hash_schema(dataframe))
+    _update_hash_with_dataframe_values(dataframe_hash, dataframe)
+    return dataframe_hash.hexdigest()
+
+
+def _update_hash_with_dataframe_values(dataframe_hash, dataframe: pandas.DataFrame):
+    dataframe_hash.update(b"\0index")
+    index_frame = dataframe.index.to_frame(index=False)
+    for index_position in range(len(index_frame.columns)):
+        dataframe_hash.update(f"\0level:{index_position}".encode())
+        _update_hash_with_pandas_object(
+            dataframe_hash, index_frame.iloc[:, index_position]
+        )
+
+    dataframe_hash.update(b"\0columns")
+    for column_position in range(len(dataframe.columns)):
+        dataframe_hash.update(f"\0column:{column_position}".encode())
+        _update_hash_with_pandas_object(
+            dataframe_hash, dataframe.iloc[:, column_position]
+        )
+
+
+def _update_hash_with_pandas_object(
+    dataframe_hash, pandas_object: pandas.Index | pandas.Series
+):
+    pandas_object_hash = pandas.util.hash_pandas_object(
+        pandas_object, index=False
+    ).values
+    dataframe_hash.update(len(pandas_object_hash).to_bytes(8, "big"))
+    dataframe_hash.update(pandas_object_hash.tobytes())
+
+
+def _get_dataframe_hash_schema(dataframe: pandas.DataFrame) -> bytes:
+    schema = {
+        "columns": [
+            {
+                "name": _serialize_pandas_label(column),
+                "dtype": str(dtype),
+                "dtype_repr": repr(dtype),
+            }
+            for column, dtype in zip(dataframe.columns, dataframe.dtypes, strict=True)
+        ],
+        "column_index": {
+            "type": type(dataframe.columns).__qualname__,
+            "names": [
+                _serialize_pandas_label(name) for name in dataframe.columns.names
+            ],
+        },
+        "index": {
+            "type": type(dataframe.index).__qualname__,
+            "names": [_serialize_pandas_label(name) for name in dataframe.index.names],
+            "dtypes": _get_dataframe_index_dtypes(dataframe.index),
+        },
+    }
+    return json.dumps(schema, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _get_dataframe_index_dtypes(index: pandas.Index) -> list[dict[str, str]]:
+    if isinstance(index, pandas.MultiIndex):
+        return [
+            {"dtype": str(dtype), "dtype_repr": repr(dtype)}
+            for dtype in index.to_frame(index=False).dtypes
+        ]
+    return [{"dtype": str(index.dtype), "dtype_repr": repr(index.dtype)}]
+
+
+def _serialize_pandas_label(label) -> dict[str, Any]:
+    if isinstance(label, tuple):
+        value = [_serialize_pandas_label(item) for item in label]
+    else:
+        value = repr(label)
+
+    return {
+        "type": type(label).__qualname__,
+        "value": value,
+    }
 
 
 def template_artifact_path(artifact_path, project, run_uid=None):

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -96,8 +96,11 @@ def test_resolve_dataset_hash_path():
                 format="csv",
             ),
             "artifact_path": "v3io://just/regular/path",
-            "expected_hash": "0d1c62a76b705b34bb70f355162f83402f3640e3",
-            "expected_file_target": "v3io://just/regular/path/0d1c62a76b705b34bb70f355162f83402f3640e3.csv",
+            "expected_hash": "63e11ea8f69464ffcacc58e69e22f2d6a0839b6c69c8e4d2d90e22a9ea3a9757",
+            "expected_file_target": (
+                "v3io://just/regular/path/"
+                "63e11ea8f69464ffcacc58e69e22f2d6a0839b6c69c8e4d2d90e22a9ea3a9757.csv"
+            ),
             "expected_error": None,
         },
         {
@@ -109,8 +112,11 @@ def test_resolve_dataset_hash_path():
                 format="parquet",
             ),
             "artifact_path": "v3io://just/regular/path",
-            "expected_hash": "f039fcf3a8b4bd6805b2bec0c6db96c2189eb9e2",
-            "expected_file_target": "v3io://just/regular/path/f039fcf3a8b4bd6805b2bec0c6db96c2189eb9e2.parquet",
+            "expected_hash": "f5470208b890d5e11dc683e0d5bd6d3098db9e3b4dff11445a8e64a21855dc6d",
+            "expected_file_target": (
+                "v3io://just/regular/path/"
+                "f5470208b890d5e11dc683e0d5bd6d3098db9e3b4dff11445a8e64a21855dc6d.parquet"
+            ),
             "expected_error": None,
         },
         {
@@ -119,8 +125,11 @@ def test_resolve_dataset_hash_path():
                 df=pandas.DataFrame({"x": [1, 2]}),
             ),
             "artifact_path": "v3io://just/regular/path",
-            "expected_hash": "0d1c62a76b705b34bb70f355162f83402f3640e3",
-            "expected_file_target": "v3io://just/regular/path/0d1c62a76b705b34bb70f355162f83402f3640e3",
+            "expected_hash": "63e11ea8f69464ffcacc58e69e22f2d6a0839b6c69c8e4d2d90e22a9ea3a9757",
+            "expected_file_target": (
+                "v3io://just/regular/path/"
+                "63e11ea8f69464ffcacc58e69e22f2d6a0839b6c69c8e4d2d90e22a9ea3a9757"
+            ),
             "expected_error": None,
         },
         {
@@ -140,8 +149,11 @@ def test_resolve_dataset_hash_path():
                 format="csv",
             ),
             "artifact_path": "v3io://just/regular/path",
-            "expected_hash": "0d1c62a76b705b34bb70f355162f83402f3640e3",
-            "expected_file_target": "v3io://just/regular/path/0d1c62a76b705b34bb70f355162f83402f3640e3.csv",
+            "expected_hash": "63e11ea8f69464ffcacc58e69e22f2d6a0839b6c69c8e4d2d90e22a9ea3a9757",
+            "expected_file_target": (
+                "v3io://just/regular/path/"
+                "63e11ea8f69464ffcacc58e69e22f2d6a0839b6c69c8e4d2d90e22a9ea3a9757.csv"
+            ),
             "expected_error": None,
         },
     ]:
@@ -161,6 +173,74 @@ def test_resolve_dataset_hash_path():
         )
         assert test_case.get("expected_hash") == dataset_hash
         assert test_case.get("expected_file_target") == target_path
+
+
+@pytest.mark.parametrize(
+    ("left_dataframe", "right_dataframe"),
+    [
+        (
+            pandas.DataFrame({"A": [1604090909467468979, 2], "B": [4, 4]}),
+            pandas.DataFrame({"A": [1, 2], "B": [3, 4]}),
+        ),
+        (
+            pandas.DataFrame({"flag": [True, False, True], "value": [10, 20, 30]}),
+            pandas.DataFrame({"flag": [1, 0, 1], "value": [10, 20, 30]}),
+        ),
+        (
+            pandas.DataFrame(
+                {
+                    "created_at": pandas.array(
+                        [
+                            pandas.Timestamp("1970-01-01")
+                            + pandas.Timedelta(nanoseconds=100)
+                        ],
+                        dtype="datetime64[ns]",
+                    )
+                }
+            ),
+            pandas.DataFrame({"created_at": pandas.array([100], dtype="int64")}),
+        ),
+        (
+            pandas.DataFrame({"sensor": numpy.array([5, -3, 127], dtype=numpy.int8)}),
+            pandas.DataFrame({"sensor": numpy.array([5, -3, 127], dtype=numpy.int64)}),
+        ),
+        (
+            pandas.DataFrame(
+                {
+                    "is_active": [True, False],
+                    "created_at": pandas.to_datetime(
+                        [
+                            "1970-01-01T00:00:00.000000001",
+                            "1970-01-01T00:00:00.000000002",
+                        ]
+                    ),
+                    "score": numpy.array([10, 20], dtype=numpy.int8),
+                }
+            ),
+            pandas.DataFrame(
+                {
+                    "is_active": [1, 0],
+                    "created_at": [1, 2],
+                    "score": numpy.array([10, 20], dtype=numpy.int64),
+                }
+            ),
+        ),
+    ],
+)
+def test_dataframe_hash_path_avoids_known_collisions(left_dataframe, right_dataframe):
+    artifact = mlrun.artifacts.dataset.DatasetArtifact(format="parquet")
+    left_hash, left_target_path = artifact.resolve_dataframe_target_hash_path(
+        left_dataframe,
+        artifact_path="v3io://just/regular/path",
+    )
+    right_hash, right_target_path = artifact.resolve_dataframe_target_hash_path(
+        right_dataframe,
+        artifact_path="v3io://just/regular/path",
+    )
+
+    assert not left_dataframe.equals(right_dataframe)
+    assert left_hash != right_hash
+    assert left_target_path != right_target_path
 
 
 def test_dataset_stats():


### PR DESCRIPTION
### Description
Fixes DataFrame artifact hash collisions caused by deriving dataset artifact paths from `pandas.util.hash_pandas_object` over the whole DataFrame only.

The previous implementation could produce the same artifact hash and target path for different DataFrames, including dtype/schema collisions such as bool vs int and datetime vs int, and pandas' cross-column hash-combination collisions.

---

### Changes Made
- Reworked `calculate_dataframe_hash` to use SHA-256 over stable DataFrame schema metadata plus separately hashed index and column values.
- Included column/index labels, index metadata, and dtype information in the hash input.
- Added regression coverage for known collision classes and updated expected dataset hash/path values.

---

### Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### Testing
- `python3.11 -m pytest tests/artifacts/test_dataset.py::test_resolve_dataset_hash_path tests/artifacts/test_dataset.py::test_dataframe_hash_path_avoids_known_collisions -q`
- `python3.11 -m ruff check mlrun/utils/helpers.py tests/artifacts/test_dataset.py`
- `python3.11 -m ruff format --check mlrun/utils/helpers.py tests/artifacts/test_dataset.py`
- `git diff --check HEAD`

Also ran `python3.11 -m pytest tests/artifacts/test_dataset.py -q`; 17 tests passed and 1 unrelated test failed due to a timeout connecting to `https://s3.wasabisys.com/iguazio/data/iris/iris.data.raw.csv`.

---

### References
- Ticket link: Fixes #9691
- Design docs links:
- External links:

---

### Breaking Changes?

- [x] Yes (explain below)
- [ ] No

Dataset artifact hashes and hash-derived target paths change for DataFrame-backed dataset artifacts because the hash algorithm now includes schema metadata and uses SHA-256. Existing artifacts stored under old hash-derived paths will not resolve to the same new hash value.

---

### Additional Notes
This intentionally avoids relying on pandas' whole-DataFrame hash combiner as the final artifact fingerprint. Each index level and column is hashed independently and then fed into SHA-256 with schema metadata and positional delimiters.