### PR TITLE
[Requirements] Make v3io-frames an optional extra

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -75,6 +75,7 @@ def extra_requirements() -> dict[str, list[str]]:
         "timescaledb": ["psycopg[binary,pool]~=3.2"],
         "opentelemetry": ["storey[otel]"],
         "snowflake": ["snowflake-connector-python~=4.6"],
+        "v3io-frames": ["v3io-frames~=0.13.11"],
     }
 
     api_deps = list(

--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -3654,8 +3654,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.4 \
-    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
+storey==1.12.5 \
+    --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt
@@ -3804,9 +3804,7 @@ v3io==0.7.2 \
 v3io-frames==0.13.13 \
     --hash=sha256:3fe8847394e32b6e23ab134356b28f9dca7466392778d6805f68735f6d8b4271 \
     --hash=sha256:c9c7d7f01c0289eeac069de5d380bb001bbe517b208d2af1f2f01eceec82aa4e
-    # via
-    #   -r requirements.txt
-    #   storey
+    # via -r extras-requirements.txt
 v3iofs==0.1.18 \
     --hash=sha256:b628588905becd70f546e700c1ec06c027cb001fe58e2a56ab1be840fd4ec5fd \
     --hash=sha256:dc52cda02573bcab5d6fd5919753c24321f50b150a44681790ae5797ac10a648

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -3406,8 +3406,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.4 \
-    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
+storey==1.12.5 \
+    --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt
@@ -3554,9 +3554,7 @@ v3io==0.7.2 \
 v3io-frames==0.13.13 \
     --hash=sha256:3fe8847394e32b6e23ab134356b28f9dca7466392778d6805f68735f6d8b4271 \
     --hash=sha256:c9c7d7f01c0289eeac069de5d380bb001bbe517b208d2af1f2f01eceec82aa4e
-    # via
-    #   -r requirements.txt
-    #   storey
+    # via -r extras-requirements.txt
 v3iofs==0.1.18 \
     --hash=sha256:b628588905becd70f546e700c1ec06c027cb001fe58e2a56ab1be840fd4ec5fd \
     --hash=sha256:dc52cda02573bcab5d6fd5919753c24321f50b150a44681790ae5797ac10a648

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -3058,8 +3058,8 @@ starlette==0.50.0 \
     --hash=sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca \
     --hash=sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca
     # via fastapi
-storey==1.12.4 \
-    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
+storey==1.12.5 \
+    --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt
@@ -3218,9 +3218,7 @@ v3io==0.7.2 \
 v3io-frames==0.13.13 \
     --hash=sha256:3fe8847394e32b6e23ab134356b28f9dca7466392778d6805f68735f6d8b4271 \
     --hash=sha256:c9c7d7f01c0289eeac069de5d380bb001bbe517b208d2af1f2f01eceec82aa4e
-    # via
-    #   -r requirements.txt
-    #   storey
+    # via -r extras-requirements.txt
 v3iofs==0.1.18 \
     --hash=sha256:b628588905becd70f546e700c1ec06c027cb001fe58e2a56ab1be840fd4ec5fd \
     --hash=sha256:dc52cda02573bcab5d6fd5919753c24321f50b150a44681790ae5797ac10a648

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -2883,8 +2883,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.4 \
-    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
+storey==1.12.5 \
+    --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt
@@ -3038,9 +3038,7 @@ v3io==0.7.2 \
 v3io-frames==0.13.13 \
     --hash=sha256:3fe8847394e32b6e23ab134356b28f9dca7466392778d6805f68735f6d8b4271 \
     --hash=sha256:c9c7d7f01c0289eeac069de5d380bb001bbe517b208d2af1f2f01eceec82aa4e
-    # via
-    #   -r requirements.txt
-    #   storey
+    # via -r extras-requirements.txt
 v3iofs==0.1.18 \
     --hash=sha256:b628588905becd70f546e700c1ec06c027cb001fe58e2a56ab1be840fd4ec5fd \
     --hash=sha256:dc52cda02573bcab5d6fd5919753c24321f50b150a44681790ae5797ac10a648

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -3654,8 +3654,8 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-storey==1.12.4 \
-    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
+storey==1.12.5 \
+    --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt
@@ -3804,9 +3804,7 @@ v3io==0.7.2 \
 v3io-frames==0.13.13 \
     --hash=sha256:3fe8847394e32b6e23ab134356b28f9dca7466392778d6805f68735f6d8b4271 \
     --hash=sha256:c9c7d7f01c0289eeac069de5d380bb001bbe517b208d2af1f2f01eceec82aa4e
-    # via
-    #   -r requirements.txt
-    #   storey
+    # via -r extras-requirements.txt
 v3iofs==0.1.18 \
     --hash=sha256:b628588905becd70f546e700c1ec06c027cb001fe58e2a56ab1be840fd4ec5fd \
     --hash=sha256:dc52cda02573bcab5d6fd5919753c24321f50b150a44681790ae5797ac10a648

--- a/dockerfiles/test-system/locked-requirements.txt
+++ b/dockerfiles/test-system/locked-requirements.txt
@@ -4683,8 +4683,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.12.4 \
-    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
+storey==1.12.5 \
+    --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt
@@ -5167,9 +5167,7 @@ v3io==0.7.2 \
 v3io-frames==0.13.13 \
     --hash=sha256:3fe8847394e32b6e23ab134356b28f9dca7466392778d6805f68735f6d8b4271 \
     --hash=sha256:c9c7d7f01c0289eeac069de5d380bb001bbe517b208d2af1f2f01eceec82aa4e
-    # via
-    #   -r requirements.txt
-    #   storey
+    # via -r extras-requirements.txt
 v3iofs==0.1.18 \
     --hash=sha256:b628588905becd70f546e700c1ec06c027cb001fe58e2a56ab1be840fd4ec5fd \
     --hash=sha256:dc52cda02573bcab5d6fd5919753c24321f50b150a44681790ae5797ac10a648

--- a/dockerfiles/test/locked-requirements.txt
+++ b/dockerfiles/test/locked-requirements.txt
@@ -4758,8 +4758,8 @@ statsmodels==0.14.6 \
     --hash=sha256:f4ff0649a2df674c7ffb6fa1a06bffdb82a6adf09a48e90e000a15a6aaa734b0 \
     --hash=sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5
     # via evidently
-storey==1.12.4 \
-    --hash=sha256:b5152b2bc482a4456d76ba9ef336228d1317e9aa9ddea6fe6d0f6d5d482f67a9
+storey==1.12.5 \
+    --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
     #   -r extras-requirements.txt
     #   -r requirements.txt
@@ -5245,9 +5245,7 @@ v3io==0.7.2 \
 v3io-frames==0.13.13 \
     --hash=sha256:3fe8847394e32b6e23ab134356b28f9dca7466392778d6805f68735f6d8b4271 \
     --hash=sha256:c9c7d7f01c0289eeac069de5d380bb001bbe517b208d2af1f2f01eceec82aa4e
-    # via
-    #   -r requirements.txt
-    #   storey
+    # via -r extras-requirements.txt
 v3iofs==0.1.18 \
     --hash=sha256:b628588905becd70f546e700c1ec06c027cb001fe58e2a56ab1be840fd4ec5fd \
     --hash=sha256:dc52cda02573bcab5d6fd5919753c24321f50b150a44681790ae5797ac10a648

--- a/docs/change-log/index.md
+++ b/docs/change-log/index.md
@@ -2,6 +2,7 @@
 # Change log
 
 The change log lists updates per version, open issues, limitations, and deprecations.
+- [v1.12.0](#v1120)
 - [v1.11.0](#v1110)
 - [v1.10.3](#v1103) | [v1.10.2](#v1102) | [v1.10.1](#v1101) | [v1.10.0](#v1100)
 - [v1.9.2](#v192) | [v1.9.1](#v191) | [v1.9.0](#v190)
@@ -24,6 +25,15 @@ Upgrading these three MLRun dependencies spans several releases.  The upgrades a
 - Pydantic: from version 1 to 2.
 
 See a full description of KFP, Python, and the workflow engines in {ref}`local-remote`. Specific changes are listed under the relevant versions.
+(v1120)=
+## v1.12.0
+
+(1.12.0-breaking)=
+### Breaking Changes
+| ID    |Description                                                                 |
+|-------|----------------------------------------------------------------------------|
+|ML-12819|`v3io-frames` is now optional. Standard `pip install mlrun` installs no longer include it. If you use v3io Frames or v3io TSDB model monitoring, install `mlrun[v3io-frames]`. The dependency is still included in `mlrun[all]`, `mlrun[complete]`, and MLRun images.|
+
 (v1110)=
 ## v1.11.0 (May 2026)
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -58,6 +58,7 @@ Run ```pip install mlrun```
      - ```pip install mlrun[s3]``` Install requirements for S3 
      - ```pip install mlrun[azure-blob-storage]``` Install requirements for Azure blob storage
      - ```pip install mlrun[google-cloud-storage]``` Install requirements for Google cloud storage
+     - ```pip install mlrun[v3io-frames]``` Install v3io Frames support, including v3io TSDB model monitoring.
    
       
    - To install all extras, run: ```pip install mlrun[complete]``` See the full list [here](https://github.com/mlrun/mlrun/blob/development/dependencies.py#L25).<br>

--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -50,3 +50,4 @@ distributed==2024.8
 psycopg[binary,pool]~=3.2
 storey[otel]
 snowflake-connector-python~=4.6
+v3io-frames~=0.13.11

--- a/mlrun/model_monitoring/db/tsdb/base.py
+++ b/mlrun/model_monitoring/db/tsdb/base.py
@@ -14,11 +14,13 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from typing import ClassVar, Literal, Union
+from typing import TYPE_CHECKING, ClassVar, Literal, Union
 
 import pandas as pd
 import pydantic.v1
-import v3io_frames.client
+
+if TYPE_CHECKING:
+    import v3io_frames.client
 
 import mlrun.common.schemas.model_monitoring as mm_schemas
 import mlrun.model_monitoring.db.tsdb.helpers
@@ -267,7 +269,7 @@ class TSDBConnector(ABC):
         start: datetime | None = None,
         end: datetime | None = None,
         get_raw: bool = False,
-    ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
+    ) -> Union[pd.DataFrame, "list[v3io_frames.client.RawFrame]"]:
         """
         Fetches data from the app-results TSDB table and returns the highest status among all
         the result in the provided time range, which by default is the last 24 hours, for each specified endpoint.
@@ -326,7 +328,7 @@ class TSDBConnector(ABC):
         start: datetime | None = None,
         end: datetime | None = None,
         get_raw: bool = False,
-    ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
+    ) -> Union[pd.DataFrame, "list[v3io_frames.client.RawFrame]"]:
         """
         Fetches data from the error TSDB table and returns the error count for each specified endpoint.
 
@@ -347,7 +349,7 @@ class TSDBConnector(ABC):
         start: datetime | None = None,
         end: datetime | None = None,
         get_raw: bool = False,
-    ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
+    ) -> Union[pd.DataFrame, "list[v3io_frames.client.RawFrame]"]:
         """
         Fetches data from the predictions TSDB table and returns the average latency for each specified endpoint
         in the provided time range, which by default is the last 24 hours.

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_predictions_queries.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 from datetime import datetime, timedelta
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import pandas as pd
-import v3io_frames.client
 
 import mlrun
 import mlrun.common.schemas.model_monitoring as mm_schemas
@@ -31,6 +30,9 @@ from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_query_builder 
     TimescaleDBQueryBuilder,
 )
 from mlrun.model_monitoring.helpers import get_invocations_fqn
+
+if TYPE_CHECKING:
+    import v3io_frames.client
 
 
 class TimescaleDBPredictionsQueries:
@@ -286,7 +288,7 @@ class TimescaleDBPredictionsQueries:
         start: datetime | None = None,
         end: datetime | None = None,
         get_raw: bool = False,
-    ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
+    ) -> Union[pd.DataFrame, "list[v3io_frames.client.RawFrame]"]:
         """Get average latency with automatic pre-aggregate optimization, returning single value per endpoint."""
 
         # Convert single endpoint to list for consistent handling

--- a/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
+++ b/mlrun/model_monitoring/db/tsdb/timescaledb/queries/timescaledb_results_queries.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 from datetime import datetime, timedelta
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import pandas as pd
-import v3io_frames.client
 
 import mlrun
 import mlrun.common.schemas.model_monitoring as mm_schemas
@@ -29,6 +28,9 @@ from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_dataframe_proc
 from mlrun.model_monitoring.db.tsdb.timescaledb.utils.timescaledb_query_builder import (
     TimescaleDBQueryBuilder,
 )
+
+if TYPE_CHECKING:
+    import v3io_frames.client
 
 
 class TimescaleDBResultsQueries:
@@ -64,7 +66,7 @@ class TimescaleDBResultsQueries:
         start: datetime | None = None,
         end: datetime | None = None,
         get_raw: bool = False,
-    ) -> Union[pd.DataFrame, list[v3io_frames.client.RawFrame]]:
+    ) -> Union[pd.DataFrame, "list[v3io_frames.client.RawFrame]"]:
         """Get drift status for specified endpoints.
 
         :param endpoint_ids: Endpoint ID(s) to get drift status for

--- a/mlrun/model_monitoring/db/tsdb/v3io/__init__.py
+++ b/mlrun/model_monitoring/db/tsdb/v3io/__init__.py
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .v3io_connector import V3IOTSDBConnector
+# NOTE: intentionally do not re-export V3IOTSDBConnector here. It pulls in v3io_frames
+# eagerly, which would force importing this package (e.g. for the pure stream_graph_steps
+# helpers) to require the optional v3io-frames extra. Import it from .v3io_connector
+# directly at construction sites instead.

--- a/mlrun/utils/v3io_clients.py
+++ b/mlrun/utils/v3io_clients.py
@@ -13,14 +13,24 @@
 # limitations under the License.
 
 from v3io.dataplane import Client as V3IOClient
-from v3io_frames import Client as V3IOFramesClient
-from v3io_frames.client import ClientBase
+
+try:
+    from v3io_frames import Client as V3IOFramesClient
+    from v3io_frames.client import ClientBase
+except ImportError:
+    V3IOFramesClient = None
+    ClientBase = None
 
 _v3io_clients: dict[frozenset, V3IOClient] = {}
-_frames_clients: dict[frozenset, ClientBase] = {}
+# string annotation so the module imports without v3io_frames installed
+_frames_clients: "dict[frozenset, ClientBase]" = {}
 
 
-def get_frames_client(**kwargs) -> ClientBase:
+def get_frames_client(**kwargs) -> "ClientBase":
+    if V3IOFramesClient is None:
+        raise ImportError(
+            "v3io-frames is not installed, run 'pip install mlrun[v3io-frames]'"
+        )
     global _frames_clients
     kw_set = frozenset(kwargs.items())
     if kw_set not in _frames_clients:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 urllib3~=2.6
-v3io-frames~=0.13.11
 GitPython~=3.1, >=3.1.41
 aiohttp~=3.11
 aiohttp-retry~=2.9
@@ -28,7 +27,7 @@ dependency-injector~=4.41
 # should be identical to gcs and s3fs.
 fsspec>=2025.5.1, <=2025.7.0
 v3iofs~=0.1.17
-storey~=1.12.4
+storey~=1.12.5
 inflection~=0.5.0
 python-dotenv~=1.0
 setuptools>=75.2

--- a/server/py/services/api/tests/unit/api/test_grafana_proxy.py
+++ b/server/py/services/api/tests/unit/api/test_grafana_proxy.py
@@ -19,8 +19,6 @@ import pytest
 from fastapi.testclient import TestClient
 from pytest import fail
 from sqlalchemy.orm import Session
-from v3io_frames import CreateError
-from v3io_frames import frames_pb2 as fpb2
 
 import mlrun
 import mlrun.common.schemas.model_monitoring
@@ -36,6 +34,11 @@ from services.api.crud.model_monitoring.grafana import (
     validate_query_parameters,
 )
 from services.api.tests.unit.api.test_model_endpoints import _mock_random_endpoint
+
+# v3io_frames is an optional extra (mlrun[v3io-frames]); skip the module when it's absent.
+v3io_frames = pytest.importorskip("v3io_frames")
+CreateError = v3io_frames.CreateError
+fpb2 = pytest.importorskip("v3io_frames.frames_pb2")
 
 ENV_PARAMS = {"V3IO_ACCESS_KEY", "V3IO_API", "V3IO_FRAMESD"}
 TEST_PROJECT = "test3"

--- a/tests/model_monitoring/test_stores/test_v3io.py
+++ b/tests/model_monitoring/test_stores/test_v3io.py
@@ -20,21 +20,24 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
-import v3io_frames
 
-import mlrun.common.schemas.model_monitoring.constants as mm_constants
-import mlrun.utils.v3io_clients
-from mlrun.common.schemas.model_monitoring.model_endpoints import (
+# v3io_frames is an optional extra (mlrun[v3io-frames]); the v3io_connector import below
+# needs it, so skip the whole module when it isn't installed.
+v3io_frames = pytest.importorskip("v3io_frames")
+
+import mlrun.common.schemas.model_monitoring.constants as mm_constants  # noqa: E402
+import mlrun.utils.v3io_clients  # noqa: E402
+from mlrun.common.schemas.model_monitoring.model_endpoints import (  # noqa: E402
     ModelEndpointDriftValues,
     ModelEndpointMonitoringMetric,
     ModelEndpointMonitoringMetricNoData,
     ModelEndpointMonitoringResultValues,
     _MetricPoint,
 )
-from mlrun.model_monitoring.db.tsdb.v3io.stream_graph_steps import (
+from mlrun.model_monitoring.db.tsdb.v3io.stream_graph_steps import (  # noqa: E402
     _normalize_dict_for_v3io_frames,
 )
-from mlrun.model_monitoring.db.tsdb.v3io.v3io_connector import (
+from mlrun.model_monitoring.db.tsdb.v3io.v3io_connector import (  # noqa: E402
     V3IOTSDBConnector,
     _is_no_schema_error,
 )

--- a/tests/model_monitoring/test_writer.py
+++ b/tests/model_monitoring/test_writer.py
@@ -21,13 +21,17 @@ from unittest.mock import Mock, patch
 import pytest
 import semver
 import v3io.dataplane.kv
-import v3io_frames.client
 
-import mlrun.common.schemas.model_monitoring as mm_schemas
-import mlrun.model_monitoring
-import mlrun.model_monitoring.db.tsdb.v3io
-from mlrun.common.schemas import EventFieldType
-from mlrun.model_monitoring.writer import (
+# v3io_frames is an optional extra (mlrun[v3io-frames]); the v3io_connector import below
+# needs it, so skip the whole module when it isn't installed.
+v3io_frames = pytest.importorskip("v3io_frames")
+pytest.importorskip("v3io_frames.client")
+
+import mlrun.common.schemas.model_monitoring as mm_schemas  # noqa: E402
+import mlrun.model_monitoring  # noqa: E402
+import mlrun.model_monitoring.db.tsdb.v3io.v3io_connector  # noqa: E402
+from mlrun.common.schemas import EventFieldType  # noqa: E402
+from mlrun.model_monitoring.writer import (  # noqa: E402
     MetricData,
     ModelMonitoringWriter,
     ResultData,
@@ -37,7 +41,7 @@ from mlrun.model_monitoring.writer import (
     _WriterEventTypeError,
     _WriterEventValueError,
 )
-from mlrun.utils.v3io_clients import V3IOClient
+from mlrun.utils.v3io_clients import V3IOClient  # noqa: E402
 
 TEST_PROJECT = "test-application-results"
 V3IO_TABLE_CONTAINER = f"bigdata/{TEST_PROJECT}"
@@ -156,7 +160,7 @@ class TestHistogramGeneralDriftResultEvent:
             with patch(
                 "mlrun.model_monitoring.get_tsdb_connector",
                 return_value=Mock(
-                    spec=mlrun.model_monitoring.db.tsdb.v3io.V3IOTSDBConnector
+                    spec=mlrun.model_monitoring.db.tsdb.v3io.v3io_connector.V3IOTSDBConnector
                 ),
             ):
                 writer = ModelMonitoringWriter(project=TEST_PROJECT)
@@ -175,9 +179,13 @@ class TestTSDB:
 
     @staticmethod
     @pytest.fixture
-    def tsdb_connector() -> mlrun.model_monitoring.db.tsdb.v3io.V3IOTSDBConnector:
-        tsdb_connector = mlrun.model_monitoring.db.tsdb.v3io.V3IOTSDBConnector(
-            project=TEST_PROJECT
+    def tsdb_connector() -> (
+        mlrun.model_monitoring.db.tsdb.v3io.v3io_connector.V3IOTSDBConnector
+    ):
+        tsdb_connector = (
+            mlrun.model_monitoring.db.tsdb.v3io.v3io_connector.V3IOTSDBConnector(
+                project=TEST_PROJECT
+            )
         )
 
         # Generate dummy tables for the test
@@ -195,7 +203,7 @@ class TestTSDB:
     @staticmethod
     @pytest.fixture
     def writer(
-        tsdb_connector: mlrun.model_monitoring.db.tsdb.v3io.V3IOTSDBConnector,
+        tsdb_connector: mlrun.model_monitoring.db.tsdb.v3io.v3io_connector.V3IOTSDBConnector,
     ) -> ModelMonitoringWriter:
         writer = Mock(spec=ModelMonitoringWriter)
         writer.project = TEST_PROJECT

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -128,8 +128,8 @@ def test_requirement_specifiers_convention():
 
     ignored_invalid_map = {
         # See comment near requirement for why we're limiting to patch changes only for all of these
-        "storey": {"~=1.12.4"},
-        # No specifier — pip resolves against the base `storey~=1.12.4` pin
+        "storey": {"~=1.12.5"},
+        # No specifier — pip resolves against the base storey requirement
         # in requirements.txt, so we don't duplicate the version constraint.
         "storey[otel]": {""},
         "pydantic": {">=1.10.15", ">=1,<2"},


### PR DESCRIPTION
### 📝 Description

`v3io-frames` is imported eagerly at `import mlrun` (`datastore/targets.py` → `utils/v3io_clients.py`), even though it's only needed for v3io frames/TSDB features. This makes `import mlrun` hard-depend on `v3io-frames` being importable, which isn't always the case. This PR moves `v3io-frames` to an optional extra (`mlrun[v3io-frames]`) and guards its imports so `import mlrun` no longer depends on it; `v3io` stays core. The extra is auto-aggregated, so `all`/`complete`/`complete-api` (and MLRun's own images) still ship it.

---

### 🛠️ Changes Made

- `requirements.txt`: removed `v3io-frames~=0.13.11` (kept `v3io~=0.7.0`); bumped `storey~=1.12.4` → `~=1.12.5`, the companion release that also stops importing `v3io_frames` eagerly — needed for `import mlrun` to be fully free of `v3io_frames`.
- `dependencies.py`: added `"v3io-frames"` to the auto-aggregated `extras_require` dict.
- `extras-requirements.txt`: mirrored the extra (keeps `test_extras_requirement_file_aligned` green).
- `mlrun/utils/v3io_clients.py` (core fix): guarded the eager import (`try/except` → `None`); `get_frames_client()` raises a clear `pip install mlrun[v3io-frames]` hint; stringized `ClientBase` hints.
- `tsdb/base.py` + `timescaledb/queries/*.py`: moved type-hint-only `import v3io_frames.client` under `TYPE_CHECKING`, quoted the annotations.
- `tsdb/v3io/__init__.py`: dropped the eager `V3IOTSDBConnector` re-export so importing the pure `stream_graph_steps` helpers no longer pulls in `v3io_frames` (matches the empty sibling `timescaledb/__init__.py`). Construction sites import from `.v3io_connector` directly; the TSDB factory already did.
- Tests (`test_stores/test_v3io.py`, `test_writer.py`, `api/test_grafana_proxy.py`): guarded with `pytest.importorskip("v3io_frames")`; `test_writer.py` now references `...v3io.v3io_connector.V3IOTSDBConnector`.
- `tsdb/v3io/v3io_connector.py` unchanged (loaded behind the v3io TSDB factory, not at `import mlrun`).
- `dockerfiles/*/locked-requirements.txt` (×7): relocked. MLRun's own images install the `v3io-frames` extra, so they still pin `v3io-frames==0.13.13` (now alongside `storey==1.12.5`).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing

- v3io_frames absent (import blocked): `import mlrun`, `tsdb/base.py`, both `timescaledb/queries/*.py`, and `tsdb.v3io.stream_graph_steps` import cleanly; `get_frames_client()` raises the clear install hint.
- v3io_frames present: `import mlrun` and the frames client work as before.
- `ruff check` clean; `tests/test_requirements.py` 5 passed (incl. extras alignment); `test_schemas.py` + `test_writer.py` + `test_v3io.py` 40 passed, 5 skipped.

---

### 🔗 References
- Ticket link: ML-12819
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

A bare `pip install mlrun` no longer installs `v3io-frames`. Users of v3io-frames features must install `mlrun[v3io-frames]` (or `mlrun[all]`/`mlrun[complete]`, which still include it). MLRun's own images continue to ship it.

---

### 🔍️ Additional Notes

The companion `storey` bump and lock-file regeneration are included here, so `import mlrun` is fully free of `v3io_frames` without further follow-ups.