### PR TITLE
[Log Collector] Fix draining in-flight streamers in StopLogs/DeleteLogs

### DIFF
--- a/server/go/services/logcollector/logcollector_test.go
+++ b/server/go/services/logcollector/logcollector_test.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -209,12 +210,17 @@ func (suite *LogCollectorTestSuite) TestStreamPodLogs() {
 	startedChan := make(chan bool)
 
 	// stream pod logs
+	handle := &streamerHandle{
+		cancel: func() {},
+		done:   make(chan struct{}),
+	}
 	go suite.logCollectorServer.startLogStreaming(context.WithoutCancel(suite.ctx),
 		runId,
 		pod.Name,
 		suite.projectName,
 		0,
-		startedChan)
+		startedChan,
+		handle)
 
 	// wait for log streaming to start
 	started := <-startedChan
@@ -796,6 +802,231 @@ func (suite *LogCollectorTestSuite) TestDeleteProjectLogs() {
 	dirEntries, err = os.ReadDir(dirPath)
 	suite.Require().NoError(err, "Failed to read dir")
 	suite.Require().Equal(1, len(dirEntries), "Expected logs to be deleted")
+}
+
+// TestStopLogsDrainsActiveWriter asserts that StopLogs blocks until the
+// streaming goroutine has observed cancellation and unwound, and that no
+// writes occur after it returns.
+func (suite *LogCollectorTestSuite) TestStopLogsDrainsActiveWriter() {
+	projectName := "drains-active-writer"
+	runUID := uuid.New().String()
+	selector := fmt.Sprintf("mlrun/uid=%s", runUID)
+
+	logFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
+	suite.Require().NoError(os.MkdirAll(path.Dir(logFilePath), 0o755))
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	suite.Require().NoError(err, "Failed to open log file")
+	defer logFile.Close() // nolint: errcheck
+
+	suite.Require().NoError(suite.logCollectorServer.stateManifest.AddLogItem(suite.ctx, runUID, selector, projectName))
+	suite.Require().NoError(suite.logCollectorServer.currentState.AddLogItem(suite.ctx, runUID, selector, projectName))
+	defer func() {
+		_ = suite.logCollectorServer.stateManifest.RemoveProject(projectName)
+		_ = suite.logCollectorServer.currentState.RemoveProject(projectName)
+	}()
+
+	streamCtx, handle := suite.logCollectorServer.registerStreamer(context.Background(), projectName, runUID)
+
+	// model the real streamer: write continuously, take ~50ms to unwind on cancel
+	const writerResidualTime = 50 * time.Millisecond
+	var writesAfterStop int64
+	stopReturned := make(chan struct{})
+	go func() {
+		defer func() {
+			suite.logCollectorServer.unregisterStreamer(projectName, runUID, handle)
+			close(handle.done)
+		}()
+		for {
+			select {
+			case <-streamCtx.Done():
+				time.Sleep(writerResidualTime)
+				return
+			default:
+			}
+			if _, werr := logFile.Write([]byte("streamed log line\n")); werr != nil {
+				return
+			}
+			select {
+			case <-stopReturned:
+				atomic.AddInt64(&writesAfterStop, 1)
+			default:
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	stopStart := time.Now()
+	stopResp, err := suite.logCollectorServer.StopLogs(suite.ctx, &protologcollector.StopLogsRequest{
+		Project: projectName,
+		RunUIDs: []string{runUID},
+	})
+	stopDuration := time.Since(stopStart)
+	close(stopReturned)
+	suite.Require().NoError(err, "StopLogs RPC returned an error")
+	suite.Require().True(stopResp.Success, "StopLogs returned non-success")
+
+	time.Sleep(100 * time.Millisecond)
+
+	suite.Require().GreaterOrEqual(stopDuration, writerResidualTime,
+		"StopLogs returned in %s — too fast to have drained the writer (expected >= %s).",
+		stopDuration, writerResidualTime)
+	suite.Require().Equal(int64(0), atomic.LoadInt64(&writesAfterStop),
+		"writer continued to write after StopLogs returned")
+
+	select {
+	case <-handle.done:
+	default:
+		suite.Require().Fail("streamer handle.done was not closed by StopLogs return")
+	}
+
+	suite.logCollectorServer.streamersMu.Lock()
+	_, present := suite.logCollectorServer.streamers[projectName]
+	suite.logCollectorServer.streamersMu.Unlock()
+	suite.Require().False(present, "registry still has entries for project after StopLogs")
+}
+
+// TestStopLogs_NoActiveStreamer_NoOp verifies StopLogs succeeds for a run that
+// was never started (no entry in the cancel registry).
+func (suite *LogCollectorTestSuite) TestStopLogs_NoActiveStreamer_NoOp() {
+	projectName := fmt.Sprintf("no-streamer-%s", uuid.New().String())
+	runUID := uuid.New().String()
+
+	// per-run path: state present but no registry entry
+	suite.Require().NoError(suite.logCollectorServer.stateManifest.AddLogItem(suite.ctx, runUID, "sel", projectName))
+	suite.Require().NoError(suite.logCollectorServer.currentState.AddLogItem(suite.ctx, runUID, "sel", projectName))
+	defer func() {
+		_ = suite.logCollectorServer.stateManifest.RemoveProject(projectName)
+		_ = suite.logCollectorServer.currentState.RemoveProject(projectName)
+	}()
+
+	resp, err := suite.logCollectorServer.StopLogs(suite.ctx, &protologcollector.StopLogsRequest{
+		Project: projectName,
+		RunUIDs: []string{runUID},
+	})
+	suite.Require().NoError(err, "StopLogs (no streamer) returned an error")
+	suite.Require().True(resp.Success, "StopLogs (no streamer) returned non-success")
+
+	// project-scope path: no registry entry at all
+	emptyProject := fmt.Sprintf("no-streamer-empty-%s", uuid.New().String())
+	resp2, err := suite.logCollectorServer.StopLogs(suite.ctx, &protologcollector.StopLogsRequest{
+		Project: emptyProject,
+		RunUIDs: nil,
+	})
+	suite.Require().NoError(err, "StopLogs (project-scope, no streamer) returned an error")
+	suite.Require().True(resp2.Success, "StopLogs (project-scope, no streamer) returned non-success")
+}
+
+// TestDeleteLogs_ProjectWide_DrainsAllStreamers asserts that project-scope
+// DeleteLogs waits for every streamer to exit before removing the log dir.
+func (suite *LogCollectorTestSuite) TestDeleteLogs_ProjectWide_DrainsAllStreamers() {
+	projectName := fmt.Sprintf("delete-project-drain-%s", uuid.New().String())
+	const numStreamers = 3
+
+	type streamerInstance struct {
+		runUID string
+		handle *streamerHandle
+	}
+	streamers := make([]streamerInstance, 0, numStreamers)
+	for i := 0; i < numStreamers; i++ {
+		runUID := uuid.New().String()
+		logFilePath := suite.logCollectorServer.resolveRunLogFilePath(projectName, runUID)
+		suite.Require().NoError(os.MkdirAll(path.Dir(logFilePath), 0o755))
+		suite.Require().NoError(common.WriteToFile(logFilePath, []byte("log\n"), false))
+
+		streamCtx, handle := suite.logCollectorServer.registerStreamer(context.Background(), projectName, runUID)
+		streamers = append(streamers, streamerInstance{runUID: runUID, handle: handle})
+
+		go func(p, r string, h *streamerHandle, sc context.Context) {
+			defer func() {
+				suite.logCollectorServer.unregisterStreamer(p, r, h)
+				close(h.done)
+			}()
+			<-sc.Done()
+		}(projectName, runUID, handle, streamCtx)
+	}
+
+	dirPath := path.Join(suite.logCollectorServer.baseDir, projectName)
+	entries, err := os.ReadDir(dirPath)
+	suite.Require().NoError(err)
+	suite.Require().Equal(numStreamers, len(entries))
+
+	resp, err := suite.logCollectorServer.DeleteLogs(suite.ctx, &protologcollector.StopLogsRequest{
+		Project: projectName,
+		RunUIDs: nil,
+	})
+	suite.Require().NoError(err, "DeleteLogs returned an error")
+	suite.Require().True(resp.Success, "DeleteLogs returned non-success")
+
+	for _, s := range streamers {
+		select {
+		case <-s.handle.done:
+		default:
+			suite.Require().Failf("streamer not drained", "runUID=%s done channel not closed", s.runUID)
+		}
+	}
+
+	_, err = os.Stat(dirPath)
+	suite.Require().True(os.IsNotExist(err), "project dir should be removed, got err=%v", err)
+
+	suite.logCollectorServer.streamersMu.Lock()
+	_, present := suite.logCollectorServer.streamers[projectName]
+	suite.logCollectorServer.streamersMu.Unlock()
+	suite.Require().False(present, "registry still has entries for project after DeleteLogs")
+}
+
+// TestStopLogs_DrainTimeout asserts that a wedged streamer does not pin StopLogs
+// forever — it returns after drainTimeout and state entries are still removed.
+func (suite *LogCollectorTestSuite) TestStopLogs_DrainTimeout() {
+	projectName := fmt.Sprintf("drain-timeout-%s", uuid.New().String())
+	runUID := uuid.New().String()
+
+	originalTimeout := suite.logCollectorServer.drainTimeout
+	suite.logCollectorServer.drainTimeout = 200 * time.Millisecond
+	defer func() { suite.logCollectorServer.drainTimeout = originalTimeout }()
+
+	suite.Require().NoError(suite.logCollectorServer.stateManifest.AddLogItem(suite.ctx, runUID, "sel", projectName))
+	suite.Require().NoError(suite.logCollectorServer.currentState.AddLogItem(suite.ctx, runUID, "sel", projectName))
+	defer func() {
+		_ = suite.logCollectorServer.stateManifest.RemoveProject(projectName)
+		_ = suite.logCollectorServer.currentState.RemoveProject(projectName)
+	}()
+
+	// wedged streamer: never closes done. released at end of test so it does not
+	// leak into subsequent cases.
+	_, handle := suite.logCollectorServer.registerStreamer(context.Background(), projectName, runUID)
+	releaseWedge := make(chan struct{})
+	go func() {
+		<-releaseWedge
+		suite.logCollectorServer.unregisterStreamer(projectName, runUID, handle)
+		close(handle.done)
+	}()
+	defer close(releaseWedge)
+
+	stopStart := time.Now()
+	resp, err := suite.logCollectorServer.StopLogs(suite.ctx, &protologcollector.StopLogsRequest{
+		Project: projectName,
+		RunUIDs: []string{runUID},
+	})
+	stopDuration := time.Since(stopStart)
+	suite.Require().NoError(err, "StopLogs returned an error")
+	suite.Require().True(resp.Success, "StopLogs returned non-success")
+
+	suite.Require().Less(stopDuration, suite.logCollectorServer.drainTimeout+500*time.Millisecond,
+		"StopLogs took too long under drainTimeout=%s: actual=%s",
+		suite.logCollectorServer.drainTimeout, stopDuration)
+	suite.Require().GreaterOrEqual(stopDuration, suite.logCollectorServer.drainTimeout,
+		"StopLogs returned before drainTimeout elapsed: %s < %s",
+		stopDuration, suite.logCollectorServer.drainTimeout)
+
+	logItemsInProgress, err := suite.logCollectorServer.stateManifest.GetItemsInProgress()
+	suite.Require().NoError(err)
+	if projectMap, ok := logItemsInProgress.Load(projectName); ok {
+		runs := projectMap.(*sync.Map)
+		_, stillThere := runs.Load(runUID)
+		suite.Require().False(stillThere, "state manifest still has run entry after timeout drain")
+	}
 }
 
 func (suite *LogCollectorTestSuite) TestGetLogFilePath() {

--- a/server/go/services/logcollector/server.go
+++ b/server/go/services/logcollector/server.go
@@ -76,6 +76,22 @@ type Server struct {
 	monitoringInterval time.Duration
 
 	listRunsChunkSize int
+
+	// streamersMu is held only across map mutations to avoid inverting lock order
+	// with stateManifest/currentState.
+	streamersMu sync.Mutex
+	streamers   map[string]map[string]*streamerHandle
+
+	// drainTimeout bounds how long StopLogs / DeleteLogs wait for streamers to exit.
+	drainTimeout time.Duration
+}
+
+// streamerHandle lets the drain path cancel an in-flight streamer and wait for it.
+// cancel unblocks the in-flight stream.Read inside streamPodLogs (via the ctx-aware
+// kube client); done is closed by the streamer's deferred cleanup on exit.
+type streamerHandle struct {
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 // NewLogCollectorServer creates a new log collector server
@@ -174,7 +190,108 @@ func NewLogCollectorServer(logger logger.Logger,
 		startLogsFindingPodsTimeout:  15 * time.Second,
 		advancedLogLevel:             advancedLogLevel,
 		listRunsChunkSize:            listRunsChunkSize,
+		streamers:                    make(map[string]map[string]*streamerHandle),
+		drainTimeout:                 10 * time.Second,
 	}, nil
+}
+
+// registerStreamer returns the cancellable context the streamer must use.
+// StartLog's isLogCollectionRunning check normally prevents duplicates, but a
+// double-registration is still possible between AddLogItem and currentState
+// AddLogItem; the existing handle is cancelled to avoid leaking it.
+func (s *Server) registerStreamer(parentCtx context.Context, project, runUID string) (context.Context, *streamerHandle) {
+	streamCtx, cancel := context.WithCancel(parentCtx)
+	handle := &streamerHandle{
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+
+	s.streamersMu.Lock()
+	projectStreamers, ok := s.streamers[project]
+	if !ok {
+		projectStreamers = make(map[string]*streamerHandle)
+		s.streamers[project] = projectStreamers
+	}
+	if existing, dup := projectStreamers[runUID]; dup {
+		existing.cancel()
+	}
+	projectStreamers[runUID] = handle
+	s.streamersMu.Unlock()
+
+	return streamCtx, handle
+}
+
+// unregisterStreamer is a no-op if the handle has already been replaced.
+func (s *Server) unregisterStreamer(project, runUID string, handle *streamerHandle) {
+	s.streamersMu.Lock()
+	defer s.streamersMu.Unlock()
+	projectStreamers, ok := s.streamers[project]
+	if !ok {
+		return
+	}
+	if current, exists := projectStreamers[runUID]; exists && current == handle {
+		delete(projectStreamers, runUID)
+		if len(projectStreamers) == 0 {
+			delete(s.streamers, project)
+		}
+	}
+}
+
+// snapshotProjectStreamers returns the project's handles without removing them
+// from the registry; each streamer self-unregisters on exit.
+func (s *Server) snapshotProjectStreamers(project string) []*streamerHandle {
+	s.streamersMu.Lock()
+	defer s.streamersMu.Unlock()
+	projectStreamers, ok := s.streamers[project]
+	if !ok || len(projectStreamers) == 0 {
+		return nil
+	}
+	handles := make([]*streamerHandle, 0, len(projectStreamers))
+	for _, h := range projectStreamers {
+		handles = append(handles, h)
+	}
+	return handles
+}
+
+func (s *Server) snapshotRunStreamer(project, runUID string) *streamerHandle {
+	s.streamersMu.Lock()
+	defer s.streamersMu.Unlock()
+	projectStreamers, ok := s.streamers[project]
+	if !ok {
+		return nil
+	}
+	return projectStreamers[runUID]
+}
+
+// drainHandles cancels each handle and waits for it to exit under a single
+// drainTimeout budget. Returns runUIDs that did not drain in time so the caller
+// can log them; deletion must not wedge indefinitely on a stuck streamer.
+func (s *Server) drainHandles(ctx context.Context, handles []*streamerHandle, runUIDsForLog []string) []string {
+	if len(handles) == 0 {
+		return nil
+	}
+	// fire cancellations first so streamers unwind in parallel
+	for _, h := range handles {
+		h.cancel()
+	}
+	deadline := time.After(s.drainTimeout)
+	var leaked []string
+	for i, h := range handles {
+		select {
+		case <-h.done:
+		case <-deadline:
+			if i < len(runUIDsForLog) {
+				leaked = append(leaked, runUIDsForLog[i:]...)
+			}
+			return leaked
+		case <-ctx.Done():
+			if i < len(runUIDsForLog) {
+				leaked = append(leaked, runUIDsForLog[i:]...)
+			}
+			return leaked
+		}
+	}
+	return nil
 }
 
 // OnBeforeStart is called before the server starts
@@ -307,8 +424,16 @@ func (s *Server) StartLog(ctx context.Context,
 		}, err
 	}
 
+	// Register the streamer before AddLogItem so any concurrent StopLogs that sees
+	// the state-store entry also sees a cancellable handle. The streamer ctx is
+	// derived from Background; it must outlive the request ctx.
+	streamCtx, handle := s.registerStreamer(context.Background(), request.ProjectName, request.RunUID)
+
 	// write log item in progress to state store
 	if err := s.stateManifest.AddLogItem(ctx, request.RunUID, request.Selector, request.ProjectName); err != nil {
+		handle.cancel()
+		close(handle.done)
+		s.unregisterStreamer(request.ProjectName, request.RunUID, handle)
 		err := errors.Wrapf(err, "Failed to add run id %s to state file", request.RunUID)
 		return &protologcollector.BaseResponse{
 			Success:      false,
@@ -320,12 +445,13 @@ func (s *Server) StartLog(ctx context.Context,
 	startedStreamingGoroutine := make(chan bool, 1)
 
 	// stream logs to file
-	go s.startLogStreaming(context.WithoutCancel(ctx),
+	go s.startLogStreaming(streamCtx,
 		request.RunUID,
 		pod.Name,
 		request.ProjectName,
 		request.LastLogTime,
-		startedStreamingGoroutine)
+		startedStreamingGoroutine,
+		handle)
 
 	// wait for the streaming goroutine to start
 	<-startedStreamingGoroutine
@@ -542,6 +668,10 @@ func (s *Server) StopLogs(ctx context.Context, request *protologcollector.StopLo
 	// if no run uids were provided, remove the entire project from the state
 	if len(request.RunUIDs) == 0 {
 
+		// drain streamers before state mutation so no writer is mid-flight when
+		// the state entries (and later, the log dir in DeleteLogs) go away
+		s.drainProjectStreamers(ctx, request.Project)
+
 		// remove entire project from state manifest
 		if err := s.stateManifest.RemoveProject(request.Project); err != nil {
 			message := fmt.Sprintf("Failed to remove project %s from state manifest", request.Project)
@@ -570,6 +700,10 @@ func (s *Server) StopLogs(ctx context.Context, request *protologcollector.StopLo
 		"project", request.Project,
 		"numRunIDs", len(request.RunUIDs))
 
+	// drain the named streamers before state mutation; unknown runs are a no-op
+	// since StopLogs is best-effort from the orchestrator and monitoring loop
+	s.drainRunStreamers(ctx, request.Project, request.RunUIDs)
+
 	// remove each run uid from the state
 	for _, runUID := range request.RunUIDs {
 
@@ -597,6 +731,64 @@ func (s *Server) StopLogs(ctx context.Context, request *protologcollector.StopLo
 	return s.successfulBaseResponse(), nil
 }
 
+func (s *Server) drainProjectStreamers(ctx context.Context, project string) {
+	handles := s.snapshotProjectStreamers(project)
+	if len(handles) == 0 {
+		return
+	}
+	runUIDs := s.runUIDsForHandles(project, handles)
+	leaked := s.drainHandles(ctx, handles, runUIDs)
+	if len(leaked) > 0 {
+		s.Logger.WarnWithCtx(ctx,
+			"Streamer drain timed out; proceeding with state removal",
+			"project", project,
+			"leakedRunUIDs", leaked,
+			"drainTimeout", s.drainTimeout)
+	}
+}
+
+func (s *Server) drainRunStreamers(ctx context.Context, project string, runUIDs []string) {
+	var handles []*streamerHandle
+	var presentRunUIDs []string
+	for _, runUID := range runUIDs {
+		if h := s.snapshotRunStreamer(project, runUID); h != nil {
+			handles = append(handles, h)
+			presentRunUIDs = append(presentRunUIDs, runUID)
+		}
+	}
+	if len(handles) == 0 {
+		return
+	}
+	leaked := s.drainHandles(ctx, handles, presentRunUIDs)
+	if len(leaked) > 0 {
+		s.Logger.WarnWithCtx(ctx,
+			"Streamer drain timed out; proceeding with state removal",
+			"project", project,
+			"leakedRunUIDs", leaked,
+			"drainTimeout", s.drainTimeout)
+	}
+}
+
+// runUIDsForHandles returns runUIDs aligned with the given handles slice. A slot
+// is "" if the handle has already been replaced or removed.
+func (s *Server) runUIDsForHandles(project string, handles []*streamerHandle) []string {
+	s.streamersMu.Lock()
+	defer s.streamersMu.Unlock()
+	projectStreamers, ok := s.streamers[project]
+	if !ok {
+		return make([]string, len(handles))
+	}
+	reverse := make(map[*streamerHandle]string, len(projectStreamers))
+	for runUID, h := range projectStreamers {
+		reverse[h] = runUID
+	}
+	result := make([]string, len(handles))
+	for i, h := range handles {
+		result[i] = reverse[h]
+	}
+	return result
+}
+
 // DeleteLogs deletes the log file for a given run id or project
 func (s *Server) DeleteLogs(ctx context.Context, request *protologcollector.StopLogsRequest) (*protologcollector.BaseResponse, error) {
 
@@ -617,6 +809,10 @@ func (s *Server) DeleteLogs(ctx context.Context, request *protologcollector.Stop
 		s.Logger.DebugWithCtx(ctx,
 			"Deleting all project logs",
 			"project", request.Project)
+
+		// drain streamers before os.RemoveAll — otherwise concurrent writers
+		// can leave the dir non-empty on NFS/SMB-backed storage
+		s.drainProjectStreamers(ctx, request.Project)
 
 		// remove entire project from persistent state
 		if err := s.deleteProjectLogs(request.Project); err != nil {
@@ -639,6 +835,9 @@ func (s *Server) DeleteLogs(ctx context.Context, request *protologcollector.Stop
 		"Deleting logs",
 		"project", request.Project,
 		"numRunIDs", len(request.RunUIDs))
+
+	// drain the named streamers before deleting their log files
+	s.drainRunStreamers(ctx, request.Project, request.RunUIDs)
 
 	errGroup, _ := errgroup.WithContext(ctx)
 	errGroup.SetLimit(10)
@@ -750,28 +949,39 @@ func (s *Server) startLogStreaming(ctx context.Context,
 	podName,
 	projectName string,
 	lastLogTime int64,
-	startedStreamingGoroutine chan bool) {
+	startedStreamingGoroutine chan bool,
+	handle *streamerHandle) {
 
 	// in case of a panic, remove this goroutine from the current state, so the
 	// monitoring loop will start logging again for this runUID.
 	defer func() {
+		// signal drain waiters and unregister even on panic
+		defer func() {
+			s.unregisterStreamer(projectName, runUID, handle)
+			close(handle.done)
+		}()
 
-		// update last log time in state manifest, so we can start from the last log time
-		if err := s.stateManifest.UpdateLastLogTime(runUID, projectName, lastLogTime); err != nil {
-			// if the pod ended properly, the run will be removed from the state file and the update will fail
-			// we can ignore this error and continue
-			s.Logger.WarnWithCtx(ctx,
-				"Failed to update last log time, run may have ended",
-				"runUID", runUID,
-				"err", err.Error())
-		}
+		// if cancelled by StopLogs/DeleteLogs the caller is tearing down state;
+		// skip the deferred touches to avoid a noisy warning
+		if ctx.Err() == nil {
 
-		// remove this goroutine from in-current state
-		if err := s.currentState.RemoveLogItem(ctx, runUID, projectName); err != nil {
-			s.Logger.WarnWithCtx(ctx,
-				"Failed to remove item from in memory state",
-				"runUID", runUID,
-				"err", err.Error())
+			// update last log time in state manifest, so we can start from the last log time
+			if err := s.stateManifest.UpdateLastLogTime(runUID, projectName, lastLogTime); err != nil {
+				// if the pod ended properly, the run will be removed from the state file and the update will fail
+				// we can ignore this error and continue
+				s.Logger.WarnWithCtx(ctx,
+					"Failed to update last log time, run may have ended",
+					"runUID", runUID,
+					"err", err.Error())
+			}
+
+			// remove this goroutine from in-current state
+			if err := s.currentState.RemoveLogItem(ctx, runUID, projectName); err != nil {
+				s.Logger.WarnWithCtx(ctx,
+					"Failed to remove item from in memory state",
+					"runUID", runUID,
+					"err", err.Error())
+			}
 		}
 
 		if err := recover(); err != nil {
@@ -856,13 +1066,19 @@ func (s *Server) startLogStreaming(ctx context.Context,
 	defer stream.Close() // nolint: errcheck
 
 	for keepLogging {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		keepLogging, err = s.streamPodLogs(ctx, runUID, podName, file, stream, &lastLogTime, projectName, &bytesSinceLogTimeUpdate)
 		if err != nil {
 			// if the pod is still running, it means the logs were rotated, so we need to get a new stream
-			// by bailing out
+			// by bailing out. context.Canceled means StopLogs/DeleteLogs drained us — expected, not a warning.
 			if !errors.Is(err, common.PodStillRunningError{
 				PodName: podName,
-			}) {
+			}) && !errors.Is(err, context.Canceled) {
 				s.Logger.WarnWithCtx(ctx,
 					"An error occurred while streaming pod logs",
 					"err", common.GetErrorStack(err, common.DefaultErrorStackDepth))
@@ -878,7 +1094,11 @@ func (s *Server) startLogStreaming(ctx context.Context,
 
 		// breathe
 		// stream pod logs might return fast when there is nothing to read and no error occurred
-		time.Sleep(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
 
 	// remove run from state file


### PR DESCRIPTION
### 📝 Description

Project delete intermittently failed with `OSError: [Errno 39] Directory not empty: '/mlrun/db/logs/<project>'` (on Azure Files/SMB labs) because the log-collector's per-run streamer goroutine could still be actively writing to the log file when mlrun-api triggered `RemoveAll` on the project's log directory.

`startLogStreaming` was launched with `context.WithoutCancel(ctx)`, so the streamer ignored caller cancellation and the `for keepLogging` loop only exited on terminal EOF. `StopLogs` was a pure `sync.Map.Delete` with no drain barrier, so the writer kept appending bytes after the registry entry was gone, and the subsequent `DeleteLogs` raced the active write.

This PR introduces a per-run `*streamerHandle` (cancel + done channel) registry on `*Server`. `StartLog` derives a cancellable streamer context from `context.Background()` and registers the handle BEFORE state-store insert. `StopLogs` and `DeleteLogs` snapshot then drain the matching handles (cancel ctx, wait on `done`, bounded by `drainTimeout` — default 10 s) before any state mutation or `RemoveAll`. Cancellation propagates through `restClientRequest.Stream(ctx)` to unblock in-flight `Read`. The streamer's outer loop now checks `<-ctx.Done()` at the top of each iteration so a wedged streamer exits without waiting for the next EOF.

---

### 🛠️ Changes Made
- `server/go/services/logcollector/server.go`:
  - Add `streamersMu sync.Mutex`, `streamers map[string]map[string]*streamerHandle`, `drainTimeout time.Duration` (default 10s) to `*Server`.
  - Introduce `streamerHandle{cancel context.CancelFunc; done chan struct{}}` and helpers: `registerStreamer`, `unregisterStreamer`, `snapshotProjectStreamers`, `snapshotRunStreamer`, `drainHandles`, `drainProjectStreamers`, `drainRunStreamers`, `runUIDsForHandles`.
  - `StartLog` derives the streamer ctx from `context.Background()` and registers the handle BEFORE `AddLogItem`; rolls back the handle on failure.
  - `StopLogs` and `DeleteLogs` (both project-wide and per-run branches) drain via `drainProjectStreamers` / `drainRunStreamers` BEFORE state mutations / `os.RemoveAll`.
  - `startLogStreaming` outer loop checks `<-ctx.Done()` at iteration top and in place of the bare 100ms sleep; deferred state-store touches are guarded by `if ctx.Err() == nil`; suppress noisy "An error occurred while streaming pod logs" warning when `errors.Is(err, context.Canceled)`.
- `server/go/services/logcollector/logcollector_test.go`:
  - `TestStreamPodLogs` updated to pass a `streamerHandle{cancel: func(){}, done: make(chan struct{})}`.
  - New tests: `TestStopLogsDrainsActiveWriter`, `TestStopLogs_NoActiveStreamer_NoOp`, `TestDeleteLogs_ProjectWide_DrainsAllStreamers`, `TestStopLogs_DrainTimeout`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- **Unit**: `go test -race -tags=test_unit -count=1 ./services/logcollector/...` — all 16 subtests pass (race-free). New tests assert: stop duration ≥ writer residual time, `writesAfterStop == 0`, no-op on unknown runs, project-wide drains all 3 streamers before rmdir, and the drainTimeout path returns cleanly on a wedged streamer.
- **Lab verification** (vmdev103ig4):
  - Pre-patch — race fingerprint reproduces on the long-sleeping-job reproducer.
  - Post-patch — clean 3 ms drain, no `Failed to find project in state store` warning, mid-flight delete succeeds in 6.4 s.
- **Regression smoke** (`regression.py`): empty project create/delete, short job to completion+delete, fetch logs after completion+delete — all clean.

---

### 🔗 References
- Ticket link: [ML-12699](https://ecliptos.atlassian.net/browse/ML-12699)


---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
