### PR TITLE
[Nuclio] Fix missing s3Endpoint when using auto_mount_params

### DIFF
--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -263,8 +263,12 @@ def compile_nuclio_archive_config(
             )
         )
 
+    auto_mount_env = _get_auto_mount_env_as_dict()
+
     def get_secret(key):
-        return builder_env.get(key) or secrets.get(key, "")
+        return (
+            builder_env.get(key) or secrets.get(key, "") or auto_mount_env.get(key, "")
+        )
 
     source = function.spec.build.source
     parsed_url = urllib.parse.urlparse(source)
@@ -380,3 +384,32 @@ def parse_extra_args_to_nuclio_build_flags(extra_args: str) -> list[str]:
     if current_flag:
         build_flags_list.append(current_flag)
     return build_flags_list
+
+
+def _get_auto_mount_env_as_dict() -> dict:
+    """Return plain-value env vars produced by the configured storage auto-mount modifier.
+
+    Mirrors the logic in builder._resolve_storage_auto_mount_env but returns a plain dict
+    instead of a list of V1EnvVar so callers can do O(1) key lookups. Only plain-value
+    entries are included; valueFrom (secretKeyRef) entries are intentionally skipped
+    because those secret values are already reachable via get_project_secret_data().
+    """
+    auto_mount_type = mlrun.runtimes.pod.AutoMountType(
+        mlrun.mlconf.storage.auto_mount_type
+    )
+    modifier = auto_mount_type.get_modifier()
+    if modifier not in mlrun.runtimes.pod.AutoMountType.env_style_modifiers():
+        return {}
+    scratch = mlrun.runtimes.KubejobRuntime()
+    scratch.try_auto_mount_based_on_config()
+    result = {}
+    for env_var in scratch.spec.env or []:
+        name = env_var["name"] if isinstance(env_var, dict) else env_var.name
+        value = (
+            env_var.get("value")
+            if isinstance(env_var, dict)
+            else getattr(env_var, "value", None)
+        )
+        if value:
+            result[name] = value
+    return result

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1509,6 +1509,39 @@ class TestNuclioRuntime(TestRuntimeBase):
             == "https://minio.example.com"
         )
 
+    def test_load_function_with_source_archive_s3_endpoint_from_auto_mount_params(self):
+        """
+        When AWS_ENDPOINT_URL_S3 is absent from both builder_env and project secrets,
+        it must be picked up from mlconf.storage.auto_mount_params so that users who
+        rely on the admin-configured auto-mount do not need to set the endpoint
+        themselves via project secrets.
+        """
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive(
+            "s3://my-bucket/path/in/bucket/my-functions-archive.tar.gz",
+            handler="main:Handler",
+            workdir="path/inside/functions/archive",
+        )
+        builder_env = {
+            "AWS_ACCESS_KEY_ID": "some-id",
+            "AWS_SECRET_ACCESS_KEY": "some-secret",
+        }
+        orig_type = mlrun.mlconf.storage.auto_mount_type
+        orig_params = mlrun.mlconf.storage.auto_mount_params
+        try:
+            mlrun.mlconf.storage.auto_mount_type = "s3"
+            mlrun.mlconf.storage.auto_mount_params = (
+                "endpoint_url=https://minio.example.com"
+            )
+            archive = get_archive_spec(fn, builder_env)
+        finally:
+            mlrun.mlconf.storage.auto_mount_type = orig_type
+            mlrun.mlconf.storage.auto_mount_params = orig_params
+        assert (
+            archive["spec"]["build"]["codeEntryAttributes"]["s3Endpoint"]
+            == "https://minio.example.com"
+        )
+
     def test_load_function_with_source_archive_v3io(self):
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(


### PR DESCRIPTION
### 📝 Description

When deploying a serving function with `with_repo=True` from a project whose source points to an S3 archive, MLRun compiles a Nuclio function spec that includes `codeEntryAttributes`; a static, build-time block that Nuclio's own builder uses to fetch the source archive. The `s3Endpoint` field in that block was resolved from only two places: `builder_env` and project k8s secrets. When the S3 endpoint was configured solely via `mlconf.storage.auto_mount_params` (e.g. `auto_mount_type=s3, endpoint_url=https://minio.example.com`) with no project secrets set, `s3Endpoint` was left empty.

With an empty `s3Endpoint`, Nuclio's builder fell back to the default AWS endpoint (`s3.amazonaws.com`), causing a build-time failure with `InvalidAccessKeyId` — MinIO credentials are not valid for real AWS.

---

### 🛠️ Changes Made

- **`compile_nuclio_archive_config` (`helpers.py`)**: Extended the `get_secret()` lookup chain from two levels (`builder_env → project secrets`) to three (`builder_env → project secrets → auto_mount_env`).

- **`_get_auto_mount_env_as_dict()` (`helpers.py`)**: New private helper that returns the plain-value env vars emitted by the configured auto-mount modifier as a dict. Creates a scratch `KubejobRuntime`, calls `try_auto_mount_based_on_config()`, and retains only `value`-typed entries — `valueFrom.secretKeyRef` entries are skipped because those values are already reachable via `get_project_secret_data()`. Gated by `AutoMountType.env_style_modifiers()` so it is a no-op for non-env-style mount types. Mirrors the existing logic in `builder._resolve_storage_auto_mount_env` for Kaniko's init container.

- **`test_nuclio.py`**: Added `test_load_function_with_source_archive_s3_endpoint_from_auto_mount_params` to `TestNuclioRuntime`, asserting that `codeEntryAttributes.s3Endpoint` is populated from `auto_mount_params` when absent from both `builder_env` and project secrets. `TestNuclioMLRunRuntime` inherits the test.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- Unit test: `test_load_function_with_source_archive_s3_endpoint_from_auto_mount_params` added to `TestNuclioRuntime`; all existing S3 archive tests continue to pass.
- Smoke-tested end-to-end on a lab system: deployed a serving function with `with_repo=True` and S3 project source, no project secrets. Verified via Nuclio dashboard API that `codeEntryAttributes.s3Endpoint = 'https://minio-lab.iguazeng.com'` was populated from `auto_mount_params`.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-11339

---

### 🚨 Breaking Changes?

- [x] No

---

### 🔍️ Additional Notes
