### PR TITLE
[Datastore] Fix Azure identity-based artifact logging when account name is absent

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -173,13 +173,22 @@ class AzureBlobStore(DataStore):
             raise ImportError("Azure adlfs not installed") from exc
 
         if not self._filesystem:
+            storage_options = self.storage_options
+            if not storage_options.get("connection_string") and not storage_options.get(
+                "account_name"
+            ):
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    "Azure Blob storage requires an account_name "
+                    "(or AZURE_STORAGE_ACCOUNT_NAME) or a connection_string, but neither "
+                    "was found."
+                )
             # in order to support az and wasbs kinds
             filesystem_class = get_filesystem_class(protocol=self.kind)
             self._filesystem = make_datastore_schema_sanitizer(
                 filesystem_class,
                 using_bucket=self.using_bucket,
                 blocksize=self.max_blocksize,
-                **self.storage_options,
+                **storage_options,
             )
         return self._filesystem
 

--- a/mlrun/runtimes/mounts.py
+++ b/mlrun/runtimes/mounts.py
@@ -576,7 +576,7 @@ def set_env_variables(
 
 
 def set_env_vars_from_secret(
-    secret_name: str,
+    secret_name: str | None = None,
     keys: typing.Union[str, list[str], None] = None,
     cleartext_env: typing.Union[str, dict[str, str], None] = None,
 ) -> typing.Callable[["KubeResource"], "KubeResource"]:
@@ -584,6 +584,11 @@ def set_env_vars_from_secret(
     Modifier function to set environment variables from a Kubernetes Secret.
     If keys are given, each key is exposed as an environment variable with the same name.
     If no keys are given, all keys in the secret are mounted as env vars (via envFrom).
+
+    ``secret_name`` is optional: when it is omitted only the ``cleartext_env`` variables are
+    injected (no secret is mounted). This supports identity-based auth (e.g. Azure workload
+    identity), where the credentials arrive via a federated token rather than a Kubernetes
+    secret, but a plain config value such as the storage account name still has to be set.
 
     Performs the same secret-name validation as other secret-mount functions
     (validate_not_forbidden_secret); when using specific keys this is done via
@@ -608,7 +613,8 @@ def set_env_vars_from_secret(
             )
         )
 
-    :param secret_name: Kubernetes secret name.
+    :param secret_name: Optional. Kubernetes secret name. When omitted, no secret is mounted
+        and only ``cleartext_env`` is injected (used for identity-based auth).
     :param keys: Optional. Secret data keys to expose as env vars. Either a semicolon-delimited
         string (e.g. "key1;key2;key3") or a list of strings. If omitted, all keys in the
         secret are mounted as environment variables.
@@ -646,15 +652,24 @@ def set_env_vars_from_secret(
 
     if secret_name:
         mlrun.common.secrets.validate_not_forbidden_secret(secret_name.strip())
+    elif keys_list:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "set_env_vars_from_secret requires a secret_name when keys are specified"
+        )
+    elif not cleartext_env_dict:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "set_env_vars_from_secret requires either a secret_name or cleartext_env"
+        )
 
     def _set_env_vars_from_secret(runtime: "KubeResource"):
-        if not keys_list:
-            runtime.set_env_from_secret_ref(secret_name)
-        else:
-            for key in keys_list:
-                runtime.set_env_from_secret(
-                    name=key, secret=secret_name, secret_key=key
-                )
+        if secret_name:
+            if not keys_list:
+                runtime.set_env_from_secret_ref(secret_name)
+            else:
+                for key in keys_list:
+                    runtime.set_env_from_secret(
+                        name=key, secret=secret_name, secret_key=key
+                    )
         for k, v in cleartext_env_dict.items():
             runtime.set_env(k, v)
         return runtime

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -826,3 +826,37 @@ class TestAzureBlobStore:
         mock_default.assert_not_called()
         _, kwargs = mock_blob_client.call_args
         assert kwargs["credential"] is mock_client_secret.return_value
+
+    def test_filesystem_missing_account_name_and_connection_string_raises(self):
+        """ML-12692: az:// with neither account_name nor connection_string fails fast.
+
+        This is the Azure identity path: credentials are routed via anon=False, but the
+        storage account name was never supplied. Instead of letting adlfs raise its cryptic
+        'Must provide ... account_name with credentials', we raise a clear MLRun error.
+        """
+        store = self._create_store(schema="az", endpoint="data")
+        mock_storage_options = {"anon": False, "container": "data"}
+
+        with patch.object(store, "_storage_options", mock_storage_options):
+            with pytest.raises(
+                mlrun.errors.MLRunInvalidArgumentError, match="account_name"
+            ):
+                _ = store.filesystem
+
+    def test_filesystem_with_account_name_does_not_raise(self):
+        """When account_name is present, the account-name guard does not trigger."""
+        store = self._create_store(schema="az", endpoint="data")
+        mock_storage_options = {"account_name": "teststorage", "anon": False}
+
+        with (
+            patch.object(store, "_storage_options", mock_storage_options),
+            patch("mlrun.datastore.azure_blob.get_filesystem_class") as mock_get_class,
+            patch(
+                "mlrun.datastore.azure_blob.make_datastore_schema_sanitizer"
+            ) as mock_make_fs,
+        ):
+            result = store.filesystem
+
+        mock_get_class.assert_called_once()
+        mock_make_fs.assert_called_once()
+        assert result is mock_make_fs.return_value

