### PR TITLE
[Serving] Add HTTP method injection to include_url_info

### DIFF
--- a/docs/serving/api-handler.md
+++ b/docs/serving/api-handler.md
@@ -191,7 +191,12 @@ config.add_endpoint_handler(
 
 ### URL info (`include_url_info`)
 
-When `include_url_info=True`, the handler injects an additional field `mlrun_request_path` into the event. This field contains the normalized URL path (without the query string). Query string parameters are always extracted as keyword arguments regardless of this setting.
+When `include_url_info=True`, the handler injects two additional fields into the event:
+
+- `mlrun_request_path` — the normalized URL path (without the query string).
+- `mlrun_request_method` — the HTTP method as an uppercase string (e.g. `"GET"`, `"DELETE"`).
+
+Both are passed together so a dispatcher handler can distinguish endpoints that share a path template but differ by method. Query string parameters are always extracted as keyword arguments regardless of this setting.
 
 ```python
 config = APIHandlerConfig(include_url_info=True)
@@ -207,24 +212,56 @@ A `GET /v1/chat/completions/abc123?limit=10` request passes the following keywor
     "completion_id": "abc123",  # from path template
     "limit": "10",  # from query string
     "mlrun_request_path": "/v1/chat/completions/abc123",  # from include_url_info
+    "mlrun_request_method": "GET",  # from include_url_info
 }
 ```
+
+Dispatch by method on a shared path template:
+
+```python
+def responses_router(
+    body, response_id, mlrun_request_path, mlrun_request_method, **kwargs
+):
+    if mlrun_request_method == "GET":
+        return get_response(response_id)
+    if mlrun_request_method == "DELETE":
+        return delete_response(response_id)
+    raise ValueError(f"unsupported method {mlrun_request_method}")
+```
+
+The handler signature must accept these names (explicitly or via `**kwargs`); otherwise Python raises `TypeError: unexpected keyword argument`.
 
 ## How downstream steps receive parameters
 
 Extracted parameters are passed as keyword arguments to the handler function or `do()` method. For example, given the endpoint `/v1/chat/completions/{completion_id}` with `include_url_info=True`, a `GET /v1/chat/completions/abc123?limit=10` request calls the next step as:
 
 ```python
-def step_handler(body, completion_id, limit, mlrun_request_path, **kwargs):
+def step_handler(
+    body,
+    completion_id,
+    limit,
+    mlrun_request_path,
+    mlrun_request_method,
+    **kwargs,
+):
     # body: original request body
     # completion_id="abc123"                            — from path template
     # limit="10"                                        — from query string
     # mlrun_request_path="/v1/chat/completions/abc123"  — from include_url_info
+    # mlrun_request_method="GET"                        — from include_url_info
     ...
 
 
 class MyStep:
-    def do(self, body, completion_id, limit, mlrun_request_path, **kwargs): ...
+    def do(
+        self,
+        body,
+        completion_id,
+        limit,
+        mlrun_request_path,
+        mlrun_request_method,
+        **kwargs,
+    ): ...
 ```
 
 ## Complete example

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -247,10 +247,14 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                         body_params = {}
 
                 # Build system-injected URL params when include_url_info is enabled.
-                # mlrun_request_path holds the normalized path of the matched request.
+                # mlrun_request_path holds the normalized path of the matched request and
+                # mlrun_request_method holds the HTTP method (e.g. "GET"). Together they
+                # let a dispatcher handler distinguish endpoints that share a path template
+                # but differ by method (e.g. GET vs DELETE on /responses/{id}).
                 url_params: dict[str, Any] = {}
                 if self.config.include_url_info:
                     url_params["mlrun_request_path"] = normalized_path
+                    url_params["mlrun_request_method"] = method.value
 
                 # Build the event body for the next step.
                 # When any params are present, always use _RequestContext so the

--- a/mlrun/serving/endpoint_mapping.py
+++ b/mlrun/serving/endpoint_mapping.py
@@ -291,7 +291,23 @@ class EndpointConfig(mlrun.model.ModelObj):
 
 
 class APIHandlerConfig(mlrun.model.ModelObj):
-    """Configuration for API handler in serving graph."""
+    """Configuration for API handler in serving graph.
+
+    :param enabled:          Whether the API handler step is active.
+    :param endpoints:        Map of endpoint key (``"METHOD:path"``) to ``EndpointConfig``
+                             (or a raw dict that will be deserialized).
+    :param include_url_info: When True, inject the request's URL info into the handler
+                             as keyword arguments — ``mlrun_request_path`` (the normalized
+                             matched path) and ``mlrun_request_method`` (the HTTP method
+                             string, e.g. ``"GET"``). Both are passed together so a
+                             dispatcher handler can distinguish endpoints that share a
+                             path template but differ by method (e.g. ``GET`` vs ``DELETE``
+                             on ``/responses/{id}``).
+
+                             The handler signature MUST accept these names (either as
+                             explicit parameters or via ``**kwargs``); otherwise Python
+                             raises ``TypeError: unexpected keyword argument``.
+    """
 
     _dict_fields = ["enabled", "endpoints", "include_url_info"]
 

--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -838,11 +838,13 @@ class TestStarPatternMatching:
 
 
 class TestIncludeUrlInfo:
-    """Tests for include_url_info parameter (ML-11658)
+    """Tests for include_url_info parameter (ML-11658, ML-12695)
 
     When include_url_info=True, the API handler injects 'mlrun_request_path'
-    (the normalized request path, without query string) into the RequestContext
-    that is forwarded to the next step.
+    (the normalized request path, without query string) and 'mlrun_request_method'
+    (the HTTP method string) into the RequestContext that is forwarded to the next
+    step. Both kwargs together let a dispatcher handler distinguish endpoints that
+    share a path template but differ by method (e.g. GET vs DELETE on /responses/{id}).
     """
 
     def test_include_url_info_default_false(self) -> None:
@@ -873,7 +875,7 @@ class TestIncludeUrlInfo:
         assert config2.include_url_info is True
 
     def test_include_url_info_disabled_no_path_injected(self) -> None:
-        """When include_url_info=False, mlrun_request_path is NOT in the context"""
+        """When include_url_info=False, neither mlrun_request_path nor mlrun_request_method is injected"""
         config = APIHandlerConfig(include_url_info=False)
         config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
         step = _APIHandlerStep(config=config)
@@ -885,7 +887,7 @@ class TestIncludeUrlInfo:
         assert result.body == "hello"
 
     def test_include_url_info_enabled_exact_path(self) -> None:
-        """When include_url_info=True the RequestContext contains mlrun_request_path"""
+        """When include_url_info=True the RequestContext contains mlrun_request_path and mlrun_request_method"""
         config = APIHandlerConfig(include_url_info=True)
         config.add_endpoint_handler("/api/test", HTTPMethod.GET, APIHandlerAction.ALLOW)
         step = _APIHandlerStep(config=config)
@@ -896,6 +898,7 @@ class TestIncludeUrlInfo:
         assert isinstance(result.body, _RequestContext)
         assert result.body.original_body == "hello"
         assert result.body["mlrun_request_path"] == "/api/test"
+        assert result.body["mlrun_request_method"] == "GET"
 
     def test_include_url_info_path_without_query_string(self) -> None:
         """mlrun_request_path must NOT include query string"""
@@ -914,6 +917,7 @@ class TestIncludeUrlInfo:
         assert result.body.original_body == "hello"
         # Path must be normalized (no query string)
         assert result.body["mlrun_request_path"] == "/api/items"
+        assert result.body["mlrun_request_method"] == "GET"
         # Query params are still extracted normally
         assert result.body["limit"] == "5"
         assert result.body["offset"] == "10"
@@ -935,6 +939,7 @@ class TestIncludeUrlInfo:
         assert result.body.original_body == "hello"
         # Actual request path, not the template pattern
         assert result.body["mlrun_request_path"] == "/api/users/abc-123"
+        assert result.body["mlrun_request_method"] == "GET"
         # Path param is also present
         assert result.body["user_id"] == "abc-123"
 
@@ -952,6 +957,7 @@ class TestIncludeUrlInfo:
         assert isinstance(result.body, _RequestContext)
         assert result.body.original_body == "hello"
         assert result.body["mlrun_request_path"] == "/api/deeply/nested/resource"
+        assert result.body["mlrun_request_method"] == "GET"
 
     def test_include_url_info_combined_with_existing_params(self) -> None:
         """mlrun_request_path is available alongside path, query, and body params"""
@@ -977,9 +983,41 @@ class TestIncludeUrlInfo:
         assert isinstance(result.body, _RequestContext)
         assert result.body.original_body == {"q": "Hello world"}
         assert result.body["mlrun_request_path"] == "/api/gpt4/ask"
+        assert result.body["mlrun_request_method"] == "POST"
         assert result.body["model_id"] == "gpt4"
         assert result.body["lang"] == "en"
         assert result.body["question"] == "Hello world"
+
+    def test_include_url_info_dispatch_get_vs_delete_same_path(self) -> None:
+        """A dispatcher handler can distinguish GET vs DELETE on the same path template (ML-12695)."""
+        config = APIHandlerConfig(include_url_info=True)
+        config.add_endpoint_handler(
+            "/responses/{response_id}", HTTPMethod.GET, APIHandlerAction.ALLOW
+        )
+        config.add_endpoint_handler(
+            "/responses/{response_id}", HTTPMethod.DELETE, APIHandlerAction.ALLOW
+        )
+        step = _APIHandlerStep(config=config)
+
+        get_event = MockEvent(
+            method=HTTPMethod.GET, path="/responses/resp-123", body=None
+        )
+        delete_event = MockEvent(
+            method=HTTPMethod.DELETE, path="/responses/resp-123", body=None
+        )
+
+        get_result = step.do(get_event)
+        delete_result = step.do(delete_event)
+
+        assert isinstance(get_result.body, _RequestContext)
+        assert isinstance(delete_result.body, _RequestContext)
+        # Same path template — only the injected method distinguishes them
+        assert get_result.body["mlrun_request_path"] == "/responses/resp-123"
+        assert delete_result.body["mlrun_request_path"] == "/responses/resp-123"
+        assert get_result.body["mlrun_request_method"] == "GET"
+        assert delete_result.body["mlrun_request_method"] == "DELETE"
+        assert get_result.body["response_id"] == "resp-123"
+        assert delete_result.body["response_id"] == "resp-123"
 
 
 class TestAPIHandlerMockServer:

--- a/tests/system/runtimes/assets/wildcard_path_handler.py
+++ b/tests/system/runtimes/assets/wildcard_path_handler.py
@@ -12,22 +12,29 @@
 # limitations under the License.
 
 
-def handle_wildcard(body, mlrun_request_path: str | None = None, **kwargs) -> dict:
-    """Handler that receives mlrun_request_path injected by the API handler.
+def handle_wildcard(
+    body,
+    mlrun_request_path: str | None = None,
+    mlrun_request_method: str | None = None,
+    **kwargs,
+) -> dict:
+    """Handler that receives mlrun_request_path and mlrun_request_method injected by the API handler.
 
     Used by system tests to verify that:
     - wildcard ``*`` patterns route requests to the correct handler
-    - ``include_url_info=True`` injects ``mlrun_request_path`` with the
-      normalized request path (no query string)
+    - ``include_url_info=True`` injects both ``mlrun_request_path`` (normalized
+      request path, no query string) and ``mlrun_request_method`` (HTTP method)
 
     Args:
-        mlrun_request_path: Injected by APIHandler when include_url_info=True.
-        **kwargs: Any additional parameters from query string / body_map.
+        mlrun_request_path:   Injected by APIHandler when include_url_info=True.
+        mlrun_request_method: Injected by APIHandler when include_url_info=True.
+        **kwargs:             Any additional parameters from query string / body_map.
 
     Returns:
-        Dict with matched_path and any extra params for verification.
+        Dict with matched_path, matched_method, and any extra params for verification.
     """
     return {
         "matched_path": mlrun_request_path,
+        "matched_method": mlrun_request_method,
         "extra": kwargs,
     }

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -434,6 +434,9 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         assert response["matched_path"] == "/api/wildcard/v1/data", (
             "mlrun_request_path should reflect the exact request path"
         )
+        assert response["matched_method"] == "POST", (
+            "mlrun_request_method should reflect the request HTTP method"
+        )
 
         # Verify a different nested path also routes correctly
         self._logger.debug("Invoking /api/wildcard/users/42")
@@ -444,6 +447,9 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
         )
         assert response2["matched_path"] == "/api/wildcard/users/42", (
             "mlrun_request_path should reflect the request path for a different sub-path"
+        )
+        assert response2["matched_method"] == "POST", (
+            "mlrun_request_method should reflect the request HTTP method"
         )
 
         self._logger.info("Wildcard path API handler test passed")


