### PR TITLE
[Artifacts] Fix code artifacts missing from project summaries and files listing

### DIFF
--- a/mlrun/common/schemas/artifact.py
+++ b/mlrun/common/schemas/artifact.py
@@ -26,7 +26,6 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
     dataset = "dataset"
     document = "document"
     llm_prompt = "llm-prompt"
-    code = "code"
     other = "other"
 
     # we define the link as a category to prevent import cycles, but it's not a real category
@@ -44,8 +43,6 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             return [ArtifactCategories.document.value, link_kind], False
         if self.value == ArtifactCategories.llm_prompt.value:
             return [ArtifactCategories.llm_prompt.value, link_kind], False
-        if self.value == ArtifactCategories.code.value:
-            return [ArtifactCategories.code.value, link_kind], False
         if self.value == ArtifactCategories.other.value:
             return (
                 [
@@ -53,7 +50,6 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
                     ArtifactCategories.dataset.value,
                     ArtifactCategories.document.value,
                     ArtifactCategories.llm_prompt.value,
-                    ArtifactCategories.code.value,
                 ],
                 True,
             )
@@ -65,7 +61,6 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             cls.dataset.value,
             cls.document.value,
             cls.llm_prompt.value,
-            cls.code.value,
         ]:
             return cls(kind)
         return cls.other
@@ -78,7 +73,6 @@ class ArtifactCategories(mlrun.common.types.StrEnum):
             ArtifactCategories.dataset,
             ArtifactCategories.document,
             ArtifactCategories.llm_prompt,
-            ArtifactCategories.code,
         ]
 
 

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -567,6 +567,12 @@ async def test_list_and_get_project_summaries(
         client, project_name, files_count, mlrun.artifacts.PlotArtifact.kind
     )
 
+    code_files_count = 3
+    _create_artifacts(
+        client, project_name, code_files_count, mlrun.artifacts.CodeArtifact.kind
+    )
+    files_count += code_files_count
+
     # create feature sets for the project
     feature_sets_count = 9
     _create_feature_sets(client, project_name, feature_sets_count)

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -28,6 +28,7 @@ import mlrun.lists
 import mlrun.utils
 from mlrun.artifacts import Artifact
 from mlrun.artifacts.base import LinkArtifact
+from mlrun.artifacts.code import CodeArtifact
 from mlrun.artifacts.dataset import DatasetArtifact
 from mlrun.artifacts.document import DocumentArtifact
 from mlrun.artifacts.model import ModelArtifact
@@ -190,12 +191,15 @@ class TestArtifacts(TestDatabaseBase):
         artifact_kind_4 = DatasetArtifact.kind
         artifact_name_5 = "artifact_name_5"
         artifact_kind_5 = DocumentArtifact.kind
+        artifact_name_6 = "artifact_name_6"
+        artifact_kind_6 = CodeArtifact.kind
 
         artifact_1 = self._generate_artifact(artifact_name_1, kind=artifact_kind_1)
         artifact_2 = self._generate_artifact(artifact_name_2, kind=artifact_kind_2)
         artifact_3 = self._generate_artifact(artifact_name_3, kind=artifact_kind_3)
         artifact_4 = self._generate_artifact(artifact_name_4, kind=artifact_kind_4)
         artifact_5 = self._generate_artifact(artifact_name_5, kind=artifact_kind_5)
+        artifact_6 = self._generate_artifact(artifact_name_6, kind=artifact_kind_6)
 
         for artifact_name, artifact_object in [
             (artifact_name_1, artifact_1),
@@ -203,6 +207,7 @@ class TestArtifacts(TestDatabaseBase):
             (artifact_name_3, artifact_3),
             (artifact_name_4, artifact_4),
             (artifact_name_5, artifact_5),
+            (artifact_name_6, artifact_6),
         ]:
             self._db.store_artifact(
                 self._db_session,
@@ -212,7 +217,7 @@ class TestArtifacts(TestDatabaseBase):
             )
 
         artifacts = self._db.list_artifacts(self._db_session, project=self.project)
-        assert len(artifacts) == 5
+        assert len(artifacts) == 6
 
         artifacts = self._db.list_artifacts(
             self._db_session,
@@ -243,9 +248,16 @@ class TestArtifacts(TestDatabaseBase):
             category=mlrun.common.schemas.ArtifactCategories.other,
             project=self.project,
         )
