### PR TITLE
[Serving] Preserve handler Response status code; skip output mapping on non-2xx (ML-12706)

### DIFF
--- a/docs/serving/api-handler.md
+++ b/docs/serving/api-handler.md
@@ -231,6 +231,14 @@ def responses_router(
 
 The handler signature must accept these names (explicitly or via `**kwargs`); otherwise Python raises `TypeError: unexpected keyword argument`.
 
+## Returning a custom HTTP status code
+
+A handler can return a `Response(body, status_code, ...)` wrapper to set a custom HTTP response. See [Returning custom HTTP responses](./serving-graph.md#returning-custom-http-responses) for the construction patterns — this section covers the **interaction with `output_body_mappings`**.
+
+`output_body_mappings` describes the *success-shape* contract, so the mapping runs **only when `status_code < 300`**. Non-2xx responses pass through with their body and status code intact, so the caller sees the original error envelope instead of a synthetic 422 from a failed mandatory-field check.
+
+If you simply return a `dict`, the runtime treats the response as `200 OK` and runs the output mapping as usual — no change from previous behavior.
+
 ## How downstream steps receive parameters
 
 Extracted parameters are passed as keyword arguments to the handler function or `do()` method. For example, given the endpoint `/v1/chat/completions/{completion_id}` with `include_url_info=True`, a `GET /v1/chat/completions/abc123?limit=10` request calls the next step as:

--- a/docs/serving/serving-graph.md
+++ b/docs/serving/serving-graph.md
@@ -52,8 +52,11 @@ class MyStep:
             content_type="application/json",
         )
 
+
 # B) Import the class directly — works the same way; the SDK normalizes it on the way out.
 from mlrun.serving.server import Response
+
+
 def my_handler(body, **kwargs):
     return Response(
         body={"id": "resp_1", "object": "response"},

--- a/docs/serving/serving-graph.md
+++ b/docs/serving/serving-graph.md
@@ -35,6 +35,37 @@ Serving graphs are built on top of the [Nuclio real-time serverless engine](http
 
 By default, all steps of the serving graph run on the same pod. It is possible to run different steps on different pods using distributed pipelines. Typically you run steps that require CPU on one pod, and steps that require a GPU on a different pod that is running on a potentially different node that has GPU support. See {ref}`distributed-graph-oview`.
 
+## Returning custom HTTP responses
+
+A graph handler can control the HTTP response by returning a `Response` wrapper instead of a plain dict. The runtime preserves `status_code`, `content_type`, and `headers` end-to-end.
+
+Two ways to construct it, both supported:
+
+```python
+# A) Use context.Response — picks the right class for the runtime
+#    (mlrun.serving.server.Response in MockServer; nuclio_sdk.Response in deployed Nuclio).
+class MyStep:
+    def do(self, body):
+        return self.context.Response(
+            body={"error": {"message": "not found"}},
+            status_code=404,
+            content_type="application/json",
+        )
+
+# B) Import the class directly — works the same way; the SDK normalizes it on the way out.
+from mlrun.serving.server import Response
+def my_handler(body, **kwargs):
+    return Response(
+        body={"id": "resp_1", "object": "response"},
+        status_code=200,
+        content_type="application/json",
+    )
+```
+
+If you simply return a `dict`, the runtime treats the response as `200 OK` — no change from previous behavior.
+
+When using the {ref}`API handler<api-handler>` with `output_body_mappings`, the mapping runs only when `status_code < 300`; see [Returning a custom HTTP status code](./api-handler.md#returning-a-custom-http-status-code) for details.
+
 ## Serving graph UI
 The realtime pipelines UI page displays: 
 - A table of serving graphs with a few parameters that can be filtered

--- a/mlrun/serving/api_handler.py
+++ b/mlrun/serving/api_handler.py
@@ -27,7 +27,7 @@ import mlrun.serving.endpoint_mapping as endpoint_mapping
 import mlrun.serving.server
 import mlrun.serving.states
 import mlrun.utils
-from mlrun.serving.utils import _RequestContext
+from mlrun.serving.utils import _RequestContext, is_event_like
 
 
 class _APIHandlerStep(mlrun.serving.states.TaskStep):
@@ -233,7 +233,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
 
                 body_params = {}
                 if effective_map:
-                    body = event.body if hasattr(event, "body") else event
+                    body = event.body if is_event_like(event) else event
                     body_params = endpoint_mapping.apply_body_map_with_dict_check(
                         body,
                         effective_map,
@@ -266,7 +266,7 @@ class _APIHandlerStep(mlrun.serving.states.TaskStep):
                         query_params=query_params,
                         url_params=url_params,
                     )
-                    original_body = event.body if hasattr(event, "body") else None
+                    original_body = event.body if is_event_like(event) else None
                     event.body = _RequestContext(
                         original_body=original_body,
                         body_params=body_params,

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -349,8 +349,9 @@ class GraphServer(ModelObj):
 
             # Unwrap an explicit Response so result_handler sees the body; skip
             # output mapping on non-2xx (success-shape contract, ML-12706).
-            explicit_response: Response | None = None
-            if isinstance(response, Response):
+            # context.Response is adapter-aware — mlrun's in MockServer, nuclio_sdk's in Nuclio.
+            explicit_response: Any = None
+            if isinstance(response, context.Response):
                 explicit_response = response
                 response = explicit_response.body
 

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -345,7 +345,10 @@ class GraphServer(ModelObj):
             response = self.graph.run(event, **(extra_args or {}))
 
             # TODO: this is only relevant in certain flows (MockServer, sync...)
-            if hasattr(response, "body"):
+            # Peel one Event wrapper, but not a Response — Response is captured below.
+            if hasattr(response, "body") and not isinstance(
+                response, (Response, nuclio_sdk.Response)
+            ):
                 response = response.body
 
             # Unwrap an explicit Response so result_handler sees the body; skip

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime
 from http import HTTPMethod
 from typing import Any, Optional, Union
 
+import nuclio_sdk
 import pandas as pd
 import storey
 from nuclio import Context as NuclioContext
@@ -351,7 +352,7 @@ class GraphServer(ModelObj):
             # output mapping on non-2xx (success-shape contract, ML-12706).
             # context.Response is adapter-aware — mlrun's in MockServer, nuclio_sdk's in Nuclio.
             explicit_response: Any = None
-            if isinstance(response, context.Response):
+            if isinstance(response, (Response, nuclio_sdk.Response)):
                 explicit_response = response
                 response = explicit_response.body
 

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -67,7 +67,7 @@ from .states import (
     get_function,
     graph_root_setter,
 )
-from .utils import event_id_key, event_path_key
+from .utils import event_id_key, event_path_key, is_event_like
 
 DUMMY_STREAM = "dummy://"
 
@@ -345,10 +345,9 @@ class GraphServer(ModelObj):
             response = self.graph.run(event, **(extra_args or {}))
 
             # TODO: this is only relevant in certain flows (MockServer, sync...)
-            # Peel one Event wrapper, but not a Response — Response is captured below.
-            if hasattr(response, "body") and not isinstance(
-                response, (Response, nuclio_sdk.Response)
-            ):
+            # Peel one Event wrapper if present. Positive event-type check avoids
+            # the .body ambiguity with Response (which is captured below).
+            if is_event_like(response):
                 response = response.body
 
             # Unwrap an explicit Response so result_handler sees the body; skip

--- a/mlrun/serving/server.py
+++ b/mlrun/serving/server.py
@@ -347,11 +347,30 @@ class GraphServer(ModelObj):
             if hasattr(response, "body"):
                 response = response.body
 
-            if self.http_trigger and self.result_handler:
+            # Unwrap an explicit Response so result_handler sees the body; skip
+            # output mapping on non-2xx (success-shape contract, ML-12706).
+            explicit_response: Response | None = None
+            if isinstance(response, Response):
+                explicit_response = response
+                response = explicit_response.body
+
+            if (
+                self.http_trigger
+                and self.result_handler
+                and (explicit_response is None or explicit_response.status_code < 300)
+            ):
                 method = getattr(event, "method", None)
                 path = getattr(event, "path", None)
                 if method and path:
                     response = self.result_handler.apply(method, path, response)
+
+            if explicit_response is not None:
+                return context.Response(
+                    body=response,
+                    status_code=explicit_response.status_code,
+                    content_type=explicit_response.content_type,
+                    headers=explicit_response.headers,
+                )
         except Exception as exc:
             # Extract appropriate status code from MLRunHTTPStatusError exceptions
             # For backwards compatibility, default to 400 for other exceptions

--- a/mlrun/serving/states.py
+++ b/mlrun/serving/states.py
@@ -77,6 +77,7 @@ from .utils import (
     _extract_input_data,
     _RequestContext,
     _update_result_body,
+    is_event_like,
 )
 
 callable_prefix = "_"
@@ -1888,7 +1889,7 @@ class ModelRunner(storey.ParallelExecution):
     def select_outlets(self, event) -> Collection[str] | None:
         is_batched = False
         if isinstance(event, list) and any(
-            hasattr(subevent, "body") for subevent in event
+            is_event_like(subevent) for subevent in event
         ):
             is_batched = True
             sys_outlets = [f"{self.name}_unpacker"]
@@ -1924,7 +1925,7 @@ class ModelRunner(storey.ParallelExecution):
                         return True
         elif isinstance(event, list):
             for sub_event in event:
-                if not hasattr(sub_event, "body"):
+                if not is_event_like(sub_event):
                     # a regular output, not a sub-event in a batch:
                     return False
                 #  batch case, event is list of sub events:

--- a/mlrun/serving/utils.py
+++ b/mlrun/serving/utils.py
@@ -15,6 +15,8 @@
 import inspect
 from typing import Any
 
+import nuclio_sdk
+
 import mlrun.errors
 from mlrun.utils import get_in, update_in
 
@@ -23,6 +25,19 @@ from mlrun.utils import get_in, update_in
 # more info https://github.com/benoitc/gunicorn/issues/2799, this comment can be removed once old keys are removed
 event_id_key = "MLRUN-EVENT-ID"
 event_path_key = "MLRUN-EVENT-PATH"
+
+
+def is_event_like(obj: Any) -> bool:
+    """Return True if obj looks like a graph event wrapper — has a `.body`
+    attribute and is not a Response. Duck-typed on `.body` so any event-like
+    class (current or future) is recognized; Response (mlrun + nuclio variants)
+    is excluded because it also has `.body` but means a final HTTP response.
+    """
+    # Response is imported lazily to avoid a circular import between
+    # mlrun.serving.server (which transitively depends on this module) and utils.
+    from mlrun.serving.server import Response
+
+    return hasattr(obj, "body") and not isinstance(obj, (Response, nuclio_sdk.Response))
 
 
 def _extract_input_data(input_path, body):

--- a/tests/serving/test_result_handler.py
+++ b/tests/serving/test_result_handler.py
@@ -17,6 +17,7 @@
 from http import HTTPMethod
 from typing import cast
 
+import nuclio_sdk
 import pytest
 
 import mlrun
@@ -440,8 +441,16 @@ class TestResultHandlerHttpTriggerGuard:
         finally:
             server.wait_for_completion()
 
-    # ML-12706 — skip output mapping on error responses
-    def test_e2e_error_response_skips_output_mapping(self) -> None:
+    # ML-12706 — skip output mapping on error responses.
+    # Parameterized over both Response classes the fix accepts (mlrun.serving.server.Response
+    # and nuclio_sdk.Response). In real Nuclio, context.Response is nuclio_sdk.Response;
+    # both must be unwrapped correctly.
+    @pytest.mark.parametrize(
+        "response_cls",
+        [Response, nuclio_sdk.Response],
+        ids=["mlrun_response", "nuclio_response"],
+    )
+    def test_e2e_error_response_skips_output_mapping(self, response_cls) -> None:
         """Response(status_code=404) — error body passes through with original status (ML-12706)."""
         error_body = {
             "error": {
@@ -451,7 +460,7 @@ class TestResultHandlerHttpTriggerGuard:
         }
 
         def error_handler(body, **kwargs):
-            return Response(
+            return response_cls(
                 body=error_body,
                 status_code=404,
                 content_type="application/json",
@@ -473,12 +482,19 @@ class TestResultHandlerHttpTriggerGuard:
         finally:
             server.wait_for_completion()
 
-    def test_e2e_response_wrapper_preserves_status_code_on_success(self) -> None:
+    @pytest.mark.parametrize(
+        "response_cls",
+        [Response, nuclio_sdk.Response],
+        ids=["mlrun_response", "nuclio_response"],
+    )
+    def test_e2e_response_wrapper_preserves_status_code_on_success(
+        self, response_cls
+    ) -> None:
         """Response(status_code=200) — output mapping applies, status_code preserved (ML-12706)."""
         success_body = {"id": "resp_1", "object": "response", "extra_field": "filter"}
 
         def success_handler(body, **kwargs):
-            return Response(
+            return response_cls(
                 body=success_body,
                 status_code=200,
                 content_type="application/json",

--- a/tests/serving/test_result_handler.py
+++ b/tests/serving/test_result_handler.py
@@ -442,7 +442,7 @@ class TestResultHandlerHttpTriggerGuard:
 
     # ML-12706 — skip output mapping on error responses
     def test_e2e_error_response_skips_output_mapping(self) -> None:
-        """Handler returns Response(status_code=404) — error body must pass through with the original status (ML-12706)."""
+        """Response(status_code=404) — error body passes through with original status (ML-12706)."""
         error_body = {
             "error": {
                 "message": "Response with id resp_x not found",
@@ -474,7 +474,7 @@ class TestResultHandlerHttpTriggerGuard:
             server.wait_for_completion()
 
     def test_e2e_response_wrapper_preserves_status_code_on_success(self) -> None:
-        """Handler returns Response(status_code=200) — output mapping still applies, status_code preserved (ML-12706)."""
+        """Response(status_code=200) — output mapping applies, status_code preserved (ML-12706)."""
         success_body = {"id": "resp_1", "object": "response", "extra_field": "filter"}
 
         def success_handler(body, **kwargs):

--- a/tests/serving/test_result_handler.py
+++ b/tests/serving/test_result_handler.py
@@ -24,6 +24,7 @@ from mlrun.common.schemas.serving import APIHandlerAction
 from mlrun.runtimes.nuclio.serving import ServingRuntime
 from mlrun.serving.endpoint_mapping import APIHandlerConfig, BodyMappings
 from mlrun.serving.result_handler import ResultHandler
+from mlrun.serving.server import Response
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -272,7 +273,11 @@ class TestResultHandlerHttpTriggerGuard:
     """
 
     @staticmethod
-    def _make_fn(output_bm: BodyMappings) -> ServingRuntime:
+    def _make_fn(
+        output_bm: BodyMappings,
+        handler=None,
+        method: HTTPMethod = HTTPMethod.POST,
+    ) -> ServingRuntime:
         fn = cast(
             ServingRuntime,
             mlrun.new_function("test-result-handler", kind="serving"),
@@ -280,13 +285,16 @@ class TestResultHandlerHttpTriggerGuard:
         config = APIHandlerConfig()
         config.add_endpoint_handler(
             "/predict",
-            HTTPMethod.POST,
+            method,
             APIHandlerAction.ALLOW,
             output_body_mappings=output_bm,
         )
         fn.set_api_handler_config(config)
         graph = fn.set_topology("flow", engine="sync")
-        graph.to(name="passthrough", handler=lambda body, **kwargs: body).respond()
+        graph.to(
+            name="handler",
+            handler=handler or (lambda body, **kwargs: body),
+        ).respond()
         return fn
 
     def test_http_trigger_true_applies_exit_mapping(self) -> None:
@@ -429,5 +437,67 @@ class TestResultHandlerHttpTriggerGuard:
         try:
             resp = server.test(request_path, method="POST", body={"any": "input"})
             assert resp == {"answer": 42}
+        finally:
+            server.wait_for_completion()
+
+    # ML-12706 — skip output mapping on error responses
+    def test_e2e_error_response_skips_output_mapping(self) -> None:
+        """Handler returns Response(status_code=404) — error body must pass through with the original status (ML-12706)."""
+        error_body = {
+            "error": {
+                "message": "Response with id resp_x not found",
+                "type": "invalid_request_error",
+            }
+        }
+
+        def error_handler(body, **kwargs):
+            return Response(
+                body=error_body,
+                status_code=404,
+                content_type="application/json",
+            )
+
+        bm = BodyMappings()
+        bm.add_mapping("$.id", destination_path="id", mandatory=True)
+        bm.add_mapping("$.object", destination_path="object", mandatory=True)
+
+        server = self._make_fn(
+            bm, handler=error_handler, method=HTTPMethod.GET
+        ).to_mock_server()
+        try:
+            resp = server.test("/predict", method="GET", body=None, silent=True)
+            # Upstream status code must reach the caller — not be masked as 422
+            assert resp.status_code == 404
+            # Error body must be returned verbatim — output mapping must NOT have run
+            assert resp.body == error_body
+        finally:
+            server.wait_for_completion()
+
+    def test_e2e_response_wrapper_preserves_status_code_on_success(self) -> None:
+        """Handler returns Response(status_code=200) — output mapping still applies, status_code preserved (ML-12706)."""
+        success_body = {"id": "resp_1", "object": "response", "extra_field": "filter"}
+
+        def success_handler(body, **kwargs):
+            return Response(
+                body=success_body,
+                status_code=200,
+                content_type="application/json",
+            )
+
+        # Distinct "output_*" destination names so a "mapping ran" verdict is unambiguous —
+        # if the mapping is skipped the body stays {"id": ..., "object": ..., "extra_field": ...}.
+        bm = BodyMappings()
+        bm.add_mapping("$.id", destination_path="output_id", mandatory=True)
+        bm.add_mapping("$.object", destination_path="output_object", mandatory=True)
+
+        server = self._make_fn(
+            bm, handler=success_handler, method=HTTPMethod.GET
+        ).to_mock_server()
+        try:
+            resp = server.test("/predict", method="GET", body=None, silent=True)
+            # Explicit Response from the handler must keep the status code
+            assert resp.status_code == 200
+            # Output mapping ran: keys renamed to output_*, extra_field filtered
+            assert resp.body == {"output_id": "resp_1", "output_object": "response"}
         finally:
             server.wait_for_completion()

--- a/tests/system/runtimes/assets/response_wrapper_handler.py
+++ b/tests/system/runtimes/assets/response_wrapper_handler.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Iguazio
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Handlers that return mlrun Response wrappers — for ML-12706 system tests."""
+
+from mlrun.serving.server import Response
+
+
+def error_response_handler(body, **kwargs):
+    """Return Response(status_code=404) — result_handler must skip output mapping."""
+    return Response(
+        body={
+            "error": {
+                "message": "Response with id resp_x not found",
+                "type": "invalid_request_error",
+            }
+        },
+        status_code=404,
+        content_type="application/json",
+    )
+
+
+def success_response_handler(body, **kwargs):
+    """Return Response(status_code=200) — output mapping must apply, status code preserved."""
+    return Response(
+        body={"id": "resp_1", "object": "response", "extra_field": "filter"},
+        status_code=200,
+        content_type="application/json",
+    )

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -552,6 +552,80 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
 
         self._logger.info("Output mandatory missing field test passed")
 
+    def test_response_wrapper_error_skips_output_mapping(self) -> None:
+        """Handler returns Response(status_code=404) — error body and status code
+        must reach the caller intact (ML-12706). Without the fix, the output
+        mapping rejects the error envelope and rewrites the response to 422.
+        """
+        out_bm = BodyMappings()
+        out_bm.add_mapping("$.id", destination_path="output_id", mandatory=True)
+        out_bm.add_mapping("$.object", destination_path="output_object", mandatory=True)
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.GET,
+            APIHandlerAction.ALLOW,
+            output_body_mappings=out_bm,
+        )
+
+        function = self._create_serving_function(
+            name="response-wrapper-error",
+            api_config=config,
+            func=str(self.assets_path / "response_wrapper_handler.py"),
+        )
+        graph = function.set_topology("flow", engine="sync", exist_ok=True)
+        graph.to(name="handler", handler="error_response_handler").respond()
+        function.deploy()
+
+        url = function.get_url() + "/predict"
+        resp = httpx.get(url, verify=mlrun.mlconf.httpdb.http.verify)
+
+        assert resp.status_code == 404
+        assert resp.json() == {
+            "error": {
+                "message": "Response with id resp_x not found",
+                "type": "invalid_request_error",
+            }
+        }
+
+        self._logger.info("Response wrapper error test passed")
+
+    def test_response_wrapper_success_preserves_status_code(self) -> None:
+        """Handler returns Response(status_code=200) — output mapping still
+        reshapes the body and the explicit 200 status code is preserved (ML-12706).
+        Distinct ``output_*`` destinations prove the mapping actually ran.
+        """
+        out_bm = BodyMappings()
+        out_bm.add_mapping("$.id", destination_path="output_id", mandatory=True)
+        out_bm.add_mapping("$.object", destination_path="output_object", mandatory=True)
+
+        config = APIHandlerConfig()
+        config.add_endpoint_handler(
+            "/predict",
+            HTTPMethod.GET,
+            APIHandlerAction.ALLOW,
+            output_body_mappings=out_bm,
+        )
+
+        function = self._create_serving_function(
+            name="response-wrapper-success",
+            api_config=config,
+            func=str(self.assets_path / "response_wrapper_handler.py"),
+        )
+        graph = function.set_topology("flow", engine="sync", exist_ok=True)
+        graph.to(name="handler", handler="success_response_handler").respond()
+        function.deploy()
+
+        url = function.get_url() + "/predict"
+        resp = httpx.get(url, verify=mlrun.mlconf.httpdb.http.verify)
+
+        assert resp.status_code == 200
+        # Output mapping ran: keys renamed to output_*, extra_field filtered
+        assert resp.json() == {"output_id": "resp_1", "output_object": "response"}
+
+        self._logger.info("Response wrapper success test passed")
+
     # ---------------------------------------------------------------------------
     # OpenAI frontend tests (set_openai_frontend)
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
### 📝 Description

When a graph handler returns `mlrun.serving.server.Response(body=…, status_code=…)`, `server.run` only peeled one wrapper layer (`Event.body → Response`) and then handed the `Response` object itself to `result_handler.apply`. The result handler's dict-check rejected it as `(got Response)` and the whole call became HTTP 422, masking the explicit status code and the body the handler had set.

This affects two cases:

1. **Non-2xx (error) responses** — e.g. handler proxies an upstream `404 {"error": {...}}` and returns `Response(body=error_envelope, status_code=404)`. Today the caller sees HTTP 422 with `"Mandatory field 'id' not found in body"` instead of the upstream 404 + error envelope.
2. **2xx (success) responses** — handler returns `Response(body=success_dict, status_code=200)` so the explicit status code reaches the caller. Today this also fails with HTTP 422 (`got Response`) because the `Response` wrapper crashes the dict-check regardless of status code.

---

### 🛠️ Changes Made

- `mlrun/serving/server.py` (`GraphServer.run`): after the existing one-level body unwrap, detect an explicit `Response`, capture its `status_code` / `content_type` / `headers`, take its `.body` as the actual payload, run `result_handler.apply` only when `status_code < 300`, and re-wrap the (possibly reshaped) body in `context.Response(...)` on return so the explicit status code reaches the caller.
- No changes to `result_handler.py` or `endpoint_mapping.py` — the success-shape contract is still correct for 2xx; it just must not run on `Response` objects with non-2xx status.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

**Unit (`tests/serving/test_result_handler.py::TestResultHandlerHttpTriggerGuard`):**
- `test_e2e_error_response_skips_output_mapping` — handler returns `Response(status_code=404, body={"error": {...}})` with mandatory output mapping; asserts `resp.status_code == 404` and `resp.body == error_body` (mapping is skipped, body unchanged).
- `test_e2e_response_wrapper_preserves_status_code_on_success` — handler returns `Response(status_code=200, body=…)` and the output mapping reshapes `$.id → output_id`, `$.object → output_object`; asserts `resp.status_code == 200` and `resp.body == {"output_id": "resp_1", "output_object": "response"}` (mapping ran, status preserved).

Helper `_make_fn` was parameterized to accept `handler` and `method` so the new tests can reuse it.

**System (`tests/system/runtimes/test_serving.py::TestServingAPIHandler`)** — same two scenarios end-to-end against a real Nuclio deployment, asserted via direct `httpx` so the 404 case can be inspected without `function.invoke` raising.

Asset: `tests/system/runtimes/assets/response_wrapper_handler.py` defines `error_response_handler` and `success_response_handler`.

---

### 🔗 References
- Ticket link: [ML-12706](https://ecliptos.atlassian.net/browse/ML-12706)
- Design docs links: n/a
- External links: n/a

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)