### PR TITLE
[Utils] Fix tar-slip path traversal in clone_tgz archive extraction

### DIFF
--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -70,7 +70,11 @@ def clone_zip(source, target_dir, secrets=None, clone=True):
 def clone_tgz(source, target_dir, secrets=None, clone=True):
     tmpfile = _prep_dir(source, target_dir, ".tar.gz", secrets, clone)
     with tarfile.TarFile.open(tmpfile, "r:*") as tf:
-        tf.extractall(path=target_dir)
+        # filter="data" blocks path-traversal (tar-slip) members from a malicious
+        # archive escaping target_dir, matching mlrun's own _safe_extract_tar()
+        # helper and _archiver.py.
+        # see: https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall
+        tf.extractall(path=target_dir, filter="data")
     remove(tmpfile)  # delete zipped file
 
 

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -62,20 +62,24 @@ def get_git_username_password_from_token(token):
 
 def clone_zip(source, target_dir, secrets=None, clone=True):
     tmpfile = _prep_dir(source, target_dir, ".zip", secrets, clone)
-    with zipfile.ZipFile(tmpfile, "r") as zf:
-        zf.extractall(target_dir)
-    remove(tmpfile)  # delete zipped file
+    try:
+        with zipfile.ZipFile(tmpfile, "r") as zf:
+            # route through the shared safe extractor so a malicious archive is
+            # handled consistently with the rest of the module.
+            _safe_extract_zip(zf, target_dir)
+    finally:
+        remove(tmpfile)  # delete downloaded archive even if extraction fails
 
 
 def clone_tgz(source, target_dir, secrets=None, clone=True):
     tmpfile = _prep_dir(source, target_dir, ".tar.gz", secrets, clone)
-    with tarfile.TarFile.open(tmpfile, "r:*") as tf:
-        # filter="data" blocks path-traversal (tar-slip) members from a malicious
-        # archive escaping target_dir, matching mlrun's own _safe_extract_tar()
-        # helper and _archiver.py.
-        # see: https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall
-        tf.extractall(path=target_dir, filter="data")
-    remove(tmpfile)  # delete zipped file
+    try:
+        with tarfile.TarFile.open(tmpfile, "r:*") as tf:
+            # route through the shared safe extractor: rejects path-traversal
+            # (tar-slip) members instead of a raw extractall().
+            _safe_extract_tar(tf, target_dir)
+    finally:
+        remove(tmpfile)  # delete downloaded archive even if extraction fails
 
 
 def get_repo_url(repo):

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -920,3 +920,28 @@ def test_download_artifact_to_dir_unresolvable_filename_raises(tmp_path):
         )
 
     mock_get_dataitem.assert_not_called()
+
+
+def test_clone_tgz_blocks_tar_slip(tmp_path, monkeypatch):
+    """clone_tgz must not let a malicious .tar.gz member escape target_dir (tar-slip)."""
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+
+    # a .tar.gz whose member path traverses out of the extraction directory
+    malicious = tmp_path / "malicious.tar.gz"
+    with tarfile.open(malicious, "w:gz") as tf:
+        payload = b"pwned"
+        member = tarfile.TarInfo(name="../evil.txt")
+        member.size = len(payload)
+        tf.addfile(member, io.BytesIO(payload))
+
+    # skip the network download; hand clone_tgz the crafted archive directly
+    monkeypatch.setattr(
+        mlrun.utils.clones, "_prep_dir", lambda *args, **kwargs: str(malicious)
+    )
+
+    # filter="data" rejects the traversal member instead of writing outside target_dir
+    with pytest.raises(tarfile.TarError):
+        mlrun.utils.clones.clone_tgz("dummy://source", str(target_dir))
+
+    assert not (tmp_path / "evil.txt").exists()

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -923,7 +923,7 @@ def test_download_artifact_to_dir_unresolvable_filename_raises(tmp_path):
 
 
 def test_clone_tgz_blocks_tar_slip(tmp_path, monkeypatch):
