### PR TITLE
[DB] Fix transient "Function tag not found" on function store

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2542,7 +2542,6 @@ class SQLDB(DBInterface):
         fn.struct = function
         # flush the function and let tag_objects_v2 commit it together with its
         # tag, so a concurrent reader never sees it without its "latest" tag
-        # ("Function tag not found", ML-12864)
         self._flush(session, [fn])
         self.tag_objects_v2(session, [fn], project, tag)
         return hash_key

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2540,7 +2540,23 @@ class SQLDB(DBInterface):
         fn.kind = function.pop("kind", None)
         fn.state = function.get("status", {}).pop("state", None)
         fn.struct = function
-        self._upsert(session, [fn])
+        # Persist the function object and its tag in a single transaction. We
+        # flush (not commit) the function so it gets an id for the tag's foreign
+        # key, then let tag_objects_v2 issue one commit that persists both.
+        # Committing the function before its tag would leave a window in which a
+        # concurrent reader (another API worker, a background job) observes the
+        # function row without its "latest" tag and fails with a spurious
+        # "Function tag not found" (ML-12864).
+        session.add(fn)
+        try:
+            session.flush()
+        except SQLAlchemyError:
+            # A concurrent create can violate the (project, name, uid) unique
+            # constraint at flush time. Roll back so retry_on_conflict re-runs
+            # store_function on a clean session (mirrors _commit's rollback on
+            # error); otherwise the retry would fail on a poisoned session.
+            session.rollback()
+            raise
         self.tag_objects_v2(session, [fn], project, tag)
         return hash_key
 

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -2540,23 +2540,10 @@ class SQLDB(DBInterface):
         fn.kind = function.pop("kind", None)
         fn.state = function.get("status", {}).pop("state", None)
         fn.struct = function
-        # Persist the function object and its tag in a single transaction. We
-        # flush (not commit) the function so it gets an id for the tag's foreign
-        # key, then let tag_objects_v2 issue one commit that persists both.
-        # Committing the function before its tag would leave a window in which a
-        # concurrent reader (another API worker, a background job) observes the
-        # function row without its "latest" tag and fails with a spurious
-        # "Function tag not found" (ML-12864).
-        session.add(fn)
-        try:
-            session.flush()
-        except SQLAlchemyError:
-            # A concurrent create can violate the (project, name, uid) unique
-            # constraint at flush time. Roll back so retry_on_conflict re-runs
-            # store_function on a clean session (mirrors _commit's rollback on
-            # error); otherwise the retry would fail on a poisoned session.
-            session.rollback()
-            raise
+        # flush the function and let tag_objects_v2 commit it together with its
+        # tag, so a concurrent reader never sees it without its "latest" tag
+        # ("Function tag not found", ML-12864)
+        self._flush(session, [fn])
         self.tag_objects_v2(session, [fn], project, tag)
         return hash_key
 
@@ -5889,6 +5876,23 @@ class SQLDB(DBInterface):
         for object_ in objects:
             session.add(object_)
         self._commit(session, objects, ignore, silent)
+
+    def _flush(self, session, objects):
+        # Flush without committing, so objects get generated fields (e.g. their
+        # id) while the transaction stays open for a single downstream commit.
+        # Use to persist an object together with its tag atomically: _flush(obj)
+        # then tag_objects_v2(obj) issues the one commit that covers both, so a
+        # concurrent reader never sees the object without its tag (ML-12864).
+        if not objects:
+            return
+        for object_ in objects:
+            session.add(object_)
+        try:
+            session.flush()
+        except SQLAlchemyError:
+            # roll back so @retry_on_conflict retries on a clean session
+            session.rollback()
+            raise
 
     def _upsert_batch(self, session, objects, ignore=False, silent=False):
         if not objects:

--- a/server/py/services/api/tests/unit/db/test_functions.py
+++ b/server/py/services/api/tests/unit/db/test_functions.py
@@ -64,10 +64,8 @@ class TestFunctions(TestDatabaseBase):
         assert function_queried_without_tag_hash == function_queried_without_tag_hash
 
     def test_store_function_tag_failure_leaves_no_orphan_function(self):
-        # Regression for ML-12864: the function object and its "latest" tag must
-        # be persisted atomically. If tagging fails, the function row must not
-        # remain committed without its tag - otherwise a reader resolving the
-        # tag first surfaces the spurious "Function tag not found".
+        # ML-12864: function and tag are stored atomically, so a failed tag
+        # write must leave no function row behind.
         function = self._generate_function()
 
         with pytest.MonkeyPatch.context() as monkeypatch:
@@ -94,10 +92,8 @@ class TestFunctions(TestDatabaseBase):
         assert remaining == []
 
     def test_store_function_rolls_back_on_flush_conflict(self):
-        # Guards the rollback added for ML-12864: a concurrent create that
-        # violates the (name, project, uid) unique constraint raises at flush;
-        # store_function must roll back so the session is not left poisoned
-        # (which would break the retry_on_conflict retry with PendingRollbackError).
+        # ML-12864: a unique-constraint violation at flush must roll back so the
+        # session stays usable for the retry_on_conflict retry.
         function = self._generate_function()
         self._db.store_function(
             self._db_session,
@@ -108,10 +104,8 @@ class TestFunctions(TestDatabaseBase):
         )
 
         with pytest.MonkeyPatch.context() as monkeypatch:
-            # disable the conflict-retry loop so the raw flush error surfaces once
+            # surface the raw flush conflict once, and force the INSERT path
             monkeypatch.setattr(mlrun.mlconf.httpdb.db, "conflict_retry_timeout", 0)
