### PR TITLE
[SDK] Fix HTTPSessionWithRetry losing retry attrs on copy/pickle

### DIFF
--- a/mlrun/runtimes/base.py
+++ b/mlrun/runtimes/base.py
@@ -174,6 +174,22 @@ class BaseRuntime(ModelObj):
         self.verbose = False
         self._enriched_image = False
 
+    def __getstate__(self) -> dict:
+        """Exclude the live run-DB connection from copy/pickle.
+
+        ``_db_conn`` holds an ``HTTPRunDB`` with a live ``requests`` session and
+        socket pool. Cloning a runtime - e.g. ``enrich_function_object`` deep-copies
+        project functions during pipeline compilation - must not clone the
+        connection; ``_get_db`` reconnects lazily (to the cached run-DB) on the
+        copy. This avoids both cloning sockets and propagating a half-initialized
+        session (see ML-12648).
+
+        :return: The instance state to pickle/copy, with ``_db_conn`` cleared.
+        """
+        state = self.__dict__.copy()
+        state["_db_conn"] = None
+        return state
+
     def set_db_connection(self, conn):
         if not self._db_conn:
             self._db_conn = conn

--- a/mlrun/utils/http.py
+++ b/mlrun/utils/http.py
@@ -130,6 +130,53 @@ class HTTPSessionWithRetry(requests.Session):
             self.mount("http://", self._http_adapter)
             self.mount("https://", self._http_adapter)
 
