### PR TITLE
[K8s] Fix build log output returned as raw bytes

### DIFF
--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -512,16 +512,21 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
     def logs(self, name, namespace=None):
         try:
+            # `_preload_content=False` returns the raw urllib3 response and skips the client's
+            # primitive-string deserialization. Since kubernetes-client 36.0.1 that step no
+            # longer decodes the body, so `read_namespaced_pod_log` would otherwise hand back
+            # `str(bytes)` - the repr `"b'\x1b...'"` instead of the decoded log (ML-12667).
             resp = self.v1api.read_namespaced_pod_log(
                 name=name,
                 namespace=self.resolve_namespace(namespace),
                 _request_timeout=self._resolve_k8s_timeout(K8S_TIMEOUT_LOGS),
+                _preload_content=False,
             )
         except k8s_client_rest.ApiException as exc:
             logger.error("Failed to get pod logs", exc=mlrun.errors.err_to_str(exc))
             raise exc
 
-        return resp
+        return resp.data.decode("utf-8")
 
     def get_logger_pods(self, project, uid, run_kind, namespace=""):
         namespace = self.resolve_namespace(namespace)

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -1138,7 +1138,9 @@ def test_build_status_events_and_logs(
         unittest.mock.patch.object(
             framework.utils.singletons.k8s.get_k8s_helper().v1api,
             "read_namespaced_pod_log",
-            return_value="log",
+            # `logs()` reads the raw response (`_preload_content=False`) and decodes
+            # `.data`, so the build-log body must be bytes (ML-12667).
+            return_value=unittest.mock.Mock(data=b"log"),
         ),
     ):
         response = client.get(

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -1138,8 +1138,6 @@ def test_build_status_events_and_logs(
         unittest.mock.patch.object(
             framework.utils.singletons.k8s.get_k8s_helper().v1api,
             "read_namespaced_pod_log",
-            # `logs()` reads the raw response (`_preload_content=False`) and decodes
-            # `.data`, so the build-log body must be bytes (ML-12667).
             return_value=unittest.mock.Mock(data=b"log"),
         ),
     ):

--- a/server/py/services/api/tests/unit/runtime_handlers/base.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/base.py
@@ -487,8 +487,6 @@ class TestRuntimeHandlerBase:
     @staticmethod
     def _mock_read_namespaced_pod_log():
         log = "Some log string"
-        # `logs()` reads the raw response (`_preload_content=False`) and decodes `.data`,
-        # so the mock must expose the body as bytes rather than a plain str.
         get_k8s_helper().v1api.read_namespaced_pod_log = unittest.mock.Mock(
             return_value=unittest.mock.Mock(data=log.encode())
         )

--- a/server/py/services/api/tests/unit/runtime_handlers/base.py
+++ b/server/py/services/api/tests/unit/runtime_handlers/base.py
@@ -487,8 +487,10 @@ class TestRuntimeHandlerBase:
     @staticmethod
     def _mock_read_namespaced_pod_log():
         log = "Some log string"
+        # `logs()` reads the raw response (`_preload_content=False`) and decodes `.data`,
+        # so the mock must expose the body as bytes rather than a plain str.
         get_k8s_helper().v1api.read_namespaced_pod_log = unittest.mock.Mock(
-            return_value=log
+            return_value=unittest.mock.Mock(data=log.encode())
         )
         return log
 
@@ -598,6 +600,7 @@ class TestRuntimeHandlerBase:
                 name=logger_pod_name,
                 namespace=get_k8s_helper().resolve_namespace(),
                 _request_timeout=unittest.mock.ANY,
+                _preload_content=False,
             )
         _, logs = await services.api.crud.Logs().get_logs(
             db, project, uid, source=LogSources.PERSISTENCY

--- a/server/py/services/api/tests/unit/runtimes/base.py
+++ b/server/py/services/api/tests/unit/runtimes/base.py
@@ -379,8 +379,6 @@ class TestRuntimeBase(services.api.tests.unit.conftest.MockedK8sHelper):
         get_k8s_helper().v1api.list_namespaced_pod = unittest.mock.Mock(
             return_value=client.V1PodList(items=[])
         )
-        # `logs()` reads the raw response (`_preload_content=False`) and decodes `.data`,
-        # so the mock must expose the body as bytes rather than a plain str.
         get_k8s_helper().v1api.read_namespaced_pod_log = unittest.mock.Mock(
             return_value=unittest.mock.Mock(data=b"Mocked pod logs")
         )

--- a/server/py/services/api/tests/unit/runtimes/base.py
+++ b/server/py/services/api/tests/unit/runtimes/base.py
@@ -379,8 +379,10 @@ class TestRuntimeBase(services.api.tests.unit.conftest.MockedK8sHelper):
         get_k8s_helper().v1api.list_namespaced_pod = unittest.mock.Mock(
             return_value=client.V1PodList(items=[])
         )
+        # `logs()` reads the raw response (`_preload_content=False`) and decodes `.data`,
+        # so the mock must expose the body as bytes rather than a plain str.
         get_k8s_helper().v1api.read_namespaced_pod_log = unittest.mock.Mock(
-            return_value="Mocked pod logs"
+            return_value=unittest.mock.Mock(data=b"Mocked pod logs")
         )
 
     def _mock_create_namespaced_custom_object(self):

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -1414,6 +1414,45 @@ def test_get_user_secret_tokens_as_igz_yml_data_all_fail(k8s_helper):
         )
 
 
