### PR TITLE
[Patch] Support Postgres/StatefulSet mlrun-db in --reset-db

### DIFF
--- a/automation/patch_igz/patch_remote.py
+++ b/automation/patch_igz/patch_remote.py
@@ -294,9 +294,6 @@ class MLRunPatcher:
                 "REGISTRY_USERNAME defined, yet REGISTRY_PASSWORD is not defined"
             )
 
-        if self._reset_db and "DB_USER" not in self._config:
-            raise RuntimeError("Must define DB_USER if requesting DB reset")
-
         if self._kubeconfig and not os.path.isfile(self._kubeconfig):
             raise RuntimeError(f"KUBECONFIG file not found: {self._kubeconfig}")
 
@@ -466,7 +463,7 @@ class MLRunPatcher:
                     "status",
                     "deployment",
                     deployment,
-                    "--timeout=120s",
+                    "--timeout=300s",
                 ],
                 live=True,
             )
@@ -672,27 +669,7 @@ class MLRunPatcher:
         )
 
         logger.info("Reset DB")
-        self._exec_remote(
-            [
-                "kubectl",
-                "-n",
-                self._namespace,
-                "exec",
-                "-it",
-                "deployment/mlrun-db",
-                "--container",
-                "mlrun-db",
-                "--",
-                "mysql",
-                "--user",
-                self._config["DB_USER"],
-                "--socket",
-                "/var/run/mysqld/mysql.sock",
-                "--execute",
-                "DROP DATABASE mlrun; CREATE DATABASE mlrun",
-            ],
-            live=True,
-        )
+        self._reset_mlrun_db_data()
 
         for deployment, replicas in current_non_mlrun_db_services.items():
             logger.info(f"Scaling up {deployment} with {replicas}")
@@ -707,6 +684,108 @@ class MLRunPatcher:
                     f"--replicas={replicas}",
                 ],
             )
+
+    def _reset_mlrun_db_data(self):
+        workload_ref = self._get_mlrun_db_workload_ref()
+        container, engine = self._get_mlrun_db_container(workload_ref)
+        if engine == "mysql":
+            db_user = self._config.get("DB_USER")
+            if not db_user:
+                raise RuntimeError(
+                    "Must define DB_USER in the patch-env config to reset a MySQL-backed mlrun-db"
+                )
+            reset_cmd = [
+                "mysql",
+                "--user",
+                db_user,
+                "--socket",
+                "/var/run/mysqld/mysql.sock",
+                "--execute",
+                "DROP DATABASE mlrun; CREATE DATABASE mlrun",
+            ]
+        else:
+            # FORCE drops the DB even if a stale connection lingers from a pod that
+            # was just scaled down; OWNER must be re-set since CREATE DATABASE
+            # otherwise assigns ownership to whichever role runs the statement.
+            # DROP/CREATE DATABASE cannot run inside a transaction block, so they
+            # must be sent to psql as separate -c statements, not joined with ";"
+            # in one -c (which Postgres executes as a single implicit transaction).
+            reset_cmd = [
+                "sh",
+                "-c",
+                'PGPASSWORD="$POSTGRES_PASSWORD" psql --username "$POSTGRES_USER"'
+                " --dbname postgres -v ON_ERROR_STOP=1"
+                ' -c "DROP DATABASE IF EXISTS mlrun WITH (FORCE);"'
+                ' -c "CREATE DATABASE mlrun OWNER $POSTGRES_USER;"',
+            ]
+        self._exec_remote(
+            [
+                "kubectl",
+                "-n",
+                self._namespace,
+                "exec",
+                "-it",
+                workload_ref,
+                "--container",
+                container,
+                "--",
+                *reset_cmd,
+            ],
+            live=True,
+        )
+
+    def _get_mlrun_db_workload_ref(self) -> str:
+        # mlrun-db is deployed as a Deployment on some systems and a StatefulSet on
+        # others (e.g. when backed by a Postgres sub-chart with per-pod storage) —
+        # resolve the live workload kind by name instead of assuming one, since the
+        # label scheme differs between the built-in MySQL chart and Postgres backends.
+        for kind in ("statefulset", "deployment"):
+            try:
+                output = self._exec_remote(
+                    [
+                        "kubectl",
+                        "-n",
+                        self._namespace,
+                        "get",
+                        kind,
+                        "mlrun-db",
+                        "-o",
+                        "name",
+                    ]
+                ).strip()
+            except RuntimeError:
+                continue
+            if output:
+                return output
+        raise RuntimeError(
+            f"Could not find mlrun-db deployment or statefulset in namespace {self._namespace}"
+        )
+
+    def _get_mlrun_db_container(self, workload_ref: str) -> tuple[str, str]:
+        # mlrun-db runs either the built-in MySQL container or a Postgres backend
+        # (e.g. a bitnami-style sub-chart) — detect the engine from the container
+        # image instead of assuming a container name or SQL dialect.
+        output = self._exec_remote(
+            [
+                "kubectl",
+                "-n",
+                self._namespace,
+                "get",
+                workload_ref,
+                "-o",
+                'jsonpath={range .spec.template.spec.containers[*]}{.name}{"\\t"}{.image}{"\\n"}{end}',
+            ]
+        ).strip()
+        for line in output.splitlines():
+            name, _, image = line.partition("\t")
+            image = image.lower()
+            if "mysql" in image:
+                return name, "mysql"
+            if "postgres" in image:
+                return name, "postgres"
+        raise RuntimeError(
+            f"Could not determine mlrun-db engine from containers: {output}"
+        )
 
     @staticmethod
     def _execute_local_proc_interactive(cmd, env=None):


