### PR TITLE
[Requirements] Re-lock pytest to 9.1.0, fix test that breaks

### DIFF
--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -3703,9 +3703,9 @@ pyreadline3==3.5.6 ; sys_platform == 'win32' \
     --hash=sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf \
     --hash=sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d
     # via humanfriendly
-pytest==9.0.3 \
-    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
-    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
+pytest==9.1.0 \
+    --hash=sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c \
+    --hash=sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32
     # via
     #   -r dev-requirements.txt
     #   pytest-alembic

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -3767,9 +3767,9 @@ pyreadline3==3.5.6 ; sys_platform == 'win32' \
     --hash=sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf \
     --hash=sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d
     # via humanfriendly
-pytest==9.0.3 \
-    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
-    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
+pytest==9.1.0 \
+    --hash=sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c \
+    --hash=sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32
     # via
     #   -r dev-requirements.txt
     #   pytest-alembic

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -1227,14 +1227,15 @@ def test_project_with_invalid_node_selector(
     _assert_project_response(project, response)
 
 
-# leader format is only relevant to follower mode
-@pytest.mark.parametrize("project_member_mode", ["follower"], indirect=True)
 def test_list_projects_leader_format(
     db: Session, client: TestClient, project_member_mode: str
 ) -> None:
     """
     See list_projects in follower.py for explanation on the rationality behind the leader format
     """
+    # leader format is only relevant to follower mode
+    if project_member_mode != "follower":
+        pytest.skip("leader format is only relevant to follower mode")
     # create some projects in the db (mocking projects left there from before when leader format was used)
     project_names = []
     for _ in range(5):

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -43,7 +43,7 @@ TEST_PROJECT = "test-application-results"
 V3IO_TABLE_CONTAINER = f"bigdata/{TEST_PROJECT}"
 
 
-@pytest.fixture(params=[(0, "1.7.0", "result")])
+@pytest.fixture
 def event(request: pytest.FixtureRequest) -> _AppResultEvent:
     now = datetime.datetime.now()
     start_infer_time = now - datetime.timedelta(minutes=5)
@@ -204,7 +204,7 @@ class TestTSDB:
 
     @staticmethod
     @pytest.mark.parametrize(
-        ("event"),
+        "event",
         [(0, "1.6.0", "result"), (0, "1.7.0", "result")],
         indirect=["event"],
     )
@@ -253,7 +253,7 @@ class TestTSDB:
 
     @staticmethod
     @pytest.mark.parametrize(
-        ("event"),
+        "event",
         [(0, "1.7.0", "metric")],
         indirect=["event"],
     )


### PR DESCRIPTION
### 📝 Description
This should unblock re-locking all requirements, as attempted in #9811 (failure – https://github.com/mlrun/mlrun/actions/runs/27492949718/job/81261520651?pr=9811).

---

### 🛠️ Changes Made
* Ran `MLRUN_UV_UPGRADE_FLAG="--upgrade-package pytest" make upgrade-mlrun-deps-lock`
* Fixed `tests/model_monitoring/test_writer.py`

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
To be validated by CI.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No


---

### 🔍️ Additional Notes

