### PR TITLE
[Model Monitoring] Fix evaluate() skip_overlap raising on fully-processed window

### DIFF
--- a/mlrun/errors.py
+++ b/mlrun/errors.py
@@ -255,6 +255,17 @@ class MLRunValueError(ValueError):
     pass
 
 
+class MLRunEmptySampleDFError(MLRunValueError):
+    """Raised when a model monitoring application's sample DataFrame is empty.
+
+    Distinct from a generic :class:`MLRunValueError` so that callers iterating over
+    monitoring windows can skip windows with no inference data without swallowing
+    unrelated value errors (e.g. missing endpoint details or storage failures).
+    """
+
+    pass
+
+
 class MLRunFatalFailureError(Exception):
     """
     Internal exception meant to be used inside mlrun.utils.helpers.retry_until_successful to signal the loop not to

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -659,10 +659,6 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 sample_df=sample_data,
             )
 
-            # A window with no inference data is a normal state we skip rather than
-            # fail on (e.g. `skip_overlap` once all data was already processed). A
-            # fetched empty window raises `MLRunEmptySampleDFError`; a directly
-            # provided `sample_data` is returned as-is and may also be empty.
             try:
                 sample_df_empty = ctx.sample_df.empty
             except mlrun.errors.MLRunEmptySampleDFError:

--- a/mlrun/model_monitoring/applications/base.py
+++ b/mlrun/model_monitoring/applications/base.py
@@ -659,8 +659,16 @@ class ModelMonitoringApplicationBase(MonitoringApplicationToDict, ABC):
                 sample_df=sample_data,
             )
 
-            if ctx.sample_df.empty:
-                # The current sample is empty
+            # A window with no inference data is a normal state we skip rather than
+            # fail on (e.g. `skip_overlap` once all data was already processed). A
+            # fetched empty window raises `MLRunEmptySampleDFError`; a directly
+            # provided `sample_data` is returned as-is and may also be empty.
+            try:
+                sample_df_empty = ctx.sample_df.empty
+            except mlrun.errors.MLRunEmptySampleDFError:
+                sample_df_empty = True
+
+            if sample_df_empty:
                 context.logger.debug(
                     "No sample data available for tracking",
                     application_name=application_name,

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -211,12 +211,13 @@ class MonitoringApplicationContext:
     def sample_df(self) -> pd.DataFrame:
         """The new sample DataFrame for the monitored window.
 
