### PR TITLE
[DB] Fix aborted-run notifications never delivered on Postgres

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -154,7 +154,11 @@ class now(GenericFunction):  # noqa: N801
 
 @compiles(now, mlrun.common.db.dialects.Dialects.POSTGRESQL)
 def _pg_now(element, compiler, **kw):
-    return "now()"
+    # clock_timestamp(), not now(): PostgreSQL now()/transaction_timestamp() is frozen at transaction start. This
+    # stamps a run's terminal end_time, and the abort flow holds one transaction open across the long runtime-
+    # resource deletion, so now() would record end_time at transaction start - dropping the run out of the
+    # notification pusher's sliding end_time window so its notifications are never sent (ML-12865).
+    return "clock_timestamp()"
 
 
 NULL = None  # Avoid flake8 issuing warnings when comparing in filter

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -17,7 +17,7 @@ import unittest.mock
 from datetime import UTC, datetime
 
 import pytest
-from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import mysql, postgresql, sqlite
 
 import mlrun.common.runtimes.constants
 import mlrun.common.schemas
@@ -25,6 +25,7 @@ import mlrun.errors
 import mlrun.model
 from tests.conftest import new_run
 
+import framework.db.sqldb.db
 import framework.db.sqldb.helpers
 import framework.db.sqldb.models
 from framework.tests.unit.db.common_fixtures import TestDatabaseBase
@@ -107,6 +108,17 @@ class TestRuns(TestDatabaseBase):
             "the multi-label OR+GROUP BY subquery must select only the grouped "
             f"column on PostgreSQL, got: {labels_subquery_select!r}"
         )
+
+    def test_terminal_end_time_uses_clock_timestamp_on_postgres(self):
+        # ML-12865: the `now` helper stamps a run's terminal end_time. On PostgreSQL it must compile to
+        # clock_timestamp(), not now()/transaction_timestamp() which is frozen at transaction start - the abort
+        # flow holds one transaction open across the long runtime-resource deletion, so now() would record
+        # end_time in the past, dropping the run out of the notification pusher's sliding end_time window.
+        # MySQL/SQLite are unaffected - only the PostgreSQL compilation is overridden.
+        now = framework.db.sqldb.db.now
+        assert str(now(6).compile(dialect=postgresql.dialect())) == "clock_timestamp()"
+        assert "clock_timestamp" not in str(now(6).compile(dialect=mysql.dialect()))
+        assert "clock_timestamp" not in str(now(6).compile(dialect=sqlite.dialect()))
 
     def test_runs_with_notifications(self):
         project_name = "project"


### PR DESCRIPTION
### 📝 Description
On PostgreSQL, notifications for aborted jobs were never delivered (ML-12865) — intermittently, and only on Postgres. A run's terminal `end_time` was stamped with the `now` SQL helper, which compiled to `now()`; PostgreSQL resolves `now()` to `transaction_timestamp()` — the time the transaction started, held constant for its whole lifetime. The abort flow holds a single transaction open across the (potentially long) runtime-resource deletion, so `end_time` was recorded at transaction start rather than at the terminal transition. The periodic notification pusher selects terminal runs by a sliding `end_time` window, so the stale `end_time` fell behind the window and the run's pending notifications were never sent. MySQL/SQLite were unaffected (their `NOW()` reflects statement time), which is why this reproduced only on Postgres and only transiently.

---

### 🛠️ Changes Made
- Compile the `now` SQL helper to `clock_timestamp()` on PostgreSQL (previously `now()`), so a run's terminal `end_time` reflects the real wall-clock time at statement execution instead of the transaction start. Only the PostgreSQL compilation is overridden; MySQL and SQLite rendering is unchanged.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added a unit test (`test_terminal_end_time_uses_clock_timestamp_on_postgres`) asserting the `now` helper compiles to `clock_timestamp()` on PostgreSQL and to neither on MySQL/SQLite (scope guard).
- `server/py/services/api/tests/unit/db/test_runs.py` — 23 tests pass locally.
- Covered by the naipi system test `test_mlrun_notifications_for_aborted_job`; not run here (requires a live Postgres-backed lab).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12865

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No