### PR TITLE
[Requirements] Pin snowflake-connector-python to <4.5 to avoid source compilation on arm64 

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -73,7 +73,7 @@ def extra_requirements() -> dict[str, list[str]]:
         ],
         "alibaba-oss": ["ossfs==2025.5.0", "oss2==2.18.4"],
         "timescaledb": ["psycopg[binary,pool]~=3.2"],
-        "snowflake": ["snowflake-connector-python~=4.4"],
+        "snowflake": ["snowflake-connector-python~=4.4,<4.5"],
     }
 
     api_deps = list(

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -48,4 +48,4 @@ dask==2024.8
 distributed==2024.8
 # TimescaleDB dependencies - optional for model monitoring
 psycopg[binary,pool]~=3.2
-snowflake-connector-python~=4.4
+snowflake-connector-python~=4.4,<4.5


### PR DESCRIPTION
### 📝 Description 

`snowflake-connector-python==4.5.0` ships no arm64 wheel, causing uv to fall back to compiling from source on M-series Macs during make install-requirements. This is slow and flaky.

Tightening the pin to ~=4.4,<4.5 keeps us on 4.4.x where arm64 wheels are available.

A follow-up ticket [ML-12581](https://ecliptos.atlassian.net/browse/ML-12581) is tracked on 1.12 to revert this back to ~=4.4 once Snowflake publishes arm64 wheels for 4.5.x. 


---

### 🛠️ Changes Made

- extras-requirements.txt: snowflake-connector-python~=4.4 → ~=4.4,<4.5
- dependencies.py: same change in the snowflake extras group    

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [x] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: [ML-12582](https://ecliptos.atlassian.net/browse/ML-12582)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
