### PR TITLE
[Runtimes] Fix mpijob results not populated after completion

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -132,6 +132,13 @@ default_config = {
             # k8s resource by default the interval will be - (monitoring.runs.interval * 2 ), if set will override the
             # default
             "missing_runtime_resources_debouncing_interval": None,
+            # Grace period, in seconds, for which monitoring will defer marking a run "completed" after its runtime
+            # resource reports completion while the run still has no results. Used by self-reporting distributed
+            # runtimes (e.g. mpijob) where the CRD completion (launcher + workers) can be observed before the
+            # logging worker has committed the run's results - deferring avoids returning a completed run with empty
+            # results (ML-12650). Once the grace period elapses the run is marked completed regardless, so a
+            # genuinely result-less run or a dead worker still terminates.
+            "result_settle_grace_seconds": 90,
             # max number of parallel abort run jobs in runs monitoring
             "concurrent_abort_stale_runs_workers": 10,
             "list_runs_time_period_in_days": 7,  # days

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -132,12 +132,10 @@ default_config = {
             # k8s resource by default the interval will be - (monitoring.runs.interval * 2 ), if set will override the
             # default
             "missing_runtime_resources_debouncing_interval": None,
-            # Grace period, in seconds, for which monitoring will defer marking a run "completed" after its runtime
-            # resource reports completion while the run still has no results. Used by self-reporting distributed
-            # runtimes (e.g. mpijob) where the CRD completion (launcher + workers) can be observed before the
-            # logging worker has committed the run's results - deferring avoids returning a completed run with empty
-            # results (ML-12650). Once the grace period elapses the run is marked completed regardless, so a
-            # genuinely result-less run or a dead worker still terminates.
+            # Grace period (seconds) for which monitoring defers marking a run "completed" after its
+            # runtime resource reports completion while the run still has no results - used by
+            # self-reporting runtimes (e.g. mpijob) to avoid completing before results are committed;
+            # past the grace the run completes regardless.
             "result_settle_grace_seconds": 90,
             # max number of parallel abort run jobs in runs monitoring
             "concurrent_abort_stale_runs_workers": 10,

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -202,11 +202,10 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             db, db_session, name, project, run, search_run=search_run, uid=uid
         )
 
-        # The mpijob CRD reports completion for the launcher and all workers, but the run's results
-        # are committed separately by the logging worker (rank 0). Defer the completed transition
-        # while the run still has no results so monitoring does not mark it completed before its
-        # results land (ML-12650). Bounded by a grace period after the CRD completion time so a
-        # genuinely result-less run or a dead worker still terminates.
+        # The mpijob CRD reports completion for the launcher + workers, but the run's results are
+        # committed separately by the logging worker (rank 0). Defer completing the run while it
+        # still has no results so monitoring does not race ahead of them, bounded by a grace period
+        # so a result-less run or a dead worker still terminates (ML-12650).
         if self._should_wait_for_results(run, run_state, runtime_resource):
             logger.debug(
                 "Deferring mpijob completed state until worker results are persisted",
@@ -254,26 +253,12 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
     def _should_wait_for_results(
         run: dict, run_state: str, runtime_resource: dict | None
     ) -> bool:
-        """Whether monitoring should defer marking this mpijob run completed until results land.
-
-        The mpijob CRD's completion is observed independently of the logging worker (rank 0)
-        committing the run's results, so a completed transition driven by monitoring can race
-        ahead of the results (ML-12650). Defer only while the desired state is completed, the run
-        still has no results, and we are within the grace period after the CRD reported completion;
-        once the grace period elapses the run is allowed to complete regardless.
-
-        :param run:              The run record.
-        :param run_state:        The run state monitoring wants to apply.
-        :param runtime_resource: The mpijob CRD object (only monitoring provides it).
-        :return: Whether to defer the completed transition.
-        """
         run_states = mlrun.common.runtimes.constants.RunStates
         if run_state != run_states.completed:
             return False
         current_state = run.get("status", {}).get("state")
-        # Only protect a run that monitoring is about to move into completion. If the run already
-        # reached a terminal state (e.g. the logging worker already committed it), or it has no
-        # state yet to defer, there is nothing to wait for.
+        # Nothing to defer if the run already reached a terminal state (e.g. the worker already
+        # committed it) or has no state yet.
         if not current_state or current_state in run_states.terminal_states():
             return False
         if run.get("status", {}).get("results"):

--- a/server/py/services/api/runtime_handlers/mpijob/abstract.py
+++ b/server/py/services/api/runtime_handlers/mpijob/abstract.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
+from datetime import UTC, datetime, timedelta
 
 from kubernetes import client
 from sqlalchemy.orm import Session
 
 import mlrun.common.constants as mlrun_constants
+import mlrun.common.runtimes.constants
 import mlrun.common.schemas
 import mlrun.k8s_utils
 import mlrun.utils.helpers
@@ -196,6 +198,23 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
         search_run: bool = True,
         runtime_resource: dict | None = None,
     ) -> tuple[bool, str, dict]:
+        run = self._ensure_run(
+            db, db_session, name, project, run, search_run=search_run, uid=uid
+        )
+
+        # The mpijob CRD reports completion for the launcher and all workers, but the run's results
+        # are committed separately by the logging worker (rank 0). Defer the completed transition
+        # while the run still has no results so monitoring does not mark it completed before its
+        # results land (ML-12650). Bounded by a grace period after the CRD completion time so a
+        # genuinely result-less run or a dead worker still terminates.
+        if self._should_wait_for_results(run, run_state, runtime_resource):
+            logger.debug(
+                "Deferring mpijob completed state until worker results are persisted",
+                project=project,
+                uid=uid,
+            )
+            return False, run.get("status", {}).get("state"), run
+
         _, run_state, run = super()._ensure_run_state(
             db,
             db_session,
@@ -204,8 +223,8 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
             name,
             run_state,
             run,
-            search_run,
-            runtime_resource,
+            search_run=False,
+            runtime_resource=runtime_resource,
         )
 
         execution = mlrun.execution.MLClientCtx.from_dict(run, store_run=False)
@@ -230,3 +249,41 @@ class AbstractMPIJobRuntimeHandler(KubeRuntimeHandler, abc.ABC):
                 project=project,
             )
         return True, run_state, run
