### PR TITLE
[Artifacts] Add docstring to resolve_dataframe_target_hash_path

### DIFF
--- a/mlrun/artifacts/dataset.py
+++ b/mlrun/artifacts/dataset.py
@@ -248,6 +248,13 @@ class DatasetArtifact(Artifact):
                 self.spec.size, self.metadata.hash = None, None
 
     def resolve_dataframe_target_hash_path(self, dataframe, artifact_path: str):
+        """
+        Resolve the target path for storing the dataframe, based on a hash of its content.
+
+        :param dataframe: The dataframe to calculate the hash for.
+        :param artifact_path: The base artifact path under which the hashed file will be stored.
+        :return: A tuple of (dataframe_hash, target_path).
+        """
         if not artifact_path:
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Unable to resolve body target hash path, artifact_path is not defined"


### PR DESCRIPTION
### 📝 Description
This PR adds a missing docstring to `resolve_dataframe_target_hash_path` in `mlrun/artifacts/dataset.py`. The function had no documentation explaining its parameters or return value, despite being a non-trivial utility (calculates a content hash and builds a target storage path from it).

---

### 🛠️ Changes Made
- Added a docstring to `resolve_dataframe_target_hash_path` following the project's documented docstring convention (`:param`, `:return` tags).
---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
Documentation-only change, no logic was modified. Ran `make fmt` and `make lint` locally to confirm formatting/linting pass.

---

### 🔗 References
- Ticket link: n/a
- Design docs links: n/a
- External links: n/a

---

### 🚨 Breaking Changes?
- [ ] Yes
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
