### PR TITLE
[DB] Fix Postgres unique-violation misclassified as fatal on store

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -168,6 +168,8 @@ conflict_messages = [
     "(sqlite3.IntegrityError) UNIQUE constraint failed",
     "(pymysql.err.IntegrityError) (1062",
     "(pymysql.err.IntegrityError) (1586",
+    "(psycopg2.errors.UniqueViolation)",
+    "(psycopg.errors.UniqueViolation)",
 ]
 
 

--- a/server/py/services/api/tests/unit/db/test_sqldb.py
+++ b/server/py/services/api/tests/unit/db/test_sqldb.py
@@ -17,7 +17,9 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 
 import mlrun.common.schemas
+import mlrun.utils.helpers
 
+import framework.db.sqldb.db
 import framework.db.sqldb.models
 from framework.tests.unit.db.common_fixtures import TestDatabaseBase
 
@@ -35,8 +37,28 @@ class TestSQLDB(TestDatabaseBase):
             ),
             ("(pymysql.err.IntegrityError) (1062", mlrun.errors.MLRunConflictError),
             ("(pymysql.err.IntegrityError) (1586", mlrun.errors.MLRunConflictError),
+            (
+                "(psycopg2.errors.UniqueViolation) duplicate key value violates "
+                'unique constraint "_functions_uc"',
+                mlrun.errors.MLRunConflictError,
+            ),
+            (
+                "(psycopg.errors.UniqueViolation) duplicate key value violates "
+                'unique constraint "_functions_uc"',
+                mlrun.errors.MLRunConflictError,
+            ),
             # other errors
             ("some other exception", mlrun.errors.MLRunRuntimeError),
+            # Postgres non-unique integrity violations must stay fatal, not be
+            # misclassified as retryable conflicts.
+            (
+                "(psycopg2.errors.NotNullViolation) null value in column",
+                mlrun.errors.MLRunRuntimeError,
+            ),
+            (
+                "(psycopg2.errors.ForeignKeyViolation) insert or update on table",
+                mlrun.errors.MLRunRuntimeError,
+            ),
         ],
     )
     def test_commit_failures(self, error_message: str, expected_exception: Exception):
@@ -52,3 +74,41 @@ class TestSQLDB(TestDatabaseBase):
 
         with pytest.raises(expected_exception):
             self._db._commit(session, objects)
+
+    @pytest.mark.parametrize(
+        "error_message, is_conflict",
+        [
+            # Postgres duplicate-key races, via both installed drivers (psycopg2 and
+            # psycopg v3). These are the get-then-insert conflicts retry_on_conflict
+            # must recognize so the store re-runs instead of failing fatally.
+            (
+                "(psycopg2.errors.UniqueViolation) duplicate key value violates "
+                'unique constraint "_functions_uc"',
+                True,
+            ),
+            (
+                "(psycopg.errors.UniqueViolation) duplicate key value violates "
+                'unique constraint "_functions_uc"',
+                True,
+            ),
+            # Non-unique Postgres integrity violations are genuine failures and must
+            # not be swallowed by the conflict-retry mechanism.
+            ("(psycopg2.errors.NotNullViolation) null value in column", False),
+            (
+                "(psycopg.errors.ForeignKeyViolation) insert or update on table",
+                False,
+            ),
+        ],
+    )
+    def test_conflict_messages_match_postgres_unique_violation(
+        self, error_message: str, is_conflict: bool
+    ):
+        # retry_on_conflict (and the current-tree store_function _flush path) classify
+        # a raw SQLAlchemy error by substring-matching its chain against conflict_messages.
+        exc = SQLAlchemyError(error_message)
+        assert (
+            mlrun.utils.helpers.are_strings_in_exception_chain_messages(
+                exc, framework.db.sqldb.db.conflict_messages
+            )
+            is is_conflict
+        )


### PR DESCRIPTION
### 📝 Description
On a Postgres-backed MLRun, a pipeline step intermittently failed with HTTP 500 `MLRunRuntimeError("Failed committing changes to DB. classes=['Function']...")` while submitting a run. A concurrent versioned `store_function` hits the `_functions_uc` unique constraint and psycopg raises `UniqueViolation`. The module-level `conflict_messages` list — used to tell a retryable get-then-insert race apart from a genuine failure — only recognized sqlite and pymysql phrasings, so on Postgres the race was treated as fatal: `retry_on_conflict` did not re-run the store and `_commit` returned a 500 instead of a 409. On MySQL/sqlite the same race is recognized and self-heals. This PR adds the Postgres phrasings so it behaves identically.

---

### 🛠️ Changes Made
- `conflict_messages` (server/py/framework/db/sqldb/db.py): add `(psycopg2.errors.UniqueViolation)` and `(psycopg.errors.UniqueViolation)`. Both drivers are shipped in the api image (psycopg2-binary and psycopg v3), so the active one depends on the DSN. Matched by class rather than message text because the class prefix is locale-independent, and scoped to unique violations so not-null / foreign-key violations remain fatal (mirroring the MySQL 1062/1586 duplicate-key codes).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Extended `test_commit_failures` with the two psycopg `UniqueViolation` phrasings (asserting `MLRunConflictError`) and with `NotNullViolation` / `ForeignKeyViolation` cases (asserting they stay `MLRunRuntimeError`).
- Added `test_conflict_messages_match_postgres_unique_violation`, exercising the conflict-chain matcher directly for both the unique-violation (match) and non-unique (no match) cases.
- Confirmed the new conflict cases fail without the fix and pass with it; full test file green. `make fmt` / `make lint` clean.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12866
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Behavior change is server-internal and Postgres-only: a unique-violation race now retries to a silent recovery (or a 409), matching MySQL/sqlite. No schema, API-contract, doc, or caller changes.