### PR TITLE
[CI] Fix system-tests branch list lost on data node reboot

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -151,19 +151,31 @@ jobs:
         python-version: 3.11
         cache-dependency-glob: "**/*requirements*.txt"
 
-    - name: Copy state branch file from remote
+    - name: Ensure persistent CI dir exists on data node
       run: |
         sshpass \
           -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          ssh \
+          -o StrictHostKeyChecking=no \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          mkdir -p /home/iguazio/ci
+
+    - name: Copy state branch file from remote
+      run: |
+        if ! sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           scp \
           -o StrictHostKeyChecking=no \
-          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/system-tests-branches-list.txt \
-          system-tests-branches-list.txt
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/home/iguazio/ci/system-tests-branches-list.txt \
+          system-tests-branches-list.txt 2>/dev/null; then
+          echo "remote branch list not found - seeding from repo default automation/system_test/system-tests-branches-list.txt"
+          cp automation/system_test/system-tests-branches-list.txt system-tests-branches-list.txt
+        fi
 
     - name: Resolve Branch To Run System Tests
       id: current-branch
       shell: bash
-      # we store a file named /tmp/system-tests-branches-list.txt which contains a list of branches to run system tests
+      # we store a file named /home/iguazio/ci/system-tests-branches-list.txt which contains a list of branches to run system tests
       # on the branches are separated with commas, so each run we pop the first branch in the list and append it to the
       # end of the list.
       # This mechanism allows us to run on multiple branches without the need to modify the file or secrets each time
@@ -206,7 +218,7 @@ jobs:
           -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
           scp \
           -o StrictHostKeyChecking=no system-tests-branches-list.txt \
-          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/tmp/
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }}:/home/iguazio/ci/
 
     # checking out to base branch and not the target(resolved) branch, to be able to run the changed preparation code
     # before merging the changes to upstream.


### PR DESCRIPTION
### 📝 Description
The enterprise system-tests pipeline stored its branch rotation state at `/tmp/system-tests-branches-list.txt` on the data node. `/tmp` is wiped on reboot, so the file vanishes and the pipeline fails until someone recreates it manually. 
This PR moves the file to a persistent location and makes the pipeline self-heal if the file is ever missing.

---

### 🛠️ Changes Made
- Moved the branch-list scp pull/push paths from `/tmp` to /`home/iguazio/ci` (persists across reboots).                                                                
- Added a bootstrap step (`mkdir -p /home/iguazio/ci`) so the persistent dir always exists before the push.                                                           
- Added self-heal: if the remote file is missing, seed it from a new repo-tracked default `automation/system_test/system-tests-branches-list.txt` instead of failing.
---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12350
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
