### PR TITLE
[Nuclio] Support `gs://`/`gcs://` source archives for Nuclio deploys

### DIFF
--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import json
 import os
 from pathlib import Path
@@ -24,6 +25,9 @@ import mlrun.errors
 from mlrun.utils import logger
 
 from .base import DataStore, FileStats, make_datastore_schema_sanitizer
+
+# Validity window for read-only signed URLs.
+_SIGNED_URL_TTL = datetime.timedelta(hours=2)
 
 # Google storage objects will be represented with the following URL: gcs://<bucket name>/<path> or gs://...
 
@@ -64,6 +68,42 @@ class GoogleCloudStorageStore(DataStore):
             raise ValueError(f"Unsupported token type: {type(token)}")
         self._storage_client = Client(credentials=credentials)
         return self._storage_client
+
+    def get_read_only_https_url(self, key, *, ttl=_SIGNED_URL_TTL):
+        """Return an ``https://`` URL for ``key`` with a short-lived read-only signed URL.
+
+        Requires service-account credentials (``GCP_CREDENTIALS`` or
+        ``GOOGLE_APPLICATION_CREDENTIALS``); V4 signing uses the private key to sign locally.
+        """
+        blob_name = key.lstrip("/")
+        bucket_name = self.endpoint
+        if not bucket_name or not blob_name:
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                f"could not resolve GCS bucket/blob for key {key!r}"
+            )
+
+        try:
+            blob = self.storage_client.bucket(bucket_name).blob(blob_name)
+        except Exception as exc:
+            # No usable signing credentials (e.g. relying on ADC / workload identity,
+            # which cannot sign locally) - surface as a client-side error.
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "GCS signed-URL generation requires service-account credentials "
+                "(GCP_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS): "
+                f"{mlrun.errors.err_to_str(exc)}"
+            ) from exc
+
+        try:
+            return blob.generate_signed_url(
+                version="v4",
+                expiration=ttl,
+                method="GET",
+            )
+        except Exception as exc:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"failed to create read-only GCS signed URL for {blob_name!r}: "
+                f"{mlrun.errors.err_to_str(exc)}"
+            ) from exc
 
     @property
     def filesystem(self):

--- a/mlrun/datastore/google_cloud_storage.py
+++ b/mlrun/datastore/google_cloud_storage.py
@@ -70,11 +70,7 @@ class GoogleCloudStorageStore(DataStore):
         return self._storage_client
 
     def get_read_only_https_url(self, key, *, ttl=_SIGNED_URL_TTL):
-        """Return an ``https://`` URL for ``key`` with a short-lived read-only signed URL.
-
-        Requires service-account credentials (``GCP_CREDENTIALS`` or
-        ``GOOGLE_APPLICATION_CREDENTIALS``); V4 signing uses the private key to sign locally.
-        """
+        """Return a short-lived GET signed URL for a GCS object."""
         blob_name = key.lstrip("/")
         bucket_name = self.endpoint
         if not bucket_name or not blob_name:
@@ -85,11 +81,9 @@ class GoogleCloudStorageStore(DataStore):
         try:
             blob = self.storage_client.bucket(bucket_name).blob(blob_name)
         except Exception as exc:
