### PR TITLE
[CI] Fix release promotion failing on whitespace in version input

### DIFF
--- a/.github/workflows/private-release.yaml
+++ b/.github/workflows/private-release.yaml
@@ -76,6 +76,9 @@ jobs:
         id: resolve
         run: |
 
+          # Trim surrounding whitespace; a stray space breaks the Docker reference downstream
+          VERSION_INPUT="$(echo -n "$VERSION_INPUT" | xargs)"
+
           # map the input to the actual mode
           declare -A bump_version_mode=(["bump-rc"]="rc" ["stable"]="rc-grad")
           NEXT_VERSION_MODE=${bump_version_mode[$BUMP_VERSION_MODE_INPUT]}

--- a/.github/workflows/release-promotion.yaml
+++ b/.github/workflows/release-promotion.yaml
@@ -100,6 +100,9 @@ jobs:
       - name: Resolve inputs
         id: resolve
         run: |
+          # Trim surrounding whitespace; a stray space breaks the Docker reference in skopeo
+          VERSION_INPUT="$(echo -n "$VERSION_INPUT" | xargs)"
+          PREVIOUS_VERSION_INPUT="$(echo -n "$PREVIOUS_VERSION_INPUT" | xargs)"
           echo "version=$VERSION_INPUT" >> $GITHUB_OUTPUT
           echo "previous_version=$PREVIOUS_VERSION_INPUT" >> $GITHUB_OUTPUT
           echo "Promoting version: $VERSION_INPUT"


### PR DESCRIPTION
A trailing space in the dispatched `version` input propagated unsanitized
into the image references, so skopeo (promote) and docker pull (ui-promotion)
both rejected the tag with "invalid reference format", failing every promote
matrix job and the UI promotion.

Trim the version (and previous_version) in the prepare-inputs step so a stray
space no longer breaks the Docker reference. Also trims the explicit version
input in private-release defensively.

### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