+
+    @staticmethod
+    def _should_wait_for_results(
+        run: dict, run_state: str, runtime_resource: dict | None
+    ) -> bool:
+        """Whether monitoring should defer marking this mpijob run completed until results land.
+
+        The mpijob CRD's completion is observed independently of the logging worker (rank 0)
+        committing the run's results, so a completed transition driven by monitoring can race
+        ahead of the results (ML-12650). Defer only while the desired state is completed, the run
+        still has no results, and we are within the grace period after the CRD reported completion;
+        once the grace period elapses the run is allowed to complete regardless.
+
+        :param run:              The run record.
+        :param run_state:        The run state monitoring wants to apply.
+        :param runtime_resource: The mpijob CRD object (only monitoring provides it).
+        :return: Whether to defer the completed transition.
+        """
+        run_states = mlrun.common.runtimes.constants.RunStates
+        if run_state != run_states.completed:
+            return False
+        current_state = run.get("status", {}).get("state")
+        # Only protect a run that monitoring is about to move into completion. If the run already
+        # reached a terminal state (e.g. the logging worker already committed it), or it has no
+        # state yet to defer, there is nothing to wait for.
+        if not current_state or current_state in run_states.terminal_states():
+            return False
+        if run.get("status", {}).get("results"):
+            return False
+        if not runtime_resource:
+            return False
+        completion_time = runtime_resource.get("status", {}).get("completionTime")
+        if not completion_time:
+            return False
+
+        completion_time = datetime.fromisoformat(completion_time.replace("Z", "+00:00"))
+        grace_seconds = float(mlrun.mlconf.monitoring.runs.result_settle_grace_seconds)
+        return datetime.now(UTC) - completion_time < timedelta(seconds=grace_seconds)

--- a/server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest.mock
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -20,6 +21,7 @@ from fastapi.testclient import TestClient
 from kubernetes import client as k8s_client
 from sqlalchemy.orm import Session
 
+import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 from mlrun.common.runtimes.constants import PodPhases, RunStates
@@ -724,3 +726,104 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
             "replicaStatuses": {"Launcher": {"failed": 1}, "Worker": {}},
             "conditions": [{"reason": "Some reason", "message": "Some message"}],
         }
