### PR TITLE
[Builder] Route gs/gcs sources through fetch-source init container

### DIFF
--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1787,8 +1787,7 @@ def _init_container_by_name(name: str):
         "wasbs://container@account.blob.core.windows.net/path/project.tar.gz",
         "ds://my-profile/path/project.tar.gz",
         "oss://bucket/path/project.tar.gz",
-        # gs/gcs are kaniko-native, but GCP needs file-based creds the storage-blind
-        # kaniko container never gets, so we route them through the init container too.
+        # gs/gcs are kaniko-native but routed through fetch for GCP's file-based creds
         "gs://bucket/path/project.tar.gz",
         "gcs://bucket/path/project.tar.gz",
     ],
@@ -2060,8 +2059,7 @@ def test_build_runtime_v3io_source_unchanged_by_fix(monkeypatch):
         ("wasbs://x@a.blob.core.windows.net/y.tar.gz", True),
         ("ds://profile/path/y.tar.gz", True),
         ("oss://bucket/path/y.tar.gz", True),
-        # gs/gcs are kaniko-native but routed through the init container so GCP's
-        # file-based creds are resolved by `mlrun load-source`, not the kaniko container.
+        # gs/gcs are kaniko-native but routed through fetch for GCP's file-based creds
         ("gs://x/y.tar.gz", True),
         ("gcs://x/y.tar.gz", True),
         # kaniko-native or otherwise handled out-of-band - must NOT be routed

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1787,6 +1787,10 @@ def _init_container_by_name(name: str):
         "wasbs://container@account.blob.core.windows.net/path/project.tar.gz",
         "ds://my-profile/path/project.tar.gz",
         "oss://bucket/path/project.tar.gz",