### PR DESCRIPTION
### 📝 Description

When `APIHandlerConfig(include_url_info=True)` is set, the API handler currently injects only `mlrun_request_path` into the downstream handler's kwargs. A dispatcher handler that routes by both path *and* method (e.g. `GET /responses/{id}` vs `DELETE /responses/{id}` — same path template, different semantics) has no way to distinguish the two from inside the handler.

This PR extends `include_url_info` to also inject `mlrun_request_method` (the HTTP method as an uppercase string). Path + method together identify the endpoint, which is what the handler actually needs.

---

### 🛠️ Changes Made

- **`mlrun/serving/api_handler.py`** — when `include_url_info=True`, also inject `mlrun_request_method` alongside `mlrun_request_path`. Updated the surrounding comment.
- **`mlrun/serving/endpoint_mapping.py`** — added a full docstring on `APIHandlerConfig` documenting both injected kwarg names and the handler signature constraint (must accept the names or `**kwargs`).
- **`tests/serving/test_api_handler.py`** — extended `TestIncludeUrlInfo`: every positive test now asserts `mlrun_request_method`, plus a new `test_include_url_info_dispatch_get_vs_delete_same_path` that directly exercises the GET-vs-DELETE-on-same-path scenario from the ticket.
- **`tests/system/runtimes/test_serving.py` + `tests/system/runtimes/assets/wildcard_path_handler.py`** — extended the wildcard system test handler to echo back `matched_method`, and the test now asserts it on both invocations.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing

- **Unit tests**: full `tests/serving/test_api_handler.py` passes (141 tests including the new GET-vs-DELETE dispatch test).
- **System test**: `tests/system/runtimes/test_serving.py::TestServingAPIHandler::test_api_handler_wildcard_path` extended to assert `matched_method == \"POST\"` on real deploy.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12695
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

\`APIHandlerConfig\` is unreleased (Fix Version 1.12.0), so widening \`include_url_info\`'s contract is acceptable. Handlers using strict signatures like \`def handler(body, mlrun_request_path):\` (no \`**kwargs\`) will break with \`TypeError: unexpected keyword argument 'mlrun_request_method'\`. The documented contract becomes: handlers using \`include_url_info\` must accept \`**kwargs\` or declare all injected names.

---

### 🔍️ Additional Notes

Considered but rejected:
- Adding a separate \`include_http_method\` flag — one flag covers both URL info kwargs; path and method together describe an endpoint.