### PR TITLE
[Serving] Fix output mandatory field errors not returned as HTTP 400

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -1153,6 +1153,12 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
         Registers pre-built input and output body mappings for each selected OpenAI
         operation group. If ``endpoints`` is ``None``, all supported groups are registered.
 
+        **Validation scope — top-level only.** Mandatory field validation applies only to
+        the top-level keys of the request/response body. Nested fields (e.g.
+        ``choices[].message.content``) are passed through as-is. Full structural validation
+        is delegated to the OpenAI Python SDK, which deserializes responses into typed
+        objects and raises a ``ValidationError`` on any structural mismatch.
+
         :param endpoints: Optional list of :class:`~mlrun.serving.openai_mappings.OpenAIEndpoint`
             values selecting which operation groups to enable. Defaults to all groups.
 

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -1154,10 +1154,9 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
         operation group. If ``endpoints`` is ``None``, all supported groups are registered.
 
         **Validation scope — top-level only.** Mandatory field validation applies only to
-        the top-level keys of the request/response body. Nested fields (e.g.
-        ``choices[].message.content``) are passed through as-is. Full structural validation
-        is delegated to the OpenAI Python SDK, which deserializes responses into typed
-        objects and raises a ``ValidationError`` on any structural mismatch.
+        the top-level keys of the request/response body. Full structural validation is
+        delegated to the OpenAI Python SDK, which deserializes responses into typed objects
+        and raises a ``ValidationError`` on any structural mismatch.
 
         :param endpoints: Optional list of :class:`~mlrun.serving.openai_mappings.OpenAIEndpoint`
             values selecting which operation groups to enable. Defaults to all groups.

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -342,6 +342,16 @@ class GraphServer(ModelObj):
                     )
         try:
             response = self.graph.run(event, **(extra_args or {}))
+
+            # TODO: this is only relevant in certain flows (MockServer, sync...)
+            if hasattr(response, "body"):
+                response = response.body
+
+            if self.http_trigger and self.result_handler:
+                method = getattr(event, "method", None)
+                path = getattr(event, "path", None)
+                if method and path:
+                    response = self.result_handler.apply(method, path, response)
         except Exception as exc:
             # Extract appropriate status code from MLRunHTTPStatusError exceptions
             # For backwards compatibility, default to 400 for other exceptions
@@ -358,16 +368,6 @@ class GraphServer(ModelObj):
             return context.Response(
                 body=message, content_type="text/plain", status_code=status_code
             )
-
-        # TODO: this is only relevant in certain flows (MockServer, sync...)
-        if hasattr(response, "body"):
-            response = response.body
-
-        if self.http_trigger and self.result_handler:
-            method = getattr(event, "method", None)
-            path = getattr(event, "path", None)
-            if method and path:
-                response = self.result_handler.apply(method, path, response)
 
         return response
 

--- a/tests/serving/openai/test_chat_completions.py
+++ b/tests/serving/openai/test_chat_completions.py
@@ -16,7 +16,6 @@
 
 import pytest
 
