### PR TITLE
[API] Support configurable system ID length and normalize UUID-based system IDs

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1004,6 +1004,7 @@ default_config = {
         },
     },
     "system_id": "",
+    "system_id_len": 12,
 }
 _is_running_as_api = None
 

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -20,6 +20,7 @@ import random
 import string
 import time
 import typing
+import uuid
 
 import alembic
 import alembic.command
@@ -1303,15 +1304,25 @@ def _init_system_id(db_session: sqlalchemy.orm.Session):
 
 
 def _get_configured_system_id() -> str | None:
-    return mlrun.mlconf.system_id or None
+    system_id = mlrun.mlconf.system_id or None
+    if system_id is None:
+        return None
+
+    # UUID has some issues in several system-id use cases (length, hyphens, etc.)
+    # so we use only a subset of the UUID.
+    try:
+        uuid.UUID(system_id)
+    except ValueError:
+        return system_id
+
+    return system_id.replace("-", "")[: mlrun.mlconf.system_id_len]
 
 
 def _generate_system_id() -> str:
-    # Generate a 6-character alphanumeric ID using lowercase letters and digits only
+    # Generate an alphanumeric ID using lowercase letters and digits only
     valid_chars = string.ascii_lowercase + string.digits
-    system_id_len = 6
 
-    return "".join(random.choices(valid_chars, k=system_id_len))
+    return "".join(random.choices(valid_chars, k=mlrun.mlconf.system_id_len))
 
 
 def main() -> None:

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -31,6 +31,9 @@ import framework.db.sqldb.sql_session
 import framework.utils.singletons.db
 import services.api.initial_data
 
+_UUID_V4 = "550e8400-e29b-41d4-a716-446655440000"
+_UUID_V7 = "018f6c4e-7b8a-7c2e-bf3a-5e4d1c2a8b90"
+
 
 def test_add_data_version_empty_db():
     db, db_session = _initialize_db_without_migrations()
@@ -461,20 +464,27 @@ def test_add_producer_uri_to_artifact():
 
 
 @pytest.mark.parametrize(
-    "system_id_source, expected_system_id",
+    "system_id_source, configured_system_id, expected_system_id",
     [
         # when no system id is configured, a new random one should be generated
-        ("random", None),
-        # when a system id is set in mlconf, it should be used
-        ("mlconf", "123"),
+        ("random", None, None),
+        # when a non-UUID system id is set in mlconf, it should be used as-is
+        ("mlconf", "123", "123"),
+        # UUIDv4 should be stripped of hyphens and truncated to system_id_len
+        ("mlconf", _UUID_V4, "550e8400e29b"),
+        # UUIDv7 should be stripped of hyphens and truncated to system_id_len
+        ("mlconf", _UUID_V7, "018f6c4e7b8a"),
     ],
 )
 def test_init_system_id(
-    system_id_source, expected_system_id, monkeypatch: pytest.MonkeyPatch
+    system_id_source,
+    configured_system_id,
+    expected_system_id,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     if system_id_source == "mlconf":
         monkeypatch.setattr(
-            mlrun.mlconf, framework.constants.SYSTEM_ID_KEY, expected_system_id
+            mlrun.mlconf, framework.constants.SYSTEM_ID_KEY, configured_system_id
         )
 
     db, db_session = _initialize_db_without_migrations()
@@ -490,7 +500,7 @@ def test_init_system_id(
 
     if system_id_source == "random":
         # ensure the generated id has the correct length
-        assert len(system_id) == 6
+        assert len(system_id) == mlrun.mlconf.system_id_len
         # ensure the generated id contains only alphanumeric characters
         assert all(char in string.ascii_lowercase + string.digits for char in system_id)
     else:
@@ -502,6 +512,30 @@ def test_init_system_id(
     services.api.initial_data._init_system_id(db_session)
     system_id_after_second_init = db.get_system_id(db_session)
     assert system_id_after_second_init == system_id
+
+
+@pytest.mark.parametrize(
+    "configured_value, expected_value",
+    [
+        # nothing configured
+        (None, None),
+        ("", None),
+        # non-UUID strings are returned as-is
+        ("123", "123"),
+        ("my-system", "my-system"),
+        # UUIDv4: hyphens stripped and truncated to system_id_len (12)
+        (_UUID_V4, "550e8400e29b"),
+        # UUIDv7: hyphens stripped and truncated to system_id_len (12)
+        (_UUID_V7, "018f6c4e7b8a"),
+    ],
+)
+def test_get_configured_system_id(
+    configured_value, expected_value, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        mlrun.mlconf, framework.constants.SYSTEM_ID_KEY, configured_value or ""
+    )
+    assert services.api.initial_data._get_configured_system_id() == expected_value
 
 
 def test_system_id_initialized_from_scratch(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
### 📝 Description

The `system_id` config value is used in several contexts (e.g., resource naming, labeling) where full UUIDs are problematic due to their length and hyphen characters. 

This PR makes the system ID length configurable and adds normalization logic for UUID-based system IDs: when `mlrun.mlconf.system_id` is set to a UUID string, hyphens are stripped and the result is truncated to `system_id_len` characters (default 12). 
Non-UUID strings are left unchanged.

---

### 🛠️ Changes Made
- **`mlrun/config.py`**: Added `system_id_len` config field (default: `12`) to `default_config`. Previously the length was hardcoded to `6` inside `_generate_system_id`.
- **`server/py/services/api/initial_data.py`**:
  - `_generate_system_id`: Uses `mlrun.mlconf.system_id_len` instead of a hardcoded `6`.
  - `_get_configured_system_id`: When the configured value is a valid UUID (v4/v7/etc.), strips hyphens and truncates to `system_id_len`. Non-UUID values are returned as-is.
- **`server/py/services/api/tests/unit/test_initial_data.py`**:
  - Extended `test_init_system_id` parametrize to cover UUID v4 and v7 inputs and their expected normalized outputs.
  - Added a dedicated `test_get_configured_system_id` test covering `None`, empty string, plain strings, and UUIDs.
  - Updated length assertion in the random-generation path to use `mlrun.mlconf.system_id_len`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Unit tests added/extended in `test_initial_data.py`:
  - `test_get_configured_system_id`: covers `None`, empty, non-UUID strings, UUIDv4, and UUIDv7 inputs.
  - `test_init_system_id`: extended parametrize to verify end-to-end behavior for UUID inputs producing correctly normalized IDs (e.g., `550e8400-e29b-41d4-a716-446655440000` → `550e8400e29b`).
  - Random-generation test now validates against the configurable `system_id_len`.

---

### 🔗 References
- Ticket link: IG4-2604
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

> Note: The default generated system ID length changes from `6` to `12`. Systems that already have a persisted `system_id` in the DB are unaffected (the stored value is reused on subsequent startups). Only freshly initialized deployments will get a 12-character ID.

---

### 🔍️ Additional Notes
- The `system_id_len` config value applies to both newly generated IDs and UUID normalization, keeping both paths consistent.
- Environments that set `mlrun.mlconf.system_id` to a UUID (e.g., passed by the platform) will now automatically receive a shorter, hyphen-free identifier suitable for use in resource names and labels.