### PR TITLE
[Tests] Fix `test_purge_redis`

### DIFF
--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -2606,7 +2606,7 @@ class TestFeatureStore(TestMLRunSystem):
         reason="mlrun.mlconf.redis.url is not set, skipping until testing against real redis",
     )
     @pytest.mark.parametrize(
-        "target_redis, ", ["", "redis://:aaa@localhost:6379", "ds://dsname"]
+        "target_redis", ["", "redis://:aaa@localhost:6379", "ds://dsname"]
     )
     def test_purge_redis(self, target_redis):
         key = "patient_id"


### PR DESCRIPTION
### 📝 Description
Fixes smoke failure in CI (e.g. https://github.com/mlrun/mlrun/actions/runs/27523167299/job/81345871823):
```
tests/system/feature_store/test_feature_store.py::TestFeatureStore::test_purge_redis: in "parametrize" the number of names (1):
  ['target_redis']
must be equal to the number of values (0):
```

**Why did this break now?**
pytest 9.1.0 was released yesterday (2026-06-14), and appears to have broken bwc for this usage. Furthermore, the smoke job appears not to use a requirements lock file.

---

### 🛠️ Changes Made
Fixed a system test.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
Smoke job must now pass.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

