### PR TITLE
[Datastore] Fix Azure workload-identity credential routing

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -215,9 +215,8 @@ class AzureBlobStore(DataStore):
 
         # Resolve an identity-based credential only when no connection-string / account-key / SAS /
         # explicit credential is supplied. A service principal needs both client_id and
-        # client_secret; for workload / managed identity the `storage_options` property has already
-        # dropped the secret-less client_id and set anon=False, which routes us to
-        # DefaultAzureCredential here (it exchanges AZURE_FEDERATED_TOKEN_FILE).
+        # client_secret; for workload / managed identity the storage_options property has already
+        # dropped the secret-less client_id and set anon=False, routing us to DefaultAzureCredential.
         identity_credential = None
         if credential is None and account_key is None and sas_token is None:
             if client_id is not None and client_secret is not None:

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -60,7 +60,10 @@ class AzureBlobStore(DataStore):
     ======================
     - Account Key (connection_string or storage_options)
     - SAS Token (connection_string or storage_options)
-    - OAuth/Azure AD (storage_options: client_id, client_secret, tenant_id)
+    - OAuth/Azure AD service principal (storage_options: client_id, client_secret, tenant_id)
+    - Workload / managed identity (client_id without client_secret, e.g. AZURE_CLIENT_ID injected by
+      the azure-workload-identity webhook): routed to DefaultAzureCredential, which exchanges the
+      federated token (AZURE_FEDERATED_TOKEN_FILE)
 
     Accepted env-var names (in priority order):
     - account_name / AZURE_STORAGE_ACCOUNT_NAME / AZURE_STORAGE_ACCOUNT
@@ -147,6 +150,17 @@ class AzureBlobStore(DataStore):
                                     res["container"] = path_parts[0]
                                     break
 
+            # Workload / managed identity: a client_id arrives (e.g. AZURE_CLIENT_ID injected by the
+            # azure-workload-identity webhook) with no client_secret. adlfs treats any client_id as
+            # an explicit service principal and builds ClientSecretCredential(client_secret=None),
+            # which raises. Drop the partial (client_id, tenant_id) and force anon=False so adlfs
+            # falls back to DefaultAzureCredential, which exchanges AZURE_FEDERATED_TOKEN_FILE.
+            # When a client_secret is present, keep the full triple (explicit service principal wins).
+            if res.get("client_id") and not res.get("client_secret"):
+                res["client_id"] = None
+                res["tenant_id"] = None
+                res["anon"] = False
+
             self._storage_options = self._sanitize_options(res)
         return self._storage_options
 
