### PR TITLE
[CI] Restore workflow_dispatch exclusion on unstable-tag push

### DIFF
--- a/.github/workflows/build-internal.yaml
+++ b/.github/workflows/build-internal.yaml
@@ -252,11 +252,13 @@ jobs:
 
     - name: Build and push unstable tag
 
-      # Push the "unstable" tag only when building from a direct push to development
-      # (not the test image; not a PR-driven build; not a non-dev branch like 1.11.x).
-      # Fork PRs don't have write access to mlrun-org packages and would fail this
-      # step with "unauthorized" if it ran on PR builds.
-      if: matrix.image-name != 'test' && inputs.pr_number == '' && github.ref_name == 'development'
+      # Push the "unstable" tag only when building from a direct push to development:
+      # - skip the test image
+      # - skip PR-driven builds (fork PRs are unauthorized to push pacakges to mlrun-org)
+      # - skip workflow_dispatch (private-release.yaml uses MLRUN_DOCKER_REPO that doesn't own the
+      #   ghcr.io path being pushed to)
+      # - skip non-dev branches (e.g., 1.11.x backports)
+      if: matrix.image-name != 'test' && inputs.pr_number == '' && github.event_name != 'workflow_dispatch' && github.ref_name == 'development'
       run: |
         for registry in "ghcr.io/" "quay.io/" "registry.hub.docker.com/"; \
           do \


### PR DESCRIPTION
### 📝 Description

Follow-up to #9709. That PR replaced the original `github.event_name != 'workflow_dispatch'` exclusion on the "Build and push unstable tag" step with `inputs.pr_number == ''` to fix the fork-PR auto-triggered smoke flow. Replacing one exclusion with the other unintentionally re-opened the path for manual release workflows (e.g., `private-release.yaml`) to hit the step — they call `build-internal` via `workflow_dispatch` with no PR number, so the new condition no longer skips them, and they fail pushing to a `ghcr.io/<release-repo>/<image>:unstable` path they don't own.

The two exclusions guard different scenarios; both are needed.

---

### 🛠️ Changes Made

**`.github/workflows/build-internal.yaml`** — restore the `workflow_dispatch` exclusion on the "Build and push unstable tag" step so the condition skips when **any** of these hold:

- `matrix.image-name == 'test'` — test image (existing)
- `inputs.pr_number != ''` — PR-driven build (from #9709, fork PRs fail with `unauthorized` on mlrun-org packages)
- `github.event_name == 'workflow_dispatch'` — manual release flows (restored; `private-release.yaml` uses a different `MLRUN_DOCKER_REPO` that doesn't own the ghcr.io path)
- `github.ref_name != 'development'` — backport branch pushes like `1.11.x` (existing)

Resulting condition:
```yaml
if: matrix.image-name != 'test' && inputs.pr_number == '' && github.event_name != 'workflow_dispatch' && github.ref_name == 'development'
```

The header comment is updated to enumerate all four exclusions and why each exists.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing

The regression was observed on https://github.com/mlrun/mlrun/actions/runs/26212451015 — "Privately ( artifactory only ) releasing (development)" `workflow_dispatch` run, where every per-image build job failed at the `Build and push unstable tag` step with:

```
docker push ghcr.io/mlrun-staging/mlrun/mlrun-kfp:unstable
error from registry: not_found: owner not found
make: *** [Makefile:373: push-mlrun-kfp] Error 1
```

The fork-PR auto-trigger path that #9709 fixed continues to be exercised by PR 9491's smoke runs and remains unaffected by this change (its run path satisfies `inputs.pr_number != ''`, so the step is skipped regardless of the `workflow_dispatch` clause).

---

### 🔗 References

- Follow-up to #9709 — _[CI] Skip unstable-tag push for PR-driven builds_
- Affected workflow: `.github/workflows/private-release.yaml` (and any other `workflow_dispatch`-based release/build flow that calls `build-internal`)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

CI-only changes. No production code touched. Restores prior behavior for manual release dispatches that was incidentally removed in #9709.