### PR TITLE
[Model Monitoring] Fix controller deploy failing on existing Kafka topic

### DIFF
--- a/server/py/services/api/api/endpoints/nuclio.py
+++ b/server/py/services/api/api/endpoints/nuclio.py
@@ -572,7 +572,6 @@ def _deploy_nuclio_runtime(
                 function=fn,
                 function_name=fn.metadata.name,
                 stream_args=config.model_endpoint_monitoring.application_stream_args,
-                ignore_stream_already_exists_failure=True,
             )
 
         if serving_to_monitor:

--- a/server/py/services/api/crud/model_monitoring/deployment.py
+++ b/server/py/services/api/crud/model_monitoring/deployment.py
@@ -365,9 +365,7 @@ class MonitoringDeployment:
                 f"Deploying {mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER} function",
                 project=self.project,
             )
-            fn = self._get_model_monitoring_controller_function(
-                image=controller_image, ignore_stream_already_exists_failure=overwrite
-            )
+            fn = self._get_model_monitoring_controller_function(image=controller_image)
 
             minutes = base_period
             hours = days = 0
@@ -461,7 +459,6 @@ class MonitoringDeployment:
         function: mlrun.runtimes.ServingRuntime,
         function_name: str,
         stream_args: mlrun.config.Config,
-        ignore_stream_already_exists_failure: bool = False,
     ) -> mlrun.runtimes.ServingRuntime:
         """
         Add stream source for the nuclio serving function. The function's stream trigger can be
@@ -476,8 +473,6 @@ class MonitoringDeployment:
                                                      trigger.
         :param function_name:                        The name of the function that be applied with the stream trigger.
         :param stream_args:                          Stream args from the config.
-        :param ignore_stream_already_exists_failure: If True, ignores `TopicAlreadyExistsError` error on
-                                                     MM-infra-functions deployment when using kafka.
 
         :return: `ServingRuntime` object with stream trigger.
         """
@@ -491,7 +486,6 @@ class MonitoringDeployment:
                 function=function,
                 function_name=function_name,
                 stream_args=stream_args,
-                ignore_stream_already_exists_failure=ignore_stream_already_exists_failure,
             )
 
         elif isinstance(
@@ -526,7 +520,6 @@ class MonitoringDeployment:
         function: mlrun.runtimes.ServingRuntime,
         function_name: str,
         stream_args: mlrun.config.Config,
-        ignore_stream_already_exists_failure: bool,
     ) -> None:
         # Generate Kafka stream source
         topic = mlrun.common.model_monitoring.helpers.get_kafka_topic(
@@ -563,8 +556,7 @@ class MonitoringDeployment:
                 num_partitions=num_partitions, replication_factor=replication_factor
             )
         except kafka.errors.TopicAlreadyExistsError as exc:
-            if not ignore_stream_already_exists_failure:
-                raise exc
+            # Idempotent: topic persists across deploys. Other errors propagate.
             logger.info(
                 "Kafka topic of model monitoring stream already exists. "
                 "Skipping topic creation",
@@ -867,7 +859,6 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.STREAM,
             stream_args=config.model_endpoint_monitoring.serving_stream,
-            ignore_stream_already_exists_failure=True,
         )
 
         # Add an explicit HTTP trigger so the stream pod is reachable via HTTP.
@@ -880,16 +871,12 @@ class MonitoringDeployment:
 
         return function
 
