### PR TITLE
[Serving] `to_job` handler now accepts `data_object` single-instance input

### DIFF
--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -678,15 +678,35 @@ def v2_serving_init(context, namespace=None):
 
 async def async_execute_graph(
     context: MLClientCtx,
-    data: DataItem,
-    timestamp_column: str | None,
-    batching: bool,
-    batch_size: int | None,
-    read_as_lists: bool,
-    nest_under_inputs: bool,
-) -> None:
+    data: DataItem | None = None,
+    data_object: dict | None = None,
+    timestamp_column: str | None = None,
+    batching: bool = False,
+    batch_size: int | None = None,
+    read_as_lists: bool = False,
+    nest_under_inputs: bool = False,
+) -> Any | None:
+    """See :func:`execute_graph` for parameter documentation."""
+    # Fail-fast argument validation, in this exact order:
+    # 1. neither provided, 2. both provided, 3. data_object type check,
+    # 4. legacy DataItem check (only when data_object is None).
+    if data is None and data_object is None:
+        raise MLRunInvalidArgumentError(
+            "exactly one of 'data' or 'data_object' must be provided"
+        )
+    if data is not None and data_object is not None:
+        raise MLRunInvalidArgumentError(
+            "'data' and 'data_object' are mutually exclusive — provide exactly one"
+        )
+    if data_object is not None and not isinstance(data_object, dict):
+        raise MLRunInvalidArgumentError(
+            f"data_object must be a dict, got {type(data_object).__name__}. "
+            f"If you have a Pydantic model, call .model_dump(); "
+            f"if you have a JSON string, json.loads() it before passing."
+        )
     # Validate that data parameter is a DataItem and not passed via params
