### PR TITLE
[K8s] Retry pod creation on transient admission-webhook dial failures

### DIFF
--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import base64
 import hashlib
+import http
 import json
 import random
 import string
@@ -310,12 +311,54 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
                     time.sleep(retry_interval)
                     continue
 
+                # Transient admission-webhook dial failure (e.g. an AKS konnectivity blip
+                # where the apiserver can't reach a mutating webhook). The pod is rejected
+                # at admission *before* it is persisted, so re-creating it has no side
+                # effect and is safe to retry.
+                if self._is_transient_admission_webhook_error(exc):
+                    logger.warning(
+                        "Failed to create pod due to transient admission-webhook error, "
+                        "sleeping and retrying",
+                        retry_interval=retry_interval,
+                    )
+                    retry_count += 1
+                    time.sleep(retry_interval)
+                    continue
+
                 raise mlrun.errors.err_for_status_code(
                     exc.status, message=mlrun.errors.err_to_str(exc)
                 ) from exc
             else:
                 logger.info("Pod created", pod_name=resp.metadata.name)
                 return resp.metadata.name, resp.metadata.namespace
+
+    @staticmethod
+    def _is_transient_admission_webhook_error(
+        exc: k8s_client_rest.ApiException,
+    ) -> bool:
+        """Return True only for transient k8s admission-webhook *dial* failures.
+
+        These mean the apiserver could not reach a mutating/validating webhook (e.g. an
+        AKS konnectivity tunnel blip). With ``failurePolicy: Fail`` the create call is
+        rejected at admission *before* the object is persisted, so it has no side effect
+        and is safe to retry. Deterministic webhook *denials* and non-500 errors are
+        never matched.
+
+        :param exc: The k8s ``ApiException`` raised by the create call.
+        :return:    True if the error matches the transient dial-failure signature.
+        """
+        if exc.status != http.HTTPStatus.INTERNAL_SERVER_ERROR.value:
+            return False
+        body = mlrun.errors.err_to_str(exc).lower()
+        # a webhook that was reached and *denied* the request is deterministic — never retry
+        if "denied the request" in body:
+            return False
+        if "failed calling webhook" not in body:
+            return False
+        return any(
+            cause in body
+            for cause in ("proxy error", "while dialing", "context deadline exceeded")
+        )
 
     def delete_pod(
         self,

--- a/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
+++ b/server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py
@@ -1557,3 +1557,105 @@ class TestK8sTimeouts:
 
         with pytest.raises(urllib3.exceptions.MaxRetryError):
             fake_k8s_call()
+
+
+# The 500 body an AKS konnectivity blip produces: the apiserver could not dial the webhook.
+_WEBHOOK_DIAL_BODY = (
+    "Internal error occurred: failed calling webhook "
+    '"mutation.azure-workload-identity.io": failed to call webhook: '
+    "proxy error from localhost:9443 while dialing 10.244.1.211:9443, code 500"
+)
+
+
+def _api_exception(status, body=""):
+    exc = k8s_client_rest.ApiException(status=status, reason="err")
+    exc.body = body
+    return exc
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        # transient webhook *dial* failures — rejected pre-persistence, safe to retry
+        (_api_exception(500, _WEBHOOK_DIAL_BODY), True),
+        (
+            _api_exception(
+                500,
+                'failed calling webhook "x": failed to call webhook: '
+                "context deadline exceeded",
+            ),
+            True,
+        ),
+        # deterministic webhook denial — never retry
+        (_api_exception(500, 'admission webhook "x" denied the request: nope'), False),
+        # generic 500 with no webhook signature
+        (
+            _api_exception(500, "Internal error occurred: etcdserver: leader changed"),
+            False,
+        ),
+        # right body, wrong status
+        (_api_exception(400, _WEBHOOK_DIAL_BODY), False),
+    ],
+)
+def test_is_transient_admission_webhook_error(exc, expected):
+    assert (
+        framework.utils.singletons.k8s.K8sHelper._is_transient_admission_webhook_error(
+            exc
+        )
+        is expected
+    )
+
+
+@pytest.fixture
+def _no_k8s_sleep():
+    """Skip the create_pod retry backoff so tests stay fast."""
+    with mock.patch("framework.utils.singletons.k8s.time.sleep"):
+        yield
+
+
+def _pod_mock(namespace="test-namespace"):
+    pod = mock.MagicMock()
+    pod.metadata.namespace = namespace
+    return pod
+
+
+def test_create_pod_retries_transient_webhook_error_then_succeeds(
+    k8s_helper, _no_k8s_sleep
+):
+    """A transient admission-webhook 500 is retried and the next attempt succeeds."""
+    created = mock.MagicMock()
+    created.metadata.name = "created-pod"
+    created.metadata.namespace = "test-namespace"
+    k8s_helper.v1api.create_namespaced_pod.side_effect = [
+        _api_exception(500, _WEBHOOK_DIAL_BODY),
+        created,
+    ]
+
+    name, namespace = k8s_helper.create_pod(_pod_mock())
+
+    assert (name, namespace) == ("created-pod", "test-namespace")
+    assert k8s_helper.v1api.create_namespaced_pod.call_count == 2
+
+
+def test_create_pod_does_not_retry_webhook_denial(k8s_helper, _no_k8s_sleep):
+    """A deterministic webhook *denial* is raised immediately, not retried."""
+    k8s_helper.v1api.create_namespaced_pod.side_effect = _api_exception(
+        500, 'admission webhook "x" denied the request: not allowed'
+    )
+
+    with pytest.raises(mlrun.errors.MLRunHTTPError):
+        k8s_helper.create_pod(_pod_mock())
+
+    assert k8s_helper.v1api.create_namespaced_pod.call_count == 1
+
+
+def test_create_pod_does_not_retry_non_webhook_500(k8s_helper, _no_k8s_sleep):
+    """A 500 without the webhook-dial signature is raised immediately, not retried."""
+    k8s_helper.v1api.create_namespaced_pod.side_effect = _api_exception(
+        500, "Internal error occurred: etcdserver: leader changed"
+    )
+
+    with pytest.raises(mlrun.errors.MLRunHTTPError):
+        k8s_helper.create_pod(_pod_mock())
+
+    assert k8s_helper.v1api.create_namespaced_pod.call_count == 1


