### PR TITLE
[Pipelines] Fix _paginate_runs dropping filters on page 2+

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.7.2"
+version = "0.7.3"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
@@ -1019,8 +1019,10 @@ class Client(
             runs, next_page_token = self._list_runs(
                 page_token=current_page_token,
                 page_size=page_size,
+                sort_by=sort_by,
                 experiment_id=experiment_id,
                 namespace=namespace,
+                filter_json=filter_json,
             )
             fetched_run_count += len(runs)
             current_page_token = next_page_token

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_list_runs.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_list_runs.py
@@ -75,3 +75,34 @@ def test_list_runs_wildcard_project_does_not_short_circuit(client, monkeypatch):
 
     get_experiments_mock.assert_not_called()
     paginate_runs_mock.assert_called_once()
+
+
+def test_paginate_runs_forwards_filter_and_sort_on_every_page(client, monkeypatch):
+    """
+    _paginate_runs must resend filter_json and sort_by to KFP on every page, not
+    just the first. page_token is an opaque seek-position cursor computed against
+    the filtered/sorted query — it does not carry the filter or sort predicates
+    with it. Dropping them on later pages makes KFP fall back to an unfiltered
+    scan while still applying a token seeked into the filtered result set.
+    """
+    list_runs_mock = unittest.mock.MagicMock(
+        side_effect=[
+            (["run-1"], "page2_token"),
+            (["run-2"], None),
+        ]
+    )
+    monkeypatch.setattr(client, "_list_runs", list_runs_mock)
+
+    pages = list(
+        client._paginate_runs(
+            page_size=1,
+            sort_by="created_at desc",
+            filter_json='{"predicates": []}',
+        )
+    )
+
+    assert [runs for runs, _ in pages] == [["run-1"], ["run-2"]]
+    assert list_runs_mock.call_count == 2
+    for call in list_runs_mock.call_args_list:
+        assert call.kwargs["sort_by"] == "created_at desc"
+        assert call.kwargs["filter_json"] == '{"predicates": []}'


### PR DESCRIPTION
### 📝 Description
KFP's `ListRuns` endpoint is stateless: `page_token` only encodes a seek position in the already filtered/sorted result set, not the filter or sort themselves, so every page request must resend both. `_paginate_runs` in the KFP v1.8 pipeline adapter sent `filter_json`/`sort_by` on the first page only — every subsequent page ran an unfiltered, default-sorted scan while still applying a seek token computed against the filtered ordering. As a result, the date-range filter on the Workflows/Pipelines list only ever bounded the first page; later pages silently returned the full, unfiltered run history regardless of the selected date range. (Status filters have a separate, independent gap — see Additional Notes — and are unaffected by this specific fix.) This is one of the contributing causes of the Workflows/Pipelines list timeout reported in ML-12832.

---

### 🛠️ Changes Made
- `_paginate_runs` (`client.py`) now passes `sort_by` and `filter_json` to `_list_runs` on every page of the pagination loop, not just the first — matching the pattern already used in `_get_candidate_experiments_for_projects` for experiment listing.
- Added `test_paginate_runs_forwards_filter_and_sort_on_every_page`, asserting both kwargs are present on every `_list_runs` call across a multi-page sequence.
- Bumped `mlrun-pipelines-kfp-v1-8` package version to `0.7.3`, following the versioning convention of the two prior fixes to this file.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New unit test (`test_paginate_runs_forwards_filter_and_sort_on_every_page`) pins the fix.
- Full `mlrun-pipelines-kfp-v1-8` adapter unit test suite: 26/26 passed.
- `ruff check` / `ruff format --check` on changed files: clean.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12832
- External links: https://ecliptos.atlassian.net/browse/IG4-3090?focusedCommentId=189115 (comment describing the "last 24h + failed" symptom this PR explains)

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This fixes one of several contributing causes to ML-12832. Two others were identified during investigation but are out of scope here: KFP's `FilterFields` enum has no STATUS/STATE entry (so status filters can't be pushed to KFP at all, independent of the page-token issue this PR fixes), and `list_pipelines` has no default date bound. Tracked separately.