-    def _get_model_monitoring_controller_function(
-        self, image: str, ignore_stream_already_exists_failure: bool
-    ):
+    def _get_model_monitoring_controller_function(self, image: str):
         """
         Initialize model monitoring controller function.
 
-        :param image:                               Base docker image to use for building the function container.
-        :param ignore_stream_already_exists_failure: If True, ignores `TopicAlreadyExistsError` error on
-                                                     MM-infra-functions deployment when using kafka.
-        :return:                                    A function object from a mlrun runtime class.
+        :param image: Base docker image to use for building the function container.
+        :return:      A function object from a mlrun runtime class.
         """
         # Create job function runtime for the controller
         function = mlrun.code_to_function(
@@ -915,7 +902,6 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.APPLICATION_CONTROLLER,
             stream_args=config.model_endpoint_monitoring.controller_stream_args,
-            ignore_stream_already_exists_failure=ignore_stream_already_exists_failure,
         )
 
         function = self._apply_access_key_and_mount_function(
@@ -1058,7 +1044,6 @@ class MonitoringDeployment:
             function=function,
             function_name=mm_constants.MonitoringFunctionNames.WRITER,
             stream_args=config.model_endpoint_monitoring.writer_stream_args,
-            ignore_stream_already_exists_failure=True,
         )
 
         # Apply feature store run configurations on the serving function

