### PR TITLE
[Serving] Return HTTP 422 for missing mandatory body mapping fields

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -172,6 +172,10 @@ class MLRunMethodNotAllowedError(MLRunHTTPStatusError):
     error_status_code = HTTPStatus.METHOD_NOT_ALLOWED.value
 
 
+class MLRunUnprocessableEntityError(MLRunHTTPStatusError):
+    error_status_code = HTTPStatus.UNPROCESSABLE_ENTITY.value
+
+
 class MLRunInvalidArgumentError(MLRunHTTPStatusError, ValueError):
     error_status_code = HTTPStatus.BAD_REQUEST.value
 

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -245,12 +245,13 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                             raise mlrun.errors.MLRunBadRequestError(
                                 f"Failed to process body mapping: {exc}"
                             ) from exc
-                    else:
-                        # Body mappings configured but body is not a dict — can't apply mappings.
+                    elif any(mandatory for _, mandatory in effective_map.values()):
+                        # Mandatory mappings configured but body is not a dict — can't satisfy contract.
                         raise mlrun.errors.MLRunUnprocessableEntityError(
-                            f"Body mappings configured but request body is not a dict "
+                            f"Mandatory body mappings configured but request body is not a dict "
                             f"(got {type(body).__name__})"
                         )
+                    # Non-dict body with only optional mappings: silently skip.
 
                 # Build system-injected URL params when include_url_info is enabled.
                 # mlrun_request_path holds the normalized path of the matched request.

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -237,11 +237,20 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                                 "Applied input body mapping",
                                 extracted_params=list(body_params.keys()),
                             )
+                        except mlrun.errors.MLRunUnprocessableEntityError as exc:
+                            raise mlrun.errors.MLRunUnprocessableEntityError(
+                                f"Failed to process body mapping: {exc}"
+                            ) from exc
                         except Exception as exc:
                             raise mlrun.errors.MLRunBadRequestError(
                                 f"Failed to process body mapping: {exc}"
                             ) from exc
-                    # Non-dict body (e.g. None, string, bytes): body mappings do not apply — silently skip.
+                    else:
+                        # Body mappings configured but body is not a dict — can't apply mappings.
+                        raise mlrun.errors.MLRunUnprocessableEntityError(
+                            f"Body mappings configured but request body is not a dict "
+                            f"(got {type(body).__name__})"
+                        )
 
                 # Build system-injected URL params when include_url_info is enabled.
                 # mlrun_request_path holds the normalized path of the matched request.

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -168,6 +168,12 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
 
         :param event: Event object (Nuclio event or MockEvent)
         :return: Original event or RequestContext with extracted parameters
