### PR TITLE
[DB] Fix Postgres/MySQL tz-aware vs tz-naive datetime crash

### DIFF
--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -502,8 +502,7 @@ def datetime_to_mysql_ts(datetime_object: datetime) -> datetime:
 
     :return: A MySQL-compatible timestamp string with millisecond precision.
     """
-    if not datetime_object.tzinfo:
-        datetime_object = datetime_object.replace(tzinfo=UTC)
+    datetime_object = ensure_tz_aware(datetime_object)
 
     # Round to the nearest millisecond
     ms = round(datetime_object.microsecond / 1000) * 1000
@@ -1594,10 +1593,8 @@ def datetime_from_iso(time_str: str) -> datetime | None:
     if not time_str:
         return
     dt = parser.isoparse(time_str)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=UTC)
     # ensure the datetime is in UTC, converting if necessary
-    return dt.astimezone(UTC)
+    return ensure_tz_aware(dt).astimezone(UTC)
 
 
 def datetime_to_iso(time_obj: datetime | None) -> str | None:
@@ -1640,9 +1637,7 @@ def format_datetime(dt: datetime, fmt: str | None = None) -> str:
     if dt is None:
         return ""
 
-    # If the datetime is naive
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=UTC)
+    dt = ensure_tz_aware(dt)
 
     # TODO: Once Python 3.12 is the minimal version, use %:z to format the timezone offset with a colon
     formatted_time = dt.strftime(fmt or "%Y-%m-%d %H:%M:%S.%f%z")

--- a/mlrun/utils/helpers.py
+++ b/mlrun/utils/helpers.py
@@ -474,6 +474,24 @@ def now_date(tz: timezone = UTC) -> datetime:
     return datetime.now(tz=tz)
 
 
+def ensure_tz_aware(dt: datetime | None, tz: timezone = UTC) -> datetime | None:
+    """
+    Normalize a datetime to be tz-aware, assuming ``tz`` for naive values.
+
+    DB dialects differ on this: PostgreSQL/MySQL TIMESTAMP columns round-trip as tz-aware
+    datetimes, SQLite's don't, so values read from the DB must be normalized before comparing
+    them against `now_date()` to avoid `TypeError: can't compare offset-naive and offset-aware
+    datetimes` on some dialects but not others.
+
+    :param dt: The datetime to normalize, may be tz-naive, tz-aware, or None.
+    :param tz: The timezone to assume for a tz-naive datetime.
+    :return: A tz-aware datetime, or None if dt is None.
+    """
+    if dt is not None and dt.tzinfo is None:
+        return dt.replace(tzinfo=tz)
+    return dt
+
+
 def datetime_to_mysql_ts(datetime_object: datetime) -> datetime:
     """
     Convert a Python datetime object to a MySQL-compatible timestamp string,

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3663,9 +3663,8 @@ class SQLDB(DBInterface):
         project_summaries = query.all()
         project_summaries_results = []
         for project_summary in project_summaries:
