### PR TITLE
[Builder] Fetch kaniko-incompatible archive sources via init-container

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -589,11 +589,9 @@ default_config = {
             "kaniko_init_container_image": "alpine:3.20",
             # image for kaniko init container when docker registry is ECR
             "kaniko_aws_cli_image": "amazon/aws-cli:2.17.16",
-            # image for the kaniko init container that fetches sources kaniko cannot resolve
-            # natively (az://, wasb(s)://, ds://, oss://). Empty derives from the mlrun image.
-            # An override is supported for clients running hardened images instead of mlrun/mlrun;
-            # the replacement image MUST have `python` installed and the `mlrun` package importable,
-            # since the init container runs `python -m mlrun load-source ...`.
+            # init container image that runs ``python -m mlrun load-source`` for sources
+            # kaniko cannot resolve natively (az://, wasb(s)://, ds://, oss://). Empty
+            # derives from the mlrun image; override must have python and the mlrun package.
             "kaniko_source_fetch_init_container_image": "",
             # kaniko sometimes fails to get filesystem from image, this is a workaround to retry the process
             # a known issue in Kaniko - https://github.com/GoogleContainerTools/kaniko/issues/1717

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -590,7 +590,10 @@ default_config = {
             # image for kaniko init container when docker registry is ECR
             "kaniko_aws_cli_image": "amazon/aws-cli:2.17.16",
             # image for the kaniko init container that fetches sources kaniko cannot resolve
-            # natively (az://, wasb(s)://, abfs(s)://, ds://, dbfs://). Empty derives from the mlrun image.
+            # natively (az://, wasb(s)://, ds://, oss://). Empty derives from the mlrun image.
+            # An override is supported for clients running hardened images instead of mlrun/mlrun;
+            # the replacement image MUST have `python` installed and the `mlrun` package importable,
+            # since the init container runs `python -m mlrun load-source ...`.
             "kaniko_source_fetch_init_container_image": "",
             # kaniko sometimes fails to get filesystem from image, this is a workaround to retry the process
             # a known issue in Kaniko - https://github.com/GoogleContainerTools/kaniko/issues/1717

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -589,6 +589,9 @@ default_config = {
             "kaniko_init_container_image": "alpine:3.20",
             # image for kaniko init container when docker registry is ECR
             "kaniko_aws_cli_image": "amazon/aws-cli:2.17.16",
+            # image for the kaniko init container that fetches sources kaniko cannot resolve
+            # natively (az://, wasb(s)://, abfs(s)://, ds://, dbfs://). Empty derives from the mlrun image.
+            "kaniko_source_fetch_init_container_image": "",
             # kaniko sometimes fails to get filesystem from image, this is a workaround to retry the process
             # a known issue in Kaniko - https://github.com/GoogleContainerTools/kaniko/issues/1717
             "kaniko_image_fs_extraction_retries": "3",

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -687,13 +687,8 @@ class AutoMountType(StrEnum):
             mlrun.runtimes.mounts.set_env_vars_from_secret.__name__,
         ]
 
-    # Modifiers that contribute only env vars / envFrom and no volumes or volume mounts -
-    # i.e. safe to harvest by reading spec.env after applying them to a scratch runtime.
-    # Callers must resolve `AutoMountType.auto` via `get_modifier()` first - `auto` is a
-    # dispatcher whose resolved modifier (v3io_cred / mount_pvc / None) is what gets
-    # classified here. `mount_v3io` is deliberately excluded: it sets v3io creds on the
-    # runtime via an inner `v3io_cred` call but also calls `with_volume`/`with_volume_mounts`,
-    # so the volume side-effect would be silently dropped by an env-only harvester.
+    # Modifiers that contribute only env vars / envFrom (no volumes) - safe to harvest
+    # by reading spec.env after applying them.
     @classmethod
     def env_style_modifiers(cls) -> set:
         return {

--- a/mlrun/runtimes/pod.py
+++ b/mlrun/runtimes/pod.py
@@ -687,6 +687,22 @@ class AutoMountType(StrEnum):
             mlrun.runtimes.mounts.set_env_vars_from_secret.__name__,
         ]
 
+    # Modifiers that contribute only env vars / envFrom and no volumes or volume mounts -
+    # i.e. safe to harvest by reading spec.env after applying them to a scratch runtime.
+    # Callers must resolve `AutoMountType.auto` via `get_modifier()` first - `auto` is a
+    # dispatcher whose resolved modifier (v3io_cred / mount_pvc / None) is what gets
+    # classified here. `mount_v3io` is deliberately excluded: it sets v3io creds on the
+    # runtime via an inner `v3io_cred` call but also calls `with_volume`/`with_volume_mounts`,
+    # so the volume side-effect would be silently dropped by an env-only harvester.
+    @classmethod
+    def env_style_modifiers(cls) -> set:
+        return {
+            mlrun.runtimes.mounts.set_env_variables,
+            mlrun.runtimes.mounts.set_env_vars_from_secret,
+            mlrun.runtimes.mounts.v3io_cred,
+            mlrun.runtimes.mounts.mount_s3,
+        }
+
     @classmethod
     def is_auto_modifier(cls, modifier):
         # Check if modifier is one of the known mount modifiers. We need to use startswith since the modifier itself is

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1747,3 +1747,321 @@ def _mock_default_service_account(monkeypatch, service_account):
         "resolve_project_service_account_details",
         resolve_project_service_account_details_mock,
     )
+
+
+# --- ML-12710: kaniko-incompatible archive sources via fetch-source init container ----------------
+
+
+def _build_with_source(source: str) -> None:
+    """Drive build_runtime end-to-end with the given source and the standard mocks."""
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    function.spec.build.source = source
+    services.api.utils.builder.build_runtime(
+        mlrun.common.schemas.AuthInfo(),
+        function,
+    )
+
+
+def _kaniko_context_arg() -> str:
+    args = _create_pod_mock_pod_spec().containers[0].args
+    return args[args.index("--context") + 1]
+
+
+def _init_container_by_name(name: str):
+    for container in _create_pod_mock_pod_spec().init_containers or []:
+        if container.name == name:
+            return container
+    return None
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "az://data/iguazio/naipi-artifacts/project.tar.gz",
+        "wasbs://container@account.blob.core.windows.net/path/project.tar.gz",
+        "abfss://container@account.dfs.core.windows.net/path/project.zip",
+        "ds://my-profile/path/project.tar.gz",
+        "dbfs://path/to/project.tar.gz",
+    ],
+)
+def test_build_runtime_kaniko_incompatible_source_uses_fetch_init_container(
+    monkeypatch, source
+):
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    _build_with_source(source)
+
+    # kaniko's context is now the local empty-dir, not the raw URI
+    assert _kaniko_context_arg() == "/empty"
+
+    fetch_container = _init_container_by_name("fetch-source")
+    assert fetch_container is not None, "fetch-source init container missing"
+    assert fetch_container.args == [
+        "-m",
+        "mlrun",
+        "load-source",
+        source,
+        "--target",
+        "/empty/source",
+    ]
+    assert fetch_container.command == ["python"]
+
+
+def test_build_runtime_kaniko_incompatible_source_dockerfile_adds_extracted_dir(
+    monkeypatch,
+):
+    """The dockerfile must ADD the extracted subdir (./source) into the image
+    so that the user's project code is actually present at runtime."""
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    with unittest.mock.patch(
+        "services.api.utils.builder.make_kaniko_pod", new=unittest.mock.MagicMock()
+    ):
+        _build_with_source("az://container/path/project.tar.gz")
+        dockerfile = services.api.utils.builder.make_kaniko_pod.call_args[1][
+            "dockertext"
+        ]
+    assert "ADD ./source /home/mlrun_code" in dockerfile
+
+
+def test_build_runtime_kaniko_incompatible_source_applies_storage_auto_mount_env(
+    monkeypatch,
+):
+    """Whatever storage.auto_mount_params already declares for user pods must
+    also reach the fetch-source init container. The builder code never names
+    Azure (or any other) env vars explicitly — it just respects the same
+    auto-mount config the chart already maintains for user pods."""
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    monkeypatch.setattr(config.storage, "auto_mount_type", "secret_env")
+    # mirrors the lab wiring: a single cleartext storage-account env name+value
+    monkeypatch.setattr(
+        config.storage,
+        "auto_mount_params",
+        "cleartext_env=STORAGE_ACCOUNT:smoke-account",
+    )
+
+    _build_with_source("az://container/path/project.tar.gz")
+
+    fetch_container = _init_container_by_name("fetch-source")
+    env_by_name = {env_var.name: env_var.value for env_var in fetch_container.env or []}
+    assert env_by_name.get("STORAGE_ACCOUNT") == "smoke-account"
+
+
+def test_build_runtime_kaniko_incompatible_source_auto_mount_none_adds_no_env(
+    monkeypatch,
+):
+    """auto_mount_type=none must not push any extra env onto the fetch-source
+    init container — operators that opt out of auto-mount opt out everywhere."""
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    monkeypatch.setattr(config.storage, "auto_mount_type", "none")
+    monkeypatch.setattr(config.storage, "auto_mount_params", "")
+
+    _build_with_source("az://container/path/project.tar.gz")
+
+    fetch_container = _init_container_by_name("fetch-source")
+    env_names = [env_var.name for env_var in fetch_container.env or []]
+    # only the project-secret-backed env from _patch_k8s_helper remains
+    assert env_names == ["KEY"]
+
+
+def test_build_runtime_kaniko_incompatible_source_project_secret_wins_over_auto_mount(
+    monkeypatch,
+):
+    """When a project secret already exposes the same env name auto-mount
+    declares, the project-secret entry must win — auto-mount is a default,
+    project-level config is more specific."""
+    _patch_k8s_helper(monkeypatch)
+    helper = framework.utils.singletons.k8s.get_k8s_helper()
+    helper.get_project_secret_keys = unittest.mock.Mock(
+        side_effect=lambda project, filter_internal: ["STORAGE_ACCOUNT"]
+    )
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    monkeypatch.setattr(config.storage, "auto_mount_type", "secret_env")
+    monkeypatch.setattr(
+        config.storage,
+        "auto_mount_params",
+        "cleartext_env=STORAGE_ACCOUNT:from-auto-mount-should-not-win",
+    )
+
+    _build_with_source("az://container/path/project.tar.gz")
+
+    fetch_container = _init_container_by_name("fetch-source")
+    storage_entries = [
+        env_var
+        for env_var in fetch_container.env or []
+        if env_var.name == "STORAGE_ACCOUNT"
+    ]
+    assert len(storage_entries) == 1
+    # the surviving entry must be the project-secret-backed one (value_from),
+    # not the plain-value copy from auto_mount_params
+    assert storage_entries[0].value is None
+    assert storage_entries[0].value_from is not None
+
+
+def test_build_runtime_kaniko_incompatible_source_skips_mount_style_auto_mount(
+    monkeypatch,
+):
+    """Mount-style auto-mounts (PVC, V3IO FUSE, S3) target shared filesystems
+    the kaniko pod does not participate in. The helper must skip them rather
+    than crashing on params the modifier doesn't understand."""
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    monkeypatch.setattr(config.storage, "auto_mount_type", "pvc")
+    monkeypatch.setattr(
+        config.storage, "auto_mount_params", "pvc_name=my-pvc,volume_mount_path=/data"
+    )
+
+    _build_with_source("az://container/path/project.tar.gz")
+
+    fetch_container = _init_container_by_name("fetch-source")
+    env_names = [env_var.name for env_var in fetch_container.env or []]
+    assert env_names == ["KEY"]
+
+
+def test_build_runtime_kaniko_incompatible_source_passes_secrets_to_fetcher(
+    monkeypatch,
+):
+    """Project secrets the kaniko container sees must also reach the fetcher,
+    otherwise the fetch step has no Azure / data-store credentials."""
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    _build_with_source("az://container/path/project.tar.gz")
+
+    fetch_container = _init_container_by_name("fetch-source")
+    env_names = [env.name for env in fetch_container.env or []]
+    # _patch_k8s_helper exposes a single project secret key named "KEY"
+    assert "KEY" in env_names
+
+
+def test_build_runtime_kaniko_incompatible_source_honours_image_override(monkeypatch):
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    custom_image = "my-registry.example.com/custom-fetcher:1.0"
+    monkeypatch.setattr(
+        config.httpdb.builder,
+        "kaniko_source_fetch_init_container_image",
+        custom_image,
+    )
+    _build_with_source("az://container/path/project.tar.gz")
+
+    assert _init_container_by_name("fetch-source").image == custom_image
+
+
+def test_build_runtime_kaniko_incompatible_source_default_image_is_mlrun(monkeypatch):
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    monkeypatch.setattr(
+        config.httpdb.builder,
+        "kaniko_source_fetch_init_container_image",
+        "",
+    )
+    _build_with_source("az://container/path/project.tar.gz")
+
+    image = _init_container_by_name("fetch-source").image
+    # enrich_image_url anchors the bare name and may attach a registry/tag;
+    # the test only asserts the canonical mlrun/mlrun repo is in there.
+    assert "mlrun/mlrun" in image
+
+
+def test_build_runtime_kaniko_incompatible_source_rejects_non_archive(monkeypatch):
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="archive"):
+        _build_with_source("az://container/path/handler.py")
+
+
+@pytest.mark.parametrize(
+    "source,expected_context",
+    [
+        # kaniko-native: URL is the build context
+        ("s3://bucket/path/project.tar.gz", "s3://bucket/path/project.tar.gz"),
+        ("gs://bucket/path/project.tar.gz", "gs://bucket/path/project.tar.gz"),
+        (
+            "git://github.com/mlrun/example.git#main",
+            "git://github.com/mlrun/example.git#refs/heads/main",
+        ),
+        # http/https are routed via Dockerfile ADD; context stays at the default /context
+        ("https://example.com/project.tar.gz", "/context"),
+        ("http://example.com/project.tar.gz", "/context"),
+    ],
+)
+def test_build_runtime_kaniko_native_source_no_fetch_init_container(
+    monkeypatch, source, expected_context
+):
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    _build_with_source(source)
+
+    assert _kaniko_context_arg() == expected_context
+    assert _init_container_by_name("fetch-source") is None
+
+
+def test_build_runtime_v3io_source_unchanged_by_fix(monkeypatch):
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    _build_with_source("v3io:///some/path/project.tar.gz")
+
+    # v3io continues to mount the volume; context remains /empty (legacy)
+    # and no fetch-source init container is added.
+    assert _init_container_by_name("fetch-source") is None
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("az://x/y.tar.gz", True),
+        ("wasb://x/y.tar.gz", True),
+        ("wasbs://x@a.blob.core.windows.net/y.tar.gz", True),
+        ("abfs://x/y.tar.gz", True),
+        ("abfss://x/y.tar.gz", True),
+        ("ds://profile/path/y.tar.gz", True),
+        ("dbfs://path/y.tar.gz", True),
+        ("s3://x/y.tar.gz", False),
+        ("gs://x/y.tar.gz", False),
+        ("git://x/y", False),
+        ("https://x/y.tar.gz", False),
+        ("http://x/y.tar.gz", False),
+        ("v3io://x/y", False),
+        ("file:///x/y.tar.gz", False),
+        ("/absolute/path/y.tar.gz", False),
+        ("relative/path", False),
+        ("", False),
+    ],
+)
+def test_needs_source_fetch_init_container_allowlist(source, expected):
+    assert (
+        services.api.utils.builder._needs_source_fetch_init_container(source)
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "source,raises",
+    [
+        # accepted: the same archive formats `mlrun load-source` handles
+        ("az://x/y.tar.gz", False),
+        ("az://x/y.zip", False),
+        ("az://x/y.TAR.GZ", False),
+        # rejected: extensions mlrun load-source does not support
+        ("az://x/y.tgz", True),
+        ("az://x/y.tar.bz2", True),
+        ("az://x/y.tar", True),
+        ("az://x/y.py", True),
+        ("az://x/y.notes", True),
+        ("az://x/y", True),
+    ],
+)
+def test_validate_source_fetch_archive(source, raises):
+    if raises:
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+            services.api.utils.builder._validate_source_fetch_archive(source)
+    else:
+        services.api.utils.builder._validate_source_fetch_archive(source)

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1784,10 +1784,10 @@ def _init_container_by_name(name: str):
     "source",
     [
         "az://data/iguazio/naipi-artifacts/project.tar.gz",
+        "wasb://container@account.blob.core.windows.net/path/project.tar.gz",
         "wasbs://container@account.blob.core.windows.net/path/project.tar.gz",
-        "abfss://container@account.dfs.core.windows.net/path/project.zip",
         "ds://my-profile/path/project.tar.gz",
-        "dbfs://path/to/project.tar.gz",
+        "oss://bucket/path/project.tar.gz",
     ],
 )
 def test_build_runtime_kaniko_incompatible_source_uses_fetch_init_container(
@@ -1921,9 +1921,9 @@ def test_build_runtime_kaniko_incompatible_source_project_secret_wins_over_auto_
 def test_build_runtime_kaniko_incompatible_source_skips_mount_style_auto_mount(
     monkeypatch,
 ):
-    """Mount-style auto-mounts (PVC, V3IO FUSE, S3) target shared filesystems
-    the kaniko pod does not participate in. The helper must skip them rather
-    than crashing on params the modifier doesn't understand."""
+    """Mount-style auto-mounts (PVC, V3IO FUSE) target shared filesystems the
+    kaniko pod does not participate in. The helper must skip them rather than
+    crashing on params the modifier doesn't understand."""
     _patch_k8s_helper(monkeypatch)
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     monkeypatch.setattr(config.storage, "auto_mount_type", "pvc")
@@ -1936,6 +1936,23 @@ def test_build_runtime_kaniko_incompatible_source_skips_mount_style_auto_mount(
     fetch_container = _init_container_by_name("fetch-source")
     env_names = [env_var.name for env_var in fetch_container.env or []]
     assert env_names == ["KEY"]
+
+
+def test_build_runtime_kaniko_incompatible_source_applies_s3_auto_mount_env(
+    monkeypatch,
+):
+    """S3 auto-mount is env-style (no volumes), so its env vars must reach the
+    fetch-source init container — same contract as the secret_env case."""
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    monkeypatch.setattr(config.storage, "auto_mount_type", "s3")
+    monkeypatch.setattr(config.storage, "auto_mount_params", "aws_region=us-east-1")
+
+    _build_with_source("az://container/path/project.tar.gz")
+
+    fetch_container = _init_container_by_name("fetch-source")
+    env_by_name = {env_var.name: env_var.value for env_var in fetch_container.env or []}
+    assert env_by_name.get("AWS_REGION") == "us-east-1"
 
 
 def test_build_runtime_kaniko_incompatible_source_passes_secrets_to_fetcher(
@@ -1965,6 +1982,50 @@ def test_build_runtime_kaniko_incompatible_source_honours_image_override(monkeyp
     _build_with_source("az://container/path/project.tar.gz")
 
     assert _init_container_by_name("fetch-source").image == custom_image
+
+
+def test_build_runtime_kaniko_incompatible_source_combines_init_containers(
+    monkeypatch,
+):
+    """When the kaniko pod needs both the create-dockerfile init container
+    (always present when dockertext is set) and the fetch-source init container,
+    both must be rendered and both must share the `empty` volume mount that the
+    kaniko main container reads. Ordering between them is irrelevant for
+    correctness as long as both finish before main."""
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
+    _build_with_source("az://container/path/project.tar.gz")
+
+    pod_spec = _create_pod_mock_pod_spec()
+    init_names = {ic.name for ic in pod_spec.init_containers or []}
+    assert {"create-dockerfile", "fetch-source"}.issubset(init_names)
+
+    # both helpers write into /empty (Dockerfile and source/ respectively), so
+    # both init containers must mount the shared `empty` volume; otherwise the
+    # main kaniko container would not see the writes.
+    for name in ("create-dockerfile", "fetch-source"):
+        container = _init_container_by_name(name)
+        mounts = {(vm.name, vm.mount_path) for vm in container.volume_mounts or []}
+        assert ("empty", "/empty") in mounts, (
+            f"{name} init container missing /empty mount"
+        )
+
+
+def test_build_runtime_kaniko_incompatible_source_combines_with_ecr_init_container(
+    monkeypatch,
+):
+    """ECR destinations add a `create-repos` init container alongside
+    `create-dockerfile`. Combined with a kaniko-incompatible source, all three
+    init containers must be present in the rendered pod."""
+    _patch_k8s_helper(monkeypatch)
+    mlrun.mlconf.httpdb.builder.docker_registry = (
+        "aws_account_id.dkr.ecr.region.amazonaws.com"
+    )
+    _build_with_source("az://container/path/project.tar.gz")
+
+    pod_spec = _create_pod_mock_pod_spec()
+    init_names = {ic.name for ic in pod_spec.init_containers or []}
+    assert {"create-dockerfile", "fetch-source", "create-repos"}.issubset(init_names)
 
 
 def test_build_runtime_kaniko_incompatible_source_default_image_is_mlrun(monkeypatch):
@@ -2032,12 +2093,16 @@ def test_build_runtime_v3io_source_unchanged_by_fix(monkeypatch):
         ("az://x/y.tar.gz", True),
         ("wasb://x/y.tar.gz", True),
         ("wasbs://x@a.blob.core.windows.net/y.tar.gz", True),
-        ("abfs://x/y.tar.gz", True),
-        ("abfss://x/y.tar.gz", True),
         ("ds://profile/path/y.tar.gz", True),
-        ("dbfs://path/y.tar.gz", True),
+        ("oss://bucket/path/y.tar.gz", True),
+        # kaniko-native or otherwise handled out-of-band - must NOT be routed
+        # through the fetch init container.
+        ("abfs://x/y.tar.gz", False),
+        ("abfss://x/y.tar.gz", False),
+        ("dbfs://path/y.tar.gz", False),
         ("s3://x/y.tar.gz", False),
         ("gs://x/y.tar.gz", False),
+        ("gcs://x/y.tar.gz", False),
         ("git://x/y", False),
         ("https://x/y.tar.gz", False),
         ("http://x/y.tar.gz", False),

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1753,7 +1753,6 @@ def _mock_default_service_account(monkeypatch, service_account):
 
 
 def _build_with_source(source: str) -> None:
-    """Drive build_runtime end-to-end with the given source and the standard mocks."""
     function = mlrun.new_function(
         "some-function",
         "some-project",
@@ -1797,11 +1796,10 @@ def test_build_runtime_kaniko_incompatible_source_uses_fetch_init_container(
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     _build_with_source(source)
 
-    # kaniko's context is now the local empty-dir, not the raw URI
     assert _kaniko_context_arg() == "/empty"
 
     fetch_container = _init_container_by_name("fetch-source")
-    assert fetch_container is not None, "fetch-source init container missing"
+    assert fetch_container is not None
     assert fetch_container.args == [
         "-m",
         "mlrun",
@@ -1812,15 +1810,10 @@ def test_build_runtime_kaniko_incompatible_source_uses_fetch_init_container(
     ]
     assert fetch_container.command == ["python"]
 
-    # the fetch-source container must share the kaniko empty-dir so its
-    # writes at /empty/source are visible to the kaniko main container as
-    # part of the build context
-    rendered = _create_pod_mock_pod_spec()
-    rendered_fetch = next(
-        ic for ic in rendered.init_containers if ic.name == "fetch-source"
-    )
+    # fetch-source writes to /empty/source; without the shared mount kaniko cannot
+    # see those writes as part of its build context.
     fetch_mounts = {
-        (vm.name, vm.mount_path) for vm in rendered_fetch.volume_mounts or []
+        (vm.name, vm.mount_path) for vm in fetch_container.volume_mounts or []
     }
     assert ("empty", "/empty") in fetch_mounts
 
@@ -1828,8 +1821,6 @@ def test_build_runtime_kaniko_incompatible_source_uses_fetch_init_container(
 def test_build_runtime_kaniko_incompatible_source_dockerfile_adds_extracted_dir(
     monkeypatch,
 ):
-    """The dockerfile must ADD the extracted subdir (./source) into the image
-    so that the user's project code is actually present at runtime."""
     _patch_k8s_helper(monkeypatch)
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     with unittest.mock.patch(
@@ -1845,14 +1836,9 @@ def test_build_runtime_kaniko_incompatible_source_dockerfile_adds_extracted_dir(
 def test_build_runtime_kaniko_incompatible_source_applies_storage_auto_mount_env(
     monkeypatch,
 ):
-    """Whatever storage.auto_mount_params already declares for user pods must
-    also reach the fetch-source init container. The builder code never names
-    Azure (or any other) env vars explicitly — it just respects the same
-    auto-mount config the chart already maintains for user pods."""
     _patch_k8s_helper(monkeypatch)
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     monkeypatch.setattr(config.storage, "auto_mount_type", "secret_env")
-    # mirrors the lab wiring: a single cleartext storage-account env name+value
     monkeypatch.setattr(
         config.storage,
         "auto_mount_params",
@@ -1880,16 +1866,12 @@ def test_build_runtime_kaniko_incompatible_source_auto_mount_none_adds_no_env(
 
     fetch_container = _init_container_by_name("fetch-source")
     env_names = [env_var.name for env_var in fetch_container.env or []]
-    # only the project-secret-backed env from _patch_k8s_helper remains
     assert env_names == ["KEY"]
 
 
 def test_build_runtime_kaniko_incompatible_source_project_secret_wins_over_auto_mount(
     monkeypatch,
 ):
-    """When a project secret already exposes the same env name auto-mount
-    declares, the project-secret entry must win — auto-mount is a default,
-    project-level config is more specific."""
     _patch_k8s_helper(monkeypatch)
     helper = framework.utils.singletons.k8s.get_k8s_helper()
     helper.get_project_secret_keys = unittest.mock.Mock(
@@ -1912,7 +1894,7 @@ def test_build_runtime_kaniko_incompatible_source_project_secret_wins_over_auto_
         if env_var.name == "STORAGE_ACCOUNT"
     ]
     assert len(storage_entries) == 1
-    # the surviving entry must be the project-secret-backed one (value_from),
+    # surviving entry must be the project-secret-backed one (value_from),
     # not the plain-value copy from auto_mount_params
     assert storage_entries[0].value is None
     assert storage_entries[0].value_from is not None
@@ -1921,9 +1903,6 @@ def test_build_runtime_kaniko_incompatible_source_project_secret_wins_over_auto_
 def test_build_runtime_kaniko_incompatible_source_skips_mount_style_auto_mount(
     monkeypatch,
 ):
-    """Mount-style auto-mounts (PVC, V3IO FUSE) target shared filesystems the
-    kaniko pod does not participate in. The helper must skip them rather than
-    crashing on params the modifier doesn't understand."""
     _patch_k8s_helper(monkeypatch)
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     monkeypatch.setattr(config.storage, "auto_mount_type", "pvc")
@@ -1941,8 +1920,6 @@ def test_build_runtime_kaniko_incompatible_source_skips_mount_style_auto_mount(
 def test_build_runtime_kaniko_incompatible_source_applies_s3_auto_mount_env(
     monkeypatch,
 ):
-    """S3 auto-mount is env-style (no volumes), so its env vars must reach the
-    fetch-source init container — same contract as the secret_env case."""
     _patch_k8s_helper(monkeypatch)
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     monkeypatch.setattr(config.storage, "auto_mount_type", "s3")
@@ -1958,15 +1935,12 @@ def test_build_runtime_kaniko_incompatible_source_applies_s3_auto_mount_env(
 def test_build_runtime_kaniko_incompatible_source_passes_secrets_to_fetcher(
     monkeypatch,
 ):
-    """Project secrets the kaniko container sees must also reach the fetcher,
-    otherwise the fetch step has no Azure / data-store credentials."""
     _patch_k8s_helper(monkeypatch)
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     _build_with_source("az://container/path/project.tar.gz")
 
     fetch_container = _init_container_by_name("fetch-source")
     env_names = [env.name for env in fetch_container.env or []]
-    # _patch_k8s_helper exposes a single project secret key named "KEY"
     assert "KEY" in env_names
 
 
@@ -1987,11 +1961,6 @@ def test_build_runtime_kaniko_incompatible_source_honours_image_override(monkeyp
 def test_build_runtime_kaniko_incompatible_source_combines_init_containers(
     monkeypatch,
 ):
-    """When the kaniko pod needs both the create-dockerfile init container
-    (always present when dockertext is set) and the fetch-source init container,
-    both must be rendered and both must share the `empty` volume mount that the
-    kaniko main container reads. Ordering between them is irrelevant for
-    correctness as long as both finish before main."""
     _patch_k8s_helper(monkeypatch)
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     _build_with_source("az://container/path/project.tar.gz")
@@ -2000,9 +1969,8 @@ def test_build_runtime_kaniko_incompatible_source_combines_init_containers(
     init_names = {ic.name for ic in pod_spec.init_containers or []}
     assert {"create-dockerfile", "fetch-source"}.issubset(init_names)
 
-    # both helpers write into /empty (Dockerfile and source/ respectively), so
-    # both init containers must mount the shared `empty` volume; otherwise the
-    # main kaniko container would not see the writes.
+    # both write into /empty (Dockerfile and source/), so both must mount the shared
+    # `empty` volume - otherwise the main kaniko container would not see the writes.
     for name in ("create-dockerfile", "fetch-source"):
         container = _init_container_by_name(name)
         mounts = {(vm.name, vm.mount_path) for vm in container.volume_mounts or []}
@@ -2014,9 +1982,6 @@ def test_build_runtime_kaniko_incompatible_source_combines_init_containers(
 def test_build_runtime_kaniko_incompatible_source_combines_with_ecr_init_container(
     monkeypatch,
 ):
-    """ECR destinations add a `create-repos` init container alongside
-    `create-dockerfile`. Combined with a kaniko-incompatible source, all three
-    init containers must be present in the rendered pod."""
     _patch_k8s_helper(monkeypatch)
     mlrun.mlconf.httpdb.builder.docker_registry = (
         "aws_account_id.dkr.ecr.region.amazonaws.com"
@@ -2038,9 +2003,8 @@ def test_build_runtime_kaniko_incompatible_source_default_image_is_mlrun(monkeyp
     )
     _build_with_source("az://container/path/project.tar.gz")
 
+    # enrich_image_url may prefix a registry and/or attach a tag; only assert the repo.
     image = _init_container_by_name("fetch-source").image
-    # enrich_image_url anchors the bare name and may attach a registry/tag;
-    # the test only asserts the canonical mlrun/mlrun repo is in there.
     assert "mlrun/mlrun" in image
 
 
@@ -2082,8 +2046,6 @@ def test_build_runtime_v3io_source_unchanged_by_fix(monkeypatch):
     config.httpdb.builder.docker_registry = "default.docker.registry/default-repository"
     _build_with_source("v3io:///some/path/project.tar.gz")
 
-    # v3io continues to mount the volume; context remains /empty (legacy)
-    # and no fetch-source init container is added.
     assert _init_container_by_name("fetch-source") is None
 
 

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1812,6 +1812,18 @@ def test_build_runtime_kaniko_incompatible_source_uses_fetch_init_container(
     ]
     assert fetch_container.command == ["python"]
 
+    # the fetch-source container must share the kaniko empty-dir so its
+    # writes at /empty/source are visible to the kaniko main container as
+    # part of the build context
+    rendered = _create_pod_mock_pod_spec()
+    rendered_fetch = next(
+        ic for ic in rendered.init_containers if ic.name == "fetch-source"
+    )
+    fetch_mounts = {
+        (vm.name, vm.mount_path) for vm in rendered_fetch.volume_mounts or []
+    }
+    assert ("empty", "/empty") in fetch_mounts
+
 
 def test_build_runtime_kaniko_incompatible_source_dockerfile_adds_extracted_dir(
     monkeypatch,
@@ -2049,7 +2061,10 @@ def test_needs_source_fetch_init_container_allowlist(source, expected):
         # accepted: the same archive formats `mlrun load-source` handles
         ("az://x/y.tar.gz", False),
         ("az://x/y.zip", False),
-        ("az://x/y.TAR.GZ", False),
+        # rejected: case-sensitive match against load_source_code; uppercased
+        # extensions would not be picked up by the runtime extractor either,
+        # so we reject at the API boundary for a clearer error
+        ("az://x/y.TAR.GZ", True),
         # rejected: extensions mlrun load-source does not support
         ("az://x/y.tgz", True),
         ("az://x/y.tar.bz2", True),

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -40,12 +40,13 @@ from mlrun.utils.helpers import remove_image_protocol_prefix
 import framework.utils.helpers
 import framework.utils.singletons.k8s
 
-# mlrun datastore schemes kaniko cannot resolve as --context. explicit
-# allow-list so unknown schemes fail fast in the existing branches rather
-# than being silently routed through the fetch path.
-_FETCH_SUPPORTED_SCHEMES = frozenset(
-    {"az", "wasb", "wasbs", "abfs", "abfss", "ds", "dbfs"}
-)
+# curated set of mlrun datastore schemes kaniko cannot resolve as --context,
+# aligned with `mlrun.datastore.datastore.schema_to_store`. excludes schemes
+# kaniko handles natively (s3, gs/gcs, http/https) and v3io/v3ios (handled
+# elsewhere via FUSE mount). explicit allow-list so unknown schemes fail fast
+# in the existing branches rather than being silently routed through the fetch
+# path (mlrun load-source can only extract .tar.gz/.zip).
+_FETCH_SUPPORTED_SCHEMES = frozenset({"az", "wasb", "wasbs", "ds", "oss"})
 
 # matches the set ``mlrun load-source`` actually extracts.
 _FETCHABLE_ARCHIVE_EXTENSIONS = (".tar.gz", ".zip")
@@ -184,6 +185,8 @@ def make_kaniko_pod(
     project_secrets=None,
     project_default_fucntion_node_selector=None,
     auth_info: mlrun.common.schemas.AuthInfo = None,
+    *,
+    source_to_fetch: str | None = None,
 ):
     extra_runtime_spec = {}
     if not registry:
@@ -347,6 +350,14 @@ def make_kaniko_pod(
     elif secret_name:
         items = [{"key": ".dockerconfigjson", "path": "config.json"}]
         kpod.mount_secret(secret_name, "/kaniko/.docker", items=items)
+
+    if source_to_fetch:
+        _append_source_fetch_init_container(
+            kpod=kpod,
+            source=source_to_fetch,
+            builder_env_list=builder_env,
+            project_secrets=project_secrets,
+        )
 
     return kpod
 
@@ -594,6 +605,7 @@ def build_image(
         },
         project_default_fucntion_node_selector=project_default_function_node_selector,
         auth_info=auth_info,
+        source_to_fetch=source if needs_source_fetch_init_container else None,
     )
 
     if to_mount:
@@ -602,14 +614,6 @@ def build_image(
             mount_path="/context",
             access_key=access_key,
             user=username,
-        )
-
-    if needs_source_fetch_init_container:
-        _append_source_fetch_init_container(
-            kpod=kpod,
-            source=source,
-            builder_env_list=builder_env_list,
-            project_secrets=project_secrets,
         )
 
     k8s = framework.utils.singletons.k8s.get_k8s_helper(silent=False)
@@ -1018,30 +1022,37 @@ def _append_source_fetch_init_container(
 def _resolve_storage_auto_mount_env() -> list:
     """Harvest env vars the configured storage auto-mount would apply to user pods.
 
-    Only env-style modifiers are honored. Mount-style modifiers (PVC, V3IO
-    FUSE, S3) mutate ``spec.volumes`` / ``spec.volume_mounts`` rather than
-    ``spec.env``, so they would be silently dropped by this harvest — and the
-    fetch step needs only credentials to call ``mlrun.get_dataitem(...).download``,
-    not a fuse-mounted filesystem.
+    Gates on ``AutoMountType.env_style_modifiers()`` so mount-style outputs
+    (volumes / volume_mounts that this env-only harvester would silently drop)
+    are skipped. ``auto`` is resolved via ``get_modifier()`` first; the resolved
+    function ref - not the enum - is what we classify.
+
+    ``KubeResource.apply`` sanitizes ``spec.env`` to plain dicts during
+    ``try_auto_mount_based_on_config``; convert them back to ``V1EnvVar`` so
+    the caller can rely on attribute access (``.name``) like every other
+    builder env source.
     """
     auto_mount_type = mlrun.runtimes.pod.AutoMountType(
         mlrun.mlconf.storage.auto_mount_type
     )
     modifier = auto_mount_type.get_modifier()
-    if modifier is None:
+    if (
+        modifier is None
+        or modifier not in mlrun.runtimes.pod.AutoMountType.env_style_modifiers()
+    ):
         return []
-    env_style_modifiers = {
-        mlrun.runtimes.mounts.set_env_vars_from_secret,
-        mlrun.runtimes.mounts.set_env_variables,
-        mlrun.runtimes.mounts.v3io_cred,
-    }
-    if modifier not in env_style_modifiers:
-        return []
-    mount_params = mlrun.mlconf.get_storage_auto_mount_params()
-    mount_params = mlrun.runtimes.pod._filter_modifier_params(modifier, mount_params)
     scratch = mlrun.runtimes.KubejobRuntime()
-    modifier(**mount_params)(scratch)
-    return list(scratch.spec.env or [])
+    scratch.try_auto_mount_based_on_config()
+    return [
+        client.V1EnvVar(
+            name=env_var["name"],
+            value=env_var.get("value"),
+            value_from=env_var.get("valueFrom"),
+        )
+        if isinstance(env_var, dict)
+        else env_var
+        for env_var in scratch.spec.env or []
+    ]
 
 
 def _generate_builder_env(

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -28,6 +28,9 @@ import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.model
+import mlrun.runtimes
+import mlrun.runtimes.mounts
+import mlrun.runtimes.pod
 import mlrun.runtimes.utils
 import mlrun.utils
 from mlrun.config import config
@@ -36,6 +39,22 @@ from mlrun.utils.helpers import remove_image_protocol_prefix
 
 import framework.utils.helpers
 import framework.utils.singletons.k8s
+
+# mlrun datastore schemes kaniko cannot resolve as --context. explicit
+# allow-list so unknown schemes fail fast in the existing branches rather
+# than being silently routed through the fetch path.
+_FETCH_SUPPORTED_SCHEMES = frozenset(
+    {"az", "wasb", "wasbs", "abfs", "abfss", "ds", "dbfs"}
+)
+
+# matches the set ``mlrun load-source`` actually extracts.
+_FETCHABLE_ARCHIVE_EXTENSIONS = (".tar.gz", ".zip")
+
+_FETCHED_SOURCE_SUBDIR = "source"
+
+# anchored as a literal (not config.default_base_image) so the builder is not
+# coupled to the SDK-side default-image knob.
+_DEFAULT_SOURCE_FETCH_IMAGE = "mlrun/mlrun"
 
 
 def make_dockerfile(
@@ -463,6 +482,7 @@ def build_image(
     parsed_url = urlparse(source)
     source_to_copy = None
     source_dir_to_mount = None
+    needs_source_fetch_init_container = False
     if inline_code or runtime_spec.build.load_source_on_run or not source:
         context = "/empty"
 
@@ -470,7 +490,14 @@ def build_image(
     elif is_http_source:
         source_to_copy = source
 
-    # source is remote
+    # source is in a scheme kaniko cannot resolve; fetch in a dedicated init container
+    elif source and _needs_source_fetch_init_container(source):
+        _validate_source_fetch_archive(source)
+        context = "/empty"
+        source_to_copy = f"./{_FETCHED_SOURCE_SUBDIR}"
+        needs_source_fetch_init_container = True
+
+    # source is remote (kaniko-native)
     elif source and "://" in source and not is_v3io_source:
         if source.startswith("git://"):
             # if the user provided branch (w/o refs/..) we add the "refs/.."
@@ -575,6 +602,14 @@ def build_image(
             mount_path="/context",
             access_key=access_key,
             user=username,
+        )
+
+    if needs_source_fetch_init_container:
+        _append_source_fetch_init_container(
+            kpod=kpod,
+            source=source,
+            builder_env_list=builder_env_list,
+            project_secrets=project_secrets,
         )
 
     k8s = framework.utils.singletons.k8s.get_k8s_helper(silent=False)
@@ -919,6 +954,91 @@ def resolve_image_target(image_target: str, registry: str | None = None) -> str:
 
     image_target = remove_image_protocol_prefix(image_target)
     return image_target
+
+
+def _needs_source_fetch_init_container(source: str) -> bool:
+    return urlparse(source).scheme in _FETCH_SUPPORTED_SCHEMES
+
+
+def _validate_source_fetch_archive(source: str) -> None:
+    if not source.lower().endswith(_FETCHABLE_ARCHIVE_EXTENSIONS):
+        scheme = urlparse(source).scheme
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Source {source} uses scheme '{scheme}://' which is not natively "
+            "supported as a kaniko build context. Provide the source as an "
+            f"archive ending in one of: {', '.join(_FETCHABLE_ARCHIVE_EXTENSIONS)}"
+        )
+
+
+def _append_source_fetch_init_container(
+    kpod,
+    source: str,
+    builder_env_list: list,
+    project_secrets: list,
+) -> None:
+    """Run ``mlrun load-source`` in an init container that extracts ``source``
+    into ``/empty/<_FETCHED_SOURCE_SUBDIR>`` for kaniko to consume as --context.
+
+    Env precedence (later layers do not overwrite earlier ones):
+    builder_env_list > project_secrets > storage.auto_mount_params.
+    """
+    image = config.httpdb.builder.kaniko_source_fetch_init_container_image
+    if not image:
+        image = mlrun.utils.enrich_image_url(_DEFAULT_SOURCE_FETCH_IMAGE)
+
+    target_dir = f"/empty/{_FETCHED_SOURCE_SUBDIR}"
+    args = ["-m", "mlrun", "load-source", source, "--target", target_dir]
+
+    env_list = list(builder_env_list or []) + list(project_secrets or [])
+    already_set = {env_var.name for env_var in env_list}
+    for env_var in _resolve_storage_auto_mount_env():
+        if env_var.name in already_set:
+            continue
+        env_list.append(env_var)
+        already_set.add(env_var.name)
+
+    mlrun.utils.logger.debug(
+        "Adding source-fetch init container",
+        image=image,
+        source=source,
+        target=target_dir,
+    )
+    kpod.append_init_container(
+        image,
+        command=["python"],
+        args=args,
+        env=env_list,
+        name="fetch-source",
+    )
+
+
+def _resolve_storage_auto_mount_env() -> list:
+    """Harvest env vars the configured storage auto-mount would apply to user pods.
+
+    Only env-style modifiers are honored. Mount-style modifiers (PVC, V3IO
+    FUSE, S3) mutate ``spec.volumes`` / ``spec.volume_mounts`` rather than
+    ``spec.env``, so they would be silently dropped by this harvest — and the
+    fetch step needs only credentials to call ``mlrun.get_dataitem(...).download``,
+    not a fuse-mounted filesystem.
+    """
+    auto_mount_type = mlrun.runtimes.pod.AutoMountType(
+        mlrun.mlconf.storage.auto_mount_type
+    )
+    modifier = auto_mount_type.get_modifier()
+    if modifier is None:
+        return []
+    env_style_modifiers = {
+        mlrun.runtimes.mounts.set_env_vars_from_secret,
+        mlrun.runtimes.mounts.set_env_variables,
+        mlrun.runtimes.mounts.v3io_cred,
+    }
+    if modifier not in env_style_modifiers:
+        return []
+    mount_params = mlrun.mlconf.get_storage_auto_mount_params()
+    mount_params = mlrun.runtimes.pod._filter_modifier_params(modifier, mount_params)
+    scratch = mlrun.runtimes.KubejobRuntime()
+    modifier(**mount_params)(scratch)
+    return list(scratch.spec.env or [])
 
 
 def _generate_builder_env(

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -40,21 +40,17 @@ from mlrun.utils.helpers import remove_image_protocol_prefix
 import framework.utils.helpers
 import framework.utils.singletons.k8s
 
-# curated set of mlrun datastore schemes kaniko cannot resolve as --context,
-# aligned with `mlrun.datastore.datastore.schema_to_store`. excludes schemes
-# kaniko handles natively (s3, gs/gcs, http/https) and v3io/v3ios (handled
-# elsewhere via FUSE mount). explicit allow-list so unknown schemes fail fast
-# in the existing branches rather than being silently routed through the fetch
-# path (mlrun load-source can only extract .tar.gz/.zip).
+# mlrun datastore schemes kaniko cannot resolve as --context.
+# excludes kaniko-native schemes (s3, gs/gcs, http/https) and v3io (igz FUSE-mount).
+# aligned with `mlrun.datastore.datastore.schema_to_store`.
 _FETCH_SUPPORTED_SCHEMES = frozenset({"az", "wasb", "wasbs", "ds", "oss"})
 
-# matches the set ``mlrun load-source`` actually extracts.
+# matches what ``mlrun load-source`` extracts.
+# TODO: support .tgz
 _FETCHABLE_ARCHIVE_EXTENSIONS = (".tar.gz", ".zip")
 
 _FETCHED_SOURCE_SUBDIR = "source"
 
-# anchored as a literal (not config.default_base_image) so the builder is not
-# coupled to the SDK-side default-image knob.
 _DEFAULT_SOURCE_FETCH_IMAGE = "mlrun/mlrun"
 
 
@@ -983,12 +979,8 @@ def _append_source_fetch_init_container(
     builder_env_list: list,
     project_secrets: list,
 ) -> None:
-    """Run ``mlrun load-source`` in an init container that extracts ``source``
-    into ``/empty/<_FETCHED_SOURCE_SUBDIR>`` for kaniko to consume as --context.
-
-    Env precedence (later layers do not overwrite earlier ones):
-    builder_env_list > project_secrets > storage.auto_mount_params.
-    """
+    # Env precedence: builder_env_list > project_secrets > storage.auto_mount_params.
+    # First-write wins so caller-supplied values are not overwritten by auto-mount defaults.
     image = config.httpdb.builder.kaniko_source_fetch_init_container_image
     if not image:
         image = mlrun.utils.enrich_image_url(_DEFAULT_SOURCE_FETCH_IMAGE)
@@ -1020,18 +1012,9 @@ def _append_source_fetch_init_container(
 
 
 def _resolve_storage_auto_mount_env() -> list:
-    """Harvest env vars the configured storage auto-mount would apply to user pods.
-
-    Gates on ``AutoMountType.env_style_modifiers()`` so mount-style outputs
-    (volumes / volume_mounts that this env-only harvester would silently drop)
-    are skipped. ``auto`` is resolved via ``get_modifier()`` first; the resolved
-    function ref - not the enum - is what we classify.
-
-    ``KubeResource.apply`` sanitizes ``spec.env`` to plain dicts during
-    ``try_auto_mount_based_on_config``; convert them back to ``V1EnvVar`` so
-    the caller can rely on attribute access (``.name``) like every other
-    builder env source.
-    """
+    # Gate on env_style_modifiers so mount-style outputs (volumes/volume_mounts) are
+    # not silently dropped. KubeResource.apply sanitizes spec.env to plain dicts, so
+    # rebuild V1EnvVar for callers that rely on attribute access.
     auto_mount_type = mlrun.runtimes.pod.AutoMountType(
         mlrun.mlconf.storage.auto_mount_type
     )

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -961,7 +961,10 @@ def _needs_source_fetch_init_container(source: str) -> bool:
 
 
 def _validate_source_fetch_archive(source: str) -> None:
-    if not source.lower().endswith(_FETCHABLE_ARCHIVE_EXTENSIONS):
+    # match ``load_source_code``'s case-sensitive extension check, so uppercased
+    # variants (.TAR.GZ, .ZIP) are rejected at the API boundary instead of slipping
+    # through and failing inside the init container with a worse error.
+    if not source.endswith(_FETCHABLE_ARCHIVE_EXTENSIONS):
         scheme = urlparse(source).scheme
         raise mlrun.errors.MLRunInvalidArgumentError(
             f"Source {source} uses scheme '{scheme}://' which is not natively "

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -599,3 +599,28 @@ def test_validate_service(
         spec.validate_service_account(
             allowed_service_accounts, forbidden_service_accounts
         )
+
+
+def test_auto_mount_type_env_style_modifiers():
+    """Locks the policy: only modifiers that contribute env vars / envFrom and
+    no volumes or volume mounts may appear in this set. Callers (e.g. builder
+    `_resolve_storage_auto_mount_env`) rely on this to safely harvest env via
+    `spec.env` without silently dropping volume side-effects."""
+    import mlrun.runtimes.mounts
+
+    expected = {
+        mlrun.runtimes.mounts.set_env_variables,
+        mlrun.runtimes.mounts.set_env_vars_from_secret,
+        mlrun.runtimes.mounts.v3io_cred,
+        mlrun.runtimes.mounts.mount_s3,
+    }
+    assert mlrun.runtimes.pod.AutoMountType.env_style_modifiers() == expected
+
+    # mount-style modifiers must stay out: they mutate spec.volumes /
+    # spec.volume_mounts which the env-only harvester would silently drop.
+    forbidden = {
+        mlrun.runtimes.mounts.mount_v3io,
+        mlrun.runtimes.mounts.mount_pvc,
+        mlrun.runtimes.mounts.auto_mount,
+    }
+    assert forbidden.isdisjoint(mlrun.runtimes.pod.AutoMountType.env_style_modifiers())

--- a/tests/runtimes/test_pod.py
+++ b/tests/runtimes/test_pod.py
@@ -602,10 +602,9 @@ def test_validate_service(
 
 
 def test_auto_mount_type_env_style_modifiers():
-    """Locks the policy: only modifiers that contribute env vars / envFrom and
-    no volumes or volume mounts may appear in this set. Callers (e.g. builder
-    `_resolve_storage_auto_mount_env`) rely on this to safely harvest env via
-    `spec.env` without silently dropping volume side-effects."""
+    # locks the policy: only env-style modifiers may appear here; mount-style
+    # modifiers would have their volume side-effects silently dropped by callers
+    # that harvest via spec.env (e.g. builder `_resolve_storage_auto_mount_env`).
     import mlrun.runtimes.mounts
 
     expected = {
@@ -616,8 +615,6 @@ def test_auto_mount_type_env_style_modifiers():
     }
     assert mlrun.runtimes.pod.AutoMountType.env_style_modifiers() == expected
 
-    # mount-style modifiers must stay out: they mutate spec.volumes /
-    # spec.volume_mounts which the env-only harvester would silently drop.
     forbidden = {
         mlrun.runtimes.mounts.mount_v3io,
         mlrun.runtimes.mounts.mount_pvc,


### PR DESCRIPTION
### 📝 Description

`project.build_image(...)` fails when the project source uses a scheme MLRun's datastore understands but Kaniko cannot resolve natively as `--context`. Today the API server hands the raw URI to Kaniko, which rejects it with `error resolving source context: unknown build context prefix provided, please use one of the following: gs://, dir://, tar://, s3://, git://, https://`. The first hit was `az://`, but `wasb(s)://`, `abfs(s)://`, `ds://`, and `dbfs://` all break the same way.

This PR routes those schemes through a new `fetch-source` init container that invokes the existing `mlrun load-source` CLI to download and extract the archive into the Kaniko empty-dir volume, then points Kaniko's `--context` at that local directory. Storage credentials for the fetch flow from the same `storage.auto_mount_params` the chart already declares for user pods — the builder code never enumerates Azure (or any other provider) env names.

---

### 🛠️ Changes Made

- **`server/py/services/api/utils/builder.py`** — new branch in `build_image` for kaniko-incompatible source schemes (explicit allow-list: `az/wasb/wasbs/abfs/abfss/ds/dbfs`). Sets `context=/empty`, `source_to_copy=./source`, and appends a `fetch-source` init container that runs `python -m mlrun load-source <uri> --target /empty/source`. Three new private helpers: `_needs_source_fetch_init_container`, `_validate_source_fetch_archive`, `_append_source_fetch_init_container`, plus `_resolve_storage_auto_mount_env` which harvests env from the existing `storage.auto_mount_*` config.
- **`mlrun/config.py`** — new `httpdb.builder.kaniko_source_fetch_init_container_image` knob. Empty default resolves at runtime to the canonical `mlrun/mlrun` image (enriched via `images_registry` + `images_tag`); operators can override for a custom fetcher image.
- **Tests** (+318 lines under `server/py/services/api/tests/unit/utils/test_builder.py`): scheme classification matrix, archive validation matrix, init-container args + image override, storage.auto_mount-driven env propagation, `auto_mount_type=none` opt-out, project-secret precedence over auto-mount, mount-style modifier skip, and that native-kaniko schemes / `v3io://` / inline-code paths are unaffected.

Behavior for existing source forms is unchanged:
- `s3://`, `gs://`, `git://`, `tar://`, `dir://` — Kaniko-native, URL still passed as `--context`.
- `http(s)://` — same code path as before (Dockerfile `ADD` of the URL).
- `v3io://` / `v3ios://` — same volume-mount path as before.
- Scheme-less local paths and inline-code — unchanged.

Single-file (non-archive) sources are rejected at the API boundary with a clear `MLRunInvalidArgumentError` before the build pod is created.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)


---

### 🧪 Testing

- **Unit — `server/py/services/api/tests/unit/utils/test_builder.py`**: 158 pre-existing tests still pass; **23 new tests** cover:
  - Kaniko-incompatible source builds attach the `fetch-source` init container with the correct image, command, args, and target dir (parametrized across `az://`, `wasbs://`, `abfss://`, `ds://`, `dbfs://`).
  - `mlrun load-source` is invoked with `-m mlrun load-source <uri> --target /empty/source`.
  - `config.httpdb.builder.kaniko_source_fetch_init_container_image` override is honoured; empty default falls back to `mlrun/mlrun`.
  - Storage credentials propagate from `storage.auto_mount_params` to the fetch-source init container; `auto_mount_type=none` opts out cleanly; project-secret entries win over auto-mount values; mount-style modifiers (PVC, V3IO FUSE, S3) are skipped.
  - Single-file (non-archive) source raises `MLRunInvalidArgumentError` at validation time.
  - Native-kaniko schemes still use the URL as `--context`; no `fetch-source` container is attached.
  - `v3io://` is unaffected.
- **Lint** — `make lint` clean (ruff, ruff format, import-linter — all 5 contracts kept).
- **Lab verification on `az-aks-msdev78-00` (AKS, namespace `x`)**: end-to-end build .

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12710
- Design docs links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No


---

### 🔍️ Additional Notes

- **Out of scope.** The symmetrical `pull_at_runtime=True` failure path through `mlrun.projects.pipelines.pull_remote_project_files` → `mlrun.load_project` has the same root cause (no `az://` archive support in the runtime-side loader) but a different fix surface. Not addressed here