### PR TITLE
[Runtimes] Fix auto-mount overriding user-set AWS env vars

### DIFF
--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -264,41 +264,42 @@ def mount_s3(
                     FutureWarning,
                 )
 
+        # Auto-mount fills only env vars the user did not already set as a plain value,
+        # so explicit user input (e.g. from the UI batch-run wizard) survives enrichment.
+        def _set_if_not_user_set(name, value=None, value_from=None):
+            if runtime.has_user_set_plain_env(name):
+                return
+            runtime.set_env(name, value=value, value_from=value_from)
+
         if _endpoint_url:
-            runtime.set_env(prefix + "AWS_ENDPOINT_URL_S3", _endpoint_url)
+            _set_if_not_user_set(prefix + "AWS_ENDPOINT_URL_S3", _endpoint_url)
         if aws_region:
-            runtime.set_env(prefix + "AWS_REGION", aws_region)
+            _set_if_not_user_set(prefix + "AWS_REGION", aws_region)
         if non_anonymous:
-            runtime.set_env(prefix + "S3_NON_ANONYMOUS", "true")
+            _set_if_not_user_set(prefix + "S3_NON_ANONYMOUS", "true")
 
         if secret_name:
-            runtime.set_envs(
-                {
-                    f"{prefix}AWS_ACCESS_KEY_ID": {
-                        "valueFrom": {
-                            "secretKeyRef": {
-                                "name": secret_name,
-                                "key": "AWS_ACCESS_KEY_ID",
-                            }
-                        }
-                    },
-                    f"{prefix}AWS_SECRET_ACCESS_KEY": {
-                        "valueFrom": {
-                            "secretKeyRef": {
-                                "name": secret_name,
-                                "key": "AWS_SECRET_ACCESS_KEY",
-                            }
-                        },
-                    },
-                }
-            )
-        else:
-            runtime.set_envs(
-                {
-                    f"{prefix}AWS_ACCESS_KEY_ID": _access_key,
-                    f"{prefix}AWS_SECRET_ACCESS_KEY": _secret_key,
+            _set_if_not_user_set(
+                f"{prefix}AWS_ACCESS_KEY_ID",
+                value_from={
+                    "secretKeyRef": {
+                        "name": secret_name,
+                        "key": "AWS_ACCESS_KEY_ID",
+                    }
                 },
             )
+            _set_if_not_user_set(
+                f"{prefix}AWS_SECRET_ACCESS_KEY",
+                value_from={
+                    "secretKeyRef": {
+                        "name": secret_name,
+                        "key": "AWS_SECRET_ACCESS_KEY",
+                    }
+                },
+            )
+        else:
+            _set_if_not_user_set(f"{prefix}AWS_ACCESS_KEY_ID", _access_key)
+            _set_if_not_user_set(f"{prefix}AWS_SECRET_ACCESS_KEY", _secret_key)
 
         return runtime
 

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -812,6 +812,20 @@ class KubeResource(BaseRuntime):
                 return True
         return False
 
+    def has_user_set_plain_env(self, name: str) -> bool:
+        """Check whether `name` is present in the runtime spec as a plain-value env var.
+
+        Returns True only for env vars with a plain `.value` (e.g. set via
+        ``set_env(name, value)`` or supplied verbatim by the user); returns False
+        for secret-injected vars that have ``.value_from``. Auto-mount modifiers
+        and secret-store injection consult this to defer to user-set values
+        instead of overriding them.
+        """
+        for env_var in self.spec.env:
+            if get_item_name(env_var) == name:
+                return get_item_name(env_var, "value") is not None
+        return False
+
     def _set_env(self, name, value=None, value_from=None):
         new_var = k8s_client.V1EnvVar(name=name, value=value, value_from=value_from)
 

--- a/server/py/services/api/runtime_handlers/base.py
+++ b/server/py/services/api/runtime_handlers/base.py
@@ -442,9 +442,7 @@ class BaseRuntimeHandler(ABC):
                     else key
                 )
                 # Don't override user-provided plain env vars
-                if not BaseRuntimeHandler._has_user_set_plain_env(
-                    runtime, env_var_name
-                ):
+                if not runtime.has_user_set_plain_env(env_var_name):
                     runtime.set_env_from_secret(env_var_name, global_secret_name, key)
 
         # the secrets param may be an empty dictionary (asking for all secrets of that project) -
@@ -484,9 +482,7 @@ class BaseRuntimeHandler(ABC):
         for key, env_var_name in secrets.items():
             if key in existing_secret_keys:
                 # Don't override user-provided plain env vars
-                if not BaseRuntimeHandler._has_user_set_plain_env(
-                    runtime, env_var_name
-                ):
+                if not runtime.has_user_set_plain_env(env_var_name):
                     runtime.set_env_from_secret(env_var_name, secret_name, key)
 
         # Keep a list of the variables that relate to secrets, so that the MLRun context (when using nuclio:mlrun)
@@ -2122,22 +2118,3 @@ class BaseRuntimeHandler(ABC):
             return run_retry_count > 0
 
         return int(pod_retry_label) < run_retry_count
-
-    @staticmethod
-    def _has_user_set_plain_env(
-        runtime: mlrun.runtimes.pod.KubeResource, name: str
-    ) -> bool:
-        """Check if runtime was explicitly set with a plain-value env var.
-
-        Returns True only for env vars with a plain .value (user-set), not for
-        secret-injected vars that have .value_from. This distinction is critical
-        to preserve the project > global secret priority.
-        """
-        for env_var in runtime.spec.env:
-            if isinstance(env_var, dict):
-                if env_var.get("name") == name:
-                    return env_var.get("value") is not None
-            else:
-                if getattr(env_var, "name", None) == name:
-                    return getattr(env_var, "value", None) is not None
-        return False

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -500,6 +500,81 @@ def test_auto_mount_raises_without_config():
         mlrun.runtimes.mounts.auto_mount()
 
 
+def test_mount_s3_does_not_override_user_set_aws_access_key():
+    """User-set plain AWS_ACCESS_KEY_ID survives mount_s3(secret_name=...).
+
+    Regression for ML-12330: on IG4 the platform auto-mounts mount_s3 with
+    secret_name='minio-credentials', which previously clobbered a user-supplied
+    AWS_ACCESS_KEY_ID (e.g. set via the UI batch-run wizard) with a secretKeyRef.
+    """
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    function.set_env("AWS_ACCESS_KEY_ID", "user-custom-value")
+
+    function.apply(
+        mlrun.runtimes.mounts.mount_s3(
+            secret_name="minio-credentials",
+            endpoint_url="http://seaweedfs:8333",
+        )
+    )
+
+    env_dict = {
+        var["name"]: var.get("value", var.get("valueFrom")) for var in function.spec.env
+    }
+    # User's plain value is preserved (no secretKeyRef override).
+    assert env_dict["AWS_ACCESS_KEY_ID"] == "user-custom-value"
+    # AWS_SECRET_ACCESS_KEY was not user-set, so the secretKeyRef from the
+    # modifier still wins — confirming the guard only fires per-key.
+    assert env_dict["AWS_SECRET_ACCESS_KEY"] == {
+        "secretKeyRef": {"key": "AWS_SECRET_ACCESS_KEY", "name": "minio-credentials"}
+    }
+    # Endpoint URL was not user-set, so the modifier's value wins.
+    assert env_dict["AWS_ENDPOINT_URL_S3"] == "http://seaweedfs:8333"
+
+
+def test_mount_s3_does_not_override_user_set_endpoint_url():
+    """User-set plain AWS_ENDPOINT_URL_S3 survives mount_s3()."""
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    function.set_env("AWS_ENDPOINT_URL_S3", "https://my-corp-s3.example.com")
+
+    function.apply(
+        mlrun.runtimes.mounts.mount_s3(
+            secret_name="minio-credentials",
+            endpoint_url="http://seaweedfs:8333",
+        )
+    )
+
+    env_dict = {
+        var["name"]: var.get("value", var.get("valueFrom")) for var in function.spec.env
+    }
+    assert env_dict["AWS_ENDPOINT_URL_S3"] == "https://my-corp-s3.example.com"
+
+
+def test_mount_s3_without_secret_does_not_override_user_set_aws_access_key():
+    """User-set plain AWS_ACCESS_KEY_ID also wins on the explicit-key path (no secret_name)."""
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    function.set_env("AWS_ACCESS_KEY_ID", "user-custom-value")
+
+    function.apply(
+        mlrun.runtimes.mounts.mount_s3(
+            aws_access_key="modifier-access-key",
+            aws_secret_key="modifier-secret-key",
+        )
+    )
+
+    env_dict = {
+        var["name"]: var.get("value", var.get("valueFrom")) for var in function.spec.env
+    }
+    assert env_dict["AWS_ACCESS_KEY_ID"] == "user-custom-value"
+    # The non-user-set key is still filled by the modifier.
+    assert env_dict["AWS_SECRET_ACCESS_KEY"] == "modifier-secret-key"
+
+
 def _auth_prefix() -> str:
     # Matches how the code builds the pattern: format(hashed_access_key="")
     return mlrun.mlconf.secret_stores.kubernetes.auth_secret_name.format(


### PR DESCRIPTION
### 📝 Description

When `auto_mount_type=s3` is configured (e.g. IG4 with `secret_name=minio-credentials`), the server-side launcher applies `mount_s3` after a UI-submitted job's env vars have already been added to the runtime spec. `mount_s3` previously wrote every AWS_* env var unconditionally via `set_envs`, which through `_set_env` replaced any existing entry with the same name. The user's explicit `AWS_ACCESS_KEY_ID` (e.g. set in the batch-run wizard) was therefore clobbered by the secretKeyRef to `minio-credentials`.

The earlier envvar-order fix (#9489) covered the secret-store path in `BaseRuntimeHandler.add_k8s_secrets_to_spec`, but not the auto-mount modifier. This PR extends the same precedence rule — user-set plain env vars beat auto-injected ones — to `mount_s3`, and consolidates the helper.

---

### 🛠️ Changes Made

- `mlrun/runtimes/pod.py`: new `KubeResource.has_user_set_plain_env(name)` method — returns True only for env vars with a plain `.value` (not for `.value_from`).
- `mlrun/runtimes/mounts.py::mount_s3._use_s3_cred`: skip each AWS_* assignment when the user has already set a plain-value env var with that name. Implemented as a local `_set_if_not_user_set` helper to keep the per-key rule explicit.
- `server/py/services/api/runtime_handlers/base.py`: switch the two existing call sites to `runtime.has_user_set_plain_env(...)` and remove the now-redundant `BaseRuntimeHandler._has_user_set_plain_env` static — single source of truth on `KubeResource`.
- `tests/runtimes/test_mounts.py`: 3 regression tests covering (a) user-set `AWS_ACCESS_KEY_ID` surviving `mount_s3(secret_name=...)`, (b) user-set `AWS_ENDPOINT_URL_S3` surviving the modifier's endpoint arg, (c) user-set `AWS_ACCESS_KEY_ID` surviving on the explicit-key (non-secret) path. The non-user-set keys still get the modifier's value, confirming per-key scope.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Unit: `tests/runtimes/test_mounts.py` — 22 passed (19 existing + 3 new regression tests).
- Unit: full SDK `tests/runtimes/` — 437 passed, 1 skipped.
- Unit (server): `server/py/services/api/tests/unit/runtimes/test_base.py` — 4 passed (the existing regression tests covering the helper that moved to `KubeResource`).
- The originally-reported scenario `test_mlrun_new_job_ui_new_data_input[ui-s3-]` is a system test (naipi) and exercises the wired-through behaviour on IG4; not run locally.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12330
- Design docs links: n/a — bugfix.
- External links: prior related fix #9489 (envvar order in the secret-store path).

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Behaviourally additive — `mount_s3` (and via it, `auto_mount` with `auto_mount_type=s3`) now defers to user-set plain env vars instead of overriding them. This matches the precedence rule already established for the secret-store path in #9489.

---

### 🔍️ Additional Notes

- ML-12572 (`AWS_ENDPOINT_URL_S3 for app runtime pod is not being set from project secret`) is the symmetric defect in the *opposite* direction — the existing `_has_user_set_plain_env` guard mistakes `mount_s3`'s plain-value writes for user-set values, so project-secret keys get suppressed. Out of scope here; left for a follow-up that needs to distinguish auto-mount-injected from user-set plain values.
