### PR TITLE
[DB] Fix MySQL-only SQL rejected by PostgreSQL

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -464,12 +464,20 @@ class SQLDB(DBInterface):
             query = query.filter(Run.uid.in_(specific_uids))
 
         if not only_uids:
-            # group_by allows us to have a row per uid with the whole record rather than just the uid (as distinct does)
-            # note we cannot promise that the same row will be returned each time per uid as the order is not guaranteed
-            query = query.group_by(Run.uid)
+            # Return one full record per uid. A plain `GROUP BY Run.uid` over full rows relies on
+            # MySQL's nonstandard "loose" GROUP BY (arbitrary row per group) and is rejected by
+            # PostgreSQL's strict GROUP BY. Instead select a representative id per uid via an
+            # aggregate (portable across dialects) and fetch those full rows. The representative is
+            # the highest primary-key id (the most recently inserted row); which row is returned was
+            # never guaranteed for this method.
+            latest_run_id_per_uid = query.with_entities(func.max(Run.id)).group_by(
+                Run.uid
+            )
 
             runs = RunList()
-            for run in query:
+            for run in self._query(session, Run).filter(
+                Run.id.in_(latest_run_id_per_uid.scalar_subquery())
+            ):
                 runs.append(run.struct)
 
             return runs
@@ -1277,7 +1285,7 @@ class SQLDB(DBInterface):
         )
         if category:
             query = self._add_artifact_category_query(category, query).with_hint(
-                ArtifactV2, "USE INDEX (idx_project_kind)"
+                ArtifactV2, "USE INDEX (idx_project_kind)", dialect_name="mysql"
             )
 
         # the query returns a list of tuples, we need to extract the tag from each tuple

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -467,6 +467,49 @@ class TestArtifacts(TestDatabaseBase):
         assert artifact_2_tag in artifact_tags
         assert "latest" in artifact_tags
 
+    def test_list_artifact_tags_with_category_hint_is_dialect_scoped(self, monkeypatch):
+        # Regression: the category-filtered tags query adds a MySQL `USE INDEX (idx_project_kind)`
+        # optimizer hint. It must be scoped to the mysql dialect so PostgreSQL's strict compiler
+        # does not raise `CompileError: Unrecognized hint`. Guards against dropping dialect_name.
+        from sqlalchemy.dialects import postgresql
+
+        key, tag = "artifact_key_hint", "v1"
+        self._db.store_artifact(
+            self._db_session,
+            key,
+            self._generate_artifact(
+                key,
+                project=self.project,
+                kind=mlrun.common.schemas.ArtifactCategories.dataset,
+                tag=tag,
+            ),
+            project=self.project,
+            tag=tag,
+        )
+
+        captured = {}
+        real_with_hint = Query.with_hint
+
+        def with_hint_spy(query, selectable, text, dialect_name=None):
+            result = real_with_hint(query, selectable, text, dialect_name=dialect_name)
+            if "USE INDEX" in str(text):
+                captured["dialect_name"] = dialect_name
+                captured["query"] = result
+            return result
+
+        monkeypatch.setattr(Query, "with_hint", with_hint_spy, raising=True)
+
+        self._db.list_artifact_tags(
+            self._db_session,
+            self.project,
+            category=mlrun.common.schemas.ArtifactCategories.dataset,
+        )
+
+        assert captured, "expected a USE INDEX hint on the category-filtered tags query"
+        assert captured["dialect_name"] == "mysql"
+        # The real query must compile under PostgreSQL without raising CompileError.
+        captured["query"].statement.compile(dialect=postgresql.dialect())
+
     def test_store_artifact_restoring_multiple_tags(self):
         artifact_key = "artifact_key_1"
         artifact_1_tree = "artifact_tree_1"

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -18,6 +18,7 @@ import unittest.mock
 
 import deepdiff
 import pytest
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Query
 
 import mlrun.common.constants
@@ -471,8 +472,6 @@ class TestArtifacts(TestDatabaseBase):
         # Regression: the category-filtered tags query adds a MySQL `USE INDEX (idx_project_kind)`
         # optimizer hint. It must be scoped to the mysql dialect so PostgreSQL's strict compiler
         # does not raise `CompileError: Unrecognized hint`. Guards against dropping dialect_name.
