### PR TITLE
[Datastore] Fix dataset size reported as 0/N-A for directory targets

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -585,8 +585,14 @@ class BaseStoreTarget(DataTargetBase):
                 **kwargs,
             )
             try:
-                return file_system.size(target_path)
-            except Exception:
+                # du() sums part files; size() returns the dir entry's own length (0/N-A).
+                return file_system.du(target_path)
+            except Exception as exc:
+                logger.debug(
+                    "Failed to read written dataframe size from target",
+                    target_path=target_path,
+                    error=mlrun.errors.err_to_str(exc),
+                )
                 return None
 
     @staticmethod

--- a/tests/artifacts/test_dataset.py
+++ b/tests/artifacts/test_dataset.py
@@ -77,6 +77,26 @@ def test_dataset_upload_with_src_path_filling_hash():
     assert artifact.hash is not None
 
 
+def test_dataset_size_reflects_real_bytes_for_directory_target(tmp_path):
+    """A non-.parquet/.pq target is written as a directory; spec.size must be the real byte
+    total, not the directory entry's own (~0) length ("0 B" on v3io, "N/A" on Azure)."""
+    data_frame = pandas.DataFrame({"x": list(range(100))})
+    # ".txt" suffix => directory write
+    target_path = tmp_path / "mydata.txt"
+    artifact = mlrun.artifacts.dataset.DatasetArtifact(
+        df=data_frame,
+        target_path=str(target_path),
+    )
+    artifact.upload()
+
+    assert target_path.is_dir()
+    real_total = sum(
+        part.stat().st_size for part in target_path.rglob("*") if part.is_file()
+    )
+    assert real_total > 0
+    assert artifact.spec.size == real_total
+
+
 def test_dataset_upload_without_df_or_body():
     artifact = mlrun.artifacts.dataset.DatasetArtifact(
         target_path=str(pathlib.Path(tests.conftest.results) / "target-dataset"),


### PR DESCRIPTION
### 📝 Description
`context.log_dataset(...)` reported a wrong size for datasets whose `target_path` does not end in `.parquet`/`.pq` (e.g. a `.txt` suffix carried over from `local_path`). Such a dataset is written as a *directory* of part files, but the size was read with `file_system.size(target_path)`, which returns only the directory entry's own length. This surfaced in the UI as "0 B" on v3io (on-prem) and "N/A" on Azure/adlfs (where `size()` on a non-blob prefix raises and the exception was silently swallowed to `None`). Genuinely partitioned datasets were affected the same way.

---

### 🛠️ Changes Made
- `mlrun/datastore/targets.py` — read the written dataframe size with `file_system.du(target_path)` instead of `file_system.size(target_path)`. `du()` returns the real byte total for a directory of part files and the file size for a single file.
- The previously silent exception in the size read is now logged at `debug`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added unit test `tests/artifacts/test_dataset.py::test_dataset_size_reflects_real_bytes_for_directory_target` — writes a dataset to a `.txt` target (directory write) and asserts `spec.size` equals the real on-disk byte total (`> 0`). Fails before the fix (`60 != 2147`), passes after.
- Reproduced and verified end-to-end against real v3io on vmdev76: before fix `spec.size = 0`; after fix `spec.size = 1897` (the real part-file size). Confirmed the `.txt` target is a directory containing `part-*.parquet` files, where `size()` -> `0` but `du()` -> real total.
- `make fmt` / `make lint` clean.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12739
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
