### PR TITLE
[DataStore] fix bare except clause in openai_provider async batch invoke

### DIFF
--- a/mlrun/datastore/model_provider/openai_provider.py
+++ b/mlrun/datastore/model_provider/openai_provider.py
@@ -332,7 +332,7 @@ class OpenAIProvider(ModelProvider):
         try:
             # gather() stops on first exception - fast fail
             return await asyncio.gather(*tasks)
-        except:
+        except BaseException:
             # Cancel all remaining tasks
             for task in tasks:
                 task.cancel()


### PR DESCRIPTION
## Summary

Fixes #9860

In `mlrun/datastore/model_provider/openai_provider.py` the async batch invoke method used a bare `except:` clause to catch exceptions during `asyncio.gather()` so it could cancel sibling tasks before re-raising.

A bare `except:` is a Python anti-pattern (Ruff E722) because it catches `BaseException` implicitly, making the intent of the code unclear. More importantly, in Python 3.8 and above `asyncio.CancelledError` is a subclass of `BaseException` not `Exception`, so changing to `except Exception:` would silently break the cancellation cleanup path.

The correct fix is `except BaseException:` which is explicit, preserves exactly the same behavior, and satisfies Ruff E722.

Changes:

- One line change in `mlrun/datastore/model_provider/openai_provider.py` from bare `except:` to `except BaseException:`

## Test plan

- [ ] Verify existing async batch invoke behavior is unchanged
- [ ] Confirm Ruff linting passes on the changed file
- [ ] Verify that cancellation of the outer coroutine still properly cancels sibling tasks