### PR TITLE
[Projects] Fix delete project authorization check for project owner

### DIFF
--- a/server/py/services/api/api/endpoints/projects_v2.py
+++ b/server/py/services/api/api/endpoints/projects_v2.py
@@ -27,6 +27,7 @@ import framework.utils.auth.verifier
 import framework.utils.background_tasks
 import framework.utils.clients.chief
 import framework.utils.helpers
+import framework.utils.project_formats
 import services.api.crud
 from framework.utils.singletons.project_member import get_project_member
 
@@ -59,7 +60,17 @@ async def delete_project(
     # check if project exists
     try:
         project = await run_in_threadpool(
-            get_project_member().get_project, db_session, name, auth_info
+            get_project_member().get_project,
+            db_session,
+            name,
+            auth_info,
+            format_=framework.utils.project_formats.ProjectFormatCustomSelection(
+                [
+                    framework.utils.project_formats.ProjectFormatCustom.name,
+                    framework.utils.project_formats.ProjectFormatCustom.owner,
+                    framework.utils.project_formats.ProjectFormatCustom.state,
+                ]
+            ),
         )
     except mlrun.errors.MLRunNotFoundError:
         logger.info("Project not found, nothing to delete", project=name)
@@ -88,8 +99,18 @@ async def delete_project(
         mlrun.mlconf.is_iguazio_v4_mode()
         or not framework.utils.helpers.is_request_from_leader(auth_info.projects_role)
     ):
-        skip_permission_check = False
-        if project.status.state == mlrun.common.schemas.ProjectState.archived:
+        # skip permission check, user owns the project
+        user_owns_project = bool(
+            auth_info.username
+            and getattr(project, "spec", None)
+            and project.spec.owner
+            and auth_info.username == project.spec.owner
+        )
+        skip_permission_check = user_owns_project
+        if (
+            not skip_permission_check
+            and project.status.state == mlrun.common.schemas.ProjectState.archived
+        ):
             try:
                 await run_in_threadpool(
                     get_project_member().get_project,

--- a/server/py/services/api/api/endpoints/projects_v2.py
+++ b/server/py/services/api/api/endpoints/projects_v2.py
@@ -99,7 +99,9 @@ async def delete_project(
         mlrun.mlconf.is_iguazio_v4_mode()
         or not framework.utils.helpers.is_request_from_leader(auth_info.projects_role)
     ):
-        # skip permission check, user owns the project
+        # Circuit breaker: a stale or missing OPA authorization record must
+        # not block a project owner from deleting their own project. When the
+        # requester matches spec.owner, skip the follower permission check.
         user_owns_project = bool(
             auth_info.username
             and getattr(project, "spec", None)

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -1523,6 +1523,55 @@ def test_delete_project_not_found_in_leader(
         assert response.status_code == HTTPStatus.OK.value
 
 
+@pytest.mark.parametrize(
+    "requester_username, expect_permission_check",
+    [
+        ("project-owner", False),
+        ("someone-else", True),
+    ],
+)
+def test_delete_project_v2_owner_skips_permission_check(
+    unversioned_client: TestClient,
+    mock_project_follower_iguazio_client,
+    mocked_k8s_helper,
+    monkeypatch: pytest.MonkeyPatch,
+    requester_username: str,
+    expect_permission_check: bool,
+) -> None:
+    """When the requester is the project owner, the v2 delete endpoint must
+    skip the follower permission check. Other requesters still go through it.
+    """
+    owner_username = "project-owner"
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="owned-project"),
+        spec=mlrun.common.schemas.ProjectSpec(owner=owner_username),
+    )
+    response = unversioned_client.post("v1/projects", json=project.dict())
+    assert response.status_code == HTTPStatus.CREATED.value
+
+    query_project_permissions = AsyncMock()
+    monkeypatch.setattr(
+        framework.utils.auth.verifier.AuthVerifier(),
+        "query_project_permissions",
+        query_project_permissions,
+    )
+
+    response = unversioned_client.delete(
+        f"v2/projects/{project.metadata.name}",
+        headers={mlrun.common.schemas.HeaderNames.remote_user: requester_username},
+    )
+    assert response.status_code == HTTPStatus.ACCEPTED.value
+
+    if expect_permission_check:
+        query_project_permissions.assert_awaited_once_with(
+            project.metadata.name,
+            mlrun.common.schemas.AuthorizationAction.delete,
+            unittest.mock.ANY,
+        )
+    else:
+        query_project_permissions.assert_not_awaited()
+
+
 # Test should not run more than a few seconds because we test that if the background task fails,
 # the wrapper task fails fast
 @pytest.mark.usefixtures("mock_process_model_monitoring_secret")


### PR DESCRIPTION
### 📝 Description

The v2 `DELETE /projects/{name}` endpoint always ran the follower permission lookup, even when the requester is the project's own owner. In iguazio-v4 mode the archived-state fallback was the only path that bypassed it, and the extra round trip opened a window where the permission record for an in-flight project could race with the delete (project owners occasionally seeing the delete rejected on a project they had just created/archived).

This change pulls the owner off the project record and short-circuits the permission check when the requester *is* the owner.

---

### 🛠️ Changes Made

- `server/py/services/api/api/endpoints/projects_v2.py` — on entry to `delete_project`, fetch the project with `ProjectFormatCustomSelection([name, owner, state])` so only the columns the endpoint needs are loaded.
- Skip the follower permission check when `auth_info.username == project.spec.owner`. The archived-state fallback is now only consulted when the requester is **not** the owner.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Patched `mlrun-api-chief` + `mlrun-api-worker` with the branch.
- As the admin user (the project's `spec.owner`), created and then deleted a fresh project.
- Server log on chief shows `DELETE /api/v2/projects/<name>` → `202` and the background `project.deletion.<name>` task cascade completed cleanly, with no permission-denied/auth warnings.
- Existing unit tests in `server/py/services/api/tests/unit/api/test_projects.py` cover the v2 delete path; the diff does not change their inputs.

---

### 🔗 References
- Ticket link: IG4-2615
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes


