### PR TITLE
[Nuclio] Support `az://` source archives for Nuclio deploys

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -13,17 +13,27 @@
 # limitations under the License.
 
 import contextlib
+import datetime
 import time
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import (
+    BlobSasPermissions,
+    BlobServiceClient,
+    generate_blob_sas,
+)
 from azure.storage.blob._shared.base_client import parse_connection_str
 from fsspec.registry import get_filesystem_class
 
 import mlrun.errors
 
 from .base import DataStore, FileStats, make_datastore_schema_sanitizer
+
+# Validity window for read-only SAS URLs minted for source-archive fetches. The blob is fetched
+# once shortly after the URL is created; the start is back-dated to absorb clock skew.
+_SAS_CLOCK_SKEW = datetime.timedelta(minutes=5)
+_SAS_TTL = datetime.timedelta(hours=2)
 
 # Azure blobs will be represented with the following URL: az://<container name>. The storage account is already
 # pointed to by the connection string, so the user is not expected to specify it in any way.
@@ -202,6 +212,84 @@ class AzureBlobStore(DataStore):
         if not self._service_client:
             self._do_connect()
         return self._service_client
+
+    def get_read_only_https_url(self, key, *, ttl=_SAS_TTL, clock_skew=_SAS_CLOCK_SKEW):
+        """Return an ``https://`` URL to ``key`` in this store's container, carrying a
+        short-lived, read-only SAS.
+
+        Lets callers without Azure-Blob SDK support (e.g. Nuclio's archive fetcher, which has no
+        native ``az://`` code-entry type) fetch the blob over plain HTTPS. The SAS type follows
+        the resolved credentials: an existing SAS token is passed through, an account key yields
+        an account-key SAS, otherwise (service principal / managed / workload identity) an AAD
+        user-delegation SAS is minted.
+        """
+        st = self.storage_options
+        account_name = st.get("account_name")
+        account_key = st.get("account_key")
+        sas_token = st.get("sas_token")
+        if not (account_key or sas_token) and (
+            connection_string := st.get("connection_string")
+        ):
+            _, _, parsed = parse_connection_str(
+                connection_string, credential=None, service="blob"
+            )
+            if isinstance(parsed, str):
+                parsed = {"sas_token": parsed}
+            account_name = account_name or parsed.get("account_name")
+            account_key = account_key or parsed.get("account_key")
+            sas_token = sas_token or parsed.get("sas_token")
+
+        container = st.get("container")
+        blob_name = key.lstrip("/")
+        if not container or not blob_name:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"could not resolve Azure container/blob for key {key!r}"
+            )
+
+        # primary_hostname is authoritative (covers custom-domain endpoints) and carries no SAS.
+        # Accessed outside the try so missing-credential errors stay client-side (400).
+        host = self.service_client.primary_hostname
+        if sas_token:
+            sas = sas_token.lstrip("?")
+        else:
+            now = datetime.datetime.now(datetime.UTC)
+            start, expiry = now - clock_skew, now + ttl
+            sas_kwargs = dict(
+                # Prefer the resolved account name; the host's first label is only a fallback
+                # and can be wrong for custom-domain endpoints.
+                account_name=account_name or host.split(".", 1)[0],
+                container_name=container,
+                blob_name=blob_name,
+                permission=BlobSasPermissions(read=True),
+                start=start,
+                expiry=expiry,
+            )
+            try:
+                if account_key:
+                    sas = generate_blob_sas(account_key=account_key, **sas_kwargs)
+                else:
+                    # AAD: service principal or managed/workload identity
+                    sas = generate_blob_sas(
+                        user_delegation_key=self.service_client.get_user_delegation_key(
+                            start, expiry
+                        ),
+                        **sas_kwargs,
+                    )
+            except Exception as exc:
+                # Only identity-auth failures warrant the Delegator-role hint.
+                hint = (
+                    ""
+                    if account_key
+                    else " (service-principal/managed-identity auth requires the "
+                    "'Storage Blob Delegator' role)"
+                )
+                raise mlrun.errors.MLRunRuntimeError(
+                    f"failed to create a read-only Azure SAS for {blob_name!r}{hint}: "
+                    f"{mlrun.errors.err_to_str(exc)}"
+                ) from exc
+
+        # Encode blob path for the URL (keep '/'); SAS is signed over the raw blob name.
+        return f"https://{host}/{container}/{quote(blob_name, safe='/')}?{sas}"
 
     def _do_connect(self):
         """

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -30,8 +30,7 @@ import mlrun.errors
 
 from .base import DataStore, FileStats, make_datastore_schema_sanitizer
 
-# Validity window for read-only SAS URLs minted for source-archive fetches. The blob is fetched
-# once shortly after the URL is created; the start is back-dated to absorb clock skew.
+# Validity window for read-only SAS URLs.
 _SAS_CLOCK_SKEW = datetime.timedelta(minutes=5)
 _SAS_TTL = datetime.timedelta(hours=2)
 
@@ -214,15 +213,7 @@ class AzureBlobStore(DataStore):
         return self._service_client
 
     def get_read_only_https_url(self, key, *, ttl=_SAS_TTL, clock_skew=_SAS_CLOCK_SKEW):
-        """Return an ``https://`` URL to ``key`` in this store's container, carrying a
-        short-lived, read-only SAS.
-
-        Lets callers without Azure-Blob SDK support (e.g. Nuclio's archive fetcher, which has no
-        native ``az://`` code-entry type) fetch the blob over plain HTTPS. The SAS type follows
-        the resolved credentials: an existing SAS token is passed through, an account key yields
-        an account-key SAS, otherwise (service principal / managed / workload identity) an AAD
-        user-delegation SAS is minted.
-        """
+        """Return an ``https://`` URL for ``key`` with a short-lived read-only SAS."""
         st = self.storage_options
         account_name = st.get("account_name")
         account_key = st.get("account_key")
@@ -246,8 +237,7 @@ class AzureBlobStore(DataStore):
                 f"could not resolve Azure container/blob for key {key!r}"
             )
 
-        # primary_hostname is authoritative (covers custom-domain endpoints) and carries no SAS.
-        # Accessed outside the try so missing-credential errors stay client-side (400).
+        # primary_hostname carries no SAS.
         host = self.service_client.primary_hostname
         if sas_token:
             sas = sas_token.lstrip("?")
@@ -255,8 +245,7 @@ class AzureBlobStore(DataStore):
             now = datetime.datetime.now(datetime.UTC)
             start, expiry = now - clock_skew, now + ttl
             sas_kwargs = dict(
-                # Prefer the resolved account name; the host's first label is only a fallback
-                # and can be wrong for custom-domain endpoints.
+                # Prefer resolved account name; host-label fallback can be wrong on custom domains.
                 account_name=account_name or host.split(".", 1)[0],
                 container_name=container,
                 blob_name=blob_name,
@@ -276,19 +265,18 @@ class AzureBlobStore(DataStore):
                         **sas_kwargs,
                     )
             except Exception as exc:
-                # Only identity-auth failures warrant the Delegator-role hint.
+                # Only identity-auth failures should include this role hint.
                 hint = (
                     ""
                     if account_key
-                    else " (service-principal/managed-identity auth requires the "
-                    "'Storage Blob Delegator' role)"
+                    else " (identity auth requires 'Storage Blob Delegator')"
                 )
                 raise mlrun.errors.MLRunRuntimeError(
-                    f"failed to create a read-only Azure SAS for {blob_name!r}{hint}: "
+                    f"failed to create read-only Azure SAS for {blob_name!r}{hint}: "
                     f"{mlrun.errors.err_to_str(exc)}"
                 ) from exc
 
-        # Encode blob path for the URL (keep '/'); SAS is signed over the raw blob name.
+        # Encode blob path for URL (keep '/'); SAS is signed over raw blob name.
         return f"https://{host}/{container}/{quote(blob_name, safe='/')}?{sas}"
 
     def _do_connect(self):

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import urllib.parse
 
 import semver
@@ -243,6 +244,107 @@ def is_nuclio_version_in_range(min_version: str, max_version: str) -> bool:
     return parsed_min_version <= parsed_current_version < parsed_max_version
 
 
