### PR TITLE
[Model Monitoring] Fix connect model endpoint to function in deployment stage

### DIFF
--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -286,8 +286,12 @@ class ModelEndpointInstruction(BaseModel):
     :param name:               Name of the model endpoint.
     :param input_schema:       List of input feature names.
     :param output_schema:      List of output / label names.
-    :param function_name:      Name of an associated MLRun function (optional).
-    :param function_tag:       Tag of the associated function (optional).
+    :param function_name:      Name of the associated MLRun function. Optional — when used with
+                               ``setup_model_monitoring``, defaults to the function's ``metadata.name``.
+                               If set to a different value, an ``MLRunInvalidArgumentError`` is raised.
+    :param function_tag:       Tag of the associated MLRun function. Optional — when used with
+                               ``setup_model_monitoring``, defaults to the function's ``metadata.tag``.
+                               If set to a different value, an ``MLRunInvalidArgumentError`` is raised.
     :param creation_strategy: Strategy for creating or updating the model endpoint:
             * **overwrite**:
             1. If model endpoints with the same name exist, delete the `latest` one.

--- a/mlrun/common/schemas/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/model_monitoring/model_endpoints.py
@@ -286,12 +286,12 @@ class ModelEndpointInstruction(BaseModel):
     :param name:               Name of the model endpoint.
     :param input_schema:       List of input feature names.
     :param output_schema:      List of output / label names.
-    :param function_name:      Name of the associated MLRun function. Optional — when used with
-                               ``setup_model_monitoring``, defaults to the function's ``metadata.name``.
-                               If set to a different value, an ``MLRunInvalidArgumentError`` is raised.
-    :param function_tag:       Tag of the associated MLRun function. Optional — when used with
-                               ``setup_model_monitoring``, defaults to the function's ``metadata.tag``.
-                               If set to a different value, an ``MLRunInvalidArgumentError`` is raised.
+    :param function_name:      Name of the associated MLRun function. Must not be set when used
+                               with ``setup_model_monitoring`` — it is derived from the function's
+                               ``metadata.name`` at deployment time.
+    :param function_tag:       Tag of the associated MLRun function. Must not be set when used
+                               with ``setup_model_monitoring`` — it is derived from the function's
+                               ``metadata.tag`` at deployment time.
     :param creation_strategy: Strategy for creating or updating the model endpoint:
             * **overwrite**:
             1. If model endpoints with the same name exist, delete the `latest` one.

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -403,10 +403,9 @@ class RemoteRuntime(KubeResource):
         when this function is deployed. Calling this method sets the ``track_models``
         flag on the spec so the deployment stage knows to create the endpoints.
 
-        On every instruction, ``function_name`` and ``function_tag`` default to the runtime's
-        ``metadata.name`` and ``metadata.tag`` when omitted, so the endpoint is always linked
-        to the deployed function. If they are set to a different value than the function's
-        name/tag, an ``MLRunInvalidArgumentError`` is raised.
+        Instructions must not set ``function_name`` or ``function_tag``; both are
+        derived from the runtime's ``metadata.name`` / ``metadata.tag`` at deployment
+        time. Setting either raises ``MLRunInvalidArgumentError``.
 
         :param general_model_endpoint_instructions: Optional ModelEndpointInstruction parameter for main model endpoint
             instructions, if not provided a default one will be created with the USER_EP endpoint type and the default
@@ -437,26 +436,17 @@ class RemoteRuntime(KubeResource):
                     general_model_endpoint_instructions
                 )
             )
-            general_model_endpoint_instructions.function_name = (
-                general_model_endpoint_instructions.function_name or self.metadata.name
-            )
-            general_model_endpoint_instructions.function_tag = (
-                general_model_endpoint_instructions.function_tag or self.metadata.tag
-            )
-            if general_model_endpoint_instructions.function_name != self.metadata.name:
+            if general_model_endpoint_instructions.function_name is not None:
                 raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Model endpoint function_name mismatch, instruction function_name must be the same as the "
-                    f"function name (endpoint={general_model_endpoint_instructions.name}, "
-                    f"got {general_model_endpoint_instructions.function_name}, "
-                    f"expected {self.metadata.name})"
+                    "function_name must not be set on ModelEndpointInstruction; "
+                    "it is derived from the function's metadata.name "
+                    f"(endpoint={general_model_endpoint_instructions.name})"
                 )
-
-            if general_model_endpoint_instructions.function_tag != self.metadata.tag:
+            if general_model_endpoint_instructions.function_tag is not None:
                 raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Model endpoint tag mismatch, instruction function_tag must be the same as the function tag "