-            # project_summary.updated is timezone naive, make it utc
-            project_summary.summary["updated"] = project_summary.updated.replace(
-                tzinfo=UTC
+            project_summary.summary["updated"] = mlrun.utils.ensure_tz_aware(
+                project_summary.updated
             )
             project_summaries_results.append(
                 mlrun.common.schemas.ProjectSummary(**project_summary.summary)
@@ -7503,20 +7502,18 @@ class SQLDB(DBInterface):
             name=alert_activation_record.name,
             project=alert_activation_record.project,
             severity=alert_activation_record.severity,
-            # the activation_time is already stored in UTC in the database as a naive datetime.
-            # we explicitly set the timezone to UTC here to make it timezone-aware, avoiding any ambiguity.
-            activation_time=alert_activation_record.activation_time.replace(tzinfo=UTC),
+            # activation_time/reset_time are stored in UTC, but round-trip as tz-naive on SQLite and
+            # tz-aware on PostgreSQL/MySQL - normalize rather than blindly relabeling as UTC.
+            activation_time=mlrun.utils.ensure_tz_aware(
+                alert_activation_record.activation_time
+            ),
             entity_id=alert_activation_record.entity_id,
             entity_kind=alert_activation_record.entity_kind,
             event_kind=alert_activation_record.event_kind,
             number_of_events=alert_activation_record.number_of_events,
             notifications=alert_activation_record.data.get("notifications", []),
             criteria=alert_activation_record.data.get("criteria"),
-            # the reset_time is already stored in UTC (if not None) in the database as a naive datetime.
-            # we explicitly set the timezone to UTC here to make it timezone-aware, avoiding any ambiguity.
-            reset_time=alert_activation_record.reset_time.replace(tzinfo=UTC)
-            if alert_activation_record.reset_time
-            else None,
+            reset_time=mlrun.utils.ensure_tz_aware(alert_activation_record.reset_time),
         )
 
     # ---- Background Tasks ----

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6319,10 +6319,7 @@ class SQLDB(DBInterface):
         sqlalchemy losing timezone information with sqlite so we're returning it
         https://stackoverflow.com/questions/6991457/sqlalchemy-losing-timezone-information-with-sqlite
         """
-        if time_value:
-            if time_value.tzinfo is None:
-                return pytz.utc.localize(time_value)
-        return time_value
+        return mlrun.utils.ensure_tz_aware(time_value)
 
     @staticmethod
     def _transform_feature_set_model_to_schema(

--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -502,7 +502,9 @@ with warnings.catch_warnings():
         body = Column(framework.db.sqldb.sql_types.Blob)
         start_time = Column(framework.db.sqldb.sql_types.DateTime)
         end_time = Column(framework.db.sqldb.sql_types.MicroSecondDateTime)
-        updated = Column(framework.db.sqldb.sql_types.DateTime, default=datetime.utcnow)
+        updated = Column(
+            framework.db.sqldb.sql_types.DateTime, default=lambda: datetime.now(UTC)
+        )
         # requested logs column indicates whether logs were requested for this run
         # None - old runs prior to the column addition, logs were already collected for them, so no need to collect them
         # False - logs were not requested for this run
@@ -623,7 +625,9 @@ with warnings.catch_warnings():
         # leaving the column as is to prevent redundant migration
         # TODO: change to JSON, see mlrun/common/schemas/function.py::FunctionState for reasoning
         _full_object = Column("spec", framework.db.sqldb.sql_types.Blob)
-        created = Column(framework.db.sqldb.sql_types.DateTime, default=datetime.utcnow)
+        created = Column(
+            framework.db.sqldb.sql_types.DateTime, default=lambda: datetime.now(UTC)
+        )
         default_function_node_selector = Column("default_function_node_selector", JSON)
         state = Column(framework.db.sqldb.sql_types.Utf8BinText)
         op_id = Column(framework.db.sqldb.sql_types.UuidType, nullable=True)

--- a/server/py/framework/tests/unit/utils/test_background_tasks.py
+++ b/server/py/framework/tests/unit/utils/test_background_tasks.py
@@ -20,19 +20,14 @@ import mlrun.utils
 
 import framework.utils.background_tasks.common
 
+_ONE_HOUR_AGO = mlrun.utils.now_date() - datetime.timedelta(hours=1)
+# start_time as SQLite (tz-naive) vs PostgreSQL/MySQL (tz-aware) would return it for the same
+# logical timestamp - the comparison against `now_date()` must behave the same either way
+_START_TIME_DIALECT_VARIANTS = [_ONE_HOUR_AGO.replace(tzinfo=None), _ONE_HOUR_AGO]
 
-@pytest.mark.parametrize(
-    "start_time",
-    [
-        # SQLite returns tz-naive datetimes for DateTime columns
-        mlrun.utils.now_date().replace(tzinfo=None) - datetime.timedelta(hours=1),
-        # PostgreSQL/MySQL return tz-aware datetimes for the same logical timestamp
-        mlrun.utils.now_date() - datetime.timedelta(hours=1),
-    ],
-)
+
+@pytest.mark.parametrize("start_time", _START_TIME_DIALECT_VARIANTS)
 def test_background_task_exceeded_timeout_across_dialects(start_time):
-    # regardless of whether start_time is tz-naive (SQLite) or tz-aware (PostgreSQL/MySQL), the
-    # comparison against `now_date()` must not raise and must reach the correct verdict
     assert framework.utils.background_tasks.common.background_task_exceeded_timeout(
         start_time,
         timeout=60,
@@ -45,13 +40,7 @@ def test_background_task_exceeded_timeout_across_dialects(start_time):
     )
 
 
-@pytest.mark.parametrize(
-    "start_time",
-    [
-        mlrun.utils.now_date().replace(tzinfo=None) - datetime.timedelta(hours=1),
-        mlrun.utils.now_date() - datetime.timedelta(hours=1),
-    ],
-)
+@pytest.mark.parametrize("start_time", _START_TIME_DIALECT_VARIANTS)
 def test_background_task_exceeded_timeout_terminal_state_short_circuits(start_time):
     assert not framework.utils.background_tasks.common.background_task_exceeded_timeout(
         start_time,

--- a/server/py/framework/tests/unit/utils/test_background_tasks.py
+++ b/server/py/framework/tests/unit/utils/test_background_tasks.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import datetime
+
+import pytest
+
+import mlrun.common.schemas
+import mlrun.utils
+
+import framework.utils.background_tasks.common
+
+
+@pytest.mark.parametrize(
+    "start_time",
+    [
+        # SQLite returns tz-naive datetimes for DateTime columns
+        mlrun.utils.now_date().replace(tzinfo=None) - datetime.timedelta(hours=1),
+        # PostgreSQL/MySQL return tz-aware datetimes for the same logical timestamp
+        mlrun.utils.now_date() - datetime.timedelta(hours=1),
+    ],
+)
+def test_background_task_exceeded_timeout_across_dialects(start_time):
+    # regardless of whether start_time is tz-naive (SQLite) or tz-aware (PostgreSQL/MySQL), the
+    # comparison against `now_date()` must not raise and must reach the correct verdict
+    assert framework.utils.background_tasks.common.background_task_exceeded_timeout(
+        start_time,
+        timeout=60,
+        task_state=mlrun.common.schemas.BackgroundTaskState.running,
+    )
+    assert not framework.utils.background_tasks.common.background_task_exceeded_timeout(
+        start_time,
+        timeout=3600 * 24,
+        task_state=mlrun.common.schemas.BackgroundTaskState.running,
+    )
+
+
+@pytest.mark.parametrize(
+    "start_time",
+    [
+        mlrun.utils.now_date().replace(tzinfo=None) - datetime.timedelta(hours=1),
+        mlrun.utils.now_date() - datetime.timedelta(hours=1),
+    ],
+)
+def test_background_task_exceeded_timeout_terminal_state_short_circuits(start_time):
+    assert not framework.utils.background_tasks.common.background_task_exceeded_timeout(
+        start_time,
+        timeout=60,
+        task_state=mlrun.common.schemas.BackgroundTaskState.succeeded,
+    )

--- a/server/py/framework/utils/background_tasks/common.py
+++ b/server/py/framework/utils/background_tasks/common.py
@@ -15,6 +15,7 @@
 import datetime
 
 import mlrun.common.schemas
+import mlrun.utils
 
 
 def background_task_exceeded_timeout(start_time, timeout, task_state) -> bool:
@@ -25,8 +26,9 @@ def background_task_exceeded_timeout(start_time, timeout, task_state) -> bool:
     if (
         timeout
         and task_state not in mlrun.common.schemas.BackgroundTaskState.terminal_states()
-        and datetime.datetime.utcnow()
-        > datetime.timedelta(seconds=int(timeout)) + start_time
+        and mlrun.utils.now_date()
+        > datetime.timedelta(seconds=int(timeout))
+        + mlrun.utils.ensure_tz_aware(start_time)
     ):
         return True
     return False

--- a/server/py/framework/utils/time_window_tracker.py
+++ b/server/py/framework/utils/time_window_tracker.py
@@ -19,6 +19,7 @@ import typing
 import sqlalchemy.orm
 
 import mlrun.common.types
+import mlrun.utils
 
 import framework.db.session
 import framework.utils.asyncio
@@ -78,10 +79,10 @@ class TimeWindowTracker:
         if not time_window_tracker_record:
             return
 
-        # Ensure the timestamp is timezone-aware, it might return as naive from the DB
-        # though it was saved as timezone-aware
-        self._timestamp = time_window_tracker_record.timestamp.replace(
-            tzinfo=datetime.UTC
+        # Ensure the timestamp is timezone-aware: it round-trips as tz-naive on SQLite and
+        # tz-aware on PostgreSQL/MySQL, even though it was saved as timezone-aware.
+        self._timestamp = mlrun.utils.ensure_tz_aware(
+            time_window_tracker_record.timestamp
         )
         self._max_window_size_seconds = (
             time_window_tracker_record.max_window_size_seconds

--- a/server/py/services/api/api/endpoints/runs.py
+++ b/server/py/services/api/api/endpoints/runs.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 import mlrun.common.formatters
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
+import mlrun.utils
 from mlrun.utils import logger
 
 import framework.utils.auth.verifier
@@ -437,7 +438,8 @@ async def abort_run(
                         )
                     )
                     if (
-                        datetime.datetime.utcnow() - background_task.metadata.updated
+                        mlrun.utils.now_date()
+                        - mlrun.utils.ensure_tz_aware(background_task.metadata.updated)
                         < grace_timedelta
                     ):
                         logger.debug(

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -38,6 +38,7 @@ from mlrun.utils.helpers import (
     StorePrefix,
     enrich_image_url,
     ensure_batch_job_suffix,
+    ensure_tz_aware,
     extend_hub_uri_if_needed,
     get_data_from_path,
     get_parsed_docker_registry,
@@ -97,6 +98,43 @@ def test_retry_until_successful_fatal_failure():
 )
 def test_enrich_datetime_with_tz_info(d, expected: datetime):
     assert expected == mlrun.utils.helpers.enrich_datetime_with_tz_info(d)
+
+
+@pytest.mark.parametrize(
+    "dt,expected",
+    [
+        (None, None),
+        (
+            datetime(2024, 11, 11, 7, 44, 56),
+            datetime(2024, 11, 11, 7, 44, 56, tzinfo=UTC),
+        ),
+        (
+            # already tz-aware (e.g. read back from a PostgreSQL/MySQL TIMESTAMP column) - untouched
+            datetime(2024, 11, 11, 7, 44, 56, tzinfo=UTC),
+            datetime(2024, 11, 11, 7, 44, 56, tzinfo=UTC),
+        ),
+        (
+            # already tz-aware in a non-UTC offset (e.g. read back from a PostgreSQL/MySQL TIMESTAMP
+            # column) - untouched, no UTC normalization
+            datetime(2024, 11, 11, 9, 44, 56, tzinfo=timezone(timedelta(hours=2))),
+            datetime(2024, 11, 11, 9, 44, 56, tzinfo=timezone(timedelta(hours=2))),
+        ),
+    ],
+)
+def test_ensure_tz_aware(dt, expected):
+    assert ensure_tz_aware(dt) == expected
+
+
+def test_ensure_tz_aware_dialect_portable_comparison():
+    # a naive datetime as returned by SQLite for a DateTime column, and a tz-aware one as
+    # returned by PostgreSQL/MySQL for the same logical timestamp - both must compare cleanly
+    # against `now_date()` once normalized, regardless of which dialect produced them
+    naive_from_sqlite = datetime(2024, 11, 11, 7, 44, 56)
+    aware_from_postgres = datetime(2024, 11, 11, 7, 44, 56, tzinfo=UTC)
+
+    now = mlrun.utils.helpers.now_date()
+    assert now > ensure_tz_aware(naive_from_sqlite)
+    assert now > ensure_tz_aware(aware_from_postgres)
 
 
 def test_retry_until_successful_sync():


### PR DESCRIPTION
### 📝 Description
MLRun compares datetimes read back from the metadata DB against `datetime.utcnow()` (tz-naive) in a couple of places. `server/py/framework/db/sqldb/sql_types.py`'s custom `DateTime` type forces `timezone=True` for PostgreSQL **and** MySQL, so those dialects return tz-aware datetimes for columns SQLite returns as naive. The naive-vs-aware comparison then raises `TypeError: can't compare offset-naive and offset-aware datetimes` on Postgres/MySQL, but never surfaces on SQLite — the default for local dev — which is why it went unnoticed.

---

### 🛠️ Changes Made
- Added `mlrun.utils.ensure_tz_aware()`: normalizes a datetime to tz-aware, assuming UTC only when it is naive, and leaving already-aware values untouched. Swapping only the "now" side of a comparison to tz-aware would fix Postgres/MySQL but break SQLite the other way around (aware `now` vs naive DB value) — this keeps all three dialects on one code path.
- Fixed the two comparisons that raise the crash: `background_task_exceeded_timeout` (`server/py/framework/utils/background_tasks/common.py`) and the abort-run grace-period check (`server/py/services/api/api/endpoints/runs.py`).
- Consolidated `SQLDB._add_utc_timezone` (`server/py/framework/db/sqldb/db.py`), a pre-existing helper doing the same normalization, to delegate to `ensure_tz_aware` instead of duplicating the logic.
- Found and fixed three more call sites relying on the same now-disproven "these columns are always naive" assumption — an unconditional `.replace(tzinfo=UTC)` that would silently mislabel (rather than convert) an already-aware, non-UTC-offset value instead of raising: the alert-activation and project-summary transforms in `db.py`, and `TimeWindowTracker._refresh_from_db`.
- Fixed two `Column(default=datetime.utcnow)` defaults (`Run.updated`, `Project.created` in `models.py`) to match the tz-aware `lambda: datetime.now(UTC)` pattern already used by sibling columns.
- Deduplicated three inline copies of the same naive-check in `mlrun/utils/helpers.py` (`datetime_to_mysql_ts`, `datetime_from_iso`, `format_datetime`) onto `ensure_tz_aware`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New unit tests: `ensure_tz_aware` against naive/aware/None inputs (`tests/utils/test_helpers.py`), and `background_task_exceeded_timeout` against both tz-naive and tz-aware `start_time` values simulating SQLite vs. PostgreSQL/MySQL (`server/py/framework/tests/unit/utils/test_background_tasks.py`).
- Manually verified against a live PostgreSQL-backed MLRun deployment: reproduced the exact `TypeError` with the pre-fix code against a real Postgres-read timestamp, then confirmed the fixed code resolves it correctly with no regressions in the existing SQLite-backed unit test suite.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/IG4-3106
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
The fix normalizes at each comparison call site rather than centralizing tz-awareness in `DateTime.load_dialect_impl`'s dialect handling (e.g. via a `process_result_value` override), which was considered but would be a larger-blast-radius change affecting every `DateTime`/`MicroSecondDateTime` column in the DB layer — left as a possible follow-up rather than folded into this fix.