### PR TITLE
[Model Monitoring] Fix ApplicationRuntime deploy forward track_models 

### DIFF
--- a/mlrun/runtimes/nuclio/application/application.py
+++ b/mlrun/runtimes/nuclio/application/application.py
@@ -513,6 +513,7 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
         mlrun_version_specifier=None,
         show_on_failure: bool = False,
         create_default_api_gateway: bool = True,
+        track_models: bool | None = None,
     ):
         """
         Deploy function, builds the application image if required (self.requires_build()) or force_build is True,
@@ -536,6 +537,9 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
         :param create_default_api_gateway:  When deploy finishes the default API gateway will be created for the
                                             application. Disabling this flag means that the application will not be
                                             accessible until an API gateway is created for it.
+        :param track_models:                override state of self.spec.track_models. If not provided, uses the spec
+                                            value (False by default, True after setup_model_monitoring() is called).
+                                            When True, model endpoints are created at deployment time.
 
         :return: The default API gateway URL if created or True if the function is ready (deployed)
         """
@@ -575,6 +579,7 @@ class ApplicationRuntime(nuclio_function.RemoteRuntime):
                 tag=tag,
                 verbose=verbose,
                 builder_env=builder_env,
+                track_models=track_models,
             )
             logger.info(
                 "Successfully deployed function.",

--- a/tests/runtimes/test_application.py
+++ b/tests/runtimes/test_application.py
@@ -25,6 +25,7 @@ import mlrun.errors
 import mlrun.runtimes
 import mlrun.utils
 from mlrun.common.runtimes.constants import ProbeTimeConfig, ProbeType
+from mlrun.common.schemas.model_monitoring import ModelEndpointInstruction
 
 assets_path = pathlib.Path(__file__).absolute().parent / "assets"
 
@@ -165,6 +166,102 @@ def test_consecutive_deploy_application_runtime(rundb_mock, igz_version_mock):
 
     # Ensure the image is updated
     _assert_application_post_deploy_spec(fn, image)
+
+
+@pytest.mark.parametrize(
+    "track_models_arg, expected_forwarded",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_deploy_forwards_track_models(
+    rundb_mock, igz_version_mock, track_models_arg, expected_forwarded
+):
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="my/web-app:latest"
+    )
+    with unittest.mock.patch.object(
+        mlrun.runtimes.nuclio.function.RemoteRuntime, "deploy"
+    ) as mock_super_deploy:
+        fn.deploy(track_models=track_models_arg)
+    mock_super_deploy.assert_called_once()
+    assert mock_super_deploy.call_args.kwargs.get("track_models") is expected_forwarded
+
+
+def test_deploy_default_track_models_is_none(rundb_mock, igz_version_mock):
+    # When track_models is not provided, ApplicationRuntime.deploy must forward None
+    # so RemoteRuntime.deploy preserves whatever value is on self.spec.track_models
+    # (e.g. set by setup_model_monitoring()).
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="my/web-app:latest"
+    )
+    with unittest.mock.patch.object(
+        mlrun.runtimes.nuclio.function.RemoteRuntime, "deploy"
+    ) as mock_super_deploy:
+        fn.deploy()
+    mock_super_deploy.assert_called_once()
+    assert mock_super_deploy.call_args.kwargs.get("track_models") is None
+
+
+def test_deploy_track_models_true_invokes_setup_model_monitoring(
+    rundb_mock, igz_version_mock
+):
+    # End-to-end: ApplicationRuntime.deploy(track_models=True) on a fresh function (no prior
+    # setup_model_monitoring) must reach RemoteRuntime.deploy and trigger setup_model_monitoring()
+    # so that model_endpoints_instructions gets populated before the deploy API call.
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="my/web-app:latest"
+    )
+    with unittest.mock.patch.object(
+        mlrun.runtimes.nuclio.function.RemoteRuntime,
+        "setup_model_monitoring",
+        autospec=True,
+    ) as mock_setup:
+        fn.deploy(track_models=True)
+    mock_setup.assert_called_once()
+
+
+def test_deploy_does_not_resetup_when_instructions_already_exist(
+    rundb_mock, igz_version_mock
+):
+    # If the user already called setup_model_monitoring() (or otherwise populated
+    # model_endpoints_instructions), a subsequent deploy(track_models=True) must NOT
+    # re-invoke setup_model_monitoring — that would override the user's instructions.
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="my/web-app:latest"
+    )
+    fn.spec.model_endpoints_instructions = [
+        ModelEndpointInstruction(
+            name="application-test_model_endpoint",
+            function_name="application-test",
+        ),
+    ]
+    fn.spec.track_models = True
+    with unittest.mock.patch.object(
+        mlrun.runtimes.nuclio.function.RemoteRuntime,
+        "setup_model_monitoring",
+        autospec=True,
+    ) as mock_setup:
+        fn.deploy(track_models=True)
+    mock_setup.assert_not_called()
+
+
+def test_deploy_default_does_not_invoke_setup_model_monitoring(
+    rundb_mock, igz_version_mock
+):
+    # A plain deploy() (no track_models arg) on a fresh function must NOT trigger
+    # setup_model_monitoring — the feature must be opt-in.
+    fn: mlrun.runtimes.ApplicationRuntime = mlrun.new_function(
+        "application-test", kind="application", image="my/web-app:latest"
+    )
+    with unittest.mock.patch.object(
+        mlrun.runtimes.nuclio.function.RemoteRuntime,
+        "setup_model_monitoring",
+        autospec=True,
+    ) as mock_setup:
+        fn.deploy()
+    mock_setup.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/serving/test_serving.py
+++ b/tests/serving/test_serving.py
@@ -990,3 +990,24 @@ def test_setup_model_monitoring_not_supported_for_serving():
     serving_fn = mlrun.new_function("test-serving", kind="serving")
     with pytest.raises(NotImplementedError, match="set_tracking"):
         serving_fn.setup_model_monitoring([])
+
+
+def test_deploy_after_set_tracking_does_not_invoke_setup_model_monitoring(rundb_mock):
+    # set_tracking() is the supported path for serving monitoring; setup_model_monitoring()
+    # raises NotImplementedError on serving. Deploying after set_tracking() must NOT route
+    # through setup_model_monitoring (which would break the deploy).
+    serving_fn = mlrun.new_function("test-serving", kind="serving")
+    serving_fn.set_topology("router")
+    serving_fn.add_model(
+        "my",
+        ".",
+        class_name=ModelTestingClass(multiplier=100),
+    )
+    serving_fn.set_tracking(stream_path="dummy://")
+    assert serving_fn.spec.track_models is True
+
+    with patch.object(
+        serving_fn, "setup_model_monitoring", autospec=True
+    ) as mock_setup:
+        serving_fn.deploy()
+    mock_setup.assert_not_called()


### PR DESCRIPTION
### 📝 Description
  ApplicationRuntime.deploy didn't accept or forward track_models to its
  RemoteRuntime parent, so spec.track_models set by setup_model_monitoring()
  was never honored at deploy time and model endpoints weren't created.

  Use bool | None = None to match the parent's sentinel so the spec value
  is preserved when the caller doesn't pass the flag.

  Add unit tests covering forwarding (True/False/default) and the
  setup_model_monitoring invocation path for both ApplicationRuntime and
  ServingRuntime (set_tracking remains the supported serving path).


---

### 🛠️ Changes Made


---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
Added unit tests, smoke tests

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
