### PR TITLE
[Events] Fix create_project_secrets

### DIFF
--- a/server/py/services/api/utils/events/iguazio_v4.py
+++ b/server/py/services/api/utils/events/iguazio_v4.py
@@ -124,7 +124,7 @@ PROJECT_LIFECYCLE_EVENTS: dict[
 
 class Client(base_events.BaseEventClient):
     """
-    Events client for Iguazio v4. Publishes events through the Iguazio (orca)
+    Events client for Iguazio v4. Publishes events through  the
     SDK using catalog event configs.
     """
 
@@ -310,9 +310,7 @@ class Client(base_events.BaseEventClient):
         action: mlrun.common.schemas.AuthSecretEventActions,
     ):
         # TODO: map v3 auth-secret events onto the v4 catalog (separate change).
-        raise NotImplementedError(
-            "Auth secret events are not yet supported on Iguazio v4"
-        )
+        pass
 
     def generate_project_secret_event(
         self,
@@ -322,9 +320,7 @@ class Client(base_events.BaseEventClient):
         action: mlrun.common.schemas.SecretEventActions = mlrun.common.schemas.SecretEventActions.created,
     ):
         # TODO: map v3 project-secret events onto the v4 catalog (separate change).
-        raise NotImplementedError(
-            "Project secret events are not yet supported on Iguazio v4"
-        )
+        pass
 
     @staticmethod
     def _resolve_entity_name() -> str:


### PR DESCRIPTION
### 📝 Description
On Iguazio v4 labs, calling `mlrun.get_run_db().create_project_secrets(...)` (and any other path that creates / updates / deletes project secrets — including project deletion) returns HTTP 500 because the v4 events client raises `NotImplementedError` from its secret-event generators. The k8s-secret write itself succeeds, but the exception escapes the synchronous `generate_project_secret_event(...)` call (callers wrap only `emit()` semantically — `emit(None)` already no-ops), surfacing as `MLRunInternalServerError: ... NotImplementedError('Project secret events are not yet supported on Iguazio v4')`. Same shape for the auth-secret path.

Aligns the v4 client with the contract documented on `BaseEventClient` and implemented by `NopClient`: when a generator can't produce an event for the active backend, return `None` and let `emit()` short-circuit. The actual v4-catalog mapping for project / auth secret events remains deferred — the existing TODOs are preserved.

---

### 🛠️ Changes Made
- `server/py/services/api/utils/events/iguazio_v4.py`: replace `raise NotImplementedError(...)` with `pass` in `generate_auth_secret_event` and `generate_project_secret_event`. `emit()` already guards `if event is None: return`, so the secret API path stays a no-op on v4 instead of 500-ing.
- TODO comments noting that the v4-catalog mapping is a separate follow-up are kept in place.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Verified the failing smoke scenario on `vmdev236ig4`: `POST /api/v1/projects/<project>/secrets` (kubernetes provider) now returns 201 instead of 500.
- `create_project_secrets`, secret update / delete, and project deletion paths all exercise the same generator and were re-checked.
- TODO: add a unit test on the v4 events client asserting `generate_auth_secret_event` / `generate_project_secret_event` return `None` and that `emit(None)` is a no-op.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/IG4-2787
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Smoke regression originally surfaced on `naipi` `test_mlrun_load_project_and_run_pipeline_with_git_token_not_set`. The k8s write itself was always succeeding; only the event-publish side trip was failing.
- The actual v4-catalog mapping for project-secret and auth-secret events is intentionally **not** in this PR (matches the prior pattern used for DB-migration and project-lifecycle events). Existing `# TODO: map v3 ... onto the v4 catalog (separate change)` comments are preserved.
