### PR TITLE
[Model Monitoring] Single OTel metric name for results/metrics with name label

### DIFF
--- a/mlrun/common/schemas/model_monitoring/constants.py
+++ b/mlrun/common/schemas/model_monitoring/constants.py
@@ -262,8 +262,10 @@ class OTelMonitoringAttribute(MonitoringStrEnum):
     Dot-separated naming follows the OpenTelemetry semantic-conventions
     convention. ``project``, ``app.name``, ``function.name``,
     ``endpoint.uid``, ``endpoint.name`` are shared by every entry in a
-    batch; ``result.kind`` and ``result.status`` apply only to entries
-    coming from a :class:`ModelMonitoringApplicationResult`.
+    batch. ``result.name``, ``result.kind`` and ``result.status`` apply only
+    to entries coming from a :class:`ModelMonitoringApplicationResult`;
+    ``metric.name`` applies only to entries coming from a
+    :class:`ModelMonitoringApplicationMetric`.
     """
 
     PROJECT = "project"
@@ -271,18 +273,29 @@ class OTelMonitoringAttribute(MonitoringStrEnum):
     FUNCTION_NAME = "function.name"
     ENDPOINT_UID = "endpoint.uid"
     ENDPOINT_NAME = "endpoint.name"
+    RESULT_NAME = "result.name"
     RESULT_KIND = "result.kind"
     RESULT_STATUS = "result.status"
+    METRIC_NAME = "metric.name"
 
 
-class OTelMonitoringMetricNamePrefix(MonitoringStrEnum):
-    """OTel instrument-name prefixes for model-monitoring application
-    outputs. The full metric name is ``<prefix><result-or-metric name>``,
-    e.g. ``mlrun.model_monitoring.result.general_drift``.
+class OTelMonitoringMetricName(MonitoringStrEnum):
+    """OTel instrument names for model-monitoring application outputs.
+
+    One fixed instrument name covers all results and another covers all
+    metrics; the specific result/metric name is carried as the
+    ``result.name`` / ``metric.name`` attribute (see
+    :class:`OTelMonitoringAttribute`) rather than being encoded in the
+    instrument name. This keeps every result under one metric family
+    (exported as ``mlrun_model_monitoring_result``) so dashboards and queries
+    can filter and aggregate by the ``result_name`` label instead of matching
+    a distinct per-result metric name, and bounds the number of OTel
+    instruments to two regardless of how many result/metric names a project
+    produces.
     """
 
-    RESULT = "mlrun.model_monitoring.result."
-    METRIC = "mlrun.model_monitoring.metric."
+    RESULT = "mlrun.model_monitoring.result"
+    METRIC = "mlrun.model_monitoring.metric"
 
 
 class EventLiveStats:

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -189,9 +189,15 @@ class _PrepareOTelEvent(StepToDict):
                 attributes[attr.RESULT_NAME.value] = entry.name
                 attributes[attr.RESULT_KIND.value] = entry.kind.name
                 attributes[attr.RESULT_STATUS.value] = entry.status.name
-            else:
+            elif isinstance(entry, ModelMonitoringApplicationMetric):
                 metric_name = metric_name_enum.METRIC.value
                 attributes[attr.METRIC_NAME.value] = entry.name
+            else:
+                logger.warning(
+                    "Skipping unexpected entry type in OTel event preparer",
+                    entry_type=type(entry).__name__,
+                )
+                continue
             metrics.append(
                 {
                     "metric_name": metric_name,

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -113,9 +113,13 @@ class _PrepareOTelEvent(StepToDict):
             ]
         }
 
-    Naming convention:
-        * ``mlrun.model_monitoring.result.<name>`` for results
-        * ``mlrun.model_monitoring.metric.<name>`` for metrics
+    Naming convention — a single fixed instrument name per family, with the
+    specific result/metric name carried as an attribute rather than encoded
+    in the instrument name:
+        * ``mlrun.model_monitoring.result`` for results, with the result name
+          in the ``result.name`` attribute
+        * ``mlrun.model_monitoring.metric`` for metrics, with the metric name
+          in the ``metric.name`` attribute
 
     Both are emitted as gauges — raw value flows through, and
     ``result.status`` is the normalized signal for alerting / dashboarding.
@@ -128,8 +132,12 @@ class _PrepareOTelEvent(StepToDict):
         * ``endpoint.name``
 
     Result-only attributes:
+        * ``result.name``   (e.g. ``"general_drift"``)
         * ``result.kind``   (e.g. ``"data_drift"``)
         * ``result.status`` (e.g. ``"detected"``)
