### PR TITLE
[Events] Remove fields when publishing orca events

### DIFF
--- a/server/py/services/api/tests/unit/utils/events/test_events_iguazio_v4.py
+++ b/server/py/services/api/tests/unit/utils/events/test_events_iguazio_v4.py
@@ -15,7 +15,6 @@
 import unittest.mock
 
 import iguazio
-import iguazio.schemas
 import pytest
 
 import mlrun.common.schemas
@@ -36,40 +35,31 @@ def client(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "action,expected_config_name,expected_severity",
+    "action,expected_config_name",
     [
         (
             mlrun.common.schemas.MigrationEventActions.required,
             iguazio_v4_events.DB_MIGRATION_REQUIRED,
-            iguazio.schemas.Severity.CRITICAL,
         ),
         (
             mlrun.common.schemas.MigrationEventActions.started,
             iguazio_v4_events.DB_MIGRATION_STARTED,
-            iguazio.schemas.Severity.INFO,
         ),
         (
             mlrun.common.schemas.MigrationEventActions.completed,
             iguazio_v4_events.DB_MIGRATION_COMPLETED,
-            iguazio.schemas.Severity.INFO,
         ),
         (
             mlrun.common.schemas.MigrationEventActions.failed,
             iguazio_v4_events.DB_MIGRATION_FAILED,
-            iguazio.schemas.Severity.CRITICAL,
         ),
     ],
 )
-def test_generate_db_migration_event_basic(
-    client, action, expected_config_name, expected_severity
-):
+def test_generate_db_migration_event_basic(client, action, expected_config_name):
     event = client.generate_db_migration_event(action)
     assert event.config_name == expected_config_name
-    assert event.kind == "system"
-    assert event.class_ == "DB"
-    assert event.severity == expected_severity
     assert event.entity_name == "mlrun-api-chief"
-    # source is left empty so the orca backend can derive it
+    # severity, class and kind are left unset so the orca catalog enriches them
     assert event.source == ""
     # description is the catalog default for non-failed actions
     if action != mlrun.common.schemas.MigrationEventActions.failed:
@@ -111,7 +101,6 @@ def test_completed_event_carries_duration(client):
         duration_seconds=12.3456,
     )
     assert event.details == {"duration_seconds": 12.346}
-    assert event.severity == iguazio.schemas.Severity.INFO
 
 
 @pytest.mark.parametrize(
@@ -274,11 +263,8 @@ def test_generate_db_connection_event_basic(client):
         mlrun.common.schemas.DBConnectionEventActions.failed,
     )
     assert event.config_name == iguazio_v4_events.DB_CONNECTION_FAILED
-    assert event.kind == "system"
-    assert event.class_ == "DB"
-    assert event.severity == iguazio.schemas.Severity.CRITICAL
     assert event.entity_name == "mlrun-api-chief"
-    # source is left empty so the orca backend can derive it
+    # severity, class and kind are left unset so the orca catalog enriches them
     assert event.source == ""
     assert event.description == "MLRun cannot connect to its database"
     assert event.details == {}
@@ -362,10 +348,8 @@ def test_generate_log_collector_event_basic(client):
         mlrun.common.schemas.LogCollectorEventActions.failed,
     )
     assert event.config_name == iguazio_v4_events.LOG_COLLECTOR_FAILED
-    assert event.kind == "system"
-    assert event.class_ == "LogCollection"
-    assert event.severity == iguazio.schemas.Severity.MAJOR
     assert event.entity_name == "mlrun-api-chief"
+    # severity, class and kind are left unset so the orca catalog enriches them
     assert event.source == ""
     assert event.description == "MLRun log collector failed to retrieve logs"
     assert event.details == {}