@@ -188,7 +202,7 @@ class AzureBlobStore(DataStore):
         based on do_connect in AzureBlobFileSystem:
         https://github.com/fsspec/adlfs/blob/2023.9.0/adlfs/spec.py#L422
         """
-        from azure.identity import ClientSecretCredential
+        from azure.identity import ClientSecretCredential, DefaultAzureCredential
 
         storage_options = self.storage_options
         connection_string = storage_options.get("connection_string")
@@ -196,20 +210,24 @@ class AzureBlobStore(DataStore):
         account_key = storage_options.get("account_key")
         sas_token = storage_options.get("sas_token")
         client_id = storage_options.get("client_id")
+        client_secret = storage_options.get("client_secret")
         credential = storage_options.get("credential")
 
-        credential_from_client_id = None
-        if (
-            credential is None
-            and account_key is None
-            and sas_token is None
-            and client_id is not None
-        ):
-            credential_from_client_id = ClientSecretCredential(
-                tenant_id=storage_options.get("tenant_id"),
-                client_id=client_id,
-                client_secret=storage_options.get("client_secret"),
-            )
+        # Resolve an identity-based credential only when no connection-string / account-key / SAS /
+        # explicit credential is supplied. A service principal needs both client_id and
+        # client_secret; for workload / managed identity the `storage_options` property has already
+        # dropped the secret-less client_id and set anon=False, which routes us to
+        # DefaultAzureCredential here (it exchanges AZURE_FEDERATED_TOKEN_FILE).
+        identity_credential = None
+        if credential is None and account_key is None and sas_token is None:
+            if client_id is not None and client_secret is not None:
+                identity_credential = ClientSecretCredential(
+                    tenant_id=storage_options.get("tenant_id"),
+                    client_id=client_id,
+                    client_secret=client_secret,
+                )
+            elif storage_options.get("anon") is False:
+                identity_credential = DefaultAzureCredential()
         try:
             if connection_string is not None:
                 self._service_client = BlobServiceClient.from_connection_string(
@@ -219,7 +237,7 @@ class AzureBlobStore(DataStore):
                 )
             elif client_name is not None:
                 account_url = f"https://{client_name}.blob.core.windows.net"
-                cred = credential_from_client_id or credential or account_key
+                cred = identity_credential or credential or account_key
                 if not cred and sas_token is not None:
                     if not sas_token.startswith("?"):
                         sas_token = f"?{sas_token}"

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -727,3 +727,106 @@ class TestAzureBlobStore:
         assert options["client_id"] is not None
         assert options["client_secret"] is not None
         assert options["tenant_id"] is not None
+
+    def test_storage_options_workload_identity_drops_partial_triple(self):
+        """ML-12668: client_id/tenant_id injected without a secret (workload identity) must be
+        dropped and anon forced to False so adlfs routes to DefaultAzureCredential instead of
+        building a ClientSecretCredential(client_secret=None)."""
+        env_vars = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "teststorage",
+            "AZURE_CLIENT_ID": "wi-client-id",
+            "AZURE_TENANT_ID": "wi-tenant-id",
+            # no client secret anywhere — the webhook injects only id/tenant/federated-token-file
+        }
+        store = self._create_store(schema="az", endpoint="mycontainer")
+
+        with patch.object(store, "_get_secret_or_env") as mock_get_secret:
+            mock_get_secret.side_effect = lambda key: env_vars.get(key)
+            options = store.storage_options
+
+        assert "client_id" not in options
+        assert "tenant_id" not in options
+        assert options["anon"] is False
+        assert options["account_name"] == "teststorage"
+
+    def test_storage_options_keeps_full_service_principal(self):
+        """An explicit service principal (client_id + client_secret + tenant_id) is preserved
+        untouched, and anon is not injected — the WI fallback must not hijack it."""
+        env_vars = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "teststorage",
+            "AZURE_CLIENT_ID": "sp-client-id",
+            "AZURE_CLIENT_SECRET": "sp-client-secret",
+            "AZURE_TENANT_ID": "sp-tenant-id",
+        }
+        store = self._create_store(schema="az", endpoint="mycontainer")
+
+        with patch.object(store, "_get_secret_or_env") as mock_get_secret:
+            mock_get_secret.side_effect = lambda key: env_vars.get(key)
+            options = store.storage_options
+
+        assert options["client_id"] == "sp-client-id"
+        assert options["client_secret"] == "sp-client-secret"
+        assert options["tenant_id"] == "sp-tenant-id"
+        assert "anon" not in options
+
+    def test_storage_options_account_key_only_unchanged(self):
+        """Account-key auth has no client_id, so the WI branch must not fire — no anon key added."""
+        env_vars = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "teststorage",
+            "AZURE_STORAGE_ACCOUNT_KEY": "the-key",
+        }
+        store = self._create_store(schema="az", endpoint="mycontainer")
+
+        with patch.object(store, "_get_secret_or_env") as mock_get_secret:
+            mock_get_secret.side_effect = lambda key: env_vars.get(key)
+            options = store.storage_options
+
+        assert options["account_key"] == "the-key"
+        assert "client_id" not in options
+        assert "anon" not in options
+
+    def test_do_connect_workload_identity_uses_default_credential(self):
+        """ML-12668: with anon=False and no key/SAS/client_id/secret, the service client must be
+        built with DefaultAzureCredential (the workload-identity path), not ClientSecretCredential."""
+        store = self._create_store(schema="az", endpoint="mycontainer")
+        mock_storage_options = {"account_name": "teststorage", "anon": False}
+
+        with (
+            patch.object(store, "_storage_options", mock_storage_options),
+            patch("azure.identity.DefaultAzureCredential") as mock_default,
+            patch("azure.identity.ClientSecretCredential") as mock_client_secret,
+            patch("mlrun.datastore.azure_blob.BlobServiceClient") as mock_blob_client,
+        ):
+            store._do_connect()
+
+        mock_default.assert_called_once()
+        mock_client_secret.assert_not_called()
+        _, kwargs = mock_blob_client.call_args
+        assert kwargs["credential"] is mock_default.return_value
+
+    def test_do_connect_service_principal_uses_client_secret_credential(self):
+        """A full service principal still builds a ClientSecretCredential with the supplied secret."""
+        store = self._create_store(schema="az", endpoint="mycontainer")
+        mock_storage_options = {
+            "account_name": "teststorage",
+            "client_id": "sp-client-id",
+            "client_secret": "sp-client-secret",
+            "tenant_id": "sp-tenant-id",
+        }
+
+        with (
+            patch.object(store, "_storage_options", mock_storage_options),
+            patch("azure.identity.DefaultAzureCredential") as mock_default,
+            patch("azure.identity.ClientSecretCredential") as mock_client_secret,
+            patch("mlrun.datastore.azure_blob.BlobServiceClient") as mock_blob_client,
+        ):
+            store._do_connect()
+
+        mock_client_secret.assert_called_once_with(
+            tenant_id="sp-tenant-id",
+            client_id="sp-client-id",
+            client_secret="sp-client-secret",
+        )
+        mock_default.assert_not_called()
+        _, kwargs = mock_blob_client.call_args
+        assert kwargs["credential"] is mock_client_secret.return_value

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -729,9 +729,7 @@ class TestAzureBlobStore:
         assert options["tenant_id"] is not None
 
     def test_storage_options_workload_identity_drops_partial_triple(self):
-        """ML-12668: client_id/tenant_id injected without a secret (workload identity) must be
-        dropped and anon forced to False so adlfs routes to DefaultAzureCredential instead of
-        building a ClientSecretCredential(client_secret=None)."""
+        """ML-12668: a client_id without a secret (workload identity) is dropped and anon set False."""
         env_vars = {
             "AZURE_STORAGE_ACCOUNT_NAME": "teststorage",
             "AZURE_CLIENT_ID": "wi-client-id",
@@ -750,8 +748,7 @@ class TestAzureBlobStore:
         assert options["account_name"] == "teststorage"
 
     def test_storage_options_keeps_full_service_principal(self):
-        """An explicit service principal (client_id + client_secret + tenant_id) is preserved
-        untouched, and anon is not injected — the WI fallback must not hijack it."""
+        """A full service principal (client_id + client_secret + tenant_id) is preserved, anon untouched."""
         env_vars = {
             "AZURE_STORAGE_ACCOUNT_NAME": "teststorage",
             "AZURE_CLIENT_ID": "sp-client-id",
@@ -786,8 +783,7 @@ class TestAzureBlobStore:
         assert "anon" not in options
 
     def test_do_connect_workload_identity_uses_default_credential(self):
-        """ML-12668: with anon=False and no key/SAS/client_id/secret, the service client must be
-        built with DefaultAzureCredential (the workload-identity path), not ClientSecretCredential."""
+        """With anon=False and no key/SAS/client_id, _do_connect uses DefaultAzureCredential."""
         store = self._create_store(schema="az", endpoint="mycontainer")
         mock_storage_options = {"account_name": "teststorage", "anon": False}
 


### PR DESCRIPTION
### 📝 Description

On an Azure cluster configured for **workload identity**, a remote job calling `context.log_artifact()` to an `az://` target failed with `ValueError: secret should be a Microsoft Entra application's client secret`.

The azure-workload-identity webhook injects `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE` into the pod but **no client secret**. `AzureBlobStore.storage_options` loaded the client-id/tenant-id with an empty `client_secret`, and adlfs then treated the partial triple as an explicit service principal — building `ClientSecretCredential(client_secret=None)`, which raises before its `DefaultAzureCredential` fallback can run.

The fix treats `(client_id, client_secret, tenant_id)` as all-or-nothing, using the secret as the signal for "explicit service principal".

---

### 🛠️ Changes Made
- `storage_options`: when a `client_id` is present without a `client_secret`, drop `client_id`/`tenant_id` and set `anon=False`, so adlfs routes to `DefaultAzureCredential` (which exchanges the federated token). The full triple is kept untouched when a secret is present.
- `_do_connect` (service-client path): build `ClientSecretCredential` only when both `client_id` and `client_secret` are set; otherwise use `DefaultAzureCredential()` when `anon is False`.
- Documented the workload/managed-identity auth path in the `AzureBlobStore` docstring.
- Added unit coverage for both routing branches.
- Account-key, SAS, connection-string and explicit service-principal auth are unchanged.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Added 5 unit tests in `tests/datastore/test_azure_blob_store.py`: `storage_options` drops the partial triple and sets `anon=False` under workload identity, preserves a full service principal, and leaves account-key auth untouched; `_do_connect` selects `DefaultAzureCredential` vs `ClientSecretCredential` on the secret signal.
- `pytest tests/datastore/test_azure_blob_store.py` → 40 passed (35 existing + 5 new); `ruff format` + `ruff check` clean.
- Live-Azure system tests (`tests/system/datastore/test_azure.py`) were **not** run — they require real Azure credentials / a lab and are out of reach in this environment.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12668
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Spark-on-Azure under workload identity (`get_spark_options`) follows a separate code path and is intentionally **out of scope** for this fix; it warrants a follow-up if needed.
- The only behavioural change is for the `client_id`-without-secret case, which previously crashed — there is no working configuration being altered.