### PR TITLE
[Model Monitoring] Fix monitoring_mode ignored in create_user_model_endpoint

### DIFF
--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -298,6 +298,10 @@ class ModelEndpointInstruction(BaseModel):
             * **archive**:
             1. If model endpoints with the same name exist, preserve them.
             2. Create a new model endpoint with the same name and set it to `latest`.
+    :param monitoring_mode: Monitoring mode written to the created endpoint's
+        ``status.monitoring_mode``. One of
+        :class:`~mlrun.common.schemas.model_monitoring.constants.ModelMonitoringMode`
+        (``enabled`` or ``disabled``). Defaults to ``enabled``.
     """
 
     name: constr(regex=MODEL_ENDPOINT_ID_PATTERN)
@@ -308,6 +312,7 @@ class ModelEndpointInstruction(BaseModel):
     creation_strategy: ModelEndpointCreationStrategy = (
         ModelEndpointCreationStrategy.INPLACE
     )
+    monitoring_mode: ModelMonitoringMode = ModelMonitoringMode.enabled
 
     def to_dict(self) -> dict:
         """Serialize to a plain dictionary (enum values are converted to their primitives)."""

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -4310,6 +4310,7 @@ class MlrunProject(ModelObj):
         function_name: str | None = None,
         function_tag: str | None = None,
         creation_strategy: mm_constants.ModelEndpointCreationStrategy | None = None,
+        monitoring_mode: mm_constants.ModelMonitoringMode | None = None,
         model_endpoint_instruction: ModelEndpointInstruction | None = None,
         **kwargs,
     ) -> tuple[str, str]:
@@ -4335,6 +4336,11 @@ class MlrunProject(ModelObj):
             * **archive**:
             1. If model endpoints with the same name exist, preserve them.
             2. Create a new model endpoint with the same name and set it to `latest`.
+        :param monitoring_mode:    Monitoring mode written to the endpoint ``status.monitoring_mode``.
+            Accepts a :class:`~mlrun.common.schemas.model_monitoring.constants.ModelMonitoringMode`
+            (``enabled`` or ``disabled``). Defaults to ``enabled`` when neither this param
+            nor ``model_endpoint_instruction.monitoring_mode`` is provided. Mutually exclusive
+            with ``model_endpoint_instruction``.
         :param model_endpoint_instruction: Optional instruction for the model endpoint, which can be used to provide
             data as above.
         :param kwargs:             Advanced: additional ``ModelEndpointSpec`` or ``ModelEndpointMetadata``
@@ -4350,6 +4356,7 @@ class MlrunProject(ModelObj):
                     function_name,
                     function_tag,
                     creation_strategy,
+                    monitoring_mode,
                 ]
             ):
                 raise mlrun.errors.MLRunInvalidArgumentError(
@@ -4366,6 +4373,8 @@ class MlrunProject(ModelObj):
                 output_schema=output_schema,
                 creation_strategy=creation_strategy
                 or mm_constants.ModelEndpointCreationStrategy.INPLACE,
+                monitoring_mode=monitoring_mode
+                or mm_constants.ModelMonitoringMode.enabled,
             )
 
         metadata_fields, spec_fields = self._split_endpoint_kwargs(kwargs)
@@ -4391,7 +4400,9 @@ class MlrunProject(ModelObj):
                 **metadata_fields,
             ),
             spec=mlrun.common.schemas.ModelEndpointSpec(**spec_fields),
-            status=mlrun.common.schemas.ModelEndpointStatus(),
+            status=mlrun.common.schemas.ModelEndpointStatus(
+                monitoring_mode=model_endpoint_instruction.monitoring_mode,
+            ),
         )
         db = mlrun.db.get_run_db(secrets=self._secrets)
         endpoint = db.create_model_endpoint(

--- a/tests/model_monitoring/test_schemas.py
+++ b/tests/model_monitoring/test_schemas.py
@@ -180,6 +180,7 @@ class TestModelEndpointInstruction:
         d = instr.to_dict()
         assert d["name"] == "my-endpoint"
         assert d["creation_strategy"] == "inplace"
+        assert d["monitoring_mode"] == "enabled"
         assert d["input_schema"] is None
         assert d["output_schema"] is None
         assert d["function_name"] is None
@@ -188,6 +189,7 @@ class TestModelEndpointInstruction:
     def test_to_dict_all_fields(self):
         from mlrun.common.schemas.model_monitoring.constants import (
             ModelEndpointCreationStrategy,
+            ModelMonitoringMode,
         )
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
@@ -200,6 +202,7 @@ class TestModelEndpointInstruction:
             function_name="my-fn",
             function_tag="v1",
             creation_strategy=ModelEndpointCreationStrategy.ARCHIVE,
+            monitoring_mode=ModelMonitoringMode.disabled,
         )
         d = instr.to_dict()
         assert d == {
@@ -209,11 +212,13 @@ class TestModelEndpointInstruction:
             "function_name": "my-fn",
             "function_tag": "v1",
             "creation_strategy": "archive",
+            "monitoring_mode": "disabled",
         }
 
     def test_from_dict_round_trip(self):
         from mlrun.common.schemas.model_monitoring.constants import (
             ModelEndpointCreationStrategy,
+            ModelMonitoringMode,
         )
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
@@ -226,13 +231,16 @@ class TestModelEndpointInstruction:
             function_name="fn",
             function_tag="latest",
             creation_strategy=ModelEndpointCreationStrategy.OVERWRITE,
+            monitoring_mode=ModelMonitoringMode.disabled,
         )
         restored = ModelEndpointInstruction.from_dict(original.to_dict())
         assert restored == original
+        assert restored.monitoring_mode == ModelMonitoringMode.disabled
 
     def test_from_dict_defaults(self):
         from mlrun.common.schemas.model_monitoring.constants import (
             ModelEndpointCreationStrategy,
+            ModelMonitoringMode,
         )
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
@@ -241,6 +249,7 @@ class TestModelEndpointInstruction:
         restored = ModelEndpointInstruction.from_dict({"name": "only-name"})
         assert restored.name == "only-name"
         assert restored.creation_strategy == ModelEndpointCreationStrategy.INPLACE
+        assert restored.monitoring_mode == ModelMonitoringMode.enabled
         assert restored.input_schema is None
 
     def test_spec_fields_excludes_none(self):

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -3997,9 +3997,7 @@ def test_create_user_model_endpoint_monitoring_mode_default(mock_create, context
     project.create_user_model_endpoint("ep1")
 
     endpoint_arg = mock_create.call_args[1]["model_endpoint"]
-    assert (
-        endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.enabled
-    )
+    assert endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.enabled
 
 
 @unittest.mock.patch.object(mlrun.db.nopdb.NopDB, "create_model_endpoint")
@@ -4014,9 +4012,7 @@ def test_create_user_model_endpoint_monitoring_mode_from_param(mock_create, cont
     )
 
     endpoint_arg = mock_create.call_args[1]["model_endpoint"]
-    assert (
-        endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.disabled
-    )
+    assert endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.disabled
 
 
 @unittest.mock.patch.object(mlrun.db.nopdb.NopDB, "create_model_endpoint")
@@ -4038,9 +4034,7 @@ def test_create_user_model_endpoint_monitoring_mode_from_instruction(
     project.create_user_model_endpoint(model_endpoint_instruction=instruction)
 
     endpoint_arg = mock_create.call_args[1]["model_endpoint"]
-    assert (
-        endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.disabled
-    )
+    assert endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.disabled
 
 
 def test_create_user_model_endpoint_monitoring_mode_with_instruction_conflicts(

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -3989,6 +3989,79 @@ def test_create_user_model_endpoint_instruction_and_params_conflict(
 
 
 @unittest.mock.patch.object(mlrun.db.nopdb.NopDB, "create_model_endpoint")
+def test_create_user_model_endpoint_monitoring_mode_default(mock_create, context):
+    """Without a monitoring_mode arg, status.monitoring_mode defaults to enabled."""
+    mock_create.return_value = _make_endpoint_response("ep1")
+    project = mlrun.new_project("project-name", context=str(context), save=False)
+
+    project.create_user_model_endpoint("ep1")
+
+    endpoint_arg = mock_create.call_args[1]["model_endpoint"]
+    assert (
+        endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.enabled
+    )
+
+
+@unittest.mock.patch.object(mlrun.db.nopdb.NopDB, "create_model_endpoint")
+def test_create_user_model_endpoint_monitoring_mode_from_param(mock_create, context):
+    """An explicit monitoring_mode param is written to status.monitoring_mode."""
+    mock_create.return_value = _make_endpoint_response("ep1")
+    project = mlrun.new_project("project-name", context=str(context), save=False)
+
+    project.create_user_model_endpoint(
+        "ep1",
+        monitoring_mode=mm_consts.ModelMonitoringMode.disabled,
+    )
+
+    endpoint_arg = mock_create.call_args[1]["model_endpoint"]
+    assert (
+        endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.disabled
+    )
+
+
+@unittest.mock.patch.object(mlrun.db.nopdb.NopDB, "create_model_endpoint")
+def test_create_user_model_endpoint_monitoring_mode_from_instruction(
+    mock_create, context
+):
+    """monitoring_mode on the instruction is written to status.monitoring_mode."""
+    from mlrun.common.schemas.model_monitoring.model_endpoints import (
+        ModelEndpointInstruction,
+    )
+
+    mock_create.return_value = _make_endpoint_response("ep1")
+    project = mlrun.new_project("project-name", context=str(context), save=False)
+    instruction = ModelEndpointInstruction(
+        name="ep1",
+        monitoring_mode=mm_consts.ModelMonitoringMode.disabled,
+    )
+
+    project.create_user_model_endpoint(model_endpoint_instruction=instruction)
+
+    endpoint_arg = mock_create.call_args[1]["model_endpoint"]
+    assert (
+        endpoint_arg.status.monitoring_mode == mm_consts.ModelMonitoringMode.disabled
+    )
+
+
+def test_create_user_model_endpoint_monitoring_mode_with_instruction_conflicts(
+    context,
+):
+    """Passing monitoring_mode together with an instruction raises."""
+    from mlrun.common.schemas.model_monitoring.model_endpoints import (
+        ModelEndpointInstruction,
+    )
+
+    project = mlrun.new_project("project-name", context=str(context), save=False)
+    instruction = ModelEndpointInstruction(name="ep1")
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        project.create_user_model_endpoint(
+            model_endpoint_instruction=instruction,
+            monitoring_mode=mm_consts.ModelMonitoringMode.disabled,
+        )
+
+
+@unittest.mock.patch.object(mlrun.db.nopdb.NopDB, "create_model_endpoint")
 def test_create_user_model_endpoint_creation_strategy_forwarded(mock_create, context):
     """The creation_strategy kwarg is forwarded to the DB call."""
     mock_create.return_value = _make_endpoint_response("ep1")

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -2901,8 +2901,8 @@ class TestHTTPIngest(TestMLRunSystemModelMonitoring):
             df = tsdb.get_results_metadata(endpoint_id=endpoint_id)
             assert not df.empty, "No application results in TSDB yet"
             assert (df.endpoint_id == endpoint_id).all()
-            assert DemoMonitoringApp.NAME in df.application_name.values, (
-                f"Expected app {DemoMonitoringApp.NAME!r} not found in TSDB results"
+            assert NoCheckDemoMonitoringApp.NAME in df.application_name.values, (
+                f"Expected app {NoCheckDemoMonitoringApp.NAME!r} not found in TSDB results"
             )
 
         self.wait_for_condition(
@@ -3033,4 +3033,232 @@ class TestHTTPIngest(TestMLRunSystemModelMonitoring):
             f"requests but single request took {single_elapsed:.2f}s — expected batch "
             f"< {single_elapsed * 2:.2f}s. "
             "This suggests the pod is serialising requests instead of processing them concurrently."
+        )
+
+
+@TestMLRunSystem.skip_test_if_env_not_configured
+class TestUserEndpointHTTPIngest(TestMLRunSystemModelMonitoring):
+    """End-to-end HTTP ingest via the explicit ``create_user_model_endpoint`` +
+    ``get_model_monitoring_url`` flow (ML-12045).
+
+    Unlike :class:`TestHTTPIngest`, this test does NOT call
+    ``fn.setup_model_monitoring()`` — which auto-creates endpoints and injects
+    env vars on the function.  Instead it exercises the lower-level flow a user
+    would follow when they already have a Nuclio function and just want to
+    register a USER_EP and push events to the stream pod:
+
+    1. ``project.create_user_model_endpoint(...)`` → returns ``(name, uid)``.
+    2. ``project.get_model_monitoring_url()`` → internal stream pod HTTP URL.
+    3. Deploy a Nuclio remote function and wire the URL + endpoint UID into
+       it manually via ``fn.set_env(...)``.
+    4. Invoke; the handler POSTs prediction events to the stream pod.
+    5. Verify TSDB receives the events and the endpoint's ``last_request``
+       is updated.
+    """
+
+    project_name = "test-mm-user-ep-http-ingest"
+    image: str | None = None
+
+    app_interval: int = 1  # minutes
+    num_events: int = 20
+    feature_names = ["age", "income", "credit_score", "balance"]
+    label_names = ["approved"]
+    model_endpoint_name = "user-ep-http-ingest"
+
+    @classmethod
+    def setup_class(cls) -> None:
+        super().setup_class()
+        cls.app_interval_seconds = timedelta(minutes=cls.app_interval).total_seconds()
+        cls.run_db = mlrun.get_run_db()
+        cls._external_stream_delay = 0
+        if isinstance(
+            cls.mm_stream_profile, DatastoreProfileKafkaStream
+        ) and cls.mm_stream_profile.attributes()["brokers"][0].endswith(
+            ".confluent.cloud:9092"
+        ):
+            cls._external_stream_delay = 90
+
+        project = mlrun.get_or_create_project(
+            cls.project_name, "./", allow_cross_project=True
+        )
+        project.register_datastore_profile(cls.mm_tsdb_profile)
+        project.register_datastore_profile(cls.mm_stream_profile)
+        project.set_model_monitoring_credentials(
+            tsdb_profile_name=cls.mm_tsdb_profile.name,
+            stream_profile_name=cls.mm_stream_profile.name,
+        )
+        try:
+            project.enable_model_monitoring(
+                base_period=cls.app_interval,
+                deploy_histogram_data_drift_app=False,
+                wait_for_deployment=True,
+                **({} if cls.image is None else {"image": cls.image}),
+            )
+        except mlrun.errors.MLRunConflictError:
+            # Monitoring already deployed from a previous run — reuse it.
+            pass
+
+    @classmethod
+    def custom_teardown_class(cls) -> None:
+        if not cls._should_clean_resources():
+            return
+        try:
+            cls._run_db.delete_project(
+                cls.project_name,
+                deletion_strategy=mlrun.common.schemas.DeletionStrategy.cascading,
+            )
+        except Exception:
+            pass
+
+    def _check_tsdb_has_data(self, endpoint_id: str) -> None:
+        tsdb = mlrun.model_monitoring.get_tsdb_connector(
+            project=self.project_name, profile=self.mm_tsdb_profile
+        )
+        lr = tsdb.get_last_request(endpoint_ids=endpoint_id)
+        assert lr and endpoint_id in lr, "TSDB last_request not yet written"
+
+        pred = tsdb.read_predictions(
+            endpoint_id=endpoint_id,
+            start=datetime.now(UTC) - timedelta(hours=1),
+            end=datetime.now(UTC),
+        )
+        assert not isinstance(
+            pred,
+            mlrun.common.schemas.model_monitoring.ModelEndpointMonitoringMetricNoData,
+        ), "No predictions in TSDB predictions table yet"
+
+    def _deploy_monitoring_app(self) -> None:
+        """Deploy the no-check demo monitoring application for this project."""
+        app_fn = self.project.set_model_monitoring_function(
+            func=str(Path(__file__).parent / "assets" / "application.py"),
+            application_class=NoCheckDemoMonitoringApp.__name__,
+            name=NoCheckDemoMonitoringApp.NAME,
+            image=self.image or mlrun.mlconf.function_defaults.image_by_kind.job,
+        )
+        self.project.deploy_function(app_fn)
+
+    def _deploy_ingest_fn(
+        self, monitoring_url: str, endpoint_id: str, endpoint_name: str
+    ) -> mlrun.runtimes.RemoteRuntime:
+        """Deploy the Nuclio HTTP-ingest function with env vars wired manually."""
+        fn = mlrun.new_function(
+            name="user-ep-ingest-fn",
+            project=self.project_name,
+            kind="remote",
+        )
+        fn.with_code(
+            from_file=str(Path(__file__).parent / "assets" / "http_ingest_handler.py")
+        )
+        fn.set_env(
+            mm_constants.NuclioMonitoringEnvVars.MODEL_MONITORING_URL,
+            monitoring_url,
+        )
+        fn.set_env(
+            mm_constants.NuclioMonitoringEnvVars.MODEL_ENDPOINT_UID,
+            endpoint_id,
+        )
+        fn.set_env(
+            mm_constants.NuclioMonitoringEnvVars.MODEL_ENDPOINT_NAME,
+            endpoint_name,
+        )
+        if self.image is not None:
+            fn.spec.image = self.image
+        fn.deploy()
+        return fn
+
+    def test_user_endpoint_http_ingest_flow(self) -> None:
+        """End-to-end: create_user_model_endpoint + get_model_monitoring_url →
+        manual env-var wiring on a remote fn → HTTP ingest → TSDB predictions
+        AND monitoring-application results.
+        """
+        # 1. Register a USER_EP via the explicit project-level API.
+        name, endpoint_id = self.project.create_user_model_endpoint(
+            name=self.model_endpoint_name,
+            input_schema=self.feature_names,
+            output_schema=self.label_names,
+            creation_strategy=mm_constants.ModelEndpointCreationStrategy.OVERWRITE,
+        )
+        assert name == self.model_endpoint_name
+        assert endpoint_id, "Expected a non-empty endpoint UID"
+        self._logger.info(
+            "USER_EP created via create_user_model_endpoint",
+            name=name,
+            endpoint_id=endpoint_id,
+        )
+
+        # 2. Fetch the stream pod HTTP URL via the project API.
+        monitoring_url = self.project.get_model_monitoring_url()
+        assert monitoring_url, (
+            "project.get_model_monitoring_url() returned no URL — "
+            "enable_model_monitoring should have provisioned the HTTP trigger"
+        )
+        assert monitoring_url.startswith("http"), (
+            f"Expected an http(s):// URL, got {monitoring_url!r}"
+        )
+        self._logger.info("Fetched monitoring URL", url=monitoring_url)
+
+        # 3. Deploy the ingest fn and the monitoring app in parallel.
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            fn_future = executor.submit(
+                self._deploy_ingest_fn, monitoring_url, endpoint_id, name
+            )
+            app_future = executor.submit(self._deploy_monitoring_app)
+        fn = fn_future.result()
+        app_future.result()
+
+        time.sleep(5)
+
+        # 4. Invoke the function; the handler POSTs num_events to the stream pod.
+        result = fn.invoke(
+            path="/",
+            body=json.dumps({"num_events": self.num_events}),
+        )
+        assert result.get("pushed") == self.num_events, (
+            f"Expected {self.num_events} accepted events (HTTP 202) "
+            f"but stream pod accepted {result.get('pushed')}"
+        )
+
+        # 5. Wait for TSDB to receive the prediction events.
+        predictions_initial_wait = (
+            mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs
+            + mlrun.mlconf.model_endpoint_monitoring.writer_graph.flush_after_seconds
+            + self._external_stream_delay
+        )
+        self.wait_for_condition(
+            condition_check=lambda: self._check_tsdb_has_data(endpoint_id),
+            initial_wait=predictions_initial_wait,
+            condition_description="TSDB to receive HTTP-ingested events",
+        )
+
+        # 6. Verify the endpoint's last_request was updated.
+        mep = self.run_db.get_model_endpoint(
+            name=self.model_endpoint_name,
+            project=self.project_name,
+            endpoint_id=endpoint_id,
+            tsdb_metrics=True,
+        )
+        assert mep.status.last_request is not None, (
+            "Model endpoint last_request not updated after HTTP ingest"
+        )
+
+        # 7. Wait for the monitoring application to write results to the TSDB.
+        tsdb = mlrun.model_monitoring.get_tsdb_connector(
+            project=self.project_name, profile=self.mm_tsdb_profile
+        )
+        app_results_initial_wait = (
+            2 * self.app_interval_seconds + predictions_initial_wait
+        )
+
+        def check_app_results() -> None:
+            df = tsdb.get_results_metadata(endpoint_id=endpoint_id)
+            assert not df.empty, "No application results in TSDB yet"
+            assert (df.endpoint_id == endpoint_id).all()
+            assert NoCheckDemoMonitoringApp.NAME in df.application_name.values, (
+                f"Expected app {NoCheckDemoMonitoringApp.NAME!r} not found in TSDB results"
+            )
+
+        self.wait_for_condition(
+            condition_check=check_app_results,
+            initial_wait=app_results_initial_wait,
+            condition_description="monitoring app to write results for HTTP-ingested events",
         )


### PR DESCRIPTION
### 🛠 Changes Made
  - **`ModelEndpointInstruction`** (`mlrun/common/schemas/model_monitoring/model_endpoints.py`):
    added a `:param monitoring_mode:` entry to the class docstring
    documenting the new field, allowed values, and `enabled` default.
  - **`MlrunProject.create_user_model_endpoint`** (`mlrun/projects/project.py`):
    - Default of the `monitoring_mode` arg switched to `None` so we can
      distinguish "user passed it" from "default" (matches how
      `creation_strategy` is handled).
    - `monitoring_mode` is now part of the mutual-exclusion check against
      `model_endpoint_instruction` — passing both raises
      `MLRunInvalidArgumentError`.
    - Param is forwarded into the synthesised
      `ModelEndpointInstruction`, falling back to
      `ModelMonitoringMode.enabled` when unset.
    - `ModelEndpointStatus.monitoring_mode` is now populated from the
      instruction instead of being hardcoded to `enabled`.
    - Filled in the empty `:param monitoring_mode:` docstring entry and
      reordered it to match the function signature.

  ---
  
  ### ✅ Checklist
  - [x] I updated the documentation (if applicable)
  - [x] I have tested the changes in this PR
  - [x] I confirmed whether my changes are covered by system tests
    - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
    - [x] I updated existing system tests and/or added new ones if needed to cover my changes
  - [ ] If I introduced a deprecation: N/A
  - [ ] Please run Smoke-tests workflow

  ---
  
  ### 🧪 Testing
  **Unit tests** (`tests/projects/test_project.py`) — 4 new cases plus all 12 prior `create_user_model_endpoint` tests still passing:
  - `test_create_user_model_endpoint_monitoring_mode_default` — no arg → `status.monitoring_mode == enabled`.
  - `test_create_user_model_endpoint_monitoring_mode_from_param` — explicit `monitoring_mode=disabled` flows to status.
  - `test_create_user_model_endpoint_monitoring_mode_from_instruction` — `ModelEndpointInstruction(monitoring_mode=disabled)` flows to status.
  - `test_create_user_model_endpoint_monitoring_mode_with_instruction_conflicts` — passing both raises `MLRunInvalidArgumentError`.

  **System tests** (`tests/system/model_monitoring/test_app.py`):
  - New class `TestUserEndpointHTTPIngest` (one method `test_user_endpoint_http_ingest_flow`) exercising the full explicit user flow:
    1. `project.create_user_model_endpoint(...)` → `(name, uid)`.
    2. `project.get_model_monitoring_url()` → internal stream-pod HTTP URL.
    3. Deploy a Nuclio remote function and wire `MODEL_MONITORING_URL` / `MODEL_ENDPOINT_UID` / `MODEL_ENDPOINT_NAME` via `fn.set_env(...)` (no `setup_model_monitoring` call) — reuses the existing 
  `assets/http_ingest_handler.py`.
    4. Deploy the no-check demo monitoring app in parallel.
    5. Invoke and verify TSDB predictions land + endpoint `last_request` is updated.
    6. Wait for the monitoring app to write results metadata to the TSDB and assert app name appears.
  - Drive-by fix in `TestHTTPIngest.test_http_ingest_with_monitoring_app`: the assertion was looking for `DemoMonitoringApp.NAME` but `_deploy_monitoring_app` deploys `NoCheckDemoMonitoringApp` — corrected 
  both references so the assertion can actually pass.

  ---
  
  ### 🔗 References
  - Ticket link: https://ecliptos.atlassian.net/browse/ML-12663
  ---

  ### 🚨 Breaking Changes?
  - [x] No.
    The behavioural change is from "always enabled" to "honour what the
    caller passed; default to enabled". Callers that omitted
    `monitoring_mode` (the only thing that worked before) keep the
    same behaviour.
