### PR TITLE
[Client] Let server set run owner inside client session

### DIFF
--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
+import os
 
 import IPython.display
 
 import mlrun
+import mlrun.client
 import mlrun.common.constants as mlrun_constants
 import mlrun.errors
 import mlrun.launcher.base as launcher
@@ -43,6 +45,21 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
         runtime._fill_credentials()
         if project_name:
             runtime.metadata.project = project_name
+
+    @staticmethod
+    def _enrich_run_labels_with_v3io_user(run: "mlrun.run.RunObject") -> None:
+        """Stamp ``v3io_user`` from ``V3IO_USERNAME`` env, unless running inside
+        a ``mlrun.Client.session()`` (process env is the host, not the caller)
+        or the label is already set."""
+        if mlrun.client.get_active_client() is not None:
+            return
+        if (
+            "V3IO_USERNAME" in os.environ
+            and mlrun_constants.MLRunInternalLabels.v3io_user not in run.metadata.labels
+        ):
+            run.metadata.labels[mlrun_constants.MLRunInternalLabels.v3io_user] = (
+                os.environ.get("V3IO_USERNAME")
+            )
 
     @staticmethod
     def prepare_image_for_deploy(runtime: "mlrun.runtimes.BaseRuntime"):

--- a/mlrun/launcher/client.py
+++ b/mlrun/launcher/client.py
@@ -48,9 +48,7 @@ class ClientBaseLauncher(launcher.BaseLauncher, abc.ABC):
 
     @staticmethod
     def _enrich_run_labels_with_v3io_user(run: "mlrun.run.RunObject") -> None:
-        """Stamp ``v3io_user`` from ``V3IO_USERNAME`` env, unless running inside
-        a ``mlrun.Client.session()`` (process env is the host, not the caller)
-        or the label is already set."""
+        """Set ``v3io_user`` from ``V3IO_USERNAME`` unless in ``Client.session()`` or already set."""
         if mlrun.client.get_active_client() is not None:
             return
         if (

--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -11,13 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import pathlib
 from collections.abc import Callable
 from os import environ
 from typing import Union
 
-import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas.schedule
 import mlrun.errors
 import mlrun.launcher.client as launcher
@@ -136,13 +134,7 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
         runtime: "mlrun.runtimes.BaseRuntime",
         run: Union["mlrun.run.RunTemplate", "mlrun.run.RunObject"] | None = None,
     ):
-        if (
-            "V3IO_USERNAME" in os.environ
-            and mlrun_constants.MLRunInternalLabels.v3io_user not in run.metadata.labels
-        ):
-            run.metadata.labels[mlrun_constants.MLRunInternalLabels.v3io_user] = (
-                os.environ.get("V3IO_USERNAME")
-            )
+        self._enrich_run_labels_with_v3io_user(run)
 
         # store function object in db unless running from within a run pod
         if not runtime.is_child:

--- a/mlrun/launcher/remote.py
+++ b/mlrun/launcher/remote.py
@@ -11,13 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from typing import Union
 
 import pandas as pd
 import requests
 
-import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas.schedule
 import mlrun.db
 import mlrun.errors
@@ -101,13 +99,7 @@ class ClientRemoteLauncher(launcher.ClientBaseLauncher):
         if runtime.verbose:
             logger.info(f"runspec:\n{run.to_yaml()}")
 
