### PR TITLE
[Model Monitoring] Fix sample df silently provide empy df. modify mm-parquet target flush time.

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -713,6 +713,10 @@ default_config = {
             "parquet_batching_max_events": 10,
             "parquet_batching_timeout_secs": 30,
         },
+        "stream_graph": {
+            "max_events": 1000,
+            "flush_after_seconds": 30,
+        },
         "lag_detection": {
             "min_lag_threshold_minutes": 5,
             "default_lag_threshold_minutes": 60,
@@ -729,7 +733,7 @@ default_config = {
         # storage such as the parquet file which is generated from the monitoring stream function for the drift analysis
         "offline_storage_path": "model-endpoints/{kind}",
         "parquet_batching_max_events": 10_000,
-        "parquet_batching_timeout_secs": timedelta(minutes=1).total_seconds(),
+        "parquet_batching_timeout_secs": 30,
         "model_endpoint_creation_check_period": 15,
         # TSDB (TimescaleDB) configuration
         "tsdb": {

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -357,4 +357,3 @@ class _ApplicationErrorHandler(StepToDict):
             name=alert_objects.EventKind.MM_APP_FAILED, event_data=event_data
         )
         logger.info("Event generated successfully")
-        return event

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -357,3 +357,4 @@ class _ApplicationErrorHandler(StepToDict):
             name=alert_objects.EventKind.MM_APP_FAILED, event_data=event_data
         )
         logger.info("Event generated successfully")
+        return event

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -230,6 +230,12 @@ class MonitoringApplicationContext:
                 time_column=mm_constants.EventFieldType.TIMESTAMP,
                 storage_options=self.storage_options,
             )
+            if df.empty:
+                raise mlrun.errors.MLRunValueError(
+                    "The sample dataframe is empty, which may indicate that there are no features logged in the "
+                    "model endpoint during the specified time window. Please check that your model endpoint is logging "
+                    "features correctly, and that the time window is correct."
+                )
             self._sample_df = df.reset_index(drop=True)
         return self._sample_df
 

--- a/mlrun/model_monitoring/applications/histogram_data_drift.py
+++ b/mlrun/model_monitoring/applications/histogram_data_drift.py
@@ -164,13 +164,7 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
         sample_df_stats = monitoring_context.dict_to_histogram(
             monitoring_context.sample_df_stats
         )
-        common_features = set(feature_stats.columns) & set(sample_df_stats.columns)
-        if common_features != set(feature_stats.columns):
-            monitoring_context.logger.warning(
-                "Some reference features are missing from the sample data",
-                missing_features=set(feature_stats.columns) - common_features,
-            )
-        for feature_name in common_features:
+        for feature_name in feature_stats:
             sample_hist = np.asarray(sample_df_stats[feature_name])
             reference_hist = np.asarray(feature_stats[feature_name])
             monitoring_context.logger.info(
@@ -274,7 +268,6 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
             {
                 key: monitoring_context.sample_df_stats[key]
                 for key in monitoring_context.feature_stats
-                if key in monitoring_context.sample_df_stats
             }
         )
 
@@ -369,11 +362,6 @@ class HistogramDataDriftApplication(ModelMonitoringApplicationBase):
             monitoring_context.logger.warning(
                 "No feature statistics found, skipping the application. \n"
                 "In order to run the application, training set must be provided when logging the model."
-            )
-            return []
-        if monitoring_context.sample_df.empty:
-            monitoring_context.logger.warning(
-                "No sample data found for the given interval, skipping the application."
             )
             return []
         metrics_per_feature = self._compute_metrics_per_feature(

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_stream.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/timescaledb_stream.py
@@ -106,8 +106,14 @@ class TimescaleDBStreamProcessor:
                     mm_schemas.EventFieldType.EFFECTIVE_SAMPLE_COUNT,
                     mm_schemas.WriterEvent.ENDPOINT_ID,
                 ],