-                    f"(endpoint={general_model_endpoint_instructions.name}, "
-                    f"got {general_model_endpoint_instructions.function_tag}, "
-                    f"expected {self.metadata.tag})"
+                    "function_tag must not be set on ModelEndpointInstruction; "
+                    "it is derived from the function's metadata.tag "
+                    f"(endpoint={general_model_endpoint_instructions.name})"
                 )
             self.spec.model_endpoints_instructions = [
                 general_model_endpoint_instructions
@@ -476,25 +466,17 @@ class RemoteRuntime(KubeResource):
                     "ModelEndpointInstruction objects or dicts, not a mix of both."
                 )
             for extra_instruction in extra_model_endpoint_instructions:
-                extra_instruction.function_name = (
-                    extra_instruction.function_name or self.metadata.name
-                )
-                extra_instruction.function_tag = (
-                    extra_instruction.function_tag or self.metadata.tag
-                )
-                if extra_instruction.function_name != self.metadata.name:
+                if extra_instruction.function_name is not None:
                     raise mlrun.errors.MLRunInvalidArgumentError(
-                        "Model endpoint function_name mismatch, all instruction function_names must be the same as the "
-                        f"function name (endpoint={extra_instruction.name}, "
-                        f"got {extra_instruction.function_name}, "
-                        f"expected {self.metadata.name})"
+                        "function_name must not be set on ModelEndpointInstruction; "
+                        "it is derived from the function's metadata.name "
+                        f"(endpoint={extra_instruction.name})"
                     )
-                if extra_instruction.function_tag != self.metadata.tag:
+                if extra_instruction.function_tag is not None:
                     raise mlrun.errors.MLRunInvalidArgumentError(
-                        "Model endpoint tag mismatch, all instruction function_tags must be the same as the "
-                        f"function tag (endpoint={extra_instruction.name}, "
-                        f"got {extra_instruction.function_tag}, "
-                        f"expected {self.metadata.tag})"
+                        "function_tag must not be set on ModelEndpointInstruction; "
+                        "it is derived from the function's metadata.tag "
+                        f"(endpoint={extra_instruction.name})"
                     )
 
             self.spec.model_endpoints_instructions.extend(

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -403,6 +403,11 @@ class RemoteRuntime(KubeResource):
         when this function is deployed. Calling this method sets the ``track_models``
         flag on the spec so the deployment stage knows to create the endpoints.
 
+        On every instruction, ``function_name`` and ``function_tag`` default to the runtime's
+        ``metadata.name`` and ``metadata.tag`` when omitted, so the endpoint is always linked
+        to the deployed function. If they are set to a different value than the function's
+        name/tag, an ``MLRunInvalidArgumentError`` is raised.
+
         :param general_model_endpoint_instructions: Optional ModelEndpointInstruction parameter for main model endpoint
             instructions, if not provided a default one will be created with the USER_EP endpoint type and the default
             name f'{function_name}_model_endpoint'.

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -432,18 +432,26 @@ class RemoteRuntime(KubeResource):
                     general_model_endpoint_instructions
                 )
             )
-            if general_model_endpoint_instructions.function_name is not None and (
-                general_model_endpoint_instructions.function_name != self.metadata.name
-            ):
+            general_model_endpoint_instructions.function_name = (
+                general_model_endpoint_instructions.function_name or self.metadata.name
+            )
+            general_model_endpoint_instructions.function_tag = (
+                general_model_endpoint_instructions.function_tag or self.metadata.tag
+            )
+            if general_model_endpoint_instructions.function_name != self.metadata.name:
                 raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Model endpoint function_name mismatch, instruction function_name must be the same as the function "
-                    "name"
+                    "Model endpoint function_name mismatch, instruction function_name must be the same as the "
+                    f"function name (endpoint={general_model_endpoint_instructions.name}, "
+                    f"got {general_model_endpoint_instructions.function_name}, "
+                    f"expected {self.metadata.name})"
                 )
-            if general_model_endpoint_instructions.function_tag is not None and (
-                general_model_endpoint_instructions.function_tag != self.metadata.tag
-            ):
+
+            if general_model_endpoint_instructions.function_tag != self.metadata.tag:
                 raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Model endpoint tag mismatch, instruction function_tag must be the same as the function tag"
+                    "Model endpoint tag mismatch, instruction function_tag must be the same as the function tag "
+                    f"(endpoint={general_model_endpoint_instructions.name}, "
+                    f"got {general_model_endpoint_instructions.function_tag}, "
+                    f"expected {self.metadata.tag})"
                 )
             self.spec.model_endpoints_instructions = [
                 general_model_endpoint_instructions
@@ -462,23 +470,28 @@ class RemoteRuntime(KubeResource):
                     "extra_model_endpoint_instructions must be a uniform list of "
                     "ModelEndpointInstruction objects or dicts, not a mix of both."
                 )
