### PR TITLE
[Model Monitoring] Remove deprecated old-batch controller monitoring path

### DIFF
--- a/docs/change-log/index.md
+++ b/docs/change-log/index.md
@@ -1607,7 +1607,6 @@ with a drill-down to view the steps and their details. [Tech Preview]
 | v1.12.0| v1.10.0 |`artifact_path` and `out_path` in `BaseRuntime.run`| `output path`|
 | v1.12.0| v1.10.0 |When using underscores as a name, the code no longer replaces them with dashes. |Use dashes|
 | v1.12.0| v1.10.0 |`any `mlrun.api.schemas.*`  import |`mlrun.common.schemas.*`| 
-| v1.12.0| v1.10.0 |processing old batch model endpoint in `mlrun.model_monitoring.controller `  |NA|
 
 
 
@@ -1622,6 +1621,7 @@ with a drill-down to view the steps and their details. [Tech Preview]
 | v1.12.0 (deprecated v1.10.0)|`record_results` in `mlrun.model_monitoring.api`|run a monitored serving function as a job|
 | v1.12.0 (deprecated v1.10.0)|`GET /projects/{project}/model-endpoints/metrics`|`GET /projects/{project}/model-monitoring/metrics`|
 | v1.12.0 (deprecated v1.10.0)|`fetch_credentials_from_sys_config` param in `enable_model_monitoring`|Set model-monitoring credentials explicitly via `set_model_monitoring_credentials`|
+| v1.12.0 (deprecated v1.10.0)|Monitoring old batch model endpoints via the real-time controller path (parquet windows) in `mlrun.model_monitoring.controller`|Run job-based serving to invoke and analyze offline batch model endpoints|
 | v1.11.0|TDEngine support is removed in v1.11.0. Data is not migrated.|MLRun supports TimescaleDB instead.|
 | v1.11.0|`get_cached_artifact` of MLClientCtx                                              |`get_artifact`|
 | v1.11.0|`remove_function` of MLrunProject                            |`delete_function`|

--- a/docs/model-monitoring/index.md
+++ b/docs/model-monitoring/index.md
@@ -29,7 +29,7 @@ When you call {py:meth}`~mlrun.projects.MlrunProject.enable_model_monitoring`, y
 
 The model monitoring process flow starts with collecting operational data from a function in the model serving pod. The model 
 monitoring stream pod forwards data to a Parquet database. MLRun supports integers, float, strings, images.
-The controller periodically checks the Parquet DB for new data and forwards it to the relevant application. 
+The controller periodically queries the time series database (TSDB) for new prediction data and forwards it to the relevant application. 
 Each model monitoring application is a separate nuclio real-time function. Each one listens to a stream that is filled by 
 the monitoring controller at each `base_period` interval.
 The stream function examines the log entry, processes it into statistics which are then written to the statistics databases 

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -317,6 +317,7 @@ class MonitoringApplicationController:
         self.tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
             project=self.project
         )
+        self._legacy_endpoints_warned = False
 
     @property
     def controller_stream(
@@ -580,17 +581,14 @@ class MonitoringApplicationController:
                         last_request=last_stream_timestamp,
                         endpoint_mode=endpoint_mode,
                     ):
-                        data_in_window = False
                         # Get the relevant window data from the TSDB
                         prediction_metric = self.tsdb_connector.read_predictions(
                             start=start_infer_time,
                             end=end_infer_time,
                             endpoint_id=endpoint_id,
                         )
-                        if prediction_metric.data:
-                            data_in_window = True
 
-                        if not data_in_window:
+                        if not prediction_metric.data:
                             logger.info(
                                 "No data found for the given interval",
                                 start=start_infer_time,
@@ -731,17 +729,19 @@ class MonitoringApplicationController:
             modes=[mm_constants.EndpointMode.REAL_TIME],
         ).endpoints
 
-        legacy_endpoints = self.project_obj.list_model_endpoints(
-            tsdb_metrics=False,
-            modes=[mm_constants.EndpointMode.BATCH_LEGACY],
-        ).endpoints
-        if legacy_endpoints:
-            logger.warning(
-                "Legacy batch model endpoints are no longer monitored by the controller; "
-                "re-create them via job-based serving to resume monitoring",
-                project=self.project,
-                count=len(legacy_endpoints),
-            )
+        if not self._legacy_endpoints_warned:
+            legacy_endpoints = self.project_obj.list_model_endpoints(
+                tsdb_metrics=False,
+                modes=[mm_constants.EndpointMode.BATCH_LEGACY],
+            ).endpoints
+            if legacy_endpoints:
+                logger.warning(
+                    "Legacy batch model endpoints are no longer monitored by the controller; "
+                    "re-create them via job-based serving to resume monitoring",
+                    project=self.project,
+                    count=len(legacy_endpoints),
+                )
+            self._legacy_endpoints_warned = True
 
         if not endpoints:
             logger.info("No model endpoints found", project=self.project)

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -11,13 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections
 import concurrent.futures
 import datetime
 import json
 import os
 import traceback
-import warnings
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from types import TracebackType
@@ -29,19 +27,17 @@ import pandas as pd
 
 import mlrun
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
-import mlrun.feature_store as fstore
 import mlrun.model_monitoring
 import mlrun.model_monitoring.db._schedules as schedules
 import mlrun.model_monitoring.helpers
 import mlrun.platforms.iguazio
-from mlrun.common.schemas import EndpointType
 from mlrun.common.schemas.model_monitoring.constants import (
     ControllerEvent,
     ControllerEventEndpointPolicy,
 )
 from mlrun.errors import err_to_str
 from mlrun.model_monitoring.helpers import batch_dict2timedelta
-from mlrun.utils import datetime_now, logger
+from mlrun.utils import logger
 
 _SECONDS_IN_DAY = int(datetime.timedelta(days=1).total_seconds())
 _SECONDS_IN_MINUTE = 60
@@ -232,28 +228,16 @@ class _BatchWindowGenerator(AbstractContextManager):
         cls,
         last_request: datetime.datetime,
         endpoint_mode: mm_constants.EndpointMode,
-        not_old_batch_endpoint: bool,
     ) -> float:
         """
         Get the last updated time of a model endpoint.
         """
 
         if endpoint_mode == mm_constants.EndpointMode.REAL_TIME:
-            last_updated = last_request.timestamp() - cast(
+            return last_request.timestamp() - cast(
                 float,
                 mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs,
             )
-            if not not_old_batch_endpoint:
-                # If the endpoint does not have a stream, `last_updated` should be
-                # the minimum between the current time and the last updated time.
-                # This compensates for the bumping mechanism - see
-                # `update_model_endpoint_last_request`.
-                last_updated = min(datetime_now().timestamp(), last_updated)
-                logger.debug(
-                    "The endpoint does not have a stream", last_updated=last_updated
-                )
-
-            return last_updated
         return last_request.timestamp()
 
     def get_intervals(
@@ -263,7 +247,6 @@ class _BatchWindowGenerator(AbstractContextManager):
         first_request: datetime.datetime,
         last_request: datetime.datetime,
         endpoint_mode: mm_constants.EndpointMode,
-        not_old_batch_endpoint: bool,
     ) -> Iterator[_Interval]:
         """
         Get the batch window for a specific endpoint and application.
@@ -275,9 +258,7 @@ class _BatchWindowGenerator(AbstractContextManager):
             schedules_file=self._schedules_file,
             application=application,
             timedelta_seconds=self._timedelta,
-            last_updated=self._get_last_updated_time(
-                last_request, endpoint_mode, not_old_batch_endpoint
-            ),
+            last_updated=self._get_last_updated_time(last_request, endpoint_mode),
             first_request=first_request.timestamp(),
             endpoint_mode=endpoint_mode,
         )
@@ -302,8 +283,6 @@ class MonitoringApplicationController:
     Note that the MonitoringApplicationController object requires access keys along with valid project configurations.
     """
 
-    _MAX_FEATURE_SET_PER_WORKER = 1000
-
     def __init__(self) -> None:
         """Initialize Monitoring Application Controller"""
         self.project = cast(str, mlrun.mlconf.active_project)
@@ -314,10 +293,6 @@ class MonitoringApplicationController:
 
         self.model_monitoring_access_key = self._get_model_monitoring_access_key()
         self.v3io_access_key = mlrun.mlconf.get_v3io_access_key()
-        store, _, _ = mlrun.store_manager.get_or_create_store(
-            mlrun.mlconf.artifact_path
-        )
-        self.storage_options = store.get_storage_options()
         self._controller_stream: (
             Union[
                 mlrun.platforms.iguazio.OutputStream,
@@ -339,9 +314,6 @@ class MonitoringApplicationController:
                 mlrun.platforms.iguazio.KafkaOutputStream,
             ],
         ] = {}
-        self.feature_sets: collections.OrderedDict[
-            str, mlrun.feature_store.FeatureSet
-        ] = collections.OrderedDict()
         self.tsdb_connector = mlrun.model_monitoring.get_tsdb_connector(
             project=self.project
         )
@@ -533,7 +505,6 @@ class MonitoringApplicationController:
         try:
             project_name = event[ControllerEvent.PROJECT]
             endpoint_id = event[ControllerEvent.ENDPOINT_ID]
-            not_old_batch_endpoint = True
             if (
                 event[ControllerEvent.KIND]
                 == mm_constants.ControllerEventKind.BATCH_COMPLETE
@@ -590,10 +561,6 @@ class MonitoringApplicationController:
 
                 endpoint_mode = mm_constants.EndpointMode.REAL_TIME
 
-                not_old_batch_endpoint = (
-                    event[ControllerEvent.ENDPOINT_TYPE] != EndpointType.BATCH_EP
-                )
-
             logger.info(
                 "Starting to analyze", timestamp=last_stream_timestamp.isoformat()
             )
@@ -612,49 +579,16 @@ class MonitoringApplicationController:
                         first_request=first_request,
                         last_request=last_stream_timestamp,
                         endpoint_mode=endpoint_mode,
-                        not_old_batch_endpoint=not_old_batch_endpoint,
                     ):
                         data_in_window = False
-                        if not_old_batch_endpoint:
-                            # Serving endpoint - get the relevant window data from the TSDB
-                            prediction_metric = self.tsdb_connector.read_predictions(
-                                start=start_infer_time,
-                                end=end_infer_time,
-                                endpoint_id=endpoint_id,
-                            )
-                            if prediction_metric.data:
-                                data_in_window = True
-                        else:
-                            # Old batch endpoint - get the relevant window data from the parquet target
-                            warnings.warn(
-                                "Analyzing batch model endpoints with real time processing events is "
-                                "deprecated in 1.10.0 and will be removed in 1.12.0. "
-                                "Instead, use job-based serving to invoke and analyze offline batch model"
-                                "endpoints.",
-                                # TODO: Remove this in 1.12.0
-                                FutureWarning,
-                            )
-
-                            if endpoint_id not in self.feature_sets:
-                                self.feature_sets[endpoint_id] = fstore.get_feature_set(
-                                    event[ControllerEvent.FEATURE_SET_URI]
-                                )
-                            self.feature_sets.move_to_end(endpoint_id, last=False)
-                            if (
-                                len(self.feature_sets)
-                                > self._MAX_FEATURE_SET_PER_WORKER
-                            ):
-                                self.feature_sets.popitem(last=True)
-                            m_fs = self.feature_sets.get(endpoint_id)
-
-                            df = m_fs.to_dataframe(
-                                start_time=start_infer_time,
-                                end_time=end_infer_time,
-                                time_column=mm_constants.EventFieldType.TIMESTAMP,
-                                storage_options=self.storage_options,
-                            )
-                            if len(df) > 0:
-                                data_in_window = True
+                        # Get the relevant window data from the TSDB
+                        prediction_metric = self.tsdb_connector.read_predictions(
+                            start=start_infer_time,
+                            end=end_infer_time,
+                            endpoint_id=endpoint_id,
+                        )
+                        if prediction_metric.data:
+                            data_in_window = True
 
                         if not data_in_window:
                             logger.info(
@@ -794,11 +728,20 @@ class MonitoringApplicationController:
         applications_names = []
         endpoints = self.project_obj.list_model_endpoints(
             tsdb_metrics=False,
-            modes=[
-                mm_constants.EndpointMode.REAL_TIME,
-                mm_constants.EndpointMode.BATCH_LEGACY,
-            ],
+            modes=[mm_constants.EndpointMode.REAL_TIME],
         ).endpoints
+
+        legacy_endpoints = self.project_obj.list_model_endpoints(
+            tsdb_metrics=False,
+            modes=[mm_constants.EndpointMode.BATCH_LEGACY],
+        ).endpoints
+        if legacy_endpoints:
+            logger.warning(
+                "Legacy batch model endpoints are no longer monitored by the controller; "
+                "re-create them via job-based serving to resume monitoring",
+                project=self.project,
+                count=len(legacy_endpoints),
+            )
 
         if not endpoints:
             logger.info("No model endpoints found", project=self.project)

--- a/mlrun/model_monitoring/controller.py
+++ b/mlrun/model_monitoring/controller.py
@@ -726,21 +726,30 @@ class MonitoringApplicationController:
         applications_names = []
         endpoints = self.project_obj.list_model_endpoints(
             tsdb_metrics=False,
-            modes=[mm_constants.EndpointMode.REAL_TIME],
+            modes=[
+                mm_constants.EndpointMode.REAL_TIME,
+                mm_constants.EndpointMode.BATCH_LEGACY,
+            ],
         ).endpoints
 
-        if not self._legacy_endpoints_warned:
-            legacy_endpoints = self.project_obj.list_model_endpoints(
-                tsdb_metrics=False,
-                modes=[mm_constants.EndpointMode.BATCH_LEGACY],
-            ).endpoints
-            if legacy_endpoints:
-                logger.warning(
-                    "Legacy batch model endpoints are no longer monitored by the controller; "
-                    "re-create them via job-based serving to resume monitoring",
-                    project=self.project,
-                    count=len(legacy_endpoints),
-                )
+        legacy_endpoints = [
+            endpoint
+            for endpoint in endpoints
+            if endpoint.metadata.mode == mm_constants.EndpointMode.BATCH_LEGACY
+        ]
+        endpoints = [
+            endpoint
+            for endpoint in endpoints
+            if endpoint.metadata.mode != mm_constants.EndpointMode.BATCH_LEGACY
+        ]
+
+        if legacy_endpoints and not self._legacy_endpoints_warned:
+            logger.warning(
+                "Legacy batch model endpoints are no longer monitored by the controller; "
+                "re-create them via job-based serving to resume monitoring",
+                project=self.project,
+                count=len(legacy_endpoints),
+            )
             self._legacy_endpoints_warned = True
 
         if not endpoints:

--- a/mlrun/model_monitoring/helpers.py
+++ b/mlrun/model_monitoring/helpers.py
@@ -28,7 +28,6 @@ import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.data_types.infer
 import mlrun.datastore.datastore_profile
 import mlrun.platforms.iguazio
-from mlrun.common.schemas import ModelEndpoint
 from mlrun.common.schemas.model_monitoring.model_endpoints import (
     ModelEndpointMonitoringMetric,
     compose_full_name,
@@ -414,39 +413,6 @@ def _get_monitoring_time_window_from_controller_run(
         mm_constants.EventFieldType.DAYS: 0,
     }
     return batch_dict2timedelta(batch_dict)
-
-
-def update_model_endpoint_last_request(
-    project: str,
-    model_endpoint: ModelEndpoint,
-    current_request: datetime.datetime,
-    db: "RunDBInterface",
-) -> None:
-    """
-    Update the last request field of the model endpoint to be after the current request time.
-
-    :param project:         Project name.
-    :param model_endpoint:  Model endpoint object.
-    :param current_request: current request time
-    :param db:              DB interface.
-    """
-
-    logger.info(
-        "Update model endpoint last request time (EP with serving)",
-        project=project,
-        endpoint_id=model_endpoint.metadata.uid,
-        name=model_endpoint.metadata.name,
-        function_name=model_endpoint.spec.function_name,
-        last_request=model_endpoint.status.last_request,
-        current_request=current_request,
-    )
-    db.patch_model_endpoint(
-        project=project,
-        endpoint_id=model_endpoint.metadata.uid,
-        name=model_endpoint.metadata.name,
-        function_name=model_endpoint.spec.function_name,
-        attributes={mm_constants.EventFieldType.LAST_REQUEST: current_request},
-    )
 
 
 def calculate_inputs_statistics(

--- a/tests/feature-store/test_common.py
+++ b/tests/feature-store/test_common.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
+from mlrun.feature_store.api import norm_column_name
 from mlrun.feature_store.common import parse_feature_string
 
 
@@ -30,3 +33,18 @@ def test_parse_feature_string_with_alias():
     assert feature_set == "fset"
     assert feature == "feature"
     assert alias == "alias"
+
+
+# ML-12672
+@pytest.mark.parametrize(
+    ("raw_name", "expected"),
+    [
+        ("feat 1", "feat_1"),
+        ("b (C)", "b_C"),
+        ("Last   for df ", "Last___for_df_"),
+        ("class (0-4) ", "class_0-4_"),
+        ("already_ok", "already_ok"),
+    ],
+)
+def test_norm_column_name_special_chars(raw_name, expected):
+    assert norm_column_name(raw_name) == expected

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -15,7 +15,7 @@
 import datetime
 from collections.abc import Iterator
 from typing import NamedTuple, Union
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import nuclio
 import numpy as np
@@ -44,6 +44,7 @@ from mlrun.datastore.datastore_profile import (
 )
 from mlrun.db.nopdb import NopDB
 from mlrun.model_monitoring.controller import (
+    MonitoringApplicationController,
     _BatchWindow,
     _BatchWindowGenerator,
     _Interval,
@@ -381,7 +382,6 @@ class TestBatchWindowGenerator:
         last_updated = _BatchWindowGenerator._get_last_updated_time(
             last_request=last_request,
             endpoint_mode=EndpointMode.REAL_TIME,
-            not_old_batch_endpoint=True,
         )
         assert last_updated
         assert last_updated < last_request.timestamp(), (
@@ -391,13 +391,44 @@ class TestBatchWindowGenerator:
         last_updated = _BatchWindowGenerator._get_last_updated_time(
             last_request=last_request,
             endpoint_mode=EndpointMode.BATCH,
-            not_old_batch_endpoint=False,
         )
 
         assert last_updated
         assert last_updated == last_request.timestamp(), (
             "The last updated time should similar to the last request time for batch endpoints"
         )
+
+
+class TestControllerLegacyEndpoints:
+    @staticmethod
+    def test_legacy_batch_endpoints_warn_and_are_not_processed(monkeypatch) -> None:
+        controller = MonitoringApplicationController.__new__(
+            MonitoringApplicationController
+        )
+        controller.project = "test-project"
+
+        def _list_model_endpoints(*, modes, **kwargs):
+            is_legacy = modes == [EndpointMode.BATCH_LEGACY]
+            return Mock(endpoints=[Mock()] if is_legacy else [])
+
+        controller.project_obj = Mock()
+        controller.project_obj.list_model_endpoints.side_effect = _list_model_endpoints
+
+        warnings_seen: list[tuple[str, dict]] = []
+        monkeypatch.setattr(
+            mlrun.model_monitoring.controller.logger,
+            "warning",
+            lambda msg, *args, **kwargs: warnings_seen.append((msg, kwargs)),
+        )
+
+        controller.push_regular_event_to_controller_stream()
+
+        assert len(warnings_seen) == 1
+        message, fields = warnings_seen[0]
+        assert "no longer monitored" in message
+        assert fields["count"] == 1
+        # No real-time endpoints -> the scan returns before processing any endpoint
+        controller.project_obj.list_model_monitoring_functions.assert_not_called()
 
 
 class TestBumpModelEndpointLastRequest:

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -33,8 +33,7 @@ from mlrun.common.model_monitoring.helpers import (
     pad_features_hist,
     pad_hist,
 )
-from mlrun.common.schemas import EndpointMode, EndpointType, ModelEndpoint
-from mlrun.common.schemas.model_monitoring.constants import EventFieldType
+from mlrun.common.schemas import EndpointMode
 from mlrun.datastore import KafkaOutputStream, OutputStream
 from mlrun.datastore.datastore_profile import (
     DatastoreProfile,
@@ -58,7 +57,6 @@ from mlrun.model_monitoring.helpers import (
     get_invocations_fqn,
     get_output_stream,
     get_start_end,
-    update_model_endpoint_last_request,
 )
 
 TIMESTAMP_RESOLUTION_MICRO = 1e-6  # 0.000001 seconds or 1 microsecond
@@ -431,7 +429,7 @@ class TestControllerLegacyEndpoints:
         controller.project_obj.list_model_monitoring_functions.assert_not_called()
 
 
-class TestBumpModelEndpointLastRequest:
+class TestGetMonitoringTimeWindow:
     @staticmethod
     @pytest.fixture
     def project() -> str:
@@ -444,67 +442,8 @@ class TestBumpModelEndpointLastRequest:
 
     @staticmethod
     @pytest.fixture
-    def empty_model_endpoint() -> ModelEndpoint:
-        return ModelEndpoint(
-            metadata=mlrun.common.schemas.ModelEndpointMetadata(
-                name="test", project="test-project"
-            ),
-            spec=mlrun.common.schemas.ModelEndpointSpec(),
-            status=mlrun.common.schemas.ModelEndpointStatus(),
-        )
-
-    @staticmethod
-    @pytest.fixture
-    def last_request() -> str:
-        return "2023-12-05 18:17:50.255143"
-
-    @staticmethod
-    @pytest.fixture
-    def model_endpoint(
-        empty_model_endpoint: ModelEndpoint, last_request: str
-    ) -> ModelEndpoint:
-        empty_model_endpoint.status.last_request = last_request
-        return empty_model_endpoint
-
-    @staticmethod
-    @pytest.fixture
     def function() -> mlrun.runtimes.ServingRuntime:
         return TemplateFunction()
-
-    @staticmethod
-    def test_update_last_request(
-        project: str,
-        model_endpoint: ModelEndpoint,
-        db: NopDB,
-        last_request: str,
-        function: mlrun.runtimes.ServingRuntime,
-    ) -> None:
-        with patch.object(db, "patch_model_endpoint") as patch_patch_model_endpoint:
-            with patch.object(db, "get_function", return_value=function):
-                update_model_endpoint_last_request(
-                    project=project,
-                    model_endpoint=model_endpoint,
-                    current_request=datetime.datetime.fromisoformat(last_request),
-                    db=db,
-                )
-        patch_patch_model_endpoint.assert_called_once()
-        assert patch_patch_model_endpoint.call_args.kwargs["attributes"][
-            EventFieldType.LAST_REQUEST
-        ] == datetime.datetime.fromisoformat(last_request)
-        model_endpoint.metadata.endpoint_type = EndpointType.BATCH_EP
-
-        with patch.object(db, "patch_model_endpoint") as patch_patch_model_endpoint:
-            with patch.object(db, "get_function", return_value=function):
-                update_model_endpoint_last_request(
-                    project=project,
-                    model_endpoint=model_endpoint,
-                    current_request=datetime.datetime.fromisoformat(last_request),
-                    db=db,
-                )
-        patch_patch_model_endpoint.assert_called_once()
-        assert patch_patch_model_endpoint.call_args.kwargs["attributes"][
-            EventFieldType.LAST_REQUEST
-        ] == datetime.datetime.fromisoformat(last_request)
 
     @staticmethod
     def test_get_monitoring_time_window_from_controller_run(

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -404,6 +404,7 @@ class TestControllerLegacyEndpoints:
             MonitoringApplicationController
         )
         controller.project = "test-project"
+        controller._legacy_endpoints_warned = False
 
         def _list_model_endpoints(*, modes, **kwargs):
             is_legacy = modes == [EndpointMode.BATCH_LEGACY]
@@ -419,12 +420,16 @@ class TestControllerLegacyEndpoints:
             lambda msg, *args, **kwargs: warnings_seen.append((msg, kwargs)),
         )
 
+        # The warning is throttled to once per controller process, so running
+        # multiple cycles still produces a single warning.
+        controller.push_regular_event_to_controller_stream()
         controller.push_regular_event_to_controller_stream()
 
         assert len(warnings_seen) == 1
         message, fields = warnings_seen[0]
         assert "no longer monitored" in message
         assert fields["count"] == 1
+        assert controller._legacy_endpoints_warned is True
         # No real-time endpoints -> the scan returns before processing any endpoint
         controller.project_obj.list_model_monitoring_functions.assert_not_called()
 

--- a/tests/model_monitoring/test_helpers.py
+++ b/tests/model_monitoring/test_helpers.py
@@ -406,12 +406,12 @@ class TestControllerLegacyEndpoints:
         controller.project = "test-project"
         controller._legacy_endpoints_warned = False
 
-        def _list_model_endpoints(*, modes, **kwargs):
-            is_legacy = modes == [EndpointMode.BATCH_LEGACY]
-            return Mock(endpoints=[Mock()] if is_legacy else [])
-
+        legacy_endpoint = Mock()
+        legacy_endpoint.metadata.mode = EndpointMode.BATCH_LEGACY
         controller.project_obj = Mock()
-        controller.project_obj.list_model_endpoints.side_effect = _list_model_endpoints
+        controller.project_obj.list_model_endpoints.return_value = Mock(
+            endpoints=[legacy_endpoint]
+        )
 
         warnings_seen: list[tuple[str, dict]] = []
         monkeypatch.setattr(

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -1945,6 +1945,69 @@ class TestMonitoredServings(TestMLRunSystemModelMonitoring):
             condition_description="parquet data with labels to be saved",
         )
 
+    def test_histogram_drift_detected_on_real_data(self):
+        # The model is logged with its training set so the endpoint carries
+        # reference feature statistics; drifted inference then drives the real
+        # histogram data-drift app to a detected result_status on the endpoint.
+        self.function_name = "drift-runner-function"
+        self.project.enable_model_monitoring(
+            image=self.image or mlrun.mlconf.function_defaults.image_by_kind.job,
+            base_period=1,
+            deploy_histogram_data_drift_app=True,
+        )
+        self._log_iris_model()
+
+        function = self.project.set_function(
+            func=str(self.assets_path / "models.py"),
+            name=self.function_name,
+            kind="serving",
+            image=self.image,
+        )
+        graph = function.set_topology("flow", engine="async")
+        model_runner_step = mlrun.serving.ModelRunnerStep(name="my_model_runner")
+        model_runner_step.add_model(
+            endpoint_name="my_model",
+            model_class="MyModel",
+            execution_mechanism="naive",
+            model_artifact=f"store://models/{self.project_name}/classification:latest",
+            input_path="inputs",
+            result_path="outputs",
+        )
+        graph.to(model_runner_step)
+        function.set_tracking()
+        function.deploy()
+
+        serving_fn = self.project.get_function(self.function_name)
+        # Inference far outside the iris training distribution -> strong drift.
+        for _ in range(20):
+            serving_fn.invoke(
+                "/", body=json.dumps({"inputs": [[-500.0, -500.0, -500.0, -500.0]]})
+            )
+
+        initial_wait = (
+            mlrun.mlconf.model_endpoint_monitoring.parquet_batching_timeout_secs + 60
+        )
+
+        def check_drift_detected() -> None:
+            endpoint = next(
+                ep
+                for ep in mlrun.get_run_db()
+                .list_model_endpoints(self.project_name, tsdb_metrics=True)
+                .endpoints
+                if ep.metadata.name == "my_model"
+            )
+            assert (
+                endpoint.status.result_status == mm_constants.ResultStatusApp.detected
+            )
+
+        self.wait_for_condition(
+            condition_check=check_drift_detected,
+            initial_wait=initial_wait,
+            timeout=360.0,
+            retry_interval=20.0,
+            condition_description="histogram data-drift to be detected on the endpoint",
+        )
+
 
 class TestAppJob(TestMLRunSystem):
     """


### PR DESCRIPTION
### 📝 Description
Removes the deprecated old-batch monitoring path from the model-monitoring controller (deprecated in v1.10.0, targeted for v1.12.0 removal) and the helper that only served it, then recovers the unique test coverage lost when the old-batch `record_results` system tests were dropped. Follow-up to #9781 (merged), which removed `record_results` / `get_or_create_model_endpoint`.

After this change the controller analyzes endpoints from the TSDB only; legacy batch model endpoints are no longer monitored and surface a single aggregated controller-cycle warning pointing users to job-based serving.

---

### 🛠️ Changes Made
- **[Model Monitoring]** Remove the deprecated real-time/parquet analysis path for old batch model endpoints in `mlrun.model_monitoring.controller` (drops `not_old_batch_endpoint`, the stream-less compensation in `_get_last_updated_time`, and the dead `feature_sets`/`storage_options`/`_MAX_FEATURE_SET_PER_WORKER` machinery). The controller scan now filters `modes=[REAL_TIME]` and emits one aggregated `logger.warning` naming the count of `BATCH_LEGACY` endpoints and the remedy.
- **[Model Monitoring]** Remove the dead `update_model_endpoint_last_request` helper (only used by the removed `record_results` flow).
- **[Docs]** Move the controller old-batch row from the changelog "Deprecated APIs" table to "Removed APIs"; correct the monitoring architecture doc to describe the controller querying the TSDB (not the Parquet DB).
- **[Tests]** Recover coverage lost with the dropped old-batch system tests: `test_histogram_drift_detected_on_real_data` (end-to-end real-time drift where the histogram data-drift app surfaces `result_status == detected` on the endpoint) and `test_norm_column_name_special_chars` (special-character feature-name normalization).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit: `test_norm_column_name_special_chars` and the controller legacy-endpoint warning unit test pass locally; the model-monitoring helper unit suite (`tests/model_monitoring/test_helpers.py`) passes (32 tests).
- System: `test_histogram_drift_detected_on_real_data` passed end-to-end on vmdev76 — the real `HistogramDataDriftApplication` detected drift on a monitored serving model (`NODE_EP` / `REAL_TIME`) and the writer surfaced `result_status == detected` on the endpoint (`1 passed in 7m54s`).

---

### 🔗 References
- Ticket link: ML-12672 — https://ecliptos.atlassian.net/browse/ML-12672
- Design docs links:
- External links: follow-up to #9781

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

Legacy batch model endpoints (created via the deprecated batch-inference `record_results` flow) are no longer monitored by the controller. Nothing crashes and the schema enums remain so existing records still deserialize, but such endpoints stop producing new monitoring results. Remedy: re-create them via job-based serving. A single aggregated controller-cycle warning names the count of affected endpoints and the migration path.

---

### 🔍️ Additional Notes
- The dropped old-batch `record_results` system tests are intentionally not 1:1 ported (the flow is removed). The supported paths remain covered: drift-result handling/alerting (`tests/system/alerts`), job-based serving monitoring (`TestModelMonitoringOverJob` / batch-serving tests), and the histogram-drift algorithm itself (`TestAppJob.test_histogram_app`). The one unique gap — the real histogram app surfacing `result_status == detected` end-to-end on an endpoint — is recovered by the new `test_histogram_drift_detected_on_real_data`.
- `fetch_credentials_from_sys_config` removal is intentionally deferred to its own PR (cross-team: it threads through platform-owned db/framework layers); it remains listed as Deprecated.
