### PR TITLE
[Serving] Add prefix parameter to set_openai_frontend() for /v1/ path support

### DIFF
--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -1175,6 +1175,11 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
             fn.set_openai_frontend([OpenAIEndpoint.RESPONSES], prefix="/v1")
         """
 
+        if prefix is not None and not prefix.startswith("/"):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"OpenAI API prefix must start with '/': {prefix!r}"
+            )
+
         existing = self.spec.api_handler_config
         config = (
             APIHandlerConfig.from_dict(existing) if existing else APIHandlerConfig()

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -1147,6 +1147,7 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
     def set_openai_frontend(
         self,
         endpoints: list[mlrun.serving.openai_mappings.OpenAIEndpoint] | None = None,
+        prefix: str | None = None,
     ) -> None:
         """Wire up OpenAI-compatible API handler endpoints in one call.
 
@@ -1160,13 +1161,18 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
 
         :param endpoints: Optional list of :class:`~mlrun.serving.openai_mappings.OpenAIEndpoint`
             values selecting which operation groups to enable. Defaults to all groups.
+        :param prefix: Optional path prefix to prepend to every registered endpoint path.
+            Use this when clients send requests with a path prefix (e.g. ``prefix="/v1"``
+            registers ``/v1/chat/completions`` instead of ``/chat/completions``).
+            Defaults to ``None`` (no prefix).
 
         Example::
 
             from mlrun.serving.openai_mappings import OpenAIEndpoint
 
-            fn.set_openai_frontend()  # all groups
-            fn.set_openai_frontend([OpenAIEndpoint.RESPONSES])  # Responses only
+            fn.set_openai_frontend()  # all groups, no prefix
+            fn.set_openai_frontend(prefix="/v1")  # all groups, /v1/ prefix
+            fn.set_openai_frontend([OpenAIEndpoint.RESPONSES], prefix="/v1")
         """
 
         existing = self.spec.api_handler_config
@@ -1183,6 +1189,8 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
             for ep in mlrun.serving.openai_mappings.ENDPOINT_CLASSES[
                 ep_group
             ].endpoints():
+                if prefix:
+                    ep.path = prefix + ep.path
                 config.add_endpoint_config(ep)
 
         self.set_api_handler_config(config)

--- a/tests/serving/openai/test_openai_api_basic.py
+++ b/tests/serving/openai/test_openai_api_basic.py
@@ -152,8 +152,7 @@ class TestSetOpenAIFrontend:
             )
 
     def test_invalid_prefix_raises(self) -> None:
-        """set_openai_frontend(prefix='v1') raises MLRunInvalidArgumentError — must start with /."""  # noqa: E501
-
+        """set_openai_frontend(prefix='v1') raises MLRunInvalidArgumentError — must start with /."""
         fn = make_fn()
         with pytest.raises(
             mlrun.errors.MLRunInvalidArgumentError,

--- a/tests/serving/openai/test_openai_api_basic.py
+++ b/tests/serving/openai/test_openai_api_basic.py
@@ -133,3 +133,17 @@ class TestSetOpenAIFrontend:
         ResponsesEndpoints.endpoints()
         ChatCompletionsEndpoints.endpoints()
         assert ResponsesEndpoints._ep_cache is not ChatCompletionsEndpoints._ep_cache
+
+    def test_prefix_prepended_to_all_paths(self) -> None:
+        """set_openai_frontend(prefix='/v1') registers paths under /v1/ and not without it."""
+        fn = make_fn()
+        fn.set_openai_frontend([OpenAIEndpoint.CHAT_COMPLETIONS], prefix="/v1")
+
+        config = get_config(fn)
+        for ep in ENDPOINT_CLASSES[OpenAIEndpoint.CHAT_COMPLETIONS].endpoints():
+            assert (
+                config.get_endpoint_config(ep.http_method, f"/v1{ep.path}") is not None
+            ), f"Expected {ep.http_method} /v1{ep.path} to be registered"
+            assert config.get_endpoint_config(ep.http_method, ep.path) is None, (
+                f"Expected {ep.http_method} {ep.path} (without prefix) to NOT be registered"
+            )

--- a/tests/serving/openai/test_openai_api_basic.py
+++ b/tests/serving/openai/test_openai_api_basic.py
@@ -16,6 +16,9 @@
 
 from http import HTTPMethod
 
+import pytest
+
+import mlrun.errors
 from mlrun.serving.endpoint_mapping import APIHandlerConfig
 from mlrun.serving.openai_mappings import (
     ENDPOINT_CLASSES,
@@ -147,3 +150,13 @@ class TestSetOpenAIFrontend:
             assert config.get_endpoint_config(ep.http_method, ep.path) is None, (
                 f"Expected {ep.http_method} {ep.path} (without prefix) to NOT be registered"
             )
+
+    def test_invalid_prefix_raises(self) -> None:
+        """set_openai_frontend(prefix='v1') raises MLRunInvalidArgumentError — must start with /."""  # noqa: E501
+
+        fn = make_fn()
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="OpenAI API prefix must start with '/'",
+        ):
+            fn.set_openai_frontend(prefix="v1")


### PR DESCRIPTION
### 📝 Description
`set_openai_frontend()` registers endpoints at root level (e.g. `/chat/completions`). Some clients prefer to send requests with a path prefix (e.g. base_url="http://my-function.com" → sends to `/v1/chat/completions`).

This PR adds an optional prefix parameter so users can register all endpoints under a custom path prefix when needed (prefix="/v1" registers `/v1/chat/completions `instead of `/chat/completions`).

---

### 🛠️ Changes Made
- `mlrun/runtimes/nuclio/serving.py` - added prefix: str | None = None to `set_openai_frontend()`; when set, prepends prefix to every registered endpoint path.
- t`ests/serving/openai/test_openai_api_basic.py ` - added `test_prefix_prepended_to_all_paths` verifying prefixed paths are registered and original paths are not.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Unit test in `test_openai_api_basic.py` verifies prefix is prepended to all paths and original unprefixed paths are not registered.

---

### 🔗 References
- Ticket link: [ML-12631](https://ecliptos.atlassian.net/browse/ML-12631)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