--- a/tests/runtimes/test_mounts.py
+++ b/tests/runtimes/test_mounts.py
@@ -17,6 +17,7 @@ import deepdiff
 import pytest
 
 import mlrun
+import mlrun.errors
 import mlrun.platforms
 import mlrun.runtimes.mounts
 
@@ -429,6 +430,53 @@ def test_auto_mount_secret_env(with_keys, with_cleartext):
         cleartext_keys = set(cleartext.keys())
         overlap = cleartext_keys & set(plain_env.keys())
         assert not overlap, f"Expected no cleartext env vars but found: {overlap}"
+
+
+def test_auto_mount_secret_env_cleartext_only_no_secret():
+    """secret_env auto-mount with only cleartext_env (no secret_name) injects a plain env var.
+
+    This is the Azure workload-identity path (ML-12692): the federated token arrives via the
+    WI webhook, so only the storage account name needs to be set, with no secret mounted.
+    """
+    mlrun.mlconf.storage.auto_mount_type = "secret_env"
+    mlrun.mlconf.storage.auto_mount_params = (
+        "cleartext_env=AZURE_STORAGE_ACCOUNT:teststorage"
+    )
+
+    function = mlrun.new_function(
+        "function-name", "function-project", kind=mlrun.runtimes.RuntimeKinds.job
+    )
+    function.apply(mlrun.runtimes.mounts.auto_mount())
+
+    # No secret is mounted (neither envFrom nor secretKeyRef env vars).
+    assert len(function.spec.env_from) == 0
+    plain_env = {}
+    for item in function.spec.env:
+        if isinstance(item, dict):
+            assert "valueFrom" not in item, f"unexpected secret-backed env: {item}"
+            plain_env[item["name"]] = item.get("value")
+        else:
+            assert getattr(item, "value_from", None) is None, (
+                f"unexpected secret-backed env: {item}"
+            )
+            plain_env[item.name] = item.value
+    assert plain_env.get("AZURE_STORAGE_ACCOUNT") == "teststorage"
+
+
+def test_set_env_vars_from_secret_requires_secret_or_cleartext():
+    """Calling without a secret_name and without cleartext_env is a usage error."""
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="secret_name or cleartext_env"
+    ):
+        mlrun.runtimes.mounts.set_env_vars_from_secret()
+
+
+def test_set_env_vars_from_secret_keys_without_secret_name_raises():
+    """Keys make no sense without a secret to read them from."""
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="secret_name when keys"
+    ):
+        mlrun.runtimes.mounts.set_env_vars_from_secret(keys="KEY_A;KEY_B")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description
Under Azure workload/managed identity (IG4-1528), remote jobs receive the federated identity env vars (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_FEDERATED_TOKEN_FILE`, `AZURE_AUTHORITY_HOST`) but **not** the storage account name, and there is no connection string. With an `az://<container>/...` artifact path (which encodes only the container), `AzureBlobStore` resolves `account_name=None`, so `adlfs` is built with neither an account name nor a connection string and raises the cryptic:

```
ValueError: unable to connect to account for Must provide either a connection_string or account_name with credentials!!
```

This is the MLRun (SDK) side of **ML-12692**. The credential-routing fix (#9766) is correct but sits downstream of this failure — adlfs needs the account name to even build the account URL, and bails first.

---

### 🛠️ Changes Made
- **`mlrun/datastore/azure_blob.py`** — in the `filesystem` path, fail fast with a clear `MLRunInvalidArgumentError` when neither `account_name` nor `connection_string` is available, instead of letting adlfs raise its cryptic message.
- **`mlrun/runtimes/mounts.py`** — `set_env_vars_from_secret` now accepts an optional `secret_name`; when omitted it injects only `cleartext_env` (no secret mounted). This lets the installer ship `AZURE_STORAGE_ACCOUNT` to identity-based jobs via the `secret_env` auto-mount without mounting a Kubernetes secret. Added guards: keys without a secret, or neither secret nor cleartext, raise a clear error.

> The companion installer change (mlefi) that actually supplies `AZURE_STORAGE_ACCOUNT` in identity mode depends on the cleartext-only support added here.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing
Unit tests (`tests/datastore/test_azure_blob_store.py`, `tests/runtimes/test_mounts.py`) — 75 passed. `make fmt` and `make lint` clean.
- `test_filesystem_missing_account_name_and_connection_string_raises` — the missing-account case (the gap #9766's suite never covered).
- `test_filesystem_with_account_name_does_not_raise` — guard does not false-trigger.
- `test_auto_mount_secret_env_cleartext_only_no_secret` — cleartext-only injection, no secret mounted.
- `test_set_env_vars_from_secret_requires_secret_or_cleartext` / `_keys_without_secret_name_raises` — usage guards.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12692 (feature: IG4-1528)
- Design docs links: N/A
- External links: related prior symptom — ML-7670

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Paired with an installer (mlefi) PR that injects `AZURE_STORAGE_ACCOUNT` into identity-mode job pods; that change relies on the cleartext-only `secret_env` auto-mount added here. nuclio identity-mode jobs may need the same account-name plumbing (IG4-1528 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)