### PR TITLE
[Makefile] Enhance Docker schema compilation with host user permissions

### DIFF
--- a/server/common/Makefile
+++ b/server/common/Makefile
@@ -18,6 +18,8 @@ MLRUN_DOCKER_IMAGE_PREFIX := $(if $(MLRUN_DOCKER_REGISTRY),$(strip $(MLRUN_DOCKE
 
 GO_VERSION=$(shell grep -m1 'go ' ../go/go.mod | awk '{split($$2,a,"."); print a[1] "." a[2]}')
 
+HOST_UID := $(shell id -u)
+HOST_GID := $(shell id -g)
 
 PROTO_DIR := proto
 
@@ -65,11 +67,13 @@ compile-schemas-local: compile-schemas-go compile-schemas-python
 .PHONY: compile-schemas-dockerized
 compile-schemas-dockerized: schemas-compiler
 	@echo Compiling schemas in docker container
+	# Container runs as root; chown generated files back to the host user so
+	# self-hosted runners can clean the workspace on the next checkout.
 	docker run \
 		--volume $(dir $(CURDIR)):/app \
 		--workdir /app/common \
 		$(MLRUN_DOCKER_IMAGE_PREFIX)/schemas-compiler:latest \
-		make compile-schemas-local
+		sh -c 'make compile-schemas-local && chown -R $(HOST_UID):$(HOST_GID) proto/build ../go/proto ../py/schemas/proto'
 
 compile-schemas-go: $(GO_TARGETS)
 	@echo "Syncing → $(GO_OUT_DIR)"


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
This update modifies the Makefile to ensure that files generated during Dockerized schema compilation are owned by the host user, allowing for easier cleanup in self-hosted runner environments.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Added `HOST_UID` and `HOST_GID` variables to capture the host user's UID and GID.
- Updated the `compile-schemas-dockerized` target to change ownership of generated files back to the host user after compilation.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: [ML-12688](https://ecliptos.atlassian.net/browse/ML-12688)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
