### PR TITLE
[Runtimes] Fix unclear error when running unsupported Dask runtime on IG4

### DIFF
--- a/mlrun/launcher/local.py
+++ b/mlrun/launcher/local.py
@@ -289,6 +289,7 @@ class ClientLocalLauncher(launcher.ClientBaseLauncher):
         runtime: "mlrun.runtimes.BaseRuntime",
         run: "mlrun.run.RunObject",
     ):
+        runtime.validate()
         super()._validate_run(runtime, run)
         if self._is_run_local and run.spec.retry.count:
             logger.warning(

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -223,6 +223,16 @@ class DaskCluster(KubejobRuntime):
     def status(self, status):
         self._status = self._verify_dict(status, "status", DaskStatus)
 
+    def validate(self):
+        super().validate()
+        # The Dask runtime is not supported on Iguazio v4 (IG4) systems, where the dask cluster can
+        # no longer be brought up. Bringing one up would otherwise fail with an opaque
+        # "Failed bringing up dask cluster" error.
+        if config.is_iguazio_v4_mode():
+            raise mlrun.errors.MLRunBadRequestError(
+                "The Dask runtime is not supported on this system."
+            )
+
     def is_deployed(self):
         if not self.spec.remote:
             return True

--- a/tests/launcher/test_local.py
+++ b/tests/launcher/test_local.py
@@ -394,3 +394,22 @@ def test_enrich_run_name_strips_handler_module_prefix(handler_value, expected_su
     )
     assert ":" not in run.metadata.name
     assert run.metadata.name == f"my-fn-{expected_suffix}"
+
+
+def test_validate_run_invokes_runtime_validate(monkeypatch):
+    # _validate_run must call runtime.validate() first, so unsupported runtimes (e.g. Dask on IG4)
+    # fail fast on the client local-run path.
+    launcher = mlrun.launcher.local.ClientLocalLauncher(local=True)
+    runtime = mlrun.code_to_function(
+        name="test", kind="job", filename=str(func_path), handler=handler
+    )
+
+    def _raise():
+        raise mlrun.errors.MLRunBadRequestError("runtime rejected by validate()")
+
+    monkeypatch.setattr(runtime, "validate", _raise)
+
+    with pytest.raises(
+        mlrun.errors.MLRunBadRequestError, match="runtime rejected by validate"
+    ):
+        launcher._validate_run(runtime, mlrun.run.RunObject())

--- a/tests/runtimes/test_dask.py
+++ b/tests/runtimes/test_dask.py
@@ -14,7 +14,10 @@
 
 import pytest
 
+import mlrun
+import mlrun.errors
 from mlrun import new_function, new_task
+from mlrun.common.types import AuthenticationMode
 from tests.conftest import tag_test, verify_state
 
 has_dask = False
@@ -48,3 +51,44 @@ def test_dask_local():
     function.spec.remote = False
     run = function.run(spec, handler=my_func)
     verify_state(run)
+
+
+@pytest.mark.parametrize(
+    "auth_mode",
+    [
+        AuthenticationMode.NONE,
+        AuthenticationMode.BASIC,
+        AuthenticationMode.BEARER,
+        AuthenticationMode.IGUAZIO,
+    ],
+)
+def test_dask_validate_passes_when_not_iguazio_v4(monkeypatch, auth_mode):
+    monkeypatch.setattr(mlrun.mlconf.httpdb.authentication, "mode", auth_mode)
+
+    # Dask is supported outside IG4 - validate() must not raise
+    new_function(kind="dask").validate()
+
+
+def test_dask_validate_raises_in_iguazio_v4(monkeypatch):
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication, "mode", AuthenticationMode.IGUAZIO_V4
+    )
+
+    with pytest.raises(
+        mlrun.errors.MLRunBadRequestError, match="not supported on this system"
+    ):
+        new_function(kind="dask").validate()
+
+
+def test_dask_run_raises_in_iguazio_v4(monkeypatch):
+    # Dask runs via the client-side local launcher (Dask is _is_remote=False), which now calls
+    # runtime.validate() in _validate_run. On IG4 run() must fail fast with the clear error
+    # instead of failing late while bringing up the cluster.
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.authentication, "mode", AuthenticationMode.IGUAZIO_V4
+    )
+
+    with pytest.raises(
+        mlrun.errors.MLRunBadRequestError, match="not supported on this system"
+    ):
+        new_function(kind="dask").run(handler=my_func)


### PR DESCRIPTION
                                                                  
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
On Iguazio v4 (IG4) systems the Dask runtime can no longer be brought up. Previously `dsf.run()` failed late and opaquely with `MLRunRuntimeError: Failed bringing up dask cluster`, giving users no indication that Dask is simply unsupported on the system.                                        
                                                                                                                                                                                                           
This makes Dask fail fast with a clear message — `The Dask runtime is not supported on this system.` — before any cluster bring-up.                                                                      
        
---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
  - **`mlrun/runtimes/daskjob.py`** — added a `DaskCluster.validate()` override that raises `MLRunBadRequestError` when `config.is_iguazio_v4_mode()` (mirrors the existing MPIJob `validate()` pattern).  
  - **`mlrun/launcher/local.py`** — `ClientLocalLauncher._validate_run` now calls `runtime.validate()` first, mirroring the server-side launcher. Dask is `_is_remote=False`, so `run()` goes through the  
  client local launcher, which previously never invoked `runtime.validate()` (only the server launcher did) — so the override would never have fired on the reproducer path without this.                  
  - **Tests** — `tests/runtimes/test_dask.py`: `validate()` passes for non-IG4 auth modes, raises on IG4, and `dsf.run()` raises on IG4. `tests/launcher/test_local.py`: `_validate_run` invokes `runtime.validate()` first.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
 - New unit tests in `tests/runtimes/test_dask.py` and `tests/launcher/test_local.py`.                                                                                                                                                         
  - Verified live on an IG4 lab: with the fix, `dsf.run()` now raises `MLRunBadRequestError: The Dask runtime is not supported on this system.` instead of the opaque "Failed bringing up dask cluster".   
             
---

### 🔗 References
- Ticket link:  https://ecliptos.atlassian.net/browse/ML-12703
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->
Behavior note (non-breaking): `runtime.validate()` now runs on every client local-launcher run, not just on the server. Today only the Dask runtime overrides `validate()` among local-launcher runtimes, so the practical impact is limited to Dask on IG4.   

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
