### PR TITLE
[DB] Fix schedule cron_trigger corruption on PostgreSQL

### DIFF
--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -609,7 +609,15 @@ with warnings.catch_warnings():
 
         @cron_trigger.setter
         def cron_trigger(self, trigger: mlrun.common.schemas.ScheduleCronTrigger):
-            self.cron_trigger_str = orjson.dumps(trigger.dict(exclude_unset=True))
+            # orjson.dumps() returns bytes. cron_trigger_str is a text column (Utf8BinText), and
+            # binding raw bytes into a text column on PostgreSQL gets adapted through psycopg's
+            # bytea adapter, so Postgres stores the bytea hex-escape representation (e.g.
+            # "\\x7b2264...") as the literal text instead of the decoded JSON - the value then fails
+            # to parse as JSON on every subsequent read. MySQL/SQLite round-trip the raw bytes
+            # transparently, which is why this only ever surfaces against Postgres.
+            self.cron_trigger_str = orjson.dumps(
+                trigger.dict(exclude_unset=True)
+            ).decode()
 
     class Project(Base, LabelMixin, framework.db.sqldb.base.BaseModel):
         __tablename__ = "projects"

--- a/server/py/framework/db/sqldb/models.py
+++ b/server/py/framework/db/sqldb/models.py
@@ -609,12 +609,10 @@ with warnings.catch_warnings():
 
         @cron_trigger.setter
         def cron_trigger(self, trigger: mlrun.common.schemas.ScheduleCronTrigger):
-            # orjson.dumps() returns bytes. cron_trigger_str is a text column (Utf8BinText), and
-            # binding raw bytes into a text column on PostgreSQL gets adapted through psycopg's
-            # bytea adapter, so Postgres stores the bytea hex-escape representation (e.g.
-            # "\\x7b2264...") as the literal text instead of the decoded JSON - the value then fails
-            # to parse as JSON on every subsequent read. MySQL/SQLite round-trip the raw bytes
-            # transparently, which is why this only ever surfaces against Postgres.
+            # orjson.dumps() returns bytes; binding bytes into this text column goes through
+            # psycopg's bytea adapter on PostgreSQL, storing the bytea hex-escape string instead
+            # of the JSON, so it fails to parse back on every read. MySQL/SQLite round-trip bytes
+            # fine, which is why this only surfaced on Postgres - ML-12860.
             self.cron_trigger_str = orjson.dumps(
                 trigger.dict(exclude_unset=True)
             ).decode()

--- a/server/py/services/api/migrations/tests/postgres/test_schedule_postgres.py
+++ b/server/py/services/api/migrations/tests/postgres/test_schedule_postgres.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import sqlalchemy.orm
+
+import mlrun.common.schemas
+
+import framework.db.sqldb.db
+
+pytest.importorskip(
+    "psycopg2",
+    reason="psycopg2 not installed",
+)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("pmr_postgres_container")
+def test_schedule_cron_trigger_round_trip_on_postgres(
+    postgres_db_session: sqlalchemy.orm.session.Session,
+):
+    # Regression for ML-12860 - see the cron_trigger setter in
+    # server/py/framework/db/sqldb/models.py for why this only ever reproduced on PostgreSQL.
+    db = framework.db.sqldb.db.SQLDB()
+    project = "postgres-cron-trigger-test"
+    name = "main"
+    cron_trigger = mlrun.common.schemas.ScheduleCronTrigger.from_crontab("*/15 * * * *")
+
+    db.store_schedule(
+        postgres_db_session,
+        project=project,
+        name=name,
+        kind=mlrun.common.schemas.ScheduleKinds.job,
+        scheduled_object={"task": {}},
+        cron_trigger=cron_trigger,
+    )
+
+    schedule = db.get_schedule(postgres_db_session, project, name)
+
+    assert schedule.cron_trigger.minute == "*/15"
+
+    # store_schedule's own pre-existence check (get_schedule with raise_on_not_found=False) is
+    # exactly where ML-12860 crashed on a second scheduling attempt for the same project/name -
+    # exercise it explicitly here.
+    db.store_schedule(
+        postgres_db_session,
+        project=project,
+        name=name,
+        kind=mlrun.common.schemas.ScheduleKinds.job,
+        scheduled_object={"task": {}},
+        cron_trigger=cron_trigger,
+    )

