### PR TITLE
[Coverage] Changed coverage mounting point

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -62,8 +62,8 @@ kubeconfig*
 
 # Coverage reports
 *.coverage
-**/coverage_reports/*.xml
-**/coverage_reports/*.html
+**/coverage_reports/*
+!**/coverage_reports/.gitkeep
 
 # AI markdown files
 CLAUDE.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: coverage_unit_tests_report_${{ matrix.python-version }}_${{ github.run_id }}_${{ matrix.test-suite }}.coverage
-        path: /tmp/coverage_reports/unit_tests_${{ matrix.test-suite }}/unit_tests_${{ matrix.test-suite }}.coverage
+        path: coverage_reports/unit_tests_${{ matrix.test-suite }}/unit_tests_${{ matrix.test-suite }}.coverage
         retention-days: 30
 
 
@@ -214,7 +214,7 @@ jobs:
       if: env.RUN_COVERAGE == 'true'
       with:
          name: coverage_integration_tests_report_${{ matrix.python-version }}_${{ matrix.test-db }}_${{ github.run_id }}.coverage
-         path: /tmp/coverage_reports/integration_tests/integration_tests.coverage
+         path: coverage_reports/integration_tests/integration_tests.coverage
          retention-days: 30
 
   migrations-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: coverage_unit_tests_report_${{ matrix.python-version }}_${{ github.run_id }}_${{ matrix.test-suite }}.coverage
-        path: coverage_reports/unit_tests_${{ matrix.test-suite }}/unit_tests_${{ matrix.test-suite }}.coverage
+        path: ${{ github.workspace }}/coverage_reports/unit_tests_${{ matrix.test-suite }}/unit_tests_${{ matrix.test-suite }}.coverage
         retention-days: 30
 
 
@@ -214,7 +214,7 @@ jobs:
       if: env.RUN_COVERAGE == 'true'
       with:
          name: coverage_integration_tests_report_${{ matrix.python-version }}_${{ matrix.test-db }}_${{ github.run_id }}.coverage
-         path: coverage_reports/integration_tests/integration_tests.coverage
+         path: ${{ github.workspace }}/coverage_reports/integration_tests/integration_tests.coverage
          retention-days: 30
 
   migrations-tests:
@@ -243,7 +243,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage_migration_tests_report-${{ github.run_id }}.coverage
-          path: /tmp/coverage_reports/migration_tests/migration_tests.coverage
+          path: ${{ github.workspace }}/coverage_reports/migration_tests/migration_tests.coverage
           retention-days: 30
 
   package-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ tests/system/env.yml
 server/py/services/api/db
 migration_tests.log
 # Coverage reports
-*.coverage
+**/*.coverage
 
 # Editors and operating system files
 # Visual Studio Code settings
@@ -114,8 +114,8 @@ server/py/schemas/proto/*pb2*.py
 # <= 1.7.x legacy project structure
 # on >= 1.8.0, server/api has been moved to server/py/services/api
 server/api
-tests/coverage_reports/*.xml
-tests/coverage_reports/*.html
+**/coverage_reports/*
+!**/coverage_reports/.gitkeep
 **/test-openai.yml
 **/test-huggingface.yml
 

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ fi
 # Verify the mount point to avoid deleting essential paths.
 # COVERAGE_MOUNT_PATH must live under the repo workspace (not /tmp), so it is
 # disjoint from the -v /tmp:/tmp mount and cannot be wiped by anything that
