### PR TITLE
[Cron] Only uppercase 'utc' timezone instead of all timezones

### DIFF
--- a/server/py/services/api/utils/scheduler.py
+++ b/server/py/services/api/utils/scheduler.py
@@ -1060,8 +1060,9 @@ class Scheduler:
     ):
         # apscheduler timezone fails when `utc` key was given as it expects
         # `UTC` key in order to work properly. this is a workaround for 3.11.0
-        if cron_trigger.timezone and isinstance(cron_trigger.timezone, str):
-            cron_trigger.timezone = cron_trigger.timezone.upper()
+        if cron_trigger.timezone == "utc":
+            cron_trigger.timezone = "UTC"
+
         return APSchedulerCronTrigger(
             cron_trigger.year,
             cron_trigger.month,


### PR DESCRIPTION
### 📝 Description
The cron trigger currently uppercases all timezone names so that 'utc' gets normalized to 'UTC'. However this is overly broad since other timezones are case sensitive.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12458
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