-        :raises mlrun.errors.MLRunEmptySampleDFError: if the sample DataFrame cannot be
-            provided - either because the model endpoint's details and times were not
-            supplied (and no ``sample_data`` was given directly), or because there is no
-            inference data logged in the requested time window. The dedicated error type
-            lets callers iterating over monitoring windows skip empty windows without
-            swallowing unrelated value errors.
+        :raises mlrun.errors.MLRunValueError: if the sample DataFrame cannot be provided
+            because the model endpoint's details and times were not supplied (and no
+            ``sample_data`` was given directly).
+        :raises mlrun.errors.MLRunEmptySampleDFError: if there is no inference data
+            logged in the requested time window. This dedicated error type lets callers
+            iterating over monitoring windows skip empty windows without swallowing
+            unrelated value errors (e.g. the missing-details case above).
         """
         if self._sample_df is None:
             if (
@@ -225,7 +226,7 @@ class MonitoringApplicationContext:
                 or pd.isnull(self.start_infer_time)
                 or pd.isnull(self.end_infer_time)
             ):
-                raise mlrun.errors.MLRunEmptySampleDFError(
+                raise mlrun.errors.MLRunValueError(
                     "You have tried to access `monitoring_context.sample_df`, but have not provided it directly "
                     "through `sample_data`, nor have you provided the model endpoint's name, ID, and the start and "
                     f"end times: `endpoint_name`={self.endpoint_name}, `endpoint_uid`={self.endpoint_id}, "

--- a/mlrun/model_monitoring/applications/context.py
+++ b/mlrun/model_monitoring/applications/context.py
@@ -209,6 +209,15 @@ class MonitoringApplicationContext:
 
     @property
     def sample_df(self) -> pd.DataFrame:
+        """The new sample DataFrame for the monitored window.
+
+        :raises mlrun.errors.MLRunEmptySampleDFError: if the sample DataFrame cannot be
+            provided - either because the model endpoint's details and times were not
+            supplied (and no ``sample_data`` was given directly), or because there is no
+            inference data logged in the requested time window. The dedicated error type
+            lets callers iterating over monitoring windows skip empty windows without
+            swallowing unrelated value errors.
+        """
         if self._sample_df is None:
             if (
                 self.endpoint_name is None
@@ -216,7 +225,7 @@ class MonitoringApplicationContext:
                 or pd.isnull(self.start_infer_time)
                 or pd.isnull(self.end_infer_time)
             ):
-                raise mlrun.errors.MLRunValueError(
+                raise mlrun.errors.MLRunEmptySampleDFError(
                     "You have tried to access `monitoring_context.sample_df`, but have not provided it directly "
                     "through `sample_data`, nor have you provided the model endpoint's name, ID, and the start and "
                     f"end times: `endpoint_name`={self.endpoint_name}, `endpoint_uid`={self.endpoint_id}, "
@@ -231,7 +240,7 @@ class MonitoringApplicationContext:
                 storage_options=self.storage_options,
             )
             if df.empty:
-                raise mlrun.errors.MLRunValueError(
+                raise mlrun.errors.MLRunEmptySampleDFError(
                     "The sample dataframe is empty, which may indicate that there are no features logged in the "
                     "model endpoint during the specified time window. Please check that your model endpoint is logging "
                     "features correctly, and that the time window is correct."

--- a/tests/model_monitoring/test_applications/test_app_context.py
+++ b/tests/model_monitoring/test_applications/test_app_context.py
@@ -120,7 +120,7 @@ def test_sample_df_raises_when_endpoint_details_missing(missing_attr: str) -> No
     stub = _make_sample_df_stub(df=pd.DataFrame({"feature_a": [1, 2, 3]}))
     setattr(stub, missing_attr, None if "endpoint" in missing_attr else pd.NaT)
     with pytest.raises(
-        MLRunEmptySampleDFError,
+        MLRunValueError,
         match="have not provided it directly",
     ):
         MonitoringApplicationContext.sample_df.fget(stub)

--- a/tests/model_monitoring/test_applications/test_app_context.py
+++ b/tests/model_monitoring/test_applications/test_app_context.py
@@ -23,7 +23,7 @@ from nuclio.request import Logger as NuclioLogger
 
 import mlrun
 from mlrun import MLClientCtx, MlrunProject
-from mlrun.errors import MLRunValueError
+from mlrun.errors import MLRunEmptySampleDFError, MLRunValueError
 from mlrun.model_monitoring.applications.context import MonitoringApplicationContext
 from mlrun.serving import GraphContext, GraphServer
 
@@ -101,7 +101,7 @@ def _make_sample_df_stub(df: pd.DataFrame) -> Mock:
 
 def test_sample_df_raises_when_feature_set_returns_empty_df() -> None:
     stub = _make_sample_df_stub(df=pd.DataFrame())
-    with pytest.raises(MLRunValueError, match="sample dataframe is empty"):
+    with pytest.raises(MLRunEmptySampleDFError, match="sample dataframe is empty"):
         MonitoringApplicationContext.sample_df.fget(stub)
 
 
@@ -110,6 +110,20 @@ def test_sample_df_returns_df_when_feature_set_returns_non_empty_df() -> None:
     stub = _make_sample_df_stub(df=df)
     result = MonitoringApplicationContext.sample_df.fget(stub)
     pd.testing.assert_frame_equal(result, df.reset_index(drop=True))
+
+
+@pytest.mark.parametrize(
+    "missing_attr",
+    ["endpoint_name", "endpoint_id", "start_infer_time", "end_infer_time"],
+)
+def test_sample_df_raises_when_endpoint_details_missing(missing_attr: str) -> None:
+    stub = _make_sample_df_stub(df=pd.DataFrame({"feature_a": [1, 2, 3]}))
+    setattr(stub, missing_attr, None if "endpoint" in missing_attr else pd.NaT)
+    with pytest.raises(
+        MLRunEmptySampleDFError,
+        match="have not provided it directly",
+    ):
+        MonitoringApplicationContext.sample_df.fget(stub)
 
 
 @patch("mlrun.db.nopdb.NopDB.get_project")

--- a/tests/model_monitoring/test_applications/test_base.py
+++ b/tests/model_monitoring/test_applications/test_base.py
@@ -470,6 +470,40 @@ def test_windows(
     )
 
 
+@pytest.mark.parametrize("base_period", [None, 1])
+def test_window_generator_skips_empty_windows(base_period: int | None) -> None:
+    """
+    A window with no inference data (e.g. ``skip_overlap`` when all data was already
+    processed - ML-12817) must be skipped, not raised, even though `sample_df` now
+    raises `MLRunEmptySampleDFError` on empty data.
+    """
+    with patch.object(
+        MonitoringApplicationContext,
+        "sample_df",
+        property(
+            lambda _: (_ for _ in ()).throw(
+                mlrun.errors.MLRunEmptySampleDFError("The sample dataframe is empty")
+            )
+        ),
+    ):
+        windows = list(
+            ModelMonitoringApplicationBase._window_generator(
+                start=datetime(2024, 12, 26, 14, 0, 0, tzinfo=UTC).isoformat(),
+                end=datetime(2024, 12, 26, 14, 2, 0, tzinfo=UTC).isoformat(),
+                base_period=base_period,
+                application_schedules=None,
+                endpoint_name="",
+                endpoint_id="",
+                application_name="",
+                existing_data_handling=ExistingDataHandling.skip_overlap,
+                context=mlrun.MLClientCtx.from_dict({}),
+                project=mlrun.projects.MlrunProject(),
+                sample_data=None,
+            )
+        )
+    assert windows == [], "Empty windows should be skipped, not yielded or raised"
+
+
 @pytest.mark.parametrize(
     ("base_period", "start_dt", "end_dt", "expectation"),
     [


### PR DESCRIPTION
### 📝 Description
`evaluate(existing_data_handling="skip_overlap")` raised `MLRunValueError: The sample dataframe is empty` when all data in the window was already processed. The window iterator relied on `sample_df` returning an empty df to skip empty windows, but #9812 made it raise instead.

---

### 🛠️ Changes Made
- Add dedicated `MLRunEmptySampleDFError` (subclass of `MLRunValueError`).
- `sample_df` raises it for both empty data and missing endpoint details.
- `_window_generator` catches only this error and skips the window, so genuine config/storage errors still propagate.

---

### ✅ Checklist
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes

---

### 🧪 Testing
- Unit tests: window generator skips empty windows; `sample_df` raises `MLRunEmptySampleDFError` on empty data and on missing endpoint details.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12817

---

### 🚨 Breaking Changes?
- [x] No
