### PR TITLE
[Datastore] Fix empty partitioned parquet read from stale listing cache 

### DIFF
--- a/mlrun/datastore/base.py
+++ b/mlrun/datastore/base.py
@@ -220,6 +220,9 @@ class DataStore(BaseRemoteClient):
             paths.append(current_path.rstrip("/"))
             return
 
+        # Invalidating here guarantees each level is listed fresh
+        filesystem.invalidate_cache(current_path)
+
         directories = filesystem.ls(current_path, detail=True)
         if len(directories) == 0:
             return


### PR DESCRIPTION
### 📝 Description
Fixes a bug where reading partitioned parquet returns an empty result even though the data exists in storage. That occurs when we use fsspec based storage filesystem that caches directory listings in memory. As a result, in a long-running system that uses time-based partitioning, a partition directory created by another process, might not be reflected in the cached listing of the reader process. This was a regression introduced by the partition discovery optimization.


---

### 🛠️ Changes Made
- Invalidate the fsspec directory-listing cache at each level of the partition-discovery walk before listing it, so partition directories created by other processes are always visible.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Reproduced against a live monitoring app pod: with a stale cached listing the read returns 0 rows (`MLRunEmptySampleDFError`); with the fix the same stale-cache read returns the data.
- Confirmed the fix preserves partition read-pruning (only in-window partitions are read).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12827
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The fix adds only a small per-read directory-listing cost (a few `ls` calls forced to hit storage).