### PR TITLE
[CI] Fix smoke auto-trigger running before PR approval

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -51,7 +51,9 @@ on:
           - 'false'
   workflow_run:
     workflows: ["CI"]
-    types: [requested]
+    # in_progress (not requested): CI reaches this state only after approval, so smoke
+    # won't run on PRs from non-members until a maintainer approves their CI.
+    types: [in_progress]
 
 jobs:
   should-run:


### PR DESCRIPTION
### 📝 Description

The smoke-tests workflow auto-triggers off the **CI** workflow via `workflow_run`, using the `requested` activity type. `requested` fires when CI is *queued* — which for PRs from **non-members** includes the window while CI is held in `action_required` awaiting maintainer approval. Because `workflow_run` runs in the trusted base context (secrets + self-hosted runners) and bypasses the fork-approval gate, smoke could execute an **unapproved** PR's code before any maintainer approved its CI.

This switches the trigger to `in_progress`, which a CI run only reaches **after** approval — so smoke is now effectively gated behind the same approval, while still running in parallel with CI.

---

### 🛠️ Changes Made

- `.github/workflows/smoke-tests.yml`: `workflow_run` trigger `types: [requested]` → `types: [in_progress]` (plus a one-line comment). Nothing else changes — the `should-run` guard (`event == 'pull_request'`), docs-only filter, concurrency group, and per-commit comments all keep working (the `in_progress` payload carries the same `workflow_run` object).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — n/a (CI workflow only)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests — n/a (CI trigger config)
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing

Validated end-to-end on a throwaway repo with two `workflow_run` consumers (`requested` vs `in_progress`) against a **real non-member fork PR** (a brand-new GitHub account):

| Phase | CI run state | `requested` consumer | `in_progress` consumer |
|---|---|---|---|
| PR opened (gated) | `action_required` | **fired** (the leak) | **silent** |
| After maintainer approval | `in_progress -> success` | — | **fired**, in parallel with CI |

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- **Latency:** `in_progress` fires when CI *starts executing* (a few seconds after queue), not when it finishes — so smoke still runs in parallel with CI; no meaningful added latency (unlike gating on `completed`).
- **Per-commit re-gating:** each new commit creates a fresh pending CI run; smoke stays dormant until that commit's CI is approved — matching GitHub's default behavior.
- GitHub's docs state the run lifecycle (`action_required` -> `in_progress` only after approval) but don't spell out the `workflow_run` event emission timing in one sentence; the empirical test above confirms it. Worth a glance on the first real fork PR after merge.