@@ -405,40 +389,32 @@ def test_log_collector_unsupported_action_raises(client):
 
 
 @pytest.mark.parametrize(
-    "action,expected_config_name,expected_severity",
+    "action,expected_config_name",
     [
         (
             mlrun.common.schemas.ProjectLifecycleEventActions.creation_succeeded,
             iguazio_v4_events.PROJECT_CREATION_SUCCEEDED,
-            iguazio.schemas.Severity.INFO,
         ),
         (
             mlrun.common.schemas.ProjectLifecycleEventActions.creation_failed,
             iguazio_v4_events.PROJECT_CREATION_FAILED,
-            iguazio.schemas.Severity.WARNING,
         ),
         (
             mlrun.common.schemas.ProjectLifecycleEventActions.deletion_succeeded,
             iguazio_v4_events.PROJECT_DELETION_SUCCEEDED,
-            iguazio.schemas.Severity.INFO,
         ),
         (
             mlrun.common.schemas.ProjectLifecycleEventActions.deletion_failed,
             iguazio_v4_events.PROJECT_DELETION_FAILED,
-            iguazio.schemas.Severity.WARNING,
         ),
     ],
 )
-def test_generate_project_lifecycle_event_basic(
-    client, action, expected_config_name, expected_severity
-):
+def test_generate_project_lifecycle_event_basic(client, action, expected_config_name):
     event = client.generate_project_lifecycle_event(
         action=action, project_name="my-project", actor="alice"
     )
     assert event.config_name == expected_config_name
-    assert event.kind == "system"
-    assert event.class_ == iguazio_v4_events.EVENT_CLASS_PROJECT == "Project"
-    assert event.severity == expected_severity
+    # severity, class and kind are left unset so the orca catalog enriches them
     assert event.entity_name == "mlrun-api-chief"
     assert event.source == ""
     assert event.details["project_name"] == "my-project"
@@ -474,9 +450,7 @@ def test_project_lifecycle_failed_carries_error(client, failed_action):
     assert event.details["error"] == "db unavailable"
     assert event.details["error_type"] == "RuntimeError"
     # error in details only; description stays the generic per-action catalog text
-    _, _, expected_description = iguazio_v4_events.PROJECT_LIFECYCLE_EVENTS[
-        failed_action
-    ]
+    _, expected_description = iguazio_v4_events.PROJECT_LIFECYCLE_EVENTS[failed_action]
     assert event.description == expected_description
 
 

--- a/server/py/services/api/utils/events/iguazio_v4.py
+++ b/server/py/services/api/utils/events/iguazio_v4.py
@@ -37,46 +37,37 @@ PROJECT_CREATION_FAILED = "MLRun.Project.Creation.Failed"
 PROJECT_DELETION_SUCCEEDED = "MLRun.Project.Deletion.Succeeded"
 PROJECT_DELETION_FAILED = "MLRun.Project.Deletion.Failed"
 
-EVENT_KIND = "system"
-EVENT_CLASS = "DB"
-EVENT_CLASS_LOG_COLLECTION = "LogCollection"
-EVENT_CLASS_PROJECT = "Project"
 ERROR_DETAIL_LIMIT = 1024
 TRUNCATION_SUFFIX = "...[truncated]"
 
 DB_MIGRATION_EVENTS: dict[
     mlrun.common.schemas.MigrationEventActions,
-    tuple[str, iguazio.schemas.Severity, str],
+    tuple[str, str],
 ] = {
     mlrun.common.schemas.MigrationEventActions.required: (
         DB_MIGRATION_REQUIRED,
-        iguazio.schemas.Severity.CRITICAL,
         "MLRun database migration required, functionality may be impaired",
     ),
     mlrun.common.schemas.MigrationEventActions.started: (
         DB_MIGRATION_STARTED,
-        iguazio.schemas.Severity.INFO,
         "MLRun database migration started",
     ),
     mlrun.common.schemas.MigrationEventActions.completed: (
         DB_MIGRATION_COMPLETED,
-        iguazio.schemas.Severity.INFO,
         "MLRun database migration completed successfully",
     ),
     mlrun.common.schemas.MigrationEventActions.failed: (
         DB_MIGRATION_FAILED,
-        iguazio.schemas.Severity.CRITICAL,
         "MLRun database migration failed, functionality may be impaired",
     ),
 }
 
 DB_CONNECTION_EVENTS: dict[
     mlrun.common.schemas.DBConnectionEventActions,
-    tuple[str, iguazio.schemas.Severity, str],
+    tuple[str, str],
 ] = {
     mlrun.common.schemas.DBConnectionEventActions.failed: (
         DB_CONNECTION_FAILED,
-        iguazio.schemas.Severity.CRITICAL,
         "MLRun cannot connect to its database",
     ),
 }
