### PR TITLE
[Tests] Collect pod logs on test_serving_as_a_job failure

### DIFF
--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -946,6 +946,7 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
 
 @TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
+@pytest.mark.collect_pod_logs
 class TestServingJobEndpoint(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
     """
     Demonstrates running a serving job with model monitoring enabled.  In this test, we deploy a simple serving model


### PR DESCRIPTION
### 📝 Description
Enables `@pytest.mark.collect_pod_logs` on the `TestServingJobEndpoint` system test so that, on failure, CI captures the model-monitoring stream / controller / application pod logs.

`test_serving_as_a_job` currently fails deterministically on `development` (the application "count" metric ends with 2 windowed values instead of 3), but the client-side test output alone (`assert 2 == 3`) does not reveal where the earliest window is lost. The collected pod logs are needed to root-cause the regression.

This is a diagnostic-only change — it does not modify test logic or behavior.

---

### 🛠️ Changes Made
- Add `@pytest.mark.collect_pod_logs` to `TestServingJobEndpoint` in `tests/system/model_monitoring/test_app.py`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- One-line change adding a pytest marker; no test logic changes.
- The `collect_pod_logs` marker (defined in `tests/system/conftest.py` and `tests/system/base.py`) collects pod logs on test failure.
- Intent: run the enterprise system test `test_serving_as_a_job` in CI so the captured model-monitoring pod logs can be used to diagnose the existing deterministic failure.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Diagnostic-only change to surface server-side logs for the deterministic `test_serving_as_a_job` failure on `development` (count app metric: 2 windows instead of 3). It does not fix the failure; it captures the stream / controller / application pod logs needed to root-cause it.
