### PR TITLE
[API] Fix OPA propagation race on `store_project` endpoint

### DIFF
--- a/server/py/framework/utils/auth/providers/opa.py
+++ b/server/py/framework/utils/auth/providers/opa.py
@@ -183,7 +183,21 @@ class Provider(
             self._allowed_project_owners_cache[auth_info.user_id].keys()
         )
         for allowed_project in allowed_projects:
-            if f"/projects/{allowed_project}/" in resource:
+            # Cover both:
+            #   * actions on resources inside the project — e.g.
+            #     ``.../projects/<name>/secrets/<key>``. The trailing slash in
+            #     the match string anchors the project-name segment so that
+            #     ``alpha`` does not match ``alpha-extended``.
+            #   * actions on the project record itself — e.g.
+            #     ``.../projects/<name>`` produced by ``PUT /projects/<name>``,
+            #     which has no trailing slash. Without this second match the
+            #     owner cache populated by ``ensure_project`` (see #9432,
+            #     #9657) only covers resources inside a project, so
+            #     ``store_project`` still goes to OPA and trips the
+            #     manifest-propagation race.
+            if f"/projects/{allowed_project}/" in resource or resource.endswith(
+                f"/projects/{allowed_project}"
+            ):
                 return True
         return False
 

--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -629,12 +629,16 @@ async def _ensure_project_create_or_update_permissions(
         return
 
     try:
+        # Use ensure_project (rather than get_project) so the OPA owner cache is
+        # populated from the DB-recorded owner before the permission check runs.
+        # Mitigates the OPA manifest propagation race on multi-replica deployments
+        # when a freshly-created project's manifest hasn't yet reached the handling
+        # pod's OPA sidecar — see #9432, #9657.
         await run_in_threadpool(
-            get_project_member().get_project,
+            get_project_member().ensure_project,
             db_session,
             project_name,
-            auth_info,
-            format_=mlrun.common.formatters.ProjectFormat.name_only,
+            auth_info=auth_info,
         )
         project_exists = True
     except mlrun.errors.MLRunNotFoundError:

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -23,6 +23,7 @@ from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
+import aioresponses
 import deepdiff
 import fastapi.testclient
 import kubernetes.client
@@ -46,6 +47,7 @@ from mlrun.common.schemas.background_task import BackGroundTaskLabel
 from mlrun.common.schemas.model_monitoring import EndpointType, ModelMonitoringAppLabel
 
 import framework.api.utils
+import framework.utils.auth.providers.opa
 import framework.utils.auth.verifier
 import framework.utils.background_tasks
 import framework.utils.clients.log_collector
@@ -2208,6 +2210,182 @@ def _assert_project_summary(
     assert (
         project_summary.failed_model_monitoring_functions
         == failed_model_monitoring_functions
+    )
+
+
+@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
+@pytest.mark.asyncio
+async def test_store_project_recovers_from_opa_propagation_lag(
+    db: Session,
+    client: TestClient,
+    project_member_mode: str,
+    monkeypatch,
+):
+    """
+    Regression: PUT /projects/{name} must succeed when the project's owner is
+    the requester even if OPA returns deny — the existing project_owners_cache
+    (populated by #9432 / #9657 for resources inside a project) should also
+    short-circuit OPA for the project's own resource string.
+
+    Reproduces the OPA-manifest-propagation race seen on multi-replica
+    deployments when a request lands on an API pod whose OPA sidecar has not
+    yet received the manifest for the just-created project.
+
+    The full fix has two parts:
+      (a) ``_ensure_project_create_or_update_permissions`` calls
+          ``ensure_project`` (populates the owner cache from the DB) instead
+          of ``get_project`` (which does not).
+      (b) ``_check_allowed_project_owners_cache`` matches the project's own
+          resource path ``/resources/projects/<name>`` (no segment after the
+          project name), not only sub-paths like ``/resources/projects/<name>/secrets``.
+
+    Without both fixes the call returns 403; with both, 200.
+    """
+    project_name = "test-store-project-cache"
+    owner_username = "project-creator"
+    owner_user_id = "owner-uid"
+    opa_api_url = "http://127.0.0.1:8181"
+    opa_query_path = "/v1/data/service/authz/allow"
+
+    # iguazio_v4 + OPA authorization
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value,
+    )
+    monkeypatch.setattr(mlrun.mlconf.httpdb.authorization, "mode", "opa")
+    monkeypatch.setattr(mlrun.mlconf.httpdb.authorization.opa, "address", opa_api_url)
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authorization.opa,
+        "permission_query_path",
+        opa_query_path,
+    )
+
+    # Swap the verifier's provider so it picks up the OPA config we just set
+    verifier = framework.utils.auth.verifier.AuthVerifier()
+    opa_provider = framework.utils.auth.providers.opa.Provider()
+    opa_provider.__init__()  # rebuild from current mlconf, also resets cache
+    monkeypatch.setattr(verifier, "_auth_provider", opa_provider)
+
+    # FastAPI auth dependency resolves to the project owner
+    async def _authenticate_as_owner(_request):
+        return mlrun.common.schemas.AuthInfo(
+            username=owner_username, user_id=owner_user_id
+        )
+
+    monkeypatch.setattr(verifier, "authenticate_request", _authenticate_as_owner)
+
+    # Seed the project in the leader DB with the owner set
+    framework.utils.singletons.project_member.get_project_member().create_project(
+        db,
+        mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.common.schemas.ProjectSpec(owner=owner_username),
+        ),
+        auth_info=mlrun.common.schemas.AuthInfo(
+            username=owner_username, user_id=owner_user_id
+        ),
+    )
+
+    update_payload = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(
+            description="updated-by-owner",
+            owner=owner_username,
+        ),
+    )
+
+    # OPA always denies — simulating a sidecar that hasn't yet received
+    # the manifest for the freshly-created project.
+    with aioresponses.aioresponses() as aiohttp_mock:
+        aiohttp_mock.post(
+            f"{opa_api_url}{opa_query_path}",
+            payload={"result": False},
+            repeat=True,
+        )
+        response = client.put(f"projects/{project_name}", json=update_payload.dict())
+
+    assert response.status_code == HTTPStatus.OK.value, (
+        "Expected 200 — owner cache should short-circuit OPA deny for the "
+        f"project's own resource path. Got {response.status_code}: {response.text}"
+    )
+
+
+@pytest.mark.parametrize("project_member_mode", ["leader"], indirect=True)
+@pytest.mark.asyncio
+async def test_store_project_uses_ensure_project_for_owner_cache_population(
+    db: Session,
+    client: TestClient,
+    project_member_mode: str,
+    monkeypatch,
+):
+    """
+    Direct call-site assertion: ``_ensure_project_create_or_update_permissions``
+    must use ``ensure_project`` (which populates the OPA owner cache from the
+    DB) instead of ``get_project`` (which does not). This is the endpoint half
+    of the OPA race fix; the cache-check widening is exercised separately in
+    ``test_opa.py::test_allowed_project_owners_cache_matches_project_resource_itself``.
+    """
+    project_name = "test-store-project-call-site"
+    owner_username = "owner-call-site"
+    owner_user_id = "owner-uid-call-site"
+
+    project_member = framework.utils.singletons.project_member.get_project_member()
+
+    # Pre-create the project via the leader (so the endpoint will hit the
+    # "exists" branch). Done before flipping to iguazio_v4 mode so the leader
+    # call doesn't itself go through OPA.
+    project_member.create_project(
+        db,
+        mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.common.schemas.ProjectSpec(owner=owner_username),
+        ),
+        auth_info=mlrun.common.schemas.AuthInfo(
+            username=owner_username, user_id=owner_user_id
+        ),
+    )
+
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication,
+        "mode",
+        mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value,
+    )
+
+    ensure_project_calls: list[str] = []
+    real_ensure_project = project_member.ensure_project
+
+    def _track_ensure(db_session, name, **kwargs):
+        ensure_project_calls.append(name)
+        return real_ensure_project(db_session, name, **kwargs)
+
+    monkeypatch.setattr(project_member, "ensure_project", _track_ensure)
+
+    # Treat the requester as the project owner so that ensure_project's
+    # cache-population path is exercised (not just any call).
+    async def _authenticate_as_owner(_request):
+        return mlrun.common.schemas.AuthInfo(
+            username=owner_username, user_id=owner_user_id
+        )
+
+    monkeypatch.setattr(
+        framework.utils.auth.verifier.AuthVerifier(),
+        "authenticate_request",
+        _authenticate_as_owner,
+    )
+
+    update_payload = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(description="updated"),
+    )
+    response = client.put(f"projects/{project_name}", json=update_payload.dict())
+    assert response.status_code == HTTPStatus.OK.value, response.text
+
+    # The store_project permission check must go through ensure_project for
+    # this project so the OPA owner cache gets populated.
+    assert project_name in ensure_project_calls, (
+        f"expected ensure_project to be called with {project_name!r}, "
+        f"saw {ensure_project_calls}"
     )
 
 