-                max_events=kwargs.get("tsdb_batching_max_events", 1000),
-                flush_after_seconds=kwargs.get("tsdb_batching_timeout_secs", 30),
+                max_events=kwargs.get(
+                    "tsdb_batching_max_events",
+                    mlrun.mlconf.model_endpoint_monitoring.stream_graph.max_events,
+                ),
+                flush_after_seconds=kwargs.get(
+                    "tsdb_batching_timeout_secs",
+                    mlrun.mlconf.model_endpoint_monitoring.stream_graph.flush_after_seconds,
+                ),
             )
 
         # Apply the processing steps
@@ -120,8 +126,8 @@ class TimescaleDBStreamProcessor:
     def handle_model_error(
         self,
         graph,
-        tsdb_batching_max_events: int = 1000,
-        tsdb_batching_timeout_secs: int = 30,
+        tsdb_batching_max_events: int | None = None,
+        tsdb_batching_timeout_secs: int | None = None,
         **kwargs,
     ) -> None:
         """
@@ -135,6 +141,15 @@ class TimescaleDBStreamProcessor:
         :param tsdb_batching_timeout_secs: Batch timeout in seconds
         :param kwargs: Additional configuration parameters
         """
+
+        if tsdb_batching_max_events is None:
+            tsdb_batching_max_events = (
+                mlrun.mlconf.model_endpoint_monitoring.stream_graph.max_events
+            )
+        if tsdb_batching_timeout_secs is None:
+            tsdb_batching_timeout_secs = (
+                mlrun.mlconf.model_endpoint_monitoring.stream_graph.flush_after_seconds
+            )
 
         errors_table = self.tables[mm_schemas.TimescaleDBTables.ERRORS]
 

--- a/tests/model_monitoring/test_applications/test_app_context.py
+++ b/tests/model_monitoring/test_applications/test_app_context.py
@@ -17,6 +17,7 @@ import logging
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pandas as pd
 import pytest
 from nuclio.request import Logger as NuclioLogger
 
@@ -76,6 +77,39 @@ def test_from_ml_context_error(ml_ctx_dict: dict[str, str]) -> None:
             event={},
             context=ml_ctx,
         )
+
+
+def _make_sample_df_stub(df: pd.DataFrame) -> Mock:
+    """Build a stub object compatible with MonitoringApplicationContext.sample_df.
+
+    The property only touches a small surface — endpoint identifiers, infer
+    times, feature_set.to_dataframe, storage_options, and the private cache —
+    so we bypass __init__ and exercise the property's underlying function via
+    .fget(stub).
+    """
+    stub = Mock(spec=MonitoringApplicationContext)
+    stub._sample_df = None
+    stub.endpoint_name = "ep-name"
+    stub.endpoint_id = "ep-id"
+    stub.start_infer_time = pd.Timestamp("2026-01-01")
+    stub.end_infer_time = pd.Timestamp("2026-01-02")
+    stub.storage_options = {}
+    stub.feature_set = Mock()
+    stub.feature_set.to_dataframe.return_value = df
+    return stub
+
+
+def test_sample_df_raises_when_feature_set_returns_empty_df() -> None:
+    stub = _make_sample_df_stub(df=pd.DataFrame())
+    with pytest.raises(MLRunValueError, match="sample dataframe is empty"):
+        MonitoringApplicationContext.sample_df.fget(stub)
+
+
+def test_sample_df_returns_df_when_feature_set_returns_non_empty_df() -> None:
+    df = pd.DataFrame({"feature_a": [1, 2, 3]})
+    stub = _make_sample_df_stub(df=df)
+    result = MonitoringApplicationContext.sample_df.fget(stub)
+    pd.testing.assert_frame_equal(result, df.reset_index(drop=True))
 
 
 @patch("mlrun.db.nopdb.NopDB.get_project")

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -29,12 +29,16 @@ from mlrun.common.schemas.model_monitoring.constants import (
     ResultKindApp,
     ResultStatusApp,
 )
+from mlrun.model_monitoring.applications._application_steps import (
+    _ApplicationErrorHandler,
+)
 from mlrun.model_monitoring.applications.histogram_data_drift import (
     DataDriftClassifier,
     HistogramDataDriftApplication,
     InvalidMetricValueError,
     InvalidThresholdValueError,
 )
