### PR TITLE
[Code Artifacts] Fix body code artifacts by requiring local_path or target_path

### DIFF
--- a/mlrun/execution.py
+++ b/mlrun/execution.py
@@ -828,6 +828,7 @@ class MLClientCtx:
         tag="",
         artifact_path=None,
         upload=True,
+        is_inline: bool = False,
         labels=None,
         target_path="",
         db_key=None,
@@ -844,6 +845,8 @@ class MLClientCtx:
         :param tag:           Version tag
         :param artifact_path: Target artifact path (when not using the default)
         :param upload:        Upload to datastore (default is True)
+        :param is_inline:     Embed the body in the artifact record instead of
+                              uploading it (default False).
         :param labels:        A set of key/value labels to tag the artifact with
         :param target_path:   Absolute target path (instead of using artifact_path + local_path)
         :param db_key:        The key to use in the artifact DB table
@@ -857,6 +860,10 @@ class MLClientCtx:
 
         :returns: Code artifact object
         """
+        if not local_path and not target_path:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "A code artifact must provide local_path or target_path."
+            )
         code = CodeArtifact(
             key,
             body=body,
@@ -864,6 +871,7 @@ class MLClientCtx:
             language=language,
             code_type=code_type,
             requirements=requirements,
+            is_inline=is_inline,
             **kwargs,
         )
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1896,6 +1896,7 @@ class MlrunProject(ModelObj):
         tag="",
         artifact_path=None,
         upload=True,
+        is_inline: bool = False,
         labels=None,
         target_path="",
         db_key=None,
@@ -1913,6 +1914,8 @@ class MlrunProject(ModelObj):
         :param tag:           version tag
         :param artifact_path: target artifact path (when not using the default)
         :param upload:        upload to datastore (default is True)
+        :param is_inline:     embed the body in the artifact record instead of
+                              uploading it (default False).
         :param labels:        a set of key/value labels to tag the artifact with
         :param target_path:   absolute target path (instead of using artifact_path + local_path)
         :param db_key:        the key to use in the artifact DB table
@@ -1926,6 +1929,10 @@ class MlrunProject(ModelObj):
 
         :returns: code artifact object
         """
+        if not local_path and not target_path:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "A code artifact must provide local_path or target_path."
+            )
         code = CodeArtifact(
             key,
             body=body,
@@ -1933,6 +1940,7 @@ class MlrunProject(ModelObj):
             language=language,
             code_type=code_type,
             requirements=requirements,
+            is_inline=is_inline,
             **kwargs,
         )
 

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -680,6 +680,29 @@ def test_inline_body(new_project_factory):
     assert artifact.metadata.key == "y"
 
 
+def test_log_code_file_body_requires_path(new_project_factory):
+    project = new_project_factory("code-body", save=False)
+
+    # a body with no local_path/target_path cannot name its file -> rejected
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError,
+        match="must provide local_path or target_path",
+    ):
+        project.log_code_file("c", body="def f(): pass")
+
+    # is_inline=True embeds the body in the record (no upload needed)
+    artifact = project.log_code_file(
+        "c",
+        body="def f(): pass",
+        local_path="c.py",
+        is_inline=True,
+        upload=False,
+        artifact_path=results_dir,
+    )
+    assert artifact.spec.get_body() == "def f(): pass"
+    assert artifact.spec._is_inline is True
+
+
 def test_register_artifacts(rundb_mock, new_project_factory):
     project_name = "my-projects"
     project = new_project_factory(project_name)
@@ -893,6 +916,7 @@ def test_log_code_file_via_project(new_project_factory):
     project = new_project_factory("test-code-proj", save=False)
     artifact = project.log_code_file(
         "my-func",
+        local_path="my-func.py",
         body="def handler(): pass",
         language="python:3.11",
         code_type="function",
@@ -912,6 +936,7 @@ def test_log_code_file_via_context(ensure_project):
     context = mlrun.get_or_create_ctx("test")
     artifact = context.log_code_file(
         "my-func",
+        local_path="my-func.py",
         body="def handler(): pass",
         language="python:3.11",
         code_type="workflow",


### PR DESCRIPTION
### 📝 Description

ML-12654: running a job from a body-based `CodeArtifact` failed with "Empty module name". A code artifact logged with only a key + inline body had no filename, so it materialized to a non-importable file and a bare handler could not be resolved.

This change requires a code artifact to name its file via `local_path` or `target_path`. The filename's extension picks the language (`.py` for Python, `.go` for Go, …) — only the caller knows it, so MLRun can't default it. A body/key-only call now fails fast at log time with a clear error instead of cryptically at run time.

---

### 🛠️ Changes Made

- `log_code_file` (project + execution context): raise `MLRunInvalidArgumentError` unless `local_path` or `target_path` is provided.
- Expose `is_inline` on `log_code_file` to embed the body in the artifact record instead of uploading it.
- Tests: add `test_log_code_file_body_requires_path`; give existing body-only tests a `local_path`.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
---

### 🧪 Testing

- Unit: `test_log_code_file_*` and `test_inline_body` pass; `ruff format`/`ruff check` clean.

---

### 🔗 References
- Ticket link: ML-12654
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

`log_code_file` now rejects a body/key-only call that previously succeeded at log time (such an artifact never ran — that was the ML-12654 bug). Callers must pass `local_path` or `target_path`.