--- a/server/py/services/api/tests/unit/utils/auth/providers/test_opa.py
+++ b/server/py/services/api/tests/unit/utils/auth/providers/test_opa.py
@@ -261,6 +261,52 @@ def test_allowed_project_owners_cache(
     )
 
 
+def test_allowed_project_owners_cache_matches_project_resource_itself(
+    api_url: str,
+    permission_query_path: str,
+    opa_provider: framework.utils.auth.providers.opa.Provider,
+):
+    """
+    The cache must short-circuit OPA both for actions on resources inside a
+    project (``/resources/projects/<name>/<child>/...``) and for actions on
+    the project record itself (``/resources/projects/<name>`` — the URL has
+    no segment after the project name). Without the latter the OPA-
+    propagation race is still visible on ``PUT /projects/<name>``.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user-id")
+    project_name = "project-name"
+    opa_provider.add_allowed_project_for_owner(project_name, auth_info)
+
+    # The project itself — must match (new behavior).
+    assert (
+        opa_provider._check_allowed_project_owners_cache(
+            f"/resources/projects/{project_name}", auth_info
+        )
+        is True
+    )
+    # A resource inside the project — must still match (pre-existing behavior).
+    assert (
+        opa_provider._check_allowed_project_owners_cache(
+            f"/resources/projects/{project_name}/functions", auth_info
+        )
+        is True
+    )
+    # A project whose name starts with the cached one must NOT match.
+    assert (
+        opa_provider._check_allowed_project_owners_cache(
+            f"/resources/projects/{project_name}-extended", auth_info
+        )
+        is False
+    )
+    # An unrelated project must NOT match.
+    assert (
+        opa_provider._check_allowed_project_owners_cache(
+            "/resources/projects/other-project", auth_info
+        )
+        is False
+    )
+
+
 def test_allowed_project_owners_cache_ttl_refresh(
     api_url: str,
     permission_query_path: str,

--- a/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
+++ b/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
@@ -785,6 +785,101 @@ async def test_ensure_project_populates_opa_owner_cache_across_replicas(
     await opa_provider._sessions.async_close()
 
 
+@pytest.mark.asyncio
+async def test_ensure_project_populates_opa_owner_cache_for_project_resource_itself(
+    db: sqlalchemy.orm.Session,
+    projects_leader: framework.utils.projects.leader.Member,
+    leader_follower: framework.utils.projects.remotes.follower.Member,
+):
+    """
+    Sibling of
+    :func:`test_ensure_project_populates_opa_owner_cache_across_replicas`,
+    but exercises the resource string for the **project itself**
+    (``/resources/projects/<name>`` — the URL ends with the project name,
+    no further path segment) rather than for a resource inside the project.
+
+    This is the path the ``store_project`` endpoint takes when it calls
+    ``query_project_permissions``. The cache check must match this shape too,
+    or the OPA-propagation race continues to surface as 403s on
+    ``PUT /projects/<name>``.
+    """
+    project_name = "test-cross-replica-project-resource"
+    owner_username = "project-creator"
+    owner_user_id = "user-id-project-resource"
+    project_resource = f"/resources/projects/{project_name}"
+
+    # --- API A creates the project in the shared DB ---
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(owner=owner_username),
+    )
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username=owner_username,
+        user_id=owner_user_id,
+    )
+    projects_leader.create_project(None, project, auth_info=auth_info)
+
+    stored = leader_follower.get_project(None, project_name)
+    assert stored.spec.owner == owner_username
+
+    # --- API B: fresh OPA provider, empty cache, OPA always denies ---
+    api_url = "http://127.0.0.1:8181"
+    permission_query_path = "/v1/data/service/authz/allow"
+    mlrun.mlconf.httpdb.authorization.opa.address = api_url
+    mlrun.mlconf.httpdb.authorization.opa.permission_query_path = permission_query_path
+    mlrun.mlconf.httpdb.authorization.opa.log_level = 10
+    mlrun.mlconf.httpdb.authorization.mode = "opa"
+
+    opa_provider = framework.utils.auth.providers.opa.Provider()
+    opa_provider.__init__()
+
+    # Before ensure_project: OPA denies the project resource itself.
+    with aioresponses.aioresponses() as aiohttp_mock:
+        aiohttp_mock.post(
+            f"{api_url}{permission_query_path}",
+            payload={"result": False},
+        )
+        with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+            await opa_provider.query_permissions(
+                project_resource,
+                mlrun.common.schemas.AuthorizationAction.update,
+                auth_info,
+            )
+
+    # ensure_project on API B populates the cache from the shared DB.
+    projects_leader.ensure_project(None, project_name, auth_info=auth_info)
+
+    # After ensure_project: cache short-circuits OPA for the project resource.
+    with aioresponses.aioresponses() as aiohttp_mock:
+        allowed = await opa_provider.query_permissions(
+            project_resource,
+            mlrun.common.schemas.AuthorizationAction.update,
+            auth_info,
+        )
+        assert allowed is True
+        aiohttp_mock.assert_not_called()
+
+    # Non-owner still gets denied — cache is per (user, project).
+    non_owner_auth = mlrun.common.schemas.AuthInfo(
+        username="other-user",
+        user_id="other-user-id",
+    )
+    projects_leader.ensure_project(None, project_name, auth_info=non_owner_auth)
+    with aioresponses.aioresponses() as aiohttp_mock:
+        aiohttp_mock.post(
+            f"{api_url}{permission_query_path}",
+            payload={"result": False},
+        )
+        with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+            await opa_provider.query_permissions(
+                project_resource,
+                mlrun.common.schemas.AuthorizationAction.update,
+                non_owner_auth,
+            )
+
+    await opa_provider._sessions.async_close()
+
+
 def _assert_project_not_in_followers(followers, name):
     for follower in followers:
         assert name not in follower._projects

--- a/tests/system/api/test_projects.py
+++ b/tests/system/api/test_projects.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+import pytest
+
+import mlrun
+import mlrun.common.schemas
+import mlrun.errors
+from tests.system.base import TestMLRunSystem
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+class TestStoreProjectOPARace(TestMLRunSystem):
+    # The test only exercises the mlrun control plane (create / save project);
+    # no V3IO data plane is touched, so we deliberately omit
+    # ``@pytest.mark.enterprise`` to keep mandatory env vars minimal
+    # (``MLRUN_DBPATH`` only).
+    """
+    End-to-end coverage of the OPA-manifest-propagation race on
+    PUT ``/projects/{name}``: a freshly-created project's manifest may not
+    yet have reached every API replica's OPA sidecar, and an immediate
+    follow-up ``store_project`` would otherwise return 403.
+
+    Each iteration creates a uniquely-named project and immediately stores
+    it again, which is the exact pattern the SDK uses in
+    ``get_or_create_project`` followed by ``project.save()``. Multiple
+    iterations give the race more chances to manifest on a multi-replica
+    deployment.
+
+    Pre-fix expectation (with the airun-side retry temporarily removed in
+    parallel): at least one iteration trips
+    ``MLRunAccessDeniedError`` for ``/resources/projects/<name>``.
+    Post-fix expectation: all iterations complete cleanly.
+    """
+
+    project_name = "system-test-store-project-opa-race"
+    _skip_set_environment = lambda self: True  # noqa: E731
+
+    def custom_setup(self):
+        # NB: the fix targets ``iguazio_v4`` mode, where the projects endpoint
+        # consults OPA on every store_project. In IG3/CE the same code path
+        # early-returns for leader-originated requests, so this test still
+        # passes there — vacuously, but it remains a valid regression guard
+        # for "create-then-store must not 403" on any backend.
+        self.created_project_names: list[str] = []
+
+    def custom_teardown(self):
+        for name in self.created_project_names:
+            try:
+                self._run_db.delete_project(
+                    name,
+                    deletion_strategy=mlrun.common.schemas.DeletionStrategy.cascading,
+                )
+            except mlrun.errors.MLRunNotFoundError:
+                pass
+
+    @pytest.mark.parametrize("iteration", range(5))
+    def test_create_then_immediate_store_does_not_403(self, iteration: int):
+        name = f"sys-opa-race-{uuid.uuid4().hex[:8]}"
+        self.created_project_names.append(name)
+
+        project = mlrun.get_or_create_project(
+            name, context="./", user_project=False, allow_cross_project=True
+        )
+
+        # The race window: create returned, OPA bundle may not have propagated
+        # to all API pods yet, immediate store_project follow-up must succeed.
+        try:
+            project.save()
+        except mlrun.errors.MLRunAccessDeniedError as exc:
+            pytest.fail(
+                f"store_project hit OPA-cache race window on iteration {iteration}: {exc}. "
+                "This is the regression fixed by the projects.py + opa.py changes."
+            )


### PR DESCRIPTION
### 📝 Description

When MLRun runs as project-leader on multi-replica deployments, a `PUT /api/v1/projects/{name}` (`store_project`) issued immediately after `POST /api/v1/projects` (`create_project`) can fail with a transient 403:

```
MLRunAccessDeniedError: Not allowed to update resource /resources/projects/<name>
```

Same OPA-manifest-propagation race already addressed for `project_secrets` in #9432 and `datastore_profile` in #9657 — but it still surfaces on `store_project` because:

1. **`_ensure_project_create_or_update_permissions` (endpoints/projects.py)** calls bare `get_project` rather than `ensure_project`. The owner cache populated by `ensure_project` (introduced in #9432) is therefore never warmed for this code path, so a pod whose OPA sidecar hasn't received the manifest has no fallback.

2. **`_check_allowed_project_owners_cache` (providers/opa.py)** matches `f"/projects/<name>/" in resource` — anchored with a trailing slash. The resource string built by `query_project_permissions` for the project itself is `/resources/projects/<name>` (no trailing slash), so even when the cache *is* populated the lookup returns `False`. The fix in #9432 / #9657 therefore only covers resources inside a project, not the project record itself.

---

### 🛠️ Changes Made
- `server/py/services/api/api/endpoints/projects.py`: `_ensure_project_create_or_update_permissions` now calls `ensure_project` instead of bare `get_project`, matching the pattern in `project_secrets.py` and `datastore_profile.py`.
- `server/py/framework/utils/auth/providers/opa.py`: `_check_allowed_project_owners_cache` now matches both resources inside a project (`.../projects/<name>/<child>/...`) and the project record itself (`.../projects/<name>`). Boundary safety preserved — a cached project named `alpha` does not match `/resources/projects/alpha-extended`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

**Unit**
- `tests/unit/utils/auth/providers/test_opa.py::test_allowed_project_owners_cache_matches_project_resource_itself` — cache lookup matches the project's own resource path; boundary safety (prefix collision) preserved.
- `tests/unit/utils/projects/test_leader_member.py::test_ensure_project_populates_opa_owner_cache_for_project_resource_itself` — multi-replica simulation: API B's empty cache gets populated from the shared DB on `ensure_project`, subsequent permission query on the project resource short-circuits OPA.
- `tests/unit/api/test_projects.py::test_store_project_uses_ensure_project_for_owner_cache_population` — endpoint call-site assertion: `_ensure_project_create_or_update_permissions` invokes `ensure_project`.
- `tests/unit/api/test_projects.py::test_store_project_recovers_from_opa_propagation_lag` — endpoint-level end-to-end: with OPA mocked to deny, `PUT /projects/{name}` as the owner returns 200 because the cache short-circuits OPA.

**System**
- `tests/system/api/test_projects.py::TestStoreProjectOPARace::test_create_then_immediate_store_does_not_403` — 5 iterations of `get_or_create_project + save` against the live backend.

**End-to-end validation on a lab**

Validated on `vmdev78ig4`:
- Against unfixed `1.12.0-rc4`: 3/5 iterations of the reproducer 403'd.
- After upgrading mlrun-api to a build of this branch: 5/5 succeeded.

---

### 🔗 References
- Ticket link: ML-12623
- Design docs links:
- External links:
  - Prior fix (project_secrets): #9432 / ML-11996
  - Prior fix (datastore_profile): #9657 / ML-12527

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
The companion AIRun retry-on-`MLRunAccessDeniedError` workaround in `airun/service/engines/mlrun/project_utils.py` is no longer load-bearing once this lands and can be removed in a follow-up.

### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