+    # Attributes set in __init__ that requests.Session.__attrs__ does not cover and
+    # that must survive copy/pickle. Extends the base allowlist rather than replacing
+    # it. _logger is intentionally absent: it is a named child logger, rebuilt in
+    # __setstate__ instead of serialized.
+    _EXTRA_PICKLE_ATTRS = (
+        "max_retries",
+        "retry_backoff_factor",
+        "retry_on_exception",
+        "verbose",
+        "_retry_methods",
+        "_http_adapter",
+    )
+
+    def __getstate__(self) -> dict:
+        """Return picklable state, extending ``requests.Session``'s allowlist.
+
+        ``requests.Session.__getstate__`` only serializes ``__attrs__`` (headers,
+        cookies, adapters, ...), which drops the retry-related attributes this
+        subclass adds in ``__init__``. A copied or pickled session would then raise
+        ``AttributeError`` the moment :meth:`update_retry_methods` reads
+        ``_retry_methods``. We add :attr:`_EXTRA_PICKLE_ATTRS` on top of the base
+        state, copying each only if present - ``_http_adapter`` is set only when
+        ``retry_on_status`` is enabled, and copying by presence (rather than the
+        base ``getattr(..., None)``) keeps it absent otherwise so the
+        ``hasattr`` guard in :meth:`update_retry_methods` stays correct.
+        ``_http_adapter`` is the same object as the mounted ``adapters`` entries;
+        ``requests.adapters.HTTPAdapter`` rebuilds a fresh connection pool on
+        restore, so the copy gets its own pool instead of sharing sockets.
+
+        :return: The instance state to pickle/copy.
+        """
+        state = super().__getstate__()
+        state.update(
+            (attr, self.__dict__[attr])
+            for attr in self._EXTRA_PICKLE_ATTRS
+            if attr in self.__dict__
+        )
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore instance state and rebuild the non-serialized logger.
+
+        :param state: The state produced by :meth:`__getstate__`.
+        """
+        super().__setstate__(state)
+        self._logger = logger.get_child("http-client")
+
     def request(self, method, url, **kwargs):
         retry_count = 0
         kwargs.setdefault("headers", {})

--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import base64
+import copy
 import json
 import os
+import pickle
 import shutil
 import tempfile
 
@@ -493,3 +495,27 @@ class TestAutoMount:
 
         assert runtime.spec.volumes == expected_volumes
         assert runtime.spec.volume_mounts == expected_mounts
+
+
+@pytest.mark.parametrize(
+    "clone",
+    [copy.deepcopy, lambda obj: pickle.loads(pickle.dumps(obj))],
+    ids=["deepcopy", "pickle"],
+)
+def test_runtime_copy_drops_live_db_connection(clone):
+    """A copied/pickled runtime must not carry the live run-DB connection.
+
+    The connection holds an HTTP session/socket pool; cloning it both wastes
+    sockets and (before the session fix) produced a half-initialized session.
+    ``_get_db`` recreates the connection lazily on the copy, so dropping it is
+    safe. Regression guard for the ML-12648 deepcopy path.
+    """
+    runtime = KubejobRuntime()
+    runtime.metadata.name = "copy-fn"
+    runtime._db_conn = "live-connection"  # stand-in for an HTTPRunDB
+
+    restored = clone(runtime)
+
+    assert restored._db_conn is None
+    # The original keeps its connection - only the copy is detached.
+    assert runtime._db_conn == "live-connection"

--- a/tests/utils/test_http.py
+++ b/tests/utils/test_http.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import http.server
 import json
+import pickle
 import socketserver
 import threading
 import time
@@ -23,6 +25,14 @@ from contextlib import nullcontext as does_not_raise
 import pytest
 
 from mlrun.utils.http import HTTPSessionWithRetry
+
+
+def _deepcopy(session: HTTPSessionWithRetry) -> HTTPSessionWithRetry:
+    return copy.deepcopy(session)
+
+
+def _pickle_roundtrip(session: HTTPSessionWithRetry) -> HTTPSessionWithRetry:
+    return pickle.loads(pickle.dumps(session))
 
 
 @pytest.fixture
@@ -125,3 +135,97 @@ def test_http_session_does_not_persist_cookies():
         server.shutdown()
         server.server_close()
         server_thread.join(timeout=1)
+
+
+@pytest.mark.parametrize(
+    "clone",
+    [_deepcopy, _pickle_roundtrip],
+    ids=["deepcopy", "pickle"],
+)
+def test_session_survives_copy(http_session: HTTPSessionWithRetry, clone):
+    """Regression for ML-12648.
+
+    ``requests.Session`` only serializes its ``__attrs__``, so before the fix a
+    ``copy.deepcopy``/``pickle`` of the session dropped the retry attributes set
+    in ``__init__``. Reusing such a session for a POST/PUT then called
+    ``update_retry_methods`` and raised
+    ``AttributeError: ... has no attribute '_retry_methods'``.
+    """
+    restored = clone(http_session)
+
+    # Attributes set in __init__ that requests.Session would otherwise drop.
+    assert restored._retry_methods == http_session._retry_methods
+    assert restored.max_retries == http_session.max_retries
+    assert restored.retry_backoff_factor == http_session.retry_backoff_factor
+    assert restored.retry_on_exception == http_session.retry_on_exception
+    assert restored.verbose == http_session.verbose
+    # _logger is excluded from the serialized state and rebuilt on restore.
+    assert restored._logger is not None
+
+    # The symptom path: reusing the session for a retriable POST must not raise.
+    restored.update_retry_methods(retry_on_post=True, retry_on_put=True)
+    assert "POST" in restored._retry_methods
+
+
+@pytest.mark.parametrize(
+    "clone",
+    [_deepcopy, _pickle_roundtrip],
+    ids=["deepcopy", "pickle"],
+)
+def test_copied_session_has_independent_connection_pool(
+    http_session: HTTPSessionWithRetry, clone
+):
+    """A copy must not share the original's urllib3 connection pool.
+
+    Sharing would regress the socket-leak fix (#9515) that motivated reusing a
+    single session - clones would keep the original's sockets alive.
+    """
+    restored = clone(http_session)
+
+    # Both schemes stay mounted on one adapter and _http_adapter points at it -
+    # update_retry_methods relies on this identity to reconfigure retries.
+    assert restored.adapters["http://"] is restored.adapters["https://"]
+    assert restored._http_adapter is restored.adapters["https://"]
+    # ...but the pool itself is a fresh object, not shared with the original.
+    assert (
+        restored._http_adapter.poolmanager is not http_session._http_adapter.poolmanager
+    )
+
+
+def test_update_retry_methods_after_copy_reconfigures_adapter(
+    http_session: HTTPSessionWithRetry,
+):
+    """After a copy, changing the retry policy must reconfigure the mounted
+    adapter's ``Retry``, not only the internal ``_retry_methods`` frozenset."""
+    restored = copy.deepcopy(http_session)
+
+    # Default session retries PUT but not POST; drop both to force a change.
+    restored.update_retry_methods(retry_on_post=False, retry_on_put=False)
+
+    allowed_methods = restored._http_adapter.max_retries.allowed_methods
+    assert "POST" not in allowed_methods
+    assert "PUT" not in allowed_methods
+    assert restored._retry_methods == allowed_methods
+
+
+@pytest.mark.parametrize(
+    "clone",
+    [_deepcopy, _pickle_roundtrip],
+    ids=["deepcopy", "pickle"],
+)
+def test_copy_without_status_retry_keeps_http_adapter_absent(clone):
+    """``_http_adapter`` is only set when ``retry_on_status`` is enabled.
+
+    A copy must preserve its *absence* - otherwise the ``hasattr`` guard in
+    ``update_retry_methods`` would treat a restored ``None`` as a real adapter
+    and raise. This is the path used by serving with retries disabled.
+    """
+    session = HTTPSessionWithRetry(retry_on_status=False)
+    assert "_http_adapter" not in session.__dict__
+
+    restored = clone(session)
+
+    assert not hasattr(restored, "_http_adapter")
+    # Must not raise even though there is no adapter to reconfigure.
+    restored.update_retry_methods(retry_on_post=True, retry_on_put=True)
+    assert "POST" in restored._retry_methods


### PR DESCRIPTION
### 📝 Description

KFP pipeline runs (`project.run(...)`) crashed during compilation with
`AttributeError: 'HTTPSessionWithRetry' object has no attribute '_retry_methods'`.

`HTTPSessionWithRetry` subclasses `requests.Session`, whose `__getstate__`
serializes only the attributes in its `__attrs__` allowlist. A `copy.deepcopy`
of the session therefore rebuilt the clone **without `__init__`**, silently
dropping the attributes set there (`_retry_methods`, `max_retries`,
`retry_backoff_factor`, `retry_on_exception`, `verbose`, `_logger`,
`_http_adapter`).

The concrete trigger: during pipeline compilation `create_pipeline` iterates
`FunctionsDict.values()`, which calls `enrich_function_object(copy_function=True)`
→ `function.copy()` (= `deepcopy`). Runtimes cache the run-DB connection in
`BaseRuntime._db_conn`, so the deepcopy recursed into the `HTTPRunDB` and its
session. The flaw was latent until #9515 (HTTPDB socket-leak fix) switched
POST/PUT from "new session per request" to reusing `self.session` and calling
`update_retry_methods()` — the first code to *read* `_retry_methods` off a
possibly-copied session.

### 🛠️ Changes Made
- `mlrun/utils/http.py` (primary fix): extend `requests.Session`'s pickle
  allowlist instead of replacing it. `_EXTRA_PICKLE_ATTRS` lists the retry
  attributes; `__getstate__` adds them on top of the base state, copying each
  **only if present** so the conditionally-set `_http_adapter` (only created when
  `retry_on_status` is enabled, e.g. serving with retries disabled) stays absent
  and the `hasattr` guard in `update_retry_methods` keeps working. `__setstate__`
  rebuilds the non-serialized `_logger`. The mounted `HTTPAdapter` rebuilds a
  fresh connection pool on restore, so the #9515 socket-leak fix is preserved.
  This repairs the fragile leaf object, so every holder of a session (runtimes,
  feature sets, future code, and the cross-process pickle case) is covered.
- `mlrun/runtimes/base.py` (defense-in-depth): `BaseRuntime.__getstate__` drops
  the live `_db_conn` on copy/pickle so a cloned runtime reconnects lazily via
  `_get_db()` instead of cloning a connection's session and sockets.
- Tests: `tests/utils/test_http.py` (deepcopy + pickle round-trips, including the
  `retry_on_status=False` path) and `tests/runtimes/test_base.py` (runtime copy
  drops `_db_conn`).

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

### 🧪 Testing
- `tests/utils/test_http.py`: deepcopy + pickle round-trips assert retry attrs
  preserved, `update_retry_methods()` no longer raises (the ML-12648 symptom),
  copy gets an independent connection pool, post-copy policy change reconfigures
  the adapter's `Retry`, and a `retry_on_status=False` session keeps
  `_http_adapter` absent. 13 passed.
- `tests/runtimes/test_base.py`: runtime deepcopy/pickle drops `_db_conn` while
  the original keeps it. Full file: 36 passed.
- No system test covers this path; it is SDK-level object serialization, fully
  exercised by the new unit tests. Heavy dockerized/system suites not run locally.

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12648
- Design docs links:
- External links: exposed by #9515 (HTTPDB http client socket leak fix)

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

### 🔍️ Additional Notes
- Additive fix to internal SDK serialization behaviour; no API/schema/CLI change.
- `GraphServer._db_conn` (vestigial) and `FeatureSet._run_db` (no in-repo
  populator) are the same shape but don't carry a live session in practice, so
  they're intentionally left untouched; the `http.py` fix would cover them anyway.
- Related downstream regression test: REG-2370 (demos `batch_inference.ipynb`).