+        :raises mlrun.errors.MLRunBadRequestError: Missing method/path, or unsupported HTTP method.
+        :raises mlrun.errors.MLRunNotFoundError: No configured endpoint matches the request path (404).
+        :raises mlrun.errors.MLRunMethodNotAllowedError: Path matches an endpoint but the method is not allowed (405).
+        :raises mlrun.errors.MLRunUnprocessableEntityError: Body mapping failed or mandatory mappings on non-dict body.
+        :raises mlrun.errors.MLRunAccessDeniedError: Matched endpoint is configured with action=FORBID.
+        :raises mlrun.errors.MLRunInternalServerError: Matched endpoint has an unknown action.
         """
         try:
             method = getattr(event, "method", None)
@@ -228,30 +234,17 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                 body_params = {}
                 if effective_map:
                     body = event.body if hasattr(event, "body") else event
-                    if isinstance(body, dict):
-                        try:
-                            body_params = endpoint_mapping.apply_body_map(
-                                body, effective_map
-                            )
-                            mlrun.utils.logger.debug(
-                                "Applied input body mapping",
-                                extracted_params=list(body_params.keys()),
-                            )
-                        except mlrun.errors.MLRunUnprocessableEntityError as exc:
-                            raise mlrun.errors.MLRunUnprocessableEntityError(
-                                f"Failed to process body mapping: {exc}"
-                            ) from exc
-                        except Exception as exc:
-                            raise mlrun.errors.MLRunBadRequestError(
-                                f"Failed to process body mapping: {exc}"
-                            ) from exc
-                    elif any(mandatory for _, mandatory in effective_map.values()):
-                        # Mandatory mappings configured but body is not a dict — can't satisfy contract.
-                        raise mlrun.errors.MLRunUnprocessableEntityError(
-                            f"Mandatory body mappings configured but request body is not a dict "
-                            f"(got {type(body).__name__})"
+                    body_params = endpoint_mapping.apply_body_map_with_dict_check(
+                        body,
+                        effective_map,
+                    )
+                    if body_params is not None:
+                        mlrun.utils.logger.debug(
+                            "Applied input body mapping",
+                            extracted_params=list(body_params.keys()),
                         )
-                    # Non-dict body with only optional mappings: silently skip.
+                    else:
+                        body_params = {}
 
                 # Build system-injected URL params when include_url_info is enabled.
                 # mlrun_request_path holds the normalized path of the matched request.

--- a/mlrun/serving/endpoint_mapping.py
+++ b/mlrun/serving/endpoint_mapping.py
@@ -725,3 +725,52 @@ def merge_body_maps(
             effective_map[dest] = (expr, mandatory)
             src_to_dest[src] = dest
     return effective_map
+
+
+def apply_body_map_with_dict_check(
+    body: Any,
+    effective_map: dict[str, tuple[Any, bool]],
+    input_body: bool = True,
+) -> dict | None:
+    """Apply a body map with the dict-check + mandatory-mapping contract.
+
+    Shared by the request-side API handler and the response-side result handler:
+    a dict body is mapped via :func:`apply_body_map`; a non-dict body raises iff
+    at least one mapping is mandatory, otherwise the non-dict body silently
+    passes through (caller receives ``None`` and treats it as 'no transformation').
+
+    :param body: Body or response object to apply the mapping to.
+    :param effective_map: Merged map of ``{destination_path: (compiled_expr, mandatory)}``.
+    :param input_body: ``True`` for the request side (default), ``False`` for the response
+        side. Drives both the error message wording and whether missing optional fields are
+        filled with ``None`` (output) or skipped (input).
+    :return: Result of :func:`apply_body_map` if ``body`` is a dict; ``None`` if ``body`` is
+        not a dict and all mappings are optional.
+    :raises mlrun.errors.MLRunUnprocessableEntityError: ``body`` is not a dict and at least
+        one mapping is mandatory, or :func:`apply_body_map` itself raised this error.
+    :raises mlrun.errors.MLRunBadRequestError: :func:`apply_body_map` raised any other
+        exception (wrapped with a descriptive prefix).
+    """
+    # Output side expects a complete structure → missing optional fields become None.
+    # Input side drops missing optional fields.
+    label = "input" if input_body else "output"
+    fill_missing_with_none = not input_body
+    if isinstance(body, dict):
+        try:
+            return apply_body_map(
+                body, effective_map, fill_missing_with_none=fill_missing_with_none
+            )
+        except mlrun.errors.MLRunUnprocessableEntityError as exc:
+            raise mlrun.errors.MLRunUnprocessableEntityError(
+                f"Failed to process {label} body mapping: {exc}"
+            ) from exc
+        except Exception as exc:
+            raise mlrun.errors.MLRunBadRequestError(
+                f"Failed to process {label} body mapping: {exc}"
+            ) from exc
+    if any(mandatory for _, mandatory in effective_map.values()):
+        raise mlrun.errors.MLRunUnprocessableEntityError(
+            f"Mandatory {label} body mappings configured but {label} body is not a dict "
+            f"(got {type(body).__name__})"
+        )
+    return None

--- a/mlrun/serving/endpoint_mapping.py
+++ b/mlrun/serving/endpoint_mapping.py
@@ -677,14 +677,14 @@ def apply_body_map(
     :param fill_missing_with_none: If True, missing non-mandatory fields are included as None
         instead of being skipped. Use for output mapping where callers expect a full structure.
     :return: Dict of extracted parameters.
-    :raises mlrun.errors.MLRunBadRequestError: If a mandatory field is missing.
+    :raises mlrun.errors.MLRunUnprocessableEntityError: If a mandatory field is missing.
     """
     result = {}
     for dest_path, (compiled_expr, mandatory) in effective_map.items():
         matches = compiled_expr.find(body)
         if not matches:
             if mandatory:
