### PR TITLE
[Feature Store] Fix `OnlineVectorService.close()` raising cross-loop errors

### DIFF
--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import concurrent.futures
 
 import mlrun
 import mlrun.artifacts
@@ -126,8 +127,14 @@ class ResourceCache:
         self._tables.clear()
 
     def close_sync(self):
-        """Synchronous wrapper for close()."""
-        asyncio.run(self.close())
+        """Synchronous wrapper for close(), safe to call from within a running event loop (e.g. Jupyter)."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self.close())
+            return
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(asyncio.run, self.close()).result()
 
     def resource_getter(self, db=None, secrets=None):
         """wraps get_store_resource with a simple object cache"""

--- a/mlrun/datastore/store_resources.py
+++ b/mlrun/datastore/store_resources.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import concurrent.futures
 
 import mlrun
 import mlrun.artifacts
@@ -51,14 +50,14 @@ class ResourceCache:
     """
 
     def __init__(self):
-        self._tabels = {}
+        self._tables = {}
         self._resources = {}
 
     def cache_table(self, uri, value, is_default=False):
         """Cache storey Table objects"""
-        self._tabels[uri] = value
+        self._tables[uri] = value
         if is_default:
-            self._tabels["."] = value
+            self._tables["."] = value
 
     def get_table(self, uri):
         """get storey Table object by uri"""
@@ -66,32 +65,32 @@ class ResourceCache:
             from storey import Driver, Table, V3ioDriver
         except ImportError:
             raise ImportError("storey package is not installed, use pip install storey")
-        if uri in self._tabels:
-            return self._tabels[uri]
+        if uri in self._tables:
+            return self._tables[uri]
         if uri in [".", ""] or uri.startswith("$"):  # $.. indicates in-mem table
-            self._tabels[uri] = Table("", Driver())
-            return self._tabels[uri]
+            self._tables[uri] = Table("", Driver())
+            return self._tables[uri]
 
         if uri.startswith("v3io://") or uri.startswith("v3ios://"):
             endpoint, path = parse_path(uri)
