### PR TITLE
[Artifacts] Fix CodeArtifact requirements arg validation

### DIFF
--- a/mlrun/artifacts/code.py
+++ b/mlrun/artifacts/code.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import mlrun.common.types
+import mlrun.errors
 
 from .base import Artifact, ArtifactSpec
 
@@ -124,6 +125,7 @@ class CodeArtifact(Artifact):
         self.spec.code_type = CodeArtifactCodeType(
             code_type or CodeArtifactCodeType.function
         )
+        _validate_requirements(requirements)
         self.spec.requirements = requirements
 
     @property
@@ -150,3 +152,14 @@ def _derive_language_from_path(path: str | None) -> str | None:
     if path.lower().endswith(_PYTHON_SUFFIXES):
         return "python"
     return ""
+
+
+def _validate_requirements(requirements: list[str] | None) -> None:
+    if requirements is None:
+        return
+    if not isinstance(requirements, list) or any(
+        not isinstance(item, str) for item in requirements
+    ):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"requirements must be a list of strings, got: {requirements!r}"
+        )

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -814,6 +814,30 @@ def test_code_artifact_create_with_requirements():
 
 
 @pytest.mark.parametrize(
+    "requirements",
+    [
+        "pandas>=1.0",  # ML-12563 reproducer: string passed instead of list
+        ("pandas",),  # tuple is not a list
+        123,  # not iterable
+        ["pandas", 123],  # list with non-str item
+        ["pandas", None],
+    ],
+)
+def test_code_artifact_invalid_requirements_raises(requirements):
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.artifacts.CodeArtifact(key="bad", requirements=requirements)
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [None, [], ["pandas"], ["pandas>=2.0", "numpy"]],
+)
+def test_code_artifact_valid_requirements_accepted(requirements):
+    artifact = mlrun.artifacts.CodeArtifact(key="ok", requirements=requirements)
+    assert artifact.spec.requirements == requirements
+
+
+@pytest.mark.parametrize(
     "target_path,src_path,language,expected",
     [
         # suffix → "python"


### PR DESCRIPTION
### 📝 Description

`CodeArtifact` (and therefore `Project.log_code_file`) silently accepted
malformed `requirements` values — e.g. `requirements="pandas>=1.0"` or
`requirements=("pandas",)` — and stored them on the spec. The malformed
value would only surface later as a confusing error in code paths that
consumed `spec.requirements`. This PR rejects the bad value at
construction time with a clear error.

---

### 🛠️ Changes Made

- `mlrun/artifacts/code.py`: added `_validate_requirements`; called from
  `CodeArtifact.__init__` before storing on spec; raises
  `MLRunInvalidArgumentError`.
- `tests/artifacts/test_artifacts.py`: parameterized invalid-rejection
  tests (str / tuple / int / list-with-non-str) and valid-acceptance
  tests (None / [] / single / multi).

---

### ✅ Checklist

- [x] I updated the documentation (if applicable) — no public docs
  reference `CodeArtifact.requirements`; SDK docstrings already accurate.
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests — unit
  only; no system test needed for arg validation.
- [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
- [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing

- `pytest tests/artifacts/test_artifacts.py -v -k requirements` — 10 passed
  (5 invalid-rejection + 4 valid-acceptance + 1 pre-existing roundtrip).
- `make lint` — clean (ruff + format).

---

### 🔗 References

- Ticket link: https://iguazio.atlassian.net/browse/ML-12563

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No