-# sweeps /tmp during the test run. See docs/design/coverage_combine_problem.md.
+# sweeps /tmp during the test run.
 SETUP_COVERAGE_MOUNTING = if [ "$(RUN_COVERAGE)" = "true" ]; then \
 		case "$$COVERAGE_MOUNT_PATH" in $(ROOT_DIR)coverage_reports/*) \
 			rm -rf $$COVERAGE_MOUNT_PATH && \

--- a/Makefile
+++ b/Makefile
@@ -98,14 +98,17 @@ CHECK_COVERAGE_ERROR = if [ "$(RUN_COVERAGE)" = "true" ] && [ $$PYTEST_EXIT -ne 
 	exit $$PYTEST_EXIT ; \
 fi
 
-# Verify the mount point to avoid deleting essential paths
+# Verify the mount point to avoid deleting essential paths.
+# COVERAGE_MOUNT_PATH must live under the repo workspace (not /tmp), so it is
+# disjoint from the -v /tmp:/tmp mount and cannot be wiped by anything that
+# sweeps /tmp during the test run. See docs/design/coverage_combine_problem.md.
 SETUP_COVERAGE_MOUNTING = if [ "$(RUN_COVERAGE)" = "true" ]; then \
-		case "$$COVERAGE_MOUNT_PATH" in /tmp/coverage_reports/*) \
+		case "$$COVERAGE_MOUNT_PATH" in $(ROOT_DIR)coverage_reports/*) \
 			rm -rf $$COVERAGE_MOUNT_PATH && \
 			mkdir -p $$COVERAGE_MOUNT_PATH; \
 			;; \
 	  	*) \
-			echo "Error: COVERAGE_MOUNT_PATH is invalid, must be under /tmp/coverage_reports/*" >&2 ; \
+			echo "Error: COVERAGE_MOUNT_PATH is invalid, must be under $(ROOT_DIR)coverage_reports/*" >&2 ; \
 			exit 1; \
 			;; \
 		esac \
@@ -634,7 +637,7 @@ clean: ## Clean python package build artifacts
 
 .PHONY: test-dockerized
 test-dockerized: build-test ## Run mlrun tests in docker container
-	COVERAGE_MOUNT_PATH="/tmp/coverage_reports/unit_tests$(COVERAGE_DIR_SUFFIX)" ;\
+	COVERAGE_MOUNT_PATH="$(ROOT_DIR)coverage_reports/unit_tests$(COVERAGE_DIR_SUFFIX)" ;\
 	$(SETUP_COVERAGE_MOUNTING) && \
 	docker run \
 		-t \
@@ -698,7 +701,7 @@ test: clean ## Run mlrun tests
 
 .PHONY: test-integration-dockerized
 test-integration-dockerized: build-test api ## Run mlrun integration tests in docker container, some tests require the api image to be built
-	COVERAGE_MOUNT_PATH="/tmp/coverage_reports/integration_tests" ;\
+	COVERAGE_MOUNT_PATH="$(ROOT_DIR)coverage_reports/integration_tests" ;\
 	$(SETUP_COVERAGE_MOUNTING)  && \
 	docker run \
 		-t \
@@ -738,7 +741,7 @@ test-integration: clean ## Run mlrun integration tests
 
 .PHONY: test-migrations-dockerized
 test-migrations-dockerized: build-test ## Run mlrun db migrations tests in docker container
-	COVERAGE_MOUNT_PATH="/tmp/coverage_reports/migration_tests" ;\
+	COVERAGE_MOUNT_PATH="$(ROOT_DIR)coverage_reports/migration_tests" ;\
 	$(SETUP_COVERAGE_MOUNTING) && \
 	docker run \
 		-t \


### PR DESCRIPTION
### 📝 Description
Fixes intermittent failures and silently-incomplete results in the `Full coverage` CI job. 
The dockerized test targets were bind-mounting `-v /tmp:/tmp` AND writing coverage reports
nested under `/tmp/coverage_reports/<suite>/` on the runner. Anything that swept `/tmp` mid-run (systemd-tmpfiles, tests doing `rm -rf /tmp/*`, etc.) could delete sidecar
`.coverage.<host>.<pid>.<rand>` files before `coverage combine` ran — producing a partial report (silent) or an empty artifact (loud failure later in the aggregator).

This PR moves the host-side coverage directory out of `/tmp` and into the repo workspace, making the coverage mount disjoint from `/tmp:/tmp`. The in-container path is unchanged, and
the GitHub-hosted runner VM is still ephemeral, so the "auto-clean" guarantee is preserved by the runner lifecycle itself.

---

### 🛠️ Changes Made
- **`Makefile`** — `SETUP_COVERAGE_MOUNTING` guard and the three dockerized test targets (`test-dockerized`, `test-integration-dockerized`, `test-migrations-dockerized`) now use
`$(ROOT_DIR)coverage_reports/<suite>/` on the host instead of `/tmp/coverage_reports/<suite>/`.
Container path (`/mlrun/tests/coverage_reports`) unchanged.
- **`.github/workflows/ci.yaml`** — `actions/upload-artifact` `path:` for unit/integration/migration jobs now reads from `${{ github.workspace }}/coverage_reports/<suite>/...`
(absolute, symmetric with the Makefile's `$(ROOT_DIR)`).
- **`.gitignore`** / **`.dockerignore`** — added `**/coverage_reports/*` + `!**/coverage_reports/.gitkeep` so the new workspace coverage dir doesn't pollute git or Docker build contexts.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- **CI end-to-end** — exercised by this PR's own run. Verified that the three writer jobs (`unit-tests` × {server, client}, `integration-tests` × {mysql, postgres},`migrations-tests`) each upload their `coverage_*.coverage` artifact from the new workspace path, and that the `Full coverage` aggregator job successfully downloads all three, runs
`make coverage-combine`, and produces `combined.coverage` + `combined.xml` + `diff_coverage.md`.
- **Path equivalence verified** — `$(ROOT_DIR)` (Makefile) and `${{ github.workspace }}` (Actions) resolve to the same physical path (`/home/runner/work/mlrun/mlrun/`) for all three coverage-producing jobs (none of them use a custom `path:` on `actions/checkout`, no step uses `working-directory:`).

---

### 🔗 References
- Ticket link: [ML-12469](https://ecliptos.atlassian.net/browse/ML-12469)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-12469]: https://iguazio.atlassian.net/browse/ML-12469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