-                raise mlrun.errors.MLRunBadRequestError(
+                raise mlrun.errors.MLRunUnprocessableEntityError(
                     f"Mandatory field '{dest_path}' not found in body"
                 )
             if fill_missing_with_none:

--- a/mlrun/serving/result_handler.py
+++ b/mlrun/serving/result_handler.py
@@ -22,7 +22,7 @@ from mlrun.serving.endpoint_mapping import (
     APIHandlerConfig,
     EndpointConfig,
     EndpointMatch,
-    apply_body_map,
+    apply_body_map_with_dict_check,
     collect_endpoint_matches,
     compile_body_map,
     compile_dynamic_path_patterns,
@@ -60,15 +60,20 @@ class ResultHandler:
     def apply(self, method: HTTPMethod | str, path: str, response: Any) -> Any:
         """Apply output body mappings to reshape the graph response.
 
+        Mirrors the input-side mapping contract: when output mappings are
+        configured for the matched endpoint, raise only when the mapping cannot
+        be applied to a response it was expected to apply to. Non-dict response
+        with only optional mappings silently passes through, mirroring the
+        input handler's behavior for non-dict bodies with optional mappings.
+
         :param method: HTTP method of the request.
         :param path: Request path.
         :param response: Graph response to reshape.
-        :return: Reshaped response, or original response if no mapping applies.
+        :return: Reshaped response, or the original response if no mapping applies.
+        :raises mlrun.errors.MLRunUnprocessableEntityError: Non-dict response with mandatory mapping, or apply error.
+        :raises mlrun.errors.MLRunBadRequestError: Other failure during mapping apply.
         """
         if not self._parsed_output_body_map:
-            return response
-
-        if not isinstance(response, dict):
             return response
 
         if isinstance(method, str):
@@ -91,4 +96,9 @@ class ResultHandler:
         if not effective_map:
             return response
 
-        return apply_body_map(response, effective_map, fill_missing_with_none=True)
+        reshaped = apply_body_map_with_dict_check(
+            response,
+            effective_map,
+            input_body=False,
+        )
+        return reshaped if reshaped is not None else response

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -729,7 +729,7 @@ class TestPerEndpointBodyMappings:
     """Unit tests for per-endpoint input_body_mappings: extraction and mandatory enforcement."""
 
     def test_mandatory_field_missing_raises(self) -> None:
-        """mandatory=True raises MLRunBadRequestError when the field is absent from the body."""
+        """mandatory=True raises MLRunUnprocessableEntityError when the field is absent from the body."""
         bm = BodyMappings()
         bm.add_mapping("$.model", destination_path="model", mandatory=True)
 
@@ -742,8 +742,32 @@ class TestPerEndpointBodyMappings:
         event = MockEvent(body={"messages": ["hello"]}, method="POST", path="/predict")
 
         with pytest.raises(
-            mlrun.errors.MLRunBadRequestError,
+            mlrun.errors.MLRunUnprocessableEntityError,
             match="Mandatory field 'model' not found",
+        ):
+            step.do(event)
+
+    @pytest.mark.parametrize("mandatory", [True, False])
+    def test_non_dict_body_with_mappings_raises(self, mandatory: bool) -> None:
+        """Non-dict body with body mappings configured raises MLRunUnprocessableEntityError (HTTP 422).
+
+        Applies regardless of whether the mappings are mandatory — once any body_map is
+        configured, the body must be a dict.
+        """
+        bm = BodyMappings()
+        bm.add_mapping("$.model", destination_path="model", mandatory=mandatory)
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/predict", HTTPMethod.POST, APIHandlerAction.ALLOW, input_body_mappings=bm
+        )
+
+        step = _APIHandlerStep(config=config)
+        event = MockEvent(body="not-a-dict", method="POST", path="/predict")
+
+        with pytest.raises(
+            mlrun.errors.MLRunUnprocessableEntityError,
+            match=r"Body mappings configured but request body is not a dict",
         ):
             step.do(event)
 
@@ -889,7 +913,7 @@ class TestBodyMapHierarchy:
         )
 
         with pytest.raises(
-            mlrun.errors.MLRunBadRequestError,
+            mlrun.errors.MLRunUnprocessableEntityError,
             match="Mandatory field 'model' not found",
         ):
             step.do(event)