--- a/server/py/services/api/migrations/tests/postgres/test_schedule_postgres.py
+++ b/server/py/services/api/migrations/tests/postgres/test_schedule_postgres.py
@@ -29,8 +29,8 @@ pytest.importorskip(
 def test_schedule_cron_trigger_round_trip_on_postgres(
     postgres_db_session: sqlalchemy.orm.session.Session,
 ):
-    # Regression for ML-12860 - see the cron_trigger setter in
-    # server/py/framework/db/sqldb/models.py for why this only ever reproduced on PostgreSQL.
+    # Regression for ML-12860 - see the cron_trigger setter in models.py for why this only
+    # reproduced on PostgreSQL.
     db = framework.db.sqldb.db.SQLDB()
     project = "postgres-cron-trigger-test"
     name = "main"

--- a/server/py/services/api/tests/unit/db/test_schedule.py
+++ b/server/py/services/api/tests/unit/db/test_schedule.py
@@ -24,7 +24,7 @@ from framework.tests.unit.db.common_fixtures import TestDatabaseBase
 
 def test_cron_trigger_setter_stores_str_not_bytes():
     # Regression for ML-12860 - see the cron_trigger setter in models.py for why bytes vs str
-    # matters here. Asserts the setter never produces bytes again, independent of DB dialect.
+    # matters here.
     schedule = Schedule()
     schedule.cron_trigger = mlrun.common.schemas.ScheduleCronTrigger.from_crontab(
         "*/15 * * * *"

--- a/server/py/services/api/tests/unit/db/test_schedule.py
+++ b/server/py/services/api/tests/unit/db/test_schedule.py
@@ -22,6 +22,18 @@ from framework.db.sqldb.models import Schedule
 from framework.tests.unit.db.common_fixtures import TestDatabaseBase
 
 
+def test_cron_trigger_setter_stores_str_not_bytes():
+    # Regression for ML-12860 - see the cron_trigger setter in models.py for why bytes vs str
+    # matters here. Asserts the setter never produces bytes again, independent of DB dialect.
+    schedule = Schedule()
+    schedule.cron_trigger = mlrun.common.schemas.ScheduleCronTrigger.from_crontab(
+        "*/15 * * * *"
+    )
+
+    assert isinstance(schedule.cron_trigger_str, str)
+    assert schedule.cron_trigger["minute"] == "*/15"
+
+
 class TestSchedules(TestDatabaseBase):
     def test_delete_schedules(self):
         names = ["some_name", "some_name2", "some_name3"]


### PR DESCRIPTION
### 📝 Description
Scheduling a workflow on a PostgreSQL-backed mlrun-db crashes with `unexpected character: line 1 column 1 (char 0)` (ML-12860). `Schedule.cron_trigger_str` is written via `orjson.dumps()`, which returns `bytes`. Binding raw bytes into a `text` column on PostgreSQL gets adapted through psycopg's `bytea` adapter, so Postgres stores the bytea hex-escape representation instead of the decoded JSON — every subsequent read then fails to parse. MySQL and SQLite round-trip the bytes transparently, which is why this only ever surfaces against a real Postgres-backed deployment. Confirmed via live reproduction against a Postgres-backed lab: it fails on the very first scheduling attempt for a brand-new project, and the corrupted row also blocks project deletion (the cascade-delete path hits the same broken property).

---

### 🛠️ Changes Made
- Decode the `orjson.dumps()` output before assigning it to `cron_trigger_str` in the `Schedule.cron_trigger` setter.
- Add a unit test asserting the setter stores a `str`, not `bytes`.
- Add a PostgreSQL integration test that stores and re-reads a schedule (twice, to also exercise `store_schedule`'s own pre-existence check, the exact path that crashed on repeat scheduling attempts) against a real Postgres container.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added `test_cron_trigger_setter_stores_str_not_bytes` (unit) and `test_schedule_cron_trigger_round_trip_on_postgres` (live-Postgres integration test via the existing `pmr_postgres_container`/`postgres_db_session` fixtures); the existing scheduler/schedule test suite (58 tests) still passes.
- Verified end-to-end by patching the fix to a Postgres-backed lab and re-running the reported repro three times consecutively (all succeeded), confirming via direct SQL query that the stored `cron_trigger_str` is now valid JSON, and confirming project deletion (previously blocked by the corrupted row) now succeeds cleanly.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12860

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Swept the rest of the codebase for the same bytes-into-text-column pattern (any serializer returning `bytes` assigned to a `Text`/`Utf8BinText` column); this was the only occurrence.