### PR TITLE
[Auth] Fix connect() discarding explicit bearer-token credentials

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -744,7 +744,10 @@ class HTTPRunDB(RunDBInterface):
                 traceback=traceback.format_exc(),
             )
 
-        # Initialize token provider after syncing config from server
+        # Explicit credentials own auth; don't override with env/config providers.
+        if self._apply_explicit_credentials():
+            return self
+
         self._init_token_provider_from_env()
 
         if config.is_iguazio_v4_mode() and config.auth_with_oauth_token.enabled:

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -679,6 +679,53 @@ def test_connect_invokes_init_token_provider_from_env():
         db.connect()
 
 
+def test_connect_preserves_explicit_credentials_in_iguazio_v4(monkeypatch):
+    """
+    Explicit ``Credentials(token=...)`` own auth for the instance: ``connect()``
+    must keep the StaticTokenProvider and must not fall back to the offline-token
+    (IGTokenProvider) flow or ``sync_secret_tokens()``, even in Iguazio V4 mode.
+    """
+    mlrun.mlconf.auth_with_client_id.enabled = False
+    mlrun.mlconf.auth_with_oauth_token.enabled = False
+    mlrun.mlconf.auth_token_endpoint = ""
+
+    server_cfg = {
+        "version": mlrun.mlconf.version,
+        "authentication_mode": mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value,
+        "oauth_external_token_endpoint": "https://dashboard.example.com/refresh",
+    }
+    # deterministic endpoint selection
+    monkeypatch.setattr(
+        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: False
+    )
+
+    token = "sa-bearer-token"
+    credentials = mlrun.Credentials(token=token)
+
+    with (
+        patch.object(HTTPRunDB, "api_call") as api_call,
+        patch.object(mlrun.secrets, "sync_secret_tokens") as sync_secret_tokens,
+        patch.object(
+            mlrun.auth.utils, "load_offline_token", return_value=("offline", "default")
+        ) as load_offline_token,
+    ):
+        api_response = MagicMock()
+        api_response.json.return_value = server_cfg
+        api_call.return_value = api_response
+
+        db = HTTPRunDB("http://some-server:1919", credentials=credentials)
+        assert isinstance(db.token_provider, StaticTokenProvider)
+        assert db.token_provider.get_token() == token
+
+        db.connect()
+
+    # provider preserved, offline-token path untouched
+    assert isinstance(db.token_provider, StaticTokenProvider)
+    assert db.token_provider.get_token() == token
+    load_offline_token.assert_not_called()
+    sync_secret_tokens.assert_not_called()
+
+
 def test_init_token_provider_stores_username_and_password_from_add_or_refresh_credentials(
     monkeypatch,
 ):


### PR DESCRIPTION
### 📝 Description

Service-account clients that authenticate with an explicit bearer access token
(via `mlrun.Credentials(token=...)`) failed at the first server handshake
(`HTTPRunDB.connect()`) in Iguazio V4 deployments.

The token is accepted at construction (`_apply_explicit_credentials()` builds a
`StaticTokenProvider`), but `connect()` then discards it: it unconditionally
re-derives the token provider from env/config and runs the offline-token sync.
In Iguazio V4 mode `connect()` force-enables `auth_with_oauth_token`, so a
bearer-only service account — which has no offline token / `~/.igz.yml` — is
pushed onto the offline-token flow and `connect()` fails.

---

### 🛠️ Changes Made
- `mlrun/db/httpdb.py`: in `connect()`, re-apply explicit credentials before the
  env/config token-provider init and offline-token sync. When a
  `Credentials(token=...)` (or basic-auth) was supplied, the `StaticTokenProvider`
  is preserved and `connect()` returns early, skipping `_init_token_provider_from_env()`
  and `sync_secret_tokens()`. The default (env / `use_env=True`) path is unchanged.
- `tests/rundb/test_httpdb.py`: add `test_connect_preserves_explicit_credentials_in_iguazio_v4`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable) <!-- N/A: internal auth flow, no public API/doc change -->
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
  <!-- Covered by a new unit test; no system test added. -->
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit: added `test_connect_preserves_explicit_credentials_in_iguazio_v4` — red without the
  fix (`connect()` builds an `IGTokenProvider` and reaches for the offline token), green with it.
  Ran the auth/connect/token subset of `tests/rundb/test_httpdb.py`: 18 passed.
- Runtime: drove a real `mlrun` client with `Credentials(token=<JWT>)` over a socket against a
  stand-in Iguazio V4 API server; captured `Authorization: Bearer <token>` on both the
  `client-spec` handshake and a follow-up call, no Iguazio session cookie, `StaticTokenProvider`
  preserved through `connect()`, no offline token present.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12788
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No
