### PR TITLE
Revert "[Tests] Respect lock files when building test docker images"

### DIFF
--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -327,11 +327,7 @@ jobs:
         sudo chmod +x /usr/local/bin/yq
         uv venv venv --seed --clear
         source venv/bin/activate
-        # Constrain installs to the locked requirements so dependency releases can't silently
-        # drift into the smoke environment (this job installs from the requirement files, not
-        # the test docker images).
-        make install-requirements install-complete-requirements install-automation-requirements \
-          MLRUN_PIP_CONSTRAINTS_FILE=dockerfiles/test-system/locked-requirements.txt
+        make install-requirements install-complete-requirements install-automation-requirements
 
         # Pin cffi below 2.0.0 to avoid wheels without _cffi_backend on the runner
         # python -m pip install --upgrade --force-reinstall "cffi<2.0.0" cryptography bcrypt paramiko orjson

--- a/Makefile
+++ b/Makefile
@@ -154,12 +154,6 @@ endif
 # Change to `--upgrade-package <package-name>` to upgrade only a specific package
 MLRUN_UV_UPGRADE_FLAG ?= --upgrade
 
-# Optional constraints file used to pin versions during installs (e.g. a locked-requirements
-# file). Empty by default so local development installs stay upgradable; CI sets it to a lock
-# so dependency releases can't silently drift into the test environment.
-MLRUN_PIP_CONSTRAINTS_FILE ?=
-MLRUN_PIP_CONSTRAINTS_FLAG := $(if $(MLRUN_PIP_CONSTRAINTS_FILE),-c $(MLRUN_PIP_CONSTRAINTS_FILE),)
-
 # absolute path to this Makefile
 THIS_MAKEFILE := $(abspath $(lastword $(MAKEFILE_LIST)))
 # its directory
@@ -183,7 +177,6 @@ install-requirements: ## Install all requirements needed for development
 
 	$(MLRUN_PYTHON_VENV_PIP_INSTALL) \
 		$(MLRUN_PIP_NO_CACHE_FLAG) \
-		$(MLRUN_PIP_CONSTRAINTS_FLAG) \
 		-r requirements.txt \
 		-r extras-requirements.txt \
 		-r dev-requirements.txt \
@@ -220,7 +213,7 @@ install-docs-requirements: ## Install all requirements needed for compiling mlru
 install-complete-requirements: ## Install all requirements needed for development and testing
 	$(MLRUN_PYTHON_VENV_PIP_INSTALL) --upgrade $(MLRUN_PIP_NO_CACHE_FLAG) pip~=$(MLRUN_PIP_VERSION)
 	$(eval MLRUN_PIP_INSTALL_FLAG := $(if $(and $(MLRUN_PYTHON_PACKAGE_INSTALLER),$(filter -m pip,$(MLRUN_PYTHON_PACKAGE_INSTALLER))),--ignore-requires-python,))
-	$(MLRUN_PYTHON_VENV_PIP_INSTALL) $(MLRUN_PIP_CONSTRAINTS_FLAG) .[complete,kfp18,dev-postgres] $(MLRUN_PIP_INSTALL_FLAG)
+	$(MLRUN_PYTHON_VENV_PIP_INSTALL) .[complete,kfp18,dev-postgres] $(MLRUN_PIP_INSTALL_FLAG)
 
 .PHONY: install-all-requirements
 install-all-requirements: ## Install all requirements needed for development and testing

--- a/dockerfiles/test-system/Dockerfile
+++ b/dockerfiles/test-system/Dockerfile
@@ -48,7 +48,7 @@ ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \
     --mount=type=bind,source=dockerfiles/test-system/locked-requirements.txt,target=locked-requirements.txt \
-    uv pip sync --require-hashes locked-requirements.txt
+    uv pip sync  --require-hashes locked-requirements.txt
 
 WORKDIR /tmp/mlrun
 COPY *.txt *.md *.py *.toml ./
@@ -56,15 +56,13 @@ COPY mlrun mlrun
 COPY dockerfiles/mlrun-api dockerfiles/mlrun-api
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \
-    --mount=type=bind,source=dockerfiles/test-system/locked-requirements.txt,target=locked-requirements.txt \
-    uv pip install -c locked-requirements.txt .[complete,dev-postgres] && rm -rf /tmp/mlrun
+    uv pip install .[complete,dev-postgres] && rm -rf /tmp/mlrun
 
 COPY pipeline-adapters pipeline-adapters
 # Install the pipeline adapters development versions since we release them only after merging
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \
-    --mount=type=bind,source=dockerfiles/test-system/locked-requirements.txt,target=locked-requirements.txt \
-    uv pip install -c locked-requirements.txt ./pipeline-adapters/mlrun-pipelines-kfp-common ./pipeline-adapters/mlrun-pipelines-kfp-v1-8 --python-version ${MLRUN_PYTHON_VERSION} && rm -rf /tmp/mlrun
+    uv pip install ./pipeline-adapters/mlrun-pipelines-kfp-common ./pipeline-adapters/mlrun-pipelines-kfp-v1-8 --python-version ${MLRUN_PYTHON_VERSION} && rm -rf /tmp/mlrun
 
 WORKDIR /mlrun
 COPY Makefile .

--- a/dockerfiles/test/Dockerfile
+++ b/dockerfiles/test/Dockerfile
@@ -55,7 +55,7 @@ ENV UV_SYSTEM_PYTHON=true UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \
     --mount=type=bind,source=dockerfiles/test/locked-requirements.txt,target=locked-requirements.txt \
-    uv pip sync --require-hashes locked-requirements.txt --python-version ${MLRUN_PYTHON_VERSION}
+    uv pip sync  --require-hashes locked-requirements.txt --python-version ${MLRUN_PYTHON_VERSION}
 
 WORKDIR /mlrun
 COPY *.txt *.md *.py *.toml ./
@@ -64,15 +64,13 @@ COPY dockerfiles/mlrun-api dockerfiles/mlrun-api
 
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \
-    --mount=type=bind,source=dockerfiles/test/locked-requirements.txt,target=locked-requirements.txt \
-    uv pip install -c locked-requirements.txt .[complete,dev-postgres] --python-version ${MLRUN_PYTHON_VERSION} && rm -rf /mlrun/build/
+    uv pip install .[complete,dev-postgres] --python-version ${MLRUN_PYTHON_VERSION} && rm -rf /mlrun/build/
 
 COPY pipeline-adapters pipeline-adapters
 # Install the pipeline adapters development versions since we release them only after merging
 RUN --mount=from=uv-image,source=/uv,target=/bin/uv \
     --mount=type=cache,id=pip-${MLRUN_PYTHON_VERSION},target=/root/.cache/uv \
-    --mount=type=bind,source=dockerfiles/test/locked-requirements.txt,target=locked-requirements.txt \
-    uv pip install -c locked-requirements.txt ./pipeline-adapters/mlrun-pipelines-kfp-common ./pipeline-adapters/mlrun-pipelines-kfp-v1-8 --python-version ${MLRUN_PYTHON_VERSION} && make -C pipeline-adapters clean
+    uv pip install ./pipeline-adapters/mlrun-pipelines-kfp-common ./pipeline-adapters/mlrun-pipelines-kfp-v1-8 --python-version ${MLRUN_PYTHON_VERSION} && make -C pipeline-adapters clean
 
 COPY Makefile .
 COPY .dockerignore .


### PR DESCRIPTION
Reverts mlrun/mlrun#9815

While we use the constraint - we lose the ability to bump + release pipeline adapters modules. we need to rethink how we ensure we dont let other requirements leak (e.g pytest) while allowing pipeline adapters requirement changes on PRs