### PR TITLE
[Storey] bump storey to 1.12.4

### DIFF
--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -3654,8 +3654,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.3 \
-    --hash=sha256:845a937e614a9343d395df1280d86cc56e27cb3d2e727ad7d7be65e6a680c2d9
+storey==1.12.4 \
+    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -3406,8 +3406,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.3 \
-    --hash=sha256:845a937e614a9343d395df1280d86cc56e27cb3d2e727ad7d7be65e6a680c2d9
+storey==1.12.4 \
+    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -3058,8 +3058,8 @@ starlette==0.50.0 \
     --hash=sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca \
     --hash=sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca
     # via fastapi
-storey==1.12.3 \
-    --hash=sha256:845a937e614a9343d395df1280d86cc56e27cb3d2e727ad7d7be65e6a680c2d9
+storey==1.12.4 \
+    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -2883,8 +2883,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.3 \
-    --hash=sha256:845a937e614a9343d395df1280d86cc56e27cb3d2e727ad7d7be65e6a680c2d9
+storey==1.12.4 \
+    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -3654,8 +3654,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.3 \
-    --hash=sha256:845a937e614a9343d395df1280d86cc56e27cb3d2e727ad7d7be65e6a680c2d9
+storey==1.12.4 \
+    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -4683,8 +4683,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.12.3 \
-    --hash=sha256:845a937e614a9343d395df1280d86cc56e27cb3d2e727ad7d7be65e6a680c2d9
+storey==1.12.4 \
+    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -4758,8 +4758,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.12.3 \
-    --hash=sha256:845a937e614a9343d395df1280d86cc56e27cb3d2e727ad7d7be65e6a680c2d9
+storey==1.12.4 \
+    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2025.5.1, <=2025.7.0
 v3iofs~=0.1.17
-storey~=1.12.3
+storey~=1.12.4
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,8 +128,8 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"~=1.12.3"},
-        # No specifier — pip resolves against the base `storey~=1.12.3` pin
+        "storey": {"~=1.12.4"},
+        # No specifier — pip resolves against the base `storey~=1.12.4` pin
         # in requirements.txt, so we don't duplicate the version constraint.
         "storey[otel]": {""},
         "pydantic": {">=1.10.15", ">=1,<2"},


### PR DESCRIPTION
### 📝 Description

Bump storey to 1.12.4 to tighten the sub-event check so a Response is no longer mistaken for a sub-event.

---

### 🛠️ Changes Made
Bump storey version

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link: part of [ML-12706](https://ecliptos.atlassian.net/browse/ML-12706) effort.
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
