### PR TITLE
[Model Monitoring] Fix drain SIGKILL by wrapping blocking I/O in run_in_threadpool

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -956,7 +956,8 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
                 attributes_to_update[EventFieldType.FEATURE_NAMES] = feature_names
 
                 if endpoint_type != EndpointType.ROUTER.value:
-                    update_monitoring_feature_set(
+                    await mlrun.utils.run_in_threadpool(
+                        update_monitoring_feature_set,
                         endpoint_record=endpoint_record,
                         feature_names=feature_names,
                         feature_values=feature_values,
@@ -976,7 +977,8 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
                 ]
                 attributes_to_update[EventFieldType.LABEL_NAMES] = label_columns
                 if endpoint_type != EndpointType.ROUTER.value:
-                    update_monitoring_feature_set(
+                    await mlrun.utils.run_in_threadpool(
+                        update_monitoring_feature_set,
                         endpoint_record=endpoint_record,
                         feature_names=label_columns,
                         feature_values=label_values,
@@ -1020,7 +1022,8 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
                 endpoint_id=endpoint_id,
                 attributes=attributes_to_update,
             )
-            update_endpoint_record(
+            await mlrun.utils.run_in_threadpool(
+                update_endpoint_record,
                 project=self.project,
                 endpoint_id=endpoint_id,
                 attributes=attributes_to_update,
@@ -1103,17 +1106,23 @@ class InferSchema(mlrun.feature_store.steps.MapClass):
         self.table = table
         self.keys = set()
 
-    def do(self, event: dict):
+    async def do(self, event: dict):
         key_set = set(event.keys())
         if not key_set.issubset(self.keys):
             import mlrun.utils.v3io_clients
 
             self.keys.update(key_set)
-            # Apply infer_schema on the kv table for generating the schema file
-            mlrun.utils.v3io_clients.get_frames_client(
+            frames_client = mlrun.utils.v3io_clients.get_frames_client(
                 container=self.container,
                 address=self.v3io_framesd,
-            ).execute(backend="kv", table=self.table, command="infer_schema")
+            )
+            # Apply infer_schema on the kv table for generating the schema file
+            await mlrun.utils.run_in_threadpool(
+                frames_client.execute,
+                backend="kv",
+                table=self.table,
+                command="infer_schema",
+            )
 
         return event
 

--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -393,14 +393,15 @@ class ProcessHTTPEvent(storey.MapClass):
             TTLCache(maxsize=_CACHE_MAX_ENDPOINTS, ttl=_CACHE_TTL_SECONDS)
         )
 
-    def _get_endpoint_schema(
+    async def _get_endpoint_schema(
         self, endpoint_id: str, name: str
     ) -> tuple[list | None, list | None, str]:
         """Return (feature_names, label_names, function_uri) for the given endpoint."""
         if endpoint_id not in self._schema_cache or self._schema_cache[endpoint_id][
             :2
         ] == (None, None):
-            ep = mlrun.db.get_run_db().get_model_endpoint(
+            ep = await mlrun.utils.run_in_threadpool(
+                mlrun.db.get_run_db().get_model_endpoint,
                 name=name,
                 project=self.project,
                 endpoint_id=endpoint_id,
@@ -413,7 +414,7 @@ class ProcessHTTPEvent(storey.MapClass):
             )
         return self._schema_cache[endpoint_id]
 
-    def do(self, event: dict) -> dict:
+    async def do(self, event: dict) -> dict:
         endpoint_id = event.get(MonitoringHTTPPayload.MODEL_ENDPOINT_UID)
         name = event.get(MonitoringHTTPPayload.MODEL_ENDPOINT_NAME)
         inputs = event.get(MonitoringHTTPPayload.INPUTS)
@@ -422,7 +423,9 @@ class ProcessHTTPEvent(storey.MapClass):
         if error := self._validate_event_fields(endpoint_id, name, inputs, outputs):
             return error
 
-        return self._process_event_content(event, endpoint_id, name, inputs, outputs)
+        return await self._process_event_content(
+            event, endpoint_id, name, inputs, outputs
+        )
 
     def _validate_event_fields(
         self,
@@ -459,7 +462,7 @@ class ProcessHTTPEvent(storey.MapClass):
             return {_HTTP_ERROR_KEY: f"missing required fields: {', '.join(missing)}"}
         return None
 
-    def _process_event_content(
+    async def _process_event_content(
         self,
         event: dict,
         endpoint_id: str,
@@ -478,9 +481,11 @@ class ProcessHTTPEvent(storey.MapClass):
         """
         try:
             # Resolve schema from DB; dict key order used when schema is absent
-            db_feature_names, db_label_names, function_uri = self._get_endpoint_schema(
-                endpoint_id, name
-            )
+            (
+                db_feature_names,
+                db_label_names,
+                function_uri,
+            ) = await self._get_endpoint_schema(endpoint_id, name)
         except mlrun.errors.MLRunNotFoundError:
             logger.error(
                 "Model endpoint not found",
@@ -651,7 +656,7 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
         # Set of endpoints in the current events
         self.endpoints: set[str] = set()
 
-    def do(self, full_event):
+    async def do(self, full_event):
         event = full_event.body
         if event.get(ControllerEvent.KIND, "") == ControllerEventKind.NOP_EVENT:
             logger.debug(
@@ -670,7 +675,7 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
         endpoint_id = event[EventFieldType.ENDPOINT_ID]
 
         # In case this process fails, resume state from existing record
-        self.resume_state(
+        await self.resume_state(
             endpoint_id=endpoint_id,
             endpoint_name=full_event.body.get(EventFieldType.MODEL),
         )
@@ -793,21 +798,19 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
         full_event.body = events
         return full_event
 
-    def resume_state(self, endpoint_id, endpoint_name):
+    async def resume_state(self, endpoint_id, endpoint_name):
         # Make sure process is resumable, if process fails for any reason, be able to pick things up close to where we
         # left them
         if endpoint_id not in self.endpoints:
             logger.info("Trying to resume state", endpoint_id=endpoint_id)
-            endpoint_record = (
-                mlrun.db.get_run_db()
-                .get_model_endpoint(
-                    project=self.project,
-                    endpoint_id=endpoint_id,
-                    name=endpoint_name,
-                    tsdb_metrics=False,
-                )
-                .flat_dict()
+            endpoint = await mlrun.utils.run_in_threadpool(
+                mlrun.db.get_run_db().get_model_endpoint,
+                project=self.project,
+                endpoint_id=endpoint_id,
+                name=endpoint_name,
+                tsdb_metrics=False,
             )
+            endpoint_record = endpoint.flat_dict()
 
             # If model endpoint found, get first_request & last_request values
             if endpoint_record:
@@ -905,7 +908,7 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
             return self.label_columns[endpoint_id]
         return None
 
-    def do(self, event: dict):
+    async def do(self, event: dict):
         if event.get(ControllerEvent.KIND, "") == ControllerEventKind.NOP_EVENT:
             return event
         endpoint_id = event[EventFieldType.ENDPOINT_ID]
@@ -922,16 +925,14 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
         endpoint_record = None
         # Get feature names and label columns
         if endpoint_id not in self.feature_names:
-            endpoint_record = (
-                mlrun.db.get_run_db()
-                .get_model_endpoint(
-                    project=self.project,
-                    endpoint_id=endpoint_id,
-                    name=event[EventFieldType.ENDPOINT_NAME],
-                    tsdb_metrics=False,
-                )
-                .flat_dict()
+            endpoint = await mlrun.utils.run_in_threadpool(
+                mlrun.db.get_run_db().get_model_endpoint,
+                project=self.project,
+                endpoint_id=endpoint_id,
+                name=event[EventFieldType.ENDPOINT_NAME],
+                tsdb_metrics=False,
             )
+            endpoint_record = endpoint.flat_dict()
             feature_names = endpoint_record.get(EventFieldType.FEATURE_NAMES)
 
             label_columns = endpoint_record.get(EventFieldType.LABEL_NAMES)
@@ -996,16 +997,15 @@ class MapFeatureNames(mlrun.feature_store.steps.MapClass):
 
         # Update the first request time in the endpoint record
         if endpoint_id not in self.first_request:
-            endpoint_record = endpoint_record or (
-                mlrun.db.get_run_db()
-                .get_model_endpoint(
+            if endpoint_record is None:
+                endpoint = await mlrun.utils.run_in_threadpool(
+                    mlrun.db.get_run_db().get_model_endpoint,
                     project=self.project,
                     endpoint_id=endpoint_id,
                     name=event[EventFieldType.ENDPOINT_NAME],
                     tsdb_metrics=False,
                 )
-                .flat_dict()
-            )
+                endpoint_record = endpoint.flat_dict()
             if not endpoint_record.get(EventFieldType.FIRST_REQUEST):
                 attributes_to_update[EventFieldType.FIRST_REQUEST] = (
                     mlrun.utils.enrich_datetime_with_tz_info(

--- a/tests/model_monitoring/test_stream_processing.py
+++ b/tests/model_monitoring/test_stream_processing.py
@@ -158,9 +158,9 @@ class TestProcessHTTPEvent:
         monkeypatch.setattr(mlrun.db, "get_run_db", lambda *a, **kw: mock_db)
         return ProcessHTTPEvent(project="test-project")
 
-    def test_valid_list_payload(self, monkeypatch):
+    async def test_valid_list_payload(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-123",
                 "inputs": [[1.0, 2.0]],
@@ -176,9 +176,9 @@ class TestProcessHTTPEvent:
         assert result[EventFieldType.FUNCTION_URI] == ""
         assert result["error"] is None
 
-    def test_dict_inputs_transposed_by_schema(self, monkeypatch):
+    async def test_dict_inputs_transposed_by_schema(self, monkeypatch):
         step = self._step(monkeypatch, feature_names=["f1", "f2"], label_names=["pred"])
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-123",
                 "model_endpoint_name": "my-model",
@@ -192,9 +192,11 @@ class TestProcessHTTPEvent:
         assert result["request"]["input_schema"] == ["f1", "f2"]
         assert result["resp"]["output_schema"] == ["pred"]
 
-    def test_dict_inputs_without_schema_warns_and_uses_dict_order(self, monkeypatch):
+    async def test_dict_inputs_without_schema_warns_and_uses_dict_order(
+        self, monkeypatch
+    ):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-123",
                 "model_endpoint_name": "my-model",
@@ -206,9 +208,9 @@ class TestProcessHTTPEvent:
         # No schema → transpose_by_key infers order from dict keys
         assert result["request"]["inputs"] == [[1.0, 2.0]]
 
-    def test_scalar_inputs_wrapped_in_list(self, monkeypatch):
+    async def test_scalar_inputs_wrapped_in_list(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-123",
                 "model_endpoint_name": "my-model",
@@ -219,9 +221,9 @@ class TestProcessHTTPEvent:
         assert result["request"]["inputs"] == [42.0]
         assert result["resp"]["outputs"] == [0.8]
 
-    def test_db_schema_used_when_not_in_event(self, monkeypatch):
+    async def test_db_schema_used_when_not_in_event(self, monkeypatch):
         step = self._step(monkeypatch, feature_names=["a", "b"], label_names=["pred"])
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -234,9 +236,9 @@ class TestProcessHTTPEvent:
         assert result["resp"]["outputs"] == [0.9]
         assert result["request"]["input_schema"] == ["a", "b"]
 
-    def test_when_added_if_missing(self, monkeypatch):
+    async def test_when_added_if_missing(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -246,9 +248,9 @@ class TestProcessHTTPEvent:
         )
         assert result["when"] is not None
 
-    def test_when_preserved_if_provided(self, monkeypatch):
+    async def test_when_preserved_if_provided(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -259,17 +261,17 @@ class TestProcessHTTPEvent:
         )
         assert result["when"] == "2024-01-01T00:00:00Z"  # internal field name
 
-    def test_missing_endpoint_id_returns_error_sentinel(self, monkeypatch):
+    async def test_missing_endpoint_id_returns_error_sentinel(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {"model_endpoint_name": "my-model", "inputs": [[1.0]], "outputs": [[0.9]]}
         )
         assert _HTTP_ERROR_KEY in result
         assert "model_endpoint_uid" in result[_HTTP_ERROR_KEY]
 
-    def test_missing_inputs_returns_error_sentinel(self, monkeypatch):
+    async def test_missing_inputs_returns_error_sentinel(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -279,9 +281,9 @@ class TestProcessHTTPEvent:
         assert _HTTP_ERROR_KEY in result
         assert "inputs" in result[_HTTP_ERROR_KEY]
 
-    def test_missing_outputs_returns_error_sentinel(self, monkeypatch):
+    async def test_missing_outputs_returns_error_sentinel(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -291,17 +293,17 @@ class TestProcessHTTPEvent:
         assert _HTTP_ERROR_KEY in result
         assert "outputs" in result[_HTTP_ERROR_KEY]
 
-    def test_missing_name_returns_error_sentinel(self, monkeypatch):
+    async def test_missing_name_returns_error_sentinel(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {"model_endpoint_uid": "ep-1", "inputs": [[1.0]], "outputs": [[0.8]]}
         )
         assert _HTTP_ERROR_KEY in result
         assert "model_endpoint_name" in result[_HTTP_ERROR_KEY]
 
-    def test_optional_metadata_forwarded(self, monkeypatch):
+    async def test_optional_metadata_forwarded(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -318,9 +320,9 @@ class TestProcessHTTPEvent:
         assert result[EventFieldType.LABELS] == {"env": "prod"}
         assert result[EventFieldType.METRICS] == {"accuracy": 0.99}
 
-    def test_request_id_generated_when_absent(self, monkeypatch):
+    async def test_request_id_generated_when_absent(self, monkeypatch):
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -331,14 +333,14 @@ class TestProcessHTTPEvent:
         assert result["request"]["id"] is not None
         assert len(result["request"]["id"]) > 0
 
-    def test_function_uri_from_endpoint_schema(self, monkeypatch):
+    async def test_function_uri_from_endpoint_schema(self, monkeypatch):
         step = self._step(
             monkeypatch,
             feature_names=["f1"],
             label_names=["out"],
             function_uri="my-project/my-fn:latest",
         )
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -348,7 +350,7 @@ class TestProcessHTTPEvent:
         )
         assert result[EventFieldType.FUNCTION_URI] == "my-project/my-fn:latest"
 
-    def test_translation_exception_returns_error_sentinel(
+    async def test_translation_exception_returns_error_sentinel(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         import mlrun.serving.system_steps
@@ -359,7 +361,7 @@ class TestProcessHTTPEvent:
             lambda data, schema: (_ for _ in ()).throw(ValueError("boom")),
         )
         step = self._step(monkeypatch)
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -371,9 +373,9 @@ class TestProcessHTTPEvent:
         assert "failed to translate event" in result[_HTTP_ERROR_KEY]
         assert "boom" in result[_HTTP_ERROR_KEY]
 
-    def test_function_uri_empty_for_user_ep(self, monkeypatch):
+    async def test_function_uri_empty_for_user_ep(self, monkeypatch):
         step = self._step(monkeypatch, function_uri="")
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-1",
                 "model_endpoint_name": "my-model",
@@ -383,7 +385,7 @@ class TestProcessHTTPEvent:
         )
         assert result[EventFieldType.FUNCTION_URI] == ""
 
-    def test_not_found_endpoint_returns_error_sentinel(self, monkeypatch):
+    async def test_not_found_endpoint_returns_error_sentinel(self, monkeypatch):
         """When the endpoint does not exist, do() returns a 'not found' error sentinel."""
         mock_db = unittest.mock.MagicMock()
         mock_db.get_model_endpoint.side_effect = mlrun.errors.MLRunNotFoundError(
@@ -392,7 +394,7 @@ class TestProcessHTTPEvent:
         monkeypatch.setattr(mlrun.db, "get_run_db", lambda *a, **kw: mock_db)
         step = ProcessHTTPEvent(project="test-project")
 
-        result = step.do(
+        result = await step.do(
             {
                 "model_endpoint_uid": "ep-missing",
                 "model_endpoint_name": "no-such-model",
@@ -429,39 +431,39 @@ class TestGetEndpointSchema:
         monkeypatch.setattr(mlrun.db, "get_run_db", lambda *a, **kw: mock_db)
         return mock_db
 
-    def test_cache_miss_calls_db_and_populates_cache(self, monkeypatch):
+    async def test_cache_miss_calls_db_and_populates_cache(self, monkeypatch):
         ep = self._make_ep(["f1"], ["out"], "proj/fn:latest")
         mock_db = self._mock_db(monkeypatch, ep)
         step = ProcessHTTPEvent(project="proj")
 
-        result = step._get_endpoint_schema("ep-1", "my-model")
+        result = await step._get_endpoint_schema("ep-1", "my-model")
 
         assert result == (["f1"], ["out"], "proj/fn:latest")
         mock_db.get_model_endpoint.assert_called_once()
         assert step._schema_cache["ep-1"] == (["f1"], ["out"], "proj/fn:latest")
 
-    def test_cache_hit_with_schema_skips_db(self, monkeypatch):
+    async def test_cache_hit_with_schema_skips_db(self, monkeypatch):
         mock_db = self._mock_db(monkeypatch, self._make_ep())
         step = ProcessHTTPEvent(project="proj")
         step._schema_cache["ep-1"] = (["f1"], ["out"], "proj/fn:latest")
 
-        result = step._get_endpoint_schema("ep-1", "my-model")
+        result = await step._get_endpoint_schema("ep-1", "my-model")
 
         assert result == (["f1"], ["out"], "proj/fn:latest")
         mock_db.get_model_endpoint.assert_not_called()
 
-    def test_cache_hit_with_none_schema_refreshes_from_db(self, monkeypatch):
+    async def test_cache_hit_with_none_schema_refreshes_from_db(self, monkeypatch):
         ep = self._make_ep(["f1"], ["out"], "proj/fn:latest")
         mock_db = self._mock_db(monkeypatch, ep)
         step = ProcessHTTPEvent(project="proj")
         step._schema_cache["ep-1"] = (None, None, "proj/fn:latest")
 
-        result = step._get_endpoint_schema("ep-1", "my-model")
+        result = await step._get_endpoint_schema("ep-1", "my-model")
 
         assert result == (["f1"], ["out"], "proj/fn:latest")
         mock_db.get_model_endpoint.assert_called_once()
 
-    def test_db_failure_propagates(self, monkeypatch):
+    async def test_db_failure_propagates(self, monkeypatch):
         """Generic DB errors propagate from _get_endpoint_schema to the caller."""
         mock_db = unittest.mock.MagicMock()
         mock_db.get_model_endpoint.side_effect = Exception("connection error")
@@ -469,9 +471,9 @@ class TestGetEndpointSchema:
         step = ProcessHTTPEvent(project="proj")
 
         with pytest.raises(Exception, match="connection error"):
-            step._get_endpoint_schema("ep-1", "my-model")
+            await step._get_endpoint_schema("ep-1", "my-model")
 
-    def test_not_found_error_propagates(self, monkeypatch):
+    async def test_not_found_error_propagates(self, monkeypatch):
         """MLRunNotFoundError from the DB is not swallowed — it propagates to the caller."""
         mock_db = unittest.mock.MagicMock()
         mock_db.get_model_endpoint.side_effect = mlrun.errors.MLRunNotFoundError(
@@ -481,9 +483,9 @@ class TestGetEndpointSchema:
         step = ProcessHTTPEvent(project="proj")
 
         with pytest.raises(mlrun.errors.MLRunNotFoundError):
-            step._get_endpoint_schema("ep-1", "my-model")
+            await step._get_endpoint_schema("ep-1", "my-model")
 
-    def test_expired_cache_entry_refreshed_from_db(self, monkeypatch):
+    async def test_expired_cache_entry_refreshed_from_db(self, monkeypatch):
         """After the TTL elapses the entry is evicted and the DB is called again."""
         from cachetools import TTLCache
 
@@ -495,13 +497,13 @@ class TestGetEndpointSchema:
         # Replace the cache with a 1-second TTL driven by a fake timer.
         step._schema_cache = TTLCache(maxsize=100, ttl=1, timer=lambda: fake_time[0])
 
-        step._get_endpoint_schema("ep-1", "my-model")
+        await step._get_endpoint_schema("ep-1", "my-model")
         assert mock_db.get_model_endpoint.call_count == 1
 
         # Advance time past TTL — entry should be evicted on next access.
         fake_time[0] = 2.0
 
-        step._get_endpoint_schema("ep-1", "my-model")
+        await step._get_endpoint_schema("ep-1", "my-model")
         assert mock_db.get_model_endpoint.call_count == 2
 
 


### PR DESCRIPTION
### 📝 Description

During Nuclio drain, the asyncio event loop was being parked inside synchronous I/O calls in the model-monitoring serving graph (`mlrun.db.get_run_db().get_model_endpoint()`, `patch_model_endpoint()`, `fstore.get_feature_set()`, v3io frames `execute()`). While the loop was blocked, the Python→Go RPC socket could not be written to, and Nuclio's Go processor SIGKILL'd the worker after the 13-second drain budget elapsed (10 s `WaitForProcessTermination` + 3 s handler-done wait).

This PR makes the affected graph steps async and wraps each blocking I/O call in `await mlrun.utils.run_in_threadpool(...)`. The event loop now stays responsive during the DB / v3io requests, so the wrapper keeps flushing the RPC socket and Go no longer kills the worker.

---

### 🛠️ Changes Made

**`mlrun/model_monitoring/stream_processing.py`**

- **Async conversions** (7 methods):
  - `ProcessHTTPEvent.do`, `_process_event_content`, `_get_endpoint_schema`
  - `ProcessEndpointEvent.do`, `resume_state`
  - `MapFeatureNames.do`
  - `InferSchema.do`
- **Wrapped in `await mlrun.utils.run_in_threadpool(...)`** (8 sites):
  - 4× `get_model_endpoint` (ProcessHTTPEvent.\_get\_endpoint\_schema, ProcessEndpointEvent.resume\_state, two in MapFeatureNames.do)
  - 1× `update_endpoint_record` (→ `patch_model_endpoint`) in MapFeatureNames.do
  - 2× `update_monitoring_feature_set` in MapFeatureNames.do (feature-names branch + label-columns branch)
  - 1× v3io frames `execute(backend="kv", ..., command="infer_schema")` in InferSchema.do
- **Granularity rationale**: wraps are at the blocking-call level, not the whole `do()` body. Cache lookups, validation, dict normalization, and per-endpoint state mutations stay on the loop. Only HTTP / gRPC calls run in worker threads, which keeps `self.*` state writes serialized.
- **Minor refactor in MapFeatureNames.do (second `get_model_endpoint` call)**: `endpoint_record = endpoint_record or (.flat_dict()...)` → `if endpoint_record is None: endpoint_record = endpoint.flat_dict()`. Functionally equivalent in real use (`flat_dict()` always returns a populated dict), but stricter — an empty dict from the prior fetch would no longer trigger a redundant DB call.

**`tests/model_monitoring/test_stream_processing.py`**

- 23 test methods converted to `async def` (auto-collected via `asyncio_mode = "auto"`).
- 24 call sites updated to `await`.
- Unrelated test classes (`TestHTTPAckResponder`, `TestTriggerRouter`, `TestGetModelMonitoringUrl`) left as sync — their step classes were not modified.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — N/A, no public API change
- [x] I have tested the changes in this PR — 44/44 unit tests pass
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing

- Unit tests: `pytest tests/model_monitoring/test_stream_processing.py` — **44 passed, 0 failed**.
- `ruff check` + `ruff format --check`: clean.
- `lint-imports`: 5/5 contracts kept.
- Verified caller chain is fully async, so the `await` is real, not a no-op:
  - Storey `MapClass._call` (`flow.py:949,970`) detects `iscoroutinefunction(self.do) == True` at step `__init__` and `await`s the returned coroutine.
  - Drain entry `mlrun/serving/server.py:1120` `drain_callback` is `async` and awaits `server.wait_for_completion()`.
  - `pytest-asyncio` `asyncio_mode = "auto"` runs every newly-async test method against the real coroutine.

---

### 🔗 References
- Ticket link:ML-12573

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

The four step classes (`ProcessHTTPEvent`, `ProcessEndpointEvent`, `MapFeatureNames`, `InferSchema`) are referenced only by name-string in the graph builder (`stream_processing.py` + `db/tsdb/v3io/v3io_connector.py`); no external code calls their `do()` methods directly. Storey transparently handles sync vs. async `do()` via `iscoroutinefunction` detection at step `__init__`.

---

