### PR TITLE
[Projects] Fix project owner OPA check on create/update

### DIFF
--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -29,6 +29,7 @@ import framework.api.utils
 import framework.utils.auth.verifier
 import framework.utils.clients.chief
 import framework.utils.helpers
+import framework.utils.project_formats
 import services.api.crud
 from framework.utils.singletons.project_member import get_project_member
 
@@ -629,21 +630,46 @@ async def _ensure_project_create_or_update_permissions(
         return
 
     try:
-        await run_in_threadpool(
+        # Fetch name + owner so we can short-circuit the OPA query when the
+        # requesting user owns the project (mirrors `ensure_project` behavior).
+        project = await run_in_threadpool(
             get_project_member().get_project,
             db_session,
             project_name,
             auth_info,
-            format_=mlrun.common.formatters.ProjectFormat.name_only,
+            format_=framework.utils.project_formats.ProjectFormatCustomSelection(
+                [
+                    framework.utils.project_formats.ProjectFormatCustom.name,
+                    framework.utils.project_formats.ProjectFormatCustom.owner,
+                ]
+            ),
         )
         project_exists = True
     except mlrun.errors.MLRunNotFoundError:
+        project = None
         project_exists = False
 
     if project_exists:
-        await framework.utils.auth.verifier.AuthVerifier().query_project_permissions(
-            project_name, mlrun.common.schemas.AuthorizationAction.update, auth_info
-        )
+        # If the requesting user is the project owner, populate the OPA owner
+        # cache and skip the permissions query. This mitigates the OPA manifest
+        # propagation race on multi-pod deployments.
+        if (
+            auth_info.username
+            and getattr(project, "spec", None)
+            and project.spec.owner
+            and auth_info.username == project.spec.owner
+        ):
+            framework.utils.auth.verifier.AuthVerifier().add_allowed_project_for_owner(
+                project_name, auth_info
+            )
+        else:
+            await (
+                framework.utils.auth.verifier.AuthVerifier().query_project_permissions(
+                    project_name,
+                    mlrun.common.schemas.AuthorizationAction.update,
+                    auth_info,
+                )
+            )
         return
 
     # In Iguazio v4 mode, mlrun is the project leader and main entrypoint so we must ensure

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -235,6 +235,36 @@ async def test_project_permissions_update_when_exists(
 
 
 @pytest.mark.asyncio
+async def test_project_permissions_owner_short_circuits_opa_check(
+    db: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the requester is the project owner, skip OPA and populate the owner cache."""
+    project_name = PERMISSIONS_PROJECT_NAME
+    owner_username = "project-owner"
+    auth_info = mlrun.common.schemas.AuthInfo(username=owner_username)
+    auth_verifier = framework.utils.auth.verifier.AuthVerifier()
+    query_project = AsyncMock()
+    add_allowed = Mock()
+    monkeypatch.setattr(auth_verifier, "query_project_permissions", query_project)
+    monkeypatch.setattr(auth_verifier, "add_allowed_project_for_owner", add_allowed)
+    existing_project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(owner=owner_username),
+    )
+    project_member = framework.utils.singletons.project_member.get_project_member()
+    monkeypatch.setattr(
+        project_member, "get_project", Mock(return_value=existing_project)
+    )
+
+    await projects_endpoints._ensure_project_create_or_update_permissions(
+        db, project_name, auth_info
+    )
+
+    add_allowed.assert_called_once_with(project_name, auth_info)
+    query_project.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "patch_body, expect_mgmt_check, expect_regular_check",
     [


### PR DESCRIPTION
### 📝 Description

`_ensure_project_create_or_update_permissions` always called OPA via `query_project_permissions` for existing projects. On multi-pod deployments this is racy: a request can land on a pod that hasn't yet received the OPA manifest, and a legitimate owner gets denied on `store_project`/`patch_project`.

`Member.ensure_project` already handles this race by populating a local OPA owner cache when the requester matches `spec.owner`. This PR mirrors that behavior in the create/update permissions path so the same store/patch flows benefit from the owner short-circuit.

---

### 🛠️ Changes Made
- `server/py/services/api/api/endpoints/projects.py`:
  - `_ensure_project_create_or_update_permissions` now fetches the project with `ProjectFormatCustomSelection([name, owner])` instead of `name_only`.
  - When `auth_info.username == project.spec.owner`, call `AuthVerifier.add_allowed_project_for_owner(...)` and skip the OPA `query_project_permissions` round-trip.
  - All other paths (non-owner update, missing project create) are unchanged.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- New unit test `test_project_permissions_owner_short_circuits_opa_check` in `server/py/services/api/tests/unit/api/test_projects.py`:
  - Stubs `get_project` to return a project whose `spec.owner` matches `auth_info.username`.
  - Asserts `AuthVerifier.add_allowed_project_for_owner` is called once with `(project_name, auth_info)`.
  - Asserts `AuthVerifier.query_project_permissions` is **not** awaited.
- Existing sibling tests (`test_project_permissions_create_when_missing`, `test_project_permissions_update_when_exists`) continue to cover the missing-project and non-owner update paths.

---

### 🔗 References
- Ticket link: ML-12623
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Mirrors the existing owner short-circuit in `framework/utils/projects/member.py::Member.ensure_project`.
- Only affects the store/patch project entry-point — the create path (missing project) still goes through the global `project_global:create` check in Iguazio v4 mode.
