### PR TITLE
[Workflows] Remove unused has_workflow_url property

### DIFF
--- a/mlrun/utils/notifications/notification_pusher.py
+++ b/mlrun/utils/notifications/notification_pusher.py
@@ -627,11 +627,8 @@ class CustomNotificationPusher(_NotificationPusherBase):
         project: str,
         commit_id: str | None = None,
         pipeline_id: str | None = None,
-        has_workflow_url: bool = False,
     ):
-        html, message = self.generate_start_message(
-            commit_id, has_workflow_url, pipeline_id, project
-        )
+        html, message = self.generate_start_message(commit_id, pipeline_id, project)
         self.push(message, "info", custom_html=html)
 
     def push_pipeline_run_results(
@@ -664,9 +661,7 @@ class CustomNotificationPusher(_NotificationPusherBase):
             text += f", state={state}"
         self.push(text, "info", runs=runs_list)
 
-    def generate_start_message(
-        self, commit_id=None, has_workflow_url=None, pipeline_id=None, project=None
-    ):
+    def generate_start_message(self, commit_id=None, pipeline_id=None, project=None):
         message = f"Workflow started in project {project}"
         if pipeline_id:
             message += f" id={pipeline_id}"
@@ -675,7 +670,7 @@ class CustomNotificationPusher(_NotificationPusherBase):
         )
         if commit_id:
             message += f", commit={commit_id}"
-        if has_workflow_url:
+        if pipeline_id is not None:
             url = mlrun.utils.helpers.get_workflow_url(project, pipeline_id)
         else:
             url = mlrun.utils.helpers.get_runs_url(project)

