### PR TITLE
[Client] Isolate `pipeline_context` per `Client` session

### DIFF
--- a/mlrun/client.py
+++ b/mlrun/client.py
@@ -96,8 +96,10 @@ class Client:
         # Deferred imports — see module-level comment.
         from mlrun.config import config
         from mlrun.db.httpdb import HTTPRunDB
+        from mlrun.projects.pipelines import _PipelineContext
 
         self._http_db = HTTPRunDB(config.dbpath, credentials=credentials)
+        self._pipeline_context = _PipelineContext()
 
     @contextmanager
     def session(self) -> Iterator[Client]:

--- a/mlrun/projects/pipelines.py
+++ b/mlrun/projects/pipelines.py
@@ -396,7 +396,36 @@ class _PipelineContext:
         return False
 
 
-pipeline_context = _PipelineContext()
+_legacy_pipeline_context = _PipelineContext()
+
+
+def _current_pipeline_context() -> _PipelineContext:
+    """Return the active ``Client``'s pipeline context if one is bound,
+    else the legacy module-global instance."""
+    from mlrun.client import get_active_client
+
+    client = get_active_client()
+    if client is not None:
+        return client._pipeline_context
+    return _legacy_pipeline_context
+
+
+class _PipelineContextProxy:
+    """Delegates every attribute read/write to the per-session
+    ``_PipelineContext`` returned by ``_current_pipeline_context()``.
+
+    Inside a ``client.session()`` that's the active client's own instance;
+    outside, the module-global legacy singleton (BWC).
+    """
+
+    def __getattr__(self, name):
+        return getattr(_current_pipeline_context(), name)
+
+    def __setattr__(self, name, value):
+        setattr(_current_pipeline_context(), name, value)
+
+
+pipeline_context = _PipelineContextProxy()
 
 
 def _set_function_attribute_on_kfp_pod(

--- a/tests/projects/test_pipeline_context_isolation.py
+++ b/tests/projects/test_pipeline_context_isolation.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``pipeline_context`` isolation across concurrent ``client.session()`` scopes"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import mlrun
+from mlrun import Client, Credentials
+from mlrun.projects.pipelines import pipeline_context
+
+
+@pytest.fixture(autouse=True)
+def _mock_dbpath(monkeypatch):
+    monkeypatch.setattr(mlrun.mlconf, "dbpath", "https://mock-server")
+
+
+async def test_pipeline_context_isolated_across_concurrent_client_sessions():
+    """Two ``client.session()``s on two tasks must not share ``pipeline_context``.
+
+    On the module-global singleton, the second writer clobbers the first.
+    """
+    client_a = Client(credentials=Credentials(token="a"))
+    client_b = Client(credentials=Credentials(token="b"))
+
+    a_assigned = asyncio.Event()
+    b_assigned = asyncio.Event()
+
+    async def task(client, project_name, mine, other):
+        with client.session():
+            pipeline_context.project = project_name
+            mine.set()
+            await other.wait()
+            assert pipeline_context.project == project_name, (
+                f"pipeline_context.project leaked across client sessions: "
+                f"expected {project_name!r}, got {pipeline_context.project!r}"
+            )
+
+    await asyncio.gather(
+        task(client_a, "proj-a", a_assigned, b_assigned),
+        task(client_b, "proj-b", b_assigned, a_assigned),
+    )
+
+
+def test_pipeline_context_unchanged_outside_client_session():
+    """Outside any ``client.session()``, ``pipeline_context`` is the legacy
+    module-global; direct attribute writes persist across calls (BWC).
+    """
+    pipeline_context.clear(with_project=True)
+    assert pipeline_context.project is None
+
+    pipeline_context.project = "legacy-singleton"
+    try:
+        assert pipeline_context.project == "legacy-singleton"
+    finally:
+        pipeline_context.clear(with_project=True)


### PR DESCRIPTION
### 📝 Description
`mlrun.projects.pipelines.pipeline_context` is a process-wide singleton, so two concurrent `client.session()` scopes that touch it (set the current project, the current workflow, the runs map, etc.) stomp on each other. Inside an asyncio event loop running multiple users, the last writer wins for everyone.

This change converts the existing `pipeline_context` module attribute into a stateless delegating wrapper. Inside a `client.session()`, attribute reads and writes go to that client's own `_PipelineContext`. Outside any session, they go to a module-global legacy instance — so existing single-user callers behave exactly as before.

---

### 🛠️ Changes Made
- `mlrun/projects/pipelines.py`: introduced `_legacy_pipeline_context` (the prior module-global) and `_current_pipeline_context()`; replaced `pipeline_context = _PipelineContext()` with a stateless `_PipelineContextProxy` that delegates every read/write to whichever instance `_current_pipeline_context()` returns.
- `mlrun/client.py`: `Client.__init__` now allocates `self._pipeline_context = _PipelineContext()` so each client gets its own.
- `tests/projects/test_pipeline_context_isolation.py` (new): two tests — one drives two concurrent `asyncio.Task`s under two `client.session()` scopes that each assign `pipeline_context.project` and assert their own value survives the other's write; one asserts BWC for the legacy module-global outside any session.

No SDK call sites changed — the `pipeline_context` symbol keeps the same shape.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New unit test `tests/projects/test_pipeline_context_isolation.py::test_pipeline_context_isolated_across_concurrent_client_sessions` fails on the prior singleton (assertion shows one task's `pipeline_context.project` clobbered by the other's write) and passes against the proxy.
- New unit test `test_pipeline_context_unchanged_outside_client_session` exercises the legacy module-global path with no session active — assigns, reads back, clears.
- Targeted BWC sweep: `tests/projects/test_local_pipeline.py` and the existing `tests/projects/test_kfp.py` (which exercise `pipeline_context.set/clear`) pass unchanged. The three pre-existing `test_kfp.py` failures (`DummyContainerOp.__init__() got an unexpected keyword argument 'output_artifact_paths'`) are kfp library-version drift and reproduce on baseline.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12598
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Outside `client.session()`, `pipeline_context` behaves identically to the prior module-global singleton. Inside a session, callers who reach the symbol get the active client's instance — which is the intent.

---

### 🔍️ Additional Notes