### PR TITLE
[Functions] Fix address not synced when updating API-gateway invocation URL

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2743,6 +2743,11 @@ class SQLDB(DBInterface):
             updated = True
             existing_invocation_urls.append(url)
             struct["status"]["external_invocation_urls"] = existing_invocation_urls
+            # Sync address to the new URL only when address is currently unset, so
+            # that the next deploy_status poll sees no address change and avoids a
+            # spurious versioned re-store that would orphan linked model endpoints.
+            if not struct["status"].get("address"):
+                struct["status"]["address"] = url
         elif (
             operation == mlrun.common.types.Operation.REMOVE
             and url in existing_invocation_urls
@@ -2755,6 +2760,9 @@ class SQLDB(DBInterface):
             )
             updated = True
             struct["status"]["external_invocation_urls"].remove(url)
+            # Clear address only when it points at the URL being removed.
+            if struct["status"].get("address") == url:
+                struct["status"]["address"] = ""
 
         # update the function record only if the external invocation URLs were updated
         if updated:

--- a/server/py/services/api/tests/unit/crud/test_functions.py
+++ b/server/py/services/api/tests/unit/crud/test_functions.py
@@ -103,7 +103,7 @@ def test_update_functions_with_api_gateway_url(db: sqlalchemy.orm.Session):
 def test_add_api_gateway_url_syncs_address_when_empty(db: sqlalchemy.orm.Session):
     """Adding an API-gateway URL to a function whose address is unset should also
     populate status.address, so the next deploy_status poll sees no address change
-    and does not trigger a spurious versioned re-store (ML-12823)."""
+    and does not trigger a spurious versioned re-store."""
     project = "test-project"
     function_name = "test-function"
     function_tag = "latest"

--- a/server/py/services/api/tests/unit/crud/test_functions.py
+++ b/server/py/services/api/tests/unit/crud/test_functions.py
@@ -100,6 +100,132 @@ def test_update_functions_with_api_gateway_url(db: sqlalchemy.orm.Session):
     assert len(updated_function["status"]["external_invocation_urls"]) == 0
 
 
+def test_add_api_gateway_url_syncs_address_when_empty(db: sqlalchemy.orm.Session):
+    """Adding an API-gateway URL to a function whose address is unset should also
+    populate status.address, so the next deploy_status poll sees no address change
+    and does not trigger a spurious versioned re-store (ML-12823)."""
+    project = "test-project"
+    function_name = "test-function"
+    function_tag = "latest"
+    gw_host = "gw.example.com"
+
+    services.api.crud.Functions().store_function(
+        db,
+        project=project,
+        function={"metadata": {"name": function_name, "tag": function_tag}},
+        name=function_name,
+        tag=function_tag,
+    )
+    uri = mlrun.utils.generate_object_uri(project, function_name)
+
+    # address is empty before the API gateway URL is added
+    fn = services.api.crud.Functions().get_function(
+        db, project=project, name=function_name, tag=function_tag
+    )
+    assert fn["status"].get("address", "") == ""
+
+    services.api.crud.Functions().add_function_external_invocation_url(
+        db, uri, project, gw_host
+    )
+    fn = services.api.crud.Functions().get_function(
+        db, project=project, name=function_name, tag=function_tag
+    )
+    assert fn["status"]["external_invocation_urls"] == [gw_host]
+    assert fn["status"]["address"] == gw_host
+
+
+def test_add_api_gateway_url_does_not_overwrite_existing_address(
+    db: sqlalchemy.orm.Session,
+):
+    """Adding an API-gateway URL must not overwrite an address that is already set."""
+    project = "test-project"
+    function_name = "test-function"
+    function_tag = "latest"
+    existing_address = "existing.example.com"
+    gw_host = "gw.example.com"
+
+    services.api.crud.Functions().store_function(
+        db,
+        project=project,
+        function={
+            "metadata": {"name": function_name, "tag": function_tag},
+            "status": {"address": existing_address},
+        },
+        name=function_name,
+        tag=function_tag,
+    )
+    uri = mlrun.utils.generate_object_uri(project, function_name)
+
+    services.api.crud.Functions().add_function_external_invocation_url(
+        db, uri, project, gw_host
+    )
+    fn = services.api.crud.Functions().get_function(
+        db, project=project, name=function_name, tag=function_tag
+    )
+    assert fn["status"]["external_invocation_urls"] == [gw_host]
+    assert fn["status"]["address"] == existing_address
+
+
+def test_delete_api_gateway_url_clears_address_when_matching(
+    db: sqlalchemy.orm.Session,
+):
+    """Removing an API-gateway URL should clear status.address when it equals the
+    removed URL, and leave it unchanged otherwise."""
+    project = "test-project"
+    function_name = "test-function"
+    function_tag = "latest"
+    gw_host = "gw.example.com"
+    other_host = "other.example.com"
+
+    services.api.crud.Functions().store_function(
+        db,
+        project=project,
+        function={
+            "metadata": {"name": function_name, "tag": function_tag},
+            "status": {
+                "external_invocation_urls": [gw_host, other_host],
+                "address": gw_host,
+            },
+        },
+        name=function_name,
+        tag=function_tag,
+    )
+    uri = mlrun.utils.generate_object_uri(project, function_name)
+
+    # removing the URL that matches address → address should be cleared
+    services.api.crud.Functions().delete_function_external_invocation_url(
+        db, uri, project, gw_host
+    )
+    fn = services.api.crud.Functions().get_function(
+        db, project=project, name=function_name, tag=function_tag
+    )
+    assert gw_host not in fn["status"]["external_invocation_urls"]
+    assert fn["status"]["address"] == ""
+
+    # removing a URL that does NOT match address → address should be untouched
+    services.api.crud.Functions().store_function(
+        db,
+        project=project,
+        function={
+            "metadata": {"name": function_name, "tag": function_tag},
+            "status": {
+                "external_invocation_urls": [gw_host, other_host],
+                "address": gw_host,
+            },
+        },
+        name=function_name,
+        tag=function_tag,
+    )
+    services.api.crud.Functions().delete_function_external_invocation_url(
+        db, uri, project, other_host
+    )
+    fn = services.api.crud.Functions().get_function(
+        db, project=project, name=function_name, tag=function_tag
+    )
+    assert other_host not in fn["status"]["external_invocation_urls"]
+    assert fn["status"]["address"] == gw_host
+
+
 def test_store_and_get_function_missing_project(db: sqlalchemy.orm.Session):
     project = "some-project"
     function_name = "test-function"


### PR DESCRIPTION
### 📝 Description
`update_function_external_invocation_url` wrote the API gateway URL into `status.external_invocation_urls` but left `status.address` unchanged. On the next `deploy_status` poll, `_handle_nuclio_deploy_status` re-derived `address` from the URL list, saw it differ from the stored empty value, and performed a versioned re-store — creating a new function DB row, moving the "latest" tag off the original row, and orphaning model endpoints linked to it, which then disappeared from the UI.

---

### 🛠️ Changes Made
- `update_function_external_invocation_url` (`server/py/framework/db/sqldb/db.py`): on **ADD**, set `status.address` to the new URL only when `status.address` is currently unset; on **REMOVE**, clear `status.address` only when it equals the URL being removed.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
3 new unit tests in `server/py/services/api/tests/unit/crud/test_functions.py`:
- ADD syncs `address` when it is empty
- ADD does not overwrite an existing `address`
- REMOVE clears `address` only when it equals the removed URL; leaves it unchanged otherwise

The 3 new tests pass locally.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12823

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No