+
+
+def _crd_with_completion_offset(offset_seconds: float) -> dict:
+    completion_time = datetime.now(UTC) - timedelta(seconds=offset_seconds)
+    return {
+        "status": {"completionTime": completion_time.isoformat().replace("+00:00", "Z")}
+    }
+
+
+# desired_state is what monitoring wants to apply; current_state is the run's state in the DB.
+# In the ML-12650 race the run is still "running" when monitoring resolves "completed" from the CRD.
+@pytest.mark.parametrize(
+    "desired_state,current_state,results,runtime_resource,expected",
+    [
+        # Not a completed transition - never deferred.
+        (
+            RunStates.running,
+            RunStates.running,
+            {},
+            _crd_with_completion_offset(5),
+            False,
+        ),
+        (RunStates.error, RunStates.running, {}, _crd_with_completion_offset(5), False),
+        # Run already terminal (the logging worker already committed it) - nothing to wait for.
+        (
+            RunStates.completed,
+            RunStates.completed,
+            {},
+            _crd_with_completion_offset(5),
+            False,
+        ),
+        # Results already present - proceed.
+        (
+            RunStates.completed,
+            RunStates.running,
+            {"time": 1.0},
+            _crd_with_completion_offset(5),
+            False,
+        ),
+        # No CRD (e.g. pre-deletion path) - proceed.
+        (RunStates.completed, RunStates.running, {}, None, False),
+        # CRD lacks a completion time - proceed.
+        (RunStates.completed, RunStates.running, {}, {"status": {}}, False),
+        # ML-12650: monitoring wants completed, run still running with no results, within grace - defer.
+        (
+            RunStates.completed,
+            RunStates.running,
+            {},
+            _crd_with_completion_offset(5),
+            True,
+        ),
+        # Grace period elapsed - proceed (do not hang).
+        (
+            RunStates.completed,
+            RunStates.running,
+            {},
+            _crd_with_completion_offset(10_000),
+            False,
+        ),
+    ],
+)
+def test_mpijob_should_wait_for_results(
+    monkeypatch, desired_state, current_state, results, runtime_resource, expected
+):
+    monkeypatch.setattr(mlrun.mlconf.monitoring.runs, "result_settle_grace_seconds", 30)
+    handler = get_runtime_handler(RuntimeKinds.mpijob)
+    run = {"status": {"state": current_state, "results": results}}
+
+    assert (
+        handler._should_wait_for_results(run, desired_state, runtime_resource)
+        is expected
+    )
+
+
+def test_mpijob_ensure_run_state_defers_completed_until_results(monkeypatch):
+    # The deferral path itself: monitoring resolves completed while the run is still running with no
+    # results -> _ensure_run_state must not advance the state and must not write to the DB this cycle.
+    monkeypatch.setattr(mlrun.mlconf.monitoring.runs, "result_settle_grace_seconds", 30)
+    handler = get_runtime_handler(RuntimeKinds.mpijob)
+    run = {
+        "metadata": {"project": "proj", "uid": "uid-1", "labels": {}},
+        "status": {"state": RunStates.running, "results": {}},
+    }
+    db = unittest.mock.MagicMock()
+
+    updated, state, returned_run = handler._ensure_run_state(
+        db,
+        None,
+        project="proj",
+        uid="uid-1",
+        name="trainer",
+        run_state=RunStates.completed,
+        run=run,
+        search_run=False,
+        runtime_resource=_crd_with_completion_offset(5),
+    )
+
+    assert updated is False
+    assert state == RunStates.running  # state not advanced to completed
+    assert returned_run is run
+    db.update_run.assert_not_called()  # no DB write while deferring

--- a/server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py
@@ -728,70 +728,40 @@ class TestMPIjobRuntimeHandler(TestRuntimeHandlerBase):
         }
 
 