--- a/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
+++ b/server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py
@@ -205,7 +205,6 @@ def test_apply_and_create_kafka_source(
         function=fn,
         function_name="test-confluent-trigger",
         stream_args=mlrun.mlconf.model_endpoint_monitoring.serving_stream,
-        ignore_stream_already_exists_failure=True,
     )
 
     create_topics_mock.assert_called_once_with(
@@ -249,7 +248,6 @@ def test_kafka_source_no_hpa_target_when_not_configured(
             function=fn,
             function_name="model-monitoring-stream",
             stream_args=stream_args,
-            ignore_stream_already_exists_failure=True,
         )
     finally:
         stream_args.kafka.target_cpu = original_target_cpu
@@ -598,7 +596,6 @@ def test_kafka_consumer_group_is_per_function_with_profile_prefix(
         function=fn,
         function_name="model-monitoring-stream",
         stream_args=mlrun.mlconf.model_endpoint_monitoring.serving_stream,
-        ignore_stream_already_exists_failure=True,
     )
 
     topic = _kafka_trigger_topic(fn)
@@ -628,7 +625,6 @@ def test_kafka_consumer_group_defaults_to_serving_when_profile_group_is_none(
         function=fn,
         function_name="model-monitoring-writer",
         stream_args=mlrun.mlconf.model_endpoint_monitoring.writer_stream_args,
-        ignore_stream_already_exists_failure=True,
     )
 
     topic = _kafka_trigger_topic(fn)
@@ -666,7 +662,6 @@ def test_kafka_migration_invoked_on_topic_already_exists(
         function=fn,
         function_name="model-monitoring-stream",
         stream_args=mlrun.mlconf.model_endpoint_monitoring.serving_stream,
-        ignore_stream_already_exists_failure=True,
     )
 
     migrate_offsets_mock.assert_called_once()
@@ -703,7 +698,6 @@ def test_kafka_migration_invoked_for_all_mm_functions(
         function=fn,
         function_name="model-monitoring-writer",
         stream_args=mlrun.mlconf.model_endpoint_monitoring.writer_stream_args,
-        ignore_stream_already_exists_failure=True,
     )
 
     migrate_offsets_mock.assert_called_once()
@@ -737,7 +731,6 @@ def test_kafka_migration_raises_on_kafka_failure(
                 function=fn,
                 function_name="model-monitoring-stream",
                 stream_args=mlrun.mlconf.model_endpoint_monitoring.serving_stream,
-                ignore_stream_already_exists_failure=True,
             )
 
 
@@ -745,14 +738,20 @@ def test_kafka_migration_raises_on_kafka_failure(
     "mlrun.datastore.sources.KafkaSource.create_topics",
     side_effect=kafka.errors.TopicAlreadyExistsError(),
 )
-def test_kafka_migration_not_invoked_when_ignore_flag_false(
+@patch(
+    "services.api.crud.model_monitoring.deployment.MonitoringDeployment"
+    "._migrate_kafka_consumer_group_offsets",
+)
+def test_controller_tolerates_existing_kafka_topic(
+    migrate_offsets_mock: Mock,
     create_topics_mock: Mock,
     monitoring_deployment: mm_dep.MonitoringDeployment,
 ) -> None:
-    """When ``ignore_stream_already_exists_failure=False`` (e.g. controller
-    deploy without overwrite), ``TopicAlreadyExistsError`` must propagate
-    as it always has — migration logic is only triggered on the tolerant
-    branch."""
+    """The controller must tolerate an existing Kafka topic (it
+    persists across deploys, so re-enabling monitoring hits it) instead of
+    failing with ``TopicAlreadyExistsError``. On this upgrade path it still
+    runs the consumer-group offset migration, so the controller resumes from
+    its committed offset rather than replaying the topic."""
     kafka_profile = DatastoreProfileKafkaStream(
         name="test-kafka-profile",
         brokers=["localhost:9092"],
@@ -760,18 +759,14 @@ def test_kafka_migration_not_invoked_when_ignore_flag_false(
     )
 
     fn = mlrun.runtimes.ServingRuntime()
-    with patch.object(
-        monitoring_deployment, "_migrate_kafka_consumer_group_offsets"
-    ) as migrate_offsets_mock:
-        with pytest.raises(kafka.errors.TopicAlreadyExistsError):
-            monitoring_deployment._apply_and_create_kafka_source(
-                kafka_profile=kafka_profile,
-                function=fn,
-                function_name="model-monitoring-controller",
-                stream_args=mlrun.mlconf.model_endpoint_monitoring.controller_stream_args,
-                ignore_stream_already_exists_failure=False,
-            )
-    migrate_offsets_mock.assert_not_called()
+    monitoring_deployment._apply_and_create_kafka_source(
+        kafka_profile=kafka_profile,
+        function=fn,
+        function_name="model-monitoring-controller",
+        stream_args=mlrun.mlconf.model_endpoint_monitoring.controller_stream_args,
+    )
+
+    migrate_offsets_mock.assert_called_once()
 
 
 # --- ML-12543: project.spec.model_monitoring persistence + OTel validation -----


### PR DESCRIPTION
### 📝 Description

Re-enabling model monitoring with the default `overwrite=False` failed with `TopicAlreadyExistsError` (HTTP 500) when the controller function was not in a `ready` state but its Kafka topic already existed from a prior enablement.

The controller was the only model-monitoring infra function that did not tolerate an already-existing Kafka topic: `deploy_model_monitoring_controller` passed `ignore_stream_already_exists_failure=overwrite`, while the stream, writer and application functions always passed `True`. Kafka topics for MM infra functions have deterministic, function-scoped names and persist across deploys, so an existing topic is expected on re-enable and is never an error — tying tolerance to `overwrite` was wrong and was the only path that failed.

---

### 🛠️ Changes Made

- Make Kafka topic-creation tolerance unconditional for all MM infra functions (the controller now matches stream/writer/apps).
- Remove the now-dead `ignore_stream_already_exists_failure` parameter from `apply_and_create_stream_trigger`, `_apply_and_create_kafka_source`, and `_get_model_monitoring_controller_function` so the inconsistency cannot be reintroduced.
- Only `TopicAlreadyExistsError` is swallowed; every other Kafka failure still propagates and fails the deploy.
- The one-time consumer-group offset migration (legacy shared group → per-function groups) is unchanged and now also runs for the controller on upgrade, so it resumes from committed offsets instead of replaying the topic.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing

Unit tests in `server/py/services/api/tests/unit/crud/model_monitoring/test_deployment.py`:
- `test_controller_tolerates_existing_kafka_topic` — the controller tolerates an existing topic (no `TopicAlreadyExistsError`) and still runs the consumer-group offset migration on the upgrade path.
- Updated the Kafka-source / migration tests for the removed parameter and dropped the obsolete "raise when flag is false" test (that branch no longer exists).
- Full file: 38 passed, 1 skipped. `make lint` is green.
\

---

### 🔗 References
- Ticket link: ML-12589
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---