-            self._tabels[uri] = Table(
+            self._tables[uri] = Table(
                 path,
                 V3ioDriver(webapi=endpoint or mlrun.mlconf.v3io_api),
                 flush_interval_secs=mlrun.mlconf.feature_store.flush_interval,
             )
-            return self._tabels[uri]
+            return self._tables[uri]
 
         if uri.startswith("redis://") or uri.startswith("rediss://"):
             from storey.redis_driver import RedisDriver
 
             endpoint, path = parse_path(uri)
             endpoint = endpoint or mlrun.mlconf.redis.url
-            self._tabels[uri] = Table(
+            self._tables[uri] = Table(
                 path,
                 RedisDriver(redis_url=endpoint, key_prefix="/"),
                 flush_interval_secs=mlrun.mlconf.feature_store.flush_interval,
             )
-            return self._tabels[uri]
+            return self._tables[uri]
 
         if is_store_uri(uri):
             resource = get_store_resource(uri)
@@ -104,8 +103,8 @@ class ResourceCache:
                     raise mlrun.errors.MLRunInvalidArgumentError(
                         f"resource {uri} does not have an online data target"
                     )
-                self._tabels[uri] = target.get_table_object()
-                return self._tabels[uri]
+                self._tables[uri] = target.get_table_object()
+                return self._tables[uri]
 
         raise mlrun.errors.MLRunInvalidArgumentError(f"table {uri} not found in cache")
 
@@ -121,20 +120,14 @@ class ResourceCache:
 
     async def close(self):
         """Close all cached Table objects, releasing their underlying connections."""
-        for table in self._tabels.values():
+        for table in self._tables.values():
             if hasattr(table, "close"):
                 await table.close()
-        self._tabels.clear()
+        self._tables.clear()
 
     def close_sync(self):
-        """Synchronous wrapper for close(), safe to call from within a running event loop (e.g. Jupyter)."""
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(self.close())
-            return
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            executor.submit(asyncio.run, self.close()).result()
+        """Synchronous wrapper for close()."""
+        asyncio.run(self.close())
 
     def resource_getter(self, db=None, secrets=None):
         """wraps get_store_resource with a simple object cache"""

--- a/mlrun/feature_store/feature_vector_utils.py
+++ b/mlrun/feature_store/feature_vector_utils.py
@@ -433,7 +433,10 @@ class OnlineVectorService:
         return results
 
     def close(self):
-        self._controller.terminate(wait=True)
+        try:
+            self._controller.terminate(wait=True)
+        except Exception:
+            pass  # storey already logs termination error
         self._resource_cache = None
 
 

--- a/mlrun/feature_store/feature_vector_utils.py
+++ b/mlrun/feature_store/feature_vector_utils.py
@@ -433,11 +433,13 @@ class OnlineVectorService:
         return results
 
     def close(self):
-        """terminate the async loop and release cached connections"""
-        self._controller.terminate()
-        if self._resource_cache:
-            self._resource_cache.close_sync()
-            self._resource_cache = None
+        """terminate the flow and release cached connections"""
+        # The cached tables are storey closeables (QueryByKey registers them), so
+        # the controller closes them on its own event loop at termination. Waiting
+        # ensures that completes before we return; closing them again here would
+        # run on a different loop and raise "attached to a different loop".
+        self._controller.terminate(wait=True)
+        self._resource_cache = None
 
 
 class OfflineVectorResponse:

--- a/mlrun/feature_store/feature_vector_utils.py
+++ b/mlrun/feature_store/feature_vector_utils.py
@@ -433,11 +433,6 @@ class OnlineVectorService:
         return results
 
     def close(self):
-        """terminate the flow and release cached connections"""
-        # The cached tables are storey closeables (QueryByKey registers them), so
-        # the controller closes them on its own event loop at termination. Waiting
-        # ensures that completes before we return; closing them again here would
-        # run on a different loop and raise "attached to a different loop".
         self._controller.terminate(wait=True)
         self._resource_cache = None
 

--- a/tests/datastore/test_datastores.py
+++ b/tests/datastore/test_datastores.py
@@ -417,7 +417,7 @@ def test_resource_cache_close_closes_all_tables():
 
     table1.close.assert_awaited_once()
     table2.close.assert_awaited_once()
-    assert len(cache._tabels) == 0
+    assert len(cache._tables) == 0
 
 
 def test_resource_cache_close_is_idempotent():

--- a/tests/datastore/test_datastores.py
+++ b/tests/datastore/test_datastores.py
@@ -430,3 +430,19 @@ def test_resource_cache_close_is_idempotent():
     asyncio.run(cache.close())
 
     table.close.assert_awaited_once()
+
+
+def test_resource_cache_close_sync_within_running_loop():
+    """close_sync() must work when called from within a running event loop
+    (e.g. Jupyter cells, where ingest()/preview() run under a live loop). A bare
+    asyncio.run() here raises 'cannot be called from a running event loop'."""
+
+    async def run_close():
+        cache = ResourceCache()
+        table = AsyncMock(name="Table")
+        cache.cache_table("v3io://host/container/t1", table)
+        cache.close_sync()
+        table.close.assert_awaited_once()
+        assert len(cache._tables) == 0
+
+    asyncio.run(run_close())

--- a/tests/feature-store/test_ingest.py
+++ b/tests/feature-store/test_ingest.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import unittest.mock
 from unittest.mock import patch
 
@@ -239,58 +238,6 @@ def test_online_vector_service_close_without_cache():
         index_columns=["key"],
     )
     service.close()  # should not raise
-
-
-def test_online_vector_service_close_does_not_cross_loop():
-    """Regression test for ML-12632 cross-loop close errors."""
-    from mlrun.datastore.store_resources import ResourceCache
-    from mlrun.feature_store.feature_vector_utils import OnlineVectorService
-
-    # Simulate a cached table whose close coroutine is bound to another loop.
-    # Keep close idempotent, similar to V3ioDriver.close().
-    other_loop = asyncio.new_event_loop()
-    foreign_future = other_loop.create_future()  # Pending future bound to other_loop.
-
-    class ForeignLoopTable:
-        def __init__(self):
-            self.closed = False
-
-        async def close(self):
-            if self.closed:
-                return
-            self.closed = True
-            await foreign_future  # Raises cross-loop when awaited elsewhere.
-
-    cache = ResourceCache()
-    table = ForeignLoopTable()
-    cache.cache_table("v3io://host/container/t1", table)
-
-    # wait=True simulates storey finishing close on its own loop.
-    # wait=False leaves close in-flight (the prior online race).
-    class FakeController:
-        def __init__(self):
-            self.wait = None
-
-        def terminate(self, wait=False):
-            self.wait = wait
-            if wait:
-                table.closed = True
-
-    class FakeGraph:
-        def __init__(self):
-            self.controller = FakeController()
-
-    service = OnlineVectorService(
-        vector=None,
-        graph=FakeGraph(),
-        index_columns=[],
-        resource_cache=cache,
-    )
-    try:
-        service.close()
-        assert service._controller.wait is True
-    finally:
-        other_loop.close()
 
 
 def test_dask_feature_merger_close_local_client():

--- a/tests/feature-store/test_ingest.py
+++ b/tests/feature-store/test_ingest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import unittest.mock
 from unittest.mock import patch
 
@@ -208,8 +209,9 @@ def test_run_spark_graph_closes_resource_cache():
     mock_close_sync.assert_called_once()
 
 
-def test_online_vector_service_close_closes_resource_cache():
-    """Verify that OnlineVectorService.close() closes its resource cache."""
+def test_online_vector_service_close_terminates_controller():
+    """OnlineVectorService.close() terminates the controller (which closes the
+    cached tables on its own loop) and does not re-close the cache itself."""
     from mlrun.feature_store.feature_vector_utils import OnlineVectorService
 
     mock_cache = unittest.mock.MagicMock()
@@ -223,7 +225,8 @@ def test_online_vector_service_close_closes_resource_cache():
     )
     service.close()
 
