### PR TITLE
[ML-12858] Fix get_previous_version to include RC tags for prerelease promotions

### DIFF
--- a/automation/version/version_file.py
+++ b/automation/version/version_file.py
@@ -216,7 +216,7 @@ def get_current_version(
 
 
 def get_previous_version(target_version: str) -> str:
-    """Greatest stable tag below target_version as a raw tag (e.g. "1.10.3"), or "" if none."""
+    """Greatest tag below target_version as a raw tag (e.g. "1.10.3"), or "" if none."""
     target = packaging.version.Version(target_version)
     candidates = []
     for tag in _run_command("git", args=["tag", "--list"]).split():
@@ -227,7 +227,7 @@ def get_previous_version(target_version: str) -> str:
             parsed = packaging.version.Version(raw)
         except packaging.version.InvalidVersion:
             continue
-        if parsed < target and not parsed.is_prerelease:
+        if parsed < target and (target.is_prerelease or not parsed.is_prerelease):
             candidates.append((parsed, raw))
     return max(candidates, default=(None, ""))[1]
 
@@ -246,12 +246,11 @@ def resolve_promotion_inputs(
     except packaging.version.InvalidVersion as exc:
         raise ValueError(f"'{version}' is not a valid version") from exc
 
-    # derive the previous stable version for release notes when not provided
     if not previous_version:
         previous_version = get_previous_version(version)
         if not previous_version:
             raise ValueError(
-                f"could not derive a previous version (no stable tag below {version}); "
+                f"could not derive a previous version (no tag below {version}); "
                 "pass --previous-version explicitly"
             )
 

--- a/tests/automation/version/test_version_file.py
+++ b/tests/automation/version/test_version_file.py
@@ -223,6 +223,8 @@ def test_is_stable_version(version: str, expected_is_stable: bool):
         ("1.5.0", ["1.4.0-rc1"], ""),
         # realistic patch line with an in-flight rc above the previous GA
         ("1.10.4", ["1.10.3", "1.10.4-rc1", "1.9.0"], "1.10.3"),
+        ("1.12.0-rc17", ["1.11.0", "1.12.0-rc16", "1.12.0-rc17"], "1.12.0-rc16"),
+        ("1.12.0-rc1", ["1.11.0", "1.12.0-rc1"], "1.11.0"),
     ],
 )
 def test_previous_version(git_repo, target_version, tags, expected_previous_version):
@@ -254,6 +256,18 @@ def test_resolve_promotion_inputs_derives_previous(git_repo):
     resolved = resolve_promotion_inputs(version="1.5.0")
     assert resolved["previous_version"] == "1.4.0"
     assert resolved["make_latest"] == "true"
+
+
+def test_resolve_promotion_inputs_derives_previous_rc(git_repo):
+    for tag in ["1.11.0", "1.12.0-rc16", "1.12.0-rc17"]:
+        subprocess.run(["git", "tag", "-a", "-m", f"test tag {tag}", f"v{tag}", "HEAD"])
+    resolved = resolve_promotion_inputs(version="1.12.0-rc17")
+    assert resolved == {
+        "version": "1.12.0-rc17",
+        "previous_version": "1.12.0-rc16",
+        "prerelease": "true",
+        "make_latest": "false",
+    }
 
 
 def test_resolve_promotion_inputs_invalid_version():


### PR DESCRIPTION
### 📝 Description

Fixes bloated release notes on RC promotions (e.g. `v1.12.0-rc17` listing changes back to `v1.11.0`).

When `release-promotion` derives `previous_version` via `promotion-inputs`, `get_previous_version()` only considered stable tags. For RC promotions that resolved to the last GA release instead of the previous RC, so release notes spanned the entire RC line.

### 🛠️ Changes Made

- Update `get_previous_version()` to include RC tags when the target version is a prerelease
- Keep stable-only behavior for GA promotions (e.g. `1.12.0` → `1.11.0`)
- Add unit tests for RC and first-RC cases

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

### 🧪 Testing

```bash
PYTHONPATH="$(pwd):$(pwd)/server/py" pytest tests/automation/version/test_version_file.py -k "previous or promotion" --confcutdir=tests/automation/version
```

Verified: `promotion-inputs --version 1.12.0-rc17` now returns `previous_version=1.12.0-rc16`.

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12858
- Design docs links:
- External links: https://github.com/mlrun/mlrun/releases/tag/v1.12.0-rc17

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

### 🔍️ Additional Notes

Regression introduced in #9868. To fix `v1.12.0-rc17` release notes after merge, re-run promotion with `previous_version: 1.12.0-rc16` or edit the release body manually.
