### PR TITLE
[Datastore] Fix OOM on Azure/GCS put with large in-memory body

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -310,6 +310,8 @@ class AzureBlobStore(DataStore):
             )
         remote_path = self._convert_key_to_remote_path(key)
         data, _ = self._prepare_put_data(data, append)
+        if isinstance(data, str):
+            data = data.encode("utf-8")
         # pipe_file streams in chunks; write() buffers the whole body.
         self.filesystem.pipe_file(remote_path, data)
 

--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -309,9 +309,9 @@ class AzureBlobStore(DataStore):
                 "Append mode not supported for Azure blob datastore"
             )
         remote_path = self._convert_key_to_remote_path(key)
-        data, mode = self._prepare_put_data(data, append)
-        with self.filesystem.open(remote_path, mode) as f:
-            f.write(data)
+        data, _ = self._prepare_put_data(data, append)
+        # pipe_file streams in chunks; write() buffers the whole body.
+        self.filesystem.pipe_file(remote_path, data)
 
     def stat(self, key):
         remote_path = self._convert_key_to_remote_path(key)

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -131,9 +131,9 @@ class GoogleCloudStorageStore(DataStore):
             raise mlrun.errors.MLRunInvalidArgumentError(
                 "Append mode not supported for Google cloud storage datastore"
             )
-        data, mode = self._prepare_put_data(data, append)
-        with self.filesystem.open(path, mode) as f:
-            f.write(data)
+        data, _ = self._prepare_put_data(data, append)
+        # pipe_file streams in chunks; write() buffers the whole body.
+        self.filesystem.pipe_file(path, data)
 
     def upload(self, key, src_path):
         file_size = os.path.getsize(src_path)

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -132,6 +132,8 @@ class GoogleCloudStorageStore(DataStore):
                 "Append mode not supported for Google cloud storage datastore"
             )
         data, _ = self._prepare_put_data(data, append)
+        if isinstance(data, str):
+            data = data.encode("utf-8")
         # pipe_file streams in chunks; write() buffers the whole body.
         self.filesystem.pipe_file(path, data)
 


### PR DESCRIPTION
### 📝 Description
Logging a large in-memory artifact body (e.g. `context.log_model(body=...)`) to Azure
OOMKilled the job pod, while the same code logged fine to S3. `AzureBlobStore.put()` (and
`GoogleCloudStorageStore.put()`) wrote the body via `filesystem.open(path, mode).write(data)`.
fsspec's `AbstractBufferedFile.write()` copies the whole body into an in-memory buffer (and
adlfs then re-copies it via `getvalue()`) before any block is flushed — roughly tripling peak
memory. On a multi-GB model that pushed the pod over its limit. S3 was unaffected because it
uses a single boto `put_object` that streams the bytes without a second copy.

Fix: hand the body to `filesystem.pipe_file(path, data)`, which routes to the SDK's streaming
`upload_blob` (shares the source buffer, stages in fixed-size chunks) — keeping peak memory at
~1x the body, matching S3.

---

### 🛠️ Changes Made
- `mlrun/datastore/azure_blob.py`: `put()` streams via `pipe_file` instead of `open().write()`.
- `mlrun/datastore/google_cloud_storage.py`: same fix (gcsfs has the identical buffering path).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing
- Verified the memory behaviour locally on the real adlfs/fsspec path (network leaf stubbed):
  the old `open().write()` path peaks at ~2x the body (proportional to size); `pipe_file` adds
  ~0 (shares the buffer). Measured at 200 MB–2.4 GB.
- Reproduction: `test_mlrun_log_large_model` on oris/azure (OOMKilled before the fix). To be
  re-run on the Azure system-test env to confirm end-to-end.
- No unit tests added (the behaviour is memory-profile, not functional).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12754

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- GCS (`google_cloud_storage.py`) had the identical latent bug (same fsspec buffered-write path)
  and is fixed in the same way here.
- S3 is unaffected (single boto `put_object`, no fsspec buffering) — no change.
- `pipe_file` is a long-standing fsspec/adlfs/gcsfs API; both are already pinned with it
  (adlfs 2024.12.0, gcsfs 2025.7.0).