-            # No usable signing credentials (e.g. relying on ADC / workload identity,
-            # which cannot sign locally) - surface as a client-side error.
             raise mlrun.errors.MLRunInvalidArgumentError(
-                "GCS signed-URL generation requires service-account credentials "
-                "(GCP_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS): "
+                "GCS signed URLs require GCP_CREDENTIALS or "
+                "GOOGLE_APPLICATION_CREDENTIALS: "
                 f"{mlrun.errors.err_to_str(exc)}"
             ) from exc
 

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -272,8 +272,6 @@ def compile_nuclio_archive_config(
 
     source = function.spec.build.source
     parsed_url = urllib.parse.urlparse(source)
-    # Nuclio has no az://, gs:// or gcs:// code-entry type; rewrite these object-store
-    # sources as archive HTTPS via a datastore-minted read-only URL.
     is_object_store_source = source.startswith(("az://", "gs://", "gcs://"))
     code_entry_type = ""
     if source.startswith("s3://"):
@@ -302,8 +300,7 @@ def compile_nuclio_archive_config(
     # archive
     if code_entry_type == "archive":
         if is_object_store_source:
-            # Nuclio can't fetch az://, gs:// or gcs:// directly; use a datastore-minted
-            # read-only HTTPS URL (SAS for Azure, signed URL for GCS).
+            # Nuclio can't fetch these schemes natively; use a signed HTTPS URL.
             store, sub_path, _ = StoreManager().get_or_create_store(
                 source, secrets={**secrets, **(builder_env or {})}
             )

--- a/server/py/services/api/crud/runtimes/nuclio/helpers.py
+++ b/server/py/services/api/crud/runtimes/nuclio/helpers.py
@@ -272,8 +272,9 @@ def compile_nuclio_archive_config(
 
     source = function.spec.build.source
     parsed_url = urllib.parse.urlparse(source)
-    # Nuclio has no az:// code-entry type; rewrite Azure source as archive HTTPS.
-    is_azure_source = source.startswith("az://")
+    # Nuclio has no az://, gs:// or gcs:// code-entry type; rewrite these object-store
+    # sources as archive HTTPS via a datastore-minted read-only URL.
+    is_object_store_source = source.startswith(("az://", "gs://", "gcs://"))
     code_entry_type = ""
     if source.startswith("s3://"):
         code_entry_type = "s3"
@@ -282,7 +283,7 @@ def compile_nuclio_archive_config(
     for archive_prefix in ["http://", "https://", "v3io://", "v3ios://"]:
         if source.startswith(archive_prefix):
             code_entry_type = "archive"
-    if is_azure_source:
+    if is_object_store_source:
         code_entry_type = "archive"
 
     if code_entry_type == "":
@@ -300,8 +301,9 @@ def compile_nuclio_archive_config(
 
     # archive
     if code_entry_type == "archive":
-        if is_azure_source:
-            # Nuclio can't fetch az:// directly; use a datastore-minted read-only HTTPS+SAS URL.
+        if is_object_store_source:
+            # Nuclio can't fetch az://, gs:// or gcs:// directly; use a datastore-minted
+            # read-only HTTPS URL (SAS for Azure, signed URL for GCS).
             store, sub_path, _ = StoreManager().get_or_create_store(
                 source, secrets={**secrets, **(builder_env or {})}
             )

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1594,6 +1594,34 @@ class TestNuclioRuntime(TestRuntimeBase):
         mock_url.assert_called_once()
         assert mock_url.call_args.args[0].lstrip("/") == "projects/x/src.tar.gz"
 
+    @pytest.mark.parametrize("scheme", ["gs", "gcs"])
+    def test_load_function_with_source_archive_gcs(self, scheme):
+        """gs:///gcs:// sources resolve to a datastore-minted read-only HTTPS URL."""
+        fn = self._generate_runtime(self.runtime_kind)
+        fn.with_source_archive(
+            f"{scheme}://data/projects/x/src.tar.gz",
+            handler="main:handler",
+            workdir="wd",
+        )
+        minted = "https://storage.googleapis.com/data/projects/x/src.tar.gz?X-Goog-Signature=fake"
+        with unittest.mock.patch(
+            "mlrun.datastore.google_cloud_storage.GoogleCloudStorageStore.get_read_only_https_url",
+            return_value=minted,
+        ) as mock_url:
+            archive = get_archive_spec(fn, {"GCP_CREDENTIALS": "{}"})
+        assert archive == {
+            "spec": {
+                "handler": "main:handler",
+                "build": {
+                    "path": minted,
+                    "codeEntryType": "archive",
+                    "codeEntryAttributes": {"workDir": "wd"},
+                },
+            },
+        }
+        mock_url.assert_called_once()
+        assert mock_url.call_args.args[0].lstrip("/") == "projects/x/src.tar.gz"
+
     @pytest.mark.parametrize(
         "image_pull_secret_name,build_secret_name,default_image_pull_secret_name,"
         "default_build_secret_name,expected_secret_name",

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -1568,7 +1568,7 @@ class TestNuclioRuntime(TestRuntimeBase):
         }
 
     def test_load_function_with_source_archive_azure_blob(self):
-        """az:// sources resolve to a datastore-minted read-only HTTPS URL."""
+        """az:// sources resolve to HTTPS archive URLs."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(
             "az://data/projects/x/src.tar.gz", handler="main:handler", workdir="wd"
@@ -1596,7 +1596,7 @@ class TestNuclioRuntime(TestRuntimeBase):
 
     @pytest.mark.parametrize("scheme", ["gs", "gcs"])
     def test_load_function_with_source_archive_gcs(self, scheme):
-        """gs:///gcs:// sources resolve to a datastore-minted read-only HTTPS URL."""
+        """gs:// and gcs:// sources resolve to HTTPS archive URLs."""
         fn = self._generate_runtime(self.runtime_kind)
         fn.with_source_archive(
             f"{scheme}://data/projects/x/src.tar.gz",

--- a/tests/datastore/test_google_cloud_storage.py
+++ b/tests/datastore/test_google_cloud_storage.py
@@ -94,8 +94,7 @@ def test_read_only_url_signing_failure_wrapped():
 
 
 def test_read_only_url_missing_credentials_raises_client_error():
-    # No signing credentials resolvable -> storage_client raises; surface as a
-    # client-side MLRunInvalidArgumentError, not a raw ValueError or a 500.
+    # Missing signing credentials should be a client-side error.
     store = GoogleCloudStorageStore(
         parent="parent", schema="gcs", name="name", endpoint="data"
     )

--- a/tests/datastore/test_google_cloud_storage.py
+++ b/tests/datastore/test_google_cloud_storage.py
@@ -14,6 +14,9 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
+import mlrun.errors
 from mlrun.datastore.google_cloud_storage import GoogleCloudStorageStore
 
 
@@ -48,3 +51,54 @@ def test_get_storage_options():
         "token": {"token": {"key1": "value1", "key2": "value2"}},
         **use_listings_cache_dict,
     }
+
+
+def _store_with_mock_client(endpoint="data", signed_url="https://signed"):
+    store = GoogleCloudStorageStore(
+        parent="parent", schema="gcs", name="name", endpoint=endpoint
+    )
+    blob = MagicMock()
+    blob.generate_signed_url.return_value = signed_url
+    client = MagicMock()
+    client.bucket.return_value.blob.return_value = blob
+    store._storage_client = client
+    return store, client, blob
+
+
+def test_read_only_url_signs_blob():
+    store, client, blob = _store_with_mock_client()
+    url = store.get_read_only_https_url("/projects/x/src.tar.gz")
+    assert url == "https://signed"
+    client.bucket.assert_called_once_with("data")
+    client.bucket.return_value.blob.assert_called_once_with("projects/x/src.tar.gz")
+    kwargs = blob.generate_signed_url.call_args.kwargs
+    assert kwargs["version"] == "v4"
+    assert kwargs["method"] == "GET"
+
+
+def test_read_only_url_no_bucket_raises():
+    store, _, _ = _store_with_mock_client(endpoint="")
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        store.get_read_only_https_url("/src.tar.gz")
+
+
+def test_read_only_url_signing_failure_wrapped():
+    store, _, blob = _store_with_mock_client()
+    blob.generate_signed_url.side_effect = Exception("no signer")
+    with pytest.raises(
+        mlrun.errors.MLRunRuntimeError,
+        match="failed to create read-only GCS signed URL",
+    ) as exc_info:
+        store.get_read_only_https_url("/src.tar.gz")
+    assert "no signer" in str(exc_info.value)
+
+
+def test_read_only_url_missing_credentials_raises_client_error():
+    # No signing credentials resolvable -> storage_client raises; surface as a
+    # client-side MLRunInvalidArgumentError, not a raw ValueError or a 500.
+    store = GoogleCloudStorageStore(
+        parent="parent", schema="gcs", name="name", endpoint="data"
+    )
+    store._get_secret_or_env = MagicMock(return_value=None)
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="GCP_CREDENTIALS"):
+        store.get_read_only_https_url("/src.tar.gz")

--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -23,6 +23,7 @@ import dask.dataframe as dd
 import fsspec
 import pandas as pd
 import pytest
+import requests
 import yaml
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -451,3 +452,28 @@ class TestGoogleCloudStorage:
         not_exist_url = f"{self.run_dir_url}/not_exist_file.txt"
         data_item = mlrun.run.get_dataitem(not_exist_url)
         data_item.delete()
+
+    @pytest.mark.parametrize("setup_by", ["credentials_file", "serialized_json"])
+    def test_read_only_https_url(self, use_datastore_profile, setup_by):
+        # ML-12896: the read-only signed URL minted for Nuclio deploys must be a working,
+        # publicly-fetchable https:// URL. Verified against real GCS, not just mocked signing.
+        if use_datastore_profile:
+            pytest.skip(
+                "signed URL is minted from env/secret service-account credentials"
+            )
+        self.setup_mapping[setup_by](self, use_datastore_profile)
+        data_item = mlrun.run.get_dataitem(
+            self.object_url, secrets=self.storage_options
+        )
+        data_item.put(self.test_string)
+        try:
+            store, sub_path, _ = store_manager.get_or_create_store(
+                self.object_url, secrets=self.storage_options
+            )
+            signed_url = store.get_read_only_https_url(sub_path)
+            assert signed_url.startswith("https://")
+            response = requests.get(signed_url, timeout=60)
+            assert response.status_code == 200
+            assert response.text == self.test_string
+        finally:
+            data_item.delete()

--- a/tests/integration/google_cloud_storage/test_google_cloud_storage.py
+++ b/tests/integration/google_cloud_storage/test_google_cloud_storage.py
@@ -455,12 +455,9 @@ class TestGoogleCloudStorage:
 
     @pytest.mark.parametrize("setup_by", ["credentials_file", "serialized_json"])
     def test_read_only_https_url(self, use_datastore_profile, setup_by):
-        # ML-12896: the read-only signed URL minted for Nuclio deploys must be a working,
-        # publicly-fetchable https:// URL. Verified against real GCS, not just mocked signing.
+        # Verify against real GCS, not just mocked signing.
         if use_datastore_profile:
-            pytest.skip(
-                "signed URL is minted from env/secret service-account credentials"
-            )
+            pytest.skip("profile credentials are not covered here")
         self.setup_mapping[setup_by](self, use_datastore_profile)
         data_item = mlrun.run.get_dataitem(
             self.object_url, secrets=self.storage_options

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import tempfile
 
@@ -44,6 +45,16 @@ has_private_source = (
 )
 need_private_git = pytest.mark.skipif(
     not has_private_source, reason="env vars for private git repo not set"
+)
+
+# for object-store archive tests (ML-12896) set GCS_BUCKET_NAME and GOOGLE_APPLICATION_CREDENTIALS
+# (a service-account JSON path or its serialized content) in the system-test env file
+_test_env = tests.system.base.TestMLRunSystem._get_env_from_file()
+gcs_bucket = _test_env.get("GCS_BUCKET_NAME")
+gcs_credentials = _test_env.get("GOOGLE_APPLICATION_CREDENTIALS")
+need_gcs = pytest.mark.skipif(
+    not (gcs_bucket and gcs_credentials),
+    reason="GCS_BUCKET_NAME / GOOGLE_APPLICATION_CREDENTIALS env vars not set",
 )
 
 
@@ -216,6 +227,32 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
         mlrun.deploy_function(fn)
         resp = fn.invoke("")
         assert "tag=" in resp.decode()
+
+    @need_gcs
+    def test_nuclio_gcs_archive(self):
+        # ML-12896: Nuclio has no gs:///gcs:// code-entry type; deploy must resolve the
+        # object-store source to a datastore-minted read-only signed URL and fetch it.
+        try:
+            json.loads(gcs_credentials)
+            credentials_content = gcs_credentials
+        except (json.JSONDecodeError, TypeError):
+            with open(gcs_credentials) as credentials_file:
+                credentials_content = credentials_file.read()
+        secrets = {"GCP_CREDENTIALS": credentials_content}
+        # nuclio resolves the credentials from the function's project secrets at deploy time
+        self.project.set_secrets(secrets)
+
+        archive_url = f"gcs://{gcs_bucket}/{self.project_name}/source_archive.tar.gz"
+        mlrun.get_dataitem(archive_url, secrets=secrets).upload(
+            str(self.assets_path / "source_archive.tar.gz")
+        )
+
+        fn = self._new_function("nuclio", "gcs")
+        fn.metadata.project = self.project.name
+        fn.with_source_archive(archive_url, handler="rootfn:nuclio_handler")
+        mlrun.deploy_function(fn)
+        resp = fn.invoke("")
+        assert resp.decode() == "tag=main"
 
     def test_job_project(self):
         project = mlrun.new_project("git-proj-job1", user_project=True, overwrite=True)

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -47,8 +47,7 @@ need_private_git = pytest.mark.skipif(
     not has_private_source, reason="env vars for private git repo not set"
 )
 
-# for object-store archive tests (ML-12896) set GCS_BUCKET_NAME and GOOGLE_APPLICATION_CREDENTIALS
-# (a service-account JSON path or its serialized content) in the system-test env file
+# GCS archive tests need a bucket and service-account credentials.
 _test_env = tests.system.base.TestMLRunSystem._get_env_from_file()
 gcs_bucket = _test_env.get("GCS_BUCKET_NAME")
 gcs_credentials = _test_env.get("GOOGLE_APPLICATION_CREDENTIALS")
@@ -230,8 +229,6 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
 
     @need_gcs
     def test_nuclio_gcs_archive(self):
-        # ML-12896: Nuclio has no gs:///gcs:// code-entry type; deploy must resolve the
-        # object-store source to a datastore-minted read-only signed URL and fetch it.
         try:
             json.loads(gcs_credentials)
             credentials_content = gcs_credentials
@@ -239,7 +236,6 @@ class TestArchiveSources(tests.system.base.TestMLRunSystem):
             with open(gcs_credentials) as credentials_file:
                 credentials_content = credentials_file.read()
         secrets = {"GCP_CREDENTIALS": credentials_content}
-        # nuclio resolves the credentials from the function's project secrets at deploy time
         self.project.set_secrets(secrets)
 
         archive_url = f"gcs://{gcs_bucket}/{self.project_name}/source_archive.tar.gz"


### PR DESCRIPTION
### 📝 Description

Fixes Nuclio deploys from Google Cloud Storage source archives (`gs://...` / `gcs://...`), which previously failed with `Couldn't resolve code entry type from source`.

Nuclio has no native code-entry type for object-store schemes. Mirroring the earlier `az://` fix (ML-12764), the source is now treated as an `archive` and rewritten to a short-lived, read-only HTTPS URL so Nuclio can fetch it without native GCS support. URL generation reuses the store's existing credential resolution, so deploy-time auth matches mlrun job reads.

---

### 🛠️ Changes Made

- Recognize `gs://`/`gcs://` as `archive` sources in Nuclio archive compilation (generalized the existing `az://` handling to a shared object-store path).
- Added `GoogleCloudStorageStore.get_read_only_https_url()`, returning a short-lived read-only V4 signed URL. Requires service-account credentials (`GCP_CREDENTIALS` / `GOOGLE_APPLICATION_CREDENTIALS`), which sign the URL locally; missing/unusable credentials raise a client-side `MLRunInvalidArgumentError`, and signing failures wrap as `MLRunRuntimeError`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- Unit: datastore layer (`get_read_only_https_url`: signing, missing bucket, wrapped signing failure) and a Nuclio-layer test asserting `gs://`/`gcs://` resolve to an `archive` whose path is the store-minted URL.
- Integration (`tests/integration/google_cloud_storage`): passed against real GCS — `get_read_only_https_url` mints a working, fetchable `https://` signed URL (HTTP 200, content matches).
- System (`tests/system/runtimes/test_archives.py::test_nuclio_gcs_archive`): added end-to-end Nuclio deploy from a `gcs://` source archive. Verified against a live cluster: without the fix the deploy fails with `Couldn't resolve code entry type from source`; with the fix the `gcs://` source resolves and Nuclio fetches the archive.

---

### 🔗 References
- Ticket link: ML-12896
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The signed URL lands in `spec.build.path` (read-only, ~2h TTL) — same trade-off as the `az://` SAS URL.