### PR TITLE
[DB] Fix Postgres GroupingError on multi-label filter queries

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -6293,8 +6293,12 @@ class SQLDB(DBInterface):
         else:
             # Basically do an "or" query on the predicates, and count how many rows each parent object has -
             # if it has as much rows as predicates, then it means it answers all the conditions.
+            # Select only the grouped column: a plain `session.query(cls.Label)` here selects every
+            # mapped column (id, name, value, parent) while grouping only by `parent`, which MySQL's
+            # nonstandard "loose" GROUP BY allows but PostgreSQL's strict GROUP BY rejects with
+            # GroupingError. The join below only needs `parent`, so that's all we select.
             subq = (
-                session.query(cls.Label)
+                session.query(cls.Label.parent)
                 .filter(or_(*preds))
                 .group_by(cls.Label.parent)
                 .having(func.count(cls.Label.parent) == len(preds))

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -17,6 +17,7 @@ import unittest.mock
 from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
@@ -58,6 +59,54 @@ class TestRuns(TestDatabaseBase):
 
         runs = self._db.list_runs(self._db_session, name="~RUN_naMe", project=project)
         assert len(runs) == 2
+
+    def test_list_runs_multi_label_filter(self):
+        # Filtering by 2+ labels routes through SQLDB._add_labels_filter's OR+GROUP BY+HAVING
+        # branch, which must return only runs matching *all* requested labels.
+        project = "project"
+        run_matches_both = {
+            "metadata": {
+                "name": "run-matches-both",
+                "labels": {"workflow-id": "wf-1", "job-type": "workflow-runner"},
+            },
+            "status": {},
+        }
+        run_matches_one = {
+            "metadata": {
+                "name": "run-matches-one",
+                "labels": {"workflow-id": "wf-1"},
+            },
+            "status": {},
+        }
+        self._db.store_run(self._db_session, run_matches_both, "uid-both", project)
+        self._db.store_run(self._db_session, run_matches_one, "uid-one", project)
+
+        query = self._db._find_runs(
+            self._db_session,
+            None,
+            project,
+            ["workflow-id=wf-1", "job-type=workflow-runner"],
+        )
+        assert {run.uid for run in query.all()} == {"uid-both"}
+
+    def test_list_runs_multi_label_filter_is_postgres_group_by_safe(self):
+        # On PostgreSQL, every column in a GROUP BY query's SELECT list must be either
+        # grouped or aggregated. The multi-label branch used to select the full Label
+        # entity (id, name, value, parent) while grouping only by `parent`, which
+        # PostgreSQL rejects with psycopg2.errors.GroupingError (see ML-12863) even
+        # though MySQL/SQLite silently tolerate it.
+        query = self._db._find_runs(
+            self._db_session,
+            None,
+            "project",
+            ["workflow-id=wf-1", "job-type=workflow-runner"],
+        )
+        compiled_sql = str(query.statement.compile(dialect=postgresql.dialect()))
+        labels_subquery_select = compiled_sql.split("JOIN (")[1].split(" \n")[0]
+        assert labels_subquery_select == "SELECT runs_labels.parent AS parent", (
+            "the multi-label OR+GROUP BY subquery must select only the grouped "
+            f"column on PostgreSQL, got: {labels_subquery_select!r}"
+        )
 
     def test_runs_with_notifications(self):
         project_name = "project"


### PR DESCRIPTION
### 📝 Description
On a PostgreSQL-backed `mlrun-db`, `mlrun.retry_pipeline()` fails with:
`psycopg2.errors.GroupingError: column "runs_labels.id" must appear in the GROUP BY clause or be used in an aggregate function`. Retry needs to resolve the original workflow-runner run by two labels at once (`workflow-id=<id>` AND `job-type=workflow-runner`), which routes into `SQLDB._add_labels_filter`'s multi-predicate branch. That branch selected the full `Label` ORM entity (`id`, `name`, `value`, `parent`) while grouping only by `parent` — legal under MySQL's "loose" GROUP BY, rejected by PostgreSQL's strict GROUP BY. Since `_add_labels_filter` is shared by ~9 callers (Runs, Functions, Schedules, Projects, artifacts, feature sets/vectors, etc.), any list/filter call with 2+ labels hit this on Postgres, not just retry. Same bug class as the already-merged #9879 and #9904.

---

### 🛠️ Changes Made
- `server/py/framework/db/sqldb/db.py`: in `_add_labels_filter`'s multi-predicate branch, select only `cls.Label.parent` (the column the outer join actually needs) instead of the full `Label` entity, so the query's SELECT list only contains grouped/aggregated columns.
- `server/py/services/api/tests/unit/db/test_runs.py`: added a regression guard that compiles the query under the PostgreSQL dialect and fails if an ungrouped column is reintroduced, plus a functional test that multi-label filtering still returns only runs matching all requested labels.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added `test_list_runs_multi_label_filter_is_postgres_group_by_safe`: verified it fails against the pre-fix code (reverted the fix, reran) and passes against the fix.
- Added `test_list_runs_multi_label_filter`: confirms filtering by 2 labels still returns only runs matching both.
- Full `server/py/services/api/tests/unit/db/` suite: 220 passed. `ruff check` / `ruff format --check` / import-linter clean.
- Not verified against a real PostgreSQL server — no Postgres test fixture exists in this repo's unit-test suite; the regression test instead compiles the query under `sqlalchemy.dialects.postgresql.dialect()` to catch the SELECT-list/GROUP BY mismatch without a live server.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12863
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- All ~9 callers of `_add_labels_filter` keep the same signature (unchanged in this diff); functional equivalence for the 2+-label case is verified for the Runs caller via the new test, and expected to hold for the other callers since the subquery's join/filter semantics are otherwise unchanged.