### PR TITLE
[Builder] Fix kaniko build pods missing workload-identity labels (ML-12670)

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -591,6 +591,11 @@ default_config = {
             "kaniko_image_push_retry": "3",
             # additional docker build args in json encoded base64 format
             "build_args": "",
+            # labels to be applied to builder pods - json string base64 encoded format.
+            # used (for example) to attach the azure.workload.identity/use label so the Azure
+            # workload-identity webhook injects credentials into the builder pod for pushing to ACR.
+            # system-assigned mlrun/* labels take precedence over these.
+            "pod_labels": "e30=",
             "pip_ca_secret_name": "",
             "pip_ca_secret_key": "",
             "pip_ca_path": "/etc/ssl/certs/mlrun/pip-ca-certificates.crt",
@@ -1177,6 +1182,11 @@ class Config:
             "default_function_pod_labels", dict
         )
 
+    def get_builder_pod_labels(self) -> dict:
+        return self.decode_base64_config_and_load_to_object(
+            "httpdb.builder.pod_labels", dict
+        )
+
     def get_preemptible_node_selector(self) -> dict:
         return self.decode_base64_config_and_load_to_object(
             "preemptible_nodes.node_selector", dict
@@ -1632,6 +1642,8 @@ def _validate_config(config):
     # Fail-fast on malformed base64/JSON in default_function_pod_labels so the
     # API pod doesn't start with config that would crash every function deploy.
     config.get_default_function_pod_labels()
+    # Fail-fast on malformed base64/JSON in the builder pod labels for the same reason.
+    config.get_builder_pod_labels()
 
 
 def _verify_gpu_requests_and_limits(

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1306,6 +1306,80 @@ def test_make_kaniko_pod_command_using_build_args(
 
 
 @pytest.mark.parametrize(
+    "builder_pod_labels,expected_present,not_expected",
+    [
+        # no configured labels - pod carries only the internal mlrun/* labels
+        ({}, {}, ["azure.workload.identity/use"]),
+        # workload-identity label is plumbed onto the builder pod
+        (
+            {"azure.workload.identity/use": "true"},
+            {"azure.workload.identity/use": "true"},
+            [],
+        ),
+        # multiple labels are all applied
+        (
+            {"azure.workload.identity/use": "true", "team": "platform"},
+            {"azure.workload.identity/use": "true", "team": "platform"},
+            [],
+        ),
+    ],
+)
+def test_make_kaniko_pod_labels(builder_pod_labels, expected_present, not_expected):
+    mlrun.mlconf.httpdb.builder.pod_labels = base64.b64encode(
+        json.dumps(builder_pod_labels).encode("utf-8")
+    )
+    with unittest.mock.patch(
+        "framework.api.utils.resolve_project_service_account_details",
+        return_value=(None, None, None),
+    ):
+        function = mlrun.new_function("test", kind="job")
+        kpod = services.api.utils.builder.make_kaniko_pod(
+            project="test",
+            context="/context",
+            dest="docker-hub/",
+            dockerfile="./Dockerfile",
+            runtime_spec=function.spec,
+        )
+
+    pod_labels = kpod.pod.metadata.labels
+    for key, value in expected_present.items():
+        assert pod_labels[key] == value
+    for key in not_expected:
+        assert key not in pod_labels
+    # system-assigned mlrun/* labels are always present
+    assert pod_labels[mlrun.common.constants.MLRunInternalLabels.mlrun_class] == "build"
+    assert pod_labels[mlrun.common.constants.MLRunInternalLabels.project] == "test"
+
+
+def test_make_kaniko_pod_labels_internal_labels_take_precedence():
+    # a configured label that collides with a system-assigned mlrun/* label must not override it
+    mlrun.mlconf.httpdb.builder.pod_labels = base64.b64encode(
+        json.dumps(
+            {
+                mlrun.common.constants.MLRunInternalLabels.mlrun_class: "should-be-ignored",
+                "azure.workload.identity/use": "true",
+            }
+        ).encode("utf-8")
+    )
+    with unittest.mock.patch(
+        "framework.api.utils.resolve_project_service_account_details",
+        return_value=(None, None, None),
+    ):
+        function = mlrun.new_function("test", kind="job")
+        kpod = services.api.utils.builder.make_kaniko_pod(
+            project="test",
+            context="/context",
+            dest="docker-hub/",
+            dockerfile="./Dockerfile",
+            runtime_spec=function.spec,
+        )
+
+    pod_labels = kpod.pod.metadata.labels
+    assert pod_labels[mlrun.common.constants.MLRunInternalLabels.mlrun_class] == "build"
+    assert pod_labels["azure.workload.identity/use"] == "true"
+
+
+@pytest.mark.parametrize(
     "extra_args,expected_result",
     [
         ("--arg1 value1", {"--arg1": ["value1"]}),

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -238,6 +238,20 @@ def make_kaniko_pod(
         if gpu_resources:
             resources["limits"] = gpu_resources
 
+    # apply the configured builder pod labels (e.g. the azure.workload.identity/use label that lets the
+    # Azure workload-identity webhook inject ACR push credentials into the builder pod).
+    # these platform-level labels are the lowest-precedence layer: mlrun's own internal labels
+    # (mlrun/class, mlrun/project, etc., set by BasePod and the call site) must never be clobbered by them.
+    configured_pod_labels = {
+        key: value
+        for key, value in config.get_builder_pod_labels().items()
+        if key not in mlrun_constants.MLRunInternalLabels.all()
+    }
+    extra_labels = mlrun.utils.helpers.merge_dicts_with_precedence(
+        configured_pod_labels,
+        extra_labels or {},
+    )
+
     kpod = framework.utils.singletons.k8s.BasePod(
         name or "mlrun-build",
         config.httpdb.builder.kaniko_image,


### PR DESCRIPTION
### 📝 Description
On Azure identity-based installs (Azure Workload Identity, no static ACR credentials), the kaniko build pod had no label path, so the Azure WI admission webhook never injected the federated token / `AZURE_*` env vars and image pushes to ACR failed with `UNAUTHORIZED`. Function pods already inherit the WI activation label via `default_function_pod_labels`, but builder pods had no equivalent knob.

This adds a builder-specific `httpdb.builder.kaniko_pod_labels` config that is applied to the kaniko pod, mirroring the existing function-pod-labels mechanism. The companion mlefi change wires it on identity installs.

---

### 🛠️ Changes Made
- Added `httpdb.builder.kaniko_pod_labels` config (base64-encoded JSON, default `{}`) and `get_builder_kaniko_pod_labels()` getter, mirroring `default_function_pod_labels`.
- Added a fail-fast validation call at startup so malformed config crashes the API pod rather than every build.
- `make_kaniko_pod` now merges the configured labels onto the build pod, filtering out any `mlrun/*` internal keys so platform labels can never clobber `mlrun/class`/`mlrun/project` etc. (precedence: configured < call-site < mlrun-internal).
- The builder continues taking its SA from the default function service account (unchanged); ACR push permission is granted to that SA operator-side.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

Note: covered by unit tests in `test_builder.py`; not a system-test path (kaniko/ACR push requires a live Azure identity cluster).

---

### 🧪 Testing
- Added 4 unit tests in `server/py/services/api/tests/unit/utils/test_builder.py`: WI label applied, multiple labels, empty-default no-op, and mlrun-internal-label precedence.
- `make fmt`, `make lint` (import-linter contracts kept), full `test_builder.py` module: 115 passed.

---

### 🔗 References
- Ticket link: ML-12670
- Design docs links: Workload Identities / Identity-Based Authentication for IG4 (ARC spec)
- External links: companion nuclio PR https://github.com/nuclio/nuclio/pull/4140 ; companion mlefi chart change wires `MLRUN_HTTPDB__BUILDER__KANIKO_POD_LABELS`

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Operational only once the mlefi chart change sets `MLRUN_HTTPDB__BUILDER__KANIKO_POD_LABELS` on identity installs. On-prem and credential-based cloud installs are unaffected (default is empty → no-op).
