### PR TITLE
[Spark] Disable executor service-account token automount

### DIFF
--- a/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
@@ -680,6 +680,16 @@ with ctx:
             "spec.executor.serviceAccount",
             runtime.spec.service_account or "sparkapp",
         )
+        # Spark's pod-template loader NPEs without a named executor container.
+        # Keep the template minimal and only disable token automount.
+        update_in(
+            job,
+            "spec.executor.template.spec",
+            {
+                "automountServiceAccountToken": False,
+                "containers": [{"name": "spark-kubernetes-executor"}],
+            },
+        )
 
         if runtime.spec.monitoring:
             if (

--- a/server/py/services/api/tests/unit/runtimes/test_spark.py
+++ b/server/py/services/api/tests/unit/runtimes/test_spark.py
@@ -1343,3 +1343,25 @@ class TestSpark3Runtime(services.api.tests.unit.runtimes.base.TestRuntimeBase):
             f"Expected secret name: {mock_secret.metadata.name}. "
             f"Actual volumes: {volumes}"
         )
+
+    def test_executor_service_account_token_not_mounted(
+        self, db: sqlalchemy.orm.Session, k8s_secrets_mock
+    ):
+        """Executor pods must not mount the service-account token."""
+        runtime: mlrun.runtimes.Spark3Runtime = self._generate_runtime()
+        self.execute_function(runtime)
+
+        body = self._get_custom_object_creation_body()
+
+        executor_template_spec = body["spec"]["executor"]["template"]["spec"]
+        assert executor_template_spec["automountServiceAccountToken"] is False, (
+            "Executor SA token must not be mounted"
+        )
+        # The named container prevents Spark's pod-template loader from failing.
+        assert executor_template_spec["containers"] == [
+            {"name": "spark-kubernetes-executor"}
+        ], "Executor template must name the spark executor container"
+        # Driver keeps its token, so no token-disabling pod template is added.
+        assert "template" not in body["spec"]["driver"], (
+            "Driver must keep its SA token (no token-disabling pod template)"
+        )


### PR DESCRIPTION
### 📝 Description

Spark executor pods do not need Kubernetes API access. This disables their service-account token automount while leaving the driver unchanged.

---

### 🛠️ Changes Made

- Added a minimal executor pod template with `automountServiceAccountToken: false`.
- Named the executor container in the template, as required by Spark.
- Added coverage for the generated SparkApplication spec.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation
- [ ] Please run Smoke-tests workflow with the PR number as input

---

### 🧪 Testing

- Added `test_executor_service_account_token_not_mounted`.
- Verified on-cluster that executor pods start without a service-account token while the driver keeps its token and the Spark job runs.

---

### 🔗 References
- Ticket link: IG4-2990

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- Executor-only change; driver token behavior is unchanged.