### PR TITLE
[Deps] Avoid bugged k8s version

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -13,7 +13,8 @@ urls = { homepage = "https://github.com/mlrun/mlrun" }
 dependencies = [
    # TODO remove the kfp_server_api version requirement once KFP 1.8 support is removed
   "kfp_server_api~=1.8",
-  "kubernetes>=25.3"
+  # pin while awaiting fix for https://github.com/kubernetes-client/python/issues/2591
+  "kubernetes>=25.3, <36.0.0"
 ]
 
 [project.optional-dependencies]

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -13,8 +13,8 @@ urls = { homepage = "https://github.com/mlrun/mlrun" }
 dependencies = [
    # TODO remove the kfp_server_api version requirement once KFP 1.8 support is removed
   "kfp_server_api~=1.8",
-  # pin while awaiting fix for https://github.com/kubernetes-client/python/issues/2591
-  "kubernetes>=25.3, <36.0.0"
+  # skip 36.0.0 because of https://github.com/kubernetes-client/python/issues/2591
+  "kubernetes>=25.3, !=36.0.0"
 ]
 
 [project.optional-dependencies]

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-common"
-version = "0.7.0"
+version = "0.7.1"
 description = "MLRun Pipelines adapter package for providing KFP common functionality"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Pin kubernetes dependency in mlrun-pipelines-kfp-common to !=36.0.0 to avoid the regression documented in https://github.com/kubernetes-client/python/issues/2591.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