-import mlrun
 from mlrun.serving.openai_mappings import OpenAIEndpoint
 from tests.serving.assets.openai_fixtures import (
     CHAT_EXPECTED_KWARGS,
@@ -109,9 +108,7 @@ class TestChatCompletionsGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.CHAT_COMPLETIONS, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(
                     "/chat/completions",
                     method="POST",
@@ -153,9 +150,7 @@ class TestChatCompletionsGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.CHAT_COMPLETIONS, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(f"/chat/completions/{COMPLETION_ID}", method="GET")
         finally:
             server.wait_for_completion()
@@ -214,9 +209,7 @@ class TestChatCompletionsGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.CHAT_COMPLETIONS, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(
                     f"/chat/completions/{COMPLETION_ID}",
                     method="POST",
@@ -256,9 +249,7 @@ class TestChatCompletionsGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.CHAT_COMPLETIONS, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(f"/chat/completions/{COMPLETION_ID}", method="DELETE")
         finally:
             server.wait_for_completion()
@@ -290,9 +281,7 @@ class TestChatCompletionsGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.CHAT_COMPLETIONS, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test("/chat/completions", method="GET")
         finally:
             server.wait_for_completion()
@@ -329,9 +318,7 @@ class TestChatCompletionsGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.CHAT_COMPLETIONS, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(f"/chat/completions/{COMPLETION_ID}/messages", method="GET")
         finally:
             server.wait_for_completion()

--- a/tests/serving/openai/test_responses.py
+++ b/tests/serving/openai/test_responses.py
@@ -16,7 +16,6 @@
 
 import pytest
 
-import mlrun
 from mlrun.serving.openai_mappings import OpenAIEndpoint
 from tests.serving.assets.openai_fixtures import (
     COMPACT_EXPECTED_KWARGS,
@@ -75,9 +74,7 @@ class TestResponsesGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.RESPONSES, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test("/responses", method="POST", body={})
         finally:
             server.wait_for_completion()
@@ -112,9 +109,7 @@ class TestResponsesGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.RESPONSES, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(f"/responses/{RESPONSE_ID}", method="GET")
         finally:
             server.wait_for_completion()
@@ -171,9 +166,7 @@ class TestResponsesGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.RESPONSES, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(f"/responses/{RESPONSE_ID}/input_items", method="GET")
         finally:
             server.wait_for_completion()
@@ -215,9 +208,7 @@ class TestResponsesGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.RESPONSES, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test("/responses/input_tokens", method="POST", body={})
         finally:
             server.wait_for_completion()
@@ -252,9 +243,7 @@ class TestResponsesGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.RESPONSES, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(f"/responses/{RESPONSE_ID}/cancel", method="POST")
         finally:
             server.wait_for_completion()
@@ -294,9 +283,7 @@ class TestResponsesGroupMock:
 
         server = make_mock_server(OpenAIEndpoint.RESPONSES, handler)
         try:
-            with pytest.raises(
-                mlrun.errors.MLRunBadRequestError, match="Mandatory field"
-            ):
+            with pytest.raises(RuntimeError, match="Mandatory field"):
                 server.test(
                     "/responses/compact",
                     method="POST",

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -540,7 +540,7 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
 
         with pytest.raises(
             RuntimeError,
-            match=r"MLRunBadRequestError.*Mandatory field 'output_result' not found",
+            match=r"bad function response 400:.*MLRunBadRequestError.*Mandatory field 'output_result' not found",  # noqa: E501
         ):
             function.invoke(path="/predict", body={"model": "gpt-4"})
 
@@ -697,14 +697,16 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
             http_client=httpx.Client(verify=mlrun.mlconf.httpdb.http.verify),
         )
 
-        with pytest.raises(
-            openai.APIStatusError,
-            match=r"MLRunBadRequestError: Mandatory field 'choices' not found in body",
-        ):
+        with pytest.raises(openai.APIStatusError) as exc_info:
             client.chat.completions.create(
                 model="gpt-4",
                 messages=[{"role": "user", "content": "Hello"}],
             )
+        assert exc_info.value.status_code == 400
+        assert (
+            "MLRunBadRequestError: Mandatory field 'choices' not found in body"
+            in str(exc_info.value)
+        )
 
         self._logger.info("Chat completions missing mandatory output field test passed")
 
@@ -731,13 +733,14 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
             http_client=httpx.Client(verify=mlrun.mlconf.httpdb.http.verify),
         )
 
-        with pytest.raises(
-            openai.APIStatusError,
-            match=r"MLRunBadRequestError: Mandatory field 'id' not found in body",
-        ):
+        with pytest.raises(openai.APIStatusError) as exc_info:
             client.responses.create(
                 model="gpt-4",
                 input="Hello",
             )
+        assert exc_info.value.status_code == 400
+        assert "MLRunBadRequestError: Mandatory field 'id' not found in body" in str(
+            exc_info.value
+        )
 
         self._logger.info("Responses missing mandatory output field test passed")


### PR DESCRIPTION
### 📝 Description
`result_handler.apply()` was called outside the try/except in `GraphServer.run()`, so missing mandatory output fields raised a raw MLRunBadRequestError instead of being caught and        
returned as a clean HTTP 400.
Input validation errors were already caught and returned as HTTP 400, creating an inconsistency for callers.                                             
                                                                                                                                                                                       
This PR moves `result_handler.apply()` (and the response body unwrap) inside the try/except block so both input and output validation errors surface identically as HTTP 400 responses. 

---

### 🛠️ Changes Made
- `mlrun/serving/server.py `— moved result_handler.apply() and hasattr(response, "body") unwrap inside the try/except in GraphServer.run()
- `tests/serving/openai/test_chat_completions.py` / `test_responses.py `— updated output error tests to expect RuntimeError (consistent with input errors) instead of raw MLRunBadRequestError.                                                                                                                                                            
- `tests/system/runtimes/test_serving.py` — tightened output mandatory field system tests to assert `exc_info.value.status_code` == 400 explicitly.
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Updated unit tests in `test_chat_completions.py` and `test_responses.py` (6 tests each) — all incomplete response tests now expect RuntimeError matching "Mandatory field".
- System tests in `test_serving.py` now assert status_code == 400 on `openai.APIStatusError`.

---

### 🔗 References
- Ticket link: [ML-12630](https://ecliptos.atlassian.net/browse/ML-12630)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
