### PR TITLE
[Auth] Treat signed JWTs as bearers, not Iguazio sessions

### DIFF
--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -316,9 +316,7 @@ def is_iguazio_endpoint(endpoint_url: str) -> bool:
 
 
 def is_iguazio_session(value: str) -> bool:
-    # A JWT (header.payload.signature, base64url, "eyJ" prefix) is a bearer
-    # token, not an Iguazio control session / access key — route it as a bearer
-    # even though it is long and contains "-".
+    # JWS-style JWTs are bearer tokens, not Iguazio sessions.
     if value.count(".") == 2 and value.startswith("eyJ"):
         return False
     # TODO: find a better heuristic

--- a/mlrun/platforms/iguazio.py
+++ b/mlrun/platforms/iguazio.py
@@ -316,6 +316,11 @@ def is_iguazio_endpoint(endpoint_url: str) -> bool:
 
 
 def is_iguazio_session(value: str) -> bool:
+    # A JWT (header.payload.signature, base64url, "eyJ" prefix) is a bearer
+    # token, not an Iguazio control session / access key — route it as a bearer
+    # even though it is long and contains "-".
+    if value.count(".") == 2 and value.startswith("eyJ"):
+        return False
     # TODO: find a better heuristic
     return len(value) > 20 and "-" in value
 

--- a/tests/platforms/test_iguazio.py
+++ b/tests/platforms/test_iguazio.py
@@ -22,7 +22,7 @@ import mlrun
 import mlrun.errors
 from mlrun import mlconf
 from mlrun.platforms import add_or_refresh_credentials
-from mlrun.platforms.iguazio import min_iguazio_versions
+from mlrun.platforms.iguazio import is_iguazio_session, min_iguazio_versions
 from mlrun.utils import logger
 
 
@@ -97,6 +97,19 @@ def test_is_iguazio_session_cookie():
         is True
     )
     assert mlrun.platforms.is_iguazio_session_cookie("dummy") is False
