### PR TITLE
[Nuclio] Add optional timeout to `wait_for_deployment()`

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -926,6 +926,7 @@ class RemoteRuntime(KubeResource):
         force_build: bool = False,
         track_models: bool | None = None,
         wait: bool = True,
+        timeout: int | None = None,
     ):
         """Deploy the nuclio function to the cluster
 
@@ -942,6 +943,9 @@ class RemoteRuntime(KubeResource):
             return ``self`` so the caller can later call
             ``wait_for_deployment()`` or poll
             ``db.get_nuclio_deploy_status``.
+        :param timeout:    optional deadline in seconds for the readiness wait
+            when ``wait=True``; forwarded to ``wait_for_deployment``. ``None``
+            waits indefinitely. Ignored when ``wait=False``.
 
         :return: the invocation command (``str``) when ``wait=True``; the
             function object (``self``) when ``wait=False``.
@@ -996,7 +1000,7 @@ class RemoteRuntime(KubeResource):
             # Caller handles wait/finalization explicitly.
             return self
 
-        return self.wait_for_deployment(verbose=verbose)
+        return self.wait_for_deployment(verbose=verbose, timeout=timeout)
 
     def wait_for_deployment(
         self, verbose: bool = False, timeout: int | None = None
@@ -1011,7 +1015,9 @@ class RemoteRuntime(KubeResource):
         :param verbose: print verbose build logs
         :param timeout: optional deadline in seconds for reaching a terminal
             deploy state. ``None`` waits indefinitely. Raises
-            :class:`RunError` on timeout.
+            :class:`mlrun.errors.MLRunTimeoutError` on timeout. The deadline is
+            checked once per status poll, so the wait may overshoot ``timeout``
+            by up to one poll interval.
         :return: the function's invocation command
         """
         db = self._get_db()
@@ -1062,7 +1068,9 @@ class RemoteRuntime(KubeResource):
 
         return self.spec.command
 
-    def _wait_for_function_deployment(self, db, verbose=False, timeout=None):
+    def _wait_for_function_deployment(
+        self, db, verbose=False, timeout: int | None = None
+    ):
         state = ""
         last_log_timestamp = 1
         deadline = monotonic() + timeout if timeout is not None else None
@@ -1073,7 +1081,7 @@ class RemoteRuntime(KubeResource):
                     function_state=state,
                     timeout=timeout,
                 )
