### PR TITLE
[Tutorials] genai-01 reduce running time

### DIFF
--- a/docs/tutorials/genai-01-basic-tutorial.ipynb
+++ b/docs/tutorials/genai-01-basic-tutorial.ipynb
@@ -697,7 +697,7 @@
     "serve_func.spec.min_replicas = 1\n",
     "serve_func.spec.max_replicas = 1\n",
     "serve_func.with_http(worker_timeout=240, gateway_timeout=600, workers=1)\n",
-    "serve_func.set_config(\"spec.readinessTimeoutSeconds\", 1200)"
+    "serve_func.set_config(\"spec.readinessTimeoutSeconds\", 3600)"
    ]
   },
   {
@@ -865,6 +865,7 @@
     "project.set_function(f\"db://{project.name}/fetch-vectordb-data\")\n",
     "project.set_function(f\"db://{project.name}/build-vectordb\")\n",
     "project.set_function(f\"db://{project.name}/serve-llm\")\n",
+    "project.set_source(f\"db://{project.name}\")\n",
     "project.save()"
    ]
   },
@@ -922,7 +923,7 @@
     "    serve_func.spec.min_replicas = 1\n",
     "    serve_func.spec.max_replicas = 1\n",
     "    serve_func.with_http(worker_timeout=120, gateway_timeout=150, workers=1)\n",
-    "    serve_func.set_config(\"spec.readinessTimeoutSeconds\", 1200)\n",
+    "    serve_func.set_config(\"spec.readinessTimeoutSeconds\", 3600)\n",
     "    \n",
     "    deploy = project.deploy_function(\"serve-llm\", verbose=True).after(vectordb_build)"
    ]

--- a/docs/tutorials/src/serving.py
+++ b/docs/tutorials/src/serving.py
@@ -82,6 +82,14 @@ def init_context(context):
 
     setattr(context.user_data, "pipe", pipe)
 
+    context.logger.info("Warming up Chroma query...")
+
+    _ = context.user_data.collection.query(
+        query_texts=["warmup"], n_results=1, where={"topic": {"$eq": "SCIENCE"}}
+    )
+
+    context.logger.info("Chroma warmup done")
+
 
 def handler(context, event):
     # Unpack payload


### PR DESCRIPTION
### 📝 Description
first serving function invocation took a-lot of time processing (over 1600 seconds on vmdev clusters) only on first invocation - this happens because when first querying the database then it actually loads all the records - to address this we have to "warm-up" the chroma in the init_context.

---

### 🛠️ Changes Made

---

### ✅ Checklist
- [X] I updated the documentation (if applicable)
- [X] I have tested the changes in this PR
- [X] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
Manually

---

### 🔗 References
- Ticket link: https://iguazio.atlassian.net/browse/ML-12138
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [X] No


---

### 🔍️ Additional Notes