-def _crd_with_completion_offset(offset_seconds: float) -> dict:
-    completion_time = datetime.now(UTC) - timedelta(seconds=offset_seconds)
-    return {
-        "status": {"completionTime": completion_time.isoformat().replace("+00:00", "Z")}
-    }
-
-
 # desired_state is what monitoring wants to apply; current_state is the run's current DB state.
 @pytest.mark.parametrize(
-    "desired_state,current_state,results,runtime_resource,expected",
+    "desired_state,current_state,results,crd_present,completion_offset_seconds,expected",
     [
         # Not a completed transition - never deferred.
-        (
-            RunStates.running,
-            RunStates.running,
-            {},
-            _crd_with_completion_offset(5),
-            False,
-        ),
-        (RunStates.error, RunStates.running, {}, _crd_with_completion_offset(5), False),
+        (RunStates.running, RunStates.running, {}, True, 5, False),
+        (RunStates.error, RunStates.running, {}, True, 5, False),
         # Run already terminal (the logging worker already committed it) - nothing to wait for.
-        (
-            RunStates.completed,
-            RunStates.completed,
-            {},
-            _crd_with_completion_offset(5),
-            False,
-        ),
+        (RunStates.completed, RunStates.completed, {}, True, 5, False),
         # Results already present - proceed.
-        (
-            RunStates.completed,
-            RunStates.running,
-            {"time": 1.0},
-            _crd_with_completion_offset(5),
-            False,
-        ),
+        (RunStates.completed, RunStates.running, {"time": 1.0}, True, 5, False),
         # No CRD (e.g. pre-deletion path) - proceed.
-        (RunStates.completed, RunStates.running, {}, None, False),
+        (RunStates.completed, RunStates.running, {}, False, None, False),
         # CRD lacks a completion time - proceed.
-        (RunStates.completed, RunStates.running, {}, {"status": {}}, False),
+        (RunStates.completed, RunStates.running, {}, True, None, False),
         # Monitoring wants completed, run still running with no results, within grace - defer (the race).
-        (
-            RunStates.completed,
-            RunStates.running,
-            {},
-            _crd_with_completion_offset(5),
-            True,
-        ),
+        (RunStates.completed, RunStates.running, {}, True, 5, True),
         # Grace period elapsed - proceed (do not hang).
-        (
-            RunStates.completed,
-            RunStates.running,
-            {},
-            _crd_with_completion_offset(10_000),
-            False,
-        ),
+        (RunStates.completed, RunStates.running, {}, True, 10_000, False),
     ],
 )
 def test_mpijob_should_wait_for_results(
-    monkeypatch, desired_state, current_state, results, runtime_resource, expected
+    monkeypatch,
+    desired_state,
+    current_state,
+    results,
+    crd_present,
+    completion_offset_seconds,
+    expected,
 ):
     monkeypatch.setattr(mlrun.mlconf.monitoring.runs, "result_settle_grace_seconds", 30)
     handler = get_runtime_handler(RuntimeKinds.mpijob)
     run = {"status": {"state": current_state, "results": results}}
+    runtime_resource = _mpijob_crd(crd_present, completion_offset_seconds)
 
     assert (
         handler._should_wait_for_results(run, desired_state, runtime_resource)
@@ -818,10 +788,24 @@ def test_mpijob_ensure_run_state_defers_completed_until_results(monkeypatch):
         run_state=RunStates.completed,
         run=run,
         search_run=False,
-        runtime_resource=_crd_with_completion_offset(5),
+        runtime_resource=_mpijob_crd(crd_present=True, completion_offset_seconds=5),
     )
 
     assert updated is False
     assert state == RunStates.running  # state not advanced to completed
     assert returned_run is run
     db.update_run.assert_not_called()  # no DB write while deferring
+
+
+def _mpijob_crd(
+    crd_present: bool, completion_offset_seconds: float | None
+) -> dict | None:
+    if not crd_present:
+        return None
+    status = {}
+    if completion_offset_seconds is not None:
+        completion_time = datetime.now(UTC) - timedelta(
+            seconds=completion_offset_seconds
+        )
+        status["completionTime"] = completion_time.isoformat().replace("+00:00", "Z")
+    return {"status": status}

--- a/server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py
@@ -735,8 +735,7 @@ def _crd_with_completion_offset(offset_seconds: float) -> dict:
     }
 
 
