### PR TITLE
[DB] Fix Postgres UndefinedColumn when listing artifacts

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1985,7 +1985,7 @@ class SQLDB(DBInterface):
                 # Third sort by tag ID to ensure consistent ordering when an artifact has multiple tags.
                 # Put "latest" tag first, then others by tag_id desc
                 latest_first_case = case(
-                    (text(f"{tag_name_alias} = 'latest'"), 0),
+                    (query.statement.selected_columns[tag_name_alias] == "latest", 0),
                     else_=1,
                 )
 

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -18,6 +18,7 @@ import unittest.mock
 
 import deepdiff
 import pytest
+from sqlalchemy import text
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Query
 
@@ -2026,6 +2027,34 @@ class TestArtifacts(TestDatabaseBase):
         assert (
             artifacts[0]["metadata"]["tag"]
             == mlrun.common.constants.RESERVED_TAG_NAME_LATEST
+        )
+
+    def test_list_artifacts_tag_ordering_uses_no_raw_alias_text(self, monkeypatch):
+        key = "artifact_key_tag_order_guard"
+        self._db.store_artifact(
+            self._db_session,
+            key,
+            self._generate_artifact(key, project=self.project, tag="v1"),
+            project=self.project,
+            tag="v1",
+        )
+
+        captured_text_calls = []
+        real_text = text
+
+        def text_spy(clause_text):
+            captured_text_calls.append(clause_text)
+            return real_text(clause_text)
+
+        monkeypatch.setattr("framework.db.sqldb.db.text", text_spy)
+
+        self._db.list_artifacts(
+            self._db_session, project=self.project, limit=3, tag=None
+        )
+
+        assert not any("tag_name" in call for call in captured_text_calls), (
+            "the tag-name comparison must not be built via raw text() referencing "
+            f"the 'tag_name' alias inside an expression: {captured_text_calls}"
         )
 
     def test_list_artifacts_producer_uri(self):


### PR DESCRIPTION
### 📝 Description
On a PostgreSQL-backed `mlrun-db`, listing artifacts without a specific tag (e.g. `list_llm_prompts()`, `list_artifacts()`) fails with `psycopg2.errors.UndefinedColumn: column "tag_name" does not exist`. `SQLDB.list_artifacts` sorted the "latest" tag first via a `CASE WHEN` that referenced a SELECT-list alias (`"tag_name"`) from inside a raw `text()` fragment. MySQL tolerates referencing an output alias from within an ORDER BY expression; PostgreSQL only allows a bare alias reference there, so it raised `UndefinedColumn` on every no-tag artifact listing.

---

### 🛠️ Changes Made
- `server/py/framework/db/sqldb/db.py`: reference the query's already-selected `tag_name` column object (`query.statement.selected_columns[tag_name_alias]`) instead of the raw alias string, so the "latest tag first" comparison resolves to a real, qualified column on both the direct-join path and the path `_create_partitioned_query` rebuilds around a subquery.
- `server/py/services/api/tests/unit/db/test_artifacts.py`: added a regression guard that fails if the raw-text alias pattern is reintroduced.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added `test_list_artifacts_tag_ordering_uses_no_raw_alias_text`; verified it fails against the pre-fix code and passes against the fix (temporarily reverted the fix to confirm), so it's a real regression guard, not a tautology.
- Full `server/py/services/api/tests/unit/db/` suite: 218 passed. `ruff check` / `ruff format --check` clean.
- Not verified against a real PostgreSQL server — no Postgres test fixture exists in this repo's unit-test suite (only `testcontainers[k3s]`, for Kubernetes). Recommend confirming against a Postgres-backed lab before/after merge.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12861
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Checked `server/py/framework/db/sqldb/db.py` for other occurrences of this same bug pattern (a raw-text SELECT-list alias embedded inside an expression) — none found; this was isolated to the one line changed.