@@ -965,7 +989,7 @@ class TestBodyMapHierarchy:
         )
 
         with pytest.raises(
-            mlrun.errors.MLRunBadRequestError,
+            mlrun.errors.MLRunUnprocessableEntityError,
             match="Mandatory field 'model' not found",
         ):
             step.do(event)

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -669,6 +669,47 @@ class TestBodyMapMockServer:
         finally:
             server.wait_for_completion()
 
+    @staticmethod
+    def test_missing_mandatory_input_field_returns_422() -> None:
+        """End-to-end: missing mandatory input field surfaces as HTTP 422 to the caller."""
+
+        def echo_handler(body, **kwargs):
+            return kwargs
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-body-map-422", kind="serving"),
+        )
+
+        bm = BodyMappings()
+        bm.add_mapping("$.model", destination_path="model", mandatory=True)
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            input_body_mappings=bm,
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="echo", handler=echo_handler).respond()
+
+        server = fn.to_mock_server()
+        try:
+            with pytest.raises(
+                RuntimeError,
+                match=r"failed \(422\):.*Mandatory field 'model' not found",
+            ):
+                server.test(
+                    "/predict",
+                    method="POST",
+                    body={"messages": ["hello"]},  # 'model' missing
+                )
+        finally:
+            server.wait_for_completion()
+
 
 def test_api_handler_with_body_map_and_processing_step(rundb_mock):
     """Test API handler with input_body_mappings followed by a processing step in the graph."""

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -766,7 +766,7 @@ class TestPerEndpointBodyMappings:
 
         with pytest.raises(
             mlrun.errors.MLRunUnprocessableEntityError,
-            match=r"Mandatory body mappings configured but request body is not a dict",
+            match=r"Mandatory input body mappings configured but input body is not a dict",
         ):
             step.do(event)
 

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -747,15 +747,14 @@ class TestPerEndpointBodyMappings:
         ):
             step.do(event)
 
-    @pytest.mark.parametrize("mandatory", [True, False])
-    def test_non_dict_body_with_mappings_raises(self, mandatory: bool) -> None:
-        """Non-dict body with body mappings configured raises MLRunUnprocessableEntityError (HTTP 422).
+    def test_non_dict_body_with_mandatory_mapping_raises(self) -> None:
+        """Non-dict body with a mandatory mapping raises MLRunUnprocessableEntityError (HTTP 422).
 
