### PR TITLE
[Tests] Pin test_import_module_from_hub to count_events:1.0.0 (#9677)

### DIFF
--- a/tests/integration/hub/test_hub_sdk.py
+++ b/tests/integration/hub/test_hub_sdk.py
@@ -137,25 +137,21 @@ class TestHub(tests.integration.sdk_api.base.TestMLRunIntegration):
 
     def test_import_module_from_hub(self):
         hub_prefix = "hub://"
-        source_name = mlrun.mlconf.hub.default_source.name
-        db = mlrun.get_run_db()
-        modules_catalog = db.get_hub_catalog(
-            source_name, object_type=mlrun.common.schemas.hub.HubSourceType.modules
-        )
-        item = random.choice(modules_catalog.catalog)
-        name = item.metadata.name
+        name = "count_events"
+        tag = "1.0.0"
+        module_ref = f"{hub_prefix}{name}:{tag}"
 
         # import_module
         # create temp dir in cwd
         Path.cwd().joinpath("temp").mkdir(exist_ok=True)
-        mod = mlrun.import_module(hub_prefix + name, local_path="./temp")
+        mod = mlrun.import_module(module_ref, local_path="./temp")
         assert isinstance(mod, types.ModuleType)
         # delete the temp dir
         shutil.rmtree("temp")
 
         # get_hub_module and module
         Path.cwd().joinpath("temp").mkdir(exist_ok=True)
-        hub_module = mlrun.get_hub_module(hub_prefix + name, download_files=False)
+        hub_module = mlrun.get_hub_module(module_ref, download_files=False)
         with pytest.raises(MLRunBadRequestError):  # didn't download files first
             hub_module.module()
         hub_module.set_local_path("./temp")
@@ -171,7 +167,7 @@ class TestHub(tests.integration.sdk_api.base.TestMLRunIntegration):
 
         # local_path doesn't exist
         with pytest.raises(ValueError):
-            mlrun.import_module(hub_prefix + name, local_path="./temp")
+            mlrun.import_module(module_ref, local_path="./temp")
 
     def test_get_hub_step(self):
         hub_prefix = "hub://"


### PR DESCRIPTION
### Description
Backport of #9677 to `1.11.x`.

Pins `test_import_module_from_hub` to a known module (`hub://count_events:1.0.0`) instead of picking one at random from the hub catalog. Random selection was occasionally hitting modules whose runtime dependencies aren't installed in the test environment, causing the import step to fail intermittently in CI.

---

### Changes Made
- `tests/integration/hub/test_hub_sdk.py`: replaced `random.choice(modules_catalog.catalog)` in `test_import_module_from_hub` with a hard-coded reference to `hub://count_events:1.0.0`. Removed the now-unused catalog fetch inside this test.

Cherry-picked from commit `a108aff2137090d309182f7477aaf5f159abace7` on `development` (clean cherry-pick, no conflicts, identical diff to the original PR).

---

### Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### Testing
- Verified on `development` in #9677. Cherry-pick applied cleanly to `1.11.x`; the resulting diff matches the original commit byte-for-byte.

---

### References
- Original PR: #9677
- Ticket link: ML-12555

---

### Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### Additional Notes
Other tests in this file still use `random.choice(...)` against the catalog — they don't actually import the chosen item (only check metadata), so they aren't affected by the same issue. The `random` import is intentionally kept.