-            if any(
-                extra_instruction.function_name is not None
-                and extra_instruction.function_name != self.metadata.name
-                for extra_instruction in extra_model_endpoint_instructions
-            ):
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Model endpoint function_name mismatch, all instruction function_names must be the same as the "
-                    "function name"
+            for extra_instruction in extra_model_endpoint_instructions:
+                extra_instruction.function_name = (
+                    extra_instruction.function_name or self.metadata.name
                 )
-            if any(
-                extra_instruction.function_tag is not None
-                and (extra_instruction.function_tag != self.metadata.tag)
-                for extra_instruction in extra_model_endpoint_instructions
-            ):
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "Model endpoint tag mismatch, all instruction function_tags must be the same as the function tag"
+                extra_instruction.function_tag = (
+                    extra_instruction.function_tag or self.metadata.tag
                 )
+                if extra_instruction.function_name != self.metadata.name:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        "Model endpoint function_name mismatch, all instruction function_names must be the same as the "
+                        f"function name (endpoint={extra_instruction.name}, "
+                        f"got {extra_instruction.function_name}, "
+                        f"expected {self.metadata.name})"
+                    )
+                if extra_instruction.function_tag != self.metadata.tag:
+                    raise mlrun.errors.MLRunInvalidArgumentError(
+                        "Model endpoint tag mismatch, all instruction function_tags must be the same as the "
+                        f"function tag (endpoint={extra_instruction.name}, "
+                        f"got {extra_instruction.function_tag}, "
+                        f"expected {self.metadata.tag})"
+                    )
+
             self.spec.model_endpoints_instructions.extend(
                 extra_model_endpoint_instructions
             )

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -2447,6 +2447,7 @@ class MonitoringDeployment:
         db_session: sqlalchemy.orm.Session,
         function: dict,
         function_name: str,
+        function_tag: str,
         project: str,
     ) -> tuple[
         list[
@@ -2507,8 +2508,6 @@ class MonitoringDeployment:
                 project=project,
             )
 
-        function_tag = (function.get("metadata") or {}).get("tag") or "latest"
-
         model_endpoints_dict: dict[str, str] = await run_in_threadpool(
             framework.utils.singletons.db.get_db().list_model_endpoints,
             project=project,
@@ -2521,12 +2520,10 @@ class MonitoringDeployment:
 
         model_endpoints_instructions = []
         for instruction in instructions:
-            effective_function_name = instruction.function_name or function_name
-            effective_function_tag = instruction.function_tag or function_tag
             uid = self._get_or_create_uid(
                 project=project,
-                function_name=effective_function_name,
-                function_tag=effective_function_tag,
+                function_name=function_name,
+                function_tag=function_tag,
                 model_endpoints_dict=model_endpoints_dict,
                 creation_strategy=instruction.creation_strategy,
                 endpoint_name=instruction.name,
@@ -2535,8 +2532,8 @@ class MonitoringDeployment:
                 name=instruction.name,
                 endpoint_type=mm_constants.EndpointType.USER_EP,
                 model_class=None,
-                function_name=effective_function_name,
-                function_tag=effective_function_tag,
+                function_name=function_name,
+                function_tag=function_tag,
                 track_models=True,
                 uid=uid,
                 label_names=instruction.output_schema,
@@ -2901,6 +2898,7 @@ class MonitoringDeployment:
         background_tasks: BackgroundTasks,
         function: dict,
         function_name: str,
+        function_tag: str,
         project: str,
     ) -> tuple[
         list[
@@ -2928,6 +2926,7 @@ class MonitoringDeployment:
             db_session=db_session,
             function=function,
             function_name=function_name,
+            function_tag=function_tag,
             project=project,
         )
 

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -451,6 +451,7 @@ class TestCreateModelEndpointsInstructionsForNuclioApp:
                 db_session=Mock(spec=mm_dep.sqlalchemy.orm.Session),
                 function=fn_dict,
                 function_name="my-fn",
+                function_tag="latest",
                 project="proj",
             )
 
@@ -475,6 +476,7 @@ class TestCreateModelEndpointsInstructionsForNuclioApp:
                 db_session=Mock(spec=mm_dep.sqlalchemy.orm.Session),
                 function=fn_dict,
                 function_name="my-fn",
+                function_tag="latest",
                 project="proj",
             )
 
@@ -506,12 +508,17 @@ class TestCreateModelEndpointsInstructionsForNuclioApp:
                 db_session=Mock(spec=mm_dep.sqlalchemy.orm.Session),
                 function=fn_dict,
                 function_name="my-fn",
+                function_tag="latest",
                 project="proj",
             )
 
         assert len(instructions) == 1
         ep, _ = instructions[0]
         assert ep.metadata.name == "ep-obj"
