### PR TITLE
[Iguazio] Fix duplicate "Using token" log from SDK client

### DIFF
--- a/server/py/framework/utils/clients/helpers.py
+++ b/server/py/framework/utils/clients/helpers.py
@@ -11,8 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+
 import mlrun.common.schemas
+import mlrun.utils
 from mlrun.utils.logger import context_id_var
+
+
+def iguazio_sdk_logger(parent_logger: mlrun.utils.Logger) -> logging.Logger:
+    """
+    Return the stdlib logger to hand the Iguazio SDK so MLRun owns its logging.
+
+    Without a logger the SDK installs its own stdout handler and also propagates into
+    MLRun's logger, duplicating every line. A dedicated "sdk" child is used so the SDK's
+    internal set_level("INFO") doesn't raise MLRun's own logger.
+    """
+    return parent_logger.get_child("sdk")._logger
 
 
 def enrich_headers(headers: dict | None = None, path: str | None = None) -> dict:

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -50,6 +50,7 @@ class Client(BaseClient, project_follower.Member):
             auto_login=False,
             use_token_file=False,
             verify_ssl=mlrun.mlconf.iguazio_api_ssl_verify,
+            logger=clients_helpers.iguazio_sdk_logger(self._logger),
         )
 
     def refresh_access_token(
@@ -218,6 +219,7 @@ class Client(BaseClient, project_follower.Member):
                     token_file_path=temp_file.name,
                     token_name=token_name,
                     verify_ssl=mlrun.mlconf.iguazio_api_ssl_verify,
+                    logger=clients_helpers.iguazio_sdk_logger(self._logger),
                 )
                 result = token_file_client.get_refresh_token()
                 if not result or not result[0]:

--- a/server/py/services/api/tests/unit/utils/clients/test_client_helpers.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_client_helpers.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import pytest
 
 import mlrun
 import mlrun.common.schemas
+import mlrun.utils
 from mlrun.utils.logger import context_id_var
 
 import framework.utils.clients.helpers as clients_helpers
@@ -173,3 +176,22 @@ def test_enrich_headers_preserves_existing_headers(set_context_id):
         result[mlrun.common.schemas.HeaderNames.projects_role]
         == mlrun.mlconf.httpdb.projects.leader
     )
+
+
+@pytest.mark.parametrize("parent_suffix", ["iguazio-client", "system-events"])
+def test_iguazio_sdk_logger(parent_suffix):
+    """
+    The SDK logger is a dedicated "sdk" child under the MLRun parent, owns no handler, and
+    the SDK's set_level("INFO") does not leak to the parent (ML-12862).
+    """
+    parent = mlrun.utils.logger.get_child(parent_suffix)
+    parent._logger.setLevel(logging.DEBUG)
+
+    sdk_logger = clients_helpers.iguazio_sdk_logger(parent)
+    sdk_logger.setLevel(logging.INFO)
+
+    assert isinstance(sdk_logger, logging.Logger)
+    assert sdk_logger.name == f"{parent._logger.name}.sdk"
+    assert sdk_logger.propagate is True
+    assert sdk_logger.handlers == []
+    assert parent._logger.level == logging.DEBUG

--- a/server/py/services/api/utils/events/iguazio_v4.py
+++ b/server/py/services/api/utils/events/iguazio_v4.py
@@ -120,6 +120,9 @@ class Client(base_events.BaseEventClient):
             auto_login=False,
             use_token_file=False,
             verify_ssl=mlrun.mlconf.iguazio_api_ssl_verify,
+            logger=clients_helpers.iguazio_sdk_logger(
+                logger.get_child("system-events")
+            ),
         )
         self._service_account_token_client = service_account_token.Client()
         self._entity_name = self._resolve_entity_name()


### PR DESCRIPTION
### 📝 Description
The MLRun API logged the Iguazio SDK line `Using token: '<name>'` twice — once as a bare stdout line with no request context, and once through MLRun's logger with the `ctx` field. Root cause: the Iguazio SDK client was constructed without a `logger`, so the SDK installed its own stdout handler and also propagated records into MLRun's logger, duplicating every SDK log line.

---

### 🛠️ Changes Made
- Added `clients_helpers.iguazio_sdk_logger()`, which returns a dedicated `"sdk"` child of a given MLRun logger. Handing this to the SDK routes all its logging through MLRun (a single line, carrying `ctx`); the dedicated child also keeps the SDK's internal `set_level("INFO")` from changing MLRun's own logger level.
- Passed that logger to all three `iguazio.Client(...)` construction sites: the main client and the token-file client in `framework/utils/clients/iguazio/v4.py`, and the events client in `services/api/utils/events/iguazio_v4.py` (nested under a `system-events` logger).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added a parametrized unit test in `test_client_helpers.py` asserting the SDK logger is a `sdk` child of the MLRun parent, owns no handler of its own, and that setting its level to `INFO` does not leak to the MLRun parent. Covers both production parent loggers (`iguazio-client`, `system-events`).
- Existing iguazio v4 client and events-client unit suites pass (113 tests).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12862
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Because the SDK is handed a dedicated `sdk` child, its verbosity stays at the SDK's default `INFO` and is not gated by `mlrun.mlconf.log_level`. This matches the pre-fix behavior (the line is now emitted once instead of twice).