### PR TITLE
[Workflows] Fix run_setup passed to pre-1.12 clients

### DIFF
--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -638,10 +638,8 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         """
         Whether the submitting client's ``load_and_run_workflow`` accepts ``run_setup``.
 
-        The parameter was introduced by #9548 and first released in 1.12.0-rc8. Dev/unstable
-        builds are built from current source and are treated as supporting it. An unknown or
-        unparseable client version is treated as unsupported so the parameter is safely
-        omitted (the workflow-runner job runs in the client image — see ML-12790).
+        Dev/unstable builds are treated as supporting it; an unknown or unparseable version is
+        treated as unsupported so the parameter is safely omitted.
 
         :param client_version: MLRun SDK version reported by the submitting client.
         :return: True if the client accepts the ``run_setup`` parameter.

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -17,6 +17,7 @@ import uuid
 from abc import abstractmethod
 from typing import Union
 
+import packaging.version
 from sqlalchemy.orm import Session
 
 import mlrun.common.constants as mlrun_constants
@@ -35,6 +36,12 @@ import framework.utils.notifications.notification_pusher
 import framework.utils.singletons.db
 import services.api.crud
 import services.api.utils.singletons.scheduler
+
+# The client's `load_and_run_workflow` gained the `run_setup` parameter in #9548, which first
+# shipped in 1.12.0-rc8. Compared with packaging.version (PEP 440) so pre-release tags order
+# numerically — validate_component_version_compatibility orders them lexically ("rc10" < "rc8")
+# and would misclassify rc10+ clients.
+_RUN_SETUP_MIN_CLIENT_VERSION = packaging.version.Version("1.12.0rc8")
 
 
 class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
@@ -600,15 +607,12 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
             url=source,
         )
 
-        # `run_setup` was added to the client's `load_and_run_workflow` in 1.12 (#9548). The
-        # workflow-runner job executes in the *client* image, so passing this parameter to an
-        # older client raises `TypeError: ... unexpected keyword argument 'run_setup'`
-        # (ML-12790). Only forward it when the client is known and new enough to accept it;
-        # otherwise omit it so the client falls back to its own default (the pre-1.12
-        # behavior). An unknown client version is treated as incompatible.
-        if client_version and mlrun_utils.helpers.validate_component_version_compatibility(
-            "mlrun-client", "1.12.0-rc0", mlrun_client_version=client_version
-        ):
+        # The workflow-runner job executes in the *client* image, so passing `run_setup` to a
+        # client whose `load_and_run_workflow` predates it raises `TypeError: ... unexpected
+        # keyword argument 'run_setup'` (ML-12790). Only forward it when the client supports
+        # it; otherwise omit it so the client falls back to its own default (the pre-#9548
+        # behavior).
+        if self._client_supports_run_setup(client_version):
             parameters["run_setup"] = workflow_request.spec.run_setup
 
         run_object = self._create_run_object(
@@ -628,6 +632,32 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         )
 
         return run_object
+
+    @staticmethod
+    def _client_supports_run_setup(client_version: str | None) -> bool:
+        """
+        Whether the submitting client's ``load_and_run_workflow`` accepts ``run_setup``.
+
+        The parameter was introduced by #9548 and first released in 1.12.0-rc8. Dev/unstable
+        builds are built from current source and are treated as supporting it. An unknown or
+        unparseable client version is treated as unsupported so the parameter is safely
+        omitted (the workflow-runner job runs in the client image — see ML-12790).
+
+        :param client_version: MLRun SDK version reported by the submitting client.
+        :return: True if the client accepts the ``run_setup`` parameter.
+        """
+        if not client_version:
+            return False
+        # Dev builds (e.g. "0.0.0+unstable") are built from current source.
+        if client_version.startswith("0.0.0+") or "unstable" in client_version:
+            return True
+        try:
+            return (
+                packaging.version.Version(client_version)
+                >= _RUN_SETUP_MIN_CLIENT_VERSION
+            )
+        except packaging.version.InvalidVersion:
+            return False
 
     @staticmethod
     def _validate_source(

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -126,6 +126,7 @@ class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
             workflow_request=workflow_request,
             run_name=runner.metadata.name,
             rerun_request=rerun_request,
+            client_version=self._resolve_client_version(runner),
         )
 
         # Set auth token name on run spec so the workflow runner can use it to mount the secret token
@@ -156,6 +157,7 @@ class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
         workflow_request: mlrun.common.schemas.WorkflowRequest,
         rerun_request: mlrun.common.schemas.RerunWorkflowRequest,
         run_name: str | None = None,
+        client_version: str | None = None,
     ) -> mlrun_model.RunObject:
         """
         Abstract method to prepare the run object.