-        Applies regardless of whether the mappings are mandatory — once any body_map is
-        configured, the body must be a dict.
+        When body_map has at least one mandatory field, the contract can't be satisfied
+        without a dict body — so we fail fast rather than silently skip.
         """
         bm = BodyMappings()
-        bm.add_mapping("$.model", destination_path="model", mandatory=mandatory)
+        bm.add_mapping("$.model", destination_path="model", mandatory=True)
 
         config = APIHandlerConfig()
         config.add_endpoint_handler(
@@ -767,9 +766,26 @@ class TestPerEndpointBodyMappings:
 
         with pytest.raises(
             mlrun.errors.MLRunUnprocessableEntityError,
-            match=r"Body mappings configured but request body is not a dict",
+            match=r"Mandatory body mappings configured but request body is not a dict",
         ):
             step.do(event)
+
+    def test_non_dict_body_with_optional_mapping_silently_skips(self) -> None:
+        """Non-dict body with only optional mappings is silently skipped (no error)."""
+        bm = BodyMappings()
+        bm.add_mapping("$.model", destination_path="model", mandatory=False)
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/predict", HTTPMethod.POST, APIHandlerAction.ALLOW, input_body_mappings=bm
+        )
+
+        step = _APIHandlerStep(config=config)
+        event = MockEvent(body="not-a-dict", method="POST", path="/predict")
+
+        # Should not raise — body mapping is silently skipped when body isn't a dict
+        # and no mappings are mandatory.
+        step.do(event)
 
     @pytest.mark.parametrize("mandatory", [True, False])
     def test_mapped_field_extracted(self, mandatory: bool) -> None:

--- a/tests/serving/test_body_map.py
+++ b/tests/serving/test_body_map.py
@@ -788,7 +788,8 @@ class TestPerEndpointBodyMappings:
         ):
             step.do(event)
 
-    def test_non_dict_body_with_mandatory_mapping_raises(self) -> None:
+    @pytest.mark.parametrize("body", ["not-a-dict", None])
+    def test_non_dict_body_with_mandatory_mapping_raises(self, body) -> None:
         """Non-dict body with a mandatory mapping raises MLRunUnprocessableEntityError (HTTP 422).
 
         When body_map has at least one mandatory field, the contract can't be satisfied
@@ -803,7 +804,7 @@ class TestPerEndpointBodyMappings:
         )
 
         step = _APIHandlerStep(config=config)
-        event = MockEvent(body="not-a-dict", method="POST", path="/predict")
+        event = MockEvent(body=body, method="POST", path="/predict")
 
         with pytest.raises(
             mlrun.errors.MLRunUnprocessableEntityError,
@@ -811,7 +812,8 @@ class TestPerEndpointBodyMappings:
         ):
             step.do(event)
 
-    def test_non_dict_body_with_optional_mapping_silently_skips(self) -> None:
+    @pytest.mark.parametrize("body", ["not-a-dict", None])
+    def test_non_dict_body_with_optional_mapping_silently_skips(self, body) -> None:
         """Non-dict body with only optional mappings is silently skipped (no error)."""
         bm = BodyMappings()
         bm.add_mapping("$.model", destination_path="model", mandatory=False)
@@ -822,7 +824,7 @@ class TestPerEndpointBodyMappings:
         )
 
         step = _APIHandlerStep(config=config)
-        event = MockEvent(body="not-a-dict", method="POST", path="/predict")
+        event = MockEvent(body=body, method="POST", path="/predict")
 
         # Should not raise — body mapping is silently skipped when body isn't a dict
         # and no mappings are mandatory.

--- a/tests/serving/test_result_handler.py
+++ b/tests/serving/test_result_handler.py
@@ -254,7 +254,7 @@ class TestResultHandlerNonDictResponse:
         handler = _make_handler("/predict", ("$.result", "answer", True))
         with pytest.raises(
             mlrun.errors.MLRunUnprocessableEntityError,
-            match=r"Failed to process output body mapping",
+            match=r"Failed to process output body mapping: Mandatory field 'answer' not found in body",
         ):
             handler.apply(HTTPMethod.POST, "/predict", {"other": "value"})
 

--- a/tests/serving/test_result_handler.py
+++ b/tests/serving/test_result_handler.py
@@ -200,7 +200,7 @@ class TestResultHandlerMissingFields:
     def test_missing_mandatory_field_raises(self) -> None:
         handler = _make_handler("/predict", ("$.result", "answer", True))
         with pytest.raises(
-            mlrun.errors.MLRunBadRequestError,
+            mlrun.errors.MLRunUnprocessableEntityError,
             match="Mandatory field 'answer' not found",
         ):
             handler.apply(HTTPMethod.POST, "/predict", {"other": "value"})

