### PR TITLE
[Runtimes] Fix application shown as running during image build

### DIFF
--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -47,6 +47,9 @@ class FunctionState:
     pending = "pending"
     # same goes for the build which is not coming from the pod, but is used and we can't just omit it for BC reasons
     build = "build"
+    # `building` is a presentational state: persisted to status.state so the UI shows an in-progress
+    #  build/deploy as "Deploying". On the application build path it's only persisted, never put in the
+    # `x-mlrun-function-status` header, so the SDK build-watch still polls the raw pod phase (running/pending).
     building = "building"
 
     # for pipeline steps

--- a/mlrun/common/schemas/function.py
+++ b/mlrun/common/schemas/function.py
@@ -47,6 +47,7 @@ class FunctionState:
     pending = "pending"
     # same goes for the build which is not coming from the pod, but is used and we can't just omit it for BC reasons
     build = "build"
+    building = "building"
 
     # for pipeline steps
     skipped = "skipped"

--- a/server/py/services/api/api/endpoints/functions.py
+++ b/server/py/services/api/api/endpoints/functions.py
@@ -608,13 +608,21 @@ Message: {event.message}
             # begin from the offset number and then encode
             out = resp[offset:].encode()
 
+    # Persist `building` for an in-progress application build instead of `running`/`pending`
+    persisted_function_state = normalized_pod_function_state
+    if fn.get("kind") == RuntimeKinds.application and normalized_pod_function_state in (
+        mlrun.common.schemas.FunctionState.running,
+        mlrun.common.schemas.FunctionState.pending,
+    ):
+        persisted_function_state = mlrun.common.schemas.FunctionState.building
+
     # check if the previous function state is different from the current build pod state, if that is the case then
     # update the function and store to the database
-    if function_state != normalized_pod_function_state:
-        update_in(fn, "status.state", normalized_pod_function_state)
+    if function_state != persisted_function_state:
+        update_in(fn, "status.state", persisted_function_state)
 
         versioned = False
-        if normalized_pod_function_state == mlrun.common.schemas.FunctionState.ready:
+        if persisted_function_state == mlrun.common.schemas.FunctionState.ready:
             update_in(fn, "spec.image", image)
             versioned = True
 

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -1202,7 +1202,7 @@ def test_build_status_building_for_application(
         unittest.mock.patch.object(
             framework.utils.singletons.k8s.get_k8s_helper().v1api,
             "read_namespaced_pod_log",
-            return_value="log",
+            return_value=unittest.mock.Mock(data=b"log"),
         ),
         unittest.mock.patch.object(
             framework.utils.singletons.k8s.get_k8s_helper(),

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -1159,6 +1159,80 @@ def test_build_status_events_and_logs(
         assert response.content.decode() == "log"
 
 
+@pytest.mark.parametrize(
+    "kind,pod_phase,expected_persisted_state",
+    [
+        # ML-12689: an application's in-progress build pod must be persisted as `building` (the UI renders that as
+        # "Deploying"), not `running`.
+        ("application", "running", mlrun.common.schemas.FunctionState.building),
+        ("application", "pending", mlrun.common.schemas.FunctionState.building),
+        # other built runtimes keep surfacing the raw build-pod phase as before.
+        ("job", "running", mlrun.common.schemas.FunctionState.running),
+        ("job", "pending", mlrun.common.schemas.FunctionState.pending),
+    ],
+)
+def test_build_status_building_for_application(
+    mocked_k8s_helper,
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    kind,
+    pod_phase,
+    expected_persisted_state,
+):
+    services.api.tests.unit.api.utils.create_project(client, PROJECT)
+    function = {
+        "kind": kind,
+        "metadata": {"name": f"fn-{kind}", "project": PROJECT, "tag": "latest"},
+        "status": {"build_pod": "some-pod-name"},
+    }
+    response = client.post(
+        FUNCTIONS_API.format(
+            project=function["metadata"]["project"], name=function["metadata"]["name"]
+        ),
+        json=function,
+    )
+    assert response.status_code == HTTPStatus.OK.value
+
+    with (
+        unittest.mock.patch.object(
+            framework.utils.singletons.k8s.get_k8s_helper(),
+            "get_pod_phase",
+            return_value=pod_phase,
+        ),
+        unittest.mock.patch.object(
+            framework.utils.singletons.k8s.get_k8s_helper().v1api,
+            "read_namespaced_pod_log",
+            return_value="log",
+        ),
+        unittest.mock.patch.object(
+            framework.utils.singletons.k8s.get_k8s_helper(),
+            "list_object_events",
+            return_value=[],
+        ),
+    ):
+        response = client.get(
+            BUILD_STATUS_API,
+            params={
+                "project": function["metadata"]["project"],
+                "name": function["metadata"]["name"],
+                "tag": function["metadata"]["tag"],
+            },
+            headers={mlrun.common.schemas.HeaderNames.client_version: "1.12.0"},
+        )
+        assert response.status_code == HTTPStatus.OK.value
+
+    assert response.headers.get("x-mlrun-function-status") == pod_phase
+
+    # The persisted state is what the UI reads; only application is remapped.
+    stored = services.api.crud.Functions().get_function(
+        db_session=db,
+        project=PROJECT,
+        name=function["metadata"]["name"],
+        tag="latest",
+    )
+    assert stored["status"]["state"] == expected_persisted_state
+
+
 def _generate_function(
     function_name: str,
     project: str = PROJECT,


### PR DESCRIPTION
### 📝 Description
While an application's image is being built, the build-status poller mapped the kaniko build pod's running/pending phase directly onto the function state and persisted it. As a result the UI showed the application as "Running"  during the entire build, even though nothing was deployed yet.                                                                                          
     
---

### 🛠️ Changes Made
- `server/py/services/api/api/endpoints/functions.py`: for an application with an in-progress build pod (running/pending), persist building instead of the raw pod phase. 
The `x-mlrun-function-status` response header still carries the live phase, so the SDK build-watch loop and build-log streaming are unaffected. Scoped to `kind == application`; other built runtimes are unchanged.           
  - `mlrun/common/schemas/function.py`: added a `building` state to `FunctionState` (the UI renders it as "Deploying").                                                                                                        

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- New parametrized test in `server/py/services/api/tests/unit/api/test_functions.py` asserts: application + running/pending build pod → persisted state building;                                                                                                                           

- Manual verification on a live cluster (vmdev26 + this patch):                                                                                                                                       
  - Deployed an application with a slow build and polled function throughout.                                                                                                      
  - During the kaniko mlrun-build-* pod's run, the persisted `status.state` was building
  - The full deploy completed normally — the Nuclio function pod came up — confirming the SDK build-watch and build-log streaming are unaffected.                                
  - In the UI, the application status showed "Deploying" during the build — previously it showed "Running" during the build.                                                                                           

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12689
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
confirmed with the UI team that showing "Deploying" during the build is the desired behavior (https://ecliptos.atlassian.net/browse/ML-12689?focusedCommentId=182965), so no UI change is required
