### PR TITLE
[Model Monitoring] Fix stream dropping events whose request id is 0

### DIFF
--- a/mlrun/model_monitoring/stream_processing.py
+++ b/mlrun/model_monitoring/stream_processing.py
@@ -522,7 +522,9 @@ class ProcessHTTPEvent(storey.MapClass):
                 _HTTP_ERROR_KEY: f"failed to translate event: {mlrun.errors.err_to_str(e)}"
             }
 
-        request_id = event.get(EventFieldType.REQUEST_ID) or str(uuid.uuid4())
+        request_id = event.get(EventFieldType.REQUEST_ID)
+        if request_id is None:
+            request_id = str(uuid.uuid4())
 
         return {
             EventFieldType.MODEL: name,
@@ -683,9 +685,10 @@ class ProcessEndpointEvent(mlrun.feature_store.steps.MapClass):
         # Validate event fields
         model_class = event.get("model_class") or event.get("class")
         timestamp = event.get("when")
-        request_id = event.get("request", {}).get("id") or event.get("resp", {}).get(
-            "id"
-        )
+        # an id of 0 is valid (execute_graph assigns row-index event ids) — only None means missing
+        request_id = event.get("request", {}).get("id")
+        if request_id is None:
+            request_id = event.get("resp", {}).get("id")
         feature_names = event.get("request", {}).get("input_schema")
         labels_names = event.get("resp", {}).get("output_schema")
         latency = event.get("microsec")

--- a/tests/model_monitoring/test_stream_processing.py
+++ b/tests/model_monitoring/test_stream_processing.py
@@ -17,6 +17,7 @@ import os
 import unittest.mock
 
 import pytest
+import storey
 
 import mlrun
 import mlrun.model_monitoring
@@ -34,6 +35,7 @@ from mlrun.model_monitoring.stream_processing import (
     _HTTP_ERROR_KEY,
     EventStreamProcessor,
     HTTPAckResponder,
+    ProcessEndpointEvent,
     ProcessHTTPEvent,
     TriggerRouter,
 )
@@ -466,6 +468,19 @@ class TestProcessHTTPEvent:
         assert result["request"]["id"] is not None
         assert len(result["request"]["id"]) > 0
 
+    async def test_zero_request_id_preserved(self, monkeypatch):
+        step = self._step(monkeypatch)
+        result = await step.do(
+            {
+                "model_endpoint_uid": "ep-1",
+                "model_endpoint_name": "my-model",
+                "inputs": [[1.0]],
+                "outputs": [[0.8]],
+                EventFieldType.REQUEST_ID: 0,
+            }
+        )
+        assert result["request"]["id"] == 0
+
     async def test_function_uri_from_endpoint_schema(self, monkeypatch):
         step = self._step(
             monkeypatch,
@@ -638,6 +653,54 @@ class TestGetEndpointSchema:
 
         await step._get_endpoint_schema("ep-1", "my-model")
         assert mock_db.get_model_endpoint.call_count == 2
+
+
+class TestProcessEndpointEvent:
+    """ProcessEndpointEvent.do() request-id extraction.
+
+    A request id of 0 is a valid id (e.g. execute_graph assigns row-index
+    event ids) and must not be treated as missing.
+    """
+
+    @staticmethod
+    def _event(request: dict, resp: dict) -> storey.Event:
+        return storey.Event(
+            body={
+                EventFieldType.FUNCTION_URI: "test-project/fn",
+                EventFieldType.MODEL: "my-model",
+                "model_class": "MyModel",
+                "when": "2025-07-24 05:00:10.000000",
+                EventFieldType.ENDPOINT_ID: "ep-1",
+                "microsec": 5,
+                "request": request,
+                "resp": resp,
+            }
+        )
+
+    async def _do(self, request: dict, resp: dict) -> storey.Event:
+        step = ProcessEndpointEvent(project="test-project")
+        step.endpoints.add("ep-1")
+        return await step.do(self._event(request=request, resp=resp))
+
+    async def test_zero_request_id_is_kept(self):
+        result = await self._do(
+            request={"id": 0, "inputs": [[1.0, 2.0]]}, resp={"outputs": [[0.8]]}
+        )
+        assert result.body is not None
+        assert result.body[0][EventFieldType.REQUEST_ID] == 0
+
+    async def test_request_id_falls_back_to_resp_id(self):
+        result = await self._do(
+            request={"inputs": [[1.0, 2.0]]}, resp={"id": "resp-1", "outputs": [[0.8]]}
+        )
+        assert result.body is not None
+        assert result.body[0][EventFieldType.REQUEST_ID] == "resp-1"
+
+    async def test_missing_request_id_drops_event(self):
+        result = await self._do(
+            request={"inputs": [[1.0, 2.0]]}, resp={"outputs": [[0.8]]}
+        )
+        assert result.body is None
 
 
 class _MockContext:

--- a/tests/system/model_monitoring/test_app.py
+++ b/tests/system/model_monitoring/test_app.py
@@ -946,7 +946,6 @@ class TestMonitoringAppFlow(TestMLRunSystemModelMonitoring, _V3IORecordsChecker)
 
 @TestMLRunSystemModelMonitoring.skip_test_if_env_not_configured
 @pytest.mark.enterprise
-@pytest.mark.collect_pod_logs
 class TestServingJobEndpoint(TestMLRunSystemModelMonitoring, _V3IORecordsChecker):
     """
     Demonstrates running a serving job with model monitoring enabled.  In this test, we deploy a simple serving model


### PR DESCRIPTION
### 📝 Description
The model-monitoring stream drops any event whose request id is `0`, because the id extraction in `ProcessEndpointEvent` uses a falsy-`or` chain:

```python
request_id = event.get("request", {}).get("id") or event.get("resp", {}).get("id")
```

`0 or None` evaluates to `None`, so the request-id validation fails and the event is discarded (`Expected event field is missing: None [Event -> request,id]`) before the parquet/TSDB fork — the prediction is silently lost from all monitoring targets.

This is the root cause of the deterministic `test_serving_as_a_job` failure on `development` (count app metric returns 2 windowed values instead of 3): since #9697, `execute_graph` assigns row-index event ids (`storey.Event(id=idx)`), so the first row of every batch gets id `0` and is dropped. Before #9697, a closure-capture bug gave all events the loop's terminal index (truthy), which masked this latent bug. The endpoint's `first_request` still looked correct because it is cached from the dropped event's timestamp before the validation runs, which made the failure hard to diagnose.

The real-time path is also exposed: `V2ModelServer` forwards a user-supplied body `id` verbatim, so a client POSTing `{"id": 0}` loses that prediction from monitoring.

Fixed by falling back only on `None` instead of on any falsy value. The same pattern in `ProcessHTTPEvent` (HTTP ingest) silently replaced a request id of `0` with a generated UUID; fixed the same way.

---

### 🛠️ Changes Made
- `ProcessEndpointEvent.do`: extract `request.id` with an `is None` fallback to `resp.id` instead of a falsy-`or` chain, so an id of `0` is kept.
- `ProcessHTTPEvent._process_event_content`: generate a UUID only when the request id is `None`, preserving an explicit id of `0`.
- Added unit tests: `TestProcessEndpointEvent` (id `0` kept, `resp.id` fallback, `None` id dropped) and `TestProcessHTTPEvent.test_zero_request_id_preserved`.
- Removed the `collect_pod_logs` diagnostic marker from `TestServingJobEndpoint` (added while root-causing this failure; no longer needed).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit: 4 new tests in `tests/model_monitoring/test_stream_processing.py`; the zero-id tests fail without the fix (reproducing the exact production error line) and pass with it. Full file: 53 passed.
- System: reproduced the `test_serving_as_a_job` failure on a dev cluster by running the serving job with a post-#9697 client image — fails `assert 2 == 3` byte-identical to the nightly CI failure, with the stream pod logging `Expected event field is missing: None [Event -> request,id]` for the first event only.
- Confirmed on the same cluster with this fix applied: `test_serving_as_a_job` passes (all 3 windowed count values), the stream pod logs zero request-id drops, and the first event traverses the full stream pipeline.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: failing nightly run https://github.com/mlrun/mlrun/actions/runs/28840783556 (first run with pod logs pinpointing the drop); #9697 (exposed the latent bug)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
The count app's earliest window (`W1`) is permanently missing in the failing test because the first event never reaches the offline parquet the app reads; the controller marks the window analyzed and never revisits it. The fix restores all three windows. Only these two occurrences of the falsy-`or`-on-id pattern exist in the codebase (checked `mlrun/` and `server/py`).