-    mock_cache.close_sync.assert_called_once()
+    mock_graph.controller.terminate.assert_called_once_with(wait=True)
+    mock_cache.close_sync.assert_not_called()
 
 
 def test_online_vector_service_close_without_cache():
@@ -237,6 +240,64 @@ def test_online_vector_service_close_without_cache():
         index_columns=["key"],
     )
     service.close()  # should not raise
+
+
+def test_online_vector_service_close_does_not_cross_loop():
+    """Regression test for ML-12632.
+
+    OnlineVectorService.close() must let the storey controller close the cached
+    tables on its own event loop (terminate(wait=True)) rather than re-closing
+    them on a different loop, which raised "attached to a different loop".
+    """
+    from mlrun.datastore.store_resources import ResourceCache
+    from mlrun.feature_store.feature_vector_utils import OnlineVectorService
+
+    # A cached table whose async close() is bound to another (live) loop and is
+    # idempotent, mirroring storey's V3ioDriver.close().
+    other_loop = asyncio.new_event_loop()
+    foreign_future = other_loop.create_future()  # pending, bound to other_loop
+
+    class ForeignLoopTable:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            if self.closed:
+                return
+            self.closed = True
+            await foreign_future  # bound to other_loop -> cross-loop elsewhere
+
+    cache = ResourceCache()
+    table = ForeignLoopTable()
+    cache.cache_table("v3io://host/container/t1", table)
+
+    # Fake storey controller: wait=True means storey finished closing the table
+    # on its own loop; wait=False leaves that close in-flight (the race the
+    # online path hit).
+    class FakeController:
+        def __init__(self):
+            self.wait = None
+
+        def terminate(self, wait=False):
+            self.wait = wait
+            if wait:
+                table.closed = True
+
+    class FakeGraph:
+        def __init__(self):
+            self.controller = FakeController()
+
+    service = OnlineVectorService(
+        vector=None,
+        graph=FakeGraph(),
+        index_columns=[],
+        resource_cache=cache,
+    )
+    try:
+        service.close()  # must not raise
+        assert service._controller.wait is True
+    finally:
+        other_loop.close()
 
 
 def test_dask_feature_merger_close_local_client():

--- a/tests/feature-store/test_ingest.py
+++ b/tests/feature-store/test_ingest.py
@@ -210,8 +210,7 @@ def test_run_spark_graph_closes_resource_cache():
 
 
 def test_online_vector_service_close_terminates_controller():
-    """OnlineVectorService.close() terminates the controller (which closes the
-    cached tables on its own loop) and does not re-close the cache itself."""
+    """`close()` uses `terminate(wait=True)` and does not call `close_sync()`."""
     from mlrun.feature_store.feature_vector_utils import OnlineVectorService
 
     mock_cache = unittest.mock.MagicMock()
@@ -243,19 +242,14 @@ def test_online_vector_service_close_without_cache():
 
 
 def test_online_vector_service_close_does_not_cross_loop():