@@ -164,6 +166,8 @@ class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
         :param labels:           Labels for the run.
         :param workflow_request: Workflow request containing the workflow spec.
         :param run_name:         Name of the run.
+        :param client_version:   MLRun SDK version of the client that submitted the request,
+                                 used to gate parameters the client image may not support.
         :return: RunObject ready for execution.
         """
         ...
@@ -249,6 +253,22 @@ class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
         for key, value in labels.items():
             run_object = run_object.set_label(key, value)
         return run_object
+
+    @staticmethod
+    def _resolve_client_version(runner: mlrun.run.KubejobRuntime) -> str | None:
+        """
+        Read the submitting client's MLRun SDK version off the runner labels.
+
+        The version is stamped onto the runner by the workflows endpoint and is used to gate
+        run parameters that older client images (which execute the workflow-runner job) may
+        not support.
+
+        :param runner: Workflow runner function object.
+        :return: The client MLRun version label, or None if it was not set.
+        """
+        return runner.metadata.labels.get(
+            mlrun_constants.MLRunInternalLabels.client_version
+        )
 
     @staticmethod
     def _enrich_run_labels_and_env(
@@ -349,6 +369,7 @@ class LoadRunner(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         run_name: str | None = None,
         workflow_request: mlrun.common.schemas.WorkflowRequest | None = None,
         rerun_request: mlrun.common.schemas.WorkflowRequest | None = None,
+        client_version: str | None = None,
     ) -> mlrun_model.RunObject:
         """
         Prepare the RunObject for loading the project.