+        # gs/gcs are kaniko-native, but GCP needs file-based creds the storage-blind
+        # kaniko container never gets, so we route them through the init container too.
+        "gs://bucket/path/project.tar.gz",
+        "gcs://bucket/path/project.tar.gz",
     ],
 )
 def test_build_runtime_kaniko_incompatible_source_uses_fetch_init_container(
@@ -2020,7 +2024,6 @@ def test_build_runtime_kaniko_incompatible_source_rejects_non_archive(monkeypatc
     [
         # kaniko-native: URL is the build context
         ("s3://bucket/path/project.tar.gz", "s3://bucket/path/project.tar.gz"),
-        ("gs://bucket/path/project.tar.gz", "gs://bucket/path/project.tar.gz"),
         (
             "git://github.com/mlrun/example.git#main",
             "git://github.com/mlrun/example.git#refs/heads/main",
@@ -2057,14 +2060,16 @@ def test_build_runtime_v3io_source_unchanged_by_fix(monkeypatch):
         ("wasbs://x@a.blob.core.windows.net/y.tar.gz", True),
         ("ds://profile/path/y.tar.gz", True),
         ("oss://bucket/path/y.tar.gz", True),
+        # gs/gcs are kaniko-native but routed through the init container so GCP's
+        # file-based creds are resolved by `mlrun load-source`, not the kaniko container.
+        ("gs://x/y.tar.gz", True),
+        ("gcs://x/y.tar.gz", True),
         # kaniko-native or otherwise handled out-of-band - must NOT be routed
         # through the fetch init container.
         ("abfs://x/y.tar.gz", False),
         ("abfss://x/y.tar.gz", False),
         ("dbfs://path/y.tar.gz", False),
         ("s3://x/y.tar.gz", False),
-        ("gs://x/y.tar.gz", False),
-        ("gcs://x/y.tar.gz", False),
         ("git://x/y", False),
         ("https://x/y.tar.gz", False),
         ("http://x/y.tar.gz", False),

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -41,11 +41,10 @@ import framework.utils.helpers
 import framework.utils.singletons.k8s
 
 # mlrun datastore schemes routed through the fetch-source init container instead of being
-# handed to kaniko as --context. Covers schemes kaniko cannot resolve (az, wasb, wasbs, ds,
-# oss) plus gs/gcs: kaniko resolves gs:// natively, but GCP expects its credentials mounted
-# as a file, which kaniko's storage-blind main container never gets - routing gs/gcs through
-# the init container lets `mlrun load-source` authenticate via the usual datastore secrets.
-# Excludes s3 and http(s) (kaniko-native, no file-based creds) and v3io (igz FUSE-mount).
+# handed to kaniko as --context: schemes kaniko cannot resolve (az, wasb, wasbs, ds, oss),
+# plus gs/gcs - kaniko resolves gs:// natively but GCP wants file-based creds its
+# storage-blind container never gets, so we let `mlrun load-source` fetch them instead.
+# excludes s3/http(s) (kaniko-native) and v3io (igz FUSE-mount).
 # aligned with `mlrun.datastore.datastore.schema_to_store`.
 _FETCH_SUPPORTED_SCHEMES = frozenset({"az", "wasb", "wasbs", "ds", "oss", "gs", "gcs"})
 

--- a/server/py/services/api/utils/builder.py
+++ b/server/py/services/api/utils/builder.py
@@ -40,10 +40,14 @@ from mlrun.utils.helpers import remove_image_protocol_prefix
 import framework.utils.helpers
 import framework.utils.singletons.k8s
 
-# mlrun datastore schemes kaniko cannot resolve as --context.
-# excludes kaniko-native schemes (s3, gs/gcs, http/https) and v3io (igz FUSE-mount).
+# mlrun datastore schemes routed through the fetch-source init container instead of being
+# handed to kaniko as --context. Covers schemes kaniko cannot resolve (az, wasb, wasbs, ds,
+# oss) plus gs/gcs: kaniko resolves gs:// natively, but GCP expects its credentials mounted
+# as a file, which kaniko's storage-blind main container never gets - routing gs/gcs through
+# the init container lets `mlrun load-source` authenticate via the usual datastore secrets.
+# Excludes s3 and http(s) (kaniko-native, no file-based creds) and v3io (igz FUSE-mount).
 # aligned with `mlrun.datastore.datastore.schema_to_store`.
-_FETCH_SUPPORTED_SCHEMES = frozenset({"az", "wasb", "wasbs", "ds", "oss"})
+_FETCH_SUPPORTED_SCHEMES = frozenset({"az", "wasb", "wasbs", "ds", "oss", "gs", "gcs"})
 
 # matches what ``mlrun load-source`` extracts.
 # TODO: support .tgz


### PR DESCRIPTION
### 📝 Description

Follow-up to #9787. When a project source uses `gs://` / `gcs://`, the API server hands the raw URI to Kaniko as `--context`. Kaniko *does* resolve `gs://` natively, but GCP's storage client expects its credentials mounted as a **file** - and Kaniko's main container is storage-blind (it never receives any credentials in MLRun's build flow), so native `gs://` builds fail to authenticate.

This PR adds `gs`/`gcs` to the fetch-source allow-list introduced in #9787, so these schemes are routed through the dedicated `fetch-source` init container instead. There, `mlrun load-source` downloads and extracts the archive into Kaniko's empty-dir volume, authenticating via the usual datastore secrets (`GCP_CREDENTIALS` / `GOOGLE_APPLICATION_CREDENTIALS`) — which the MLRun datastore accepts as a JSON-string secret, no file mount required. Kaniko then builds from the local directory.

---

### 🛠️ Changes Made

- **`server/py/services/api/utils/builder.py`** — added `gs` and `gcs` to `_FETCH_SUPPORTED_SCHEMES`. Updated the accompanying comment to explain why `gs`/`gcs` are routed through the init container despite being Kaniko-native (file-based GCP creds vs. storage-blind Kaniko container).
- **Tests** (`server/py/services/api/tests/unit/utils/test_builder.py`):
  - `gs://`/`gcs://` archives added to the parametrized "uses fetch-source init container" test.
  - `gs://` removed from the "Kaniko-native, no fetch container" test (no longer native-routed).
  - `gs`/`gcs` flipped from `False` → `True` in the `_needs_source_fetch_init_container` allow-list test.

Behavior for other source forms is unchanged. Single-file (non-archive) `gs://`/`gcs://` sources are now rejected at the API boundary with `MLRunInvalidArgumentError`, consistent with the other fetched schemes.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

unit tests only.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12710
- Design docs links:
- External links: Follows #9787

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The MLRun GCS datastore (`mlrun/datastore/google_cloud_storage.py`) accepts `GCP_CREDENTIALS` as a JSON-string secret and passes it to `gcsfs` as a dict token, so the init container needs no file-mounted service-account key — which is precisely why this works where native Kaniko `gs://` does not.
- Same archive constraint as the other fetched schemes: only `.tar.gz` / `.zip` sources are accepted.