--- a/tests/serving/test_result_handler.py
+++ b/tests/serving/test_result_handler.py
@@ -218,7 +218,49 @@ class TestResultHandlerMissingFields:
 
 
 # ---------------------------------------------------------------------------
-# Group 5 — http_trigger guard (end-to-end via to_mock_server())
+# Group 5 — Non-dict response handling
+# ---------------------------------------------------------------------------
+class TestResultHandlerNonDictResponse:
+    """Non-dict responses: silently pass through unless any mapping is mandatory."""
+
+    def test_non_dict_string_response_with_optional_mapping_passes_through(
+        self,
+    ) -> None:
+        """Non-dict response + all-optional mappings → return unchanged."""
+        handler = _make_handler("/predict", ("$.result", "answer", False))
+        response = "plain string"
+        assert handler.apply(HTTPMethod.POST, "/predict", response) is response
+
+    def test_non_dict_response_with_mandatory_mapping_raises(self) -> None:
+        """Non-dict response + any mandatory mapping → raise with output body wording."""
+        handler = _make_handler("/predict", ("$.result", "answer", True))
+        with pytest.raises(
+            mlrun.errors.MLRunUnprocessableEntityError,
+            match=r"Mandatory output body mappings configured but output body is not a dict",
+        ):
+            handler.apply(HTTPMethod.POST, "/predict", "plain string")
+
+    def test_non_dict_response_error_includes_actual_type(self) -> None:
+        """Error message includes the actual response type to aid debugging."""
+        handler = _make_handler("/predict", ("$.result", "answer", True))
+        with pytest.raises(
+            mlrun.errors.MLRunUnprocessableEntityError,
+            match=r"got list",
+        ):
+            handler.apply(HTTPMethod.POST, "/predict", [1, 2, 3])
+
+    def test_missing_mandatory_field_error_wrapped_with_output_prefix(self) -> None:
+        """Mandatory-field-missing errors from apply_body_map gain an output-body prefix."""
+        handler = _make_handler("/predict", ("$.result", "answer", True))
+        with pytest.raises(
+            mlrun.errors.MLRunUnprocessableEntityError,
+            match=r"Failed to process output body mapping",
+        ):
+            handler.apply(HTTPMethod.POST, "/predict", {"other": "value"})
+
+
+# ---------------------------------------------------------------------------
+# Group 6 — http_trigger guard (end-to-end via to_mock_server())
 # ---------------------------------------------------------------------------
 class TestResultHandlerHttpTriggerGuard:
     """Exit mapping is only applied when http_trigger=True on GraphServer."""
@@ -302,5 +344,40 @@ class TestResultHandlerHttpTriggerGuard:
                 body={"prediction": "dog"},
             )
             assert resp == {"label": "dog", "score": None}
+        finally:
+            server.wait_for_completion()
+
+    def test_e2e_non_dict_response_with_mandatory_returns_422(self) -> None:
+        """End-to-end: handler returns a non-dict response with mandatory output mapping → HTTP 422."""
+
+        def broken_handler(body, **kwargs):
+            # Returns a non-dict so the output mapping can't apply at all.
+            return "not-a-dict"
+
+        bm = BodyMappings()
+        bm.add_mapping("$.prediction", destination_path="label", mandatory=True)
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-result-handler-422", kind="serving"),
+        )
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            output_body_mappings=bm,
+        )
+        fn.set_api_handler_config(config)
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="broken", handler=broken_handler).respond()
+
+        server = fn.to_mock_server()
+        try:
+            with pytest.raises(
+                RuntimeError,
+                match=r"failed \(422\):.*Mandatory output body mappings configured but output body is not a dict",
+            ):
+                server.test("/predict", method="POST", body={"any": "input"})
         finally:
             server.wait_for_completion()

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -302,8 +302,8 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
 
         self._logger.info("Body map inheritance and HTTP method isolation test passed")
 