+        # Instruction has function_name=None/function_tag=None; the deployment-supplied
+        # values are what get stored on the created ModelEndpoint (ML-12727).
+        assert ep.spec.function_name == "my-fn"
+        assert ep.spec.function_tag == "latest"
 
     @pytest.mark.asyncio
     async def test_stream_url_none_logs_warning(self):
@@ -532,6 +539,7 @@ class TestCreateModelEndpointsInstructionsForNuclioApp:
                 db_session=Mock(spec=mm_dep.sqlalchemy.orm.Session),
                 function=fn_dict,
                 function_name="my-fn",
+                function_tag="latest",
                 project="proj",
             )
 
@@ -552,6 +560,7 @@ class TestCreateModelEndpointsInstructionsForNuclioApp:
                 db_session=Mock(spec=mm_dep.sqlalchemy.orm.Session),
                 function=fn_dict,
                 function_name="my-fn",
+                function_tag="latest",
                 project="proj",
             )
 

--- a/server/py/services/api/utils/endpoints.py
+++ b/server/py/services/api/utils/endpoints.py
@@ -82,6 +82,7 @@ async def start_model_endpoint_creation_background_task(
             background_tasks=background_tasks,
             function=function,
             function_name=name,
+            function_tag=function.get("metadata", {}).get("tag") or "latest",
             project=project,
         )
 

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -630,7 +630,7 @@ class TestSetupModelMonitoring:
         ):
             fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
 