-        if (
-            "V3IO_USERNAME" in os.environ
-            and mlrun_constants.MLRunInternalLabels.v3io_user not in run.metadata.labels
-        ):
-            run.metadata.labels[mlrun_constants.MLRunInternalLabels.v3io_user] = (
-                os.environ.get("V3IO_USERNAME")
-            )
+        self._enrich_run_labels_with_v3io_user(run)
 
         logger.info(
             "Storing function",

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -23,6 +23,7 @@ from sys import stderr
 import pandas as pd
 
 import mlrun
+import mlrun.client
 import mlrun.common.constants
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.runtimes.constants
@@ -470,6 +471,11 @@ def resolve_owner(
         == mlrun.common.constants.JOB_TYPE_RERUN_WORKFLOW_RUNNER
     ):
         return owner_to_enrich
+
+    # Inside a ``mlrun.Client.session()``, the process env identifies the
+    # host, not the caller — let the server fill the owner from auth_info.
+    if mlrun.client.get_active_client() is not None:
+        return None
 
     # Check V3IO_USERNAME first (IG3 environments)
     if v3io_username := os.environ.get("V3IO_USERNAME"):

--- a/mlrun/runtimes/utils.py
+++ b/mlrun/runtimes/utils.py
@@ -472,8 +472,7 @@ def resolve_owner(
     ):
         return owner_to_enrich
 
-    # Inside a ``mlrun.Client.session()``, the process env identifies the
-    # host, not the caller — let the server fill the owner from auth_info.
+    # In ``Client.session()``, process env belongs to the host, so skip owner enrichment.
     if mlrun.client.get_active_client() is not None:
         return None
 

--- a/tests/launcher/test_remote.py
+++ b/tests/launcher/test_remote.py
@@ -164,10 +164,7 @@ def test_store_function_set_token_name():
         assert run.spec.auth["token_name"] == "context-run-token"
 
 
-# ---------------------------------------------------------------------------
-# _enrich_run_labels_with_v3io_user lives on ClientBaseLauncher; testing via
-# ClientRemoteLauncher covers both subclasses through inheritance.
-# ---------------------------------------------------------------------------
+# Test through ClientRemoteLauncher; helper is inherited from ClientBaseLauncher.
 
 
 def _make_run() -> mlrun.run.RunObject:
@@ -202,8 +199,7 @@ def test_enrich_run_labels_with_v3io_user_stamps_outside_session(monkeypatch):
 
 
 def test_enrich_run_labels_with_v3io_user_preserves_existing_label(monkeypatch):
-    """A workflow runner (or any caller) that pre-set v3io_user must not be
-    overwritten by the env value."""
+    """Do not overwrite an existing ``v3io_user`` label."""
     monkeypatch.setenv("V3IO_USERNAME", "process-user")
     run = _make_run()
     run.metadata.labels[mlrun_constants.MLRunInternalLabels.v3io_user] = "preset-user"

--- a/tests/launcher/test_remote.py
+++ b/tests/launcher/test_remote.py
@@ -17,8 +17,12 @@ import unittest.mock
 
 import pytest
 
+import mlrun
+import mlrun.common.constants as mlrun_constants
 import mlrun.config
 import mlrun.launcher.remote
+import mlrun.runtimes.utils
+from mlrun import Client, Credentials
 
 assets_path = pathlib.Path(__file__).parent / "assets"
 func_path = assets_path / "sample_function.py"
@@ -158,3 +162,60 @@ def test_store_function_set_token_name():
     with mlrun.RuntimeConfigurationContext(auth_token_name="context-run-token"):
         launcher._store_function(runtime, run)
         assert run.spec.auth["token_name"] == "context-run-token"
+
+
+# ---------------------------------------------------------------------------
+# _enrich_run_labels_with_v3io_user lives on ClientBaseLauncher; testing via
+# ClientRemoteLauncher covers both subclasses through inheritance.
+# ---------------------------------------------------------------------------
+
+
+def _make_run() -> mlrun.run.RunObject:
+    run = mlrun.run.RunObject()
+    run.metadata.name = "r"
+    run.metadata.uid = "u"
+    return run
+
+
+def test_enrich_run_labels_with_v3io_user_skips_inside_session(monkeypatch):
+    monkeypatch.setattr(mlrun.mlconf, "dbpath", "https://mock-server")
+    monkeypatch.setenv("V3IO_USERNAME", "process-user")
+    run = _make_run()
+    client = Client(credentials=Credentials(token="t"))
+    with client.session():
+        mlrun.launcher.remote.ClientRemoteLauncher._enrich_run_labels_with_v3io_user(
+            run
+        )
+    assert mlrun_constants.MLRunInternalLabels.v3io_user not in run.metadata.labels, (
+        f"v3io_user label stamped from env inside session: {run.metadata.labels!r}"
+    )
+
+
+def test_enrich_run_labels_with_v3io_user_stamps_outside_session(monkeypatch):
+    monkeypatch.setenv("V3IO_USERNAME", "process-user")
+    run = _make_run()
+    mlrun.launcher.remote.ClientRemoteLauncher._enrich_run_labels_with_v3io_user(run)
+    assert (
+        run.metadata.labels.get(mlrun_constants.MLRunInternalLabels.v3io_user)
+        == "process-user"
+    )
+
+
+def test_enrich_run_labels_with_v3io_user_preserves_existing_label(monkeypatch):
+    """A workflow runner (or any caller) that pre-set v3io_user must not be
+    overwritten by the env value."""
+    monkeypatch.setenv("V3IO_USERNAME", "process-user")
+    run = _make_run()
+    run.metadata.labels[mlrun_constants.MLRunInternalLabels.v3io_user] = "preset-user"
+    mlrun.launcher.remote.ClientRemoteLauncher._enrich_run_labels_with_v3io_user(run)
+    assert (
+        run.metadata.labels[mlrun_constants.MLRunInternalLabels.v3io_user]
+        == "preset-user"
+    )
+
+
+def test_enrich_run_labels_with_v3io_user_no_op_without_env(monkeypatch):
+    monkeypatch.delenv("V3IO_USERNAME", raising=False)
+    run = _make_run()
+    mlrun.launcher.remote.ClientRemoteLauncher._enrich_run_labels_with_v3io_user(run)
+    assert mlrun_constants.MLRunInternalLabels.v3io_user not in run.metadata.labels

--- a/tests/runtimes/test_utils.py
+++ b/tests/runtimes/test_utils.py
@@ -297,8 +297,7 @@ def test_resolve_owner_skips_env_inside_client_session(monkeypatch):
 
 
 def test_resolve_owner_honors_workflow_owner_to_enrich_inside_session(monkeypatch):
-    """Workflow-runner override still wins inside a session — only the
-    env/getpass *fallback* is suppressed."""
+    """Inside a session, keep workflow ``owner_to_enrich`` and skip env/getpass fallback."""
     monkeypatch.setattr(mlrun.mlconf, "dbpath", "https://mock-server")
     monkeypatch.setenv("V3IO_USERNAME", "process-user")
     client = Client(credentials=Credentials(token="t"))

--- a/tests/runtimes/test_utils.py
+++ b/tests/runtimes/test_utils.py
@@ -20,9 +20,11 @@ import deepdiff
 import git
 import pytest
 
+import mlrun
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.runtimes.constants
 import mlrun.runtimes.utils
+from mlrun import Client, Credentials
 
 
 @pytest.fixture
@@ -284,6 +286,28 @@ def test_resolve_owner_v3io_username_takes_precedence_over_ig4():
         with unittest.mock.patch("mlrun.get_run_db", return_value=mock_db):
             owner = mlrun.runtimes.utils.resolve_owner({})
             assert owner == "v3io_user"
+
+
+def test_resolve_owner_skips_env_inside_client_session(monkeypatch):
+    monkeypatch.setattr(mlrun.mlconf, "dbpath", "https://mock-server")
+    monkeypatch.setenv("V3IO_USERNAME", "process-user")
+    client = Client(credentials=Credentials(token="t"))
+    with client.session():
+        assert mlrun.runtimes.utils.resolve_owner(labels={}) is None
+
+
+def test_resolve_owner_honors_workflow_owner_to_enrich_inside_session(monkeypatch):
+    """Workflow-runner override still wins inside a session — only the
+    env/getpass *fallback* is suppressed."""
+    monkeypatch.setattr(mlrun.mlconf, "dbpath", "https://mock-server")
+    monkeypatch.setenv("V3IO_USERNAME", "process-user")
+    client = Client(credentials=Credentials(token="t"))
+    labels = {"job-type": mlrun.common.constants.JOB_TYPE_WORKFLOW_RUNNER}
+    with client.session():
+        owner = mlrun.runtimes.utils.resolve_owner(
+            labels=labels, owner_to_enrich="workflow-owner"
+        )
+    assert owner == "workflow-owner"
 
 
 def test_results_to_iter_status_resolution(rundb_mock):


### PR DESCRIPTION
### 📝 Description
Today the SDK stamps two identity labels on every submitted run from process env: `owner` (from `V3IO_USERNAME`, falling back to `getpass.getuser()`) and `v3io_user` (from `V3IO_USERNAME`). Both reflect the host process. Under `mlrun.Client`, that means every concurrent user submitting through a multi-tenant SDK consumer ends up labelled with the same identity regardless of who actually invoked the run.

The server-side override at `services/api/launcher.py` only covers `owner`, and only in authenticated deployments — `v3io_user` is never overridden, and `owner` survives untouched on CE and on local runs. So the right place to fix it is the client side: inside `client.session()`, skip both env reads. Outside, unchanged.

---

### 🛠️ Changes Made
- `resolve_owner` (`mlrun/runtimes/utils.py`) returns `None` inside a `client.session()`. The caller stamps the `owner` label only when the resolved value is truthy, so an absent value falls through to the server-side override (when one is available) or is simply left unset.
- Added a `_enrich_run_labels_with_v3io_user(run)` static helper on `ClientBaseLauncher` (`mlrun/launcher/client.py`). It early-returns inside a session; otherwise stamps `v3io_user` from `V3IO_USERNAME` unless the label is already present. `ClientRemoteLauncher` and `ClientLocalLauncher` call the inherited helper at the same points where they previously inlined the env logic.
- Workflow-runner `owner_to_enrich` override still wins inside a session — only the env / getpass *fallback* is suppressed.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `tests/runtimes/test_utils.py` gains two new `resolve_owner` cases (env skipped inside a session; workflow `owner_to_enrich` still honored inside a session) next to the existing `test_resolve_owner_*` suite.
- `tests/launcher/test_remote.py` gains four cases covering the new shared helper (skips inside session, stamps outside, preserves an already-set label, no-op without env). The helper lives on `ClientBaseLauncher`, so testing through `ClientRemoteLauncher` covers both subclasses via inheritance.
- The existing 75-test combined `tests/runtimes/test_utils.py` + `tests/launcher/` suite still passes; lint + format clean.

---

### 🔗 References
- Ticket link: ML-12677
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Outside `client.session()`, identity resolution is unchanged.

---

### 🔍️ Additional Notes