@@ -356,6 +377,8 @@ class LoadRunner(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         :param project: MLRun project.
         :param labels:  Labels for the run.
         :param run_name: Name of the run.
+        :param client_version: Accepted for signature compatibility with the base runner;
+                               the project loader does not gate any parameters on it.
         :return: RunObject ready for execution.
         """
         source, save, is_context = LoadRunner._validate_source(project, "")
@@ -450,6 +473,7 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
             run_name=workflow_request.spec.name,
             uid=meta_uid,
             scrape_metrics=mlrun_config.config.scrape_metrics,
+            client_version=self._resolve_client_version(runner),
         )
 
         mlrun_utils.helpers.set_auth_token_name(
@@ -527,6 +551,7 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         uid: str | None = None,
         scrape_metrics: str | None = None,
         rerun_request: mlrun.common.schemas.RerunWorkflowRequest | None = None,
+        client_version: str | None = None,
     ) -> mlrun_model.RunObject:
         """
         Prepare the RunObject for running the workflow.
@@ -538,6 +563,8 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         :param uid:              Unique identifier for the run.
         :param scrape_metrics:   Whether to scrape metrics.
         :param rerun_request:    Workflow request containing the rerun spec.
+        :param client_version:   MLRun SDK version of the submitting client, used to gate the
+                                 ``run_setup`` parameter (see below).
         :return: RunObject ready for execution.
         """
         source, save, is_context = WorkflowRunners._validate_source(
@@ -571,8 +598,18 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
             local=workflow_request.spec.run_local,
             subpath=project.spec.subpath,
             url=source,
-            run_setup=workflow_request.spec.run_setup,
         )
+
+        # `run_setup` was added to the client's `load_and_run_workflow` in 1.12 (#9548). The
+        # workflow-runner job executes in the *client* image, so passing this parameter to an
+        # older client raises `TypeError: ... unexpected keyword argument 'run_setup'`
+        # (ML-12790). Only forward it when the client is known and new enough to accept it;
+        # otherwise omit it so the client falls back to its own default (the pre-1.12
+        # behavior). An unknown client version is treated as incompatible.
+        if client_version and mlrun_utils.helpers.validate_component_version_compatibility(
+            "mlrun-client", "1.12.0-rc0", mlrun_client_version=client_version
+        ):
+            parameters["run_setup"] = workflow_request.spec.run_setup
 
         run_object = self._create_run_object(
             source=source,
@@ -741,6 +778,7 @@ class RerunRunner(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         run_name: str | None = None,
         uid: str | None = None,
         scrape_metrics: str | None = None,
+        client_version: str | None = None,
     ) -> mlrun_model.RunObject:
         """
         Prepare the RunObject for rerunning the workflow.
@@ -751,6 +789,8 @@ class RerunRunner(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         :param run_name:         Name of the run.
         :param uid:              Unique identifier for the run.
         :param scrape_metrics:   Whether to scrape metrics.
+        :param client_version:   Accepted for signature compatibility with the base runner;
+                                 the rerun runner does not gate any parameters on it.
         :return: RunObject ready for execution.
         """
 

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -640,8 +640,10 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         """
         if not client_version:
             return False
-        # Dev builds (e.g. "0.0.0+unstable") are built from current source.
-        if client_version.startswith("0.0.0+") or "unstable" in client_version:
+        # Dev builds report version "0.0.0+<sha>" and are built from current source. The
+        # client_version label is sanitized for k8s ("+" -> "-"), so match on the "0.0.0"
+        # prefix rather than the build-metadata suffix.
+        if client_version.startswith("0.0.0"):
             return True
         # `run_setup` first shipped to the client in 1.12.0-rc8 (#9548). Compared with
         # packaging.version (PEP 440) so pre-release tags order numerically —

--- a/server/py/services/api/crud/workflows.py
+++ b/server/py/services/api/crud/workflows.py
@@ -37,12 +37,6 @@ import framework.utils.singletons.db
 import services.api.crud
 import services.api.utils.singletons.scheduler
 
-# The client's `load_and_run_workflow` gained the `run_setup` parameter in #9548, which first
-# shipped in 1.12.0-rc8. Compared with packaging.version (PEP 440) so pre-release tags order
-# numerically — validate_component_version_compatibility orders them lexically ("rc10" < "rc8")
-# and would misclassify rc10+ clients.
-_RUN_SETUP_MIN_CLIENT_VERSION = packaging.version.Version("1.12.0rc8")
-
 
 class BaseRunner(metaclass=mlrun.utils.singleton.Singleton):
     """
@@ -649,11 +643,14 @@ class WorkflowRunners(BaseRunner, metaclass=mlrun.utils.singleton.Singleton):
         # Dev builds (e.g. "0.0.0+unstable") are built from current source.
         if client_version.startswith("0.0.0+") or "unstable" in client_version:
             return True
+        # `run_setup` first shipped to the client in 1.12.0-rc8 (#9548). Compared with
+        # packaging.version (PEP 440) so pre-release tags order numerically —
+        # validate_component_version_compatibility orders them lexically ("rc10" < "rc8")
+        # and would misclassify rc10+ clients.
         try:
-            return (
-                packaging.version.Version(client_version)
-                >= _RUN_SETUP_MIN_CLIENT_VERSION
-            )
+            return packaging.version.Version(
+                client_version
+            ) >= packaging.version.Version("1.12.0rc8")
         except packaging.version.InvalidVersion:
             return False
 

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -18,10 +18,15 @@ import unittest.mock
 import pytest
 import sqlalchemy.orm
 
+import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 
 import services.api.crud
 import services.api.tests.unit.conftest
+
+# Sentinel marking that the `run_setup` parameter is expected to be absent from the
+# workflow-runner parameters (older clients can't accept the kwarg — ML-12790).
+_RUN_SETUP_ABSENT = object()
 
 
 class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
@@ -75,21 +80,32 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             ].startswith("mlrun.notifications.")
 
     @pytest.mark.parametrize(
-        "run_setup_kwargs, expected_run_setup",
+        "client_version, run_setup_kwargs, expected_run_setup",
         [
+            # >= 1.12 clients accept the `run_setup` kwarg, so it is forwarded.
             # default: setup is skipped on the runner pod (DB is the source of truth)
-            ({}, False),
-            ({"run_setup": False}, False),
+            ("1.12.0-rc14", {}, False),
+            ("1.12.0-rc14", {"run_setup": False}, False),
             # users can opt-in to running the setup script on the runner pod
-            ({"run_setup": True}, True),
+            ("1.12.0-rc14", {"run_setup": True}, True),
+            ("1.12.0", {"run_setup": True}, True),
+            # dev/unstable clients are built from current source and accept the kwarg
+            ("0.0.0+unstable", {"run_setup": True}, True),
+            # < 1.12 clients have no `run_setup` parameter on load_and_run_workflow, so the
+            # key must be omitted entirely rather than passed (ML-12790 regression).
+            ("1.10.2", {"run_setup": True}, _RUN_SETUP_ABSENT),
+            ("1.11.0", {"run_setup": True}, _RUN_SETUP_ABSENT),
+            # unknown client version -> assume incompatible -> omit (safe default).
+            (None, {"run_setup": True}, _RUN_SETUP_ABSENT),
         ],
     )
     def test_run_workflow_run_setup_flag(
         self,
         db: sqlalchemy.orm.Session,
         k8s_secrets_mock,
+        client_version: str | None,
         run_setup_kwargs: dict,
-        expected_run_setup: bool,
+        expected_run_setup,
     ):
         project = mlrun.common.schemas.ProjectOut(
             metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
@@ -105,6 +121,12 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             auth_info=mlrun.common.schemas.AuthInfo(),
             image="mlrun/mlrun",
         )
+        # The workflows endpoint stamps the submitting client's SDK version onto the runner;
+        # emulate that here so the version gating can read it.
+        if client_version is not None:
+            runner.metadata.labels[
+                mlrun_constants.MLRunInternalLabels.client_version
+            ] = client_version
 
         run = services.api.crud.WorkflowRunners().run(
             runner=runner,
@@ -122,7 +144,76 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             auth_info=mlrun.common.schemas.AuthInfo(username="test-user"),
         )
 
-        assert run.spec.parameters["run_setup"] == expected_run_setup
+        if expected_run_setup is _RUN_SETUP_ABSENT:
+            assert "run_setup" not in run.spec.parameters
+        else:
+            assert run.spec.parameters["run_setup"] == expected_run_setup
+
+    @pytest.mark.parametrize(
+        "client_version, expected_present",
+        [
+            ("1.12.0-rc14", True),
+            ("1.10.2", False),
+            (None, False),
+        ],
+    )
+    def test_schedule_workflow_gates_run_setup_by_client_version(
+        self,
+        db: sqlalchemy.orm.Session,
+        k8s_secrets_mock,
+        client_version: str | None,
+        expected_present: bool,
+    ):
+        # The scheduled-workflow path builds the workflow-runner parameters independently of
+        # the immediate-run path, so it must gate `run_setup` on the client version too.
+        project = mlrun.common.schemas.ProjectOut(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+            spec=mlrun.common.schemas.ProjectSpecOut(),
+        )
+        services.api.crud.Projects().create_project(db, project)
+
+        run_name = "run-name"
+        runner = services.api.crud.WorkflowRunners().create_runner(
+            run_name=run_name,
+            project=project.metadata.name,
+            db_session=db,
+            auth_info=mlrun.common.schemas.AuthInfo(),
+            image="mlrun/mlrun",
+        )
+        if client_version is not None:
+            runner.metadata.labels[
+                mlrun_constants.MLRunInternalLabels.client_version
+            ] = client_version
+
+        with unittest.mock.patch(
+            "services.api.utils.singletons.scheduler.get_scheduler"
+        ) as get_scheduler_mock:
+            services.api.crud.WorkflowRunners().schedule(
+                runner=runner,
+                project=project,
+                workflow_request=mlrun.common.schemas.WorkflowRequest(
+                    spec=mlrun.common.schemas.WorkflowSpec(
+                        name=run_name,
+                        engine="remote",
+                        image="mlrun/mlrun",
+                        run_setup=True,
+                    ),
+                    source="/home/mlrun/project-name/",
+                    artifact_path="/home/mlrun/artifacts",
+                ),
+                auth_info=mlrun.common.schemas.AuthInfo(username="test-user"),
+            )
+
+        scheduled_object = (
+            get_scheduler_mock.return_value.store_schedule.call_args.kwargs[
+                "scheduled_object"
+            ]
+        )
+        parameters = scheduled_object["task"]["spec"]["parameters"]
+        if expected_present:
+            assert parameters["run_setup"] is True
+        else:
+            assert "run_setup" not in parameters
 
     @pytest.mark.parametrize(
         "source_code_target_dir",

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -24,10 +24,6 @@ import mlrun.common.schemas
 import services.api.crud
 import services.api.tests.unit.conftest
 
-# Sentinel marking that the `run_setup` parameter is expected to be absent from the
-# workflow-runner parameters (older clients can't accept the kwarg — ML-12790).
-_RUN_SETUP_ABSENT = object()
-
 
 class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
     def test_schedule_workflow_with_local_source(
@@ -94,13 +90,14 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             # dev/unstable clients are built from current source and accept the kwarg
             ("0.0.0+unstable", {"run_setup": True}, True),
             # clients without the `run_setup` parameter on load_and_run_workflow: the key must
-            # be omitted entirely rather than passed (ML-12790 regression).
+            # be omitted entirely rather than passed (ML-12790 regression). Omitted is
+            # expressed as None, i.e. parameters.get("run_setup") is None.
             # rc7 is the boundary: the last 1.12 release before #9548 landed.
-            ("1.12.0-rc7", {"run_setup": True}, _RUN_SETUP_ABSENT),
-            ("1.10.2", {"run_setup": True}, _RUN_SETUP_ABSENT),
-            ("1.11.0", {"run_setup": True}, _RUN_SETUP_ABSENT),
+            ("1.12.0-rc7", {"run_setup": True}, None),
+            ("1.10.2", {"run_setup": True}, None),
+            ("1.11.0", {"run_setup": True}, None),
             # unknown client version -> assume incompatible -> omit (safe default).
-            (None, {"run_setup": True}, _RUN_SETUP_ABSENT),
+            (None, {"run_setup": True}, None),
         ],
     )
     def test_run_workflow_run_setup_flag(
@@ -109,7 +106,7 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
         k8s_secrets_mock,
         client_version: str | None,
         run_setup_kwargs: dict,
-        expected_run_setup,
+        expected_run_setup: bool | None,
     ):
         project = mlrun.common.schemas.ProjectOut(
             metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
@@ -148,17 +145,14 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             auth_info=mlrun.common.schemas.AuthInfo(username="test-user"),
         )
 
-        if expected_run_setup is _RUN_SETUP_ABSENT:
-            assert "run_setup" not in run.spec.parameters
-        else:
-            assert run.spec.parameters["run_setup"] == expected_run_setup
+        assert run.spec.parameters.get("run_setup") == expected_run_setup
 
     @pytest.mark.parametrize(
-        "client_version, expected_present",
+        "client_version, expected_run_setup",
         [
             ("1.12.0-rc14", True),
-            ("1.10.2", False),
-            (None, False),
+            ("1.10.2", None),
+            (None, None),
         ],
     )
     def test_schedule_workflow_gates_run_setup_by_client_version(
@@ -166,7 +160,7 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
         db: sqlalchemy.orm.Session,
         k8s_secrets_mock,
         client_version: str | None,
-        expected_present: bool,
+        expected_run_setup: bool | None,
     ):
         # The scheduled-workflow path builds the workflow-runner parameters independently of
         # the immediate-run path, so it must gate `run_setup` on the client version too.
@@ -214,10 +208,7 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             ]
         )
         parameters = scheduled_object["task"]["spec"]["parameters"]
-        if expected_present:
-            assert parameters["run_setup"] is True
-        else:
-            assert "run_setup" not in parameters
+        assert parameters.get("run_setup") == expected_run_setup
 
     @pytest.mark.parametrize(
         "source_code_target_dir",

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -20,6 +20,7 @@ import sqlalchemy.orm
 
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
+import mlrun.k8s_utils
 
 import services.api.crud
 import services.api.tests.unit.conftest
@@ -87,8 +88,10 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             # users can opt-in to running the setup script on the runner pod
             ("1.12.0-rc14", {"run_setup": True}, True),
             ("1.12.0", {"run_setup": True}, True),
-            # dev/unstable clients are built from current source and accept the kwarg
+            # dev clients are built from current source and accept the kwarg; the version is
+            # sanitized into the label ("+" -> "-"), so both forms must be recognised.
             ("0.0.0+unstable", {"run_setup": True}, True),
+            ("0.0.0+abc1234", {"run_setup": True}, True),
             # clients without the `run_setup` parameter on load_and_run_workflow: the key must
             # be omitted entirely rather than passed (ML-12790 regression). Omitted is
             # expressed as None, i.e. parameters.get("run_setup") is None.
@@ -122,12 +125,12 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             auth_info=mlrun.common.schemas.AuthInfo(),
             image="mlrun/mlrun",
         )
-        # The workflows endpoint stamps the submitting client's SDK version onto the runner;
-        # emulate that here so the version gating can read it.
+        # The workflows endpoint stamps the submitting client's SDK version onto the runner,
+        # sanitized for k8s labels; emulate that exactly so the gating sees the real value.
         if client_version is not None:
             runner.metadata.labels[
                 mlrun_constants.MLRunInternalLabels.client_version
-            ] = client_version
+            ] = mlrun.k8s_utils.sanitize_label_value(client_version)
 
         run = services.api.crud.WorkflowRunners().run(
             runner=runner,
@@ -181,7 +184,7 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
         if client_version is not None:
             runner.metadata.labels[
                 mlrun_constants.MLRunInternalLabels.client_version
-            ] = client_version
+            ] = mlrun.k8s_utils.sanitize_label_value(client_version)
 
         with unittest.mock.patch(
             "services.api.utils.singletons.scheduler.get_scheduler"

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -84,7 +84,6 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
         [
             # `run_setup` shipped to the client in 1.12.0-rc8 (#9548); >= rc8 clients accept
             # the kwarg, so it is forwarded.
-            # rc8 is the boundary: the first release that has the parameter.
             ("1.12.0-rc8", {"run_setup": True}, True),
             # default: setup is skipped on the runner pod (DB is the source of truth)
             ("1.12.0-rc14", {}, False),

--- a/server/py/services/api/tests/unit/crud/test_workflows.py
+++ b/server/py/services/api/tests/unit/crud/test_workflows.py
@@ -82,7 +82,10 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
     @pytest.mark.parametrize(
         "client_version, run_setup_kwargs, expected_run_setup",
         [
-            # >= 1.12 clients accept the `run_setup` kwarg, so it is forwarded.
+            # `run_setup` shipped to the client in 1.12.0-rc8 (#9548); >= rc8 clients accept
+            # the kwarg, so it is forwarded.
+            # rc8 is the boundary: the first release that has the parameter.
+            ("1.12.0-rc8", {"run_setup": True}, True),
             # default: setup is skipped on the runner pod (DB is the source of truth)
             ("1.12.0-rc14", {}, False),
             ("1.12.0-rc14", {"run_setup": False}, False),
@@ -91,8 +94,10 @@ class TestWorkflows(services.api.tests.unit.conftest.MockedK8sHelper):
             ("1.12.0", {"run_setup": True}, True),
             # dev/unstable clients are built from current source and accept the kwarg
             ("0.0.0+unstable", {"run_setup": True}, True),
-            # < 1.12 clients have no `run_setup` parameter on load_and_run_workflow, so the
-            # key must be omitted entirely rather than passed (ML-12790 regression).
+            # clients without the `run_setup` parameter on load_and_run_workflow: the key must
+            # be omitted entirely rather than passed (ML-12790 regression).
+            # rc7 is the boundary: the last 1.12 release before #9548 landed.
+            ("1.12.0-rc7", {"run_setup": True}, _RUN_SETUP_ABSENT),
             ("1.10.2", {"run_setup": True}, _RUN_SETUP_ABSENT),
             ("1.11.0", {"run_setup": True}, _RUN_SETUP_ABSENT),
             # unknown client version -> assume incompatible -> omit (safe default).


### PR DESCRIPTION
### 📝 Description

A workflow submitted by an older client against a 1.12 server crashed the workflow-runner pod with:

```
TypeError: load_and_run_workflow() got an unexpected keyword argument 'run_setup'
```

The workflow-runner job runs inside the *submitting client's* image and invokes `mlrun.projects.load_and_run`. PR #9548 started passing a `run_setup` parameter to that call unconditionally, but `load_and_run_workflow` only gained the parameter in 1.12.0-rc8 — so a newer server submitting to an older client sent a kwarg the client couldn't accept.

This change forwards `run_setup` to the workflow-runner only when the submitting client is new enough to accept it.

---

### 🛠️ Changes Made

- `server/py/services/api/crud/workflows.py`: in `WorkflowRunner._prepare_run_object`, only include `run_setup` in the runner parameters when the submitting client supports it, instead of always.
- Determine support via a new `WorkflowRunners._client_supports_run_setup` helper: the parameter first shipped in **1.12.0-rc8** (#9548), so the client version is compared against that floor using `packaging.version` (PEP 440). PEP 440 is used rather than `validate_component_version_compatibility` because the latter orders pre-release tags **lexically** (`"rc10" < "rc8"`), which would wrongly classify rc10+ clients (including the rc14 used in labs) as incompatible.
- Resolve the client version from the runner's `client_version` label via a new `BaseRunner._resolve_client_version` helper, threaded into `_prepare_run_object` on both the immediate-run path (`prepare_and_run`) and the scheduled-workflow path (`schedule`).
- Dev/unstable client builds are treated as supporting the parameter; a missing or unparseable client version is treated as unsupported, so the parameter is omitted and the client falls back to its pre-#9548 default. The shared semver-based `validate_component_version_compatibility` helper is left unchanged to avoid affecting other version gates.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- Unit tests in `server/py/services/api/tests/unit/crud/test_workflows.py` — **25 passed**.
- Expanded `test_run_workflow_run_setup_flag` into a client-version matrix with boundary cases: `1.12.0-rc7` → `run_setup` omitted; `1.12.0-rc8` / `1.12.0-rc14` / `1.12.0` / `0.0.0+unstable` → forwarded with the correct value; `1.10.2` / `1.11.0` / missing version → omitted (the ML-12790 regression cases). The `rc7` vs `rc8`/`rc14` cases specifically guard against lexical pre-release comparison.
- Added `test_schedule_workflow_gates_run_setup_by_client_version` to confirm the scheduled-workflow path gates identically to the immediate-run path.
- System tests not run in CI (no lab/QA environment there). Covered by the `mlrun_backward_compatibility` system test that surfaced the regression (see REG-2521).

#### Lab verification (dev lab, before/after)

Built this branch into an `mlrun-api` image, deployed it over `mlrun-api-chief`/`-worker` on a dev lab (gating code confirmed present in the running chief), and ran an **identical** ML-12790 reproduction against the pre-fix and post-fix server — same client, same runner image, same submission; only the server changed.

- **Repro setup:** a real `1.12.0-rc2` SDK client (i.e. `< 1.12.0-rc8`) submits a remote KFP workflow. The workflow-runner image is pinned to `mlrun/mlrun-kfp:1.12.0-rc2`, a genuine pre-`rc8` image whose `load_and_run_workflow` lacks the `run_setup` kwarg. The client version is what the gate keys on; the pin only guarantees the runner actually executes pre-`rc8` code (natural resolution would tag the runner from the *server's* version).
- **Before the fix** (`run_setup` forwarded unconditionally): the runner's `MLRUN_EXEC_CONFIG` params carried `"run_setup": false`, and the runner pod failed with the exact ML-12790 error:
  ```
  File ".../mlrun/projects/pipelines.py", line 1166, in load_and_run
      load_and_run_workflow(context, *args, **kwargs)
  TypeError: load_and_run_workflow() got an unexpected keyword argument 'run_setup'
  ```
- **After the fix** (this branch): `run_setup` is **absent** from the runner's params, and `load_and_run_workflow` executes — the traceback now runs *through* it into handler resolution, i.e. well past the previous crash point. The only remaining failure was an unrelated artifact of the throwaway test project (its pipeline entrypoint wasn't named `pipeline` / no handler passed), not the `run_setup` `TypeError`.

This confirms end-to-end that the gate omits `run_setup` for `< 1.12.0-rc8` clients while leaving the runner path otherwise unchanged.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12790
- Related: https://ecliptos.atlassian.net/browse/REG-2521 (backward-compat regression that surfaced this)
- Regression introduced by: #9548 (first released in 1.12.0-rc8)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Affected areas: remote workflow execution (run + schedule) across mixed client/server versions. `LoadRunner` (project load) and `RerunRunner` (rerun) are unaffected — they never sent `run_setup`.
- Reviewer note: the floor `1.12.0-rc8` is the first release containing #9548 (verified via `git tag --contains`). PEP 440 comparison orders all rc8+ pre-releases and the 1.12.0 release as compatible while rejecting rc1–rc7 and any < 1.12 client.

#### ⚠️ Open question for review: shared `validate_component_version_compatibility` orders pre-release tags lexically

While fixing this, we found that `mlrun.utils.helpers.validate_component_version_compatibility` (semver-based) compares pre-release identifiers **lexically**, not numerically. Because mlrun tags releases as single `rcN` identifiers (e.g. `1.12.0-rc8`), this means:

```
"1.12.0-rc10" < "1.12.0-rc8"   # lexical: '1' < '8'
"1.12.0-rc14" < "1.12.0-rc8"
```

So any caller passing a `min_version` above `-rc0` gets wrong results for rc10+ clients. Today this is masked because the only existing caller (`enrich_image_url`, gating at `1.10.0-rc0`) uses an `-rc0` floor, where lexical and numeric ordering happen to agree. It would bite the next caller that needs a higher pre-release floor (as this PR did).

This PR works around it locally with `packaging.version` (PEP 440) to keep the blast radius small. The alternative — **fixing the shared helper** to compare pre-releases numerically (e.g. via `packaging.version`) — is arguably the better long-term fix but touches iguazio/nuclio/mlrun-client gating across the codebase and needs its own review + regression coverage. Flagging here so we can decide in review whether to:
1. keep this local PEP 440 workaround (current state), or
2. fix `validate_component_version_compatibility` centrally and have this call site use it.