-        from sqlalchemy.dialects import postgresql
-
         key, tag = "artifact_key_hint", "v1"
         self._db.store_artifact(
             self._db_session,

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -187,6 +187,10 @@ class TestRuns(TestDatabaseBase):
         assert len(distinct_runs) == 1
         assert isinstance(distinct_runs[0], dict)
         assert distinct_runs[0]["metadata"]["uid"] == uid
+        # The full record per uid is the representative (highest-id) row, i.e. the last
+        # iteration stored. This is resolved via a portable max(id)+IN query rather than a
+        # MySQL-only loose GROUP BY, so PostgreSQL's strict GROUP BY does not reject it.
+        assert distinct_runs[0]["metadata"]["iter"] == 2
 
         only_uids = self._db.list_distinct_runs_uids(
             self._db_session, project=project_name, only_uids=True

--- a/server/py/services/api/tests/unit/test_collect_runs_logs.py
+++ b/server/py/services/api/tests/unit/test_collect_runs_logs.py
@@ -390,17 +390,30 @@ class TestCollectRunSLogs:
         mlrun.mlconf.log_collector.failed_runs_grace_period = 20
         mlrun.mlconf.log_collector.periodic_start_log_interval = 10
 
-        log_collector_call_mock = unittest.mock.AsyncMock(
-            side_effect=[
-                # failure response for the first call (failure_uid)
-                BaseLogCollectorResponse(False, "some error"),
-                # success response for the second call (success_uid)
-                BaseLogCollectorResponse(True, ""),
-                # failure response for the third call (failure_uid)
-                BaseLogCollectorResponse(False, "some error"),
-                BaseLogCollectorResponse(False, "some error"),
-            ]
-        )
+        # `list_distinct_runs_uids` doesn't guarantee row order, so the mocked
+        # responses are keyed by run uid rather than by call order.
+        responses_by_uid = {
+            failure_uid: iter(
+                [
+                    # fails on both attempts, exhausting the consecutive
+                    # start-log budget (max_consecutive_start_log_requests == 2)
+                    BaseLogCollectorResponse(False, "some error"),
+                    BaseLogCollectorResponse(False, "some error"),
+                ]
+            ),
+            success_uid: iter(
+                [
+                    # succeeds on the first attempt, resetting its counter
+                    BaseLogCollectorResponse(True, ""),
+                    BaseLogCollectorResponse(False, "some error"),
+                ]
+            ),
+        }
+
+        def _call_mock(endpoint, request):
+            return next(responses_by_uid[request.runUID])
+
+        log_collector_call_mock = unittest.mock.AsyncMock(side_effect=_call_mock)
         monkeypatch.setattr(log_collector, "_call", log_collector_call_mock)
         update_runs_requested_logs_mock = unittest.mock.Mock()
         monkeypatch.setattr(


### PR DESCRIPTION
### 📝 Description

Running the MLRun API against a PostgreSQL metadata DB surfaced two queries in the SQL DB layer (`server/py/framework/db/sqldb/db.py`) that only work on MySQL. Both are rewritten to dialect-portable SQL so the API runs cleanly on PostgreSQL (and continues to work on MySQL/SQLite).

---

### 🛠️ Changes Made

- **`list_artifact_tags` (category filter):** scope the `USE INDEX (idx_project_kind)` optimizer hint to `dialect_name="mysql"`. Emitting it for every dialect made PostgreSQL raise `CompileError: Unrecognized hint`; scoping it keeps the MySQL optimization while other dialects ignore it.
- **`list_distinct_runs_uids(only_uids=False)`:** replace the loose `GROUP BY Run.uid` over full rows (which relies on MySQL's nonstandard GROUP BY) with a portable representative-row select — `max(Run.id)` per uid via `scalar_subquery()` + an `IN` filter. PostgreSQL's strict GROUP BY rejected the old form with `GroupingError`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- Added `test_list_artifact_tags_with_category_hint_is_dialect_scoped`: asserts the `USE INDEX` hint is scoped to the mysql dialect and that the real category-tags query compiles under the PostgreSQL dialect (reproduces the original `CompileError`).
- Extended `test_list_distinct_runs_uids`: asserts one full record per uid and that it is the representative (highest-id / latest-iteration) row.
- Targeted DB unit tests pass. Verified live on a lab running MLRun on PostgreSQL: both query paths execute without error, and the previously-recurring `GroupingError` / `USE INDEX` `CompileError` no longer appear in the API logs.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/IG4-3091
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- `list_distinct_runs_uids(only_uids=False)` now returns a deterministic representative row per uid (the highest `id`) instead of an arbitrary one. The previous row choice was explicitly not guaranteed, so no caller contract changes.