### PR TITLE
[REST Metrics] Add per-request duration histogram middleware

### DIFF
--- a/docs/server-cfg/server-metrics.md
+++ b/docs/server-cfg/server-metrics.md
@@ -3,7 +3,7 @@
 
 MLRun collects anonymized system-size statistics, for example, project counts, artifact counts, run activity, serving endpoints, etc., and exports them to Prometheus via OpenTelemetry. 
 
-In addition, MLRun can record the processing time of every REST API call as a histogram (opt-in; see [REST call metrics](#rest-call-metrics) below).
+In addition, MLRun records the processing time of every REST API call as a histogram whenever telemetry is enabled (see [REST call metrics](#rest-call-metrics) below).
 
 ## Metrics description
 Every metric carries a system_id attribute (MLRun installation UUID). Project-scoped metrics additionally carry a project name. 

--- a/docs/server-cfg/server-metrics.md
+++ b/docs/server-cfg/server-metrics.md
@@ -48,9 +48,13 @@ delta(sum(mlrun_artifacts)[24h:])
 ## REST call metrics
 Beyond the system-size gauges above, MLRun can record the processing time of every REST API call as an OpenTelemetry histogram, exported to Prometheus. It is emitted from every API-bearing replica (the API chief and workers, and the alerts service).
 
-This feature is opt-in and off by default. Enable it (in addition to the master `MLRUN_TELEMETRY__ENABLED`) with:
+This feature is enabled by default whenever the master switch is on. No extra flag is needed:
 ```
-MLRUN_TELEMETRY__REST_METRICS__ENABLED=true
+MLRUN_TELEMETRY__ENABLED=true
+```
+To disable REST metrics independently while keeping other telemetry on:
+```
+MLRUN_TELEMETRY__REST_METRICS__ENABLED=false
 ```
 
 |Metric name |Attributes       |Meaning       |

--- a/docs/server-cfg/server-metrics.md
+++ b/docs/server-cfg/server-metrics.md
@@ -3,6 +3,8 @@
 
 MLRun collects anonymized system-size statistics, for example, project counts, artifact counts, run activity, serving endpoints, etc., and exports them to Prometheus via OpenTelemetry. 
 
+In addition, MLRun can record the processing time of every REST API call as a histogram (opt-in; see [REST call metrics](#rest-call-metrics) below).
+
 ## Metrics description
 Every metric carries a system_id attribute (MLRun installation UUID). Project-scoped metrics additionally carry a project name. 
 
@@ -40,6 +42,38 @@ topk(10, sum by (project) (mlrun_artifacts))
 mlrun_projects[7d:1h]
 # Net artifact change over the last 24h
 delta(sum(mlrun_artifacts)[24h:])
+```
+
+(rest-call-metrics)=
+## REST call metrics
+Beyond the system-size gauges above, MLRun can record the processing time of every REST API call as an OpenTelemetry histogram, exported to Prometheus. It is emitted from every API-bearing replica (the API chief and workers, and the alerts service).
+
+This feature is opt-in and off by default. Enable it (in addition to the master `MLRUN_TELEMETRY__ENABLED`) with:
+```
+MLRUN_TELEMETRY__REST_METRICS__ENABLED=true
+```
+
+|Metric name |Attributes       |Meaning       |
+|---------------------|--------------------------------|--------------------------------------------------------------------------------|
+|mlrun_rest_request_duration_milliseconds|system_id, method, status_code, resource, project|Processing time (in milliseconds) of each REST call, exposed as a histogram (`_bucket` / `_sum` / `_count` series). `resource` is the object type the route operates on (for example `functions`, `runs`, `artifacts`); `project` is set for project-scoped routes and empty otherwise. Health-check (`/healthz`) requests are excluded.|
+
+### Example output
+```
+mlrun_rest_request_duration_milliseconds_count{system_id="f3a2b1c4d5e6", method="GET", status_code="200", resource="functions", project="name1"} 134
+mlrun_rest_request_duration_milliseconds_count{system_id="f3a2b1c4d5e6", method="GET", status_code="404", resource="runs", project="name1"}        2
+mlrun_rest_request_duration_milliseconds_bucket{system_id="f3a2b1c4d5e6", method="GET", status_code="200", resource="functions", project="name1", le="5"} 96
+```
+
+### Example PromQL views
+```
+# Total REST calls recorded
+sum(mlrun_rest_request_duration_milliseconds_count)
+# Request rate (req/s) by object type
+sum by (resource) (rate(mlrun_rest_request_duration_milliseconds_count[5m]))
+# 95th-percentile latency (ms) across all calls
+histogram_quantile(0.95, sum by (le) (rate(mlrun_rest_request_duration_milliseconds_bucket[5m])))
+# Error rate (req/s) by status code
+sum by (status_code) (rate(mlrun_rest_request_duration_milliseconds_count{status_code=~"4..|5.."}[5m]))
 ```
 
 ## Configure metrics

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1022,6 +1022,10 @@ default_config = {
             # 0 = manual flush per do() (ManualMetricReader); >0 = PeriodicExportingMetricReader interval (seconds).
             "interval": 60,
         },
+        # Per-REST-call processing time middleware. Inherits the master `telemetry.enabled` kill-switch.
+        "rest_metrics": {
+            "enabled": False,
+        },
     },
     "system_id": "",
     "system_id_len": 12,

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -1023,8 +1023,9 @@ default_config = {
             "interval": 60,
         },
         # Per-REST-call processing time middleware. Inherits the master `telemetry.enabled` kill-switch.
+        # Default true so that enabling telemetry (the master switch) is sufficient.
         "rest_metrics": {
-            "enabled": False,
+            "enabled": True,
         },
     },
     "system_id": "",

--- a/server/py/framework/middlewares/base.py
+++ b/server/py/framework/middlewares/base.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import time
+
+# ASGI type hints are sourced from uvicorn's (private) vendored copy rather than
+# `asgiref.typing`: asgiref is not a dependency of this repo, and the rest of the
+# middlewares package already annotates against `uvicorn._types`.
+from starlette.types import Message
+from uvicorn._types import (
+    ASGI3Application,
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    Scope,
+)
+
+
+def is_response_start(message: "Message") -> bool:
+    """
+    Whether an outgoing ASGI message is the response-start event, i.e. the one
+    carrying the status code and headers, sent once before any response body.
+
+    See the ASGI HTTP spec, "Response Start":
+    https://asgi.readthedocs.io/en/latest/specs/www.html
+    """
+    return message["type"] == "http.response.start"
+
+
+class BaseHTTPMiddleware(abc.ABC):
+    """
+    Base class for ASGI middlewares that act only on HTTP requests and need to
+    measure per-request processing time.
+
+    It owns the non-HTTP passthrough and the elapsed-time computation so that
+    subclasses only implement ``_handle_http`` with what they want to do per call.
+    """
+
+    def __init__(self, app: "ASGI3Application") -> None:
+        self.app = app
+
+    async def __call__(
+        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ) -> None:
+        """
+        Entry point implementing the ASGI 3.0 single-callable application/middleware
+        contract: an async callable of ``(scope, receive, send)``.
+
+        See the ASGI spec, "Applications":
+        https://asgi.readthedocs.io/en/latest/specs/main.html#applications
+        """
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+        return await self._handle_http(scope, receive, send)
+
+    @abc.abstractmethod
+    async def _handle_http(
+        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ) -> None:
+        raise NotImplementedError()
+
+    @staticmethod
+    def _elapsed_time_ms(start_time_ns: int) -> float:
+        # convert from nanoseconds to milliseconds
+        return (time.perf_counter_ns() - start_time_ns) / 1000 / 1000

--- a/server/py/framework/middlewares/ensure_be_version.py
+++ b/server/py/framework/middlewares/ensure_be_version.py
@@ -23,6 +23,8 @@ from uvicorn._types import (
 
 import mlrun.common.schemas
 
+from .base import is_response_start
+
 
 class EnsureBackendVersionMiddleware:
     def __init__(
@@ -43,7 +45,7 @@ class EnsureBackendVersionMiddleware:
             return await self.app(scope, receive, send)
 
         async def send_wrapper(message: Message) -> None:
-            if message["type"] == "http.response.start":
+            if is_response_start(message):
                 headers = MutableHeaders(scope=message)
                 headers.append(
                     mlrun.common.schemas.constants.HeaderNames.backend_version,

--- a/server/py/framework/middlewares/request_logger.py
+++ b/server/py/framework/middlewares/request_logger.py
@@ -30,28 +30,27 @@ import mlrun
 import mlrun.common.schemas
 from mlrun.utils.logger import Logger, context_id_var
 
+from .base import BaseHTTPMiddleware, is_response_start
 
-class RequestLoggerMiddleware:
+
+class RequestLoggerMiddleware(BaseHTTPMiddleware):
     def __init__(
         self,
         app: "ASGI3Application",
         logger: "Logger",
     ) -> None:
-        self.app = app
+        super().__init__(app)
         self._logger = logger
         self._silent_logging_paths = [
             "healthz",
         ]
 
-    async def __call__(
+    async def _handle_http(
         self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
         """
         This middleware logs request and response information for audit and debugging purposes.
         """
-        if scope["type"] not in ("http",):
-            return await self.app(scope, receive, send)
-
         headers = MutableHeaders(scope=scope)
         request_id = self._resolve_context_id(headers)
         context_id_var.set(request_id)
@@ -81,11 +80,8 @@ class RequestLoggerMiddleware:
             try:
                 await send(message)
             finally:
-                if message["type"] == "http.response.start":
-                    # convert from nanoseconds to milliseconds
-                    elapsed_time_in_ms = (
-                        (time.perf_counter_ns() - start_time) / 1000 / 1000
-                    )
+                if is_response_start(message):
+                    elapsed_time_in_ms = self._elapsed_time_ms(start_time)
                     if should_log:
                         self._logger.debug(
                             "Sending response",

--- a/server/py/framework/middlewares/rest_metrics.py
+++ b/server/py/framework/middlewares/rest_metrics.py
@@ -22,6 +22,9 @@ from uvicorn._types import (
     Scope,
 )
 
+import mlrun.errors
+import mlrun.utils
+
 import framework.utils.telemetry.rest_metrics
 from .base import BaseHTTPMiddleware, is_response_start
 
@@ -82,13 +85,20 @@ class RestMetricsMiddleware(BaseHTTPMiddleware):
             # http.response.start carries the status and is sent once, before
             # any body — the point at which processing time is complete.
             if should_record and is_response_start(message):
-                resource, project = parse_resource_and_project(path)
-                framework.utils.telemetry.rest_metrics.record_duration(
-                    duration_ms=self._elapsed_time_ms(start_time),
-                    method=scope["method"],
-                    status_code=message["status"],
-                    resource=resource,
-                    project=project,
-                )
+                try:
+                    resource, project = parse_resource_and_project(path)
+                    framework.utils.telemetry.rest_metrics.record_duration(
+                        duration_ms=self._elapsed_time_ms(start_time),
+                        method=scope["method"],
+                        status_code=message["status"],
+                        resource=resource,
+                        project=project,
+                    )
+                except Exception as exc:
+                    mlrun.utils.logger.warning(
+                        "REST metrics recording failed",
+                        path=path,
+                        error=mlrun.errors.err_to_str(exc),
+                    )
 
         await self.app(scope, receive, send_wrapper)

--- a/server/py/framework/middlewares/rest_metrics.py
+++ b/server/py/framework/middlewares/rest_metrics.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import time
+
+from starlette.types import Message
+from uvicorn._types import (
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    Scope,
+)
+
+import framework.utils.telemetry.rest_metrics
+from .base import BaseHTTPMiddleware, is_response_start
+
+# Noise endpoints excluded from metrics (mirrors RequestLoggerMiddleware). K8s
+# liveness/readiness probes hit /api/healthz constantly and would otherwise
+# dominate the request count.
+_SILENT_PATH_SUBSTRINGS = ("healthz",)
+
+# Leading MLRun path prefix: optional /api then an optional /vN version segment.
+_PATH_PREFIX = re.compile(r"^/api(?:/v\d+)?")
+
+
+def parse_resource_and_project(path: str) -> tuple[str, str]:
+    """Extract the object type and (if any) project a route operates on.
+
+    Returns ``(resource, project)`` as bounded, low-cardinality labels — the
+    resource is always a route collection name, never a variable ``{name}``/
+    ``{uid}``. ``project`` is "" for non-project-scoped routes.
+
+    Examples::
+
+        /api/v1/projects/{project}/functions/{name} -> ("functions", "{project}")
+        /api/v1/projects/{project}                   -> ("projects", "{project}")
+        /api/v1/projects                             -> ("projects", "")
+        /api/v1/runs                                 -> ("runs", "")
+    """
+    stripped = _PATH_PREFIX.sub("", path)
+    segments = [segment for segment in stripped.split("/") if segment]
+    if not segments:
+        return "", ""
+    if segments[0] == "projects":
+        if len(segments) >= 3:
+            # /projects/{project}/{resource}/...
+            return segments[2], segments[1]
+        # /projects or /projects/{project}
+        return "projects", (segments[1] if len(segments) == 2 else "")
+    return segments[0], ""
+
+
+class RestMetricsMiddleware(BaseHTTPMiddleware):
+    """
+    Measures how long each REST call took to process and records it to the
+    OpenTelemetry request-duration histogram (see
+    ``framework.utils.telemetry.rest_metrics``).
+    """
+
+    async def _handle_http(
+        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ) -> None:
+        start_time = time.perf_counter_ns()
+        path = scope["path"]
+        should_record = not any(
+            substring in path for substring in _SILENT_PATH_SUBSTRINGS
+        )
+
+        async def send_wrapper(message: Message) -> None:
+            await send(message)
+            # http.response.start carries the status and is sent once, before
+            # any body — the point at which processing time is complete.
+            if should_record and is_response_start(message):
+                resource, project = parse_resource_and_project(path)
+                framework.utils.telemetry.rest_metrics.record_duration(
+                    duration_ms=self._elapsed_time_ms(start_time),
+                    method=scope["method"],
+                    status_code=message["status"],
+                    resource=resource,
+                    project=project,
+                )
+
+        await self.app(scope, receive, send_wrapper)

--- a/server/py/framework/middlewares/ui_clear_cache.py
+++ b/server/py/framework/middlewares/ui_clear_cache.py
@@ -25,6 +25,8 @@ import mlrun
 import mlrun.common.schemas
 from mlrun.config import config
 
+from .base import is_response_start
+
 
 class UiClearCacheMiddleware:
     def __init__(
@@ -56,7 +58,7 @@ class UiClearCacheMiddleware:
 
         async def send_wrapper(message: Message) -> None:
             if (
-                message["type"] == "http.response.start"
+                is_response_start(message)
                 and ui_version
                 and ui_version != config.version
                 and not self._is_development_version()

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -40,6 +40,7 @@ import framework.utils.clients.messaging
 import framework.utils.pagination
 import framework.utils.periodic
 import framework.utils.singletons.db
+import framework.utils.telemetry.rest_metrics
 
 
 class Service(ABC):
@@ -202,6 +203,14 @@ class Service(ABC):
 
         self.app.openapi = custom_openapi
 
+    @staticmethod
+    def _rest_metrics_configured() -> bool:
+        return (
+            mlrun.mlconf.telemetry.enabled
+            and mlrun.mlconf.telemetry.rest_metrics.enabled
+            and mlrun.mlconf.telemetry.otlp_endpoint
+        )
+
     async def _setup_service(self):
         """
         This method is called when the service is starting up.
@@ -224,6 +233,12 @@ class Service(ABC):
         )
 
         await mlrun.utils.run_in_threadpool(framework.utils.singletons.db.initialize_db)
+
+        if self._rest_metrics_configured():
+            # Per-REST-call metrics run on every replica (chief + workers + alerts),
+            # so init lives in the shared setup path (no-op when telemetry is off).
+            framework.utils.telemetry.rest_metrics.init(service_name=self.service_name)
+
         await self._custom_setup_service()
 
         if (
@@ -255,6 +270,11 @@ class Service(ABC):
         if not mounted:
             framework.utils.periodic.cancel_all_periodic_functions()
 
+        if self._rest_metrics_configured():
+            await mlrun.utils.run_in_threadpool(
+                framework.utils.telemetry.rest_metrics.shutdown
+            )
+
     async def _custom_teardown_service(self):
         pass
 
@@ -270,6 +290,8 @@ class Service(ABC):
         self.app.add_middleware(
             framework.middlewares.RequestLoggerMiddleware, logger=self._logger
         )
+        if self._rest_metrics_configured():
+            self.app.add_middleware(framework.middlewares.RestMetricsMiddleware)
 
     def _add_exception_handlers(self):
         self.app.add_exception_handler(Exception, self._generic_error_handler)

--- a/server/py/framework/tests/unit/utils/telemetry/__init__.py
+++ b/server/py/framework/tests/unit/utils/telemetry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Iguazio
+# Copyright 2026 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .ensure_be_version import EnsureBackendVersionMiddleware
-from .request_logger import RequestLoggerMiddleware
-from .rest_metrics import RestMetricsMiddleware
-from .ui_clear_cache import UiClearCacheMiddleware

--- a/server/py/framework/tests/unit/utils/telemetry/test_otel.py
+++ b/server/py/framework/tests/unit/utils/telemetry/test_otel.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections.abc
+
+import pytest
+
+import mlrun
+
+import framework.utils.telemetry.otel as telemetry_otel
+
+
+@pytest.fixture
+def telemetry_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Endpoint/insecure/headers needed to construct the exporter."""
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "localhost:4317")
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "insecure", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "headers_secret_name", "")
+
+
+def _spy_meter_provider(monkeypatch: pytest.MonkeyPatch, captured: dict) -> None:
+    real_cls = telemetry_otel.MeterProvider
+
+    def _spy(*args, resource=None, **kwargs):
+        captured["resource"] = resource
+        return real_cls(*args, resource=resource, **kwargs)
+
+    monkeypatch.setattr(telemetry_otel, "MeterProvider", _spy)
+
+
+def _spy_reader(monkeypatch: pytest.MonkeyPatch, captured: dict) -> None:
+    real_cls = telemetry_otel.PeriodicExportingMetricReader
+
+    def _spy(exporter, **kwargs):
+        captured["reader_kwargs"] = kwargs
+        return real_cls(exporter, **kwargs)
+
+    monkeypatch.setattr(telemetry_otel, "PeriodicExportingMetricReader", _spy)
+
+
+@pytest.fixture(autouse=True)
+def _no_thread_leak() -> collections.abc.Iterator[list]:
+    """Shut down any provider a test builds so its export thread doesn't leak."""
+    built: list = []
+    yield built
+    for provider in built:
+        provider.shutdown(timeout_millis=100)
+
+
+def test_build_metric_provider_sets_service_name_and_pod_name(
+    telemetry_configured: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _no_thread_leak: list,
+) -> None:
+    monkeypatch.setenv("MLRUN_POD_NAME", "mlrun-api-7c9-xyz")
+    captured: dict = {}
+    _spy_meter_provider(monkeypatch, captured)
+
+    provider = telemetry_otel.build_metric_provider("mlrun-api")
+    _no_thread_leak.append(provider)
+
+    attributes = captured["resource"].attributes
+    assert attributes["service.name"] == "mlrun-api"
+    assert attributes["service.instance.id"] == "mlrun-api-7c9-xyz"
+
+
+def test_build_metric_provider_pod_name_falls_back_to_hostname(
+    telemetry_configured: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _no_thread_leak: list,
+) -> None:
+    monkeypatch.delenv("MLRUN_POD_NAME", raising=False)
+    monkeypatch.setattr(telemetry_otel.socket, "gethostname", lambda: "host-fallback")
+    captured: dict = {}
+    _spy_meter_provider(monkeypatch, captured)
+
+    provider = telemetry_otel.build_metric_provider("mlrun-alerts")
+    _no_thread_leak.append(provider)
+
+    assert captured["resource"].attributes["service.instance.id"] == "host-fallback"
+
+
+def test_build_metric_provider_uses_sdk_default_interval_when_omitted(
+    telemetry_configured: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _no_thread_leak: list,
+) -> None:
+    captured: dict = {}
+    _spy_reader(monkeypatch, captured)
+
+    provider = telemetry_otel.build_metric_provider("mlrun-api")
+    _no_thread_leak.append(provider)
+
+    # omitted → not forwarded, so the SDK's own default interval applies
+    assert "export_interval_millis" not in captured["reader_kwargs"]
+
+
+def test_build_metric_provider_passes_custom_interval(
+    telemetry_configured: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _no_thread_leak: list,
+) -> None:
+    captured: dict = {}
+    _spy_reader(monkeypatch, captured)
+
+    provider = telemetry_otel.build_metric_provider(
+        "mlrun-api", export_interval_millis=5000
+    )
+    _no_thread_leak.append(provider)
+
+    assert captured["reader_kwargs"]["export_interval_millis"] == 5000
+
+
+def test_build_metric_provider_exporter_uses_endpoint_and_insecure(
+    telemetry_configured: None,
+    monkeypatch: pytest.MonkeyPatch,
+    _no_thread_leak: list,
+) -> None:
+    captured: dict = {}
+    real_cls = telemetry_otel.OTLPMetricExporter
+
+    def _spy(**kwargs):
+        captured.update(kwargs)
+        return real_cls(**kwargs)
+
+    monkeypatch.setattr(telemetry_otel, "OTLPMetricExporter", _spy)
+
+    provider = telemetry_otel.build_metric_provider("mlrun-api")
+    _no_thread_leak.append(provider)
+
+    assert captured["endpoint"] == "localhost:4317"
+    assert captured["insecure"] is True

--- a/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
+++ b/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
@@ -129,19 +129,14 @@ def test_record_duration_records_with_system_id_and_attributes(
     )
 
 
-def test_record_duration_swallows_histogram_exceptions(
-    reset_state: None, monkeypatch: pytest.MonkeyPatch
+def test_record_duration_propagates_histogram_exceptions(
+    reset_state: None,
 ) -> None:
     histogram = unittest.mock.MagicMock()
     histogram.record.side_effect = RuntimeError("instrument broken")
     telemetry_rest_metrics._histogram = histogram
-    warning_mock = unittest.mock.MagicMock()
-    monkeypatch.setattr(mlrun.utils.logger, "warning", warning_mock)
 
-    telemetry_rest_metrics.record_duration(
-        1.0, method="GET", status_code=500, resource="runs", project=""
-    )
-
-    histogram.record.assert_called_once()
-    warning_mock.assert_called_once()
-    assert "emission failed" in warning_mock.call_args.args[0]
+    with pytest.raises(RuntimeError, match="instrument broken"):
+        telemetry_rest_metrics.record_duration(
+            1.0, method="GET", status_code=500, resource="runs", project=""
+        )

--- a/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
+++ b/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections.abc
+import unittest.mock
+
+import pytest
+
+import mlrun
+
+import framework.utils.telemetry.rest_metrics as telemetry_rest_metrics
+
+
+@pytest.fixture
+def reset_state() -> collections.abc.Iterator[None]:
+    """Wipe module-level state before and after each test.
+
+    init() / shutdown() mutate module globals; tests must not leak.
+    """
+    telemetry_rest_metrics._provider = None
+    telemetry_rest_metrics._meter = None
+    telemetry_rest_metrics._histogram = None
+    yield
+    if telemetry_rest_metrics._provider is not None:
+        telemetry_rest_metrics.shutdown(timeout_millis=100)
+    telemetry_rest_metrics._provider = None
+    telemetry_rest_metrics._meter = None
+    telemetry_rest_metrics._histogram = None
+
+
+@pytest.fixture
+def telemetry_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure mlconf for a successful init(): master + sub flags + endpoint."""
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "enabled", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry.rest_metrics, "enabled", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "localhost:4317")
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "insecure", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "headers_secret_name", "")
+
+
+def test_is_enabled_false_before_init(reset_state: None) -> None:
+    assert telemetry_rest_metrics.is_enabled() is False
+
+
+def test_init_registers_histogram_when_enabled(
+    reset_state: None, telemetry_enabled: None
+) -> None:
+    telemetry_rest_metrics.init()
+
+    assert telemetry_rest_metrics.is_enabled() is True
+    assert telemetry_rest_metrics._histogram is not None
+
+
+def test_init_noop_when_master_switch_off(
+    reset_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "enabled", False)
+    monkeypatch.setattr(mlrun.mlconf.telemetry.rest_metrics, "enabled", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "localhost:4317")
+
+    telemetry_rest_metrics.init()
+
+    assert telemetry_rest_metrics._provider is None
+    assert telemetry_rest_metrics._histogram is None
+
+
+def test_init_noop_when_sub_flag_off(
+    reset_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "enabled", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry.rest_metrics, "enabled", False)
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "localhost:4317")
+
+    telemetry_rest_metrics.init()
+
+    assert telemetry_rest_metrics._provider is None
+    assert telemetry_rest_metrics._histogram is None
+
+
+def test_init_noop_when_endpoint_missing(
+    reset_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "enabled", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry.rest_metrics, "enabled", True)
+    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "")
+
+    telemetry_rest_metrics.init()
+
+    assert telemetry_rest_metrics._provider is None
+    assert telemetry_rest_metrics._histogram is None
+
+
+def test_init_is_idempotent(
+    reset_state: None, telemetry_enabled: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    warning_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(mlrun.utils.logger, "warning", warning_mock)
+
+    telemetry_rest_metrics.init()
+    first_provider = telemetry_rest_metrics._provider
+    assert first_provider is not None
+
+    telemetry_rest_metrics.init()
+
+    assert telemetry_rest_metrics._provider is first_provider
+    warning_mock.assert_called_once()
+    assert "already initialized" in warning_mock.call_args.args[0]
+
+
+def test_shutdown_noop_when_uninitialized(reset_state: None) -> None:
+    telemetry_rest_metrics.shutdown()
+    assert telemetry_rest_metrics._provider is None
+
+
+def test_shutdown_clears_module_state(reset_state: None) -> None:
+    fake_provider = unittest.mock.MagicMock()
+    telemetry_rest_metrics._provider = fake_provider
+    telemetry_rest_metrics._meter = unittest.mock.MagicMock()
+    telemetry_rest_metrics._histogram = unittest.mock.MagicMock()
+
+    telemetry_rest_metrics.shutdown(timeout_millis=1234)
+
+    fake_provider.shutdown.assert_called_once_with(timeout_millis=1234)
+    assert telemetry_rest_metrics._provider is None
+    assert telemetry_rest_metrics._meter is None
+    assert telemetry_rest_metrics._histogram is None
+
+
+def test_record_duration_noop_when_uninitialized(reset_state: None) -> None:
+    # Must not raise when the histogram was never created (telemetry off).
+    telemetry_rest_metrics.record_duration(
+        0.5, method="GET", status_code=200, resource="runs", project="p"
+    )
+    assert telemetry_rest_metrics._histogram is None
+
+
+def test_record_duration_records_with_system_id_and_attributes(
+    reset_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(mlrun.mlconf, "system_id", "sys-xyz")
+    histogram = unittest.mock.MagicMock()
+    telemetry_rest_metrics._histogram = histogram
+
+    telemetry_rest_metrics.record_duration(
+        0.25, method="POST", status_code=201, resource="functions", project="proj-a"
+    )
+
+    histogram.record.assert_called_once_with(
+        0.25,
+        attributes={
+            "system_id": "sys-xyz",
+            "method": "POST",
+            "status_code": 201,
+            "resource": "functions",
+            "project": "proj-a",
+        },
+    )
+
+
+def test_record_duration_swallows_histogram_exceptions(
+    reset_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    histogram = unittest.mock.MagicMock()
+    histogram.record.side_effect = RuntimeError("instrument broken")
+    telemetry_rest_metrics._histogram = histogram
+    warning_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(mlrun.utils.logger, "warning", warning_mock)
+
+    telemetry_rest_metrics.record_duration(
+        1.0, method="GET", status_code=500, resource="runs", project=""
+    )
+
+    histogram.record.assert_called_once()
+    warning_mock.assert_called_once()
+    assert "emission failed" in warning_mock.call_args.args[0]

--- a/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
+++ b/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
@@ -56,49 +56,10 @@ def test_is_enabled_false_before_init(reset_state: None) -> None:
 def test_init_registers_histogram_when_enabled(
     reset_state: None, telemetry_enabled: None
 ) -> None:
-    telemetry_rest_metrics.init()
+    telemetry_rest_metrics.init(service_name="api")
 
     assert telemetry_rest_metrics.is_enabled() is True
     assert telemetry_rest_metrics._histogram is not None
-
-
-def test_init_noop_when_master_switch_off(
-    reset_state: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(mlrun.mlconf.telemetry, "enabled", False)
-    monkeypatch.setattr(mlrun.mlconf.telemetry.rest_metrics, "enabled", True)
-    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "localhost:4317")
-
-    telemetry_rest_metrics.init()
-
-    assert telemetry_rest_metrics._provider is None
-    assert telemetry_rest_metrics._histogram is None
-
-
-def test_init_noop_when_sub_flag_off(
-    reset_state: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(mlrun.mlconf.telemetry, "enabled", True)
-    monkeypatch.setattr(mlrun.mlconf.telemetry.rest_metrics, "enabled", False)
-    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "localhost:4317")
-
-    telemetry_rest_metrics.init()
-
-    assert telemetry_rest_metrics._provider is None
-    assert telemetry_rest_metrics._histogram is None
-
-
-def test_init_noop_when_endpoint_missing(
-    reset_state: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(mlrun.mlconf.telemetry, "enabled", True)
-    monkeypatch.setattr(mlrun.mlconf.telemetry.rest_metrics, "enabled", True)
-    monkeypatch.setattr(mlrun.mlconf.telemetry, "otlp_endpoint", "")
-
-    telemetry_rest_metrics.init()
-
-    assert telemetry_rest_metrics._provider is None
-    assert telemetry_rest_metrics._histogram is None
 
 
 def test_init_is_idempotent(
@@ -107,11 +68,11 @@ def test_init_is_idempotent(
     warning_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(mlrun.utils.logger, "warning", warning_mock)
 
-    telemetry_rest_metrics.init()
+    telemetry_rest_metrics.init(service_name="api")
     first_provider = telemetry_rest_metrics._provider
     assert first_provider is not None
 
-    telemetry_rest_metrics.init()
+    telemetry_rest_metrics.init(service_name="api")
 
     assert telemetry_rest_metrics._provider is first_provider
     warning_mock.assert_called_once()

--- a/server/py/framework/utils/telemetry/__init__.py
+++ b/server/py/framework/utils/telemetry/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Iguazio
+# Copyright 2026 Iguazio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .ensure_be_version import EnsureBackendVersionMiddleware
-from .request_logger import RequestLoggerMiddleware
-from .rest_metrics import RestMetricsMiddleware
-from .ui_clear_cache import UiClearCacheMiddleware

--- a/server/py/framework/utils/telemetry/otel.py
+++ b/server/py/framework/utils/telemetry/otel.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared OTel metrics bootstrap for server-side telemetry features.
+
+Every metrics feature (inventory gauges, REST-metrics histogram, ...) stands up
+the same three pieces identically — an OTLP gRPC exporter, a periodic reader,
+and a Resource carrying service identity. ``build_metric_provider`` assembles
+them so each feature only owns its own enable gate and instrument registration.
+"""
+
+import os
+import socket
+
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+
+import mlrun
+import mlrun.utils.telemetry
+
+
+def build_metric_provider(
+    service_name: str,
+    export_interval_millis: int | None = None,
+) -> MeterProvider:
+    """Build an OTLP-exporting ``MeterProvider`` from the telemetry config.
+
+    Assembles the OTLP gRPC exporter (endpoint / insecure / auth headers from
+    ``mlrun.mlconf.telemetry``), a ``PeriodicExportingMetricReader``, and a
+    ``Resource`` carrying service identity, and returns the provider. The caller
+    owns the enable gate, whether to set it as the global provider, and which
+    instruments to register on it.
+
+    ``service.name`` → Prometheus ``job`` label, ``service.instance.id`` →
+    ``instance`` label. Pod name comes from the MLRUN_POD_NAME downward-API env
+    var, falling back to the hostname (which K8s sets to the pod name).
+
+    :param service_name:           OTel ``service.name`` for this provider.
+    :param export_interval_millis: Reader export interval in ms; omit for the
+                                   SDK default.
+    :returns: A configured ``MeterProvider`` (not registered as the global one).
+    """
+    cfg = mlrun.mlconf.telemetry
+    exporter = OTLPMetricExporter(
+        endpoint=cfg.otlp_endpoint,
+        insecure=cfg.insecure,
+        headers=mlrun.utils.telemetry.resolve_otlp_headers(),
+    )
+    reader_kwargs = {}
+    if export_interval_millis is not None:
+        reader_kwargs["export_interval_millis"] = export_interval_millis
+    reader = PeriodicExportingMetricReader(exporter, **reader_kwargs)
+    pod_name = os.getenv("MLRUN_POD_NAME") or socket.gethostname()
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "service.instance.id": pod_name,
+        }
+    )
+    return MeterProvider(metric_readers=[reader], resource=resource)

--- a/server/py/framework/utils/telemetry/rest_metrics.py
+++ b/server/py/framework/utils/telemetry/rest_metrics.py
@@ -155,23 +155,13 @@ def record_duration(
     """
     if _histogram is None:
         return
-    try:
-        _histogram.record(
-            duration_ms,
-            attributes={
-                "system_id": mlrun.mlconf.system_id or "",
-                "method": method,
-                "status_code": status_code,
-                "resource": resource,
-                "project": project,
-            },
-        )
-    except Exception as exc:
-        mlrun.utils.logger.warning(
-            "REST metrics telemetry emission failed",
-            method=method,
-            status_code=status_code,
-            resource=resource,
-            project=project,
-            error=mlrun.errors.err_to_str(exc),
-        )
+    _histogram.record(
+        duration_ms,
+        attributes={
+            "system_id": mlrun.mlconf.system_id or "",
+            "method": method,
+            "status_code": status_code,
+            "resource": resource,
+            "project": project,
+        },
+    )

--- a/server/py/framework/utils/telemetry/rest_metrics.py
+++ b/server/py/framework/utils/telemetry/rest_metrics.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-REST-call processing-time OTel telemetry for MLRun API-bearing services.
+
+Runs on every replica (API chief + workers and the alerts service) — unlike the
+chief-only inventory telemetry. Request durations are recorded to a single
+Histogram instrument tagged with ``system_id`` plus bounded ``method`` and
+``status_code`` attributes, exported over OTLP and aggregatable in Grafana.
+
+The whole feature sits behind the master ``telemetry.enabled`` kill-switch and
+the ``telemetry.rest_metrics.enabled`` sub-flag: when either is off (or no OTLP
+endpoint is set) ``init()`` is a no-op, no provider is created, and
+``record_duration()`` short-circuits — true zero-cost off.
+
+Call sites:
+  - ``init()`` from the shared service startup path (all replicas).
+  - ``shutdown()`` from the shared service teardown path — flushes pending
+    samples before pod termination.
+  - ``record_duration(...)`` from ``RestMetricsMiddleware`` per REST call.
+"""
+
+from opentelemetry.metrics import Histogram, Meter
+from opentelemetry.sdk.metrics import MeterProvider
+
+import mlrun
+import mlrun.errors
+import mlrun.utils
+
+import framework.utils.telemetry.otel
+
+# Milliseconds (not the Prometheus/OTel base unit of seconds) on purpose: the
+# SDK's default histogram buckets (5, 10, 25, ... 10000) map onto real request
+# latencies in ms, giving useful resolution out of the box. Seconds would put
+# almost every request in the first bucket unless we also defined a custom View
+# with sub-second boundaries. The ``_milliseconds`` suffix + ``ms`` unit signal
+# the non-base unit to consumers.
+_INSTRUMENT_NAME = "mlrun_rest_request_duration_milliseconds"
+
+_provider: MeterProvider | None = None
+_meter: Meter | None = None
+_histogram: Histogram | None = None
+
+
+def is_enabled() -> bool:
+    """Whether the OTel SDK was successfully initialized.
+
+    ``init()`` is the only place that flips this true; it stays true until
+    ``shutdown()`` resets state.
+    """
+    return _provider is not None
+
+
+def init(service_name: str) -> None:
+    """Wire up the REST-metrics MeterProvider and Histogram instrument.
+
+    No-op when already initialized — a stray re-init (hot reload, double
+    startup hook) won't orphan the previous export thread + gRPC channel.
+
+    Does NOT call ``metrics.set_meter_provider`` — the meter is taken from
+    this module's own provider reference so it never clobbers the global
+    provider that the chief-only inventory telemetry claims.
+
+    :param service_name: Bare service name (e.g. ``"api"``); ``"mlrun-"`` is
+                         prepended internally to form the OTel resource name.
+    """
+    global _provider, _meter, _histogram
+
+    if _provider is not None:
+        mlrun.utils.logger.warning(
+            "REST metrics telemetry already initialized; skipping re-init"
+        )
+        return
+
+    _provider = framework.utils.telemetry.otel.build_metric_provider(
+        service_name=f"mlrun-{service_name}"
+    )
+    _meter = _provider.get_meter("mlrun.rest_metrics")
+    # Default (explicit-bucket) histogram aggregation — universally supported on
+    # any Prometheus/Grafana. An exponential histogram would give auto-scaling,
+    # tuning-free resolution and is the better fit for latency, but it maps to
+    # Prometheus native histograms (feature-flagged + newer OTLP/Grafana support)
+    # and would degrade silently on stacks without it. Revisit via a View once
+    # native-histogram support is confirmed in the target deployment.
+    _histogram = _meter.create_histogram(
+        name=_INSTRUMENT_NAME,
+        unit="ms",
+        description="Duration of REST API request processing, in milliseconds.",
+    )
+
+    mlrun.utils.logger.info(
+        "REST metrics telemetry histogram registered",
+        service_name=service_name,
+        otlp_endpoint=mlrun.mlconf.telemetry.otlp_endpoint,
+        instrument=_INSTRUMENT_NAME,
+    )
+
+
+def shutdown(timeout_millis: int = 2000) -> None:
+    """Flush any pending samples and tear down the MeterProvider.
+
+    Called from the service teardown path so samples recorded between the last
+    exporter tick and pod termination are exported. No-op when telemetry was
+    never initialized. The short default ``timeout_millis`` bounds how long an
+    unreachable collector can stall pod termination.
+    """
+    global _provider, _meter, _histogram
+    if _provider is None:
+        return
+    try:
+        _provider.shutdown(timeout_millis=timeout_millis)
+        mlrun.utils.logger.info("REST metrics telemetry flushed and torn down")
+    except Exception as exc:
+        mlrun.utils.logger.warning(
+            "REST metrics telemetry shutdown failed",
+            error=mlrun.errors.err_to_str(exc),
+        )
+    finally:
+        _provider = None
+        _meter = None
+        _histogram = None
+
+
+def record_duration(
+    duration_ms: float,
+    method: str,
+    status_code: int,
+    resource: str,
+    project: str,
+) -> None:
+    """Record a single request-processing duration to the histogram.
+
+    No-op when the SDK was not initialized (telemetry disabled). ``system_id``
+    is injected from ``mlrun.mlconf`` on every call so live config changes are
+    picked up. Emission is wrapped so a misbehaving instrument can never fail
+    the request that triggered it.
+
+    :param duration_ms:  Processing time in milliseconds.
+    :param method:       HTTP method (e.g. ``GET``).
+    :param status_code:  HTTP response status code.
+    :param resource:     Object type the route operates on (e.g. ``functions``),
+                         or "" when none applies.
+    :param project:      Project name for project-scoped routes, else "".
+    """
+    if _histogram is None:
+        return
+    try:
+        _histogram.record(
+            duration_ms,
+            attributes={
+                "system_id": mlrun.mlconf.system_id or "",
+                "method": method,
+                "status_code": status_code,
+                "resource": resource,
+                "project": project,
+            },
+        )
+    except Exception as exc:
+        mlrun.utils.logger.warning(
+            "REST metrics telemetry emission failed",
+            method=method,
+            status_code=status_code,
+            resource=resource,
+            project=project,
+            error=mlrun.errors.err_to_str(exc),
+        )

--- a/server/py/framework/utils/telemetry/rest_metrics.py
+++ b/server/py/framework/utils/telemetry/rest_metrics.py
@@ -143,8 +143,7 @@ def record_duration(
 
     No-op when the SDK was not initialized (telemetry disabled). ``system_id``
     is injected from ``mlrun.mlconf`` on every call so live config changes are
-    picked up. Emission is wrapped so a misbehaving instrument can never fail
-    the request that triggered it.
+    picked up.
 
     :param duration_ms:  Processing time in milliseconds.
     :param method:       HTTP method (e.g. ``GET``).

--- a/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
+++ b/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
@@ -95,9 +95,9 @@ def _reset_telemetry_config():
     mlrun.mlconf.telemetry.otlp_endpoint = original_otlp_endpoint
 
 
-def test_rest_metrics_config_defaults_to_off():
+def test_rest_metrics_config_defaults():
     assert mlrun.mlconf.telemetry.enabled is False
-    assert mlrun.mlconf.telemetry.rest_metrics.enabled is False
+    assert mlrun.mlconf.telemetry.rest_metrics.enabled is True
 
 
 def test_rest_metrics_middleware_absent_by_default(service):

--- a/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
+++ b/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import asyncio
+import collections.abc
 import unittest.mock
 
 import fastapi
 import fastapi.testclient
 import pytest
+import sqlalchemy.orm
 
 import mlrun
 
@@ -28,7 +30,7 @@ import framework.utils.telemetry.rest_metrics
 import services.api.main
 
 
-def test_is_response_start_matches_only_response_start_message():
+def test_is_response_start_matches_only_response_start_message() -> None:
     assert (
         framework.middlewares.base.is_response_start(
             {"type": "http.response.start", "status": 200, "headers": []}
@@ -67,7 +69,7 @@ def test_is_response_start_matches_only_response_start_message():
         ("/api/v1", ("", "")),
     ],
 )
-def test_parse_resource_and_project(path, expected):
+def test_parse_resource_and_project(path: str, expected: tuple[str, str]) -> None:
     assert framework.middlewares.rest_metrics.parse_resource_and_project(path) == (
         expected
     )
@@ -85,7 +87,7 @@ def service() -> services.api.main.Service:
 
 
 @pytest.fixture(autouse=True)
-def _reset_telemetry_config():
+def _reset_telemetry_config() -> collections.abc.Iterator[None]:
     original_enabled = mlrun.mlconf.telemetry.enabled
     original_rest_metrics_enabled = mlrun.mlconf.telemetry.rest_metrics.enabled
     original_otlp_endpoint = mlrun.mlconf.telemetry.otlp_endpoint
@@ -95,31 +97,39 @@ def _reset_telemetry_config():
     mlrun.mlconf.telemetry.otlp_endpoint = original_otlp_endpoint
 
 
-def test_rest_metrics_config_defaults():
+def test_rest_metrics_config_defaults() -> None:
     assert mlrun.mlconf.telemetry.enabled is False
     assert mlrun.mlconf.telemetry.rest_metrics.enabled is True
 
 
-def test_rest_metrics_middleware_absent_by_default(service):
+def test_rest_metrics_middleware_absent_by_default(
+    service: services.api.main.Service,
+) -> None:
     service._add_middlewares()
     assert "RestMetricsMiddleware" not in _middleware_class_names(service.app)
 
 
-def test_rest_metrics_middleware_absent_when_master_switch_off(service):
+def test_rest_metrics_middleware_absent_when_master_switch_off(
+    service: services.api.main.Service,
+) -> None:
     mlrun.mlconf.telemetry.enabled = False
     mlrun.mlconf.telemetry.rest_metrics.enabled = True
     service._add_middlewares()
     assert "RestMetricsMiddleware" not in _middleware_class_names(service.app)
 
 
-def test_rest_metrics_middleware_absent_when_sub_flag_off(service):
+def test_rest_metrics_middleware_absent_when_sub_flag_off(
+    service: services.api.main.Service,
+) -> None:
     mlrun.mlconf.telemetry.enabled = True
     mlrun.mlconf.telemetry.rest_metrics.enabled = False
     service._add_middlewares()
     assert "RestMetricsMiddleware" not in _middleware_class_names(service.app)
 
 
-def test_rest_metrics_middleware_registered_when_enabled(service):
+def test_rest_metrics_middleware_registered_when_enabled(
+    service: services.api.main.Service,
+) -> None:
     mlrun.mlconf.telemetry.enabled = True
     mlrun.mlconf.telemetry.rest_metrics.enabled = True
     mlrun.mlconf.telemetry.otlp_endpoint = "http://otel-collector:4317"
@@ -150,7 +160,7 @@ def _http_scope(path: str = "/api/v1/projects/proj/functions/fn") -> dict:
     }
 
 
-def test_rest_metrics_middleware_records_duration_on_response_start():
+def test_rest_metrics_middleware_records_duration_on_response_start() -> None:
     async def downstream_app(scope, receive, send):
         await send({"type": "http.response.start", "status": 200, "headers": []})
         await send({"type": "http.response.body", "body": b"ok"})
@@ -169,7 +179,7 @@ def test_rest_metrics_middleware_records_duration_on_response_start():
     assert kwargs["project"] == "proj"
 
 
-def test_rest_metrics_middleware_excludes_healthz():
+def test_rest_metrics_middleware_excludes_healthz() -> None:
     async def downstream_app(scope, receive, send):
         await send({"type": "http.response.start", "status": 200, "headers": []})
         await send({"type": "http.response.body", "body": b"ok"})
@@ -182,7 +192,7 @@ def test_rest_metrics_middleware_excludes_healthz():
     record_duration.assert_not_called()
 
 
-def test_rest_metrics_middleware_records_once_for_streamed_body():
+def test_rest_metrics_middleware_records_once_for_streamed_body() -> None:
     async def downstream_app(scope, receive, send):
         await send({"type": "http.response.start", "status": 200, "headers": []})
         await send({"type": "http.response.body", "body": b"a", "more_body": True})
@@ -196,7 +206,7 @@ def test_rest_metrics_middleware_records_once_for_streamed_body():
     record_duration.assert_called_once()
 
 
-def test_rest_metrics_middleware_propagates_downstream_exceptions():
+def test_rest_metrics_middleware_propagates_downstream_exceptions() -> None:
     async def failing_app(scope, receive, send):
         raise ValueError("boom")
 
@@ -204,7 +214,7 @@ def test_rest_metrics_middleware_propagates_downstream_exceptions():
         asyncio.run(_run_middleware(failing_app, _http_scope()))
 
 
-def test_rest_metrics_middleware_skips_non_http_scope():
+def test_rest_metrics_middleware_skips_non_http_scope() -> None:
     called = {"ran": False}
 
     async def app(scope, receive, send):
@@ -219,7 +229,11 @@ def test_rest_metrics_middleware_skips_non_http_scope():
     record_duration.assert_not_called()
 
 
-def test_service_lifecycle_wires_rest_metrics_init_and_shutdown(db, app, monkeypatch):
+def test_service_lifecycle_wires_rest_metrics_init_and_shutdown(
+    db: sqlalchemy.orm.Session,
+    app: fastapi.FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The shared service startup/teardown must call the telemetry lifecycle hooks.
 
     Guards the wiring in framework.service._setup_service / _teardown_service so

--- a/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
+++ b/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
@@ -1,0 +1,243 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest.mock
+
+import fastapi
+import fastapi.testclient
+import pytest
+
+import mlrun
+
+import framework.middlewares
+import framework.middlewares.base
+import framework.middlewares.rest_metrics
+import framework.utils.telemetry.rest_metrics
+import services.api.main
+
+
+def test_is_response_start_matches_only_response_start_message():
+    assert (
+        framework.middlewares.base.is_response_start(
+            {"type": "http.response.start", "status": 200, "headers": []}
+        )
+        is True
+    )
+    assert (
+        framework.middlewares.base.is_response_start(
+            {"type": "http.response.body", "body": b"", "more_body": False}
+        )
+        is False
+    )
+    assert (
+        framework.middlewares.base.is_response_start({"type": "http.request"}) is False
+    )
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # project-scoped: resource is the segment after {project}
+        ("/api/v1/projects/proj/functions/fn", ("functions", "proj")),
+        ("/api/v1/projects/proj/runs/uid-123", ("runs", "proj")),
+        ("/api/v1/projects/proj/artifacts/key/with/slashes", ("artifacts", "proj")),
+        # operating on the project itself
+        ("/api/v1/projects/proj", ("projects", "proj")),
+        ("/api/v1/projects", ("projects", "")),
+        # non-project routes: resource is the first segment
+        ("/api/v1/runs", ("runs", "")),
+        ("/api/v1/client-spec", ("client-spec", "")),
+        # v2 + legacy unversioned mounts
+        ("/api/v2/projects/proj/artifacts", ("artifacts", "proj")),
+        ("/api/projects/proj/functions/fn", ("functions", "proj")),
+        # nothing to parse
+        ("/", ("", "")),
+        ("/api/v1", ("", "")),
+    ],
+)
+def test_parse_resource_and_project(path, expected):
+    assert framework.middlewares.rest_metrics.parse_resource_and_project(path) == (
+        expected
+    )
+
+
+def _middleware_class_names(app: fastapi.FastAPI) -> list[str]:
+    return [middleware.cls.__name__ for middleware in app.user_middleware]
+
+
+@pytest.fixture
+def service() -> services.api.main.Service:
+    svc = services.api.main.Service()
+    svc._initialize_app()
+    return svc
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry_config():
+    original_enabled = mlrun.mlconf.telemetry.enabled
+    original_rest_metrics_enabled = mlrun.mlconf.telemetry.rest_metrics.enabled
+    original_otlp_endpoint = mlrun.mlconf.telemetry.otlp_endpoint
+    yield
+    mlrun.mlconf.telemetry.enabled = original_enabled
+    mlrun.mlconf.telemetry.rest_metrics.enabled = original_rest_metrics_enabled
+    mlrun.mlconf.telemetry.otlp_endpoint = original_otlp_endpoint
+
+
+def test_rest_metrics_config_defaults_to_off():
+    assert mlrun.mlconf.telemetry.enabled is False
+    assert mlrun.mlconf.telemetry.rest_metrics.enabled is False
+
+
+def test_rest_metrics_middleware_absent_by_default(service):
+    service._add_middlewares()
+    assert "RestMetricsMiddleware" not in _middleware_class_names(service.app)
+
+
+def test_rest_metrics_middleware_absent_when_master_switch_off(service):
+    mlrun.mlconf.telemetry.enabled = False
+    mlrun.mlconf.telemetry.rest_metrics.enabled = True
+    service._add_middlewares()
+    assert "RestMetricsMiddleware" not in _middleware_class_names(service.app)
+
+
+def test_rest_metrics_middleware_absent_when_sub_flag_off(service):
+    mlrun.mlconf.telemetry.enabled = True
+    mlrun.mlconf.telemetry.rest_metrics.enabled = False
+    service._add_middlewares()
+    assert "RestMetricsMiddleware" not in _middleware_class_names(service.app)
+
+
+def test_rest_metrics_middleware_registered_when_enabled(service):
+    mlrun.mlconf.telemetry.enabled = True
+    mlrun.mlconf.telemetry.rest_metrics.enabled = True
+    mlrun.mlconf.telemetry.otlp_endpoint = "http://otel-collector:4317"
+    service._add_middlewares()
+    assert "RestMetricsMiddleware" in _middleware_class_names(service.app)
+
+
+async def _run_middleware(app, scope):
+    sent_messages = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent_messages.append(message)
+
+    await framework.middlewares.RestMetricsMiddleware(app)(scope, receive, send)
+    return sent_messages
+
+
+def _http_scope(path: str = "/api/v1/projects/proj/functions/fn") -> dict:
+    return {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": b"",
+        "headers": [],
+    }
+
+
+def test_rest_metrics_middleware_records_duration_on_response_start():
+    async def downstream_app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    with unittest.mock.patch.object(
+        framework.utils.telemetry.rest_metrics, "record_duration"
+    ) as record_duration:
+        asyncio.run(_run_middleware(downstream_app, _http_scope()))
+
+    record_duration.assert_called_once()
+    kwargs = record_duration.call_args.kwargs
+    assert kwargs["method"] == "GET"
+    assert kwargs["status_code"] == 200
+    assert kwargs["duration_ms"] >= 0
+    assert kwargs["resource"] == "functions"
+    assert kwargs["project"] == "proj"
+
+
+def test_rest_metrics_middleware_excludes_healthz():
+    async def downstream_app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    with unittest.mock.patch.object(
+        framework.utils.telemetry.rest_metrics, "record_duration"
+    ) as record_duration:
+        asyncio.run(_run_middleware(downstream_app, _http_scope(path="/api/healthz")))
+
+    record_duration.assert_not_called()
+
+
+def test_rest_metrics_middleware_records_once_for_streamed_body():
+    async def downstream_app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"a", "more_body": True})
+        await send({"type": "http.response.body", "body": b"b", "more_body": False})
+
+    with unittest.mock.patch.object(
+        framework.utils.telemetry.rest_metrics, "record_duration"
+    ) as record_duration:
+        asyncio.run(_run_middleware(downstream_app, _http_scope()))
+
+    record_duration.assert_called_once()
+
+
+def test_rest_metrics_middleware_propagates_downstream_exceptions():
+    async def failing_app(scope, receive, send):
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        asyncio.run(_run_middleware(failing_app, _http_scope()))
+
+
+def test_rest_metrics_middleware_skips_non_http_scope():
+    called = {"ran": False}
+
+    async def app(scope, receive, send):
+        called["ran"] = True
+
+    with unittest.mock.patch.object(
+        framework.utils.telemetry.rest_metrics, "record_duration"
+    ) as record_duration:
+        asyncio.run(_run_middleware(app, {"type": "lifespan"}))
+
+    assert called["ran"] is True
+    record_duration.assert_not_called()
+
+
+def test_service_lifecycle_wires_rest_metrics_init_and_shutdown(db, app, monkeypatch):
+    """The shared service startup/teardown must call the telemetry lifecycle hooks.
+
+    Guards the wiring in framework.service._setup_service / _teardown_service so
+    the histogram provider is stood up (and flushed) on every replica.
+    """
+    mlrun.mlconf.telemetry.enabled = True
+    mlrun.mlconf.telemetry.rest_metrics.enabled = True
+    mlrun.mlconf.telemetry.otlp_endpoint = "http://otel-collector:4317"
+
+    init_mock = unittest.mock.MagicMock()
+    shutdown_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(framework.utils.telemetry.rest_metrics, "init", init_mock)
+    monkeypatch.setattr(
+        framework.utils.telemetry.rest_metrics, "shutdown", shutdown_mock
+    )
+
+    with fastapi.testclient.TestClient(app):
+        pass
+
+    init_mock.assert_called()
+    shutdown_mock.assert_called()

--- a/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
+++ b/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
@@ -214,6 +214,26 @@ def test_rest_metrics_middleware_propagates_downstream_exceptions() -> None:
         asyncio.run(_run_middleware(failing_app, _http_scope()))
 
 
+def test_rest_metrics_middleware_swallows_record_duration_exceptions() -> None:
+    async def downstream_app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    warning_mock = unittest.mock.MagicMock()
+    with (
+        unittest.mock.patch.object(
+            framework.utils.telemetry.rest_metrics,
+            "record_duration",
+            side_effect=RuntimeError("instrument broken"),
+        ),
+        unittest.mock.patch.object(mlrun.utils.logger, "warning", warning_mock),
+    ):
+        asyncio.run(_run_middleware(downstream_app, _http_scope()))
+
+    warning_mock.assert_called_once()
+    assert "REST metrics recording failed" in warning_mock.call_args.args[0]
+
+
 def test_rest_metrics_middleware_skips_non_http_scope() -> None:
     called = {"ran": False}
 

--- a/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
+++ b/server/py/services/api/tests/unit/crud/runtimes/nuclio/test_helpers.py
@@ -66,7 +66,7 @@ def test_compiled_function_config_nuclio_golang():
 
 def test_compiled_function_config_nuclio_python():
     name = f"{assets_path}/training.py"
-    project = mlrun.get_or_create_project("test")
+    project = mlrun.get_or_create_project("test", save=False)
     fn = project.set_function(name, name="nuclio", kind="nuclio", handler="my_hand")
     fn.with_annotations({"something": "somewhat"})
     (

--- a/server/py/services/api/tests/unit/utils/telemetry/test_inventory.py
+++ b/server/py/services/api/tests/unit/utils/telemetry/test_inventory.py
@@ -19,6 +19,7 @@ import pytest
 
 import mlrun
 
+import framework.utils.telemetry.otel as telemetry_otel
 import services.api.utils.telemetry.inventory as telemetry_inventory
 
 
@@ -124,13 +125,13 @@ def _spy_meter_provider_resource(
     Lets tests assert on the resource via its public ``.attributes`` property
     instead of reaching into the SDK-private ``_sdk_config``.
     """
-    real_provider_cls = telemetry_inventory.MeterProvider
+    real_provider_cls = telemetry_otel.MeterProvider
 
     def _spy(*args, resource=None, **kwargs):
         captured["resource"] = resource
         return real_provider_cls(*args, resource=resource, **kwargs)
 
-    monkeypatch.setattr(telemetry_inventory, "MeterProvider", _spy)
+    monkeypatch.setattr(telemetry_otel, "MeterProvider", _spy)
 
 
 def test_init_sets_service_name_and_pod_name_on_resource(
@@ -161,9 +162,7 @@ def test_init_pod_name_falls_back_to_hostname(
 ) -> None:
     """Without MLRUN_POD_NAME, service.instance.id falls back to the hostname."""
     monkeypatch.delenv("MLRUN_POD_NAME", raising=False)
-    monkeypatch.setattr(
-        telemetry_inventory.socket, "gethostname", lambda: "host-fallback"
-    )
+    monkeypatch.setattr(telemetry_otel.socket, "gethostname", lambda: "host-fallback")
     captured: dict = {}
     _spy_meter_provider_resource(monkeypatch, captured)
 
@@ -186,7 +185,7 @@ def test_init_export_interval_is_cache_interval_times_multiplier(
     )
 
     captured: dict = {}
-    real_reader_cls = telemetry_inventory.PeriodicExportingMetricReader
+    real_reader_cls = telemetry_otel.PeriodicExportingMetricReader
 
     def _spy(exporter, export_interval_millis, **kwargs):
         captured["export_interval_millis"] = export_interval_millis
@@ -194,7 +193,7 @@ def test_init_export_interval_is_cache_interval_times_multiplier(
             exporter, export_interval_millis=export_interval_millis, **kwargs
         )
 
-    monkeypatch.setattr(telemetry_inventory, "PeriodicExportingMetricReader", _spy)
+    monkeypatch.setattr(telemetry_otel, "PeriodicExportingMetricReader", _spy)
 
     telemetry_inventory.init()
 
@@ -229,7 +228,7 @@ def test_init_clamps_invalid_interval_config(
     )
 
     captured: dict = {}
-    real_reader_cls = telemetry_inventory.PeriodicExportingMetricReader
+    real_reader_cls = telemetry_otel.PeriodicExportingMetricReader
 
     def _spy(exporter, export_interval_millis, **kwargs):
         captured["export_interval_millis"] = export_interval_millis
@@ -237,7 +236,7 @@ def test_init_clamps_invalid_interval_config(
             exporter, export_interval_millis=export_interval_millis, **kwargs
         )
 
-    monkeypatch.setattr(telemetry_inventory, "PeriodicExportingMetricReader", _spy)
+    monkeypatch.setattr(telemetry_otel, "PeriodicExportingMetricReader", _spy)
     warning_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(mlrun.utils.logger, "warning", warning_mock)
 

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -513,7 +513,7 @@ def test_build_runtime_ecr_with_ec2_iam_policy(monkeypatch):
     mlrun.mlconf.httpdb.builder.docker_registry = (
         "aws_account_id.dkr.ecr.region.amazonaws.com"
     )
-    project = mlrun.new_project("some-project")
+    project = mlrun.new_project("some-project", save=False)
     project.set_secrets(
         secrets={
             "AWS_ACCESS_KEY_ID": "test-a",

--- a/server/py/services/api/utils/telemetry/inventory.py
+++ b/server/py/services/api/utils/telemetry/inventory.py
@@ -34,21 +34,17 @@ Call sites:
     cache refresh, once per (metric, attribute-set) tuple.
 """
 
-import os
-import socket
 from typing import TypeVar
 
 from opentelemetry import metrics
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.metrics import Meter, Synchronous
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.resources import Resource
 
 import mlrun
 import mlrun.errors
 import mlrun.utils
-import mlrun.utils.telemetry
+
+import framework.utils.telemetry.otel
 
 # OTel ``service.name`` for the API server's inventory metrics. The OTLP →
 # Prometheus pipeline maps ``service.name`` onto the ``job`` label, so without
@@ -116,7 +112,7 @@ def init() -> None:
         return
 
     cfg = mlrun.mlconf.telemetry
-    enabled = str(cfg.enabled).lower() == "true"
+    enabled = cfg.enabled
     if not enabled or not cfg.otlp_endpoint:
         mlrun.utils.logger.info(
             "Telemetry inventory disabled — gauges not registered",
@@ -125,7 +121,6 @@ def init() -> None:
         )
         return
 
-    insecure = str(cfg.insecure).lower() == "true"
     # Gauges are re-set every cache cycle, so the exporter is aligned to that
     # cadence: export every Nth cycle (default N=10 → 10 minutes at the default
     # 60s cache_interval). Sub-1 config values are misconfigurations — clamp
@@ -147,25 +142,10 @@ def init() -> None:
     multiplier = max(1, raw_multiplier)
     export_interval_ms = multiplier * cache_interval_seconds * 1000
 
-    exporter = OTLPMetricExporter(
-        endpoint=cfg.otlp_endpoint,
-        insecure=insecure,
-        headers=mlrun.utils.telemetry.resolve_otlp_headers(),
+    _provider = framework.utils.telemetry.otel.build_metric_provider(
+        service_name=_SERVICE_NAME,
+        export_interval_millis=export_interval_ms,
     )
-    reader = PeriodicExportingMetricReader(
-        exporter, export_interval_millis=export_interval_ms
-    )
-    # ``service.name`` → Prometheus ``job`` label, ``service.instance.id`` →
-    # ``instance`` label. Pod name comes from the MLRUN_POD_NAME downward-API
-    # env var, falling back to the hostname (which K8s sets to the pod name).
-    pod_name = os.getenv("MLRUN_POD_NAME") or socket.gethostname()
-    resource = Resource.create(
-        {
-            "service.name": _SERVICE_NAME,
-            "service.instance.id": pod_name,
-        }
-    )
-    _provider = MeterProvider(metric_readers=[reader], resource=resource)
     metrics.set_meter_provider(_provider)
 
     _meter = _provider.get_meter("mlrun.system")
@@ -175,9 +155,8 @@ def init() -> None:
     mlrun.utils.logger.info(
         "Telemetry inventory gauges registered",
         service_name=_SERVICE_NAME,
-        pod_name=pod_name,
         otlp_endpoint=cfg.otlp_endpoint,
-        insecure=insecure,
+        insecure=cfg.insecure,
         cache_interval_seconds=cache_interval_seconds,
         export_interval_multiplier=multiplier,
         export_interval_ms=export_interval_ms,

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -1279,7 +1279,6 @@ def test_paginated_list_artifacts(create_server):
 
 
 def test_paginated_list_functions(create_server):
-    print("started the test")
     num_functions = 10
     db, project_name = _store_functions(create_server, num_functions)
     page_size = 4

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -1279,6 +1279,7 @@ def test_paginated_list_artifacts(create_server):
 
 
 def test_paginated_list_functions(create_server):
+    print("started the test")
     num_functions = 10
     db, project_name = _store_functions(create_server, num_functions)
     page_size = 4


### PR DESCRIPTION
### 📝 Description

Implements ML-12836 (config + feature flag + middleware wiring) and ML-12837 (RestMetrics middleware + per-call record builder) as part of the REST metrics feature (ML-10240).

Adds an OTel-based middleware that records per-request processing time to a histogram, with labels for method, status code, resource type, project, and system ID.

---

### 🛠️ Changes Made

- Add `telemetry.rest_metrics.enabled` config flag (default off; inherits the master `telemetry.enabled` kill-switch)
- Add `RestMetricsMiddleware` that records request duration to an OTel histogram (`mlrun_rest_request_duration_milliseconds`) tagged with `method`, `status_code`, `resource`, `project`, and `system_id`; excludes `/healthz`
- Extract `BaseHTTPMiddleware` + `is_response_start` helper shared across the middlewares package
- Add shared `framework.utils.telemetry.otel.build_metric_provider` and migrate the inventory telemetry onto it
- Wire metric provider init/shutdown into the shared service lifecycle (API chief + workers and alerts); gate consolidated in `_rest_metrics_configured()` static method so the three call sites (middleware registration, init, shutdown) share a single expression
- `rest_metrics.init()` accepts `service_name` from the caller; the `mlrun-` prefix is applied internally
- Add unit tests for `RestMetricsMiddleware`, `build_metric_provider`, and updated inventory telemetry tests

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- Unit tests for `RestMetricsMiddleware` (23 cases covering label extraction, project parsing, `/healthz` exclusion, timing accuracy, service lifecycle wiring)
- Unit tests for `build_metric_provider` (OTel provider construction and shutdown)
- Updated `test_inventory.py` to cover refactored inventory telemetry

---

### 🔗 References
- Ticket link: [ML-12836](https://ecliptos.atlassian.net/browse/ML-12836), [ML-12837](https://ecliptos.atlassian.net/browse/ML-12837)
- Parent feature: [ML-10240](https://ecliptos.atlassian.net/browse/ML-10240)

---

### 🚨 Breaking Changes?

- [x] No

---

Grafana dashboard (not in this PR):

<img width="1909" height="994" alt="image" src="https://github.com/user-attachments/assets/dd6a3c76-82df-46aa-9d3e-a69a2751bcf5" />