### PR TITLE
[Tests] Add ML-12647 repro: include_url_info body delivery

### DIFF
--- a/tests/serving/test_api_handler.py
+++ b/tests/serving/test_api_handler.py
@@ -1618,6 +1618,64 @@ class TestAPIHandlerMockServer:
         finally:
             server.wait_for_completion()
 
+    @pytest.mark.parametrize("with_body_mapping", [False, True], ids=["no-bm", "bm"])
+    def test_include_url_info_delivers_body_to_handler(
+        self, with_body_mapping: bool
+    ) -> None:
+        """ML-12647: with ``include_url_info=True`` the original body must reach
+        the handler — both with and without body_mapping. URL info and mapped
+        fields are additive kwargs, not a replacement for the positional body.
+        """
+        received: dict = {}
+
+        def chat_handler(
+            event=None,
+            mlrun_request_path=None,
+            mlrun_request_method=None,
+            model_name=None,
+            **kwargs,
+        ):
+            received["event"] = event
+            received["mlrun_request_path"] = mlrun_request_path
+            received["mlrun_request_method"] = mlrun_request_method
+            received["model_name"] = model_name
+            return "ok"
+
+        fn = cast(
+            ServingRuntime,
+            mlrun.new_function("test-include-url-info-body", kind="serving"),
+        )
+
+        config = APIHandlerConfig(include_url_info=True)
+        bm = None
+        if with_body_mapping:
+            bm = BodyMappings()
+            bm.add_mapping("$.model", destination_path="model_name")
+        config.add_endpoint_handler(
+            "/v1/chat/completions",
+            HTTPMethod.POST,
+            APIHandlerAction.ALLOW,
+            input_body_mappings=bm,
+        )
+        fn.set_api_handler_config(config)
+
+        graph = fn.set_topology("flow", engine="sync")
+        graph.to(name="chat", handler=chat_handler).respond()
+
+        body = {"model": "my-llm", "messages": [{"role": "user", "content": "Hello"}]}
+
+        server = fn.to_mock_server()
+        try:
+            server.test("/v1/chat/completions", method="POST", body=body)
+        finally:
+            server.wait_for_completion()
+
+        assert received["event"] == body
+        assert received["mlrun_request_path"] == "/v1/chat/completions"
+        assert received["mlrun_request_method"] == "POST"
+        if with_body_mapping:
+            assert received["model_name"] == "my-llm"
+
 
 class TestAPIHandlerConfig:
     """Direct tests for APIHandlerConfig class"""


### PR DESCRIPTION
### 📝 Description
Adds a parameterized unit test that pins the contract for `include_url_info=True` in the API handler: the original request body must still reach the handler as the first positional arg, while URL info and body-mapping fields arrive as additive kwargs.

This is the baseline test for ML-12647 — @GiladShapira94  reported that with `include_url_info=True` and no body_mapping, the body never reaches the handler. The test passes in the mock-server path, which suggests the actual failure is fixed in 1.12.

---

### 🛠️ Changes Made
- Added `TestAPIHandlerMockServer.test_include_url_info_delivers_body_to_handler`, parameterized over body_mapping on/off, both with `include_url_info=True`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit test added in `tests/serving/test_api_handler.py`. Run with:
  `PYTHONPATH="$(pwd):$(pwd)/server/py" python -m pytest tests/serving/test_api_handler.py::TestAPIHandlerMockServer::test_include_url_info_delivers_body_to_handler -v`
- Covers both `no-bm` and `bm` cases.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12647
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
The test currently passes — the body IS delivered through this code path. Gilad's notebook (`func=func2.py` + `handler="chat_handler"` string-name resolution) reports a different result; that path needs separate investigation before we ship a fix.