### PR TITLE
[API] Forward custom S3 endpoint to Nuclio for source-archive fetch

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -315,6 +315,7 @@ def compile_nuclio_archive_config(
         code_entry_attributes["s3AccessKeyId"] = get_secret("AWS_ACCESS_KEY_ID")
         code_entry_attributes["s3SecretAccessKey"] = get_secret("AWS_SECRET_ACCESS_KEY")
         code_entry_attributes["s3SessionToken"] = get_secret("AWS_SESSION_TOKEN")
+        code_entry_attributes["s3Endpoint"] = get_secret("AWS_ENDPOINT_URL_S3")
 
     # git
     if code_entry_type == "git":

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1479,10 +1479,35 @@ class TestNuclioRuntime(TestRuntimeBase):
                         "s3AccessKeyId": "some-id",
                         "s3SecretAccessKey": "some-secret",
                         "s3SessionToken": "",
+                        "s3Endpoint": "",
                     },
                 },
             },
         }
+
+    def test_load_function_with_source_archive_s3_with_custom_endpoint(self):
+        """
+        AWS_ENDPOINT_URL_S3 in project secrets must flow through
+        codeEntryAttributes.s3Endpoint so nuclio's source fetcher can talk to
+        S3-compatible backends (e.g. minio) instead of falling through to its
+        own pod env via the AWS SDK default loader.
+        """
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive(
+            "s3://my-bucket/path/in/bucket/my-functions-archive.tar.gz",
+            handler="main:Handler",
+            workdir="path/inside/functions/archive",
+        )
+        secrets = {
+            "AWS_ACCESS_KEY_ID": "some-id",
+            "AWS_SECRET_ACCESS_KEY": "some-secret",
+            "AWS_ENDPOINT_URL_S3": "https://minio.example.com",
+        }
+        archive = get_archive_spec(fn, secrets)
+        assert (
+            archive["spec"]["build"]["codeEntryAttributes"]["s3Endpoint"]
+            == "https://minio.example.com"
+        )
 
     def test_load_function_with_source_archive_v3io(self):
         fn = self._generate_runtime(self.runtime_kind)


### PR DESCRIPTION
### 📝 Description

When a function's source archive lives on an S3-compatible backend (e.g. MinIO) rather than real AWS S3, Nuclio cannot fetch it because `codeEntryAttributes` carries only the bucket, key, region, and credentials — no endpoint URL. Forward `AWS_ENDPOINT_URL_S3` from the project secret as a new `codeEntryAttributes["s3Endpoint"]`, matching the existing pattern used for `s3AccessKeyId` / `s3SecretAccessKey` / `s3SessionToken`.

The corresponding Nuclio change is in https://github.com/nuclio/nuclio/pull/4124, and is not a dependency of this PR.

---

### 🛠️ Changes Made
- `server/py/services/api/crud/runtimes/nuclio/helpers.py`: populate `code_entry_attributes["s3Endpoint"]` from `get_secret("AWS_ENDPOINT_URL_S3")`.
- `server/py/services/api/tests/unit/runtimes/test_nuclio.py`: existing s3 archive test asserts `s3Endpoint: ""` when no override is set; a new test asserts the override is forwarded when present in project secrets.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
`test_load_function_with_source_archive_s3` and `test_load_function_with_source_archive_s3_with_custom_endpoint` pass.
- For ML-12586: end-to-end on an IG4 lab with MinIO as the artifact store: nuclio function deploy with an `s3://` source archive succeeds when the project secret holds `AWS_ENDPOINT_URL_S3` (together with https://github.com/nuclio/nuclio/pull/4124).

---

### 🔗 References
- Ticket link: ML-12586

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Forward-compatible with older Nuclio releases: `codeEntryAttributes` is a free-form `map[string]interface{}` and Nuclio's parser iterates only known keys, so an older Nuclio silently ignores `s3Endpoint`. New behavior activates only if Nuclio has https://github.com/nuclio/nuclio/pull/4124 applied.