--- a/tests/utils/test_notifications.py
+++ b/tests/utils/test_notifications.py
@@ -912,6 +912,157 @@ def test_inverse_dependencies(
     assert mock_ipython_push.call_count == expected_ipython_call_amount
 
 
+def test_generate_start_message_workflow_url_when_pipeline_id(monkeypatch):
+    # Env vars feed into the commit_id fallback, so clear them for exact output.
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("CI_COMMIT_SHA", raising=False)
+
+    pusher = mlrun.utils.notifications.CustomNotificationPusher(
+        [mlrun.utils.notifications.NotificationTypes.console]
+    )
+    mock_workflow_url = unittest.mock.MagicMock(
+        return_value="http://example.com/workflow/pipeline-123"
+    )
+    mock_runs_url = unittest.mock.MagicMock(return_value="http://example.com/runs")
+    monkeypatch.setattr(mlrun.utils.helpers, "get_workflow_url", mock_workflow_url)
+    monkeypatch.setattr(mlrun.utils.helpers, "get_runs_url", mock_runs_url)
+
+    html, message = pusher.generate_start_message(
+        pipeline_id="pipeline-123", project="my-project"
+    )
+
+    mock_workflow_url.assert_called_once_with("my-project", "pipeline-123")
+    mock_runs_url.assert_not_called()
+    assert message == (
+        "Workflow started in project my-project id=pipeline-123, "
+        "check progress in http://example.com/workflow/pipeline-123"
+    )
+    assert html == (
+        "Workflow started in project my-project id=pipeline-123"
+        '<div><a href="http://example.com/workflow/pipeline-123" target="_blank">'
+        "click here to view progress</a></div>"
+    )
+
+
+def test_generate_start_message_runs_url_when_no_pipeline_id(monkeypatch):
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("CI_COMMIT_SHA", raising=False)
+
+    pusher = mlrun.utils.notifications.CustomNotificationPusher(
+        [mlrun.utils.notifications.NotificationTypes.console]
+    )
+    mock_workflow_url = unittest.mock.MagicMock(
+        return_value="http://example.com/workflow"
+    )
+    mock_runs_url = unittest.mock.MagicMock(return_value="http://example.com/runs")
+    monkeypatch.setattr(mlrun.utils.helpers, "get_workflow_url", mock_workflow_url)
+    monkeypatch.setattr(mlrun.utils.helpers, "get_runs_url", mock_runs_url)
+
+    html, message = pusher.generate_start_message(project="my-project")
+
+    mock_runs_url.assert_called_once_with("my-project")
+    mock_workflow_url.assert_not_called()
+    assert message == (
+        "Workflow started in project my-project, "
+        "check progress in http://example.com/runs"
+    )
+    assert html == (
+        "Workflow started in project my-project"
+        '<div><a href="http://example.com/runs" target="_blank">'
+        "click here to view progress</a></div>"
+    )
+
+
+def test_generate_start_message_no_url_when_helpers_return_empty(monkeypatch):
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("CI_COMMIT_SHA", raising=False)
+
+    pusher = mlrun.utils.notifications.CustomNotificationPusher(
+        [mlrun.utils.notifications.NotificationTypes.console]
+    )
+    monkeypatch.setattr(
+        mlrun.utils.helpers,
+        "get_workflow_url",
+        unittest.mock.MagicMock(return_value=""),
+    )
+    monkeypatch.setattr(
+        mlrun.utils.helpers,
+        "get_runs_url",
+        unittest.mock.MagicMock(return_value=""),
+    )
+
+    html, message = pusher.generate_start_message(
+        pipeline_id="pipeline-123", project="my-project"
+    )
+
+    assert html == ""
+    assert message == "Workflow started in project my-project id=pipeline-123"
+
+
+def test_push_pipeline_start_message_from_client_uses_workflow_url(monkeypatch):
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("CI_COMMIT_SHA", raising=False)
+
+    pusher = mlrun.utils.notifications.CustomNotificationPusher(
+        [mlrun.utils.notifications.NotificationTypes.console]
+    )
+    monkeypatch.setattr(
+        mlrun.utils.helpers,
+        "get_workflow_url",
+        unittest.mock.MagicMock(return_value="http://example.com/workflow/abc"),
+    )
+    mock_push = unittest.mock.MagicMock()
+    monkeypatch.setattr(pusher, "push", mock_push)
+
+    pusher.push_pipeline_start_message_from_client(
+        project="my-project", pipeline_id="abc"
+    )
+
+    expected_message = (
+        "Workflow started in project my-project id=abc, "
+        "check progress in http://example.com/workflow/abc"
+    )
+    expected_html = (
+        "Workflow started in project my-project id=abc"
+        '<div><a href="http://example.com/workflow/abc" target="_blank">'
+        "click here to view progress</a></div>"
+    )
+    mock_push.assert_called_once_with(
+        expected_message, "info", custom_html=expected_html
+    )
+
+
+def test_push_pipeline_start_message_from_client_falls_back_to_runs_url(monkeypatch):
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
+    monkeypatch.delenv("CI_COMMIT_SHA", raising=False)
+
+    pusher = mlrun.utils.notifications.CustomNotificationPusher(
+        [mlrun.utils.notifications.NotificationTypes.console]
+    )
+    monkeypatch.setattr(
+        mlrun.utils.helpers,
+        "get_runs_url",
+        unittest.mock.MagicMock(return_value="http://example.com/runs"),
+    )
+    mock_push = unittest.mock.MagicMock()
+    monkeypatch.setattr(pusher, "push", mock_push)
+
+    pusher.push_pipeline_start_message_from_client(project="my-project")
+
+    expected_message = (
+        "Workflow started in project my-project, "
+        "check progress in http://example.com/runs"
+    )
+    expected_html = (
+        "Workflow started in project my-project"
+        '<div><a href="http://example.com/runs" target="_blank">'
+        "click here to view progress</a></div>"
+    )
+    mock_push.assert_called_once_with(
+        expected_message, "info", custom_html=expected_html
+    )
+
+
 NOTIFICATION_VALIDATION_PARMETRIZE = [
     (
         {


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

Remove unused has_workflow_url property from url generation and use the presence of pipeline id instead.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-11824
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