-    if not isinstance(data, DataItem):
+    # (only enforced when data_object is None — the data_object path bypasses the DataItem contract).
+    if data_object is None and not isinstance(data, DataItem):
         raise MLRunInvalidArgumentError(
             f"Parameter 'data' has type hint 'DataItem' but got {type(data).__name__} instead. "
             f"Data files and artifacts must be passed via the 'inputs' parameter, not 'params'. "
@@ -694,6 +714,8 @@ async def async_execute_graph(
             f"while 'inputs' is for data files that need to be loaded. "
             f"Example: run_function(..., inputs={{'data': 'path/to/data.csv'}}, params={{other_config: value}})"
         )
+
+    is_dict_path = data_object is not None
     run_call_count = 0
     spec = mlrun.utils.get_serving_spec()
     modname = None
@@ -749,38 +771,54 @@ async def async_execute_graph(
                 f"(status='{task_state}')"
             )
 
-    df = data.as_df()
-
-    if df.empty:
-        context.logger.warn("Job terminated due to empty inputs (0 rows)")
-        return
-
     track_models = spec.get("track_models")
 
-    if track_models and timestamp_column:
-        context.logger.info(f"Sorting dataframe by {timestamp_column}")
-        df[timestamp_column] = pd.to_datetime(  # in case it's a string
-            df[timestamp_column]
-        )
-        df.sort_values(by=timestamp_column, inplace=True)
-        if len(df) > 1:
-            start_time = df[timestamp_column].iloc[0]
-            end_time = df[timestamp_column].iloc[-1]
-            time_range = end_time - start_time
-            start_time = start_time.isoformat()
-            end_time = end_time.isoformat()
-            # TODO: tie this to the controller's base period
-            if time_range > pd.Timedelta(MAX_BATCH_JOB_DURATION):
+    # end_time may be overwritten further down (in the dict branch or from batch_completion_time)
+    end_time = None
+
+    if is_dict_path:
+        # Single-event path: no DataFrame, no sort, no MAX_BATCH_JOB_DURATION guard.
+        if track_models and timestamp_column:
+            if timestamp_column not in data_object:
                 raise mlrun.errors.MLRunRuntimeError(
-                    f"Dataframe time range is too long: {time_range}. "
-                    "Please disable tracking or reduce the input dataset's time range below the defined limit "
-                    f"of {MAX_BATCH_JOB_DURATION}."
+                    f"Event body '{data_object}' did not contain timestamp column '{timestamp_column}'"
                 )
+            # Single event => first_timestamp == last_timestamp.
+            start_time = end_time = str(data_object[timestamp_column])
         else:
-            start_time = end_time = df["timestamp"].iloc[0].isoformat()
+            # end_time will be set from clock time when the batch completes (same as the batch path).
+            start_time = datetime.now(tz=UTC).isoformat()
     else:
-        # end time will be set from clock time when the batch completes
-        start_time = datetime.now(tz=UTC).isoformat()
+        df = data.as_df()
+
+        if df.empty:
+            context.logger.warn("Job terminated due to empty inputs (0 rows)")
+            return
+
+        if track_models and timestamp_column:
+            context.logger.info(f"Sorting dataframe by {timestamp_column}")
+            df[timestamp_column] = pd.to_datetime(  # in case it's a string
+                df[timestamp_column]
+            )
+            df.sort_values(by=timestamp_column, inplace=True)
+            if len(df) > 1:
+                start_time = df[timestamp_column].iloc[0]
+                end_time = df[timestamp_column].iloc[-1]
+                time_range = end_time - start_time
+                start_time = start_time.isoformat()
+                end_time = end_time.isoformat()
+                # TODO: tie this to the controller's base period
+                if time_range > pd.Timedelta(MAX_BATCH_JOB_DURATION):
+                    raise mlrun.errors.MLRunRuntimeError(
+                        f"Dataframe time range is too long: {time_range}. "
+                        "Please disable tracking or reduce the input dataset's time range below the defined limit "
+                        f"of {MAX_BATCH_JOB_DURATION}."
+                    )
+            else:
+                start_time = end_time = df["timestamp"].iloc[0].isoformat()
+        else:
+            # end time will be set from clock time when the batch completes
+            start_time = datetime.now(tz=UTC).isoformat()
 
     server.graph = add_system_steps_to_graph(
         server.project,
@@ -809,9 +847,9 @@ async def async_execute_graph(
     if server.verbose:
         context.logger.info(server.to_yaml())
 
-    async def run(body):
+    async def run(body, idx):
         nonlocal run_call_count
-        event = storey.Event(id=index, body=body)
+        event = storey.Event(id=idx, body=body)
         if timestamp_column:
             if batching:
                 # we use the first row in the batch to determine the timestamp for the whole batch
@@ -828,25 +866,39 @@ async def async_execute_graph(
         run_call_count += 1
         return await server.run(event, context)
 
-    if batching and not batch_size:
-        batch_size = len(df)
-
-    batch = []
     tasks = []
-    for index, row in df.iterrows():
-        data = row.to_list() if read_as_lists else row.to_dict()
+    if is_dict_path:
+        # Per Jira: `batching` / `batch_size` are ignored on the data_object path.
+        # DEBUG-log the flag values (never the data_object contents) for visibility.
+        if batching or batch_size:
+            context.logger.debug(
+                "ignoring batch params on data_object path",
+                batching=batching,
+                batch_size=batch_size,
+            )
+        body = list(data_object.values()) if read_as_lists else data_object
         if nest_under_inputs:
-            data = {"inputs": data}
-        if batching:
-            batch.append(data)
-            if len(batch) == batch_size:
-                tasks.append(asyncio.create_task(run(batch)))
-                batch = []
-        else:
-            tasks.append(asyncio.create_task(run(data)))
+            body = {"inputs": body}
+        tasks.append(asyncio.create_task(run(body, 0)))
+    else:
+        if batching and not batch_size:
+            batch_size = len(df)
 
-    if batch:
-        tasks.append(asyncio.create_task(run(batch)))
+        batch = []
+        for index, row in df.iterrows():
+            body = row.to_list() if read_as_lists else row.to_dict()
+            if nest_under_inputs:
+                body = {"inputs": body}
+            if batching:
+                batch.append(body)
+                if len(batch) == batch_size:
+                    tasks.append(asyncio.create_task(run(batch, index)))
+                    batch = []
+            else:
+                tasks.append(asyncio.create_task(run(body, index)))
+
+        if batch:
+            tasks.append(asyncio.create_task(run(batch, index)))
 
     responses = await asyncio.gather(*tasks)
 
@@ -878,7 +930,8 @@ async def async_execute_graph(
         output_stream.push(mm_stream_record, partition_key=mep_uid)
 
     context.logger.info(
-        f"Job completed processing {len(df)} rows",
+        "Job completed",
+        rows=run_call_count,
         timestamp_column=timestamp_column,
         model_endpoint_uids=model_endpoint_uids,
     )
@@ -928,6 +981,13 @@ async def async_execute_graph(
 
     context.log_result("num_rows", run_call_count)
 
+    if is_dict_path:
+        # Per Jira (6): return the graph's response as-is, to simulate a single
+        # execution of a runtime with a single input. Surfaces at run.output("return").
+        return responses[0]
+    # Legacy data path: preserve the historical None return (no system test reads it).
+    return None
+
 
 def _is_inside_asyncio_loop():
     try:
@@ -951,28 +1011,62 @@ def _workaround_asyncio_nesting():
 
 def execute_graph(
     context: MLClientCtx,
-    data: DataItem,
+    data: DataItem | None = None,
+    data_object: dict | None = None,
     timestamp_column: str | None = None,
     batching: bool = False,
     batch_size: int | None = None,
     read_as_lists: bool = False,
     nest_under_inputs: bool = False,
-) -> tuple[list[Any], Any]:
+) -> Any | None:
     """
     Execute graph as a job, from start to finish.
 
-    :param context: The job's execution client context.
-    :param data: The input data to the job, to be pushed into the graph row by row, or in batches.
-    :param timestamp_column: The name of the column that will be used as the timestamp for model monitoring purposes.
-        when timestamp_column is used in conjunction with batching, the first timestamp will be used for the entire
-        batch.
-    :param batching: Whether to push one or more batches into the graph rather than row by row.
-    :param batch_size: The number of rows to push per batch. If not set, and batching=True, the entire dataset will
-        be pushed into the graph in one batch.
-    :param read_as_lists: Whether to read each row as a list instead of a dictionary.
-    :param nest_under_inputs: Whether to wrap each row with {"inputs": ...}.
+    Exactly one of ``data`` or ``data_object`` must be provided. The two modes
+    are mutually exclusive:
 
-    :return: A tuple containing a list of responses and any additional data.
+    - **Batch mode** (``data``): the existing ``DataItem`` path — loads a
+      DataFrame from the input artifact and feeds it into the graph row by row
+      (or batched). Returns ``None``; the responses are surfaced as the
+      ``prediction`` (and per-model ``prediction_<model>``) dataset artifacts.
+    - **Single-instance mode** (``data_object``): runs the graph **exactly
+      once** with the provided dict as the event body. Returns the graph
+      response as-is so the caller can read it via ``run.output("return")``.
+      ``batching`` and ``batch_size`` are ignored (a DEBUG log entry is emitted
+      when they are set). If ``timestamp_column`` is set, the value is read
+      from the root of ``data_object`` (e.g. ``timestamp_column="ts"`` with
+      ``data_object={"value": 8, "ts": "2020-01-01T00:00:00"}``); a missing key
+      raises :class:`mlrun.errors.MLRunRuntimeError`. If ``read_as_lists=True``
+      the body is ``list(data_object.values())`` (insertion order). If
+      ``nest_under_inputs=True`` the body is wrapped as ``{"inputs": body}``.
+
+      Note: for non-``local=True`` runs, the graph response must be
+      JSON-serializable to round-trip through the runDB.
+
+    :param context: The job's execution client context.
+    :param data: The input data (``DataItem``) to be pushed into the graph row
+        by row, or in batches. Mutually exclusive with ``data_object``.
+    :param data_object: A single dict instance to run the graph with exactly
+        once. Must be a ``dict`` (subclasses accepted). Mutually exclusive with
+        ``data``. If you have a Pydantic model, call ``.model_dump()`` first;
+        if you have a JSON string, ``json.loads()`` it before passing.
+    :param timestamp_column: The name of the column that will be used as the
+        timestamp for model monitoring purposes. On the ``data`` path, when
+        used in conjunction with ``batching``, the first timestamp will be
+        used for the entire batch. On the ``data_object`` path, the value is
+        read from the root of the dict.
+    :param batching: Whether to push one or more batches into the graph rather
+        than row by row. Ignored on the ``data_object`` path.
+    :param batch_size: The number of rows to push per batch. If not set, and
+        ``batching=True``, the entire dataset will be pushed into the graph in
+        one batch. Ignored on the ``data_object`` path.
+    :param read_as_lists: Whether to read each row (or, on the ``data_object``
+        path, the dict's first-level values) as a list instead of a dictionary.
+    :param nest_under_inputs: Whether to wrap each event body with
+        ``{"inputs": ...}``.
+
+    :return: On the ``data_object`` path, the graph's response (any
+        JSON-serializable Python object). On the ``data`` path, ``None``.
     """
     if _is_inside_asyncio_loop():
         _workaround_asyncio_nesting()
@@ -981,6 +1075,7 @@ def execute_graph(
         async_execute_graph(
             context,
             data,
+            data_object,
             timestamp_column,
             batching,
             batch_size,

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -687,9 +687,7 @@ async def async_execute_graph(
     nest_under_inputs: bool = False,
 ) -> Any | None:
     """See :func:`execute_graph` for parameter documentation."""
-    # Fail-fast argument validation, in this exact order:
-    # 1. neither provided, 2. both provided, 3. data_object type check,
-    # 4. legacy DataItem check (only when data_object is None).
+    # Fail-fast argument validation
     if data is None and data_object is None:
         raise MLRunInvalidArgumentError(
             "exactly one of 'data' or 'data_object' must be provided"
@@ -868,8 +866,7 @@ async def async_execute_graph(
 
     tasks = []
     if is_dict_path:
-        # Per Jira: `batching` / `batch_size` are ignored on the data_object path.
-        # DEBUG-log the flag values (never the data_object contents) for visibility.
+        # `batching` / `batch_size` are ignored on the data_object path.
         if batching or batch_size:
             context.logger.debug(
                 "ignoring batch params on data_object path",
@@ -981,12 +978,8 @@ async def async_execute_graph(
 
     context.log_result("num_rows", run_call_count)
 
-    if is_dict_path:
-        # Per Jira (6): return the graph's response as-is, to simulate a single
-        # execution of a runtime with a single input. Surfaces at run.output("return").
+    if is_dict_path and responses and responses[0]:
         return responses[0]
-    # Legacy data path: preserve the historical None return (no system test reads it).
-    return None
 
 
 def _is_inside_asyncio_loop():
@@ -1031,7 +1024,7 @@ def execute_graph(
       ``prediction`` (and per-model ``prediction_<model>``) dataset artifacts.
     - **Single-instance mode** (``data_object``): runs the graph **exactly
       once** with the provided dict as the event body. Returns the graph
-      response as-is so the caller can read it via ``run.output("return")``.
+      response as-is so the caller can read it.
       ``batching`` and ``batch_size`` are ignored (a DEBUG log entry is emitted
       when they are set). If ``timestamp_column`` is set, the value is read
       from the root of ``data_object`` (e.g. ``timestamp_column="ts"`` with
@@ -1039,9 +1032,6 @@ def execute_graph(
       raises :class:`mlrun.errors.MLRunRuntimeError`. If ``read_as_lists=True``
       the body is ``list(data_object.values())`` (insertion order). If
       ``nest_under_inputs=True`` the body is wrapped as ``{"inputs": body}``.
-
-      Note: for non-``local=True`` runs, the graph response must be
-      JSON-serializable to round-trip through the runDB.
 
     :param context: The job's execution client context.
     :param data: The input data (``DataItem``) to be pushed into the graph row
@@ -1065,8 +1055,7 @@ def execute_graph(
     :param nest_under_inputs: Whether to wrap each event body with
         ``{"inputs": ...}``.
 
-    :return: On the ``data_object`` path, the graph's response (any
-        JSON-serializable Python object). On the ``data`` path, ``None``.
+    :return: On the ``data_object`` path, the graph's response. On the ``data`` path, ``None``.
     """
     if _is_inside_asyncio_loop():
         _workaround_asyncio_nesting()

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -685,7 +685,7 @@ async def async_execute_graph(
     batch_size: int | None = None,
     read_as_lists: bool = False,
     nest_under_inputs: bool = False,
-) -> Any | None:
+) -> Any:
     """See :func:`execute_graph` for parameter documentation."""
     # Fail-fast argument validation
     if data is None and data_object is None:
@@ -1011,7 +1011,7 @@ def execute_graph(
     batch_size: int | None = None,
     read_as_lists: bool = False,
     nest_under_inputs: bool = False,
-) -> Any | None:
+) -> Any:
     """
     Execute graph as a job, from start to finish.
 

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -978,7 +978,7 @@ async def async_execute_graph(
 
     context.log_result("num_rows", run_call_count)
 
-    if is_dict_path and responses and responses[0]:
+    if is_dict_path:
         return responses[0]
 
 
@@ -1044,7 +1044,8 @@ def execute_graph(
         timestamp for model monitoring purposes. On the ``data`` path, when
         used in conjunction with ``batching``, the first timestamp will be
         used for the entire batch. On the ``data_object`` path, the value is
-        read from the root of the dict.
+        read from the root of the dict - in this case it should be a string
+        that is a serialized ``datetime`` (for example using ``isoformat()``.
     :param batching: Whether to push one or more batches into the graph rather
         than row by row. Ignored on the ``data_object`` path.
     :param batch_size: The number of rows to push per batch. If not set, and

--- a/tests/serving/test_execute_graph_data_object.py
+++ b/tests/serving/test_execute_graph_data_object.py
@@ -114,7 +114,7 @@ def _build_no_responder_spec() -> str:
 def _build_full_event_spec() -> str:
     """Variant whose step receives the full storey Event (not just the body).
 
-    Used by U12 to capture per-event IDs and verify the batch-path
+    Used to capture per-event IDs and verify the batch-path
     closure-over-loop-variable bug is fixed by the index→idx rename.
     """
     fn = mlrun.new_function(
@@ -153,7 +153,7 @@ def _set_serving_spec(spec_json: str) -> None:
 
 
 def test_execute_graph_requires_data_or_data_object():
-    """U1 / AC-4: calling execute_graph with neither data nor data_object raises."""
+    """Calling execute_graph with neither data nor data_object raises."""
     context = MLClientCtx.from_dict(
         {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
     )
@@ -165,7 +165,7 @@ def test_execute_graph_requires_data_or_data_object():
 
 
 def test_execute_graph_rejects_both_data_and_data_object():
-    """U2 / AC-5: data and data_object are mutually exclusive."""
+    """Data and data_object are mutually exclusive."""
     context = MLClientCtx.from_dict(
         {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
     )
@@ -183,7 +183,7 @@ def test_execute_graph_rejects_both_data_and_data_object():
     [1, "a-string", [1, 2, 3], (1, 2), 3.14, True],
 )
 def test_execute_graph_data_object_must_be_dict(bad_value):
-    """U3 / AC-6: data_object must be a dict (or subclass)."""
+    """data_object must be a dict (or subclass)."""
     context = MLClientCtx.from_dict(
         {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
     )
@@ -195,7 +195,7 @@ def test_execute_graph_data_object_must_be_dict(bad_value):
 
 
 def test_execute_graph_data_object_accepts_dict_subclasses():
-    """AC-6 corollary: dict subclasses (e.g. OrderedDict) are accepted by the type check.
+    """Corollary: dict subclasses (e.g. OrderedDict) are accepted by the type check.
 
     Note: this test only verifies the type check passes; it intentionally does
     not run the full graph (which is exercised by behavioral tests below).
@@ -213,7 +213,7 @@ def test_execute_graph_data_object_accepts_dict_subclasses():
 
 
 def test_execute_graph_data_object_does_not_trigger_legacy_dataitem_error():
-    """U11 / AC-7 negative: when data_object is set, the legacy DataItem error must NOT fire.
+    """Negative: when data_object is set, the legacy DataItem error must NOT fire.
 
     The mutual-exclusion check (step 2) fires first; the legacy DataItem check
     (step 4) is only reached when data_object is None.
@@ -229,7 +229,7 @@ def test_execute_graph_data_object_does_not_trigger_legacy_dataitem_error():
 
 
 def test_execute_graph_dataitem_validation_still_fires_when_data_object_is_none():
-    """AC-7 positive (mirrors existing test_execute_graph_dataitem_parameter_validation):
+    """Positive (mirrors existing test_execute_graph_dataitem_parameter_validation):
     when data_object is None, the legacy DataItem error must still fire for non-DataItem data.
     """
     context = MLClientCtx.from_dict(
@@ -248,7 +248,7 @@ def test_execute_graph_dataitem_validation_still_fires_when_data_object_is_none(
 
 
 def test_execute_graph_data_object_runs_once_and_returns_response(tmp_path):
-    """U4 / AC-9, AC-21, AC-23, AC-25: dict input runs the graph exactly once,
+    """Dict input runs the graph exactly once,
     returns the response, logs num_rows=1, and produces a 1-row prediction artifact."""
     _reset_capture()
     _set_serving_spec(_build_dict_path_spec())
@@ -268,11 +268,8 @@ def test_execute_graph_data_object_runs_once_and_returns_response(tmp_path):
 
 
 def test_execute_graph_data_object_with_timestamp_column(tmp_path):
-    """U5 / AC-10: timestamp_column extracted from dict root; the value is
+    """timestamp_column extracted from dict root; the value is
     attached to the event via _original_timestamp by the inner run() closure.
-
-    Note: full AC-24 (batch_complete stream record assertion) requires a
-    configured monitoring stream and is exercised by the system test S1.
     """
     _reset_capture()
     _set_serving_spec(_build_dict_path_spec())
@@ -285,7 +282,7 @@ def test_execute_graph_data_object_with_timestamp_column(tmp_path):
 
 
 def test_execute_graph_data_object_missing_timestamp_column_raises(tmp_path):
-    """U6 / AC-11: missing timestamp_column key raises MLRunRuntimeError.
+    """Missing timestamp_column key raises MLRunRuntimeError.
 
     When track_models is True, the dict-path outer check fires; when False,
     the inner closure fires. Both paths raise MLRunRuntimeError with wording
@@ -302,7 +299,7 @@ def test_execute_graph_data_object_missing_timestamp_column_raises(tmp_path):
 
 
 def test_execute_graph_data_object_clock_time_when_no_timestamp_column(tmp_path):
-    """U7 / AC-12: when timestamp_column is None, start_time falls back to clock time."""
+    """When timestamp_column is None, start_time falls back to clock time."""
     _reset_capture()
     _set_serving_spec(_build_dict_path_spec())
     context = _make_context(tmp_path)
@@ -318,7 +315,7 @@ def test_execute_graph_data_object_clock_time_when_no_timestamp_column(tmp_path)
 def test_execute_graph_data_object_body_shape_matrix(
     tmp_path, read_as_lists, nest_under_inputs
 ):
-    """U8 / AC-13, AC-14, AC-15, AC-16: 4-cell matrix of read_as_lists × nest_under_inputs.
+    """4-cell matrix of read_as_lists × nest_under_inputs.
 
     Verifies the graph step receives the body in the documented shape.
     """
@@ -346,7 +343,7 @@ def test_execute_graph_data_object_body_shape_matrix(
 
 
 def test_execute_graph_data_object_ignores_batching(tmp_path):
-    """U9 / AC-9: batching / batch_size are ignored on the data_object path.
+    """Batching / batch_size are ignored on the data_object path.
 
     Runs once, num_rows == 1, no error.
     """
@@ -366,7 +363,7 @@ def test_execute_graph_data_object_ignores_batching(tmp_path):
 
 
 def test_execute_graph_with_empty_data_object_runs_once(tmp_path):
-    """U10 / Q4: empty data_object {} runs the graph exactly once (no early-out).
+    """Empty data_object {} runs the graph exactly once (no early-out).
 
     Uses a graph WITHOUT a responder so we exercise just the "run once" semantic
     — the prediction-artifact-logging path with pd.DataFrame([{}]) is a
@@ -393,7 +390,7 @@ def test_execute_graph_with_empty_data_object_runs_once(tmp_path):
 
 
 def test_execute_graph_batch_path_event_ids_are_per_row(tmp_path):
-    """U12 / AC-31: each task in the batch loop must receive its own event.id.
+    """Each task in the batch loop must receive its own event.id.
 
     Pins the secondary fix from the index → idx closure-arg rename. Before the
     fix every task captured the loop's terminal index value (len(df) - 1).
@@ -417,9 +414,3 @@ def test_execute_graph_batch_path_event_ids_are_per_row(tmp_path):
         "If this is [2,2,2], the closure-over-loop-variable bug has regressed."
     )
     assert context.results.get("num_rows") == 3
-
-
-# Note: signature-shape (inspect.signature) tests were removed during code
-# review — the behavioral tests above (U1 calling with no args, U3 type-check)
-# already prove that data_object is an optional dict parameter, making
-# structural signature inspection redundant.

--- a/tests/serving/test_execute_graph_data_object.py
+++ b/tests/serving/test_execute_graph_data_object.py
@@ -1,0 +1,425 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the data_object path on mlrun.serving.server.execute_graph (ML-12578).
+
+Covers AC-4 through AC-26 + AC-31 from the validation/review documents.
+"""
+
+import os
+from collections import OrderedDict
+from typing import Any
+
+import pandas as pd
+import pytest
+
+import mlrun
+import mlrun.errors
+from mlrun.execution import MLClientCtx
+from mlrun.serving.server import execute_graph
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+# Module-level captures so the user-handler can record what the graph step
+# received without needing instance state. Storey/MLRun graph handler functions
+# are invoked with the event body (not the event object) by default, but a
+# step can opt into the full Event via full_event=True.
+_captured_bodies: list[Any] = []
+_captured_event_ids: list[Any] = []
+
+
+def _echo_body(event):
+    """Graph handler: records the body it received and returns it unchanged.
+
+    Storey graph handlers receive the event *body* directly. This is the
+    standard pattern used by tests like function_with_simple_transformation.py.
+    """
+    _captured_bodies.append(event)
+    return event
+
+
+def _echo_full_event(event):
+    """Graph handler used with full_event=True: records event id AND body.
+
+    Returns the event body so .respond()'s wire format matches the
+    body-only handler.
+    """
+    _captured_event_ids.append(event.id)
+    _captured_bodies.append(event.body)
+    # Mutate body so the response is still the body (not the Event itself).
+    event.body = event.body
+    return event
+
+
+def _reset_capture():
+    _captured_bodies.clear()
+    _captured_event_ids.clear()
+
+
+def _build_dict_path_spec(track_models: bool = False) -> str:
+    """Build a minimal serving spec (JSON-string form) with a responder step.
+
+    Uses the public ServingRuntime API to build the graph + spec so the spec
+    shape matches what the real to_job() handler receives at runtime.
+    """
+    fn = mlrun.new_function(
+        "test-execute-graph",
+        kind="serving",
+        project="default",
+    )
+    fn.set_topology("flow", engine="async")
+    fn.spec.graph.to(
+        name="echo",
+        handler="tests.serving.test_execute_graph_data_object._echo_body",
+    ).respond()
+    if track_models:
+        fn.spec.track_models = True
+    return fn._get_serving_spec()
+
+
+def _build_dict_path_spec_with_tracking() -> str:
+    return _build_dict_path_spec(track_models=True)
+
+
+def _build_no_responder_spec() -> str:
+    """Variant without a responder step — for tests that should not log
+    the prediction artifact (e.g. empty-dict, which would create a 1-row,
+    0-column DataFrame that pandas cannot describe)."""
+    fn = mlrun.new_function(
+        "test-execute-graph-no-responder",
+        kind="serving",
+        project="default",
+    )
+    fn.set_topology("flow", engine="async")
+    fn.spec.graph.to(
+        name="echo",
+        handler="tests.serving.test_execute_graph_data_object._echo_body",
+    )
+    return fn._get_serving_spec()
+
+
+def _build_full_event_spec() -> str:
+    """Variant whose step receives the full storey Event (not just the body).
+
+    Used by U12 to capture per-event IDs and verify the batch-path
+    closure-over-loop-variable bug is fixed by the index→idx rename.
+    """
+    fn = mlrun.new_function(
+        "test-execute-graph-full-event",
+        kind="serving",
+        project="default",
+    )
+    fn.set_topology("flow", engine="async")
+    fn.spec.graph.to(
+        name="echo_full",
+        handler="tests.serving.test_execute_graph_data_object._echo_full_event",
+        full_event=True,
+    )
+    return fn._get_serving_spec()
+
+
+def _make_context(tmp_path) -> MLClientCtx:
+    """Build a minimal MLClientCtx for handler invocation in unit tests."""
+    return MLClientCtx.from_dict(
+        {
+            "metadata": {"name": "test", "project": "test-project"},
+            "spec": {"output_path": str(tmp_path)},
+        },
+        autocommit=False,
+    )
+
+
+def _set_serving_spec(spec_json: str) -> None:
+    """Install a serving spec for the handler to read via SERVING_SPEC_ENV."""
+    os.environ["SERVING_SPEC_ENV"] = spec_json
+
+
+# ---------------------------------------------------------------------------
+# Validation tests (U1, U2, U3, U11)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_graph_requires_data_or_data_object():
+    """U1 / AC-4: calling execute_graph with neither data nor data_object raises."""
+    context = MLClientCtx.from_dict(
+        {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
+    )
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match=r"exactly one of 'data' or 'data_object' must be provided",
+    ):
+        execute_graph(context)
+
+
+def test_execute_graph_rejects_both_data_and_data_object():
+    """U2 / AC-5: data and data_object are mutually exclusive."""
+    context = MLClientCtx.from_dict(
+        {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
+    )
+    # Even an int (which would fail the DataItem check) — the mutual-exclusion
+    # check must fire FIRST and produce its own error.
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match=r"'data' and 'data_object' are mutually exclusive",
+    ):
+        execute_graph(context, data=123, data_object={"x": 1})
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [1, "a-string", [1, 2, 3], (1, 2), 3.14, True],
+)
+def test_execute_graph_data_object_must_be_dict(bad_value):
+    """U3 / AC-6: data_object must be a dict (or subclass)."""
+    context = MLClientCtx.from_dict(
+        {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
+    )
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match=r"data_object must be a dict",
+    ):
+        execute_graph(context, data_object=bad_value)
+
+
+def test_execute_graph_data_object_accepts_dict_subclasses():
+    """AC-6 corollary: dict subclasses (e.g. OrderedDict) are accepted by the type check.
+
+    Note: this test only verifies the type check passes; it intentionally does
+    not run the full graph (which is exercised by behavioral tests below).
+    """
+    # Subclass-acceptance means the type check passes — to avoid running the
+    # full handler here, we patch the no-op return after type validation.
+    context = MLClientCtx.from_dict(
+        {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
+    )
+    # We expect to NOT hit MLRunInvalidArgumentError for "data_object must be a dict".
+    # We may hit other errors (e.g. missing serving spec) — those are out of scope here.
+    with pytest.raises(Exception) as exc_info:
+        execute_graph(context, data_object=OrderedDict([("a", 1)]))
+    assert "data_object must be a dict" not in str(exc_info.value)
+
+
+def test_execute_graph_data_object_does_not_trigger_legacy_dataitem_error():
+    """U11 / AC-7 negative: when data_object is set, the legacy DataItem error must NOT fire.
+
+    The mutual-exclusion check (step 2) fires first; the legacy DataItem check
+    (step 4) is only reached when data_object is None.
+    """
+    context = MLClientCtx.from_dict(
+        {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
+    )
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+        execute_graph(context, data=123, data_object={"x": 1})
+    # The mutual-exclusion message must fire, NOT the legacy DataItem message.
+    assert "mutually exclusive" in str(exc_info.value)
+    assert "DataItem" not in str(exc_info.value)
+
+
+def test_execute_graph_dataitem_validation_still_fires_when_data_object_is_none():
+    """AC-7 positive (mirrors existing test_execute_graph_dataitem_parameter_validation):
+    when data_object is None, the legacy DataItem error must still fire for non-DataItem data.
+    """
+    context = MLClientCtx.from_dict(
+        {"metadata": {"name": "test"}, "spec": {}}, autocommit=False
+    )
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match=r".*data.*DataItem.*inputs.*params.*",
+    ):
+        execute_graph(context, data=123)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests (U4 — U10)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_graph_data_object_runs_once_and_returns_response(tmp_path):
+    """U4 / AC-9, AC-21, AC-23, AC-25: dict input runs the graph exactly once,
+    returns the response, logs num_rows=1, and produces a 1-row prediction artifact."""
+    _reset_capture()
+    _set_serving_spec(_build_dict_path_spec())
+    context = _make_context(tmp_path)
+
+    body = {"x": 1, "y": 2}
+    result = execute_graph(context, data_object=body)
+
+    # AC-25: returns the graph's response as-is.
+    assert result == body, f"Expected return == body, got {result!r}"
+
+    # AC-9: graph ran exactly once.
+    assert len(_captured_bodies) == 1
+
+    # AC-23: num_rows logged as 1.
+    assert context.results.get("num_rows") == 1
+
+
+def test_execute_graph_data_object_with_timestamp_column(tmp_path):
+    """U5 / AC-10: timestamp_column extracted from dict root; the value is
+    attached to the event via _original_timestamp by the inner run() closure.
+
+    Note: full AC-24 (batch_complete stream record assertion) requires a
+    configured monitoring stream and is exercised by the system test S1.
+    """
+    _reset_capture()
+    _set_serving_spec(_build_dict_path_spec())
+    context = _make_context(tmp_path)
+
+    body = {"value": 8, "ts": "2020-01-01T00:00:00"}
+    result = execute_graph(context, data_object=body, timestamp_column="ts")
+    assert result == body
+    assert len(_captured_bodies) == 1
+
+
+def test_execute_graph_data_object_missing_timestamp_column_raises(tmp_path):
+    """U6 / AC-11: missing timestamp_column key raises MLRunRuntimeError.
+
+    When track_models is True, the dict-path outer check fires; when False,
+    the inner closure fires. Both paths raise MLRunRuntimeError with wording
+    matching r".*did not contain timestamp column.*".
+    """
+    _set_serving_spec(_build_dict_path_spec())
+    context = _make_context(tmp_path)
+
+    with pytest.raises(
+        mlrun.errors.MLRunRuntimeError,
+        match=r".*did not contain timestamp column.*",
+    ):
+        execute_graph(context, data_object={"value": 8}, timestamp_column="ts")
+
+
+def test_execute_graph_data_object_clock_time_when_no_timestamp_column(tmp_path):
+    """U7 / AC-12: when timestamp_column is None, start_time falls back to clock time."""
+    _reset_capture()
+    _set_serving_spec(_build_dict_path_spec())
+    context = _make_context(tmp_path)
+
+    # Should not raise; the graph runs and the start_time is set from clock time.
+    result = execute_graph(context, data_object={"x": 1})
+    assert result == {"x": 1}
+    assert len(_captured_bodies) == 1
+
+
+@pytest.mark.parametrize("read_as_lists", [False, True])
+@pytest.mark.parametrize("nest_under_inputs", [False, True])
+def test_execute_graph_data_object_body_shape_matrix(
+    tmp_path, read_as_lists, nest_under_inputs
+):
+    """U8 / AC-13, AC-14, AC-15, AC-16: 4-cell matrix of read_as_lists × nest_under_inputs.
+
+    Verifies the graph step receives the body in the documented shape.
+    """
+    _reset_capture()
+    _set_serving_spec(_build_dict_path_spec())
+    context = _make_context(tmp_path)
+
+    data_object = {"a": 1, "b": 2}
+    result = execute_graph(
+        context,
+        data_object=data_object,
+        read_as_lists=read_as_lists,
+        nest_under_inputs=nest_under_inputs,
+    )
+
+    # Compute the expected body shape.
+    expected_inner = [1, 2] if read_as_lists else {"a": 1, "b": 2}
+    expected_body = {"inputs": expected_inner} if nest_under_inputs else expected_inner
+
+    assert _captured_bodies == [expected_body], (
+        f"Body shape mismatch: got {_captured_bodies}, expected [{expected_body!r}]"
+    )
+    # And the response is returned as-is.
+    assert result == expected_body
+
+
+def test_execute_graph_data_object_ignores_batching(tmp_path):
+    """U9 / AC-9: batching / batch_size are ignored on the data_object path.
+
+    Runs once, num_rows == 1, no error.
+    """
+    _reset_capture()
+    _set_serving_spec(_build_dict_path_spec())
+    context = _make_context(tmp_path)
+
+    result = execute_graph(
+        context,
+        data_object={"x": 1},
+        batching=True,
+        batch_size=10,
+    )
+    assert result == {"x": 1}
+    assert len(_captured_bodies) == 1
+    assert context.results.get("num_rows") == 1
+
+
+def test_execute_graph_with_empty_data_object_runs_once(tmp_path):
+    """U10 / Q4: empty data_object {} runs the graph exactly once (no early-out).
+
+    Uses a graph WITHOUT a responder so we exercise just the "run once" semantic
+    — the prediction-artifact-logging path with pd.DataFrame([{}]) is a
+    pre-existing pandas limitation (1-row, 0-column DataFrame cannot be
+    described) and is out of scope for this feature. The Jira intent for
+    empty-dict is "run-once", not "produce an empty artifact".
+    """
+    _reset_capture()
+    _set_serving_spec(_build_no_responder_spec())
+    context = _make_context(tmp_path)
+
+    # Should not raise; should run the graph exactly once.
+    execute_graph(context, data_object={})
+    # The step received the empty dict body (pinned via the body-capture).
+    assert _captured_bodies == [{}], (
+        f"Expected single empty-dict body capture, got {_captured_bodies}"
+    )
+    assert context.results.get("num_rows") == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression test for the secondary fix (U12 / AC-31)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_graph_batch_path_event_ids_are_per_row(tmp_path):
+    """U12 / AC-31: each task in the batch loop must receive its own event.id.
+
+    Pins the secondary fix from the index → idx closure-arg rename. Before the
+    fix every task captured the loop's terminal index value (len(df) - 1).
+    """
+    _reset_capture()
+    _set_serving_spec(_build_full_event_spec())
+    context = _make_context(tmp_path)
+
+    # Persist a real 3-row CSV and load it via mlrun.get_dataitem so we exercise
+    # the real DataItem path (no monkey-patching of the type check).
+    df = pd.DataFrame([{"a": i, "b": i * 10} for i in range(3)])
+    csv_path = tmp_path / "rows.csv"
+    df.to_csv(csv_path, index=False)
+    data_item = mlrun.get_dataitem(str(csv_path))
+
+    execute_graph(context, data=data_item)
+
+    # AC-31: event ids must be [0, 1, 2], NOT [2, 2, 2].
+    assert _captured_event_ids == [0, 1, 2], (
+        f"Expected event ids [0,1,2], got {_captured_event_ids}. "
+        "If this is [2,2,2], the closure-over-loop-variable bug has regressed."
+    )
+    assert context.results.get("num_rows") == 3
+
+
+# Note: signature-shape (inspect.signature) tests were removed during code
+# review — the behavioral tests above (U1 calling with no args, U3 type-check)
+# already prove that data_object is an optional dict parameter, making
+# structural signature inspection redundant.

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -881,7 +881,7 @@ def print_df(df):
 
     @pytest.mark.parametrize("local", [True, False])
     def test_job_from_serving_runtime_with_data_object(self, local: bool) -> None:
-        """ML-12578 S1: data_object single-instance path on to_job() serving runtime.
+        """data_object single-instance path on to_job() serving runtime.
 
         Builds a serving function with a responder graph, converts to a job, then
         runs it with a single dict input via params={"data_object": ...}. Asserts:

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -880,6 +880,57 @@ def print_df(df):
             v3io_client.close()
 
     @pytest.mark.parametrize("local", [True, False])
+    def test_job_from_serving_runtime_with_data_object(self, local: bool) -> None:
+        """ML-12578 S1: data_object single-instance path on to_job() serving runtime.
+
+        Builds a serving function with a responder graph, converts to a job, then
+        runs it with a single dict input via params={"data_object": ...}. Asserts:
+        - num_rows == 1 (graph ran exactly once)
+        - run.output("return") equals the responder's output (returned as-is per Jira (6))
+        - prediction artifact has 1 row matching the input
+        """
+        serving_func_obj = self.project.set_function(
+            func=str(self.assets_path / "function_with_model.py"),
+            name="srv_fn_data_object",
+            kind="serving",
+            image=self.image,
+        )
+        model_runner_obj = ModelRunnerStep(name="model_runner_step_name")
+        model_runner_obj.add_model(
+            endpoint_name="my-endpoint",
+            model_class="DummyModel",
+            execution_mechanism="naive",
+        )
+        graph_obj = serving_func_obj.set_topology("flow", engine="async")
+        graph_obj.to(model_runner_obj).respond()
+        job = serving_func_obj.to_job()
+
+        run_object = self.project.run_function(
+            job,
+            params={
+                "data_object": {"x": "a", "y": 1},
+                "timestamp_column": None,
+            },
+            local=local,
+        )
+
+        # num_rows must be 1 (graph executed exactly once).
+        assert run_object.status.results.get("num_rows") == 1, (
+            f"Expected num_rows=1 on data_object path, got "
+            f"{run_object.status.results.get('num_rows')}"
+        )
+
+        # Per Jira (6): the graph response is returned as-is via run.output("return").
+        returned = run_object.output("return")
+        assert returned is not None, "Expected non-None return on data_object path"
+
+        # prediction artifact should be a 1-row dataset.
+        prediction_df = run_object.artifact("prediction").as_df()
+        assert len(prediction_df) == 1, (
+            f"Expected 1-row prediction artifact, got {len(prediction_df)} rows"
+        )
+
+    @pytest.mark.parametrize("local", [True, False])
     def test_async_handler_completes(self, local: bool) -> None:
         """Async handler completes with correct output for both local and remote (K8s) execution."""
         name = "async-fetch-data-local" if local else "async-fetch-data"


### PR DESCRIPTION
### 📝 Description
`mlrun.serving.server.execute_graph` (and its async core `async_execute_graph`) — the handler wired by `ServingRuntime.to_job()` as the job's `default_handler` — was strictly batch-oriented: it required a `DataItem` containing a DataFrame, iterated rows, never returned the graph response, and silently no-op'd on empty input. AIRun introduced a new use-case where the same serving graph is executed **once** with a single dict/JSON instance (e.g. a Runnable or a Workflow run as a job, not as a Nuclio function).

This change adds an optional `data_object: dict | None = None` parameter alongside an `Optional`-ed `data: DataItem | None = None`, enforces "exactly one of" at the top of the handler (fail-fast), bypasses the DataFrame/sorting/batching logic in the dict path, extracts `timestamp_column` from the dict root, supports `read_as_lists` / `nest_under_inputs` on the dict body, preserves the model-monitoring `batch_complete` push and the responder-driven `prediction` / `prediction_<model>` artifact logging on a 1-row dataset, and returns `responses[0]` so the graph response is visible to the caller via `run.output("return")`.

The change is **additive and fully backwards-compatible**: existing `DataItem`-based callers continue to work without code changes. No `ServingRuntime.to_job()` / `KubeResourceSpec` / `LocalRuntime.to_job()` modifications were needed — the new parameter flows via run-time `params`, the same plumbing already used for `timestamp_column` / `batching` / `batch_size` / `read_as_lists` / `nest_under_inputs`.

---

### 🛠️ Changes Made
- `mlrun/serving/server.py:async_execute_graph` and `execute_graph` extended with `data_object: dict | None = None`; `data` made `Optional`.
- Four-step entry validation (mutual exclusion + dict-shape + legacy `DataItem` check) using `MLRunInvalidArgumentError`.
- Single-event execution branch around input-materialization; shared tail (model-monitoring push, responder/artifact logging, `num_rows` accounting) untouched.
- `timestamp_column` extracted from the root of `data_object` when set; `MLRunRuntimeError` raised on missing key (wording mirrors the existing batch-path error).
- `read_as_lists=True` converts to `list(data_object.values())` (insertion order — Python 3.7+); `nest_under_inputs=True` wraps body as `{"inputs": body}`.
- `batching` / `batch_size` are **ignored** on the dict path; a DEBUG log line is emitted (flag values only, never the `data_object` contents).
- Handler returns `responses[0]` on the `data_object` path (graph response as-is); legacy `data` path return value preserved as `None`.
- Return annotation corrected from misleading `-> tuple[list[Any], Any]` to honest `-> Any | None` on both handlers.
- Docstring rewritten to be the public API reference.
- 22 new unit tests; 1 new parametrized system test (`local=[True, False]`).

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR
- [X] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
22 unit tests total. All in `tests/serving/test_execute_graph_data_object.py`. 
1 System test added - `test_job_from_serving_runtime_with_data_object` (parametrized `local=[True, False]`) in `tests/system/runtimes/test_kubejob.py`.

---

### 🔗 References
- Jira ticket: ML-12578 - _[Serving] Allow executing serving graph as a job with a simple input (JSON/dict)_

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No

---

### 🔍️ Additional Notes
Side effect: latent batch-path event-id bug fixed

The pre-existing inner closure at `async_execute_graph` had:

```python
for index, row in df.iterrows():
    ...
    tasks.append(asyncio.create_task(run(body)))   # run closes over `index`
```

with `run` defined as `async def run(body):` and reading `index` from the enclosing scope. Because `asyncio.create_task(...)` schedules the task immediately but `index` keeps mutating through the loop until `asyncio.gather(...)` is awaited *after* the loop completes, **every task captured the loop's terminal `index` value** — i.e. `len(df) - 1`. All `storey.Event(id=...)` instances ended up with the same id.

As part of the modification, `index → idx` rename converts the closure to `async def run(body, idx):` with explicit `idx=index` passed at task-creation time. Each task now receives its own `idx`. This is a **free secondary improvement** that falls out naturally of the refactor — not scope creep.

The unit-test (`test_execute_graph_batch_path_event_ids_are_per_row`) pins this behavior: a 3-row CSV through the batch path is asserted to yield captured event ids `[0, 1, 2]`, not `[2, 2, 2]`. 