-        assert len(artifacts) == 2
-        assert artifacts[1]["metadata"]["key"] == artifact_name_1
-        assert artifacts[0]["metadata"]["key"] == artifact_name_2
+        assert len(artifacts) == 3
+        assert artifacts[0]["metadata"]["key"] == artifact_name_6
+        assert artifacts[1]["metadata"]["key"] == artifact_name_2
+        assert artifacts[2]["metadata"]["key"] == artifact_name_1
+
+        artifacts = self._db.list_artifacts(
+            self._db_session, kind=CodeArtifact.kind, project=self.project
+        )
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["key"] == artifact_name_6
 
     def test_list_artifact_label_filter(self):
         total_artifacts = 5

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -876,23 +876,15 @@ def test_code_artifact_registered_in_artifact_types():
     )
 
 
-def test_code_artifact_category_filtering():
+def test_code_artifact_categorized_as_other():
     assert (
         mlrun.common.schemas.artifact.ArtifactCategories.from_kind("code")
-        == mlrun.common.schemas.artifact.ArtifactCategories.code
+        == mlrun.common.schemas.artifact.ArtifactCategories.other
     )
-    kinds, exclude = (
-        mlrun.common.schemas.artifact.ArtifactCategories.code.to_kinds_filter()
-    )
-    assert "code" in kinds
-    assert not exclude
-
-
-def test_code_artifact_other_category_excludes_code():
     kinds, exclude = (
         mlrun.common.schemas.artifact.ArtifactCategories.other.to_kinds_filter()
     )
-    assert "code" in kinds
+    assert "code" not in kinds
     assert exclude
 
 


### PR DESCRIPTION
### 📝 Description

Code artifacts (`kind="code"`, added in ML-12337) were modeled as a dedicated `ArtifactCategories.code`. That category was dropped from the project-summary counters and excluded from the `other` category. Since the UI's project summary surfaces code under `files_count` and its Artifacts/Files tab queries `category=other`, code artifacts were **neither counted** in `GET /project-summaries` **nor shown** in the UI.

This demotes `code` to a plain "other"/file artifact — categorized as `other` like `plot` and any other non-special kind — so it is counted in `files_count` and listed under `category=other` (the existing Files tab) with **no UI change required**. Code remains filterable via the generic `kind="code"` list-artifacts parameter.

---

### 🛠️ Changes Made

- `mlrun/common/schemas/artifact.py`: remove `code` from the `ArtifactCategories` enum, `from_kind`, `to_kinds_filter` (both the dedicated `code` branch and the `other` exclusion) and `all()`. `from_kind("code")` now returns `other`, and the `other` listing no longer excludes code.
- No change needed in the summary counter (`get_project_resources_counters`): code flows into the `other` bucket via `from_kind`, so no special-case handling.
- Net effect: `category=code` is no longer a category (redundant with the generic `kind=code` filter); `code` is counted and listed as a file.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the Deprecation Guidelines
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing

Unit (all pass; ruff + import-linter clean on changed files):
- `tests/artifacts/test_artifacts.py` — rewrote the ML-12337 category tests to the new behavior (`from_kind("code") == other`, `other` includes code).
- `server/py/services/api/tests/unit/db/test_artifacts.py` — code listed under `category=other`, and filterable by `kind="code"`.
- `server/py/services/api/tests/unit/api/test_projects.py` — code counted in project summary `files_count`.

Manual (dev cluster): created a `CodeArtifact` via `project.log_code_file(...)` and confirmed `files_count` includes it, it appears under `category=other`, and `kind="code"` returns it.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12597
- Parent feature: ML-12337 (CodeArtifact type)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

`category=code` was introduced by the in-flight ML-12337 feature and is unused by the UI, so removing it does not affect a released API. Filtering for code artifacts uses the existing `kind=code` parameter.

---

### 🔍️ Additional Notes

- `code` remains a first-class artifact **kind** (`CodeArtifact`); only its status as a distinct **category** is removed.
- This reverses the "first-class category" portion of ML-12337 — worth a heads-up to that ticket's owner.

### Note to the reviewer
Ignore the BC test failure - its on purpuse 