+def test_logs_decodes_raw_bytes_response(k8s_helper):
+    """logs() decodes the raw pod-log body to text.
+
+    Regression for ML-12667: kubernetes-client 36.0.1 stopped decoding the
+    `read_namespaced_pod_log` body, so the previous `return resp` handed callers the repr
+    of a bytes object (`"b'\\x1b...'"`). logs() now requests the log with
+    `_preload_content=False` and decodes `.data` itself, restoring plain log text.
+    """
+    log_text = "\x1b[0mbuilding image\nmlrun version: 1.12.0\n"
+    k8s_helper.v1api.read_namespaced_pod_log.return_value = mock.Mock(
+        data=log_text.encode("utf-8")
+    )
+
+    result = k8s_helper.logs("build-pod")
+
+    assert result == log_text
+    k8s_helper.v1api.read_namespaced_pod_log.assert_called_once_with(
+        name="build-pod",
+        namespace=k8s_helper.resolve_namespace(),
+        _request_timeout=mock.ANY,
+        _preload_content=False,
+    )
+
+
+def test_logs_reraises_api_exception(k8s_helper):
+    """logs() re-raises ApiException unchanged.
+
+    `_preload_content=False` does not alter the client's non-2xx handling, so callers that
+    rely on catching ApiException (build-status endpoint, log CRUD) keep working.
+    """
+    api_exception = k8s_client_rest.ApiException(status=404, reason="Not Found")
+    k8s_helper.v1api.read_namespaced_pod_log.side_effect = api_exception
+
+    with pytest.raises(k8s_client_rest.ApiException) as exc_info:
+        k8s_helper.logs("missing-pod")
+
+    assert exc_info.value is api_exception
+
+
 def _make_user_token_secret(
     secret_name,
     token_name="my-token",

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -1415,13 +1415,7 @@ def test_get_user_secret_tokens_as_igz_yml_data_all_fail(k8s_helper):
 
 
 def test_logs_decodes_raw_bytes_response(k8s_helper):
-    """logs() decodes the raw pod-log body to text.
-
-    Regression for ML-12667: kubernetes-client 36.0.1 stopped decoding the
-    `read_namespaced_pod_log` body, so the previous `return resp` handed callers the repr
-    of a bytes object (`"b'\\x1b...'"`). logs() now requests the log with
-    `_preload_content=False` and decodes `.data` itself, restoring plain log text.
-    """
+    """logs() decodes the raw pod-log body to text (regression for ML-12667)."""
     log_text = "\x1b[0mbuilding image\nmlrun version: 1.12.0\n"
     k8s_helper.v1api.read_namespaced_pod_log.return_value = mock.Mock(
         data=log_text.encode("utf-8")
@@ -1439,11 +1433,7 @@ def test_logs_decodes_raw_bytes_response(k8s_helper):
 
 
 def test_logs_reraises_api_exception(k8s_helper):
-    """logs() re-raises ApiException unchanged.
-
-    `_preload_content=False` does not alter the client's non-2xx handling, so callers that
-    rely on catching ApiException (build-status endpoint, log CRUD) keep working.
-    """
+    """logs() re-raises ApiException unchanged so callers' error handling keeps working."""
     api_exception = k8s_client_rest.ApiException(status=404, reason="Not Found")
     k8s_helper.v1api.read_namespaced_pod_log.side_effect = api_exception
 

--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -537,12 +537,17 @@ class TestMLRunSystem:
         :returns: Pod logs or error message
         """
         try:
-            logs = self.kube_client.read_namespaced_pod_log(
+            # `_preload_content=False` + manual decode avoids kubernetes-client 36.0.1
+            # handing back `str(bytes)` (the repr `"b'\x1b...'"`) instead of the decoded
+            # log - same root cause as ML-12667.
+            resp = self.kube_client.read_namespaced_pod_log(
                 name=pod_name,
                 namespace=namespace,
                 tail_lines=tail_lines,
                 since_seconds=since_seconds,
+                _preload_content=False,
             )
+            logs = resp.data.decode("utf-8")
             self._logger.debug(
                 f"Collected logs from {pod_name}",
                 lines=len(logs.splitlines()) if logs else 0,


### PR DESCRIPTION
### 📝 Description

Since the `kubernetes` Python client was bumped 35.0.0 → 36.0.1, function **build logs** came back as the `repr` of a bytes object (`b'\x1b[0m...'`) instead of decoded text. 36.0.1 dropped the body-decoding step on the `_preload_content=True` path in `rest.py`, so `CoreV1Api.read_namespaced_pod_log()` deserializes the log via `str(bytes)` and hands back the literal `b'...'` string.

This fixes it by reading the log with `_preload_content=False` and decoding the raw response body ourselves, bypassing the client's broken primitive-string deserialization. Behaviour is now independent of the client version.

---

### 🛠️ Changes Made
- `server/py/framework/utils/singletons/k8s.py` — `K8sHelper.logs()` requests the pod log with `_preload_content=False` and returns `resp.data.decode("utf-8")`. The non-2xx `ApiException` is still raised (it lives outside the `_preload_content` block in the client), so the error contract callers rely on is unchanged.
- `tests/system/base.py` — applied the same fix to the system-test log-collection helper, which had the identical latent bug.
- Unit tests — updated the mocks of `read_namespaced_pod_log` to expose the body as `.data` bytes (matching the real client) and added regression tests for `logs()`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Added two unit regression tests in `test_k8s_utils.py`: `logs()` decodes a raw bytes body to text (the ML-12667 case), and `logs()` re-raises `ApiException` unchanged.
- `test_k8s_utils.py` (83) and the kubejob/mpijob/sparkjob runtime-handler suites (81) pass locally; the latter exercise `logs()` through the updated mock.
- Pre-existing failures in `test_functions.py` / `test_logs.py` in my local env (missing compiled `schemas.proto.log_collector_pb2`, missing `forbidden_service_accounts` config attr) are unrelated — the failing set is identical with and without this change. The build-log endpoint's decode path is covered by the `test_k8s_utils.py` unit tests.
- System tests (e.g. `test_mlrun_version_during_build_function`) were **not** run locally — they require a lab.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12667
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Root cause is purely the dependency bump; the mlrun build-log code is otherwise unchanged between the affected tags. The fix is version-independent, so it is safe whether the deployed client is 35.x or 36.x.