-            # force the existence check to miss so the re-store takes the INSERT
-            # path and collides on (name, project, uid)
             monkeypatch.setattr(
                 self._db, "_get_class_instance_by_uid", lambda *args, **kwargs: None
             )
@@ -124,8 +118,7 @@ class TestFunctions(TestDatabaseBase):
                     versioned=False,
                 )
 
-        # the session must be usable (rolled back), not poisoned; the original
-        # row is intact and the duplicate was not committed
+        # the session is usable (rolled back) and the original row is intact
         remaining = (
             self._db_session.query(Function)
             .filter_by(project=self.project, name=function.metadata.name)

--- a/server/py/services/api/tests/unit/db/test_functions.py
+++ b/server/py/services/api/tests/unit/db/test_functions.py
@@ -17,6 +17,7 @@ import time
 
 import deepdiff
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 import mlrun.common.schemas
 import mlrun.errors
@@ -61,6 +62,76 @@ class TestFunctions(TestDatabaseBase):
         assert function_queried_with_tag is not None
         assert function_queried_with_tag["metadata"]["tag"] == "latest"
         assert function_queried_without_tag_hash == function_queried_without_tag_hash
+
+    def test_store_function_tag_failure_leaves_no_orphan_function(self):
+        # Regression for ML-12864: the function object and its "latest" tag must
+        # be persisted atomically. If tagging fails, the function row must not
+        # remain committed without its tag - otherwise a reader resolving the
+        # tag first surfaces the spurious "Function tag not found".
+        function = self._generate_function()
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+
+            def _raise(*args, **kwargs):
+                raise RuntimeError("tag write failed")
+
+            monkeypatch.setattr(self._db, "tag_objects_v2", _raise)
+            with pytest.raises(RuntimeError):
+                self._db.store_function(
+                    self._db_session,
+                    function=function.to_dict(),
+                    name=function.metadata.name,
+                    project=self.project,
+                )
+
+        # discard the aborted transaction and confirm nothing was committed
+        self._db_session.rollback()
+        remaining = (
+            self._db_session.query(Function)
+            .filter_by(project=self.project, name=function.metadata.name)
+            .all()
+        )
+        assert remaining == []
+
+    def test_store_function_rolls_back_on_flush_conflict(self):
+        # Guards the rollback added for ML-12864: a concurrent create that
+        # violates the (name, project, uid) unique constraint raises at flush;
+        # store_function must roll back so the session is not left poisoned
+        # (which would break the retry_on_conflict retry with PendingRollbackError).
+        function = self._generate_function()
+        self._db.store_function(
+            self._db_session,
+            function=function.to_dict(),
+            name=function.metadata.name,
+            project=self.project,
+            versioned=False,
+        )
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            # disable the conflict-retry loop so the raw flush error surfaces once
+            monkeypatch.setattr(mlrun.mlconf.httpdb.db, "conflict_retry_timeout", 0)
+            # force the existence check to miss so the re-store takes the INSERT
+            # path and collides on (name, project, uid)
+            monkeypatch.setattr(
+                self._db, "_get_class_instance_by_uid", lambda *args, **kwargs: None
+            )
+            with pytest.raises(IntegrityError):
+                self._db.store_function(
+                    self._db_session,
+                    function=function.to_dict(),
+                    name=function.metadata.name,
+                    project=self.project,
+                    versioned=False,
+                )
+
+        # the session must be usable (rolled back), not poisoned; the original
+        # row is intact and the duplicate was not committed
+        remaining = (
+            self._db_session.query(Function)
+            .filter_by(project=self.project, name=function.metadata.name)
+            .all()
+        )
+        assert len(remaining) == 1
 
     def test_store_function_versioned(self):
         function_1 = self._generate_function()


### PR DESCRIPTION
### 📝 Description
`project.set_source("db://...")` intermittently failed with `MLRunNotFoundError('Function tag not found ...')` on a multi-worker API over Postgres; reruns passed. `store_function` persisted the function row and its `latest` tag in two separate transactions, so a concurrent reader (another API worker or background job) landing between the two commits observed the function without its tag — and `get_function` resolves the tag first, surfacing the spurious error. This change makes the function and its `latest` tag persist atomically.

---

### 🛠️ Changes Made
- `store_function` now flushes the function (to obtain its id for the tag's foreign key) instead of committing it, then lets `tag_objects_v2` issue a single commit that persists the function and its tag together — closing the window in which a reader could observe a function without its `latest` tag.
- On a flush-time database error (e.g. a concurrent create violating the `(name, project, uid)` unique constraint), roll back and re-raise so the existing `retry_on_conflict` retry re-runs on a clean session instead of a poisoned one.
- Added two regression tests: a tagging failure leaves no orphan function row; a flush conflict rolls back the session so it stays usable.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New unit tests in `test_functions.py` (both fail on the pre-fix code, pass after): `test_store_function_tag_failure_leaves_no_orphan_function` and `test_store_function_rolls_back_on_flush_conflict`. Full `test_functions.py` passes (32 tests).
- Reproduced the race on a lab (single Postgres) by driving the DB layer concurrently: a reader hit the function-without-tag window 3/120 times before the fix and 0/120 after.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12864
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- `store_artifact`, `store_feature_set`, and `store_feature_vector` share the same two-commit-then-tag pattern and the same latent window; left out of scope for this functions-only fix and worth a follow-up.