### PR TITLE
[CI] Fix smoke tests posting "Fail / HEAD null" on transient API errors

### DIFF
--- a/.github/workflows/build-internal.yaml
+++ b/.github/workflows/build-internal.yaml
@@ -121,6 +121,14 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         BASE_SHA="${{ inputs.pr_base_sha }}"
 
+        # Guard against an unresolved base SHA (e.g. "null" from a transient API
+        # error upstream) so it surfaces as a clear infra error rather than a
+        # misleading "fetch failed" / "merge conflict".
+        if ! [[ "${BASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::Invalid base SHA '${BASE_SHA}' for PR #${{ inputs.pr_number }}; the base branch HEAD was not resolved (likely a transient API/rate-limit error). Re-run the smoke tests."
+          exit 1
+        fi
+
         git fetch origin "${BASE_SHA}"
         if ! git merge "${BASE_SHA}" --no-edit; then
           echo "::error::Merge of ${BASE_SHA} into PR #${{ inputs.pr_number }} failed due to conflicts. Please merge or rebase your branch locally and push."

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -124,28 +124,41 @@ jobs:
           # Fetch PR + base info from GitHub API. Compute once here so the merge
           # step in system-tests-opensource.yml and the PR comments all see the
           # same values (single source of truth).
-          PR_JSON=$(curl -sS \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUM}")
+          #
+          # gh_api retries transient failures (5xx / 429 / secondary rate limits)
+          # and fails the step on a non-2xx response instead of letting a `-sS`
+          # error body slip through as data. Without this, a transient API hiccup
+          # makes `jq -r '.sha'` yield the string "null", which then propagates
+          # downstream as `git fetch origin null` and surfaces as a misleading
+          # "Fail ❌ ... HEAD null" smoke result rather than an honest, re-runnable
+          # infra error.
+          gh_api() {
+            curl -fsS --retry 3 --retry-all-errors --retry-delay 2 \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "$@"
+          }
+
+          PR_JSON=$(gh_api "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUM}")
           PR_HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
           BASE_REF=$(echo "$PR_JSON" | jq -r '.base.ref')
-          BASE_SHA=$(curl -sS \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/${BASE_REF}" \
+          BASE_SHA=$(gh_api "https://api.github.com/repos/${{ github.repository }}/commits/${BASE_REF}" \
             | jq -r '.sha')
 
+          # Guard: refuse to propagate a non-SHA (e.g. "null" from an error body).
+          # A transient API/rate-limit error must fail loudly here so the run is
+          # obviously re-runnable, not masquerade as a test or merge failure.
+          for var in PR_HEAD_SHA BASE_SHA; do
+            if ! [[ "${!var}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::Failed to resolve ${var} from the GitHub API (got '${!var}'). This is likely a transient API or rate-limit error — re-run the smoke tests."
+              exit 1
+            fi
+          done
+
           # Count base-branch commits since the PR's merge-base (the real "sync point").
-          MERGE_BASE_SHA=$(curl -sS \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/compare/${BASE_REF}...${PR_HEAD_SHA}" \
+          MERGE_BASE_SHA=$(gh_api "https://api.github.com/repos/${{ github.repository }}/compare/${BASE_REF}...${PR_HEAD_SHA}" \
             | jq -r '.merge_base_commit.sha')
-          BASE_COMMITS_SINCE_SYNC=$(curl -sS \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/compare/${MERGE_BASE_SHA}...${BASE_SHA}" \
+          BASE_COMMITS_SINCE_SYNC=$(gh_api "https://api.github.com/repos/${{ github.repository }}/compare/${MERGE_BASE_SHA}...${BASE_SHA}" \
             | jq -r '.ahead_by // 0')
 
           echo "PR #${PR_NUM} @ ${PR_HEAD_SHA:0:8} | base: ${BASE_REF} @ ${BASE_SHA:0:8} (${BASE_COMMITS_SINCE_SYNC} commits since sync)"

--- a/.github/workflows/system-tests-opensource.yml
+++ b/.github/workflows/system-tests-opensource.yml
@@ -302,6 +302,14 @@ jobs:
         BASE_SHA="${{ needs.prepare-inputs.outputs.pr_base_sha }}"
         BASE_REF="${{ needs.prepare-inputs.outputs.pr_base_ref }}"
 
+        # Guard against an unresolved base SHA (e.g. "null" from a transient API
+        # error upstream) so it surfaces as a clear infra error rather than a
+        # misleading merge conflict.
+        if ! [[ "${BASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::Invalid base SHA '${BASE_SHA}' for PR #${{ inputs.pr_number }}; the base branch HEAD was not resolved (likely a transient API/rate-limit error). Re-run the smoke tests."
+          exit 1
+        fi
+
         git fetch origin "${BASE_REF}"
         if ! git merge "${BASE_SHA}" --no-edit; then
           echo "::error::Merge of ${BASE_REF} (${BASE_SHA}) into PR #${{ inputs.pr_number }} failed due to conflicts. Please merge or rebase your branch locally and push."


### PR DESCRIPTION
### 📝 Description

Smoke-test runs were posting **`Smoke Tests ... HEAD `null`: Fail ❌`** on some PRs (e.g. #9650). This was **not** a real test failure — it was a transient GitHub API / rate-limit hiccup being silently turned into a hard failure.

Root cause: the smoke `should-run` job resolves the base branch (`development`) HEAD with `curl -sS ... | jq -r '.sha'`. `curl -sS` does **not** fail on a non-2xx response, so a transient error / (secondary) rate-limit returns an error body whose `.sha` field is absent, and `jq -r` renders that as the literal string `"null"`. That `null` then propagates as `pr_base_sha` into the build and system-test merge steps (`git fetch origin null` → `couldn't find remote ref null`, exit 128), failing the build before any test runs. The result is posted as `HEAD `null`: Fail ❌`, indistinguishable from a genuine test failure.

Verified on run [28369911049](https://github.com/mlrun/mlrun/actions/runs/28369911049): `should-run` logged `base: development @ null (0 commits since sync)` while the PR head SHA resolved fine; the build job then died on `fatal: couldn't find remote ref null`.

---

### 🛠️ Changes Made

- **`smoke-tests.yml`** — route all GitHub API calls in the resolve step through a `gh_api` helper that uses `curl -fsS --retry 3 --retry-all-errors --retry-delay 2` (fails on HTTP errors; retries 5xx / 429 / secondary rate limits). Added a guard that validates the resolved PR-head and base SHAs are 40-hex **before** propagating them — otherwise the step fails loudly with an actionable, re-runnable `::error::` instead of emitting `null`.
- **`build-internal.yaml`** / **`system-tests-opensource.yml`** — guard the "Merge base branch into PR" steps against a non-SHA base value so an unresolved base surfaces as a clear infra error rather than a misleading `git fetch` failure / "merge conflict".

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- Validated the guard logic locally under `bash -eo pipefail`: a real 40-hex SHA passes; `null` (and empty/short values) are rejected with exit 1.
- YAML syntax of all three edited workflows validated (`yaml.safe_load`).
- CI-only change (GitHub Actions workflows); no product/runtime code paths affected. Full validation is the smoke-tests workflow itself running green on this PR.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: Observed on PR #9650 smoke comments; failing run https://github.com/mlrun/mlrun/actions/runs/28369911049

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

The `should-run` job now fails (red) on an unrecoverable API error instead of posting a misleading test-failure comment — that's intentional: a transient infra error should be an obvious, re-runnable red rather than masquerading as broken PR code. Follow-up worth considering (out of scope here): have `post-results` distinguish an infra/resolve failure from a real test outcome so the PR comment wording reflects "could not resolve base — re-run" rather than a generic "Fail".