+from mlrun.serving.server import MockEvent
 
 assets_folder = Path(__file__).parent / "assets"
 
@@ -276,4 +280,30 @@ class TestMetricsPerFeature:
         }, "Different metrics than expected"
         assert set(metrics_per_feature.index) == set(feature_stats.columns), (
             "The features are different than expected"
+        )
+
+
+class TestApplicationErrorHandler:
+    """ML-12380 secondary issue: _ApplicationErrorHandler.do() must return the event."""
+
+    @staticmethod
+    def test_do_returns_event() -> None:
+        handler = _ApplicationErrorHandler(project="test-project")
+
+        event = MockEvent()
+        event.body = Mock(endpoint_id="ep-123", application_name="test-app")
+        event.error = ValueError("test error")
+        event.timestamp = "2024-01-01T00:00:00"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mock_db = Mock()
+            mp.setattr(
+                "mlrun.model_monitoring.applications._application_steps.mlrun.get_run_db",
+                lambda: mock_db,
+            )
+            result = handler.do(event)
+
+        assert result is event, (
+            "_ApplicationErrorHandler.do() must return the event to avoid "
+            "passing None downstream in the serving graph"
         )

--- a/tests/model_monitoring/test_applications/test_histogram_data_drift.py
+++ b/tests/model_monitoring/test_applications/test_histogram_data_drift.py
@@ -29,16 +29,12 @@ from mlrun.common.schemas.model_monitoring.constants import (
     ResultKindApp,
     ResultStatusApp,
 )
-from mlrun.model_monitoring.applications._application_steps import (
-    _ApplicationErrorHandler,
-)
 from mlrun.model_monitoring.applications.histogram_data_drift import (
     DataDriftClassifier,
     HistogramDataDriftApplication,
     InvalidMetricValueError,
     InvalidThresholdValueError,
 )
-from mlrun.serving.server import MockEvent
 
 assets_folder = Path(__file__).parent / "assets"
 
@@ -191,7 +187,6 @@ class TestApplication:
         )
         monitoring_context._sample_df_stats = sample_df_stats
         monitoring_context._feature_stats = feature_stats
-        monitoring_context._sample_df = pd.DataFrame({"f1": [1], "f2": [2], "l": [3]})
 
         return monitoring_context
 
@@ -235,49 +230,6 @@ class TestApplication:
             "drift_table_plot.html",
             "features_drift_results.json",
         }, "The artifact files were not found or are different than expected"
-
-
-class TestEmptySampleDf:
-    """Reproduce ML-12380: do_tracking should handle empty sample data gracefully."""
-
-    @staticmethod
-    def test_do_tracking_with_empty_sample_df(
-        application: HistogramDataDriftApplication,
-        logger: mlrun.utils.Logger,
-        project: mlrun.MlrunProject,
-    ) -> None:
-        monitoring_context = mm_context.MonitoringApplicationContext(
-            application_name=application.NAME,
-            event={},
-            artifacts_logger=project,
-            logger=logger,
-            project=project,
-            nuclio_logger=logger,
-        )
-        monitoring_context._feature_stats = (
-            mlrun.common.model_monitoring.helpers.FeatureStats(
-                {
-                    "f1": {
-                        "count": 100,
-                        "hist": [
-                            [0, 0, 0, 30, 70, 0],
-                            [-10, -5, 0, 5, 10, 15, 20],
-                        ],
-                    },
-                    "f2": {
-                        "count": 100,
-                        "hist": [
-                            [0, 45, 5, 15, 35, 0],
-                            [66, 67, 68, 69, 70, 71, 72],
-                        ],
-                    },
-                }
-            )
-        )
-        monitoring_context._sample_df = pd.DataFrame()
-
-        results = application.do_tracking(monitoring_context)
-        assert results == [], "Expected empty results when sample data is empty"
 
 
 class TestMetricsPerFeature:
