### PR TITLE
[Utils] fix MyEncoder to serialize datetime.date and datetime.datetime as ISO 8601 strings

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -30,7 +30,7 @@ import typing
 import uuid
 import warnings
 from copy import deepcopy
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from importlib import import_module, reload
 from os import path
 from types import ModuleType
@@ -789,6 +789,8 @@ class MyEncoder(json.JSONEncoder):
             return float(obj)
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
+        elif isinstance(obj, (datetime, date)):
+            return obj.isoformat()
         else:
             return str(obj)
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -2328,3 +2328,20 @@ def test_split_handler_module_and_function(handler, expected):
     from mlrun.utils.helpers import split_handler_module_and_function
 
     assert split_handler_module_and_function(handler) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ({"d": __import__("datetime").date(2023, 1, 1)}, '{"d": "2023-01-01"}'),
+        (
+            {"ts": __import__("datetime").datetime(2023, 1, 1, 12, 0, 0)},
+            '{"ts": "2023-01-01T12:00:00"}',
+        ),
+        ({"n": 42, "s": "hello"}, '{"n": 42, "s": "hello"}'),
+    ],
+)
+def test_dict_to_json_datetime_serialization(value, expected):
+    from mlrun.utils.helpers import dict_to_json
+
+    assert dict_to_json(value) == expected


### PR DESCRIPTION
## Summary

Fixes #9858

The `MyEncoder` class in `mlrun/utils/helpers.py` is the custom JSON encoder used throughout MLRun via `dict_to_json`. It handled numpy types correctly but had no case for `datetime.date` or `datetime.datetime`. Both types fell through to the `else: return str(obj)` branch which produces strings like `"datetime.date(2023, 1, 1)"` instead of the expected ISO 8601 format `"2023-01-01"`.

This caused `TypeError: Object of type date is not JSON serializable` errors and silent data corruption when using `RedisNoSqlTarget` or `ParquetSource` with feature sets that contain date typed columns.

The YAML serialization path already handled dates correctly via `date_representer`, but this was never applied to the JSON path.

Changes:

- Added `date` to the `datetime` module import
- Added an `elif isinstance(obj, (datetime, date)): return obj.isoformat()` case in `MyEncoder.default` before the `else` fallback
- Added unit tests covering `datetime.date`, `datetime.datetime`, and normal primitive values

## Test plan

- [ ] Run `pytest tests/utils/test_helpers.py::test_dict_to_json_datetime_serialization`
- [ ] Verify `dict_to_json({"d": datetime.date(2023, 1, 1)})` returns `'{"d": "2023-01-01"}'`
- [ ] Verify `dict_to_json({"ts": datetime.datetime(2023, 1, 1, 12, 0, 0)})` returns `'{"ts": "2023-01-01T12:00:00"}'`
- [ ] Confirm existing tests in `tests/utils/test_helpers.py` still pass