### PR DESCRIPTION
### 📝 Description
Remote runs on AKS could fail with a 500 when the Kubernetes apiserver could not *dial* the `mutation.azure-workload-identity.io` mutating webhook — a transient AKS konnectivity (apiserver→node tunnel) blip, confirmed by DevOps to be infra-side and not fixable in our deployment. Because the pod is rejected at admission *before* it is persisted, re-creating it has no side effect and is safe to retry — but only on that exact signature.

The retry lives **server-side** at the k8s pod-creation call (`K8sHelper.create_pod`), which is exactly where the failure occurs and where "no side effect" holds. This covers all submit paths (SDK, UI, scheduler), not just the Python SDK, and is a tighter retry than re-POSTing the whole `submit_job`.

---

### 🛠️ Changes Made
- `server/py/framework/utils/singletons/k8s.py`: `create_pod` now retries the transient admission-webhook *dial* failure, as a sibling to the existing `gke-resource-quotas` retry — re-creating the pod only when the `ApiException` is a 500 whose body contains `failed calling webhook` AND one of `proxy error` / `while dialing` / `context deadline exceeded`, and **never** on a deterministic `denied the request`. Reuses the existing `max_retry` / `retry_interval` budget. Gating logic extracted to `_is_transient_admission_webhook_error`.
- `server/py/services/api/tests/unit/utils/singletons/test_k8s_utils.py`: unit tests for the gate and the `create_pod` retry behavior.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- New unit tests in `test_k8s_utils.py` (8 cases): the gate matches the ticket reproducer + the `context deadline exceeded` variant, and rejects webhook *denials*, generic 500s, and non-500s; `create_pod` retries a transient webhook 500 then succeeds, and does **not** retry a webhook denial or a non-webhook 500. Full `test_k8s_utils.py` (91 tests) passes locally; lint clean.
- The transient infra failure itself cannot be reproduced on demand (requires the konnectivity blip); the retry is covered by the unit tests above.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12711
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Server-side only — no SDK, client, or schema change. The retry is bounded by `create_pod`'s existing `max_retry`/`retry_interval` and applies to all runtimes that create pods through `K8sHelper.create_pod`.
- An earlier revision of this PR put the retry client-side in the SDK `submit_job`; moved to the API server per review (it's where the failure occurs, is side-effect-free, and covers all callers).