### PR TITLE
[Tests] Fix kfp remote workflow system tests by saving project after set_function

### DIFF
--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -293,8 +293,8 @@ class TestKFP(tests.system.base.TestMLRunSystem):
         # a known-cloneable demo repo. Its content isn't used here — the
         # function comes from hub://describe and the workflow from store://.
         self.project.spec.source = "git://github.com/mlrun/project-demo.git"
-        self.project.save()
         self.project.set_function("hub://describe", "describe")
+        self.project.save()
 
         workflow_src = self._write_kfp_pipeline_tempfile()
         try:
@@ -343,7 +343,6 @@ class TestKFP(tests.system.base.TestMLRunSystem):
         # Cloneable project source for the remote runner pod (its content is
         # unused — function is hub://, workflow is store://).
         self.project.spec.source = "git://github.com/mlrun/project-demo.git"
-        self.project.save()
 
         workflow_src = self._write_kfp_pipeline_tempfile()
         try:
@@ -360,6 +359,7 @@ class TestKFP(tests.system.base.TestMLRunSystem):
             store_uri = artifact.uri
 
             self.project.set_function("hub://describe", "describe")
+            self.project.save()
             workflow_name = f"store_pipeline_ds_{engine}"
             self.project.set_workflow(
                 workflow_name, workflow_path=store_uri, engine=engine


### PR DESCRIPTION
### 📝 Description
The `[remote]` parametrizations of `test_run_workflow_from_store_artifact` and
`test_run_workflow_with_ds_profile_target` (`tests/system/runtimes/test_kfp.py`)
fail with `MLRunNotFoundError('Function tag not found .../describe')`.

For `engine=remote`, the workflow runner pod reloads the project fresh from the
DB (`get_or_create_project`) and — unlike `engine=kfp` — `project.run()` skips
the client-side function sync (it expects functions to be loaded dynamically on
the runner). The tests called `project.save()` before `set_function(...)`, so
the `describe` function was never persisted to the DB and the runner could not
resolve it. The `[kfp]` variants were unaffected because client-side pipeline
compilation syncs functions on its own.

Fix: save the project after `set_function` so the function is persisted for
the remote runner to load.

---

### 🛠️ Changes Made
- `tests/system/runtimes/test_kfp.py`: in both `test_run_workflow_from_store_artifact`
  and `test_run_workflow_with_ds_profile_target`, move `project.save()` to after
  `set_function("hub://describe", "describe")` so the function reaches the DB
  before the remote run.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
Ran both tests against vmdev76:

- `test_run_workflow_from_store_artifact[kfp]` — PASSED
- `test_run_workflow_with_ds_profile_target[kfp]` — PASSED
- `[remote]` variants — could not be validated on vmdev76: that cluster has a
  pre-existing, unrelated server↔workflow-runner-image skew that rejects a
  `run_setup` kwarg (`load_and_run_workflow() got an unexpected keyword argument
  'run_setup'`), which fails all remote workflows there before our code path is
  reached.

The remote root cause and the fix were verified end-to-end on the cluster via a
runner simulation that replicates exactly what the remote runner does (reload
the project fresh from the DB, then run the `store://` workflow with
`engine=kfp`):

- buggy ordering (save before set_function) → `Failed`, `Function tag not found`
  (reproduces the CI failure exactly)
- fixed ordering (save after set_function) → `Succeeded`

A fully green `[remote]` run requires a cluster whose API server and
workflow-runner image are both on matching `development` code (as the original
CI cluster was).

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
The `run_setup` skew on vmdev76 is a cluster-deployment issue, not part of this
change. This PR only reorders two `save()` calls in the system tests.