+
+    Metric-only attributes:
+        * ``metric.name``   (e.g. ``"hellinger"``)
 
     Attribute key names live in
     :class:`mlrun.common.schemas.model_monitoring.constants.OTelMonitoringAttribute`
@@ -158,7 +166,7 @@ class _PrepareOTelEvent(StepToDict):
     ) -> dict[str, Any]:
         results, ctx = event
         attr = mm_constants.OTelMonitoringAttribute
-        prefix = mm_constants.OTelMonitoringMetricNamePrefix
+        metric_name_enum = mm_constants.OTelMonitoringMetricName
         base_attributes = {
             attr.PROJECT.value: ctx.project_name,
             attr.APP_NAME.value: ctx.application_name,
@@ -177,11 +185,13 @@ class _PrepareOTelEvent(StepToDict):
                 continue
             attributes = dict(base_attributes)
             if isinstance(entry, ModelMonitoringApplicationResult):
-                metric_name = f"{prefix.RESULT.value}{entry.name}"
+                metric_name = metric_name_enum.RESULT.value
+                attributes[attr.RESULT_NAME.value] = entry.name
                 attributes[attr.RESULT_KIND.value] = entry.kind.name
                 attributes[attr.RESULT_STATUS.value] = entry.status.name
             else:
-                metric_name = f"{prefix.METRIC.value}{entry.name}"
+                metric_name = metric_name_enum.METRIC.value
+                attributes[attr.METRIC_NAME.value] = entry.name
             metrics.append(
                 {
                     "metric_name": metric_name,

--- a/tests/model_monitoring/test_application_steps.py
+++ b/tests/model_monitoring/test_application_steps.py
@@ -390,6 +390,20 @@ class TestPrepareOTelEvent:
         assert event["metrics"][0]["attributes"]["metric.name"] == "some_metric"
 
     @classmethod
+    def test_unexpected_entry_type_skipped(cls, app_ctx: Mock) -> None:
+        """Entries that are neither a result, metric, nor stats are not
+        silently coerced into a metric — they're skipped (and logged)."""
+        results = [
+            object(),  # unexpected type
+            ModelMonitoringApplicationMetric(name="some_metric", value=1.0),
+        ]
+        event = _PrepareOTelEvent().do((results, app_ctx))
+        assert [m["metric_name"] for m in event["metrics"]] == [
+            "mlrun.model_monitoring.metric"
+        ]
+        assert event["metrics"][0]["attributes"]["metric.name"] == "some_metric"
+
+    @classmethod
     def test_none_attributes_stripped(cls) -> None:
         """The OTel SDK warns on None-valued attributes; the step must
         drop them rather than forward them."""

--- a/tests/model_monitoring/test_application_steps.py
+++ b/tests/model_monitoring/test_application_steps.py
@@ -304,9 +304,10 @@ class TestPrepareOTelEvent:
 
     @classmethod
     def test_result_and_metric_shape(cls, app_ctx: Mock) -> None:
-        """Results carry `result.kind` + `result.status` and the
-        `mlrun.model_monitoring.result.` prefix; metrics use the
-        `.metric.` prefix and don't get those extra attributes."""
+        """Results carry `result.name` + `result.kind` + `result.status` under
+        the single `mlrun.model_monitoring.result` instrument name; metrics
+        carry `metric.name` under `mlrun.model_monitoring.metric` and don't get
+        the result-only attributes."""
         results = [
             ModelMonitoringApplicationResult(
                 name="general_drift",
@@ -319,24 +320,56 @@ class TestPrepareOTelEvent:
         event = _PrepareOTelEvent().do((results, app_ctx))
         by_name = cls._by_name(event["metrics"])
 
-        result_entry = by_name["mlrun.model_monitoring.result.general_drift"]
+        result_entry = by_name["mlrun.model_monitoring.result"]
         assert result_entry == {
-            "metric_name": "mlrun.model_monitoring.result.general_drift",
+            "metric_name": "mlrun.model_monitoring.result",
             "value": 0.42,
             "type": "gauge",
             "attributes": {
                 **cls.BASE_ATTRS,
+                "result.name": "general_drift",
                 "result.kind": "data_drift",
                 "result.status": "detected",
             },
         }
-        metric_entry = by_name["mlrun.model_monitoring.metric.hellinger"]
+        metric_entry = by_name["mlrun.model_monitoring.metric"]
         assert metric_entry == {
-            "metric_name": "mlrun.model_monitoring.metric.hellinger",
+            "metric_name": "mlrun.model_monitoring.metric",
             "value": 0.1,
             "type": "gauge",
-            "attributes": cls.BASE_ATTRS,
+            "attributes": {**cls.BASE_ATTRS, "metric.name": "hellinger"},
         }
+
+    @classmethod
+    def test_multiple_results_share_one_metric_name(cls, app_ctx: Mock) -> None:
+        """Distinct result names share the single `mlrun.model_monitoring.result`
+        instrument name and are distinguished only by the `result.name`
+        attribute — keeping all results under one metric family and bounding
+        the OTel instrument count regardless of how many results exist."""
+        results = [
+            ModelMonitoringApplicationResult(
+                name="general_drift",
+                value=0.42,
+                kind=mm_constants.ResultKindApp.data_drift,
+                status=mm_constants.ResultStatusApp.detected,
+            ),
+            ModelMonitoringApplicationResult(
+                name="concept_drift",
+                value=0.13,
+                kind=mm_constants.ResultKindApp.concept_drift,
+                status=mm_constants.ResultStatusApp.no_detection,
+            ),
+        ]
+        event = _PrepareOTelEvent().do((results, app_ctx))
+
+        assert [m["metric_name"] for m in event["metrics"]] == [
+            "mlrun.model_monitoring.result",
+            "mlrun.model_monitoring.result",
+        ]
+        assert [m["attributes"]["result.name"] for m in event["metrics"]] == [
+            "general_drift",
+            "concept_drift",
+        ]
 
     @classmethod
     def test_stats_entries_skipped(cls, app_ctx: Mock) -> None:
@@ -352,8 +385,9 @@ class TestPrepareOTelEvent:
         ]
         event = _PrepareOTelEvent().do((results, app_ctx))
         assert [m["metric_name"] for m in event["metrics"]] == [
-            "mlrun.model_monitoring.metric.some_metric"
+            "mlrun.model_monitoring.metric"
         ]
+        assert event["metrics"][0]["attributes"]["metric.name"] == "some_metric"
 
     @classmethod
     def test_none_attributes_stripped(cls) -> None:
@@ -374,6 +408,7 @@ class TestPrepareOTelEvent:
             "project": cls.PROJECT,
             "app.name": cls.APP,
             "function.name": cls.FUNC_NAME,
+            "metric.name": "m",
         }
 
     @classmethod


### PR DESCRIPTION
### 📝 Description
MM application results/metrics are currently exported via OTel under a distinct instrument name per result (`mlrun.model_monitoring.result.<name>`), so projects with many results generate many distinct metric names — making Grafana dashboards, generic queries, and cross-result comparison harder.

This PR consolidates them into a single instrument name per family (`mlrun.model_monitoring.result` / `mlrun.model_monitoring.metric`) and moves the specific name into a `result.name` / `metric.name` attribute (label). Total time series cardinality is unchanged (a series is one unique name+labels combination either way); it is purely a reorganization that keeps all results under one metric family and bounds the number of OTel instruments to two regardless of how many result/metric names a project produces (avoiding the storey `OTelMetricsExporter` `max_instruments` cap).

---

### 🛠️ Changes Made
- `OTelMonitoringAttribute`: added `result.name` and `metric.name` attribute keys.
- Renamed `OTelMonitoringMetricNamePrefix` → `OTelMonitoringMetricName`; values are now the fixed full instrument names `mlrun.model_monitoring.result` / `mlrun.model_monitoring.metric`.
- `_PrepareOTelEvent`: emit the single instrument name and carry the specific result/metric name as the `result.name` / `metric.name` attribute (alongside `result.kind` / `result.status`).
- Tests: updated the OTel-event-preparer unit tests; added a case asserting distinct result names share one instrument name, distinguished only by the `result.name` attribute.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the Deprecation Guidelines
  - [ ] I updated the relevant Jira ticket for documentation

---

### 🧪 Testing
- Unit: `tests/model_monitoring/test_application_steps.py` — 12 passed (incl. new `test_multiple_results_share_one_metric_name`). `make lint` clean.
- A dedicated system test (OTLP export → in-cluster collector assertion) is planned as a follow-up.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12715

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

The exported OTel metric-name scheme changes, but the MM-application OTel export feature (ML-12532) is unreleased, so no downstream consumers should depend on the old per-result names yet.

---

### 🔍️ Additional Notes
Same single-name + label treatment is applied symmetrically to metrics. Dashboards should `group by (result_name)` so unlike result types aren't aggregated together.