-    def test_extra_instructions_no_tag_skips_tag_check(self):
+    def test_extra_instructions_no_tag_backfills_from_metadata(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
@@ -639,8 +639,10 @@ class TestSetupModelMonitoring:
         fn.metadata.tag = "v1"
         extra = [ModelEndpointInstruction(name="my-fn")]  # function_tag=None
         fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
-        names = [i.name for i in fn.spec.model_endpoints_instructions]
-        assert "my-fn" in names
+        stored_extra = fn.spec.model_endpoints_instructions[-1]
+        assert stored_extra.name == "my-fn"
+        assert stored_extra.function_name == "my-fn"
+        assert stored_extra.function_tag == "v1"
 
     def test_function_name_mismatch_raises(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
@@ -690,7 +692,7 @@ class TestSetupModelMonitoring:
         fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
         assert fn.spec.model_endpoints_instructions[0].function_tag == "v1"
 
-    def test_no_function_tag_skips_tag_check(self):
+    def test_no_function_tag_backfills_from_metadata(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
@@ -699,4 +701,57 @@ class TestSetupModelMonitoring:
         fn.metadata.tag = "v1"
         instruction = ModelEndpointInstruction(name="my-fn")  # function_tag=None
         fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
-        assert fn.spec.model_endpoints_instructions[0].name == "my-fn"
+        stored = fn.spec.model_endpoints_instructions[0]
+        assert stored.name == "my-fn"
+        assert stored.function_tag == "v1"
+
+    def test_no_function_name_backfills_from_metadata(self):
+        # Reproduces ML-12727: ModelEndpointInstruction passed without function_name
+        # must still be linked to the function so the endpoint appears in the UI.
+        from mlrun.common.schemas.model_monitoring.model_endpoints import (
+            ModelEndpointInstruction,
+        )
+
+        fn = self._nuclio_fn(name="my-fn")
+        fn.metadata.tag = "v2"
+        instruction = ModelEndpointInstruction(
+            name="my-ep",
+            input_schema=["age", "income"],
+            output_schema=["approved"],
+        )  # function_name=None, function_tag=None
+        fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
+        stored = fn.spec.model_endpoints_instructions[0]
+        assert stored.function_name == "my-fn"
+        assert stored.function_tag == "v2"
+
+    def test_extra_instructions_no_function_name_backfills_from_metadata(self):
+        from mlrun.common.schemas.model_monitoring.model_endpoints import (
+            ModelEndpointInstruction,
+        )
+
+        fn = self._nuclio_fn(name="my-fn")
+        fn.metadata.tag = "v2"
+        extra = [
+            ModelEndpointInstruction(name="ep-a"),
+            ModelEndpointInstruction(name="ep-b", function_name="my-fn"),
+        ]
+        fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
+        # primary default + 2 extras
+        assert len(fn.spec.model_endpoints_instructions) == 3
+        for instr in fn.spec.model_endpoints_instructions:
+            assert instr.function_name == "my-fn"
+            assert instr.function_tag == "v2"
+
+    def test_function_name_mismatch_error_includes_endpoint_and_values(self):
+        from mlrun.common.schemas.model_monitoring.model_endpoints import (
+            ModelEndpointInstruction,
+        )
+
+        fn = self._nuclio_fn(name="my-fn")
+        instruction = ModelEndpointInstruction(name="my-ep", function_name="wrong-fn")
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+            fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
+        msg = str(exc_info.value)
+        assert "my-ep" in msg
+        assert "wrong-fn" in msg
+        assert "my-fn" in msg

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -617,97 +617,66 @@ class TestSetupModelMonitoring:
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="mix"):
             fn.setup_model_monitoring(extra_model_endpoint_instructions=mixed)
 
-    def test_extra_instructions_tag_mismatch_raises(self):
+    def test_function_name_provided_raises(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
 
         fn = self._nuclio_fn(name="my-fn")
-        fn.metadata.tag = "v1"
-        extra = [ModelEndpointInstruction(name="my-fn", function_tag="v2")]
+        # Providing function_name is rejected, even when it matches metadata.name.
+        instruction = ModelEndpointInstruction(name="my-ep", function_name="my-fn")
         with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError, match="tag mismatch"
-        ):
-            fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
-
-    def test_extra_instructions_no_tag_backfills_from_metadata(self):
-        from mlrun.common.schemas.model_monitoring.model_endpoints import (
-            ModelEndpointInstruction,
-        )
-
-        fn = self._nuclio_fn(name="my-fn")
-        fn.metadata.tag = "v1"
-        extra = [ModelEndpointInstruction(name="my-fn")]  # function_tag=None
-        fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
-        stored_extra = fn.spec.model_endpoints_instructions[-1]
-        assert stored_extra.name == "my-fn"
-        assert stored_extra.function_name == "my-fn"
-        assert stored_extra.function_tag == "v1"
-
-    def test_function_name_mismatch_raises(self):
-        from mlrun.common.schemas.model_monitoring.model_endpoints import (
-            ModelEndpointInstruction,
-        )
-
-        fn = self._nuclio_fn(name="my-fn")
-        instruction = ModelEndpointInstruction(name="my-ep", function_name="wrong-fn")
-        with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError, match="function_name mismatch"
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="function_name must not be set",
         ):
             fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
 
-    def test_extra_instructions_function_name_mismatch_raises(self):
-        from mlrun.common.schemas.model_monitoring.model_endpoints import (
-            ModelEndpointInstruction,
-        )
-
-        fn = self._nuclio_fn(name="my-fn")
-        extra = [ModelEndpointInstruction(name="my-ep", function_name="wrong-fn")]
-        with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError, match="function_name mismatch"
-        ):
-            fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
-
-    def test_function_tag_mismatch_raises(self):
+    def test_function_tag_provided_raises(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
 
         fn = self._nuclio_fn(name="my-fn")
         fn.metadata.tag = "v1"
-        instruction = ModelEndpointInstruction(name="my-fn", function_tag="v2")
+        # Providing function_tag is rejected, even when it matches metadata.tag.
+        instruction = ModelEndpointInstruction(name="my-ep", function_tag="v1")
         with pytest.raises(
-            mlrun.errors.MLRunInvalidArgumentError, match="tag mismatch"
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="function_tag must not be set",
         ):
             fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
 
-    def test_matching_tag_does_not_raise(self):
+    def test_extra_instructions_function_name_provided_raises(self):
+        from mlrun.common.schemas.model_monitoring.model_endpoints import (
+            ModelEndpointInstruction,
+        )
+
+        fn = self._nuclio_fn(name="my-fn")
+        extra = [ModelEndpointInstruction(name="my-ep", function_name="my-fn")]
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="function_name must not be set",
+        ):
+            fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
+
+    def test_extra_instructions_function_tag_provided_raises(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
 
         fn = self._nuclio_fn(name="my-fn")
         fn.metadata.tag = "v1"
-        instruction = ModelEndpointInstruction(name="my-fn", function_tag="v1")
-        fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
-        assert fn.spec.model_endpoints_instructions[0].function_tag == "v1"
+        extra = [ModelEndpointInstruction(name="my-ep", function_tag="v1")]
+        with pytest.raises(
+            mlrun.errors.MLRunInvalidArgumentError,
+            match="function_tag must not be set",
+        ):
+            fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
 
-    def test_no_function_tag_backfills_from_metadata(self):
-        from mlrun.common.schemas.model_monitoring.model_endpoints import (
-            ModelEndpointInstruction,
-        )
-
-        fn = self._nuclio_fn(name="my-fn")
-        fn.metadata.tag = "v1"
-        instruction = ModelEndpointInstruction(name="my-fn")  # function_tag=None
-        fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
-        stored = fn.spec.model_endpoints_instructions[0]
-        assert stored.name == "my-fn"
-        assert stored.function_tag == "v1"
-
-    def test_no_function_name_backfills_from_metadata(self):
-        # Reproduces ML-12727: ModelEndpointInstruction passed without function_name
-        # must still be linked to the function so the endpoint appears in the UI.
+    def test_no_function_identity_kept_none(self):
+        # Reproduces ML-12727: omitting function_name/function_tag is the supported usage.
+        # The instruction is stored as-is with None values; the deployment side derives them
+        # from the function's metadata.
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
@@ -718,13 +687,14 @@ class TestSetupModelMonitoring:
             name="my-ep",
             input_schema=["age", "income"],
             output_schema=["approved"],
-        )  # function_name=None, function_tag=None
+        )
         fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
         stored = fn.spec.model_endpoints_instructions[0]