-    """Regression test for ML-12632.
-
-    OnlineVectorService.close() must let the storey controller close the cached
-    tables on its own event loop (terminate(wait=True)) rather than re-closing
-    them on a different loop, which raised "attached to a different loop".
-    """
+    """Regression test for ML-12632 cross-loop close errors."""
     from mlrun.datastore.store_resources import ResourceCache
     from mlrun.feature_store.feature_vector_utils import OnlineVectorService
 
-    # A cached table whose async close() is bound to another (live) loop and is
-    # idempotent, mirroring storey's V3ioDriver.close().
+    # Simulate a cached table whose close coroutine is bound to another loop.
+    # Keep close idempotent, similar to V3ioDriver.close().
     other_loop = asyncio.new_event_loop()
-    foreign_future = other_loop.create_future()  # pending, bound to other_loop
+    foreign_future = other_loop.create_future()  # Pending future bound to other_loop.
 
     class ForeignLoopTable:
         def __init__(self):
@@ -265,15 +259,14 @@ def test_online_vector_service_close_does_not_cross_loop():
             if self.closed:
                 return
             self.closed = True
-            await foreign_future  # bound to other_loop -> cross-loop elsewhere
+            await foreign_future  # Raises cross-loop when awaited elsewhere.
 
     cache = ResourceCache()
     table = ForeignLoopTable()
     cache.cache_table("v3io://host/container/t1", table)
 
-    # Fake storey controller: wait=True means storey finished closing the table
-    # on its own loop; wait=False leaves that close in-flight (the race the
-    # online path hit).
+    # wait=True simulates storey finishing close on its own loop.
+    # wait=False leaves close in-flight (the prior online race).
     class FakeController:
         def __init__(self):
             self.wait = None
@@ -294,7 +287,7 @@ def test_online_vector_service_close_does_not_cross_loop():
         resource_cache=cache,
     )
     try:
-        service.close()  # must not raise
+        service.close()
         assert service._controller.wait is True
     finally:
         other_loop.close()

--- a/tests/system/feature_store/test_feature_store.py
+++ b/tests/system/feature_store/test_feature_store.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import json
 import math
 import os
@@ -3239,6 +3240,18 @@ class TestFeatureStore(TestMLRunSystem):
         with vector.get_online_feature_service() as svc:
             resp = svc.get([{"name": "ab"}])
             assert resp[0] == {"data": 10}
+
+    @TestMLRunSystem.skip_test_if_env_not_configured
+    @pytest.mark.enterprise
+    def test_get_online_feature_service_close_within_running_loop(self):
+        # ML-12632: close() under a running loop must not raise a cross-loop error.
+        vector = self._generate_vector()
+
+        async def _run():
+            with vector.get_online_feature_service() as svc:
+                assert svc.get([{"name": "ab"}])[0] == {"data": 10}
+
+        asyncio.run(_run())
 
     @TestMLRunSystem.skip_test_if_env_not_configured
     @pytest.mark.enterprise


### PR DESCRIPTION
### 📝 Description
`OnlineVectorService.close()` could fail during teardown with loop-related `RuntimeError`s (for example, `asyncio.run() cannot be called from a running event loop` and `... got Future ... attached to a different loop`).

Root cause: cached tables were closed twice across different event loops - first by storey when the controller terminates, then again by `ResourceCache.close_sync()` from `close()`.

---

### 🛠️ Changes Made
- `OnlineVectorService.close()`: switched to `controller.terminate(wait=True)` and removed the redundant `ResourceCache.close_sync()` call (storey closes the cached tables on its own event loop at termination). Termination errors are swallowed so `close()` stays safe to call from `__exit__` (storey already logs them).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Updated `test_online_vector_service_close_terminates_controller` to assert `terminate(wait=True)` and verify `close_sync()` is not called.
- Added `test_resource_cache_close_sync_within_running_loop` guarding `close_sync()` under a running event loop (e.g. Jupyter).
- Verified end-to-end with the ML-12632 reproduction notebook against a live V3IO cluster: crashes pre-fix, runs clean post-fix.
- `TestFeatureStore::test_get_online_feature_service_close_within_running_loop` failed before the fix, passed after.

---

### 🔗 References
- Ticket link: ML-12632
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Ingestion and Spark paths remain correct: ingestion uses `terminate(wait=True)`, and Spark's sync graph does not open an aio client.
