### PR TITLE
[Datastore] Bound Azure put() upload concurrency (fix log_model OOM)

### DIFF
--- a/mlrun/datastore/azure_blob.py
+++ b/mlrun/datastore/azure_blob.py
@@ -388,8 +388,10 @@ class AzureBlobStore(DataStore):
         data, _ = self._prepare_put_data(data, append)
         if isinstance(data, str):
             data = data.encode("utf-8")
-        # pipe_file streams in chunks; write() buffers the whole body.
-        self.filesystem.pipe_file(remote_path, data)
+        # Bound concurrency; adlfs default is unbounded -> buffers whole body (ML-12754).
+        self.filesystem.pipe_file(
+            remote_path, data, max_concurrency=self.max_concurrency
+        )
 
     def stat(self, key):
         remote_path = self._convert_key_to_remote_path(key)

--- a/tests/datastore/test_azure_blob_store.py
+++ b/tests/datastore/test_azure_blob_store.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 
@@ -162,6 +162,40 @@ class TestAzureBlobStore:
         store = self._create_store(schema="az", endpoint="data", secrets={})
         with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
             store.get_read_only_https_url("/src.tar.gz")
+
+    def test_put_bounds_upload_concurrency(self):
+        """put() must bound pipe_file concurrency to avoid buffering the whole body (ML-12754)."""
+        store = self._create_store(schema="az", endpoint="test-container")
+        mock_fs = Mock()
+        with patch.object(
+            AzureBlobStore,
+            "filesystem",
+            new_callable=PropertyMock,
+            return_value=mock_fs,
+        ):
+            store.put("path/to/obj.bin", b"some-bytes")
+
+        mock_fs.pipe_file.assert_called_once()
+        args, kwargs = mock_fs.pipe_file.call_args
+        assert kwargs.get("max_concurrency") == store.max_concurrency
+        assert args[0] == "test-container/path/to/obj.bin"
+        assert args[1] == b"some-bytes"
+
+    def test_put_encodes_str_body(self):
+        """str bodies must be encoded to bytes before pipe_file, and still bounded."""
+        store = self._create_store(schema="az", endpoint="test-container")
+        mock_fs = Mock()
+        with patch.object(
+            AzureBlobStore,
+            "filesystem",
+            new_callable=PropertyMock,
+            return_value=mock_fs,
+        ):
+            store.put("obj.yaml", "key: value")
+
+        args, kwargs = mock_fs.pipe_file.call_args
+        assert args[1] == b"key: value"
+        assert kwargs.get("max_concurrency") == store.max_concurrency
 
     def test_spark_url_az_schema_with_endpoint_container(self):
         """Test spark_url generation for az:// URLs where endpoint is container"""


### PR DESCRIPTION
### 📝 Description
`AzureBlobStore.put()` called `filesystem.pipe_file()` without `max_concurrency`, inheriting adlfs's effectively-unbounded filesystem default (131072). azure-storage-blob's async block uploader then buffers every 4 MiB chunk of the body **at once** — a full second copy of the body (~2× peak RSS) — OOMKilling large-artifact jobs (e.g. `log_model(body=<multi-GiB>)`) on Azure.

The earlier `open().write()` → `pipe_file()` change removed adlfs's write-buffer doubling but the ~2× remained, just relocated to azure's async uploader — which is why ML-12754 was reopened.

---

### 🛠️ Changes Made
- `AzureBlobStore.put()` now passes `max_concurrency=self.max_concurrency` (100) to `pipe_file`, matching the existing file `upload()` path.
- Added unit tests asserting `put()` bounds upload concurrency and still encodes `str` bodies.
- GCS left unchanged — `gcsfs.pipe_file` streams a single resumable upload and has no `max_concurrency` knob, so it does not exhibit the doubling.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — n/a
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation — n/a
- [ ] Please run Smoke-tests workflow

> Not covered by an existing system test; verified manually end-to-end on a live Azure (oris) cluster and with unit tests.

---

### 🧪 Testing
- **Unit:** `tests/datastore/test_azure_blob_store.py` — 53 passed, incl. 2 new tests (`test_put_bounds_upload_concurrency`, `test_put_encodes_str_body`).
- **Profiled on a live Azure job** (real `log_model` remote job, `tracemalloc` snapshot at peak): a 3 GiB body shows the original `bytes` plus 768 × 4 MiB resident chunk buffers in `azure/.../uploads_async.py` → ~2× body. Peak factor by `max_concurrency`: default → ~2.0×, `100` → 1.15×, `2` → 1.007×.
- Reproduced the ticket end-to-end first (`state=error, reason=OOMKilled`), then confirmed bounding concurrency collapses the second copy.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12754

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Root cause: adlfs filesystem default `max_concurrency` is 131072 (effectively unbounded); azure's async block uploader primes a future per chunk and holds them all simultaneously. The blocks are always *created/staged* regardless of concurrency — `max_concurrency` only bounds how many chunk buffers are resident at once.
