### PR TITLE
[Tests] Remove needless webhook SSL notification system test [1.11.x]

### DIFF
--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -292,64 +292,6 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
             params=params or {},
         )
 
-    @pytest.mark.parametrize(
-        "verify_ssl,expected_run_status,url",
-        [
-            (True, "error", "https://self-signed.badssl.com/"),
-            (False, "sent", "https://self-signed.badssl.com/"),
-            (None, "sent", "http://httpbin.org/get"),
-            (False, "sent", "http://httpbin.org/get"),
-        ],
-    )
-    def test_webhook_notification_ssl(self, verify_ssl, expected_run_status, url):
-        notification_name = "ssl-notification"
-
-        def _assert_notifications():
-            runs = self._run_db.list_runs(
-                project=self.project_name,
-                with_notifications=True,
-            )
-            assert len(runs) == 1
-            run_notifications = runs[0]["status"]["notifications"]
-            assert len(run_notifications) == 1
-            assert run_notifications[notification_name]["status"] == expected_run_status
-
-        notification = self._create_notification(
-            kind="webhook",
-            when=["completed", "error"],
-            name=notification_name,
-            message="completed",
-            severity="info",
-            secret_params={
-                "url": url,
-                "method": "GET",
-                "verify_ssl": verify_ssl,
-            },
-        )
-
-        function = mlrun.new_function(
-            "function-from-module",
-            kind="job",
-            project=self.project_name,
-            image="mlrun/mlrun",
-        )
-
-        run = function.run(
-            handler="json.dumps",
-            params={"obj": {"x": 99}},
-            notifications=[notification],
-        )
-        assert run.output("return") == '{"x": 99}'
-
-        # the notifications are sent asynchronously, so we need to wait for them
-        mlrun.utils.retry_until_successful(
-            1,
-            40,
-            self._logger,
-            True,
-            _assert_notifications,
-        )
-
     def _create_sleep_func_in_project(self):
         code_path = str(self.assets_path / "sleep.py")
 


### PR DESCRIPTION
### 📝 Description

Removes the `test_webhook_notification_ssl` system test from `tests/system/runtimes/test_notifications.py`. The behavior it covered — webhook notification `verify_ssl` handling — is now exercised by a unit test in `tests/utils/test_notifications.py` (added in 2881051fc), so the system test is redundant. It also relied on external endpoints (`self-signed.badssl.com`, `httpbin.org`), making it a needless source of flakiness and external dependency in the system test suite.

---

### 🛠️ Changes Made
- Removed the parametrized `test_webhook_notification_ssl` test and its decorator from `tests/system/runtimes/test_notifications.py` (58 lines).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/system-tests-opensource.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the RP)

---

### 🧪 Testing
- `make lint` (ruff check + format) passes.
- Test deletion only — no behavior change. Equivalent `verify_ssl` coverage lives in the unit test added in the preceding commit.

---

### 🔗 References
- Ticket link:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- This branch targets `1.11.x` (it is one commit ahead of `upstream/1.11.x`).