### PR TITLE
[Model Monitoring] Remove deprecated fetch_credentials_from_sys_config param

### DIFF
--- a/docs/change-log/index.md
+++ b/docs/change-log/index.md
@@ -1608,7 +1608,6 @@ with a drill-down to view the steps and their details. [Tech Preview]
 | v1.12.0| v1.10.0 |When using underscores as a name, the code no longer replaces them with dashes. |Use dashes|
 | v1.12.0| v1.10.0 |`any `mlrun.api.schemas.*`  import |`mlrun.common.schemas.*`| 
 | v1.12.0| v1.10.0 |processing old batch model endpoint in `mlrun.model_monitoring.controller `  |NA|
-| v1.12.0| v1.10.0 |`fetch_credentials_from_sys_config`                                       |NA|
 
 
 
@@ -1622,6 +1621,7 @@ with a drill-down to view the steps and their details. [Tech Preview]
 | v1.12.0 (deprecated v1.10.0)|`get_or_create_model_endpoint` in `mlrun.model_monitoring.api`|deploy a monitored serving function or use `project.list_model_endpoints()`|
 | v1.12.0 (deprecated v1.10.0)|`record_results` in `mlrun.model_monitoring.api`|run a monitored serving function as a job|
 | v1.12.0 (deprecated v1.10.0)|`GET /projects/{project}/model-endpoints/metrics`|`GET /projects/{project}/model-monitoring/metrics`|
+| v1.12.0 (deprecated v1.10.0)|`fetch_credentials_from_sys_config` param in `enable_model_monitoring`|Set model-monitoring credentials explicitly via `set_model_monitoring_credentials`|
 | v1.11.0|TDEngine support is removed in v1.11.0. Data is not migrated.|MLRun supports TimescaleDB instead.|
 | v1.11.0|`get_cached_artifact` of MLClientCtx                                              |`get_artifact`|
 | v1.11.0|`remove_function` of MLrunProject                            |`delete_function`|

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -1079,7 +1079,6 @@ class RunDBInterface(ABC):
         base_period: int = 10,
         image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
-        fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,
         lag_event_cooldown: int | None = None,
         otlp_enabled: bool = False,

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -4110,7 +4110,6 @@ class HTTPRunDB(RunDBInterface):
         base_period: int = 10,
         image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
-        fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,
         lag_event_cooldown: int | None = None,
         otlp_enabled: bool = False,
@@ -4131,7 +4130,6 @@ class HTTPRunDB(RunDBInterface):
                                                   Defaults to
                                                   ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
-        :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
         :param lag_threshold:                     Lag threshold in minutes for writer lag detection.
         :param lag_event_cooldown:                Cooldown in minutes between consecutive lag events per worker.
         :param otlp_enabled:                      If true, monitoring application results and metrics are also
@@ -4144,7 +4142,6 @@ class HTTPRunDB(RunDBInterface):
         params = {
             "base_period": base_period,
             "deploy_histogram_data_drift_app": deploy_histogram_data_drift_app,
-            "fetch_credentials_from_sys_config": fetch_credentials_from_sys_config,
             "auth_token_name": auth_token_name,
             "otlp_enabled": otlp_enabled,
         }

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -863,7 +863,6 @@ class NopDB(RunDBInterface):
         base_period: int = 10,
         image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
-        fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,
         lag_event_cooldown: int | None = None,
         otlp_enabled: bool = False,

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -2883,7 +2883,6 @@ class MlrunProject(ModelObj):
         *,
         deploy_histogram_data_drift_app: bool = True,
         wait_for_deployment: bool = False,
-        fetch_credentials_from_sys_config: bool = False,  # deprecated
         lag_threshold: int | None = None,
         lag_event_cooldown: int | None = None,
         otlp_enabled: bool = False,
@@ -2922,8 +2921,6 @@ class MlrunProject(ModelObj):
         :param wait_for_deployment:               If true, return only after the deployment is done on the backend.
                                                   Otherwise, deploy the model monitoring infrastructure on the
                                                   background, including the histogram data drift app if selected.
-        :param fetch_credentials_from_sys_config: Deprecated. If true, fetch the credentials from the project
-                                                  configuration.
         :param lag_threshold:                     Duration in minutes that will be considered as lag in the writer.
                                                   Must be at least
                                                   ``model_endpoint_monitoring.lag_detection.min_lag_threshold_minutes``
@@ -2940,12 +2937,6 @@ class MlrunProject(ModelObj):
                                                   ``project.spec.model_monitoring.otlp_enabled``. Per-function
                                                   override via ``set_model_monitoring_function(otlp_enabled=...)``.
         """
-        if fetch_credentials_from_sys_config:
-            warnings.warn(
-                "`fetch_credentials_from_sys_config` is deprecated in 1.10.0 and will be removed in 1.12.0.",
-                # TODO: Remove this in 1.12.0
-                FutureWarning,
-            )
         if base_period < 10:
             logger.warn(
                 "enable_model_monitoring: 'base_period' < 10 minutes is not supported in production environments",
@@ -2957,7 +2948,6 @@ class MlrunProject(ModelObj):
             image=image,
             base_period=base_period,
             deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
-            fetch_credentials_from_sys_config=fetch_credentials_from_sys_config,
             lag_threshold=lag_threshold,
             lag_event_cooldown=lag_event_cooldown,
             otlp_enabled=otlp_enabled,

--- a/server/py/framework/rundb/sqldb.py
+++ b/server/py/framework/rundb/sqldb.py
@@ -1241,7 +1241,6 @@ class SQLRunDB(RunDBInterface):
         base_period: int = 10,
         image: str = "mlrun/mlrun",
         deploy_histogram_data_drift_app: bool = True,
-        fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,
         lag_event_cooldown: int | None = None,
     ) -> None:

--- a/server/py/services/api/api/endpoints/model_monitoring.py
+++ b/server/py/services/api/api/endpoints/model_monitoring.py
@@ -144,13 +144,6 @@ def enable_model_monitoring(
     base_period: int = 10,
     image: str | None = None,
     deploy_histogram_data_drift_app: bool = True,
-    fetch_credentials_from_sys_config: bool = Query(
-        False,
-        deprecated=True,
-        description=(
-            "`fetch_credentials_from_sys_config` is deprecated as of 1.10.0 and will be removed in 1.12.0."
-        ),
-    ),
     lag_threshold: int | None = Query(
         None, description="Lag threshold in minutes for writer lag detection."
     ),
@@ -183,7 +176,6 @@ def enable_model_monitoring(
                                               Defaults to
                                               ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
     :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
-    :param fetch_credentials_from_sys_config: Deprecated. If true, fetch the credentials from the system configuration.
     :param lag_threshold:                     Lag threshold in minutes for writer lag detection.
     :param lag_event_cooldown:                Cooldown in minutes between consecutive lag events per worker.
     :param otlp_enabled:                      If true, export monitoring application results/metrics via OTel.
@@ -194,7 +186,6 @@ def enable_model_monitoring(
         image=image,
         base_period=base_period,
         deploy_histogram_data_drift_app=deploy_histogram_data_drift_app,
-        fetch_credentials_from_sys_config=fetch_credentials_from_sys_config,
         lag_threshold=lag_threshold,
         lag_event_cooldown=lag_event_cooldown,
         otlp_enabled=otlp_enabled,

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -170,7 +170,6 @@ class MonitoringDeployment:
         base_period: int = 10,
         image: str | None = None,
         deploy_histogram_data_drift_app: bool = True,
-        fetch_credentials_from_sys_config: bool = False,
         lag_threshold: int | None = None,
         lag_event_cooldown: int | None = None,
         otlp_enabled: bool = False,
@@ -184,7 +183,6 @@ class MonitoringDeployment:
                                                   stream functions, which are real time nuclio function.
                                                   Defaults to ``mlrun.mlconf.function_defaults.image_by_kind.nuclio``.
         :param deploy_histogram_data_drift_app:   If true, deploy the default histogram-based data drift application.
-        :param fetch_credentials_from_sys_config: If true, fetch the credentials from the system configuration.
         :param lag_threshold:                     Lag threshold in minutes for writer lag detection.
         :param lag_event_cooldown:                Cooldown in minutes between consecutive lag events per worker.
         :param otlp_enabled:                      If true, persist OTel export opt-in to the project spec.
@@ -205,9 +203,6 @@ class MonitoringDeployment:
                     "(mlconf.telemetry.otlp_endpoint is blank)."
                 )
 
-        # check if credentials should be fetched from the system configuration or if they are already been set.
-        if fetch_credentials_from_sys_config:
-            self.set_credentials()
         # reject the request if controller and/or writer pods are already deployed.
         # stream-pod is not checked since by default it is not deleted by disable_model_monitoring.
         if deployed_functions := [


### PR DESCRIPTION
### 📝 Description
Removes `fetch_credentials_from_sys_config` from `enable_model_monitoring`. This is one of the two data-flows deprecations PR #9781 explicitly deferred to their own PRs. The parameter was deprecated in v1.10.0 and targeted for removal in v1.12.0. It is a pure removal with no behavior change for the default deploy path.

---

### 🛠️ Changes Made
- **[Model Monitoring]** Remove the `fetch_credentials_from_sys_config` parameter across its full call chain: the SDK public API (`MlrunProject.enable_model_monitoring`, including the deprecation `FutureWarning` block), the run-DB interface and all implementors (`RunDBInterface`, `HTTPRunDB` request params, `NopDB`, `SQLRunDB`), the FastAPI endpoint (including the deprecated `Query(...)` declaration), and the `MonitoringDeployment` CRUD (including the `if fetch_credentials_from_sys_config: self.set_credentials()` guard). Credentials are set explicitly via `set_model_monitoring_credentials`; the unconditional `check_if_credentials_are_set()` gate is unchanged, so the default deploy path is unaffected and `set_credentials()` keeps its live caller (the `set_model_monitoring_credentials` endpoint).
- **[Docs]** Move the parameter from the changelog "Deprecated APIs" table to the "Removed APIs" table, with the migration note.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit: `server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py`, `tests/model_monitoring/test_lag_detection.py` — 68 passed, 1 skipped.
- No system test exercised this parameter: it gated an opt-in auto-fetch of credentials (default `False`). The credential requirement on the default deploy path is enforced by the unconditional `check_if_credentials_are_set()` call, which is already covered.

---

### 🔗 References
- Ticket link: ML-12672
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

Removes a parameter deprecated since v1.10.0. Callers that passed `fetch_credentials_from_sys_config=True` must instead set monitoring credentials explicitly via `set_model_monitoring_credentials` before enabling monitoring. The default path (flag was `False`) is unaffected.

---

### 🔍️ Additional Notes
- Completes one of the two data-flows deprecations PR #9781 deferred to their own PRs. The remaining deferred item — processing old batch model endpoints in `mlrun.model_monitoring.controller` — is still tracked in the changelog "Deprecated APIs" table and will be removed in its own PR.