@@ -324,73 +276,4 @@ class TestMetricsPerFeature:
         }, "Different metrics than expected"
         assert set(metrics_per_feature.index) == set(feature_stats.columns), (
             "The features are different than expected"
-        )
-
-    @staticmethod
-    def test_compute_metrics_mismatched_features(
-        application: HistogramDataDriftApplication,
-        monitoring_context: Mock,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """feature_stats has features not present in sample_df_stats (ML-12380)."""
-        feature_stats = pd.DataFrame(
-            {"f1": [1, 2, 3], "f2": [4, 5, 6], "f3": [7, 8, 9]}
-        )
-        sample_df_stats = pd.DataFrame({"f1": [10, 20, 30]})
-
-        monitoring_context.sample_df_stats = sample_df_stats
-        monitoring_context.feature_stats = feature_stats
-
-        metrics_per_feature = application._compute_metrics_per_feature(
-            monitoring_context=monitoring_context
-        )
-        assert set(metrics_per_feature.index) == {"f1"}, (
-            "Should only compute metrics for shared features"
-        )
-        assert "missing from the sample data" in caplog.text
-
-
-class TestGetSharedFeaturesSampleStats:
-    @staticmethod
-    def test_missing_keys(
-        application: HistogramDataDriftApplication,
-    ) -> None:
-        """feature_stats keys not in sample_df_stats should not cause KeyError (ML-12380)."""
-        ctx = Mock()
-        ctx.feature_stats = mlrun.common.model_monitoring.helpers.FeatureStats(
-            {"f1": {"count": 100}, "f2": {"count": 200}}
-        )
-        ctx.sample_df_stats = mlrun.common.model_monitoring.helpers.FeatureStats(
-            {"f1": {"count": 50}}
-        )
-
-        result = application._get_shared_features_sample_stats(ctx)
-        assert set(result.keys()) == {"f1"}, (
-            "Should only include features present in both stats dicts"
-        )
-
-
-class TestApplicationErrorHandler:
-    """ML-12380 secondary issue: _ApplicationErrorHandler.do() must return the event."""
-
-    @staticmethod
-    def test_do_returns_event() -> None:
-        handler = _ApplicationErrorHandler(project="test-project")
-
-        event = MockEvent()
-        event.body = Mock(endpoint_id="ep-123", application_name="test-app")
-        event.error = ValueError("test error")
-        event.timestamp = "2024-01-01T00:00:00"
-
-        with pytest.MonkeyPatch.context() as mp:
-            mock_db = Mock()
-            mp.setattr(
-                "mlrun.model_monitoring.applications._application_steps.mlrun.get_run_db",
-                lambda: mock_db,
-            )
-            result = handler.do(event)
-
-        assert result is event, (
-            "_ApplicationErrorHandler.do() must return the event to avoid "
-            "passing None downstream in the serving graph"
         )

--- a/tests/model_monitoring/test_stream_processing.py
+++ b/tests/model_monitoring/test_stream_processing.py
@@ -101,6 +101,139 @@ def test_plot_monitoring_serving_graph(
     print(graph)
 
 
+def _find_step_call(graph_mock: unittest.mock.Mock, step_name: str):
+    for call in graph_mock.add_step.call_args_list:
+        if call.kwargs.get("name") == step_name:
+            return call
+    raise AssertionError(
+        f"graph.add_step was not called with name={step_name!r}; "
+        f"calls were: {graph_mock.add_step.call_args_list}"
+    )
+
+
+def _make_timescaledb_connector(monkeypatch: pytest.MonkeyPatch, project_name: str):
+    monkeypatch.setattr(mlrun.mlconf, "system_id", "123456")
+    return mlrun.model_monitoring.get_tsdb_connector(
+        project=project_name,
+        profile=DatastoreProfilePostgreSQL(
+            name="postgresql-tsdb-test",
+            user="testuser",
+            password="testpass",
+            host="localhost",
+            port=5432,
+            database="postgres",
+        ),
+    )
+
+
+def test_timescaledb_stream_steps_read_max_events_and_flush_from_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TimescaleDB predictions target picks up mlconf values when no kwargs."""
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph, "max_events", 4242
+    )
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph,
+        "flush_after_seconds",
+        77,
+    )
+
+    tsdb_connector = _make_timescaledb_connector(
+        monkeypatch, project_name="test-stream-config-read"
+    )
+    graph = unittest.mock.Mock()
+
+    tsdb_connector.apply_monitoring_stream_steps(graph)
+
+    call = _find_step_call(graph, "TimescaleDBTarget")
+    assert call.kwargs["max_events"] == 4242
+    assert call.kwargs["flush_after_seconds"] == 77
+
+
+def test_timescaledb_stream_steps_kwargs_override_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit kwargs override mlconf values for the predictions target."""
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph, "max_events", 4242
+    )
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph,
+        "flush_after_seconds",
+        77,
+    )
+
+    tsdb_connector = _make_timescaledb_connector(
+        monkeypatch, project_name="test-stream-kwargs-override"
+    )
+    graph = unittest.mock.Mock()
+
+    tsdb_connector.apply_monitoring_stream_steps(
+        graph,
+        tsdb_batching_max_events=11,
+        tsdb_batching_timeout_secs=22,
+    )
+
+    call = _find_step_call(graph, "TimescaleDBTarget")
+    assert call.kwargs["max_events"] == 11
+    assert call.kwargs["flush_after_seconds"] == 22
+
+
+def test_timescaledb_handle_model_error_reads_from_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TimescaleDB errors target picks up mlconf values when no kwargs."""
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph, "max_events", 555
+    )
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph,
+        "flush_after_seconds",
+        66,
+    )
+
+    tsdb_connector = _make_timescaledb_connector(
+        monkeypatch, project_name="test-errors-config-read"
+    )
+    graph = unittest.mock.Mock()
+
+    tsdb_connector.handle_model_error(graph)
+
+    call = _find_step_call(graph, "timescaledb_error")
+    assert call.kwargs["max_events"] == 555
+    assert call.kwargs["flush_after_seconds"] == 66
+
+
+def test_timescaledb_handle_model_error_kwargs_override_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit kwargs override mlconf values for the errors target."""
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph, "max_events", 555
+    )
+    monkeypatch.setattr(
+        mlrun.mlconf.model_endpoint_monitoring.stream_graph,
+        "flush_after_seconds",
+        66,
+    )
+
+    tsdb_connector = _make_timescaledb_connector(
+        monkeypatch, project_name="test-errors-kwargs-override"
+    )
+    graph = unittest.mock.Mock()
+
+    tsdb_connector.handle_model_error(
+        graph,
+        tsdb_batching_max_events=7,
+        tsdb_batching_timeout_secs=8,
+    )
+
+    call = _find_step_call(graph, "timescaledb_error")
+    assert call.kwargs["max_events"] == 7
+    assert call.kwargs["flush_after_seconds"] == 8
+
+
 class _MockTrigger:
     def __init__(self, kind: str):
         self.kind = kind

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -2606,7 +2606,7 @@ class TestFeatureStore(TestMLRunSystem):
         reason="mlrun.mlconf.redis.url is not set, skipping until testing against real redis",
     )
     @pytest.mark.parametrize(
-        "target_redis, ", ["", "redis://:aaa@localhost:6379", "ds://dsname"]
+        "target_redis", ["", "redis://:aaa@localhost:6379", "ds://dsname"]
     )
     def test_purge_redis(self, target_redis):
         key = "patient_id"


### PR DESCRIPTION
### 📝 Description

As part of [ML-12380](https://ecliptos.atlassian.net/browse/ML-12380) two fixes introduce:
1) Preventing application silent error query of parquet and ended up without data. This suggest miss alignment with  the TSDB that we want the user to know about.
2) Minimize race condition between parquet and TSDB by lowering the parquet flush time to 30 seconds.

---

### 🛠️ Changes Made

1. Error raise - when no data found when calling `sample_df` from the application using application context.
2. Config change for the parquet flush time + introducing TimeScaleDB configs for flush time and max events.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

CI + Smoke.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12380
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->


[ML-12380]: https://iguazio.atlassian.net/browse/ML-12380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