+
+
+def test_is_iguazio_session():
+    # A JWT (header.payload.signature, "eyJ" prefix) is a bearer token, not an
+    # Iguazio control session / access key — even though it is long and contains
+    # "-". It must NOT be routed through the session-cookie path.
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdmMtYWNjdCJ9.ab-cd_ef"
+    assert is_iguazio_session(jwt) is False
+    # An Iguazio access key / control session (UUID-like) is a session.
+    assert is_iguazio_session("946b0749-5c40-4837-a4ac-341d295bfaf7") is True
+    # Too short, or no hyphen — not a session.
+    assert is_iguazio_session("short") is False
+    assert is_iguazio_session("nohyphenbutquitelongvalue123") is False
 
 
 @pytest.mark.parametrize(

--- a/tests/platforms/test_iguazio.py
+++ b/tests/platforms/test_iguazio.py
@@ -100,14 +100,12 @@ def test_is_iguazio_session_cookie():
 
 
 def test_is_iguazio_session():
-    # A JWT (header.payload.signature, "eyJ" prefix) is a bearer token, not an
-    # Iguazio control session / access key — even though it is long and contains
-    # "-". It must NOT be routed through the session-cookie path.
+    # JWTs are bearer tokens, not Iguazio sessions.
     jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdmMtYWNjdCJ9.ab-cd_ef"
     assert is_iguazio_session(jwt) is False
-    # An Iguazio access key / control session (UUID-like) is a session.
+    # UUID-like control sessions/access keys are sessions.
     assert is_iguazio_session("946b0749-5c40-4837-a4ac-341d295bfaf7") is True
-    # Too short, or no hyphen — not a session.
+    # Too short or missing hyphen -> not a session.
     assert is_iguazio_session("short") is False
     assert is_iguazio_session("nohyphenbutquitelongvalue123") is False
 

--- a/tests/rundb/test_client.py
+++ b/tests/rundb/test_client.py
@@ -62,12 +62,7 @@ def test_session_carries_client_credentials_to_requests():
 
 
 def test_jwt_token_routes_as_bearer_not_session():
-    """A signed JWT is sent as an ``Authorization`` bearer, not a session cookie.
-
-    Guards the ``is_iguazio_session`` classifier at the request-routing layer:
-    ``api_call`` must emit the bearer header (and no ``session`` cookie) for a
-    JWT, while an Iguazio access key / control session still routes as a cookie.
-    """
+    """JWT -> bearer header, access key/session -> session cookie."""
     jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdmMtYWNjdCJ9.ab-cd_ef"
     client = Client(credentials=Credentials(token=jwt))
     client._http_db.session = unittest.mock.Mock()
@@ -79,7 +74,7 @@ def test_jwt_token_routes_as_bearer_not_session():
     assert request_kwargs.get("headers", {}).get("authorization") == f"Bearer {jwt}"
     assert "cookies" not in request_kwargs
 
-    # Contrast: an Iguazio access key / control session still routes as a cookie.
+    # Access key/control session still routes as a cookie.
     access_key = "946b0749-5c40-4837-a4ac-341d295bfaf7"
     session_client = Client(credentials=Credentials(token=access_key))
     session_client._http_db.session = unittest.mock.Mock()

--- a/tests/rundb/test_client.py
+++ b/tests/rundb/test_client.py
@@ -61,6 +61,37 @@ def test_session_carries_client_credentials_to_requests():
     assert headers.get("authorization") == "Bearer my-token"
 
 
+def test_jwt_token_routes_as_bearer_not_session():
+    """A signed JWT is sent as an ``Authorization`` bearer, not a session cookie.
+
+    Guards the ``is_iguazio_session`` classifier at the request-routing layer:
+    ``api_call`` must emit the bearer header (and no ``session`` cookie) for a
+    JWT, while an Iguazio access key / control session still routes as a cookie.
+    """
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdmMtYWNjdCJ9.ab-cd_ef"
+    client = Client(credentials=Credentials(token=jwt))
+    client._http_db.session = unittest.mock.Mock()
+
+    with client.session():
+        mlrun.get_run_db().api_call("GET", "some-path")
+
+    request_kwargs = client._http_db.session.request.call_args[1]
+    assert request_kwargs.get("headers", {}).get("authorization") == f"Bearer {jwt}"
+    assert "cookies" not in request_kwargs
+
+    # Contrast: an Iguazio access key / control session still routes as a cookie.
+    access_key = "946b0749-5c40-4837-a4ac-341d295bfaf7"
+    session_client = Client(credentials=Credentials(token=access_key))
+    session_client._http_db.session = unittest.mock.Mock()
+
+    with session_client.session():
+        mlrun.get_run_db().api_call("GET", "some-path")
+
+    session_kwargs = session_client._http_db.session.request.call_args[1]
+    assert "session" in session_kwargs.get("cookies", {})
+    assert session_kwargs.get("headers", {}).get("authorization") is None
+
+
 def test_credentials_use_env_matches_legacy_singleton_auth(monkeypatch):
     """``Credentials(use_env=True)`` resolves auth like the legacy singleton."""
     monkeypatch.setenv("V3IO_ACCESS_KEY", "host-process-token")


### PR DESCRIPTION
### 📝 Description
`is_iguazio_session()` decides cookie-vs-bearer token routing. Its legacy heuristic (`len(value) > 20 and "-" in value`) also matched signed JWTs (JWS compact), so `Credentials(token=<jwt>)` could be sent as a `session` cookie instead of `Authorization: Bearer ...`.

This change treats signed JWTs as bearers (matching the OAuth provider behavior).

---

### 🛠️ Changes Made
- `mlrun/platforms/iguazio.py`: `is_iguazio_session()` now returns `False` for JWS-compact JWT shape (`<header>.<payload>.<signature>`, `eyJ` prefix) before the existing Iguazio session heuristic.
- `tests/platforms/test_iguazio.py`: added classifier coverage for JWT vs access-key/UUID examples.
- `tests/rundb/test_client.py`: added routing coverage to verify JWT -> bearer header, access-key/UUID -> session cookie.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing
- `tests/platforms/test_iguazio.py::test_is_iguazio_session`
- `tests/rundb/test_client.py::test_jwt_token_routes_as_bearer_not_session`
- Root cause was observed on a live cluster (JWT static token 401'd on the cookie path); post-fix routing is verified by unit tests, and live re-run is pending.

---

### 🔗 References
- Ticket link: Part of ML-12697
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No — only re-routes JWT-shaped static tokens that already failed on the cookie path; access keys/session UUIDs are unchanged.

---

### 🔍️ Additional Notes
- Scope is intentionally JWS-compact JWTs; other JWT families (e.g. JWE) are out of scope for this patch.