-                raise RunError(
+                raise mlrun.errors.MLRunTimeoutError(
                     f"Function {self.metadata.name} deployment timed out after "
                     f"{timeout}s (last state={state!r})"
                 )

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1005,20 +1005,19 @@ class RemoteRuntime(KubeResource):
 
         Waits for terminal deploy status, handles model-endpoint tasks,
         enriches the invocation command from status, and returns it.
-        ``deploy(wait=True)`` calls this directly; callers that used
+        ``deploy(wait=True)`` calls this directly; callers of
         ``deploy(wait=False)`` can call it explicitly.
 
-        :param verbose: set True for verbose build-log output
-        :param timeout: overall deadline (seconds) for reaching a terminal
-            deploy state. ``None`` (default) waits indefinitely; a value fails
-            with a :class:`RunError` if the deploy never becomes ready (e.g. an
-            image that never pulls), instead of polling forever.
+        :param verbose: print verbose build logs
+        :param timeout: optional deadline in seconds for reaching a terminal
+            deploy state. ``None`` waits indefinitely. Raises
+            :class:`RunError` on timeout.
         :return: the function's invocation command
         """
         db = self._get_db()
-        # Wait for readiness and refresh function status.
+        # Wait for terminal state and refresh status.
         self._wait_for_function_deployment(db, verbose=verbose, timeout=timeout)
-        # Consume submit-captured model-endpoint tasks at most once.
+        # Consume submit-time model-endpoint tasks once.
         model_endpoints_creation_background_tasks = (
             mlrun.common.schemas.BackgroundTaskList(
                 **getattr(self, "_deploy_background_tasks", None)
@@ -1070,13 +1069,13 @@ class RemoteRuntime(KubeResource):
         while state not in ["ready", "error", "unhealthy"]:
             if deadline is not None and monotonic() > deadline:
                 logger.error(
-                    "Nuclio function deploy timed out",
+                    "Nuclio deploy timed out",
                     function_state=state,
                     timeout=timeout,
                 )
                 raise RunError(
-                    f"Function {self.metadata.name} deployment did not reach a "
-                    f"terminal state within {timeout}s (last state={state!r})"
+                    f"Function {self.metadata.name} deployment timed out after "
+                    f"{timeout}s (last state={state!r})"
                 )
             sleep(
                 int(mlrun.mlconf.httpdb.logs.nuclio.pull_deploy_status_default_interval)

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -19,7 +19,7 @@ import typing
 import warnings
 from dataclasses import dataclass
 from datetime import datetime
-from time import sleep
+from time import monotonic, sleep
 
 import inflection
 import nuclio
@@ -998,7 +998,9 @@ class RemoteRuntime(KubeResource):
 
         return self.wait_for_deployment(verbose=verbose)
 
-    def wait_for_deployment(self, verbose: bool = False) -> str:
+    def wait_for_deployment(
+        self, verbose: bool = False, timeout: int | None = None
+    ) -> str:
         """Finalize a submitted Nuclio deploy.
 
         Waits for terminal deploy status, handles model-endpoint tasks,
@@ -1007,11 +1009,15 @@ class RemoteRuntime(KubeResource):
         ``deploy(wait=False)`` can call it explicitly.
 
         :param verbose: set True for verbose build-log output
+        :param timeout: overall deadline (seconds) for reaching a terminal
+            deploy state. ``None`` (default) waits indefinitely; a value fails
+            with a :class:`RunError` if the deploy never becomes ready (e.g. an
+            image that never pulls), instead of polling forever.
         :return: the function's invocation command
         """
         db = self._get_db()
         # Wait for readiness and refresh function status.
-        self._wait_for_function_deployment(db, verbose=verbose)
+        self._wait_for_function_deployment(db, verbose=verbose, timeout=timeout)
         # Consume submit-captured model-endpoint tasks at most once.
         model_endpoints_creation_background_tasks = (
             mlrun.common.schemas.BackgroundTaskList(
@@ -1057,10 +1063,21 @@ class RemoteRuntime(KubeResource):
 
         return self.spec.command
 
-    def _wait_for_function_deployment(self, db, verbose=False):
+    def _wait_for_function_deployment(self, db, verbose=False, timeout=None):
         state = ""
         last_log_timestamp = 1
+        deadline = monotonic() + timeout if timeout is not None else None
         while state not in ["ready", "error", "unhealthy"]:
+            if deadline is not None and monotonic() > deadline:
+                logger.error(
+                    "Nuclio function deploy timed out",
+                    function_state=state,
+                    timeout=timeout,
+                )
+                raise RunError(
+                    f"Function {self.metadata.name} deployment did not reach a "
+                    f"terminal state within {timeout}s (last state={state!r})"
+                )
             sleep(
                 int(mlrun.mlconf.httpdb.logs.nuclio.pull_deploy_status_default_interval)
             )

--- a/mlrun/runtimes/nuclio/serving.py
+++ b/mlrun/runtimes/nuclio/serving.py
@@ -751,6 +751,7 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
         builder_env: dict | None = None,
         force_build: bool = False,
         wait: bool = True,
+        timeout: int | None = None,
     ):
         """deploy model serving function to a local/remote cluster
 
@@ -761,6 +762,8 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
         :param force_build: set True for force building the image
         :param wait:      when True (default), block until ready and return the invocation command (``str``).
             When ``False``, submit and return ``self`` so the caller can poll. See ``RemoteRuntime.deploy``.
+        :param timeout:   optional deadline in seconds for the readiness wait when ``wait=True``;
+            forwarded to ``RemoteRuntime.deploy``. ``None`` waits indefinitely. Ignored when ``wait=False``.
         """
 
         load_mode = self.spec.load_mode
@@ -824,6 +827,7 @@ class ServingRuntime(nuclio_function.RemoteRuntime):
             builder_env=builder_env,
             force_build=force_build,
             wait=wait,
+            timeout=timeout,
         )
 
     def _get_serving_spec(self):

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -222,22 +222,20 @@ def test_wait_for_deployment_finalizes_after_submit():
 
 
 def test_wait_for_deployment_times_out():
-    """A deploy that never reaches a terminal state fails after ``timeout``
-    instead of polling forever (e.g. an image stuck in ImagePullBackOff)."""
+    """A non-terminal deploy fails after ``timeout`` instead of polling forever."""
     function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
     function.status.state = "building"  # never reaches a terminal state
     db = MagicMock()
     db.get_nuclio_deploy_status = MagicMock(return_value=("", 1))
 
-    # monotonic: deadline calc (100 -> deadline 110), iter1 check (100, ok),
-    # iter2 check (120 > 110 -> time out).
+    # deadline=110; second loop check (120) times out.
     with (
         patch("mlrun.runtimes.nuclio.function.sleep"),
         patch(
             "mlrun.runtimes.nuclio.function.monotonic",
             side_effect=[100.0, 100.0, 120.0],
         ),
-        pytest.raises(RunError, match="did not reach a terminal state within 10s"),
+        pytest.raises(RunError, match="timed out after 10s"),
     ):
         function._wait_for_function_deployment(db, timeout=10)
 

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -25,6 +25,7 @@ import mlrun.common.schemas
 import mlrun.errors
 from mlrun import code_to_function
 from mlrun.datastore.datastore_profile import DatastoreProfileRabbitMQ
+from mlrun.runtimes.utils import RunError
 from mlrun.utils.helpers import resolve_git_reference_from_source
 from tests.runtimes.test_base import TestAutoMount
 
@@ -218,6 +219,27 @@ def test_wait_for_deployment_finalizes_after_submit():
     function._wait_for_function_deployment.assert_called_once()
     function._enrich_command_from_status.assert_called_once()
     assert result == "http://invocation"
+
+
+def test_wait_for_deployment_times_out():
+    """A deploy that never reaches a terminal state fails after ``timeout``
+    instead of polling forever (e.g. an image stuck in ImagePullBackOff)."""
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    function.status.state = "building"  # never reaches a terminal state
+    db = MagicMock()
+    db.get_nuclio_deploy_status = MagicMock(return_value=("", 1))
+
+    # monotonic: deadline calc (100 -> deadline 110), iter1 check (100, ok),
+    # iter2 check (120 > 110 -> time out).
+    with (
+        patch("mlrun.runtimes.nuclio.function.sleep"),
+        patch(
+            "mlrun.runtimes.nuclio.function.monotonic",
+            side_effect=[100.0, 100.0, 120.0],
+        ),
+        pytest.raises(RunError, match="did not reach a terminal state within 10s"),
+    ):
+        function._wait_for_function_deployment(db, timeout=10)
 
 
 def test_wait_for_deployment_clears_background_tasks_after_processing():

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -25,7 +25,6 @@ import mlrun.common.schemas
 import mlrun.errors
 from mlrun import code_to_function
 from mlrun.datastore.datastore_profile import DatastoreProfileRabbitMQ
-from mlrun.runtimes.utils import RunError
 from mlrun.utils.helpers import resolve_git_reference_from_source
 from tests.runtimes.test_base import TestAutoMount
 
@@ -193,6 +192,30 @@ def test_serving_deploy_forwards_wait():
     assert super_deploy.call_args.kwargs.get("wait") is False
 
 
+def test_deploy_forwards_timeout():
+    """``deploy(wait=True, timeout=...)`` forwards the deadline to wait_for_deployment."""
+    function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
+    _mock_nuclio_deploy(function)
+    function.wait_for_deployment = MagicMock(return_value="http://invocation")
+
+    function.deploy(timeout=30)
+
+    assert function.wait_for_deployment.call_args.kwargs.get("timeout") == 30
+
+
+def test_serving_deploy_forwards_timeout():
+    """``ServingRuntime.deploy`` must forward ``timeout`` to ``super().deploy``."""
+    function = mlrun.new_function("tst", kind="serving")
+    function.set_topology("router")
+
+    with patch.object(
+        mlrun.runtimes.nuclio.function.RemoteRuntime, "deploy", return_value="cmd"
+    ) as super_deploy:
+        function.deploy(wait=False, timeout=30)
+
+    assert super_deploy.call_args.kwargs.get("timeout") == 30
+
+
 def test_nuclio_deploy_wait_true_waits_and_enriches():
     """``deploy(wait=True)`` keeps legacy wait+enrich behavior."""
     function: mlrun.runtimes.RemoteRuntime = mlrun.new_function("tst", kind="nuclio")
@@ -235,7 +258,7 @@ def test_wait_for_deployment_times_out():
             "mlrun.runtimes.nuclio.function.monotonic",
             side_effect=[100.0, 100.0, 120.0],
         ),
-        pytest.raises(RunError, match="timed out after 10s"),
+        pytest.raises(mlrun.errors.MLRunTimeoutError, match="timed out after 10s"),
     ):
         function._wait_for_function_deployment(db, timeout=10)
 


### PR DESCRIPTION
### 📝 Description

`wait_for_deployment()` polls Nuclio deploy status in an unbounded loop. A deploy that never reaches a terminal state — e.g. an image stuck in `ImagePullBackOff` because the base image doesn't exist — blocks the caller forever.

This adds an optional `timeout` (default `None`) so a caller can put a deadline on the build-wait. `None` keeps the current wait-forever behavior; a value fails fast with a `RunError` once the deadline elapses. Builds on #9790's submit/wait split, where the wait is a separately callable phase.

---

### 🛠️ Changes Made

- `wait_for_deployment(verbose=False, timeout=None)` threads the deadline to `_wait_for_function_deployment`, which raises `RunError` (function name + last state) once `monotonic()` passes it.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

`tests/runtimes/test_function.py::test_wait_for_deployment_times_out`: a function stuck in `building`, with `sleep` patched out and `monotonic` patched to step past the deadline, asserts `RunError`. The `timeout=None` path stays covered by the existing `test_wait_for_deployment_*` tests.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: builds on #9790 (deploy submit/wait split)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

`timeout` defaults to `None`, reproducing the existing unbounded wait. Existing callers are unaffected.

---

### 🔍️ Additional Notes

Motivated by AIRun's MLRun engine, which owns the build-wait under a service-account identity and wants to fail a stuck deploy rather than hold a reconciliation task open indefinitely. Opt-in only — no AIRun work depends on it.