-    def test_api_handler_mandatory_field_missing_returns_400(self) -> None:
-        """Test that a missing mandatory field returns HTTP 400."""
+    def test_api_handler_mandatory_field_missing_returns_422(self) -> None:
+        """Test that a missing mandatory field returns HTTP 422."""
         self._logger.info("Testing mandatory field enforcement")
 
         bm = BodyMappings()
@@ -329,8 +329,8 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         self._logger.debug("Deploying function for mandatory field test")
         function.deploy()
 
-        # Missing mandatory field → expect 400
-        with pytest.raises(RuntimeError, match="400"):
+        # Missing mandatory field → expect 422
+        with pytest.raises(RuntimeError, match="422"):
             function.invoke(
                 path="/api/v1/predict",
                 method="POST",
@@ -514,8 +514,8 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
 
         self._logger.info("Output body mapping test passed")
 
-    def test_output_body_mapping_mandatory_missing_returns_400(self) -> None:
-        """Missing mandatory output field raises HTTP 400."""
+    def test_output_body_mapping_mandatory_missing_returns_422(self) -> None:
+        """Missing mandatory output field raises HTTP 422."""
         out_bm = BodyMappings()
         out_bm.add_mapping(
             "$.nonexistent", destination_path="output_result", mandatory=True
@@ -540,7 +540,7 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
 
         with pytest.raises(
             RuntimeError,
-            match=r"bad function response 400:.*MLRunBadRequestError.*Mandatory field 'output_result' not found",  # noqa: E501
+            match=r"bad function response 422:.*MLRunUnprocessableEntityError.*Mandatory field 'output_result' not found",  # noqa: E501
         ):
             function.invoke(path="/predict", body={"model": "gpt-4"})
 
@@ -702,9 +702,9 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
                 model="gpt-4",
                 messages=[{"role": "user", "content": "Hello"}],
             )
-        assert exc_info.value.status_code == 400
+        assert exc_info.value.status_code == 422
         assert (
-            "MLRunBadRequestError: Mandatory field 'choices' not found in body"
+            "MLRunUnprocessableEntityError: Mandatory field 'choices' not found in body"
             in str(exc_info.value)
         )
 
@@ -738,9 +738,10 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
                 model="gpt-4",
                 input="Hello",
             )
-        assert exc_info.value.status_code == 400
-        assert "MLRunBadRequestError: Mandatory field 'id' not found in body" in str(
-            exc_info.value
+        assert exc_info.value.status_code == 422
+        assert (
+            "MLRunUnprocessableEntityError: Mandatory field 'id' not found in body"
+            in str(exc_info.value)
         )
 
         self._logger.info("Responses missing mandatory output field test passed")

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -704,8 +704,8 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
             )
         assert exc_info.value.status_code == 422
         assert (
-            "MLRunUnprocessableEntityError: Mandatory field 'choices' not found in body"
-            in str(exc_info.value)
+            "MLRunUnprocessableEntityError: Failed to process output body mapping: "
+            "Mandatory field 'choices' not found in body" in str(exc_info.value)
         )
 
         self._logger.info("Chat completions missing mandatory output field test passed")
@@ -740,8 +740,8 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
             )
         assert exc_info.value.status_code == 422
         assert (
-            "MLRunUnprocessableEntityError: Mandatory field 'id' not found in body"
-            in str(exc_info.value)
+            "MLRunUnprocessableEntityError: Failed to process output body mapping: "
+            "Mandatory field 'id' not found in body" in str(exc_info.value)
         )
 
         self._logger.info("Responses missing mandatory output field test passed")