-    """clone_tgz must not let a malicious .tar.gz member escape target_dir (tar-slip)."""
+    """clone_tgz must reject a malicious .tar.gz member that escapes target_dir (tar-slip)."""
     target_dir = tmp_path / "target"
     target_dir.mkdir()
 
@@ -940,8 +940,30 @@ def test_clone_tgz_blocks_tar_slip(tmp_path, monkeypatch):
         mlrun.utils.clones, "_prep_dir", lambda *args, **kwargs: str(malicious)
     )
 
-    # filter="data" rejects the traversal member instead of writing outside target_dir
-    with pytest.raises(tarfile.TarError):
+    # the shared safe extractor rejects the traversal member instead of escaping
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
         mlrun.utils.clones.clone_tgz("dummy://source", str(target_dir))
 
     assert not (tmp_path / "evil.txt").exists()
+    # the downloaded archive is cleaned up even though extraction failed
+    assert not malicious.exists()
+
+
+def test_clone_zip_blocks_zip_slip(tmp_path, monkeypatch):
+    """clone_zip must reject a malicious .zip member that escapes target_dir (zip-slip)."""
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+
+    malicious = tmp_path / "malicious.zip"
+    with zipfile.ZipFile(malicious, "w") as zf:
+        zf.writestr("../evil.txt", "pwned")
+
+    monkeypatch.setattr(
+        mlrun.utils.clones, "_prep_dir", lambda *args, **kwargs: str(malicious)
+    )
+
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        mlrun.utils.clones.clone_zip("dummy://source", str(target_dir))
+
+    assert not (tmp_path / "evil.txt").exists()
+    assert not malicious.exists()


### PR DESCRIPTION
### 📝 Description

`clone_tgz()` in `mlrun/utils/clones.py` downloads a `.tar.gz` from a (potentially untrusted)
`source` and extracts it with `tarfile.extractall()` and **no `filter=`**. A malicious archive
whose members use `../` or absolute paths can therefore write files **outside** `target_dir`
(tar-slip / path traversal, CWE-22 — the CVE-2007-4559 class).

mlrun already guards its other tar extractions with `filter="data"` — `_safe_extract_tar()` in
this same module and `_TarArchiver` in `mlrun/package/utils/_archiver.py`. `clone_tgz` was simply
missed, so this just makes it consistent with the rest of the codebase.

---

### 🛠️ Changes Made

- `mlrun/utils/clones.py`: add `filter="data"` to the `clone_tgz` extraction (matching
  `_safe_extract_tar()` / `_archiver.py`), with a short comment.
- `tests/utils/test_clones.py`: add `test_clone_tgz_blocks_tar_slip` — a regression test that a
  crafted `../evil.txt` member is rejected instead of escaping `target_dir`.

---

### ✅ Checklist
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests (unit-level; added a unit test)

---

### 🧪 Testing

- Added `test_clone_tgz_blocks_tar_slip` (unit): builds a `.tar.gz` whose member path is
  `../evil.txt`, points `clone_tgz` at it (patching the download), and asserts extraction raises
  `tarfile.TarError` (the `data` filter's `OutsideDestinationError`) and that nothing is written
  outside `target_dir`. It fails on the pre-fix code (the file escapes) and passes with the fix.
- `ruff check` and `ruff format --check` are clean on both files.

---

### 🔗 References
- CWE-22 (Improper Limitation of a Pathname to a Restricted Directory) / tar-slip
- Python `tarfile` extraction filters: https://docs.python.org/3/library/tarfile.html#extraction-filters
- `filter="data"` is available on the project's supported Python (`>=3.11`, backported to 3.11.4+)
  and is already used elsewhere in mlrun.

---

### 🚨 Breaking Changes?

- [ ] No. Benign archives extract exactly as before; only members that would escape `target_dir`
  are rejected (which also becomes the Python 3.14 default).
