### PR TITLE
[Nuclio] Fix invoke scheme for NodePort external URLs

### DIFF
--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1677,7 +1677,13 @@ class RemoteRuntime(KubeResource):
         if self.status.external_invocation_urls:
             external_url = self.status.external_invocation_urls[0]
             if "://" not in external_url:
-                external_url = f"https://{external_url}"
+                # NodePort serves plain HTTP (no TLS termination); use http for NodePort and
+                # https for ClusterIP so we don't force TLS against an HTTP port.
+                service_type = (
+                    self.spec.service_type or mlconf.httpdb.nuclio.default_service_type
+                )
+                scheme = "http" if service_type == "NodePort" else "https"
+                external_url = f"{scheme}://{external_url}"
             return mlrun.utils.helpers.join_urls(external_url, path)
 
         if not self.status.address:

--- a/tests/runtimes/test_function.py
+++ b/tests/runtimes/test_function.py
@@ -614,18 +614,30 @@ def test_with_sidecar(command: str, args: list, expected_sidecars: list):
 
 
 @pytest.mark.parametrize(
-    "external_url, expected_scheme",
+    "external_url, default_service_type, spec_service_type, expected_scheme",
     [
-        ("my-gateway.default-tenant.app.example.com", "https://"),
-        ("https://my-gateway.example.com", "https://"),
-        ("http://my-gateway.example.com", "http://"),
+        # scheme-less URL: scheme follows the service type. NodePort serves plain HTTP
+        # (no TLS termination), ClusterIP is fronted by TLS ingress. Regression for ML-12522:
+        # a NodePort host:port must resolve to http, not https.
+        ("192.168.238.32:32649", "NodePort", None, "http://"),
+        ("my-gateway.default-tenant.app.example.com", "ClusterIP", None, "https://"),
+        # the function's own service type overrides the cluster default
+        ("192.168.238.32:32649", "ClusterIP", "NodePort", "http://"),
+        ("my-gateway.example.com", "NodePort", "ClusterIP", "https://"),
+        # an explicit scheme on the URL is preserved regardless of service type
+        ("https://my-gateway.example.com", "NodePort", None, "https://"),
+        ("http://my-gateway.example.com", "ClusterIP", None, "http://"),
     ],
 )
-def test_resolve_invocation_url_uses_https_for_external_urls(
-    external_url, expected_scheme
+def test_resolve_invocation_url_scheme_for_external_urls(
+    monkeypatch, external_url, default_service_type, spec_service_type, expected_scheme
 ):
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.nuclio, "default_service_type", default_service_type
+    )
     fn = mlrun.new_function("test-fn", kind="nuclio")
     fn.status.external_invocation_urls = [external_url]
+    fn.spec.service_type = spec_service_type
 
     resolved = fn._resolve_invocation_url("/test-path", force_external_address=False)
 

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import concurrent.futures
-import ipaddress
 import json
 import pickle
 import tempfile
@@ -560,36 +559,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
             serving_fn.spec.image = serving_fn.spec.build.image = cls.image
 
         serving_fn.deploy()
-        cls._workaround_ml_12522_force_http_for_nodeport(serving_fn)
         return serving_fn
-
-    @staticmethod
-    def _workaround_ml_12522_force_http_for_nodeport(
-        fn: mlrun.runtimes.nuclio.serving.ServingRuntime,
-    ) -> None:
-        """Workaround for ML-12522.
-
-        Nuclio reports ``status.external_invocation_urls`` as scheme-less.
-        Since mlrun #9578, ``_resolve_invocation_url`` prepends ``https://``
-        to scheme-less external URLs, which breaks plain-HTTP NodePort
-        setups (open-source CE / k3s) with ``SSL: WRONG_VERSION_NUMBER``.
-        Iguazio setups expose functions via TLS-terminated ingress
-        (hostname/path form) and must keep the ``https://`` default.
-
-        Only rewrite the NodePort form (IPv4 ``host:port`` with no path)
-        to ``http://`` here. Remove once ML-12522 routes API-gateway
-        invocations through ``APIGateway.invoke_url`` and
-        ``_resolve_invocation_url`` defaults back to ``http://``.
-        """
-        for i, url in enumerate(fn.status.external_invocation_urls or []):
-            if "://" in url or "/" in url:
-                continue
-            host = url.split(":", 1)[0]
-            try:
-                ipaddress.ip_address(host)
-            except ValueError:
-                continue
-            fn.status.external_invocation_urls[i] = f"http://{url}"
 
     @classmethod
     def _infer(


### PR DESCRIPTION
### 📝 Description

`function.invoke()` always failed on TLS-less mlrun-CE / NodePort clusters. Nuclio reports `status.external_invocation_urls` as scheme-less `host:port`, and since #9578 `_resolve_invocation_url` unconditionally prepended `https://`. NodePort functions serve plain HTTP (no TLS termination), so the client opened
a TLS handshake against an HTTP port and failed with `SSL: WRONG_VERSION_NUMBER`.

The scheme is now derived from the function's service type - the same resolution the server uses at deploy time (`spec.service_type or httpdb.nuclio.default_service_type`): `http://` for NodePort, `https://` for ClusterIP. URLs that already carry an explicit scheme are left unchanged.

---

### 🛠️ Changes Made
- `mlrun/runtimes/nuclio/function.py`: in `_resolve_invocation_url`, choose the scheme for scheme-less external URLs from `spec.service_type` (falling back to `httpdb.nuclio.default_service_type`) - `http` for NodePort, `https` for ClusterIP.


---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — no user-facing/API change; behavior now honors existing `default_service_type` config
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR — see Testing notes (manual E2E only; full system suite needs CI/lab)
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- `tests/runtimes/test_function.py`: rewrote the external-URL test into 6 parametrized cases (NodePort→http incl. the exact `192.168.238.32:32649` regression, per-function service-type override, and explicit-scheme-preserved).
- `tests/system/model_monitoring/test_app.py`: removed the obsolete _workaround_ml_12522_force_http_for_nodeport` helper (and unused `ipaddress` import) that only existed to mask this bug.
- **End-to-end**: deployed a nuclio function with default_service_type=NodePort.
  - `status.external_invocation_urls` came back scheme-less (`...:30786`) -> the fixed `_resolve_invocation_url(force_external_address=True)` resolved to `http://...:30786/`.
  - From inside the cluster - `curl http://...:30786/` → `200`, while `https://...:30786/` failed at the TLS layer (`packet length too long` / record overflow - OpenSSL form of `WRONG_VERSION_NUMBER`), confirming the listener is HTTP-only and the fix targets the working scheme.
Why from inside the cluster? the NodePort isn't reachable from a laptop over the VPN, so the round-trip was run from a cluster node where the port is reachable.


---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12522
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No


---

### 🔍️ Additional Notes