-        assert stored.function_name == "my-fn"
-        assert stored.function_tag == "v2"
+        assert stored.name == "my-ep"
+        assert stored.function_name is None
+        assert stored.function_tag is None
 
-    def test_extra_instructions_no_function_name_backfills_from_metadata(self):
+    def test_extra_instructions_no_function_identity_kept_none(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
@@ -733,25 +703,24 @@ class TestSetupModelMonitoring:
         fn.metadata.tag = "v2"
         extra = [
             ModelEndpointInstruction(name="ep-a"),
-            ModelEndpointInstruction(name="ep-b", function_name="my-fn"),
+            ModelEndpointInstruction(name="ep-b"),
         ]
         fn.setup_model_monitoring(extra_model_endpoint_instructions=extra)
         # primary default + 2 extras
         assert len(fn.spec.model_endpoints_instructions) == 3
-        for instr in fn.spec.model_endpoints_instructions:
-            assert instr.function_name == "my-fn"
-            assert instr.function_tag == "v2"
+        # The primary default still carries the function identity (set explicitly when
+        # generated). Extras intentionally stay None — the deployment side fills them in.
+        for instr in fn.spec.model_endpoints_instructions[1:]:
+            assert instr.function_name is None
+            assert instr.function_tag is None
 
-    def test_function_name_mismatch_error_includes_endpoint_and_values(self):
+    def test_function_name_provided_error_includes_endpoint(self):
         from mlrun.common.schemas.model_monitoring.model_endpoints import (
             ModelEndpointInstruction,
         )
 
         fn = self._nuclio_fn(name="my-fn")
-        instruction = ModelEndpointInstruction(name="my-ep", function_name="wrong-fn")
+        instruction = ModelEndpointInstruction(name="my-ep", function_name="anything")
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
             fn.setup_model_monitoring(general_model_endpoint_instructions=instruction)
-        msg = str(exc_info.value)
-        assert "my-ep" in msg
-        assert "wrong-fn" in msg
-        assert "my-fn" in msg
+        assert "my-ep" in str(exc_info.value)

--- a/tests/system/model_monitoring/test_model_monitoring.py
+++ b/tests/system/model_monitoring/test_model_monitoring.py
@@ -3036,17 +3036,48 @@ class TestGetModelMonitoringURL(TestMLRunSystemModelMonitoring):
         )
 
 
