### PR TITLE
[Projects] Fix load_project() overwriting the project owner

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3390,10 +3390,19 @@ class SQLDB(DBInterface):
         self._upsert(session, tags)
 
     # ---- Projects ----
-    def create_project(self, session: Session, project: mlrun.common.schemas.Project):
+    def create_project(
+        self,
+        session: Session,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
+    ):
         logger.debug("Creating project in DB", project_name=project.metadata.name)
         created = datetime.now(UTC)
         project.metadata.created = created
+        # Ownership is set once, at creation: default to the caller when the
+        # body omits an owner.
+        if project.spec.owner is None:
+            project.spec.owner = auth_info.username
         # TODO: handle taking out the functions/workflows/artifacts out of the project and save them separately
         project_record = Project(
             name=project.metadata.name,
@@ -3426,7 +3435,11 @@ class SQLDB(DBInterface):
 
     @retry_on_conflict
     def store_project(
-        self, session: Session, name: str, project: mlrun.common.schemas.Project
+        self,
+        session: Session,
+        name: str,
+        project: mlrun.common.schemas.Project,
+        auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ):
         logger.debug(
             "Storing project in DB",
@@ -3443,8 +3456,14 @@ class SQLDB(DBInterface):
             session, name, raise_on_not_found=False
         )
         if not project_record:
-            self.create_project(session, project)
+            self.create_project(session, project, auth_info)
         else:
+            # Preserve the stored owner when the body omits one (fall back to
+            # the caller only if the project has no owner) so a member can't
+            # null it to seize ownership; an explicit change is authorized at
+            # the endpoint.
+            if project.spec.owner is None:
+                project.spec.owner = project_record.owner or auth_info.username
             self._update_project_record_from_project(session, project_record, project)
 
     @staticmethod

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3458,12 +3458,11 @@ class SQLDB(DBInterface):
         if not project_record:
             self.create_project(session, project, auth_info)
         else:
-            # Preserve the stored owner when the body omits one (fall back to
-            # the caller only if the project has no owner) so a member can't
-            # null it to seize ownership; an explicit change is authorized at
-            # the endpoint.
+            # Preserve the stored owner when the body omits one so a member
+            # can't null it to seize ownership; an explicit change is
+            # authorized at the endpoint.
             if project.spec.owner is None:
-                project.spec.owner = project_record.owner or auth_info.username
+                project.spec.owner = project_record.owner
             self._update_project_record_from_project(session, project_record, project)
 
     @staticmethod

--- a/server/py/framework/utils/projects/leader.py
+++ b/server/py/framework/utils/projects/leader.py
@@ -81,7 +81,7 @@ class Member(
         wait_for_completion: bool = True,
         commit_before_get: bool = False,
     ) -> tuple[mlrun.common.schemas.ProjectOut | None, bool]:
-        self._enrich_and_validate(project, auth_info)
+        self._enrich_and_validate(project)
         self._run_on_all_followers(
             True, "create_project", db_session, project, auth_info
         )
@@ -96,7 +96,7 @@ class Member(
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
         wait_for_completion: bool = True,
     ) -> tuple[mlrun.common.schemas.ProjectOut | None, bool]:
-        self._enrich_and_validate(project, auth_info)
+        self._enrich_and_validate(project)
         self._validate_body_and_path_names_matches(name, project)
         self._run_on_all_followers(
             True, "store_project", db_session, name, project, auth_info
@@ -462,21 +462,14 @@ class Member(
             raise ValueError(f"Unknown follower name: {name}")
         return followers_classes_map[name]()
 
-    def _enrich_and_validate(
-        self,
-        project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo | None = None,
-    ):
-        self._enrich_project(project, auth_info)
+    def _enrich_and_validate(self, project: mlrun.common.schemas.Project):
+        self._enrich_project(project)
         self._validate_project(project)
 
     @staticmethod
-    def _enrich_project(
-        project: mlrun.common.schemas.Project,
-        auth_info: mlrun.common.schemas.AuthInfo | None = None,
-    ):
-        if auth_info and project.spec.owner is None:
-            project.spec.owner = auth_info.username
+    def _enrich_project(project: mlrun.common.schemas.Project):
+        # Owner enrichment lives in the DB layer so it can't be bypassed on the
+        # store path.
         project.status.state = project.spec.desired_state
 
     @staticmethod

--- a/server/py/framework/utils/projects/leader.py
+++ b/server/py/framework/utils/projects/leader.py
@@ -468,8 +468,6 @@ class Member(
 
     @staticmethod
     def _enrich_project(project: mlrun.common.schemas.Project):
-        # Owner enrichment lives in the DB layer so it can't be bypassed on the
-        # store path.
         project.status.state = project.spec.desired_state
 
     @staticmethod

--- a/server/py/services/api/api/endpoints/projects.py
+++ b/server/py/services/api/api/endpoints/projects.py
@@ -101,7 +101,9 @@ async def store_project(
         framework.api.deps.get_db_session
     ),
 ):
-    await _ensure_project_create_or_update_permissions(db_session, name, auth_info)
+    await _ensure_project_create_or_update_permissions(
+        db_session, name, auth_info, requested_project=project
+    )
     project, is_running_in_background = await run_in_threadpool(
         get_project_member().store_project,
         db_session,
@@ -636,8 +638,14 @@ async def _ensure_project_create_or_update_permissions(
     db_session: sqlalchemy.orm.Session,
     project_name: str,
     auth_info: mlrun.common.schemas.AuthInfo,
+    requested_project: mlrun.common.schemas.Project | None = None,
 ):
-    """Ensure create or update permissions based on project existence."""
+    """Ensure create or update permissions based on project existence.
+
+    If the request reassigns an existing project's owner, also require the
+    management-level owner-update permission, so a plain project-update
+    permission can't change ownership.
+    """
     # Only check leader header in iguazio v3
     if (
         not mlrun.mlconf.is_iguazio_v4_mode()
@@ -678,6 +686,17 @@ async def _ensure_project_create_or_update_permissions(
                 mlrun.common.schemas.AuthorizationAction.update,
                 auth_info,
             )
+        # Changing the owner also needs the owner-update permission, even for
+        # the current owner.
+        if _store_reassigns_owner(requested_project, project):
+            await verifier.query_project_resource_permissions(
+                mlrun.common.schemas.AuthorizationResourceTypes.project_owner,
+                project_name,
+                "",
+                mlrun.common.schemas.AuthorizationAction.update,
+                auth_info,
+                resource_namespace=mlrun.common.schemas.AuthorizationResourceNamespace.mgmt,
+            )
         return
 
     # In Iguazio v4 mode, mlrun is the project leader and main entrypoint so we must ensure
@@ -688,3 +707,18 @@ async def _ensure_project_create_or_update_permissions(
             mlrun.common.schemas.AuthorizationAction.create,
             auth_info,
         )
+
+
+def _store_reassigns_owner(
+    requested_project: mlrun.common.schemas.Project | None,
+    stored_project: mlrun.common.schemas.Project,
+) -> bool:
+    """Whether a store request changes an existing project's owner.
+
+    ``spec.owner = None`` means "no change" (the stored owner is kept by the
+    DB layer) and echoing the current owner is a no-op; only a different
+    explicit owner is a reassignment.
+    """
+    if requested_project is None or requested_project.spec.owner is None:
+        return False
+    return requested_project.spec.owner != stored_project.spec.owner

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -84,7 +84,9 @@ class Projects(
             workflows_amount=len(project.spec.workflows or []),
         )
         try:
-            framework.utils.singletons.db.get_db().create_project(session, project)
+            framework.utils.singletons.db.get_db().create_project(
+                session, project, auth_info
+            )
         except Exception as exc:
             self._emit_project_lifecycle_event(
                 action=mlrun.common.schemas.ProjectLifecycleEventActions.creation_failed,
@@ -117,7 +119,9 @@ class Projects(
             artifact_amount=len(project.spec.artifacts or []),
             workflows_amount=len(project.spec.workflows or []),
         )
-        framework.utils.singletons.db.get_db().store_project(session, name, project)
+        framework.utils.singletons.db.get_db().store_project(
+            session, name, project, auth_info
+        )
 
     def patch_project(
         self,

--- a/server/py/services/api/tests/unit/api/test_projects.py
+++ b/server/py/services/api/tests/unit/api/test_projects.py
@@ -421,6 +421,74 @@ async def test_project_permissions_patch_owner_denied(monkeypatch: pytest.Monkey
         )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "requested_owner, expect_mgmt_check",
+    [
+        # Reassigning to a different user -> mgmt owner-update permission required.
+        ("new-owner", True),
+        # No owner in the body -> no owner change intended (stored owner preserved
+        # downstream), so no mgmt check.
+        (None, False),
+        # Body echoes the current owner -> no-op, so no mgmt check.
+        ("current-owner", False),
+    ],
+)
+async def test_store_project_permissions_owner_reassignment_routing(
+    db: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    requested_owner: str | None,
+    expect_mgmt_check: bool,
+) -> None:
+    """A PUT that reassigns the owner to a different user requires the mgmt owner-update permission."""
+    project_name = PERMISSIONS_PROJECT_NAME
+    stored_owner = "current-owner"
+    # Requester is not the owner, so the regular update-permission path is taken
+    # regardless of the owner routing.
+    auth_info = mlrun.common.schemas.AuthInfo(username="requester")
+    auth_verifier = framework.utils.auth.verifier.AuthVerifier()
+    query_project = AsyncMock()
+    query_resource = AsyncMock()
+    monkeypatch.setattr(auth_verifier, "query_project_permissions", query_project)
+    monkeypatch.setattr(
+        auth_verifier, "query_project_resource_permissions", query_resource
+    )
+    existing_project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(owner=stored_owner),
+    )
+    project_member = framework.utils.singletons.project_member.get_project_member()
+    monkeypatch.setattr(
+        project_member, "get_project", Mock(return_value=existing_project)
+    )
+    requested_project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+        spec=mlrun.common.schemas.ProjectSpec(owner=requested_owner),
+    )
+
+    await projects_endpoints._ensure_project_create_or_update_permissions(
+        db, project_name, auth_info, requested_project=requested_project
+    )
+
+    # Regular update permission is always required for a non-owner requester.
+    query_project.assert_awaited_once_with(
+        project_name,
+        mlrun.common.schemas.AuthorizationAction.update,
+        auth_info,
+    )
+    if expect_mgmt_check:
+        query_resource.assert_awaited_once_with(
+            mlrun.common.schemas.AuthorizationResourceTypes.project_owner,
+            project_name,
+            "",
+            mlrun.common.schemas.AuthorizationAction.update,
+            auth_info,
+            resource_namespace=mlrun.common.schemas.AuthorizationResourceNamespace.mgmt,
+        )
+    else:
+        query_resource.assert_not_awaited()
+
+
 @pytest.fixture()
 def mock_process_model_monitoring_secret() -> collections.abc.Iterator[None]:
     with unittest.mock.patch(

--- a/server/py/services/api/tests/unit/db/test_projects.py
+++ b/server/py/services/api/tests/unit/db/test_projects.py
@@ -255,6 +255,84 @@ class TestProjects(TestDatabaseBase):
         # Created in request body should be ignored and set by the DB layer
         assert project_output.metadata.created != project.metadata.created
 
+    @pytest.mark.parametrize(
+        "method_name",
+        ["create_project", "store_project"],
+    )
+    @pytest.mark.parametrize(
+        "body_owner, caller, expected_owner",
+        [
+            # Body omits the owner -> default to the caller on creation.
+            (None, "caller", "caller"),
+            # Explicit owner in the body is kept as-is.
+            ("explicit-owner", "caller", "explicit-owner"),
+        ],
+    )
+    def test_project_owner_defaults_to_caller_on_creation(
+        self,
+        method_name: str,
+        body_owner: str | None,
+        caller: str,
+        expected_owner: str,
+    ):
+        project_name = "project-name"
+        project = mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+            spec=mlrun.common.schemas.ProjectSpec(owner=body_owner),
+        )
+        auth_info = mlrun.common.schemas.AuthInfo(username=caller)
+
+        if method_name == "create_project":
+            self._db.create_project(self._db_session, project, auth_info)
+        else:
+            self._db.store_project(self._db_session, project_name, project, auth_info)
+
+        project_output = self._db.get_project(self._db_session, project_name)
+        assert project_output.spec.owner == expected_owner
+
+    @pytest.mark.parametrize(
+        "existing_owner, body_owner, expected_owner",
+        [
+            # Regression: the body nulls the owner on update (as
+            # load_project(clone=True) + save() does), so a different caller must
+            # NOT seize ownership - the stored owner is preserved.
+            ("original-owner", None, "original-owner"),
+            # No stored owner to preserve: the caller becomes the owner.
+            (None, None, "caller"),
+            # An explicit owner overrides; the endpoint authorizes the change.
+            ("original-owner", "new-owner", "new-owner"),
+        ],
+    )
+    def test_store_project_preserves_owner_on_update(
+        self,
+        existing_owner: str | None,
+        body_owner: str | None,
+        expected_owner: str,
+    ):
+        project_name = "project-name"
+        self._db.create_project(
+            self._db_session,
+            mlrun.common.schemas.Project(
+                metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+                spec=mlrun.common.schemas.ProjectSpec(owner=existing_owner),
+            ),
+        )
+
+        self._db.store_project(
+            self._db_session,
+            project_name,
+            mlrun.common.schemas.Project(
+                metadata=mlrun.common.schemas.ProjectMetadata(name=project_name),
+                spec=mlrun.common.schemas.ProjectSpec(
+                    description="updated", owner=body_owner
+                ),
+            ),
+            mlrun.common.schemas.AuthInfo(username="caller"),
+        )
+
+        project_output = self._db.get_project(self._db_session, project_name)
+        assert project_output.spec.owner == expected_owner
+
     def test_patch_project(self):
         project = self._generate_project()
         self._db.create_project(

--- a/server/py/services/api/tests/unit/db/test_projects.py
+++ b/server/py/services/api/tests/unit/db/test_projects.py
@@ -297,8 +297,8 @@ class TestProjects(TestDatabaseBase):
             # load_project(clone=True) + save() does), so a different caller must
             # NOT seize ownership - the stored owner is preserved.
             ("original-owner", None, "original-owner"),
-            # No stored owner to preserve: the caller becomes the owner.
-            (None, None, "caller"),
+            # No stored owner: stays None on store (caller ownership is set only on create).
+            (None, None, None),
             # An explicit owner overrides; the endpoint authorizes the change.
             ("original-owner", "new-owner", "new-owner"),
         ],

--- a/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
+++ b/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
@@ -65,58 +65,6 @@ def leader_follower(
     return projects_leader._leader_follower
 
 
-@pytest.mark.parametrize(
-    "method_name",
-    [
-        "create_project",
-        "store_project",
-    ],
-)
-@pytest.mark.parametrize(
-    "explicit_owner, auth_user, expected_owner",
-    [
-        (None, "auth-user", "auth-user"),
-        ("explicit-owner", "auth-user", "explicit-owner"),
-        ("explicit-owner", "explicit-owner", "explicit-owner"),
-    ],
-)
-def test_project_owner_from_auth_info_only_when_missing(
-    projects_leader: framework.utils.projects.leader.Member,
-    method_name: str,
-    explicit_owner: str | None,
-    auth_user: str,
-    expected_owner: str,
-):
-    project = mlrun.common.schemas.Project(
-        metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
-        spec=mlrun.common.schemas.ProjectSpec(
-            description="some description",
-            owner=explicit_owner,
-        ),
-    )
-    auth_info = mlrun.common.schemas.AuthInfo(username=auth_user)
-
-    if method_name == "create_project":
-        created_project, _ = projects_leader.create_project(
-            None,
-            project,
-            auth_info=auth_info,
-        )
-        project_out = created_project
-    elif method_name == "store_project":
-        stored_project, _ = projects_leader.store_project(
-            None,
-            project.metadata.name,
-            project,
-            auth_info=auth_info,
-        )
-        project_out = stored_project
-    else:
-        raise ValueError(f"Unexpected method name: {method_name}")
-
-    assert project_out.spec.owner == expected_owner
-
-
 def test_projects_sync_follower_project_adoption(
     db: sqlalchemy.orm.Session,
     projects_leader: framework.utils.projects.leader.Member,


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
Owner assignment should only happen at project creation — not on every store (PUT). The old `_enrich_project` in the projects leader assigned `auth_info.username` as owner whenever the body omitted one, which applied on      
  updates too. This meant a project member could call `load_project(clone=True)` + `save()` — which issues a PUT with `spec.owner=None` — and seize project ownership, gaining the project-owner OPA short-circuit.                
                                                                                                                                                                                                                                   
  The fix ensures owner lifecycle is handled exclusively in the DB layer: `create_project` defaults the owner to the caller; `store_project` preserves the stored owner when the body omits one; ownership enrichment is removed   
  from the projects leader. Owner reassignment through the store path additionally requires the `project_owner` update permission at management level, mirroring the existing PATCH guard.                                         
                                                                                                 

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
 - **`SQLDB.create_project`**: new `auth_info` param; defaults `spec.owner` to `auth_info.username` when omitted.                                                                                                                 
  - **`SQLDB.store_project`**: new `auth_info` param (forwarded to `create_project` on first-store); on update, preserves the stored owner when the body omits one — no caller fallback.                                           
  - **`leader._enrich_project`**: owner-assignment line and `auth_info` param removed; owner lifecycle now lives entirely in the DB layer.                                                                                         
  - **`crud.projects`**: `auth_info` added to both the `create_project` and `store_project` DB call signatures.                                                                                                                    
  - **`endpoints/projects._ensure_project_create_or_update_permissions`**: new `requested_project` param; calls new `_store_reassigns_owner` helper; when the body explicitly changes the owner, issues an additional              
  `project_owner` / `update` / mgmt permission check.                                                                                                                                                                              
  - **`endpoints/projects._store_reassigns_owner`**: new helper — returns `True` only when `requested_project.spec.owner` is non-`None` and differs from the stored owner.                                                         
                                                                                                           

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
  - Unit tests: `test_project_owner_defaults_to_caller_on_creation` and `test_store_project_preserves_owner_on_update` (DB layer); `test_store_project_permissions_owner_reassignment_routing` (API endpoint).                     
  - Removed `test_project_owner_from_auth_info_only_when_missing` from `test_leader_member.py` (behavior now lives in DB layer, covered by the new DB tests).                                                                      
  - Manual: DB-level test on vmdev130ig4 confirmed `store_project` with `owner=None` by a non-owner preserves the stored owner.     

---

### 🔗 References
- Ticket link:  [load_project() should not overwrite project owner](https://ecliptos.atlassian.net/browse/ML-12783)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