+def _parse_azure_connection_string(connection_string: str) -> dict:
+    """Parse an Azure ``key=value;...`` connection string into a dict. Values can contain ``=``
+    (base64 account keys, SAS tokens), so split on the first ``=`` only.
+
+    Hand-rolled rather than reusing adlfs's internal ``parse_connection_str`` to avoid depending
+    on a private API for the few fields we need (``AccountName``/``AccountKey``/SAS).
+    """
+    parts = {}
+    for segment in connection_string.split(";"):
+        if "=" in segment:
+            key, value = segment.split("=", 1)
+            parts[key.strip()] = value.strip()
+    return parts
+
+
+def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
+    """Rewrite an ``az://`` source archive into an HTTPS blob URL carrying a short-lived,
+    read-only SAS, so Nuclio can fetch it as a regular ``archive`` (Nuclio has no native Azure
+    Blob code-entry type).
+
+    Credential + endpoint resolution is delegated to mlrun's ``AzureBlobStore`` via a fresh,
+    request-scoped ``StoreManager`` (never the process-global ``store_manager`` — its URL-keyed
+    cache must not be shared across projects). This makes Nuclio deploys authenticate ``az://``
+    exactly like mlrun jobs — account-key, connection-string, SAS pass-through, service
+    principal, and managed/workload identity — rather than a parallel auth implementation. The
+    SAS *type* is chosen from whatever the store resolved.
+    """
+    from azure.storage.blob import BlobSasPermissions, generate_blob_sas
+
+    from mlrun.datastore.datastore import StoreManager
+
+    store, sub_path, _ = StoreManager().get_or_create_store(source, secrets=secrets)
+    options = store.storage_options
+    account_name = options.get("account_name")
+    account_key = options.get("account_key")
+    sas_token = options.get("sas_token")
+    if not (account_key or sas_token) and options.get("connection_string"):
+        conn = _parse_azure_connection_string(options["connection_string"])
+        account_key = conn.get("AccountKey")
+        sas_token = conn.get("SharedAccessSignature")
+        account_name = account_name or conn.get("AccountName")
+
+    container = options.get("container")
+    blob_name = sub_path.lstrip("/")
+    if not container or not blob_name:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"could not resolve Azure container/blob from source {source!r}"
+        )
+
+    now = datetime.datetime.now(datetime.UTC)
+    # back-date the start to absorb clock skew (a "future" start is rejected as not-yet-valid);
+    # keep the window generous so a queued Nuclio build still fetches before the SAS expires
+    start = now - datetime.timedelta(minutes=5)
+    expiry = now + datetime.timedelta(hours=6)
+
+    try:
+        host = (
+            store.service_client.primary_hostname
+        )  # <account>.blob.<suffix>, carries no SAS
+        # Sign with the resolved storage-account name; the host's first label is only a fallback
+        # (a custom-domain BlobEndpoint's first label is not the account, which would otherwise
+        # produce an invalid SAS signature).
+        sas_kwargs = dict(
+            account_name=account_name or host.split(".", 1)[0],
+            container_name=container,
+            blob_name=blob_name,
+            permission=BlobSasPermissions(read=True),
+            expiry=expiry,
+            start=start,
+        )
+        if sas_token:
+            sas = sas_token.lstrip("?")
+        elif account_key:
+            sas = generate_blob_sas(account_key=account_key, **sas_kwargs)
+        else:
+            # AAD: service principal or managed/workload identity
+            sas = generate_blob_sas(
+                user_delegation_key=store.service_client.get_user_delegation_key(
+                    start, expiry
+                ),
+                **sas_kwargs,
+            )
+    except mlrun.errors.MLRunBaseError:
+        raise  # e.g. missing credentials — keep the client-error status, don't mask as 500
+    except Exception as exc:
+        raise mlrun.errors.MLRunRuntimeError(
+            "failed to mint an Azure SAS for the Nuclio source archive — verify the project's "
+            "Azure credentials (for service-principal / identity auth the principal needs the "
+            "'Storage Blob Delegator' role on the storage account)"
+        ) from exc
+
+    logger.debug(
+        "rewrote azure source archive to https with a read-only SAS",
+        container=container,
+        blob=blob_name,
+    )
+    # The SAS rides in spec.build.path (persisted on the Nuclio function); it is read-only and
+    # short-lived. Moving it to a request header (codeEntryAttributes) is a follow-up (ML-12764).
+    return f"https://{host}/{container}/{blob_name}?{sas}"
+
+
 @pure_nuclio_deployed_restricted()
 def compile_nuclio_archive_config(
     function: mlrun.runtimes.nuclio.function.RemoteRuntime,
@@ -267,6 +369,9 @@ def compile_nuclio_archive_config(
 
     source = function.spec.build.source
     parsed_url = urllib.parse.urlparse(source)
+    # Azure Blob has no native Nuclio code-entry type, but the blob is reachable over HTTPS, so
+    # we resolve az:// as a (rewritten, SAS-signed) archive below.
+    is_azure_source = source.startswith("az://")
     code_entry_type = ""
     if source.startswith("s3://"):
         code_entry_type = "s3"
@@ -275,6 +380,8 @@ def compile_nuclio_archive_config(
     for archive_prefix in ["http://", "https://", "v3io://", "v3ios://"]:
         if source.startswith(archive_prefix):
             code_entry_type = "archive"
+    if is_azure_source:
+        code_entry_type = "archive"
 
     if code_entry_type == "":
         raise mlrun.errors.MLRunInvalidArgumentError(
@@ -291,6 +398,11 @@ def compile_nuclio_archive_config(
 
     # archive
     if code_entry_type == "archive":
+        if is_azure_source:
+            source = _build_azure_blob_sas_url(
+                source, {**secrets, **(builder_env or {})}
+            )
+
         v3io_access_key = builder_env.get("V3IO_ACCESS_KEY", "")
         if source.startswith("v3io"):
             if not parsed_url.netloc:

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -18,6 +18,7 @@ import semver
 
 import mlrun
 import mlrun.runtimes
+from mlrun.datastore.datastore import StoreManager
 from mlrun.runtimes.nuclio.function import validate_nuclio_version_compatibility
 from mlrun.utils import logger
 
@@ -299,8 +300,6 @@ def compile_nuclio_archive_config(
             # Nuclio can't fetch az:// directly; have the datastore mint a read-only HTTPS+SAS
             # URL (auth resolved exactly like mlrun jobs) and hand Nuclio that instead. A fresh
             # StoreManager keeps credential resolution request-scoped (not the global cache).
-            from mlrun.datastore.datastore import StoreManager
-
             store, sub_path, _ = StoreManager().get_or_create_store(
                 source, secrets={**secrets, **(builder_env or {})}
             )

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -297,9 +297,7 @@ def compile_nuclio_archive_config(
     # archive
     if code_entry_type == "archive":
         if is_azure_source:
-            # Nuclio can't fetch az:// directly; have the datastore mint a read-only HTTPS+SAS
-            # URL (auth resolved exactly like mlrun jobs) and hand Nuclio that instead. A fresh
-            # StoreManager keeps credential resolution request-scoped (not the global cache).
+            # Nuclio can't fetch az:// directly; use a datastore-minted read-only HTTPS+SAS URL.
             store, sub_path, _ = StoreManager().get_or_create_store(
                 source, secrets={**secrets, **(builder_env or {})}
             )

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import urllib.parse
 
 import semver
@@ -244,98 +243,6 @@ def is_nuclio_version_in_range(min_version: str, max_version: str) -> bool:
     return parsed_min_version <= parsed_current_version < parsed_max_version
 
 
-# SAS window for Nuclio source-archive fetch.
-_AZURE_SAS_CLOCK_SKEW = datetime.timedelta(minutes=5)
-_AZURE_SAS_TTL = datetime.timedelta(hours=2)
-
-
-def _parse_azure_connection_string(connection_string: str) -> dict[str, str]:
-    """Parse Azure ``key=value;...`` connection strings (split on first ``=``)."""
-    parts = {}
-    for segment in connection_string.split(";"):
-        if "=" in segment:
-            key, value = segment.split("=", 1)
-            parts[key.strip()] = value.strip()
-    return parts
-
-
-def _build_azure_blob_sas_url(source: str, secrets: dict[str, str]) -> str:
-    """Rewrite ``az://`` source archives to HTTPS + read-only SAS for Nuclio."""
-    from azure.storage.blob import BlobSasPermissions, generate_blob_sas
-
-    from mlrun.datastore.datastore import StoreManager
-
-    store, sub_path, _ = StoreManager().get_or_create_store(source, secrets=secrets)
-    options = store.storage_options
-    account_name = options.get("account_name")
-    account_key = options.get("account_key")
-    sas_token = options.get("sas_token")
-    if not (account_key or sas_token) and options.get("connection_string"):
-        conn = _parse_azure_connection_string(options["connection_string"])
-        account_key = conn.get("AccountKey")
-        sas_token = conn.get("SharedAccessSignature")
-        account_name = account_name or conn.get("AccountName")
-
-    container = options.get("container")
-    blob_name = sub_path.lstrip("/")
-    if not container or not blob_name:
-        raise mlrun.errors.MLRunInvalidArgumentError(
-            f"could not resolve Azure container/blob from source {source!r}"
-        )
-
-    now = datetime.datetime.now(datetime.UTC)
-    start = now - _AZURE_SAS_CLOCK_SKEW
-    expiry = now + _AZURE_SAS_TTL
-
-    # primary_hostname carries no SAS. Kept outside the try so missing-cred errors stay
-    # client-side (400) instead of being wrapped as a 500 below.
-    host = store.service_client.primary_hostname
-    if sas_token:
-        sas = sas_token.lstrip("?")
-    else:
-        sas_kwargs = dict(
-            # Prefer resolved account name; host-label fallback can be wrong on custom domains.
-            account_name=account_name or host.split(".", 1)[0],
-            container_name=container,
-            blob_name=blob_name,
-            permission=BlobSasPermissions(read=True),
-            expiry=expiry,
-            start=start,
-        )
-        try:
-            if account_key:
-                sas = generate_blob_sas(account_key=account_key, **sas_kwargs)
-            else:
-                # AAD: service principal or managed/workload identity
-                sas = generate_blob_sas(
-                    user_delegation_key=store.service_client.get_user_delegation_key(
-                        start, expiry
-                    ),
-                    **sas_kwargs,
-                )
-        except Exception as exc:
-            # Only identity auth failures should include the Delegator-role hint.
-            hint = (
-                ""
-                if account_key
-                else " (service-principal/managed-identity auth requires "
-                "'Storage Blob Delegator')"
-            )
-            raise mlrun.errors.MLRunRuntimeError(
-                f"failed to create Azure SAS for Nuclio source archive{hint}: "
-                f"{mlrun.errors.err_to_str(exc)}"
-            ) from exc
-
-    logger.debug(
-        "rewrote az:// source archive to https with read-only SAS",
-        container=container,
-        blob=blob_name,
-    )
-    # Encode blob path for URL (keep '/'); SAS is signed over raw blob name.
-    encoded_blob = urllib.parse.quote(blob_name, safe="/")
-    return f"https://{host}/{container}/{encoded_blob}?{sas}"
-
-
 @pure_nuclio_deployed_restricted()
 def compile_nuclio_archive_config(
     function: mlrun.runtimes.nuclio.function.RemoteRuntime,
@@ -389,9 +296,15 @@ def compile_nuclio_archive_config(
     # archive
     if code_entry_type == "archive":
         if is_azure_source:
-            source = _build_azure_blob_sas_url(
-                source, {**secrets, **(builder_env or {})}
+            # Nuclio can't fetch az:// directly; have the datastore mint a read-only HTTPS+SAS
+            # URL (auth resolved exactly like mlrun jobs) and hand Nuclio that instead. A fresh
+            # StoreManager keeps credential resolution request-scoped (not the global cache).
+            from mlrun.datastore.datastore import StoreManager
+
+            store, sub_path, _ = StoreManager().get_or_create_store(
+                source, secrets={**secrets, **(builder_env or {})}
             )
+            source = store.get_read_only_https_url(sub_path)
 
         v3io_access_key = builder_env.get("V3IO_ACCESS_KEY", "")
         if source.startswith("v3io"):

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -287,7 +287,8 @@ def _build_azure_blob_sas_url(source: str, secrets: dict[str, str]) -> str:
     start = now - _AZURE_SAS_CLOCK_SKEW
     expiry = now + _AZURE_SAS_TTL
 
-    # primary_hostname carries no SAS.
+    # primary_hostname carries no SAS. Kept outside the try so missing-cred errors stay
+    # client-side (400) instead of being wrapped as a 500 below.
     host = store.service_client.primary_hostname
     if sas_token:
         sas = sas_token.lstrip("?")

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -245,11 +245,9 @@ def is_nuclio_version_in_range(min_version: str, max_version: str) -> bool:
 
 
 def _parse_azure_connection_string(connection_string: str) -> dict:
-    """Parse an Azure ``key=value;...`` connection string into a dict. Values can contain ``=``
-    (base64 account keys, SAS tokens), so split on the first ``=`` only.
+    """Parse ``key=value;...`` Azure connection strings.
 
-    Hand-rolled rather than reusing azure-storage-blob's internal ``parse_connection_str`` to
-    avoid depending on a private API for the few fields we need (``AccountName``/``AccountKey``/SAS).
+    Split each segment on the first ``=`` so base64 keys and SAS values are preserved.
     """
     parts = {}
     for segment in connection_string.split(";"):
@@ -260,18 +258,10 @@ def _parse_azure_connection_string(connection_string: str) -> dict:
 
 
 def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
-    """Rewrite an ``az://`` source archive into an HTTPS blob URL carrying a short-lived,
-    read-only SAS, so Nuclio can fetch it as a regular ``archive`` (Nuclio has no native Azure
-    Blob code-entry type).
+    """Rewrite ``az://`` source archives to HTTPS + read-only SAS for Nuclio.
 
-    Credential + endpoint resolution is delegated to mlrun's ``AzureBlobStore`` so deploys
-    resolve ``az://`` credentials the same way mlrun jobs do — account-key, connection-string,
-    SAS pass-through, service principal, and managed/workload identity — rather than a parallel
-    auth implementation. The SAS *type* is then chosen from whatever the store resolved.
-
-    A fresh ``StoreManager`` is constructed per call rather than the process-global one to keep
-    resolution request-scoped (the API server already bypasses the datastore cache, so this is
-    defense-in-depth).
+    Uses request-scoped ``StoreManager`` + ``AzureBlobStore`` resolution so auth behavior matches
+    mlrun jobs.
     """
     from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 
@@ -296,18 +286,14 @@ def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
         )
 
     now = datetime.datetime.now(datetime.UTC)
-    # back-date the start to absorb clock skew (a "future" start is rejected as not-yet-valid);
-    # keep the window generous so a queued Nuclio build still fetches before the SAS expires
+    # Backdate start for clock skew; keep expiry long enough for queued builds.
     start = now - datetime.timedelta(minutes=5)
     expiry = now + datetime.timedelta(hours=6)
 
     try:
-        host = (
-            store.service_client.primary_hostname
-        )  # <account>.blob.<suffix>, carries no SAS
-        # Sign with the resolved storage-account name; the host's first label is only a fallback
-        # (a custom-domain BlobEndpoint's first label is not the account, which would otherwise
-        # produce an invalid SAS signature).
+        # primary_hostname contains no SAS.
+        host = store.service_client.primary_hostname
+        # Prefer resolved account_name; host-label fallback can be wrong on custom domains.
         sas_kwargs = dict(
             account_name=account_name or host.split(".", 1)[0],
             container_name=container,
@@ -329,21 +315,19 @@ def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
                 **sas_kwargs,
             )
     except mlrun.errors.MLRunBaseError:
-        raise  # e.g. missing credentials — keep the client-error status, don't mask as 500
+        raise  # Keep client-side errors (e.g. missing credentials).
     except Exception as exc:
         raise mlrun.errors.MLRunRuntimeError(
-            "failed to mint an Azure SAS for the Nuclio source archive — verify the project's "
-            "Azure credentials (for service-principal / identity auth the principal needs the "
-            "'Storage Blob Delegator' role on the storage account)"
+            "failed to build Azure SAS for Nuclio source archive; verify Azure credentials "
+            "and ensure the principal has the 'Storage Blob Delegator' role"
         ) from exc
 
     logger.debug(
-        "rewrote azure source archive to https with a read-only SAS",
+        "rewrote az:// source archive to https with read-only SAS",
         container=container,
         blob=blob_name,
     )
-    # The SAS rides in spec.build.path (persisted on the Nuclio function); it is read-only and
-    # short-lived.
+    # SAS currently rides in spec.build.path; keep it read-only and short-lived.
     return f"https://{host}/{container}/{blob_name}?{sas}"
 
 
@@ -371,8 +355,7 @@ def compile_nuclio_archive_config(
 
     source = function.spec.build.source
     parsed_url = urllib.parse.urlparse(source)
-    # Azure Blob has no native Nuclio code-entry type, but the blob is reachable over HTTPS, so
-    # we resolve az:// as a (rewritten, SAS-signed) archive below.
+    # Nuclio has no az:// code-entry type; rewrite Azure source as archive HTTPS.
     is_azure_source = source.startswith("az://")
     code_entry_type = ""
     if source.startswith("s3://"):

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -248,8 +248,8 @@ def _parse_azure_connection_string(connection_string: str) -> dict:
     """Parse an Azure ``key=value;...`` connection string into a dict. Values can contain ``=``
     (base64 account keys, SAS tokens), so split on the first ``=`` only.
 
-    Hand-rolled rather than reusing adlfs's internal ``parse_connection_str`` to avoid depending
-    on a private API for the few fields we need (``AccountName``/``AccountKey``/SAS).
+    Hand-rolled rather than reusing azure-storage-blob's internal ``parse_connection_str`` to
+    avoid depending on a private API for the few fields we need (``AccountName``/``AccountKey``/SAS).
     """
     parts = {}
     for segment in connection_string.split(";"):
@@ -264,12 +264,14 @@ def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
     read-only SAS, so Nuclio can fetch it as a regular ``archive`` (Nuclio has no native Azure
     Blob code-entry type).
 
-    Credential + endpoint resolution is delegated to mlrun's ``AzureBlobStore`` via a fresh,
-    request-scoped ``StoreManager`` (never the process-global ``store_manager`` — its URL-keyed
-    cache must not be shared across projects). This makes Nuclio deploys authenticate ``az://``
-    exactly like mlrun jobs — account-key, connection-string, SAS pass-through, service
-    principal, and managed/workload identity — rather than a parallel auth implementation. The
-    SAS *type* is chosen from whatever the store resolved.
+    Credential + endpoint resolution is delegated to mlrun's ``AzureBlobStore`` so deploys
+    resolve ``az://`` credentials the same way mlrun jobs do — account-key, connection-string,
+    SAS pass-through, service principal, and managed/workload identity — rather than a parallel
+    auth implementation. The SAS *type* is then chosen from whatever the store resolved.
+
+    A fresh ``StoreManager`` is constructed per call rather than the process-global one to keep
+    resolution request-scoped (the API server already bypasses the datastore cache, so this is
+    defense-in-depth).
     """
     from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -341,7 +341,7 @@ def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
         blob=blob_name,
     )
     # The SAS rides in spec.build.path (persisted on the Nuclio function); it is read-only and
-    # short-lived. Moving it to a request header (codeEntryAttributes) is a follow-up (ML-12764).
+    # short-lived.
     return f"https://{host}/{container}/{blob_name}?{sas}"
 
 

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -244,17 +244,13 @@ def is_nuclio_version_in_range(min_version: str, max_version: str) -> bool:
     return parsed_min_version <= parsed_current_version < parsed_max_version
 
 
-# SAS validity window for Nuclio source-archive fetches. The archive is fetched once early in
-# the build; the start is back-dated to absorb clock skew.
+# SAS window for Nuclio source-archive fetch.
 _AZURE_SAS_CLOCK_SKEW = datetime.timedelta(minutes=5)
 _AZURE_SAS_TTL = datetime.timedelta(hours=2)
 
 
 def _parse_azure_connection_string(connection_string: str) -> dict[str, str]:
-    """Parse ``key=value;...`` Azure connection strings.
-
-    Split each segment on the first ``=`` so base64 keys and SAS values are preserved.
-    """
+    """Parse Azure ``key=value;...`` connection strings (split on first ``=``)."""
     parts = {}
     for segment in connection_string.split(";"):
         if "=" in segment:
@@ -264,11 +260,7 @@ def _parse_azure_connection_string(connection_string: str) -> dict[str, str]:
 
 
 def _build_azure_blob_sas_url(source: str, secrets: dict[str, str]) -> str:
-    """Rewrite ``az://`` source archives to HTTPS + read-only SAS for Nuclio.
-
-    Uses request-scoped ``StoreManager`` + ``AzureBlobStore`` resolution so auth behavior matches
-    mlrun jobs.
-    """
+    """Rewrite ``az://`` source archives to HTTPS + read-only SAS for Nuclio."""
     from azure.storage.blob import BlobSasPermissions, generate_blob_sas
 
     from mlrun.datastore.datastore import StoreManager
@@ -295,14 +287,13 @@ def _build_azure_blob_sas_url(source: str, secrets: dict[str, str]) -> str:
     start = now - _AZURE_SAS_CLOCK_SKEW
     expiry = now + _AZURE_SAS_TTL
 
-    # primary_hostname contains no SAS; missing-credential errors surface here as client errors.
+    # primary_hostname carries no SAS.
     host = store.service_client.primary_hostname
     if sas_token:
         sas = sas_token.lstrip("?")
     else:
         sas_kwargs = dict(
-            # Prefer the resolved account name; the host's first label is only a fallback and
-            # can be wrong for custom-domain endpoints.
+            # Prefer resolved account name; host-label fallback can be wrong on custom domains.
             account_name=account_name or host.split(".", 1)[0],
             container_name=container,
             blob_name=blob_name,
@@ -322,16 +313,15 @@ def _build_azure_blob_sas_url(source: str, secrets: dict[str, str]) -> str:
                     **sas_kwargs,
                 )
         except Exception as exc:
-            # Wrap all SDK failures consistently; only the AAD path warrants the
-            # 'Storage Blob Delegator' hint, so account-key failures aren't misdiagnosed.
+            # Only identity auth failures should include the Delegator-role hint.
             hint = (
                 ""
                 if account_key
-                else " (for service-principal / managed-identity auth, the principal needs "
-                "the 'Storage Blob Delegator' role)"
+                else " (service-principal/managed-identity auth requires "
+                "'Storage Blob Delegator')"
             )
             raise mlrun.errors.MLRunRuntimeError(
-                f"failed to build Azure SAS for the Nuclio source archive{hint}: "
+                f"failed to create Azure SAS for Nuclio source archive{hint}: "
                 f"{mlrun.errors.err_to_str(exc)}"
             ) from exc
 
@@ -340,8 +330,7 @@ def _build_azure_blob_sas_url(source: str, secrets: dict[str, str]) -> str:
         container=container,
         blob=blob_name,
     )
-    # SAS currently rides in spec.build.path; keep it read-only and short-lived. The blob name is
-    # percent-encoded for the URL (path separators kept); the SAS is signed over the raw name.
+    # Encode blob path for URL (keep '/'); SAS is signed over raw blob name.
     encoded_blob = urllib.parse.quote(blob_name, safe="/")
     return f"https://{host}/{container}/{encoded_blob}?{sas}"
 

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -244,7 +244,13 @@ def is_nuclio_version_in_range(min_version: str, max_version: str) -> bool:
     return parsed_min_version <= parsed_current_version < parsed_max_version
 
 
-def _parse_azure_connection_string(connection_string: str) -> dict:
+# SAS validity window for Nuclio source-archive fetches. The archive is fetched once early in
+# the build; the start is back-dated to absorb clock skew.
+_AZURE_SAS_CLOCK_SKEW = datetime.timedelta(minutes=5)
+_AZURE_SAS_TTL = datetime.timedelta(hours=2)
+
+
+def _parse_azure_connection_string(connection_string: str) -> dict[str, str]:
     """Parse ``key=value;...`` Azure connection strings.
 
     Split each segment on the first ``=`` so base64 keys and SAS values are preserved.
@@ -257,7 +263,7 @@ def _parse_azure_connection_string(connection_string: str) -> dict:
     return parts
 
 
-def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
+def _build_azure_blob_sas_url(source: str, secrets: dict[str, str]) -> str:
     """Rewrite ``az://`` source archives to HTTPS + read-only SAS for Nuclio.
 
     Uses request-scoped ``StoreManager`` + ``AzureBlobStore`` resolution so auth behavior matches
@@ -286,15 +292,17 @@ def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
         )
 
     now = datetime.datetime.now(datetime.UTC)
-    # Backdate start for clock skew; keep expiry long enough for queued builds.
-    start = now - datetime.timedelta(minutes=5)
-    expiry = now + datetime.timedelta(hours=6)
+    start = now - _AZURE_SAS_CLOCK_SKEW
+    expiry = now + _AZURE_SAS_TTL
 
-    try:
-        # primary_hostname contains no SAS.
-        host = store.service_client.primary_hostname
-        # Prefer resolved account_name; host-label fallback can be wrong on custom domains.
+    # primary_hostname contains no SAS; missing-credential errors surface here as client errors.
+    host = store.service_client.primary_hostname
+    if sas_token:
+        sas = sas_token.lstrip("?")
+    else:
         sas_kwargs = dict(
+            # Prefer the resolved account name; the host's first label is only a fallback and
+            # can be wrong for custom-domain endpoints.
             account_name=account_name or host.split(".", 1)[0],
             container_name=container,
             blob_name=blob_name,
@@ -302,33 +310,40 @@ def _build_azure_blob_sas_url(source: str, secrets: dict) -> str:
             expiry=expiry,
             start=start,
         )
-        if sas_token:
-            sas = sas_token.lstrip("?")
-        elif account_key:
-            sas = generate_blob_sas(account_key=account_key, **sas_kwargs)
-        else:
-            # AAD: service principal or managed/workload identity
-            sas = generate_blob_sas(
-                user_delegation_key=store.service_client.get_user_delegation_key(
-                    start, expiry
-                ),
-                **sas_kwargs,
+        try:
+            if account_key:
+                sas = generate_blob_sas(account_key=account_key, **sas_kwargs)
+            else:
+                # AAD: service principal or managed/workload identity
+                sas = generate_blob_sas(
+                    user_delegation_key=store.service_client.get_user_delegation_key(
+                        start, expiry
+                    ),
+                    **sas_kwargs,
+                )
+        except Exception as exc:
+            # Wrap all SDK failures consistently; only the AAD path warrants the
+            # 'Storage Blob Delegator' hint, so account-key failures aren't misdiagnosed.
+            hint = (
+                ""
+                if account_key
+                else " (for service-principal / managed-identity auth, the principal needs "
+                "the 'Storage Blob Delegator' role)"
             )
-    except mlrun.errors.MLRunBaseError:
-        raise  # Keep client-side errors (e.g. missing credentials).
-    except Exception as exc:
-        raise mlrun.errors.MLRunRuntimeError(
-            "failed to build Azure SAS for Nuclio source archive; verify Azure credentials "
-            "and ensure the principal has the 'Storage Blob Delegator' role"
-        ) from exc
+            raise mlrun.errors.MLRunRuntimeError(
+                f"failed to build Azure SAS for the Nuclio source archive{hint}: "
+                f"{mlrun.errors.err_to_str(exc)}"
+            ) from exc
 
     logger.debug(
         "rewrote az:// source archive to https with read-only SAS",
         container=container,
         blob=blob_name,
     )
-    # SAS currently rides in spec.build.path; keep it read-only and short-lived.
-    return f"https://{host}/{container}/{blob_name}?{sas}"
+    # SAS currently rides in spec.build.path; keep it read-only and short-lived. The blob name is
+    # percent-encoded for the URL (path separators kept); the SAS is signed over the raw name.
+    encoded_blob = urllib.parse.quote(blob_name, safe="/")
+    return f"https://{host}/{container}/{encoded_blob}?{sas}"
 
 
 @pure_nuclio_deployed_restricted()

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1535,7 +1535,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         }
 
     def test_load_function_with_source_archive_azure_blob(self):
-        """az:// resolves to an archive whose path is the datastore-minted read-only HTTPS URL."""
+        """az:// sources resolve to a datastore-minted read-only HTTPS URL."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(
             "az://data/projects/x/src.tar.gz", handler="main:handler", workdir="wd"

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1543,12 +1543,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         )
 
     def test_load_function_with_source_archive_azure_blob_service_principal(self):
-        """az:// + service-principal → archive at an HTTPS URL with a user-delegation SAS.
-
-        Credential/endpoint resolution is delegated to AzureBlobStore (so secret-name handling
-        and auth modes match mlrun jobs); the authenticated client is mocked so the rewrite runs
-        without a live account.
-        """
+        """Service-principal auth mints a user-delegation SAS and rewrites to HTTPS."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(
             "az://data/projects/airun-test/artifacts/src.tar.gz",
@@ -1594,7 +1589,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         assert sas_kwargs["start"] < sas_kwargs["expiry"]
 
     def test_load_function_with_source_archive_azure_blob_account_key(self):
-        """az:// + account key → an account-key SAS, with no user-delegation call."""
+        """Account-key auth mints account-key SAS without user-delegation."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
         secrets = {
@@ -1622,7 +1617,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         assert "user_delegation_key" not in sas_kwargs
 
     def test_load_function_with_source_archive_azure_blob_sas_passthrough(self):
-        """az:// + an existing SAS token → the token is passed through, nothing is minted."""
+        """Existing SAS token is passed through (no SAS minting)."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
         secrets = {
@@ -1646,10 +1641,10 @@ class TestNuclioRuntime(TestRuntimeBase):
         mock_client.get_user_delegation_key.assert_not_called()
 
     def test_load_function_with_source_archive_azure_blob_connection_string(self):
-        """az:// + a connection string → account-key SAS, signed with the parsed AccountName."""
+        """Connection-string auth mints account-key SAS using parsed AccountName."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
-        # base64-style key contains '=' — exercises the split-on-first-'=' contract
+        # Key includes '=' to verify split-on-first-'=' parsing.
         secrets = {
             "AZURE_STORAGE_CONNECTION_STRING": (
                 "DefaultEndpointsProtocol=https;AccountName=connacct;"
@@ -1672,21 +1667,19 @@ class TestNuclioRuntime(TestRuntimeBase):
             == "https://connacct.blob.core.windows.net/data/src.tar.gz?sig=cs"
         )
         _, sas_kwargs = mock_gen_sas.call_args
-        assert (
-            sas_kwargs["account_key"] == "YWJjZA=="
-        )  # split on first '=' kept the trailing ==
+        assert sas_kwargs["account_key"] == "YWJjZA=="
         assert sas_kwargs["account_name"] == "connacct"
         mock_client.get_user_delegation_key.assert_not_called()
 
     def test_load_function_with_source_archive_azure_blob_missing_secrets(self):
-        """az:// without any Azure credentials surfaces a client-side error (not a 500)."""
+        """Missing Azure credentials returns a client-side error."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             get_archive_spec(fn, {})
 
     def test_load_function_with_source_archive_azure_blob_sas_failure_wrapped(self):
-        """An Azure SDK failure while minting the SAS is wrapped as an MLRun runtime error."""
+        """Azure SDK SAS failures are wrapped as MLRunRuntimeError."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
         secrets = {
@@ -2607,7 +2600,7 @@ def get_archive_spec(function, secrets):
 
 
 def test_parse_azure_connection_string():
-    """Values may contain '=' (base64 keys, SAS); only the first '=' separates key/value."""
+    """Split on first '=' so base64 keys and SAS values are preserved."""
     parsed = services.api.crud.runtimes.nuclio.helpers._parse_azure_connection_string(
         "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=YWJjZA==;"
         "SharedAccessSignature=sv=2023&sig=x%3D%3D"

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1700,6 +1700,65 @@ class TestNuclioRuntime(TestRuntimeBase):
         ):
             get_archive_spec(fn, secrets)
 
+    def test_load_function_with_source_archive_azure_blob_url_encodes_blob_name(self):
+        """The blob name is percent-encoded in the URL (path slashes preserved), while the SAS
+        is signed over the raw blob name."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive(
+            "az://data/projects/a b/src.tar.gz", handler="main:handler"
+        )
+        secrets = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
+            "AZURE_CLIENT_ID": "cid",
+            "AZURE_CLIENT_SECRET": "csecret",
+            "AZURE_TENANT_ID": "tid",
+        }
+        mock_client = unittest.mock.Mock()
+        mock_client.primary_hostname = "acct.blob.core.windows.net"
+        mock_client.get_user_delegation_key.return_value = "the-udk"
+
+        with (
+            self._patch_azure_service_client(mock_client),
+            unittest.mock.patch(
+                "azure.storage.blob.generate_blob_sas", return_value="sig=x"
+            ) as mock_gen_sas,
+        ):
+            archive = get_archive_spec(fn, secrets)
+
+        assert (
+            archive["spec"]["build"]["path"]
+            == "https://acct.blob.core.windows.net/data/projects/a%20b/src.tar.gz?sig=x"
+        )
+        # Azure signs the canonical (raw) blob name, not the percent-encoded one
+        _, sas_kwargs = mock_gen_sas.call_args
+        assert sas_kwargs["blob_name"] == "projects/a b/src.tar.gz"
+
+    def test_load_function_with_source_archive_azure_blob_account_key_failure_not_mislabeled(
+        self,
+    ):
+        """An account-key signing failure is wrapped consistently as MLRunRuntimeError (with the
+        underlying cause), but must not carry the AAD-only 'Storage Blob Delegator' hint."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
+        secrets = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
+            "AZURE_STORAGE_ACCOUNT_KEY": "the-key",
+        }
+        mock_client = unittest.mock.Mock()
+        mock_client.primary_hostname = "acct.blob.core.windows.net"
+
+        with (
+            self._patch_azure_service_client(mock_client),
+            unittest.mock.patch(
+                "azure.storage.blob.generate_blob_sas",
+                side_effect=ValueError("bad key"),
+            ),
+            pytest.raises(mlrun.errors.MLRunRuntimeError) as exc_info,
+        ):
+            get_archive_spec(fn, secrets)
+        assert "Storage Blob Delegator" not in str(exc_info.value)
+        assert "bad key" in str(exc_info.value)  # underlying cause surfaced
+
     @pytest.mark.parametrize(
         "image_pull_secret_name,build_secret_name,default_image_pull_secret_name,"
         "default_build_secret_name,expected_secret_name",

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1534,6 +1534,179 @@ class TestNuclioRuntime(TestRuntimeBase):
             },
         }
 
+    @staticmethod
+    def _patch_azure_service_client(mock_client):
+        return unittest.mock.patch(
+            "mlrun.datastore.azure_blob.AzureBlobStore.service_client",
+            new_callable=unittest.mock.PropertyMock,
+            return_value=mock_client,
+        )
+
+    def test_load_function_with_source_archive_azure_blob_service_principal(self):
+        """az:// + service-principal → archive at an HTTPS URL with a user-delegation SAS.
+
+        Credential/endpoint resolution is delegated to AzureBlobStore (so secret-name handling
+        and auth modes match mlrun jobs); the authenticated client is mocked so the rewrite runs
+        without a live account.
+        """
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive(
+            "az://data/projects/airun-test/artifacts/src.tar.gz",
+            handler="main:handler",
+            workdir="path/inside/archive",
+        )
+        secrets = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "mystorageacct",
+            "AZURE_CLIENT_ID": "cid",
+            "AZURE_CLIENT_SECRET": "csecret",
+            "AZURE_TENANT_ID": "tid",
+        }
+        mock_client = unittest.mock.Mock()
+        mock_client.primary_hostname = "mystorageacct.blob.core.windows.net"
+        mock_client.get_user_delegation_key.return_value = "the-udk"
+
+        with (
+            self._patch_azure_service_client(mock_client),
+            unittest.mock.patch(
+                "azure.storage.blob.generate_blob_sas", return_value="sig=fake-sas"
+            ) as mock_gen_sas,
+        ):
+            archive = get_archive_spec(fn, secrets)
+
+        assert archive == {
+            "spec": {
+                "handler": "main:handler",
+                "build": {
+                    "path": "https://mystorageacct.blob.core.windows.net/data/"
+                    "projects/airun-test/artifacts/src.tar.gz?sig=fake-sas",
+                    "codeEntryType": "archive",
+                    "codeEntryAttributes": {"workDir": "path/inside/archive"},
+                },
+            },
+        }
+        mock_client.get_user_delegation_key.assert_called_once()
+        _, sas_kwargs = mock_gen_sas.call_args
+        assert sas_kwargs["user_delegation_key"] == "the-udk"
+        assert sas_kwargs["account_name"] == "mystorageacct"
+        assert sas_kwargs["container_name"] == "data"
+        assert sas_kwargs["blob_name"] == "projects/airun-test/artifacts/src.tar.gz"
+        assert sas_kwargs["permission"].read is True
+        assert sas_kwargs["start"] < sas_kwargs["expiry"]
+
+    def test_load_function_with_source_archive_azure_blob_account_key(self):
+        """az:// + account key → an account-key SAS, with no user-delegation call."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
+        secrets = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
+            "AZURE_STORAGE_ACCOUNT_KEY": "the-key",
+        }
+        mock_client = unittest.mock.Mock()
+        mock_client.primary_hostname = "acct.blob.core.windows.net"
+
+        with (
+            self._patch_azure_service_client(mock_client),
+            unittest.mock.patch(
+                "azure.storage.blob.generate_blob_sas", return_value="sig=ak"
+            ) as mock_gen_sas,
+        ):
+            archive = get_archive_spec(fn, secrets)
+
+        assert (
+            archive["spec"]["build"]["path"]
+            == "https://acct.blob.core.windows.net/data/src.tar.gz?sig=ak"
+        )
+        mock_client.get_user_delegation_key.assert_not_called()
+        _, sas_kwargs = mock_gen_sas.call_args
+        assert sas_kwargs["account_key"] == "the-key"
+        assert "user_delegation_key" not in sas_kwargs
+
+    def test_load_function_with_source_archive_azure_blob_sas_passthrough(self):
+        """az:// + an existing SAS token → the token is passed through, nothing is minted."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
+        secrets = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
+            "AZURE_STORAGE_SAS_TOKEN": "?sv=2023&sig=abc",
+        }
+        mock_client = unittest.mock.Mock()
+        mock_client.primary_hostname = "acct.blob.core.windows.net"
+
+        with (
+            self._patch_azure_service_client(mock_client),
+            unittest.mock.patch("azure.storage.blob.generate_blob_sas") as mock_gen_sas,
+        ):
+            archive = get_archive_spec(fn, secrets)
+
+        assert (
+            archive["spec"]["build"]["path"]
+            == "https://acct.blob.core.windows.net/data/src.tar.gz?sv=2023&sig=abc"
+        )
+        mock_gen_sas.assert_not_called()
+        mock_client.get_user_delegation_key.assert_not_called()
+
+    def test_load_function_with_source_archive_azure_blob_connection_string(self):
+        """az:// + a connection string → account-key SAS, signed with the parsed AccountName."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
+        # base64-style key contains '=' — exercises the split-on-first-'=' contract
+        secrets = {
+            "AZURE_STORAGE_CONNECTION_STRING": (
+                "DefaultEndpointsProtocol=https;AccountName=connacct;"
+                "AccountKey=YWJjZA==;EndpointSuffix=core.windows.net"
+            ),
+        }
+        mock_client = unittest.mock.Mock()
+        mock_client.primary_hostname = "connacct.blob.core.windows.net"
+
+        with (
+            self._patch_azure_service_client(mock_client),
+            unittest.mock.patch(
+                "azure.storage.blob.generate_blob_sas", return_value="sig=cs"
+            ) as mock_gen_sas,
+        ):
+            archive = get_archive_spec(fn, secrets)
+
+        assert (
+            archive["spec"]["build"]["path"]
+            == "https://connacct.blob.core.windows.net/data/src.tar.gz?sig=cs"
+        )
+        _, sas_kwargs = mock_gen_sas.call_args
+        assert (
+            sas_kwargs["account_key"] == "YWJjZA=="
+        )  # split on first '=' kept the trailing ==
+        assert sas_kwargs["account_name"] == "connacct"
+        mock_client.get_user_delegation_key.assert_not_called()
+
+    def test_load_function_with_source_archive_azure_blob_missing_secrets(self):
+        """az:// without any Azure credentials surfaces a client-side error (not a 500)."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+            get_archive_spec(fn, {})
+
+    def test_load_function_with_source_archive_azure_blob_sas_failure_wrapped(self):
+        """An Azure SDK failure while minting the SAS is wrapped as an MLRun runtime error."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
+        secrets = {
+            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
+            "AZURE_CLIENT_ID": "cid",
+            "AZURE_CLIENT_SECRET": "csecret",
+            "AZURE_TENANT_ID": "tid",
+        }
+        mock_client = unittest.mock.Mock()
+        mock_client.primary_hostname = "acct.blob.core.windows.net"
+        mock_client.get_user_delegation_key.side_effect = Exception("boom")
+
+        with (
+            self._patch_azure_service_client(mock_client),
+            pytest.raises(
+                mlrun.errors.MLRunRuntimeError, match="Storage Blob Delegator"
+            ),
+        ):
+            get_archive_spec(fn, secrets)
+
     @pytest.mark.parametrize(
         "image_pull_secret_name,build_secret_name,default_image_pull_secret_name,"
         "default_build_secret_name,expected_secret_name",
@@ -2431,3 +2604,14 @@ def get_archive_spec(function, secrets):
     )
     spec.merge(config)
     return config
+
+
+def test_parse_azure_connection_string():
+    """Values may contain '=' (base64 keys, SAS); only the first '=' separates key/value."""
+    parsed = services.api.crud.runtimes.nuclio.helpers._parse_azure_connection_string(
+        "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=YWJjZA==;"
+        "SharedAccessSignature=sv=2023&sig=x%3D%3D"
+    )
+    assert parsed["AccountName"] == "acct"
+    assert parsed["AccountKey"] == "YWJjZA=="
+    assert parsed["SharedAccessSignature"] == "sv=2023&sig=x%3D%3D"

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1534,228 +1534,32 @@ class TestNuclioRuntime(TestRuntimeBase):
             },
         }
 
-    @staticmethod
-    def _patch_azure_service_client(mock_client):
-        return unittest.mock.patch(
-            "mlrun.datastore.azure_blob.AzureBlobStore.service_client",
-            new_callable=unittest.mock.PropertyMock,
-            return_value=mock_client,
-        )
-
-    def test_load_function_with_source_archive_azure_blob_service_principal(self):
-        """Service-principal auth mints a user-delegation SAS and rewrites to HTTPS."""
+    def test_load_function_with_source_archive_azure_blob(self):
+        """az:// resolves to an archive whose path is the datastore-minted read-only HTTPS URL."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(
-            "az://data/projects/airun-test/artifacts/src.tar.gz",
-            handler="main:handler",
-            workdir="path/inside/archive",
+            "az://data/projects/x/src.tar.gz", handler="main:handler", workdir="wd"
         )
-        secrets = {
-            "AZURE_STORAGE_ACCOUNT_NAME": "mystorageacct",
-            "AZURE_CLIENT_ID": "cid",
-            "AZURE_CLIENT_SECRET": "csecret",
-            "AZURE_TENANT_ID": "tid",
-        }
-        mock_client = unittest.mock.Mock()
-        mock_client.primary_hostname = "mystorageacct.blob.core.windows.net"
-        mock_client.get_user_delegation_key.return_value = "the-udk"
-
-        with (
-            self._patch_azure_service_client(mock_client),
-            unittest.mock.patch(
-                "azure.storage.blob.generate_blob_sas", return_value="sig=fake-sas"
-            ) as mock_gen_sas,
-        ):
-            archive = get_archive_spec(fn, secrets)
-
+        minted = (
+            "https://acct.blob.core.windows.net/data/projects/x/src.tar.gz?sig=fake"
+        )
+        with unittest.mock.patch(
+            "mlrun.datastore.azure_blob.AzureBlobStore.get_read_only_https_url",
+            return_value=minted,
+        ) as mock_url:
+            archive = get_archive_spec(fn, {"AZURE_STORAGE_ACCOUNT_NAME": "acct"})
         assert archive == {
             "spec": {
                 "handler": "main:handler",
                 "build": {
-                    "path": "https://mystorageacct.blob.core.windows.net/data/"
-                    "projects/airun-test/artifacts/src.tar.gz?sig=fake-sas",
+                    "path": minted,
                     "codeEntryType": "archive",
-                    "codeEntryAttributes": {"workDir": "path/inside/archive"},
+                    "codeEntryAttributes": {"workDir": "wd"},
                 },
             },
         }
-        mock_client.get_user_delegation_key.assert_called_once()
-        _, sas_kwargs = mock_gen_sas.call_args
-        assert sas_kwargs["user_delegation_key"] == "the-udk"
-        assert sas_kwargs["account_name"] == "mystorageacct"
-        assert sas_kwargs["container_name"] == "data"
-        assert sas_kwargs["blob_name"] == "projects/airun-test/artifacts/src.tar.gz"
-        assert sas_kwargs["permission"].read is True
-        assert sas_kwargs["start"] < sas_kwargs["expiry"]
-
-    def test_load_function_with_source_archive_azure_blob_account_key(self):
-        """Account-key auth mints account-key SAS without user-delegation."""
-        fn = self._generate_runtime(self.runtime_kind)
-        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
-        secrets = {
-            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
-            "AZURE_STORAGE_ACCOUNT_KEY": "the-key",
-        }
-        mock_client = unittest.mock.Mock()
-        mock_client.primary_hostname = "acct.blob.core.windows.net"
-
-        with (
-            self._patch_azure_service_client(mock_client),
-            unittest.mock.patch(
-                "azure.storage.blob.generate_blob_sas", return_value="sig=ak"
-            ) as mock_gen_sas,
-        ):
-            archive = get_archive_spec(fn, secrets)
-
-        assert (
-            archive["spec"]["build"]["path"]
-            == "https://acct.blob.core.windows.net/data/src.tar.gz?sig=ak"
-        )
-        mock_client.get_user_delegation_key.assert_not_called()
-        _, sas_kwargs = mock_gen_sas.call_args
-        assert sas_kwargs["account_key"] == "the-key"
-        assert "user_delegation_key" not in sas_kwargs
-
-    def test_load_function_with_source_archive_azure_blob_sas_passthrough(self):
-        """Existing SAS token is passed through (no SAS minting)."""
-        fn = self._generate_runtime(self.runtime_kind)
-        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
-        secrets = {
-            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
-            "AZURE_STORAGE_SAS_TOKEN": "?sv=2023&sig=abc",
-        }
-        mock_client = unittest.mock.Mock()
-        mock_client.primary_hostname = "acct.blob.core.windows.net"
-
-        with (
-            self._patch_azure_service_client(mock_client),
-            unittest.mock.patch("azure.storage.blob.generate_blob_sas") as mock_gen_sas,
-        ):
-            archive = get_archive_spec(fn, secrets)
-
-        assert (
-            archive["spec"]["build"]["path"]
-            == "https://acct.blob.core.windows.net/data/src.tar.gz?sv=2023&sig=abc"
-        )
-        mock_gen_sas.assert_not_called()
-        mock_client.get_user_delegation_key.assert_not_called()
-
-    def test_load_function_with_source_archive_azure_blob_connection_string(self):
-        """Connection-string auth mints account-key SAS using parsed AccountName."""
-        fn = self._generate_runtime(self.runtime_kind)
-        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
-        # Key includes '=' to verify split-on-first-'=' parsing.
-        secrets = {
-            "AZURE_STORAGE_CONNECTION_STRING": (
-                "DefaultEndpointsProtocol=https;AccountName=connacct;"
-                "AccountKey=YWJjZA==;EndpointSuffix=core.windows.net"
-            ),
-        }
-        mock_client = unittest.mock.Mock()
-        mock_client.primary_hostname = "connacct.blob.core.windows.net"
-
-        with (
-            self._patch_azure_service_client(mock_client),
-            unittest.mock.patch(
-                "azure.storage.blob.generate_blob_sas", return_value="sig=cs"
-            ) as mock_gen_sas,
-        ):
-            archive = get_archive_spec(fn, secrets)
-
-        assert (
-            archive["spec"]["build"]["path"]
-            == "https://connacct.blob.core.windows.net/data/src.tar.gz?sig=cs"
-        )
-        _, sas_kwargs = mock_gen_sas.call_args
-        assert sas_kwargs["account_key"] == "YWJjZA=="
-        assert sas_kwargs["account_name"] == "connacct"
-        mock_client.get_user_delegation_key.assert_not_called()
-
-    def test_load_function_with_source_archive_azure_blob_missing_secrets(self):
-        """Missing Azure credentials returns a client-side error."""
-        fn = self._generate_runtime(self.runtime_kind)
-        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
-        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
-            get_archive_spec(fn, {})
-
-    def test_load_function_with_source_archive_azure_blob_sas_failure_wrapped(self):
-        """Azure SDK SAS failures are wrapped as MLRunRuntimeError."""
-        fn = self._generate_runtime(self.runtime_kind)
-        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
-        secrets = {
-            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
-            "AZURE_CLIENT_ID": "cid",
-            "AZURE_CLIENT_SECRET": "csecret",
-            "AZURE_TENANT_ID": "tid",
-        }
-        mock_client = unittest.mock.Mock()
-        mock_client.primary_hostname = "acct.blob.core.windows.net"
-        mock_client.get_user_delegation_key.side_effect = Exception("boom")
-
-        with (
-            self._patch_azure_service_client(mock_client),
-            pytest.raises(
-                mlrun.errors.MLRunRuntimeError, match="Storage Blob Delegator"
-            ),
-        ):
-            get_archive_spec(fn, secrets)
-
-    def test_load_function_with_source_archive_azure_blob_url_encodes_blob_name(self):
-        """URL encodes blob name (keeping '/'); SAS is signed over raw blob name."""
-        fn = self._generate_runtime(self.runtime_kind)
-        fn.with_source_archive(
-            "az://data/projects/a b/src.tar.gz", handler="main:handler"
-        )
-        secrets = {
-            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
-            "AZURE_CLIENT_ID": "cid",
-            "AZURE_CLIENT_SECRET": "csecret",
-            "AZURE_TENANT_ID": "tid",
-        }
-        mock_client = unittest.mock.Mock()
-        mock_client.primary_hostname = "acct.blob.core.windows.net"
-        mock_client.get_user_delegation_key.return_value = "the-udk"
-
-        with (
-            self._patch_azure_service_client(mock_client),
-            unittest.mock.patch(
-                "azure.storage.blob.generate_blob_sas", return_value="sig=x"
-            ) as mock_gen_sas,
-        ):
-            archive = get_archive_spec(fn, secrets)
-
-        assert (
-            archive["spec"]["build"]["path"]
-            == "https://acct.blob.core.windows.net/data/projects/a%20b/src.tar.gz?sig=x"
-        )
-        # Blob name for SAS signing stays raw.
-        _, sas_kwargs = mock_gen_sas.call_args
-        assert sas_kwargs["blob_name"] == "projects/a b/src.tar.gz"
-
-    def test_load_function_with_source_archive_azure_blob_account_key_failure_not_mislabeled(
-        self,
-    ):
-        """Account-key failures are wrapped but must not include AAD Delegator hint."""
-        fn = self._generate_runtime(self.runtime_kind)
-        fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
-        secrets = {
-            "AZURE_STORAGE_ACCOUNT_NAME": "acct",
-            "AZURE_STORAGE_ACCOUNT_KEY": "the-key",
-        }
-        mock_client = unittest.mock.Mock()
-        mock_client.primary_hostname = "acct.blob.core.windows.net"
-
-        with (
-            self._patch_azure_service_client(mock_client),
-            unittest.mock.patch(
-                "azure.storage.blob.generate_blob_sas",
-                side_effect=ValueError("bad key"),
-            ),
-            pytest.raises(mlrun.errors.MLRunRuntimeError) as exc_info,
-        ):
-            get_archive_spec(fn, secrets)
-        assert "Storage Blob Delegator" not in str(exc_info.value)
-        assert "bad key" in str(exc_info.value)
+        mock_url.assert_called_once()
+        assert mock_url.call_args.args[0].lstrip("/") == "projects/x/src.tar.gz"
 
     @pytest.mark.parametrize(
         "image_pull_secret_name,build_secret_name,default_image_pull_secret_name,"
@@ -2654,14 +2458,3 @@ def get_archive_spec(function, secrets):
     )
     spec.merge(config)
     return config
-
-
-def test_parse_azure_connection_string():
-    """Split on first '=' so base64 keys and SAS values are preserved."""
-    parsed = services.api.crud.runtimes.nuclio.helpers._parse_azure_connection_string(
-        "DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=YWJjZA==;"
-        "SharedAccessSignature=sv=2023&sig=x%3D%3D"
-    )
-    assert parsed["AccountName"] == "acct"
-    assert parsed["AccountKey"] == "YWJjZA=="
-    assert parsed["SharedAccessSignature"] == "sv=2023&sig=x%3D%3D"

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1701,8 +1701,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             get_archive_spec(fn, secrets)
 
     def test_load_function_with_source_archive_azure_blob_url_encodes_blob_name(self):
-        """The blob name is percent-encoded in the URL (path slashes preserved), while the SAS
-        is signed over the raw blob name."""
+        """URL encodes blob name (keeping '/'); SAS is signed over raw blob name."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(
             "az://data/projects/a b/src.tar.gz", handler="main:handler"
@@ -1729,15 +1728,14 @@ class TestNuclioRuntime(TestRuntimeBase):
             archive["spec"]["build"]["path"]
             == "https://acct.blob.core.windows.net/data/projects/a%20b/src.tar.gz?sig=x"
         )
-        # Azure signs the canonical (raw) blob name, not the percent-encoded one
+        # Blob name for SAS signing stays raw.
         _, sas_kwargs = mock_gen_sas.call_args
         assert sas_kwargs["blob_name"] == "projects/a b/src.tar.gz"
 
     def test_load_function_with_source_archive_azure_blob_account_key_failure_not_mislabeled(
         self,
     ):
-        """An account-key signing failure is wrapped consistently as MLRunRuntimeError (with the
-        underlying cause), but must not carry the AAD-only 'Storage Blob Delegator' hint."""
+        """Account-key failures are wrapped but must not include AAD Delegator hint."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive("az://data/src.tar.gz", handler="main:handler")
         secrets = {
@@ -1757,7 +1755,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         ):
             get_archive_spec(fn, secrets)
         assert "Storage Blob Delegator" not in str(exc_info.value)
-        assert "bad key" in str(exc_info.value)  # underlying cause surfaced
+        assert "bad key" in str(exc_info.value)
 
     @pytest.mark.parametrize(
         "image_pull_secret_name,build_secret_name,default_image_pull_secret_name,"

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -39,7 +39,7 @@ class TestAzureBlobStore:
             secrets=secrets or {},
         )
 
-    # --- get_read_only_https_url (read-only SAS URLs for source-archive fetches) ---
+    # --- get_read_only_https_url ---
 
     def _store_with_mock_client(
         self, secrets, hostname="acct.blob.core.windows.net", udk="udk"
@@ -123,7 +123,7 @@ class TestAzureBlobStore:
             url
             == "https://acct.blob.core.windows.net/data/projects/a%20b/src.tar.gz?sig=x"
         )
-        # SAS is signed over the raw (unencoded) blob name
+        # SAS signs the raw blob name.
         assert gen.call_args.kwargs["blob_name"] == "projects/a b/src.tar.gz"
 
     def test_read_only_url_account_key_failure_not_mislabeled(self):

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -156,6 +156,13 @@ class TestAzureBlobStore:
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             store.get_read_only_https_url("/src.tar.gz")
 
+    def test_read_only_url_missing_credentials_raises_client_error(self):
+        # No credentials: the service_client build (outside the try) must surface as a
+        # client-side MLRunInvalidArgumentError (400), not get wrapped as a 500.
+        store = self._create_store(schema="az", endpoint="data", secrets={})
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+            store.get_read_only_https_url("/src.tar.gz")
+
     def test_spark_url_az_schema_with_endpoint_container(self):
         """Test spark_url generation for az:// URLs where endpoint is container"""
         secrets = {

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -39,6 +39,123 @@ class TestAzureBlobStore:
             secrets=secrets or {},
         )
 
+    # --- get_read_only_https_url (read-only SAS URLs for source-archive fetches) ---
+
+    def _store_with_mock_client(
+        self, secrets, hostname="acct.blob.core.windows.net", udk="udk"
+    ):
+        store = self._create_store(schema="az", endpoint="data", secrets=secrets)
+        client = Mock()
+        client.primary_hostname = hostname
+        client.get_user_delegation_key.return_value = udk
+        store._service_client = client
+        return store, client
+
+    def test_read_only_url_service_principal_user_delegation(self):
+        store, client = self._store_with_mock_client({"account_name": "acct"})
+        with patch(
+            "mlrun.datastore.azure_blob.generate_blob_sas", return_value="sig=x"
+        ) as gen:
+            url = store.get_read_only_https_url("/projects/x/src.tar.gz")
+        assert (
+            url == "https://acct.blob.core.windows.net/data/projects/x/src.tar.gz?sig=x"
+        )
+        client.get_user_delegation_key.assert_called_once()
+        kwargs = gen.call_args.kwargs
+        assert kwargs["user_delegation_key"] == "udk"
+        assert kwargs["account_name"] == "acct"
+        assert kwargs["container_name"] == "data"
+        assert kwargs["blob_name"] == "projects/x/src.tar.gz"
+        assert kwargs["permission"].read is True
+        assert kwargs["start"] < kwargs["expiry"]
+
+    def test_read_only_url_account_key(self):
+        store, client = self._store_with_mock_client(
+            {"account_name": "acct", "account_key": "the-key"}
+        )
+        with patch(
+            "mlrun.datastore.azure_blob.generate_blob_sas", return_value="sig=ak"
+        ) as gen:
+            url = store.get_read_only_https_url("/src.tar.gz")
+        assert url == "https://acct.blob.core.windows.net/data/src.tar.gz?sig=ak"
+        client.get_user_delegation_key.assert_not_called()
+        assert gen.call_args.kwargs["account_key"] == "the-key"
+
+    def test_read_only_url_sas_passthrough(self):
+        store, client = self._store_with_mock_client(
+            {"account_name": "acct", "sas_token": "?sv=2023&sig=abc"}
+        )
+        with patch("mlrun.datastore.azure_blob.generate_blob_sas") as gen:
+            url = store.get_read_only_https_url("/src.tar.gz")
+        assert (
+            url == "https://acct.blob.core.windows.net/data/src.tar.gz?sv=2023&sig=abc"
+        )
+        gen.assert_not_called()
+        client.get_user_delegation_key.assert_not_called()
+
+    def test_read_only_url_connection_string_account_key(self):
+        cs = (
+            "DefaultEndpointsProtocol=https;AccountName=connacct;"
+            "AccountKey=YWJjZA==;EndpointSuffix=core.windows.net"
+        )
+        store, client = self._store_with_mock_client(
+            {"connection_string": cs}, hostname="connacct.blob.core.windows.net"
+        )
+        with patch(
+            "mlrun.datastore.azure_blob.generate_blob_sas", return_value="sig=cs"
+        ) as gen:
+            url = store.get_read_only_https_url("/src.tar.gz")
+        assert url == "https://connacct.blob.core.windows.net/data/src.tar.gz?sig=cs"
+        kwargs = gen.call_args.kwargs
+        assert kwargs["account_key"] == "YWJjZA=="
+        assert kwargs["account_name"] == "connacct"
+        client.get_user_delegation_key.assert_not_called()
+
+    def test_read_only_url_encodes_blob_name(self):
+        store, _ = self._store_with_mock_client(
+            {"account_name": "acct", "account_key": "k"}
+        )
+        with patch(
+            "mlrun.datastore.azure_blob.generate_blob_sas", return_value="sig=x"
+        ) as gen:
+            url = store.get_read_only_https_url("/projects/a b/src.tar.gz")
+        assert (
+            url
+            == "https://acct.blob.core.windows.net/data/projects/a%20b/src.tar.gz?sig=x"
+        )
+        # SAS is signed over the raw (unencoded) blob name
+        assert gen.call_args.kwargs["blob_name"] == "projects/a b/src.tar.gz"
+
+    def test_read_only_url_account_key_failure_not_mislabeled(self):
+        store, _ = self._store_with_mock_client(
+            {"account_name": "acct", "account_key": "k"}
+        )
+        with (
+            patch(
+                "mlrun.datastore.azure_blob.generate_blob_sas",
+                side_effect=ValueError("bad key"),
+            ),
+            pytest.raises(mlrun.errors.MLRunRuntimeError) as exc_info,
+        ):
+            store.get_read_only_https_url("/src.tar.gz")
+        assert "Storage Blob Delegator" not in str(exc_info.value)
+        assert "bad key" in str(exc_info.value)
+
+    def test_read_only_url_user_delegation_failure_hints_role(self):
+        store, client = self._store_with_mock_client({"account_name": "acct"})
+        client.get_user_delegation_key.side_effect = Exception("boom")
+        with pytest.raises(
+            mlrun.errors.MLRunRuntimeError, match="Storage Blob Delegator"
+        ):
+            store.get_read_only_https_url("/src.tar.gz")
+
+    def test_read_only_url_no_container_raises(self):
+        store = self._create_store(
+            schema="az", endpoint="", secrets={"account_name": "acct"}
+        )
+        with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+            store.get_read_only_https_url("/src.tar.gz")
+
     def test_spark_url_az_schema_with_endpoint_container(self):
         """Test spark_url generation for az:// URLs where endpoint is container"""
         secrets = {


### PR DESCRIPTION
### 📝 Description

Fixes Nuclio deploys from Azure Blob source archives (`az://...`), which previously failed with:
`Couldn't resolve code entry type from source`.

`compile_nuclio_archive_config` now treats `az://` as an archive source and rewrites it to an HTTPS blob URL with a short-lived, read-only SAS, so Nuclio can fetch it without native `az://` support.

The SAS generation itself lives on `AzureBlobStore` (`get_read_only_https_url`), reusing the store's existing credential/endpoint resolution — so deploy-time auth matches mlrun job reads and there's no second Azure-auth implementation. The Nuclio helper just resolves the store (via a fresh, request-scoped `StoreManager`) and asks it for the URL.

---

### 🛠️ Changes Made

- Added `az://` source recognition as `archive` in Nuclio archive compilation.
- Added `AzureBlobStore.get_read_only_https_url()`, which mints a read-only SAS URL whose type follows the store-resolved credentials:
  - existing SAS token -> pass-through
  - account key (including one parsed from a connection string, via the store's existing `parse_connection_str`) -> account-key SAS
  - service principal / managed identity / workload identity -> user-delegation SAS
- Signs with the resolved account name (host-label only as fallback), derives the host from `service_client.primary_hostname` (covers custom-domain endpoints), percent-encodes the blob path in the URL while signing over the raw name, and wraps SDK failures as `MLRunRuntimeError` (the `Storage Blob Delegator` hint is added only on the identity path).
- Reduced the Nuclio helper to a single `store.get_read_only_https_url(sub_path)` call; removed the hand-rolled SAS/connection-string logic from the crud layer.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- Unit tests: `get_read_only_https_url` covered at the datastore layer (service principal / user-delegation, account key, SAS pass-through, connection string, blob-name URL encoding, account-key-failure wrapping, identity-failure role hint, missing container); a Nuclio-layer test asserts `az://` resolves to an `archive` whose path is the store-minted URL.
- Lint/format: `make fmt lint` passed.
- E2E (Azure IG4, service principal auth): deploy -> invoke -> undeploy succeeds from auto-uploaded `az://` source archive.

---

### 🔗 References
- Ticket link: ML-12764
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- SAS is read-only and short-lived (clock-skew-safe start, bounded expiry), but currently appears in `spec.build.path`.
- Sovereign/custom-domain endpoint nuances remain aligned with current `AzureBlobStore` behavior.