-# desired_state is what monitoring wants to apply; current_state is the run's state in the DB.
-# In the ML-12650 race the run is still "running" when monitoring resolves "completed" from the CRD.
+# desired_state is what monitoring wants to apply; current_state is the run's current DB state.
 @pytest.mark.parametrize(
     "desired_state,current_state,results,runtime_resource,expected",
     [
@@ -769,7 +768,7 @@ def _crd_with_completion_offset(offset_seconds: float) -> dict:
         (RunStates.completed, RunStates.running, {}, None, False),
         # CRD lacks a completion time - proceed.
         (RunStates.completed, RunStates.running, {}, {"status": {}}, False),
-        # ML-12650: monitoring wants completed, run still running with no results, within grace - defer.
+        # Monitoring wants completed, run still running with no results, within grace - defer (the race).
         (
             RunStates.completed,
             RunStates.running,
@@ -801,8 +800,7 @@ def test_mpijob_should_wait_for_results(
 
 
 def test_mpijob_ensure_run_state_defers_completed_until_results(monkeypatch):
-    # The deferral path itself: monitoring resolves completed while the run is still running with no
-    # results -> _ensure_run_state must not advance the state and must not write to the DB this cycle.
+    # While deferring, _ensure_run_state must not advance the state nor write to the DB.
     monkeypatch.setattr(mlrun.mlconf.monitoring.runs, "result_settle_grace_seconds", 30)
     handler = get_runtime_handler(RuntimeKinds.mpijob)
     run = {


### PR DESCRIPTION
### 📝 Description

Reading an mpijob's results immediately after it completes (e.g. `run.status.results['time']`) intermittently raised `KeyError` — the run was `completed` but `status.results` was empty.

The run's terminal `completed` state has two independent writers: the function process (which persists state **and** results together) and the server-side runtime **monitor**, which resolves `completed` from the mpijob CRD's `completionTime` and writes state only — never results. The CRD aggregates the launcher and all workers, but the results are committed separately by the logging worker (rank 0), so the monitor could mark the run `completed` before those results landed. The bad state was then visible to every reader — the watching SDK, the UI, and pipeline steps.

This fixes it where the state is written: the mpijob runtime handler now **defers** the `completed` transition while the run is still non-terminal and has no results, bounded by a grace period after the CRD completion time. Once results are present (or the grace elapses) the run completes as before, so a genuinely result-less run or a dead worker still terminates.

---

### 🛠️ Changes Made

- `server/py/services/api/runtime_handlers/mpijob/abstract.py`: `_ensure_run_state` defers the `completed` transition via a new `_should_wait_for_results` predicate — when monitoring wants `completed` but the run is still non-terminal, has no results, and is within the grace window after the CRD `completionTime`, the cycle is skipped (no state change, no DB write) and retried on the next monitoring pass.
- `mlrun/config.py`: new `monitoring.runs.result_settle_grace_seconds` (default 90); set to 0 to disable the deferral.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

- Added unit tests in `server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py`: a parametrized truth table for `_should_wait_for_results` (non-completed transition, run already terminal, results present, no CRD, CRD without completion time, within-grace → defer, grace elapsed → proceed) and an integration test asserting the deferral path returns `(False, running, run)` without writing to the DB.
- `pytest server/py/services/api/tests/unit/runtime_handlers/test_mpijob.py` → 20 passed (existing + new). Ruff clean.
- **Not run:** the live intermittent race only reproduces against a real MPIJob on a lab. The fix is verified by unit-level simulation of the monitor-resolves-completed-before-results sequence, not an end-to-end horovod run. Covered indirectly by the horovod demo system test (REG-2371).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12650
- Design docs links:
- External links: related regression — REG-2371 (ce demos test-horovod-tensorflow `KeyError: 'time'`)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- **Prioritization flag:** a Jira maintainer comment on ML-12650 (Liran Ben Gida, 2026-05-27) states this is *"CE / IG3 only. decided to drop it due to vulnerabilities and relevancy on IG4."* Surfacing it so reviewers can decline if that decision still stands. The change is deliberately minimal and scoped to the mpijob handler.
- An earlier revision of this PR mitigated the symptom client-side (an SDK wait in `RunObject`); per review it was replaced with this server-side fix so the persisted run state is correct for all readers, not just the Python SDK.
- Blast radius is limited to the mpijob runtime handler; other runtimes' monitoring is unchanged. A result-less mpijob now sits in `running` for at most `result_settle_grace_seconds` before monitoring completes it (the process normally completes it first).
