### PR TITLE
[Application] Fix store:// artifact source rejection for ApplicationRuntime

### DIFF
--- a/server/py/services/api/tests/unit/utils/test_functions.py
+++ b/server/py/services/api/tests/unit/utils/test_functions.py
@@ -143,6 +143,62 @@ def test_enrich_function_preserves_explicit_load_source_on_run_false():
     assert func.spec.build.load_source_on_run is False
 
 
+def test_enrich_function_application_accepts_artifact_kind():
+    """Application runtime accepts a generic Artifact (kind='artifact') source.
+
+    Backward compatibility for the pre-CodeArtifact single-file source workflow:
+    `project.log_artifact()` produces kind='artifact', and ApplicationRuntime
+    historically allowed pointing `spec.build.source` at such a store:// URI.
+    """
+    func = mlrun.new_function("test", kind="application")
+    func.spec.build.source = "store://artifacts/proj/app_py"
+
+    artifact = MagicMock()
+    artifact.kind = "artifact"
+    artifact.spec.requirements = None
+
+    with patch("mlrun.datastore.get_store_resource", return_value=artifact):
+        enrich_function_from_code_artifact(func, "proj")
+
+    assert func.spec.build.load_source_on_run is True
+
+
+def test_enrich_function_application_still_rejects_non_code_non_artifact_kinds():
+    """Application accepts only kind='code' or 'artifact'; other kinds still raise."""
+    func = mlrun.new_function("test", kind="application")
+    func.spec.build.source = "store://artifacts/proj/some_model"
+
+    artifact = MagicMock()
+    artifact.kind = "model"
+
+    with patch("mlrun.datastore.get_store_resource", return_value=artifact):
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="resolves to a 'model' artifact",
+        ):
+            enrich_function_from_code_artifact(func, "proj")
+
+
+def test_enrich_function_job_rejects_artifact_kind():
+    """Generic Artifact (kind='artifact') is accepted only for Application runtime.
+
+    Other runtimes (here: job) require a CodeArtifact — the artifact-as-source
+    workflow was never supported for non-Application runtimes.
+    """
+    func = mlrun.new_function("test", kind="job")
+    func.spec.build.source = "store://artifacts/proj/app_py"
+
+    artifact = MagicMock()
+    artifact.kind = "artifact"
+
+    with patch("mlrun.datastore.get_store_resource", return_value=artifact):
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="resolves to a 'artifact' artifact",
+        ):
+            enrich_function_from_code_artifact(func, "proj")
+
+
 def test_enrich_function_falls_back_to_application_source():
     """When spec.build.source is empty, falls back to status.application_source.
 

--- a/server/py/services/api/utils/functions.py
+++ b/server/py/services/api/utils/functions.py
@@ -146,7 +146,10 @@ def enrich_function_from_code_artifact(
 
     When ``function.spec.build.source`` is a store:// URI:
 
-    1. Validates that the artifact is a CodeArtifact (kind == "code").
+    1. Validates the artifact kind. Most runtimes require a CodeArtifact
+       (kind == "code"). Application runtime additionally accepts a generic
+       Artifact (kind == "artifact") for backward compatibility with the
+       single-file source workflow that predates CodeArtifact.
     2. Merges artifact ``spec.requirements`` into ``function.spec.build.requirements``
        (user requirements win on conflict).
     3. Defaults ``function.spec.build.load_source_on_run`` to True when unset, so
@@ -175,7 +178,10 @@ def enrich_function_from_code_artifact(
             f"Cannot resolve code artifact {source}: {err_to_str(exc)}"
         ) from exc
 
-    if artifact.kind != "code":
+    allowed_kinds = {"code"}
+    if function.kind == mlrun.runtimes.RuntimeKinds.application:
+        allowed_kinds.add("artifact")
+    if artifact.kind not in allowed_kinds:
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"Source {source} resolves to a {artifact.kind!r} artifact; "
             "expected a code artifact (kind='code')."


### PR DESCRIPTION
## 📝 Description

Regression introduced when CodeArtifact (`kind='code'`) support was added for `store://` function sources. The new strict kind validation in `enrich_function_from_code_artifact` runs on every deploy and rejects ApplicationRuntime's previously-supported workflow of pointing `spec.build.source` at a `project.log_artifact()`-produced URI (which produces `kind='artifact'`).

ApplicationRuntime kept generic Artifact support as a documented feature (single-file source, archives, Git) introduced across PRs #9244, #9267, #9279, #9306, #9312, #9346, #9357, #9429, #9434 — months before CodeArtifact. The strict gate added later inadvertently broke that path.

## 🛠️ Changes Made

- `server/py/services/api/utils/functions.py`: Relax the `kind != "code"` validation to also accept `kind == "artifact"` **only** when `function.kind == RuntimeKinds.application`. Other runtimes (job, vanilla Nuclio, serving) continue to require `kind == "code"`, since they never had any other path to `store://` source.
- Updated the function docstring to reflect the new Application-runtime exception.
- Added three unit tests covering the 2×2 (runtime kind × artifact kind) matrix.


## 🔗 References

- Jira: ML-12571