### PR DESCRIPTION
### 📝 Description
- Missing mandatory body-mapping field (input or output) now raises `MLRunUnprocessableEntityError` (HTTP 422) instead of `MLRunBadRequestError` (HTTP 400).
422 is the semantically correct status code per RFC 9110 — the request parses fine as JSON but fails schema validation.
- Non-dict request body raises 422 only when at least one configured body mapping is mandatory.
-  Optional-only mappings still silently skip (matches prior behavior for that case).


---

### 🛠️ Changes Made

- `mlrun/errors.py` — added `MLRunUnprocessableEntityError(MLRunHTTPStatusError)` with `error_status_code = 422`.
- `mlrun/serving/endpoint_mapping.py` — `apply_body_map` raises `MLRunUnprocessableEntityError` on missing mandatory field; docstring updated.
- `mlrun/serving/api_handler.py` — input wrapper lets `MLRunUnprocessableEntityError` through; non-dict body with mandatory mappings raises 422; optional-only path unchanged.
- `tests/serving/test_body_map.py` — unit tests assert `MLRunUnprocessableEntityError`; new tests for non-dict-body with mandatory vs. optional mappings.
- `tests/serving/test_result_handler.py` — unit test asserts `MLRunUnprocessableEntityError`.
- `tests/system/runtimes/test_serving.py` — system tests assert 422 / `MLRunUnprocessableEntityError` (input + output mandatory cases; OpenAI chat completions + responses). 
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
Unit tests:
- tests/serving/test_body_map.py::test_mandatory_field_missing_raises (updated to expect 422)
- tests/serving/test_body_map.py::test_non_dict_body_with_mandatory_mapping_raises (new)
- tests/serving/test_body_map.py::test_non_dict_body_with_optional_mapping_silently_skips (new)
- tests/serving/test_result_handler.py::test_missing_mandatory_field_raises (updated to expect 422)

  System tests (renamed/updated):
- tests/system/runtimes/test_serving.py::test_api_handler_mandatory_field_missing_returns_422 (renamed from _returns_400)
- tests/system/runtimes/test_serving.py::test_output_body_mapping_mandatory_missing_returns_422 (renamed from _returns_400)
- tests/system/runtimes/test_serving.py::test_chat_completions_missing_mandatory_output_raises (assertions updated for 422)
- tests/system/runtimes/test_serving.py::test_responses_missing_mandatory_output_raises (assertions updated for 422)


---

### 🔗 References
- Ticket link: [ML-12690](https://ecliptos.atlassian.net/browse/ML-12690)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
Why 422 over 400
RFC 9110: 422 ("Unprocessable Content") = "the server understands the content type and the syntax is correct, but it was unable to process the contained instructions."
 That fits both cases this PR raises 422 on:
  - Missing mandatory field — the body parses fine as JSON, the endpoint matched, the HTTP method was valid; one specific piece of business validation failed.
  - Non-dict body with mandatory mapping — the body still parses as valid JSON (e.g. a list, string, or null), it just isn't the shape the mapping contract expects.
  
In both, the request was successfully parsed; what failed is schema validation. 400 implies the request itself couldn't be parsed at all, which isn't what's happening.

  Reverts [#9517](https://github.com/mlrun/mlrun/pull/9517)

This effectively reverts #9517 (https://github.com/mlrun/mlrun/pull/9517), which removed `MLRunUnprocessableEntityError` and silenced the 422 raises.
 That fix was correct for its time: under the global body_map, any JSONPath miss raised 422 unconditionally, which made cross-endpoint graph sharing impossible.

The new per-endpoint BodyMappings design ([ML-12439](https://ecliptos.atlassian.net/browse/ML-12439)) plus the explicit mandatory flag makes 422 safe to bring back - it now only fires when a field that was deliberately marked
mandatory on the matched endpoint is missing, never as a side effect of cross-endpoint sharing. Optional fields still silently skip, preserving the cross-endpoint flexibility [#9517](https://github.com/mlrun/mlrun/pull/9517) was built to enable.