@@ -86,37 +77,32 @@ DB_CONNECTION_EVENTS: dict[
 # across producer and catalog; per-operation context is attached to ``details``.
 LOG_COLLECTOR_EVENTS: dict[
     mlrun.common.schemas.LogCollectorEventActions,
-    tuple[str, iguazio.schemas.Severity, str],
+    tuple[str, str],
 ] = {
     mlrun.common.schemas.LogCollectorEventActions.failed: (
         LOG_COLLECTOR_FAILED,
-        iguazio.schemas.Severity.MAJOR,
         "MLRun log collector failed to retrieve logs",
     ),
 }
 
 PROJECT_LIFECYCLE_EVENTS: dict[
     mlrun.common.schemas.ProjectLifecycleEventActions,
-    tuple[str, iguazio.schemas.Severity, str],
+    tuple[str, str],
 ] = {
     mlrun.common.schemas.ProjectLifecycleEventActions.creation_succeeded: (
         PROJECT_CREATION_SUCCEEDED,
-        iguazio.schemas.Severity.INFO,
         "Project was successfully created",
     ),
     mlrun.common.schemas.ProjectLifecycleEventActions.creation_failed: (
         PROJECT_CREATION_FAILED,
-        iguazio.schemas.Severity.WARNING,
         "Project creation failed",
     ),
     mlrun.common.schemas.ProjectLifecycleEventActions.deletion_succeeded: (
         PROJECT_DELETION_SUCCEEDED,
-        iguazio.schemas.Severity.INFO,
         "Project was successfully deleted",
     ),
     mlrun.common.schemas.ProjectLifecycleEventActions.deletion_failed: (
         PROJECT_DELETION_FAILED,
-        iguazio.schemas.Severity.WARNING,
         "Project deletion failed",
     ),
 }
@@ -169,7 +155,7 @@ class Client(base_events.BaseEventClient):
         versions: dict | None = None,
     ) -> iguazio.schemas.EventActivationSpec:
         try:
-            config_name, severity, description = DB_MIGRATION_EVENTS[action]
+            config_name, description = DB_MIGRATION_EVENTS[action]
         except KeyError as exc:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Unsupported DB migration action {action}"
@@ -190,10 +176,6 @@ class Client(base_events.BaseEventClient):
 
         return iguazio.schemas.EventActivationSpec(
             config_name=config_name,
-            source="",
-            kind=EVENT_KIND,
-            severity=severity,
-            class_=EVENT_CLASS,
             entity_name=self._entity_name,
             description=description,
             details=details,
@@ -208,7 +190,7 @@ class Client(base_events.BaseEventClient):
         dialect: str | None = None,
     ) -> iguazio.schemas.EventActivationSpec:
         try:
-            config_name, severity, description = DB_CONNECTION_EVENTS[action]
+            config_name, description = DB_CONNECTION_EVENTS[action]
         except KeyError as exc:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Unsupported DB connection action {action}"
@@ -226,10 +208,6 @@ class Client(base_events.BaseEventClient):
 
         return iguazio.schemas.EventActivationSpec(
             config_name=config_name,
-            source="",
-            kind=EVENT_KIND,
-            severity=severity,
-            class_=EVENT_CLASS,
             entity_name=self._entity_name,
             description=description,
             details=details,
@@ -243,7 +221,7 @@ class Client(base_events.BaseEventClient):
         project: str | None = None,
     ) -> iguazio.schemas.EventActivationSpec:
         try:
-            config_name, severity, description = LOG_COLLECTOR_EVENTS[action]
+            config_name, description = LOG_COLLECTOR_EVENTS[action]
         except KeyError as exc:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Unsupported log collector action {action}"
@@ -259,10 +237,6 @@ class Client(base_events.BaseEventClient):
 
         return iguazio.schemas.EventActivationSpec(
             config_name=config_name,
-            source="",
-            kind=EVENT_KIND,
-            severity=severity,
-            class_=EVENT_CLASS_LOG_COLLECTION,
             entity_name=self._entity_name,
             description=description,
             details=details,
@@ -276,7 +250,7 @@ class Client(base_events.BaseEventClient):
         error: BaseException | str | None = None,
     ) -> iguazio.schemas.EventActivationSpec:
         try:
-            config_name, severity, description = PROJECT_LIFECYCLE_EVENTS[action]
+            config_name, description = PROJECT_LIFECYCLE_EVENTS[action]
         except KeyError as exc:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 f"Unsupported project lifecycle action {action}"
@@ -294,10 +268,6 @@ class Client(base_events.BaseEventClient):
 
         return iguazio.schemas.EventActivationSpec(
             config_name=config_name,
-            source="",
-            kind=EVENT_KIND,
-            severity=severity,
-            class_=EVENT_CLASS_PROJECT,
             entity_name=self._entity_name,
             description=description,
             details=details,


### PR DESCRIPTION
### 📝 Description
Catalog events have their `severity`, `class`, `kind` (and `source`) enriched automatically by the Orca's Events service from the catalog configuration. Specifying them at publish time is redundant and confusing for future maintainers. This PR removes those fields from the catalog-event publisher in MLRun (the `iguazio_v4` events client). No behavior change — the Events service still derives these values from the catalog.

---

### 🛠️ Changes Made
- **`server/py/services/api/utils/events/iguazio_v4.py`**: removed `source`/`kind`/`severity`/`class_` from every `EventActivationSpec` and dropped the now-unused severity slot from the `DB_MIGRATION_EVENTS`, `DB_CONNECTION_EVENTS`, `LOG_COLLECTOR_EVENTS`, and `PROJECT_LIFECYCLE_EVENTS` maps (now `(config_name, description)` tuples). Removed the unused `EVENT_KIND`, `EVENT_CLASS`, `EVENT_CLASS_LOG_COLLECTION`, and `EVENT_CLASS_PROJECT` constants.
- All 10 published events (`MLRun.DB.Migration.{Required,Started,Completed,Failed}`, `MLRun.DB.Connection.Failed`, `MLRun.LogCollector.Failed`, `MLRun.Project.{Creation,Deletion}.{Succeeded,Failed}`) are present in the Orca events catalog, so their fields are enriched downstream and safe to drop.
- Dropped the corresponding `kind`/`class_`/`severity` assertions and the `expected_severity` parametrization from the affected unit tests.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- Unit tests updated and passing: `services/api/tests/unit/utils/events/test_events_iguazio_v4.py` — **47 passed**.
- Removal is safe by design: the `EventActivationSpec` schema defaults (`source=""`, `kind=""`, `severity=UNSPECIFIED`, `class_=None`) are exactly the "let the catalog enrich" sentinels, as documented in the schema docstring.
- Not covered by system tests — this is a pure publish-time refactor with no behavior change.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/IG4-2656
- Design docs links: https://ecliptos.atlassian.net/wiki/spaces/PM12345/pages/430342266/IG4+System+Events+Spec+-+Phase+2
- External links: Orca counterpart PR https://github.com/McK-Private/orca/pull/835

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The legacy `iguazio.py` events client (igz 3.x / `igz_mgmt`) is intentionally untouched — its events do not go through the IG4 catalog, so they must keep their severity/kind values.
- The `adding-event-configs.md` documentation update called out in the ticket lives in the Orca repo (covered by Orca PR #835), not MLRun.