-def _assert_endpoint_exists(project, name: str) -> None:
-    endpoints = project.list_model_endpoints(names=name)
-    assert len(endpoints.endpoints) >= 1, (
-        f"Expected at least one model endpoint named {name!r}"
+def _assert_endpoint_exists(
+    project,
+    name: str,
+    function_name: str | None = None,
+    function_tag: str = "latest",
+) -> None:
+    endpoints = project.list_model_endpoints(names=name).endpoints
+    assert len(endpoints) >= 1, f"Expected at least one model endpoint named {name!r}"
+    if function_name is not None:
+        ep = endpoints[0]
+        assert ep.spec.function_name == function_name, (
+            f"Endpoint {name!r} not linked to function: "
+            f"spec.function_name={ep.spec.function_name!r}, expected {function_name!r}"
+        )
+        assert ep.spec.function_tag == function_tag, (
+            f"Endpoint {name!r} not linked to function tag: "
+            f"spec.function_tag={ep.spec.function_tag!r}, expected {function_tag!r}"
+        )
+
+
+def _assert_endpoints_exist(
+    project,
+    names: set,
+    function_name: str | None = None,
+    function_tag: str = "latest",
+) -> None:
+    endpoints = project.list_model_endpoints().endpoints
+    by_name = {ep.metadata.name: ep for ep in endpoints}
+    assert names.issubset(by_name.keys()), (
+        f"Expected {names} in DB, found: {set(by_name)}"
     )
-
-
-def _assert_endpoints_exist(project, names: set) -> None:
-    endpoints = project.list_model_endpoints()
-    ep_names = {ep.metadata.name for ep in endpoints.endpoints}
-    assert names.issubset(ep_names), f"Expected {names} in DB, found: {ep_names}"
+    if function_name is not None:
+        for n in names:
+            ep = by_name[n]
+            assert ep.spec.function_name == function_name, (
+                f"Endpoint {n!r} not linked to function: "
+                f"spec.function_name={ep.spec.function_name!r}, expected {function_name!r}"
+            )
+            assert ep.spec.function_tag == function_tag, (
+                f"Endpoint {n!r} not linked to function tag: "
+                f"spec.function_tag={ep.spec.function_tag!r}, expected {function_tag!r}"
+            )
 
 
 @TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
@@ -3139,7 +3170,7 @@ class TestNuclioAppModelEndpointCreation(TestMLRunSystemModelMonitoring):
                 name=fn_name,
                 kind=kind,
                 project=self.project_name,
-                image=self.image or os.environ.get("MLRUN_TEST_IMAGE", "mlrun/mlrun"),
+                image="python:3.11",
             )
             fn.spec.command = "python"
             fn.spec.args = ["-m", "http.server", "8050"]