### PR DESCRIPTION
### 📝 Description
`mlrun-db` isn't always the built-in MySQL Deployment — on systems where it's backed by Postgres (deployed as a StatefulSet), `automation/patch_igz/patch_remote.py --reset-db` failed outright: it hardcoded `deployment/mlrun-db`, a `mlrun-db` container name, and the `mysql` CLI to drop/recreate the database. This PR generalizes the reset path to detect the actual workload kind and DB engine at runtime, and fixes two bugs found while validating the change against a live Postgres-backed system.

---

### 🛠️ Changes Made
- `_reset_mlrun_db_data()` + `_get_mlrun_db_workload_ref()` + `_get_mlrun_db_container()`: resolve `mlrun-db` by resource name across `statefulset`/`deployment` (label schemes differ between the MySQL sub-chart and a Postgres backend), detect MySQL vs Postgres from the container image, and run the engine-correct reset command.
- Postgres reset issues `DROP DATABASE` / `CREATE DATABASE` as two separate `psql -c` statements — Postgres rejects both inside an implicit transaction block, which is what a single `;`-joined `-c` string produces (`ERROR: DROP DATABASE cannot run inside a transaction block`). The drop uses `WITH (FORCE)` to terminate any stale connection left by a pod that was just scaled down, and the recreated database's `OWNER` is explicitly reassigned to the Postgres role mlrun connects as, since `CREATE DATABASE` would otherwise assign it to whichever role ran the statement.
- `_wait_deployment_ready()`: rollout timeout `120s` → `300s` — a from-scratch Postgres schema init took just over 120s in testing, causing the script to report a failure even though the pod became ready moments later.
- Removed the eager "`DB_USER` must be set for `--reset-db`" config check — `DB_USER` is now only required for the MySQL path, checked at the point of use, since the engine can't be known until the live workload is queried.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Manually validated `--reset-db` end-to-end against a live system where `mlrun-db` runs as a Postgres StatefulSet: confirmed the DB reset (`DROP DATABASE` / `CREATE DATABASE`) succeeds and `mlrun-api-chief`/`mlrun-api-worker` return to Ready with `/api/v1/healthz` responding `200` within the new wait window.
- `make fmt` / `make lint` (ruff format, ruff check, import-linter) pass clean on the changed file.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No