### PR TITLE
[Secrets] Use canonicalized lowercased uernames in secrets API

### DIFF
--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -1402,6 +1402,10 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                 "auth_info.user_id and auth_info.username should always be filled"
             )
 
+        # Canonicalize to lowercase: Keycloak/Iguazio treat usernames case-insensitively,
+        # so labels and annotations must use a single form to keep lookups consistent.
+        username = username.lower()
+
         labels = {
             mlrun_constants.MLRunInternalLabels.auth_userid: user_id,
             mlrun_constants.MLRunInternalLabels.auth_username: self._hash_label(
@@ -1512,6 +1516,9 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
         :return: List of SecretTokenInfo objects, each containing the token name, expiration and user id.
         """
         namespace = self.resolve_namespace(namespace)
+        # Canonicalize to lowercase — secrets are stored with the lowercase form
+        # of the username (see store_user_token_secret). The "*" sentinel is a no-op.
+        username = username.lower()
         # Always filter by auth token label to only get auth token secrets
         # Use None as value to perform "label exists" check (more efficient than fetching all secrets)
         labels: dict[str, str | None] = {

--- a/server/py/services/api/api/endpoints/user_secrets.py
+++ b/server/py/services/api/api/endpoints/user_secrets.py
@@ -203,8 +203,7 @@ async def _resolve_target_username_for_list_secret_tokens(
     # Keycloak/Iguazio treat usernames case-insensitively.
     # auth_info.username may be None; in that case the comparison must fail.
     if not has_system_admin_permissions and (
-        auth_info.username is None
-        or username.lower() != auth_info.username.lower()
+        auth_info.username is None or username.lower() != auth_info.username.lower()
     ):
         raise mlrun.errors.MLRunAccessDeniedError(
             "Only system admins can list tokens for other users"
@@ -245,8 +244,7 @@ async def _resolve_target_username_for_delete_secret_tokens(
     # Keycloak/Iguazio treat usernames case-insensitively.
     # auth_info.username may be None; in that case the comparison must fail.
     if not has_system_admin_permissions and (
-        auth_info.username is None
-        or username.lower() != auth_info.username.lower()
+        auth_info.username is None or username.lower() != auth_info.username.lower()
     ):
         raise mlrun.errors.MLRunAccessDeniedError(
             "Only system admins can delete tokens for other users"

--- a/server/py/services/api/api/endpoints/user_secrets.py
+++ b/server/py/services/api/api/endpoints/user_secrets.py
@@ -199,8 +199,13 @@ async def _resolve_target_username_for_list_secret_tokens(
         return username
 
     # Specific username provided
-    # Regular users can only query themselves
-    if not has_system_admin_permissions and username != auth_info.username:
+    # Regular users can only query themselves — compare case-insensitively because
+    # Keycloak/Iguazio treat usernames case-insensitively.
+    # auth_info.username may be None; in that case the comparison must fail.
+    if not has_system_admin_permissions and (
+        auth_info.username is None
+        or username.lower() != auth_info.username.lower()
+    ):
         raise mlrun.errors.MLRunAccessDeniedError(
             "Only system admins can list tokens for other users"
         )
@@ -236,8 +241,13 @@ async def _resolve_target_username_for_delete_secret_tokens(
     )
 
     # Specific username provided
-    # Regular users can only delete their own tokens
-    if not has_system_admin_permissions and username != auth_info.username:
+    # Regular users can only delete their own tokens — compare case-insensitively because
+    # Keycloak/Iguazio treat usernames case-insensitively.
+    # auth_info.username may be None; in that case the comparison must fail.
+    if not has_system_admin_permissions and (
+        auth_info.username is None
+        or username.lower() != auth_info.username.lower()
+    ):
         raise mlrun.errors.MLRunAccessDeniedError(
             "Only system admins can delete tokens for other users"
         )

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -796,8 +796,12 @@ class Secrets(
         :return: The user_id, or "*" for all users.
         :raises mlrun.errors.MLRunNotFoundError: If the username cannot be found.
         """
-        # No username provided or matches self -> use authenticated user's user_id
-        if not username or username == auth_info.username:
+        # No username provided or matches self -> use authenticated user's user_id.
+        # Compare case-insensitively because Keycloak/Iguazio treat usernames as such.
+        if not username or (
+            auth_info.username is not None
+            and username.lower() == auth_info.username.lower()
+        ):
             return auth_info.user_id
 
         # Wildcard for all users (list operation)

--- a/server/py/services/api/tests/unit/api/test_user_secrets.py
+++ b/server/py/services/api/tests/unit/api/test_user_secrets.py
@@ -96,6 +96,9 @@ def test_iguazio_v4_only_dependency(db: Session, client: TestClient):
         (False, "", "auth-user", None),
         # Username is self -> self
         (False, "auth-user", "auth-user", None),
+        # Username is self in different case -> self (Keycloak treats usernames case-insensitively)
+        (False, "AUTH-USER", "AUTH-USER", None),
+        (False, "Auth-User", "Auth-User", None),
         # Username is other user -> forbidden
         (
             False,
@@ -167,6 +170,9 @@ async def test_resolve_target_username_for_list(
         (False, "", "auth-user", None),
         # Username is self -> self
         (False, "auth-user", "auth-user", None),
+        # Username is self in different case -> self (Keycloak treats usernames case-insensitively)
+        (False, "AUTH-USER", "AUTH-USER", None),
+        (False, "Auth-User", "Auth-User", None),
         # Username is other user -> forbidden
         (
             False,
@@ -210,3 +216,49 @@ async def test_resolve_target_username_for_delete(
             auth_info, username_param
         )
         assert result == expected_result
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_username_for_list_handles_none_auth_username(monkeypatch):
+    # auth_info.username can be None (it's typed str | None); the self-check must not crash
+    # and must deny non-admins who supply a concrete username.
+    async def _no_admin(self, *args, **kwargs):
+        return False
+
+    monkeypatch.setattr(
+        user_secrets.framework.utils.auth.verifier.AuthVerifier,
+        "query_global_resource_permissions",
+        _no_admin,
+    )
+    auth_info = mlrun.common.schemas.AuthInfo(username=None, user_id="x")
+
+    with pytest.raises(
+        mlrun.errors.MLRunAccessDeniedError,
+        match="Only system admins can list tokens for other users",
+    ):
+        await user_secrets._resolve_target_username_for_list_secret_tokens(
+            auth_info, "some-user"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_username_for_delete_handles_none_auth_username(
+    monkeypatch,
+):
+    async def _no_admin(self, *args, **kwargs):
+        return False
+
+    monkeypatch.setattr(
+        user_secrets.framework.utils.auth.verifier.AuthVerifier,
+        "query_global_resource_permissions",
+        _no_admin,
+    )
+    auth_info = mlrun.common.schemas.AuthInfo(username=None, user_id="x")
+
+    with pytest.raises(
+        mlrun.errors.MLRunAccessDeniedError,
+        match="Only system admins can delete tokens for other users",
+    ):
+        await user_secrets._resolve_target_username_for_delete_secret_tokens(
+            auth_info, "some-user"
+        )

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -1236,5 +1236,38 @@ def test_get_secret_token_not_found():
         )
 
 
+@pytest.mark.parametrize(
+    "supplied_username", ["dummy-user", "Dummy-User", "DUMMY-USER"]
+)
+def test_get_user_id_self_match_is_case_insensitive(
+    mock_iguazio_client, supplied_username
+):
+    """When the supplied username matches the authenticated user case-insensitively,
+    _get_user_id returns auth_info.user_id directly and does NOT call Iguazio
+    (Keycloak/Iguazio treat usernames case-insensitively)."""
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
+
+    user_id = services.api.crud.Secrets()._get_user_id(auth_info, supplied_username)
+
+    assert user_id == auth_info.user_id
+    mock_iguazio_client.get_user_id_by_username.assert_not_called()
+
+
+def test_get_user_id_handles_none_auth_username(mock_iguazio_client):
+    """auth_info.username is typed str | None; _get_user_id must not crash when it's
+    None and must fall through to the Iguazio lookup."""
+    auth_info = mlrun.common.schemas.AuthInfo(username=None, user_id="user-id-123")
+    mock_iguazio_client.get_user_id_by_username.return_value = "other-user-id"
+
+    user_id = services.api.crud.Secrets()._get_user_id(auth_info, "some-user")
+
+    assert user_id == "other-user-id"
+    mock_iguazio_client.get_user_id_by_username.assert_called_once_with(
+        "some-user", auth_info
+    )
+
+
 def _generate_token(payload: dict) -> str:
     return jwt.encode(payload, key="dummy", algorithm="HS256")

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -920,6 +920,84 @@ def test_list_user_token_secrets_valid(k8s_helper):
     )
 
 
+def test_store_user_token_secret_canonicalizes_username_to_lowercase(k8s_helper):
+    """Usernames are stored canonically (lowercase) so list lookups match regardless of
+    the case the user originally registered with — Keycloak/Iguazio are case-insensitive."""
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[])
+
+    mixed_case_username = "Mixed.Case-User"
+    auth_info = mlrun.common.schemas.AuthInfo(
+        user_id="user-id-1", username=mixed_case_username
+    )
+
+    k8s_helper.store_user_token_secret(
+        auth_info=auth_info,
+        token_name="my-token",
+        token="abc123",
+        issued_at=1,
+        expiration=9999,
+        namespace="default",
+    )
+
+    labels = k8s_helper._create_secret.call_args.kwargs["labels"]
+    annotations = k8s_helper._create_secret.call_args.kwargs["annotations"]
+    assert labels[
+        mlrun_constants.MLRunInternalLabels.auth_username
+    ] == k8s_helper._hash_label(mixed_case_username.lower())
+    assert (
+        annotations[mlrun_constants.InternalAnnotations.auth_username]
+        == mixed_case_username.lower()
+    )
+
+
+def test_list_user_token_secrets_canonicalizes_username_to_lowercase(k8s_helper):
+    """Listing with mixed-case username must hit the same hashed label that was written
+    using the canonical (lowercase) form."""
+    canonical_username = "mixed.case-user"
+    secret_name = k8s_helper._resolve_auth_secret_name("user-id-1", "token1")
+    secret = _make_user_token_secret(
+        secret_name,
+        token_name="token1",
+        issued_at=1,
+        expiration=9999,
+        user_id="user-id-1",
+        username=canonical_username,
+    )
+    k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[secret])
+
+    result = k8s_helper.list_user_token_secrets(
+        username="Mixed.Case-User", namespace="default"
+    )
+
+    # The hash-collision post-filter compares against the canonical stored username,
+    # so the match succeeds and the token is returned.
+    assert len(result) == 1
+    assert result[0].name == "token1"
+
+    k8s_helper.list_secrets.assert_called_once_with(
+        namespace="default",
+        labels={
+            mlrun_constants.MLRunInternalLabels.auth_token_name: None,
+            mlrun_constants.MLRunInternalLabels.auth_username: k8s_helper._hash_label(
+                canonical_username
+            ),
+        },
+    )
+
+
+def test_list_user_token_secrets_wildcard_not_canonicalized(k8s_helper):
+    """The "*" sentinel must not be lowercased or hashed — it skips the username filter."""
+    k8s_helper.resolve_namespace = mock.MagicMock(return_value="default")
+    k8s_helper.list_secrets = mock.MagicMock(return_value=[])
+
+    k8s_helper.list_user_token_secrets(username="*", namespace="default")
+
+    # No auth_username label key should be present — the wildcard skips the filter
+    called_labels = k8s_helper.list_secrets.call_args.kwargs["labels"]
+    assert mlrun_constants.MLRunInternalLabels.auth_username not in called_labels
+
+
 def test_list_user_token_secrets_invalid_expiration(k8s_helper):
     user_id = "test-user-id"
     username = "test-username"


### PR DESCRIPTION
### 📝 Description

We had a bug report that an admin querying another user's tokens by name did not work anymore. After further investigation it turned out that the real issue was that the old implementation was case insensitive on the username lookup  (because the underlying username -> user id lookup in keycloak is). This PR makes sure our API is also case insensitive to match.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/IG4-2308
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