@@ -3221,7 +3252,9 @@ class TestNuclioAppModelEndpointCreation(TestMLRunSystemModelMonitoring):
         # then retry the check every 30s until the endpoint appears in the DB.
         self._wait_for_model_endpoint_background_task()
         self.wait_for_condition(
-            lambda: _assert_endpoint_exists(self.project, "ep1"),
+            lambda: _assert_endpoint_exists(
+                self.project, "ep1", function_name=fn_name, function_tag="latest"
+            ),
             retry_interval=30.0,
             timeout=120.0,
             condition_description="model endpoint 'ep1' to exist in DB",
@@ -3265,7 +3298,12 @@ class TestNuclioAppModelEndpointCreation(TestMLRunSystemModelMonitoring):
         # then retry the check every 30s until both endpoints appear in the DB.
         self._wait_for_model_endpoint_background_task()
         self.wait_for_condition(
-            lambda: _assert_endpoints_exist(self.project, {"ep1", "ep2"}),
+            lambda: _assert_endpoints_exist(
+                self.project,
+                {"ep1", "ep2"},
+                function_name=fn_name,
+                function_tag="latest",
+            ),
             retry_interval=30.0,
             timeout=120.0,
             condition_description="model endpoints 'ep1' and 'ep2' to exist in DB",
@@ -3287,6 +3325,7 @@ class TestApplicationRuntimeModelEndpointCreation(TestNuclioAppModelEndpointCrea
     """
 
     project_name = "pr-app-me-creation"
+    image: str | None = None
 
     @pytest.mark.timeout(600)
     def test_single_endpoint_env_vars_injected(self) -> None:
@@ -3316,7 +3355,9 @@ class TestApplicationRuntimeModelEndpointCreation(TestNuclioAppModelEndpointCrea
 
         self._wait_for_model_endpoint_background_task()
         self.wait_for_condition(
-            lambda: _assert_endpoint_exists(self.project, "ep1"),
+            lambda: _assert_endpoint_exists(
+                self.project, "ep1", function_name=fn_name, function_tag="latest"
+            ),
             retry_interval=30.0,
             timeout=120.0,
             condition_description="model endpoint 'ep1' to exist in DB",
@@ -3351,7 +3392,12 @@ class TestApplicationRuntimeModelEndpointCreation(TestNuclioAppModelEndpointCrea
 
         self._wait_for_model_endpoint_background_task()
         self.wait_for_condition(
-            lambda: _assert_endpoints_exist(self.project, {"ep1", "ep2"}),
+            lambda: _assert_endpoints_exist(
+                self.project,
+                {"ep1", "ep2"},
+                function_name=fn_name,
+                function_tag="latest",
+            ),
             retry_interval=30.0,
             timeout=120.0,
             condition_description="model endpoints 'ep1' and 'ep2' to exist in DB",


### PR DESCRIPTION
### 📝 Description
When calling `function.setup_model_monitoring(general_model_endpoint_instructions=ModelEndpointInstruction(...))` (or via `extra_model_endpoint_instructions`) without explicitly setting `function_name` / `function_tag`, the created model endpoint was not associated with the function and did not appear in the UI.

Root cause was a contract that allowed `function_name` / `function_tag` to be set on the instruction, then validated equality with the function's metadata — but never propagated the value when it was omitted, so it landed on the server as `None`. The server-side path had a defensive `instruction.function_name or function_name` fallback that mostly papered over it, leaving the SDK <-> server contract ambiguous.

This PR establishes a single source of truth: **`function_name` and `function_tag` on `ModelEndpointInstruction` must not be set when used with `setup_model_monitoring`**. They are derived from the runtime's `metadata.name` / `metadata.tag` at deployment time. Providing either field raises `MLRunInvalidArgumentError`.

Fixes [ML-12727](https://ecliptos.atlassian.net/browse/ML-12727).

---

### 🛠️ Changes Made

**SDK (`mlrun/runtimes/nuclio/function.py`)** — `RemoteRuntime.setup_model_monitoring` (inherited by `ApplicationRuntime`):
- Reject the call (with a concise, endpoint-named error) if `function_name` or `function_tag` is set on the primary `general_model_endpoint_instructions` or on any entry in `extra_model_endpoint_instructions`.
- Otherwise the instruction is stored as-is — `function_name` / `function_tag` stay `None` and are resolved server-side from the deployed function.

**Server (`server/py/services/api/crud/model_monitoring/deployment.py`, `server/py/services/api/utils/endpoints.py`)**:
- `_create_model_endpoints_instructions_for_nuclio_app` and `_create_nuclio_app_model_endpoint_background_task` now take `function_tag` as an explicit parameter, threaded from the caller in `endpoints.py` (which already had it via `function["metadata"]["tag"]`).
- Removed the per-instruction `instruction.function_name or function_name` / `instruction.function_tag or function_tag` fallback. The deployment-supplied `function_name` and `function_tag` are now the only source for the created `ModelEndpoint`'s `spec.function_name` / `spec.function_tag`.

**Docs**:
- `RemoteRuntime.setup_model_monitoring` docstring spells out the new contract.
- `ModelEndpointInstruction.function_name` / `function_tag` field docs state they must not be set when used with `setup_model_monitoring` and are derived at deployment time.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation
- [x] Please run Smoke-tests workflow

---

### 🧪 Testing

**SDK unit tests** — `tests/runtimes/test_function.py::TestSetupModelMonitoring` (13 tests pass):
- `test_function_name_provided_raises` / `test_function_tag_provided_raises` — primary instruction with `function_name` (or `function_tag`) set is rejected, even when the value matches `metadata`.
- `test_extra_instructions_function_name_provided_raises` / `test_extra_instructions_function_tag_provided_raises` — same for each entry in `extra_model_endpoint_instructions`.
- `test_no_function_identity_kept_none` — direct ML-12727 reproducer: instruction with `function_name`/`function_tag` omitted is stored with `None` for both fields (the deployment side resolves them).
- `test_extra_instructions_no_function_identity_kept_none` — same for extras.
- `test_function_name_provided_error_includes_endpoint` — locks in the endpoint-name detail in the error message.

**Server unit tests** — `server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py::TestCreateModelEndpointsInstructionsForNuclioApp` (5 tests pass):
- All call sites updated for the new `function_tag` parameter.
- `test_instruction_objects_accepted_directly` extended to assert that with `instruction.function_name=None` / `function_tag=None`, the created `ModelEndpoint.spec.function_name` / `function_tag` are sourced from the deployment-supplied values — the contract ML-12727 was missing.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12727

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

Previously, passing `function_name` or `function_tag` on a `ModelEndpointInstruction` was allowed when the value equaled the function's metadata. With this PR, passing either field — even with a matching value — raises `MLRunInvalidArgumentError`.

Downstream impact is expected to be small: in practice the field was either omitted (the supported case after this PR) or supplied with a mismatched value (already rejected before this PR). Callers that explicitly set the matching value should simply drop those keyword arguments.

---

### 🔍️ Additional Notes
- `ServingRuntime.setup_model_monitoring` raises `NotImplementedError`, so this code path only affects `RemoteRuntime` and `ApplicationRuntime`.
- The `function_name` / `function_tag` fields remain on the `ModelEndpointInstruction` schema (still used downstream for the persisted `ModelEndpoint` spec) — they just must not be set by the caller of `setup_model_monitoring`.
