### PR TITLE
[Runs] Return empty list when listing cross-project runs for users with no projects

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -546,7 +546,10 @@ class SQLDB(DBInterface):
         offset: int | None = None,
         limit: int | None = None,
     ) -> RunList:
-        if not project:
+        # An empty list is a valid project filter (e.g. cross-project listing for a user with no
+        # accessible projects) and yields an empty result via `.in_([])`. Only a missing project
+        # (None / "") is an error, since that would apply no project filter at all.
+        if not project and not isinstance(project, list):
             raise mlrun.errors.MLRunMissingProjectError()
         query = self._find_runs(session, uid, project, labels)
         if name is not None:

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -546,9 +546,11 @@ class SQLDB(DBInterface):
         offset: int | None = None,
         limit: int | None = None,
     ) -> RunList:
-        # An empty list is valid (user with no accessible projects). Only a missing project
-        # (None / "") is an error, since that would apply no project filter at all.
-        if not project and not isinstance(project, list):
+        # Empty list (user with no accessible projects) matches nothing, so skip the
+        # DB query. A missing project (None / "") applies no filter, so it's an error.
+        if isinstance(project, list) and not project:
+            return RunList()
+        if not project:
             raise mlrun.errors.MLRunMissingProjectError()
         query = self._find_runs(session, uid, project, labels)
         if name is not None:
@@ -2550,6 +2552,10 @@ class SQLDB(DBInterface):
         since: datetime | None = None,
         until: datetime | None = None,
     ) -> list[dict]:
+        # Empty list (user with no accessible projects) matches nothing, so skip the
+        # DB query. A missing project (None / "") applies no filter, so it's an error.
+        if isinstance(project, list) and not project:
+            return []
         if not project:
             raise mlrun.errors.MLRunMissingProjectError()
         functions = []

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -546,8 +546,7 @@ class SQLDB(DBInterface):
         offset: int | None = None,
         limit: int | None = None,
     ) -> RunList:
-        # An empty list is a valid project filter (e.g. cross-project listing for a user with no
-        # accessible projects) and yields an empty result via `.in_([])`. Only a missing project
+        # An empty list is valid (user with no accessible projects). Only a missing project
         # (None / "") is an error, since that would apply no project filter at all.
         if not project and not isinstance(project, list):
             raise mlrun.errors.MLRunMissingProjectError()

--- a/server/py/services/api/tests/unit/db/test_functions.py
+++ b/server/py/services/api/tests/unit/db/test_functions.py
@@ -414,6 +414,33 @@ class TestFunctions(TestDatabaseBase):
                 assert function["metadata"]["tag"] == ""
                 assert function["status"] is None
 
+    def test_list_functions_empty_project_list_returns_empty(self):
+        # Cross-project listing for a user with no accessible projects resolves to an
+        # empty project list. That must yield an empty result, not an error.
+        self._db.store_function(
+            self._db_session,
+            function={"metadata": {"name": "some-function"}},
+            name="some-function",
+            project=self.project,
+            tag="latest",
+            versioned=True,
+        )
+
+        functions = self._db.list_functions(self._db_session, project=[])
+        assert len(functions) == 0
+
+        # A populated project list still filters normally (the empty-list relaxation doesn't
+        # weaken the list path).
+        functions = self._db.list_functions(self._db_session, project=[self.project])
+        assert len(functions) == 1
+
+    @pytest.mark.parametrize("project", [None, ""])
+    def test_list_functions_missing_project_raises(self, project):
+        # A truly missing project (None / "") applies no project filter, so it must keep
+        # raising rather than silently listing across all projects.
+        with pytest.raises(mlrun.errors.MLRunMissingProjectError):
+            self._db.list_functions(self._db_session, project=project)
+
     def test_list_functions_by_tag(self):
         tag = "function_name_1"
 

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -592,7 +592,7 @@ class TestRuns(TestDatabaseBase):
         assert runs[0]["status"]["end_time"].endswith(".000000+00:00")
 
     def test_list_runs_empty_project_list_returns_empty(self):
-        # ML-12404: cross-project listing (project="*") for a user with no accessible projects
+        # Cross-project listing (project="*") for a user with no accessible projects
         # resolves to an empty project list. That must yield an empty result, not an error.
         self._create_new_run(project="some-project")
 

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -20,6 +20,7 @@ import pytest
 
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
+import mlrun.errors
 import mlrun.model
 from tests.conftest import new_run
 
@@ -589,6 +590,26 @@ class TestRuns(TestDatabaseBase):
 
         assert runs[0]["status"]["start_time"].endswith(".000000+00:00")
         assert runs[0]["status"]["end_time"].endswith(".000000+00:00")
+
+    def test_list_runs_empty_project_list_returns_empty(self):
+        # ML-12404: cross-project listing (project="*") for a user with no accessible projects
+        # resolves to an empty project list. That must yield an empty result, not an error.
+        self._create_new_run(project="some-project")
+
+        runs = self._db.list_runs(self._db_session, project=[])
+        assert len(runs) == 0
+
+        # A populated project list still filters normally (the empty-list relaxation doesn't
+        # weaken the list path).
+        runs = self._db.list_runs(self._db_session, project=["some-project"])
+        assert len(runs) == 1
+
+    @pytest.mark.parametrize("project", [None, ""])
+    def test_list_runs_missing_project_raises(self, project):
+        # A truly missing project (None / "") applies no project filter, so it must keep
+        # raising rather than silently listing across all projects.
+        with pytest.raises(mlrun.errors.MLRunMissingProjectError):
+            self._db.list_runs(self._db_session, project=project)
 
     @staticmethod
     def _change_run_record_to_before_align_runs_migration(run, time_before_creation):


### PR DESCRIPTION
### 📝 Description

Listing runs across all projects resolves the caller's accessible projects to a list and passes it down to the DB layer. For a user with **no project policies** that list is empty, and the `db.list_runs` guard treated the empty list as a *missing* project — raising `MLRunMissingProjectError`. 

The fix relaxes the guard so an empty project **list** yields an empty result.

### 🛠️ Changes Made

- `server/py/framework/db/sqldb/db.py` — in `list_runs`, relaxed the guard so an empty allowed-projects list returns an empty `RunList` instead of erroring. `None`/`""` still raise.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

Added unit tests in `server/py/services/api/tests/unit/db/test_runs.py`:
- `list_runs(project=[])` returns an empty list even when runs exist in some project.
- `list_runs(project=["some-project"])` still filters normally (list path unaffected).
- `list_runs(project=None)` and `list_runs(project="")` still raise `MLRunMissingProjectError`.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12404

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
