### PR TITLE
[Builder] Add rootless Buildah backend and BasePod security context

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -568,10 +568,10 @@ default_config = {
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",
         "builder": {
-            # the container-image build engine used for kubernetes-based function builds. "kaniko" is the
-            # default and currently the only implemented backend; additional backends (e.g. buildah) are
-            # selected here without code changes once available. see BuilderBackend in
-            # services/api/utils/builder.py.
+            # the container-image build engine used for kubernetes-based function builds. "kaniko" (default)
+            # and "buildah" are implemented; the engine is selected here without code changes. see
+            # BuilderBackend in services/api/utils/builder/. buildah is opt-in and, until its follow-ups land,
+            # transparently falls back to kaniko for inputs it can't handle yet (see resolve_builder_backend).
             "builder_backend": "kaniko",
             # setting the docker registry to be used for built images, can include the repository as well, e.g.
             # index.docker.io/<username>, if not included repository will default to mlrun
@@ -603,6 +603,20 @@ default_config = {
             "kaniko_image_fs_extraction_retries": "3",
             # kaniko sometimes fails to push image to registry due to network issues
             "kaniko_image_push_retry": "3",
+            # buildah builder image (used when builder_backend="buildah"). the stock image is used as-is:
+            # it ships subuid/subgid for its "build" user (uid 1000), which is all the rootless build needs.
+            "buildah_image": "quay.io/buildah/stable",
+            # buildah storage driver, "overlay" (default, fast, shares layers) or "vfs" (slower, works
+            # anywhere). not auto-negotiated - buildah errors if the configured driver can't mount.
+            "buildah_storage_driver": "overlay",
+            # AppArmor profile for the buildah build container, applied via the
+            # container.apparmor.security.beta.kubernetes.io annotation. "unconfined" (default) is required
+            # wherever the runtime enforces its default profile (e.g. GKE/AKS) - that profile blocks the
+            # mount/unshare syscalls the rootless build needs; it is a harmless no-op where AppArmor is not
+            # loaded. "" skips the annotation; "localhost/<profile>" selects a site-provided profile.
+            "buildah_apparmor_profile": "unconfined",
+            # buildah retries a failed image push this many times (maps to `buildah push --retry`)
+            "buildah_push_retry": "3",
             # additional docker build args in json encoded base64 format
             "build_args": "",
             # labels to be applied to builder pods - json string base64 encoded format.

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -2045,6 +2045,8 @@ class BasePod:
         default_pod_spec_attributes=None,
         resources=None,
         labels=None,
+        security_context=None,
+        env=None,
     ):
         self.namespace = namespace
         self.name = ""
@@ -2054,8 +2056,12 @@ class BasePod:
         self.args = args
         self._volumes = []
         self._mounts = []
-        self.env = None
+        self.env = env
         self.node_selector = None
+        # optional container-level security context (e.g. the rootless build pod's runAsUser +
+        # capabilities). None (the default) leaves the container security context unset, so pods
+        # that don't pass one are byte-for-byte unchanged.
+        self.security_context = security_context
         self.project = project
         self._labels = {
             mlrun_constants.MLRunInternalLabels.task_name: task_name,
@@ -2170,6 +2176,7 @@ class BasePod:
             args=self.args,
             volume_mounts=self._mounts,
             resources=self.resources,
+            security_context=self.security_context,
         )
 
         pod_spec = client.V1PodSpec(

--- a/server/py/framework/utils/singletons/k8s.py
+++ b/server/py/framework/utils/singletons/k8s.py
@@ -2033,6 +2033,10 @@ class K8sHelper(mlsecrets.SecretProviderInterface):
 
 
 class BasePod:
+    # the single build-pod container's name. Exposed as a constant so callers that key resources off
+    # it (e.g. the per-container AppArmor annotation) share one source of truth and can't drift.
+    container_name = "base"
+
     def __init__(
         self,
         task_name="",
@@ -2169,7 +2173,7 @@ class BasePod:
         else:
             env = self.env
         container = client.V1Container(
-            name="base",
+            name=self.container_name,
             image=self.image,
             env=env,
             command=self.command,

--- a/server/py/services/api/tests/unit/utils/test_builder.py
+++ b/server/py/services/api/tests/unit/utils/test_builder.py
@@ -1612,7 +1612,7 @@ def test_matching_args_dockerfile_and_kpod(builder_env, source, extra_args):
         extra_args=extra_args,
     )
     with unittest.mock.patch(
-        "services.api.utils.builder.kaniko.get_kaniko_spec_attributes_from_runtime",
+        "services.api.utils.builder.base.resolve_build_pod_spec_attributes",
         return_value={},
     ):
         kpod = services.api.utils.builder.kaniko.make_kaniko_pod(

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -246,10 +246,15 @@ def test_make_buildah_pod_invalid_storage_driver_raises(monkeypatch):
 )
 def test_make_buildah_pod_apparmor_annotation(monkeypatch, profile, expected):
     monkeypatch.setattr(config.httpdb.builder, "buildah_apparmor_profile", profile)
-    annotations = _make_buildah_pod().pod.metadata.annotations or {}
-    key = "container.apparmor.security.beta.kubernetes.io/base"
+    pod = _make_buildah_pod().pod
+    annotations = pod.metadata.annotations or {}
+    prefix = "container.apparmor.security.beta.kubernetes.io"
+    # the annotation must be keyed to the *actual* build container's name, otherwise k8s silently
+    # ignores it (stale key -> default profile stays enforced -> GKE/AKS build fails with no clue).
+    key = f"{prefix}/{pod.spec.containers[0].name}"
     if expected is None:
-        assert key not in annotations
+        # unset -> no apparmor annotation under any key
+        assert not any(k.startswith(f"{prefix}/") for k in annotations)
     else:
         assert annotations[key] == expected
 

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -14,13 +14,14 @@
 
 # Tests for the pluggable builder seam (ML-12884): the BuilderBackend selection
 # gate and the BuildRequest contract. The behaviour of the Kaniko path itself is
-# the byte-identical regression anchor covered by test_builder.py; here we only
-# lock the *new* seam. Buildah / config-flip / force-kaniko selection is exercised
-# when the second backend lands (ML-12885), so it is intentionally not tested here.
+# the byte-identical regression anchor covered by test_builder.py; here we lock the
+# seam, and (ML-12885) the Buildah backend: config-flip selection, the transparent
+# Kaniko fallback for inputs Buildah can't handle yet, and the rootless pod spec.
 
 import unittest.mock
 
 import pytest
+from kubernetes import client
 
 import mlrun
 import mlrun.common.schemas
@@ -30,6 +31,7 @@ from mlrun.runtimes import RuntimeKinds
 
 import framework.utils.singletons.k8s
 import services.api.utils.builder
+import services.api.utils.builder.buildah
 
 
 def test_resolve_builder_backend_default_is_kaniko():
@@ -138,3 +140,212 @@ def _make_build_request(**overrides) -> services.api.utils.builder.BuildRequest:
     )
     defaults.update(overrides)
     return services.api.utils.builder.BuildRequest(**defaults)
+
+
+# --- Buildah backend (ML-12885) ------------------------------------------------------------------
+
+
+def test_resolve_builder_backend_buildah_selected(monkeypatch):
+    # a buildah-configured cluster with a plain-registry, no-source build routes to the Buildah adapter
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    backend = services.api.utils.builder.resolve_builder_backend(
+        _make_build_request(image_target="registry.example.com/some-image:tag")
+    )
+    assert isinstance(backend, services.api.utils.builder.BuildahBackend)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "123456789012.dkr.ecr.us-east-1.amazonaws.com/some-image:tag",  # ECR
+        "myregistry.azurecr.io/some-image:tag",  # ACR
+        "us-docker.pkg.dev/proj/repo/some-image:tag",  # GAR
+    ],
+)
+def test_resolve_builder_backend_buildah_falls_back_for_cloud_registry(
+    monkeypatch, target
+):
+    # cloud registries need credential-helper auth not yet on Buildah (ML-12886) -> fall back to Kaniko
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    backend = services.api.utils.builder.resolve_builder_backend(
+        _make_build_request(image_target=target, registry=None)
+    )
+    assert isinstance(backend, services.api.utils.builder.KanikoBackend)
+
+
+def test_resolve_builder_backend_buildah_falls_back_for_source(monkeypatch):
+    # a source needing acquisition is not on Buildah yet (ML-12887) -> fall back to Kaniko
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    backend = services.api.utils.builder.resolve_builder_backend(
+        _make_build_request(source="git://github.com/some-org/some-repo.git#main")
+    )
+    assert isinstance(backend, services.api.utils.builder.KanikoBackend)
+
+
+def test_resolve_builder_backend_buildah_keeps_inline_code_with_source(monkeypatch):
+    # inline_code doesn't stage a build-context source (Kaniko uses /empty too), so Buildah keeps it
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    backend = services.api.utils.builder.resolve_builder_backend(
+        _make_build_request(
+            source="git://github.com/some-org/some-repo.git#main",
+            inline_code="print('hi')",
+        )
+    )
+    assert isinstance(backend, services.api.utils.builder.BuildahBackend)
+
+
+def test_buildah_backend_rejects_unacquirable_source():
+    # the source guard in resolve_builder_backend should route this to Kaniko; if the adapter is
+    # somehow reached with an unacquirable source it must fail fast, not silently drop the source
+    request = _make_build_request(source="git://github.com/some-org/some-repo.git#main")
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="ML-12887"):
+        services.api.utils.builder.BuildahBackend().make_build_pod(request)
+
+
+def test_make_buildah_pod_security_context_is_caps_rootless():
+    # the caps rootless model (POC-1): non-root uid 1000 + SETUID/SETGID + allowPrivilegeEscalation,
+    # never privileged. The hostUsers model was dropped, so host_users is never set on the pod.
+    security_context = _make_buildah_pod().pod.spec.containers[0].security_context
+    assert security_context.run_as_user == 1000
+    assert security_context.run_as_group == 1000
+    assert security_context.run_as_non_root is True
+    assert security_context.allow_privilege_escalation is True
+    assert security_context.privileged is False
+    assert security_context.capabilities.add == ["SETUID", "SETGID"]
+
+
+def test_make_buildah_pod_never_sets_host_users():
+    # caps-only: the hostUsers rootless model was dropped (POC-1 showed it non-viable)
+    assert getattr(_make_buildah_pod().pod.spec, "host_users", None) is None
+
+
+@pytest.mark.parametrize("driver", ["overlay", "vfs"])
+def test_make_buildah_pod_storage_driver_and_isolation(monkeypatch, driver):
+    monkeypatch.setattr(config.httpdb.builder, "buildah_storage_driver", driver)
+    buildah_pod = _make_buildah_pod()
+    container = buildah_pod.pod.spec.containers[0]
+    assert f"--storage-driver {driver}" in container.args[0]
+    env = {env_var.name: env_var.value for env_var in container.env}
+    assert env["BUILDAH_ISOLATION"] == "chroot"
+    assert env["HOME"] == "/home/build"
+
+
+def test_make_buildah_pod_invalid_storage_driver_raises(monkeypatch):
+    monkeypatch.setattr(config.httpdb.builder, "buildah_storage_driver", "devicemapper")
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="devicemapper"):
+        _make_buildah_pod()
+
+
+@pytest.mark.parametrize(
+    "profile,expected",
+    [
+        ("unconfined", "unconfined"),
+        ("localhost/buildah", "localhost/buildah"),
+        ("", None),
+    ],
+)
+def test_make_buildah_pod_apparmor_annotation(monkeypatch, profile, expected):
+    monkeypatch.setattr(config.httpdb.builder, "buildah_apparmor_profile", profile)
+    annotations = _make_buildah_pod().pod.metadata.annotations or {}
+    key = "container.apparmor.security.beta.kubernetes.io/base"
+    if expected is None:
+        assert key not in annotations
+    else:
+        assert annotations[key] == expected
+
+
+def test_make_buildah_pod_bud_and_push_args(monkeypatch):
+    monkeypatch.setattr(config.httpdb.builder, "insecure_push_registry_mode", "enabled")
+    monkeypatch.setattr(config.httpdb.builder, "insecure_pull_registry_mode", "enabled")
+    monkeypatch.setattr(config.httpdb.builder, "buildah_push_retry", "5")
+    script = _make_buildah_pod(verbose=True).pod.spec.containers[0].args[0]
+    assert "buildah" in script and "bud" in script and "push" in script
+    assert "--tls-verify=false" in script
+    assert "--retry 5" in script
+    assert "--log-level debug" in script
+    assert "docker://docker-hub/some-image:tag" in script
+
+
+def test_make_buildah_pod_tls_verify_disabled(monkeypatch):
+    monkeypatch.setattr(
+        config.httpdb.builder, "insecure_push_registry_mode", "disabled"
+    )
+    monkeypatch.setattr(
+        config.httpdb.builder, "insecure_pull_registry_mode", "disabled"
+    )
+    script = _make_buildah_pod().pod.spec.containers[0].args[0]
+    assert "--tls-verify=false" not in script
+
+
+def test_make_buildah_pod_authfile_when_secret():
+    buildah_pod = _make_buildah_pod(secret_name="my-docker-secret")
+    container = buildah_pod.pod.spec.containers[0]
+    assert "--authfile /auth/config.json" in container.args[0]
+    env = {env_var.name: env_var.value for env_var in container.env}
+    assert env["REGISTRY_AUTH_FILE"] == "/auth/config.json"
+    mounted_secrets = {
+        volume.secret.secret_name
+        for volume in buildah_pod.pod.spec.volumes
+        if volume.secret
+    }
+    assert "my-docker-secret" in mounted_secrets
+
+
+def test_make_buildah_pod_stages_inline_code_and_requirements():
+    container = _make_buildah_pod(
+        inline_code="print('hi')",
+        inline_path="handler.py",
+        requirements=["pandas==2.0.0"],
+        requirements_path="/empty/requirements.txt",
+    ).pod.spec.containers[0]
+    env_names = {env_var.name for env_var in container.env}
+    assert {"MLRUN_DOCKERFILE", "MLRUN_INLINE_CODE", "MLRUN_REQUIREMENTS"} <= env_names
+    assert "/empty/handler.py" in container.args[0]
+    assert "/empty/requirements.txt" in container.args[0]
+
+
+def test_make_buildah_pod_renders_build_args():
+    container = _make_buildah_pod(
+        builder_env=[client.V1EnvVar(name="ARG1", value="v1")],
+        project_secrets=[client.V1EnvVar(name="SECRET1", value="s1")],
+    ).pod.spec.containers[0]
+    # build-args are referenced by name in the script; values are read from the pod env
+    assert "--build-arg ARG1" in container.args[0]
+    assert "--build-arg SECRET1" in container.args[0]
+    assert {"ARG1", "SECRET1"} <= {env_var.name for env_var in container.env}
+
+
+def test_base_pod_security_context_and_env_are_optional():
+    # absent by default -> container security context / env unset (the Kaniko byte-identity anchor)
+    pod = framework.utils.singletons.k8s.BasePod(
+        task_name="t", image="img", default_pod_spec_attributes={}
+    ).pod
+    assert pod.spec.containers[0].security_context is None
+    assert pod.spec.containers[0].env is None
+    # when provided, they land on the container
+    pod = framework.utils.singletons.k8s.BasePod(
+        task_name="t",
+        image="img",
+        default_pod_spec_attributes={},
+        security_context=client.V1SecurityContext(run_as_user=1000),
+        env=[client.V1EnvVar(name="K", value="V")],
+    ).pod
+    assert pod.spec.containers[0].security_context.run_as_user == 1000
+    assert pod.spec.containers[0].env[0].name == "K"
+
+
+def _make_buildah_pod(**overrides) -> framework.utils.singletons.k8s.BasePod:
+    """Build a Buildah pod with a real runtime spec; override only what a test cares about."""
+    with unittest.mock.patch(
+        "framework.api.utils.resolve_project_service_account_details",
+        return_value=(None, None, None),
+    ):
+        function = mlrun.new_function("test", "test", kind=RuntimeKinds.job)
+        defaults = dict(
+            project="test",
+            dest="docker-hub/some-image:tag",
+            dockerfile="FROM alpine:3.20\n",
+            runtime_spec=function.spec,
+        )
+        defaults.update(overrides)
+        return services.api.utils.builder.buildah.make_buildah_pod(**defaults)

--- a/server/py/services/api/utils/builder/__init__.py
+++ b/server/py/services/api/utils/builder/__init__.py
@@ -201,57 +201,6 @@ def resolve_builder_backend(request: BuildRequest) -> BuilderBackend:
     return backend_class()
 
 
-def _buildah_fallback_reason(request: BuildRequest) -> str | None:
-    """Return why a Buildah build must fall back to Kaniko, or ``None`` if Buildah can handle it.
-
-    Each guard is temporary — it exists only until its follow-up ships the missing capability, and
-    should be removed when that ticket merges.
-
-    :param request: The resolved build request.
-    :return: A human-readable fallback reason, or ``None`` when Buildah can build the request.
-    """
-    # (1) Cloud-registry credential-helper auth -> ML-12886. The Buildah adapter authenticates only
-    #     via a mounted static docker-config secret; ECR/ACR/GAR workload-identity credential
-    #     exchange is wired in ML-12886. Remove this guard when ML-12886 merges.
-    #     (The registry host is a plain hostname - safe to log; the source below is not, see below.)
-    target = request.registry or request.image_target or ""
-    if _is_cloud_registry(target):
-        return (
-            f"target registry '{target}' requires credential-helper auth not yet supported "
-            "on Buildah (ML-12886)"
-        )
-
-    # (2) Source acquisition -> ML-12887. The adapter builds only the no-source-context case;
-    #     fetching or mounting a source into the build context (local path, v3io, remote scheme) is
-    #     added in ML-12887. inline_code and load_source_on_run don't stage a build-context source,
-    #     so they stay on Buildah. Remove this guard when ML-12887 merges.
-    #     Only the scheme is put in the reason - a source URI can embed credentials
-    #     (e.g. https://<token>@github.com/...), which must never be logged.
-    loads_source_on_run = bool(
-        request.runtime_spec and request.runtime_spec.build.load_source_on_run
-    )
-    if request.source and not (request.inline_code or loads_source_on_run):
-        source_scheme = urlparse(request.source).scheme or "local"
-        return (
-            f"source (scheme '{source_scheme}') requires acquisition not yet supported "
-            "on Buildah (ML-12887)"
-        )
-
-    return None
-
-
-def _is_cloud_registry(target: str) -> bool:
-    # cloud registries whose auth needs a credential-helper token exchange (ML-12886).
-    if not target:
-        return False
-    if mlrun.utils.helpers.is_ecr_url(target):
-        return True
-    # ACR (Azure) and Artifact Registry / GCR (Google).
-    return any(
-        marker in target for marker in (".azurecr.io", "-docker.pkg.dev", "gcr.io")
-    )
-
-
 def build_runtime(
     auth_info: mlrun.common.schemas.AuthInfo,
     runtime: mlrun.runtimes.BaseRuntime,
@@ -391,3 +340,54 @@ def build_runtime(
     runtime.spec.image = local + build.image
     runtime.status.state = mlrun.common.schemas.FunctionState.ready
     return True
+
+
+def _buildah_fallback_reason(request: BuildRequest) -> str | None:
+    """Return why a Buildah build must fall back to Kaniko, or ``None`` if Buildah can handle it.
+
+    Each guard is temporary — it exists only until its follow-up ships the missing capability, and
+    should be removed when that ticket merges.
+
+    :param request: The resolved build request.
+    :return: A human-readable fallback reason, or ``None`` when Buildah can build the request.
+    """
+    # (1) Cloud-registry credential-helper auth -> ML-12886. The Buildah adapter authenticates only
+    #     via a mounted static docker-config secret; ECR/ACR/GAR workload-identity credential
+    #     exchange is wired in ML-12886. Remove this guard when ML-12886 merges.
+    #     (The registry host is a plain hostname - safe to log; the source below is not, see below.)
+    target = request.registry or request.image_target or ""
+    if _is_cloud_registry(target):
+        return (
+            f"target registry '{target}' requires credential-helper auth not yet supported "
+            "on Buildah (ML-12886)"
+        )
+
+    # (2) Source acquisition -> ML-12887. The adapter builds only the no-source-context case;
+    #     fetching or mounting a source into the build context (local path, v3io, remote scheme) is
+    #     added in ML-12887. inline_code and load_source_on_run don't stage a build-context source,
+    #     so they stay on Buildah. Remove this guard when ML-12887 merges.
+    #     Only the scheme is put in the reason - a source URI can embed credentials
+    #     (e.g. https://<token>@github.com/...), which must never be logged.
+    loads_source_on_run = bool(
+        request.runtime_spec and request.runtime_spec.build.load_source_on_run
+    )
+    if request.source and not (request.inline_code or loads_source_on_run):
+        source_scheme = urlparse(request.source).scheme or "local"
+        return (
+            f"source (scheme '{source_scheme}') requires acquisition not yet supported "
+            "on Buildah (ML-12887)"
+        )
+
+    return None
+
+
+def _is_cloud_registry(target: str) -> bool:
+    # cloud registries whose auth needs a credential-helper token exchange (ML-12886).
+    if not target:
+        return False
+    if mlrun.utils.helpers.is_ecr_url(target):
+        return True
+    # ACR (Azure) and Artifact Registry / GCR (Google).
+    return any(
+        marker in target for marker in (".azurecr.io", "-docker.pkg.dev", "gcr.io")
+    )

--- a/server/py/services/api/utils/builder/__init__.py
+++ b/server/py/services/api/utils/builder/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from base64 import b64decode
+from urllib.parse import urlparse
 
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
@@ -36,6 +37,7 @@ from services.api.utils.builder.base import (
     resolve_image_target,
     resolve_mlrun_install_command_version,
 )
+from services.api.utils.builder.buildah import BuildahBackend
 from services.api.utils.builder.kaniko import KanikoBackend
 
 
@@ -160,19 +162,20 @@ def build_image(
 def resolve_builder_backend(request: BuildRequest) -> BuilderBackend:
     """Return the builder backend to use for a build request.
 
-    By default this is the engine named in ``httpdb.builder.builder_backend``. The
-    whole ``request`` is accepted so a future backend can add a narrow,
-    request-derived override (e.g. force Kaniko for a specific target registry)
-    without changing this signature; no such override exists yet.
+    By default this is the engine named in ``httpdb.builder.builder_backend``. The whole
+    ``request`` is accepted so the choice can vary per build: when Buildah is configured but the
+    request needs a capability the Buildah adapter doesn't ship yet, this transparently falls back
+    to Kaniko (see :func:`_buildah_fallback_reason`).
 
     :param request: The resolved build request.
     :return: The builder backend instance for this build.
     :raises mlrun.errors.MLRunInvalidArgumentError: If the configured backend is unknown.
     """
-    # keyed by the httpdb.builder.builder_backend config value; buildah and future
-    # engines register here without touching the shared path.
+    # keyed by the httpdb.builder.builder_backend config value; future engines register here
+    # without touching the shared path.
     backends: dict[str, type[BuilderBackend]] = {
         "kaniko": KanikoBackend,
+        "buildah": BuildahBackend,
     }
     backend_name = config.httpdb.builder.builder_backend
     backend_class = backends.get(backend_name)
@@ -181,7 +184,72 @@ def resolve_builder_backend(request: BuildRequest) -> BuilderBackend:
             f"Unsupported builder backend '{backend_name}'. "
             f"Supported backends: {', '.join(sorted(backends))}"
         )
+
+    # Buildah is opt-in and, as of ML-12885, ships the rootless build pod but not yet the full
+    # runnable path. Fall back to Kaniko for the inputs it can't handle yet so a buildah-configured
+    # cluster never emits a pod that can't build or push.
+    if backend_class is BuildahBackend:
+        fallback_reason = _buildah_fallback_reason(request)
+        if fallback_reason:
+            mlrun.utils.logger.info(
+                "Builder backend falling back to Kaniko for an unsupported build",
+                requested_backend=backend_name,
+                reason=fallback_reason,
+            )
+            return KanikoBackend()
+
     return backend_class()
+
+
+def _buildah_fallback_reason(request: BuildRequest) -> str | None:
+    """Return why a Buildah build must fall back to Kaniko, or ``None`` if Buildah can handle it.
+
+    Each guard is temporary — it exists only until its follow-up ships the missing capability, and
+    should be removed when that ticket merges.
+
+    :param request: The resolved build request.
+    :return: A human-readable fallback reason, or ``None`` when Buildah can build the request.
+    """
+    # (1) Cloud-registry credential-helper auth -> ML-12886. The Buildah adapter authenticates only
+    #     via a mounted static docker-config secret; ECR/ACR/GAR workload-identity credential
+    #     exchange is wired in ML-12886. Remove this guard when ML-12886 merges.
+    #     (The registry host is a plain hostname - safe to log; the source below is not, see below.)
+    target = request.registry or request.image_target or ""
+    if _is_cloud_registry(target):
+        return (
+            f"target registry '{target}' requires credential-helper auth not yet supported "
+            "on Buildah (ML-12886)"
+        )
+
+    # (2) Source acquisition -> ML-12887. The adapter builds only the no-source-context case;
+    #     fetching or mounting a source into the build context (local path, v3io, remote scheme) is
+    #     added in ML-12887. inline_code and load_source_on_run don't stage a build-context source,
+    #     so they stay on Buildah. Remove this guard when ML-12887 merges.
+    #     Only the scheme is put in the reason - a source URI can embed credentials
+    #     (e.g. https://<token>@github.com/...), which must never be logged.
+    loads_source_on_run = bool(
+        request.runtime_spec and request.runtime_spec.build.load_source_on_run
+    )
+    if request.source and not (request.inline_code or loads_source_on_run):
+        source_scheme = urlparse(request.source).scheme or "local"
+        return (
+            f"source (scheme '{source_scheme}') requires acquisition not yet supported "
+            "on Buildah (ML-12887)"
+        )
+
+    return None
+
+
+def _is_cloud_registry(target: str) -> bool:
+    # cloud registries whose auth needs a credential-helper token exchange (ML-12886).
+    if not target:
+        return False
+    if mlrun.utils.helpers.is_ecr_url(target):
+        return True
+    # ACR (Azure) and Artifact Registry / GCR (Google).
+    return any(
+        marker in target for marker in (".azurecr.io", "-docker.pkg.dev", "gcr.io")
+    )
 
 
 def build_runtime(

--- a/server/py/services/api/utils/builder/base.py
+++ b/server/py/services/api/utils/builder/base.py
@@ -358,6 +358,62 @@ def make_dockerfile(
     return dock
 
 
+def build_pod_resources(runtime_spec) -> dict:
+    """Resolve the build-pod resource policy shared by every builder backend.
+
+    Requests-only + GPU-limit-zero, in one place so it can't drift between engines:
+
+    * Only **requests** are set. Requests affect scheduling; setting a limit could kill the
+      build mid-run (destructive), so the build pod is never given a limit for cpu/memory.
+    * A **zero GPU limit** is added when the function requests GPUs. Some cloud providers add a
+      toleration only when a GPU limit is present; without it a build pod that inherited a
+      GPU-related node selector from the function could stay pending. Zero keeps the toleration
+      applied while allocating no GPU.
+
+    :param runtime_spec: The function's runtime spec (for its resource limits), or ``None``.
+    :return: A resources dict with ``requests`` (and ``limits`` only when GPUs are requested).
+    """
+    # we cannot specify gpu requests without specifying gpu limits, so we set requests without gpu field
+    default_requests = config.get_default_function_pod_requirement_resources(
+        "requests", with_gpu=False
+    )
+    resources = {
+        "requests": mlrun.runtimes.utils.generate_resources(
+            mem=default_requests.get("memory"), cpu=default_requests.get("cpu")
+        )
+    }
+    if runtime_spec:
+        gpu_resources = mlrun.utils.get_enriched_gpu_limits(
+            runtime_spec.resources.get("limits", {})
+        )
+        if gpu_resources:
+            resources["limits"] = gpu_resources
+    return resources
+
+
+def resolve_builder_pod_labels(extra_labels: dict | None) -> dict:
+    """Merge the configured builder-pod labels under the caller's labels.
+
+    Shared by every builder backend so the precedence can't drift between engines. The
+    configured ``pod_labels`` (e.g. ``azure.workload.identity/use``, which lets the Azure
+    workload-identity webhook inject ACR push credentials) are the lowest-precedence layer:
+    MLRun's own internal labels (``mlrun/class``, ``mlrun/project``, ...) must never be clobbered
+    by them, so they are filtered out and the caller's ``extra_labels`` win on any conflict.
+
+    :param extra_labels: The backend/caller labels, which take precedence.
+    :return: The merged label dict for the build pod.
+    """
+    configured_pod_labels = {
+        key: value
+        for key, value in config.get_builder_pod_labels().items()
+        if key not in mlrun.common.constants.MLRunInternalLabels.all()
+    }
+    return mlrun.utils.helpers.merge_dicts_with_precedence(
+        configured_pod_labels,
+        extra_labels or {},
+    )
+
+
 def _generate_builder_env(
     project: str, builder_env: dict
 ) -> (list[client.V1EnvVar], list[client.V1EnvVar]):

--- a/server/py/services/api/utils/builder/base.py
+++ b/server/py/services/api/utils/builder/base.py
@@ -31,6 +31,7 @@ import mlrun.runtimes.pod
 import mlrun.runtimes.utils
 import mlrun.utils
 from mlrun.config import config
+from mlrun.k8s_utils import enrich_preemption_mode
 from mlrun.utils.helpers import remove_image_protocol_prefix
 
 import framework.utils.helpers
@@ -412,6 +413,97 @@ def resolve_builder_pod_labels(extra_labels: dict | None) -> dict:
         configured_pod_labels,
         extra_labels or {},
     )
+
+
+def resolve_build_pod_spec_attributes(
+    project: str,
+    runtime_spec,
+    project_default_function_node_selector,
+    auth_info: mlrun.common.schemas.AuthInfo | None = None,
+) -> dict:
+    """Resolve the runtime-derived pod-spec attributes shared by every builder backend.
+
+    Reads the function's runtime spec and returns the pod-spec attributes the build pod should
+    carry - node name/selector, affinity, tolerations, priority class and service account - applying
+    the same preemption-mode enrichment and service-account resolution a regular function pod gets.
+    Engine-agnostic: both Kaniko and Buildah apply the result via
+    ``BasePod.default_pod_spec_attributes``, so scheduling/identity can't drift between engines.
+
+    :param project:            The project the build belongs to.
+    :param runtime_spec:       The function's runtime spec.
+    :param project_default_function_node_selector: Project-level default node selector.
+    :param auth_info:          The caller's auth info (for service-account resolution).
+    :return: The resolved pod-spec attributes (only non-empty values).
+    """
+    # preemption mode scheduling constraints cache
+    _preemption_enrichment_result = {}
+
+    def service_account_handler(attr_value):
+        from framework.api.utils import resolve_project_service_account_details
+
+        (
+            allowed_service_accounts,
+            forbidden_service_accounts,
+            default_service_account,
+        ) = resolve_project_service_account_details(project, auth_info=auth_info)
+        if attr_value:
+            runtime_spec.validate_service_account(
+                allowed_service_accounts, forbidden_service_accounts
+            )
+        else:
+            attr_value = default_service_account
+        return attr_value
+
+    def get_merged_node_selector(attr_value):
+        return mlrun.utils.to_non_empty_values_dict(
+            mlrun.utils.helpers.merge_dicts_with_precedence(
+                mlrun.mlconf.get_default_function_node_selector(),
+                project_default_function_node_selector,
+                attr_value,
+            )
+        )
+
+    def preemption_mode_handler(key):
+        if key not in _preemption_enrichment_result:
+            keys = ["node_selector", "tolerations", "affinity"]
+            values = enrich_preemption_mode(
+                preemption_mode=runtime_spec.preemption_mode,
+                node_selector=get_merged_node_selector(runtime_spec.node_selector),
+                affinity=runtime_spec.affinity,
+                tolerations=runtime_spec.tolerations,
+            )
+            _preemption_enrichment_result.update(dict(zip(keys, values)))
+        return _preemption_enrichment_result[key]
+
+    def node_selector_handler(attr_value):
+        return preemption_mode_handler("node_selector")
+
+    def affinity_handler(attr_value):
+        return preemption_mode_handler("affinity")
+
+    def tolerations_handler(attr_value):
+        return preemption_mode_handler("tolerations")
+
+    def identity_handler(attr_value):
+        return attr_value
+
+    # spec attributes defined on the runtime that should also apply to the build pod, each with the
+    # handler that resolves its value.
+    handlers = {
+        "node_name": identity_handler,
+        "node_selector": node_selector_handler,
+        "affinity": affinity_handler,
+        "tolerations": tolerations_handler,
+        "priority_class_name": identity_handler,
+        "service_account": service_account_handler,
+    }
+
+    resolved = {}
+    for attribute, handler in handlers.items():
+        attr_value = handler(getattr(runtime_spec, attribute, None))
+        if attr_value:
+            resolved[attribute] = attr_value
+    return resolved
 
 
 def _generate_builder_env(

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -43,11 +43,11 @@ _CONTEXT_DIR = "/empty"
 _AUTHFILE_DIR = "/auth"
 _AUTHFILE_PATH = f"{_AUTHFILE_DIR}/config.json"
 
-# the AppArmor annotation is keyed by the build container's name, which BasePod hard-codes to "base".
-_BUILD_CONTAINER_NAME = "base"
-_APPARMOR_ANNOTATION = (
-    f"container.apparmor.security.beta.kubernetes.io/{_BUILD_CONTAINER_NAME}"
-)
+# the AppArmor profile is applied via a per-container annotation (the k8s client in the test image is
+# capped below the securityContext.appArmorProfile field by KFP v1, and the annotation is also honored
+# by pre-1.30 clusters). The annotation is keyed by the build container's name; we read that name from
+# the pod itself (BasePod.container_name) so there is a single source of truth and it can't drift.
+_APPARMOR_ANNOTATION_PREFIX = "container.apparmor.security.beta.kubernetes.io"
 
 _SUPPORTED_STORAGE_DRIVERS = ("overlay", "vfs")
 
@@ -225,7 +225,10 @@ def make_buildah_pod(
     # mount/unshare syscalls the build performs); the annotation is keyed to the build container name.
     apparmor_profile = config.httpdb.builder.buildah_apparmor_profile
     if apparmor_profile:
-        buildah_pod.add_annotation(_APPARMOR_ANNOTATION, apparmor_profile)
+        buildah_pod.add_annotation(
+            f"{_APPARMOR_ANNOTATION_PREFIX}/{buildah_pod.container_name}",
+            apparmor_profile,
+        )
 
     # a writable containers store (overlay/vfs data) off the read-only image layers.
     buildah_pod.mount_empty(name="context", mount_path=_CONTEXT_DIR)

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -23,7 +23,7 @@ import mlrun.utils
 from mlrun.config import config
 
 import framework.utils.singletons.k8s
-from services.api.utils.builder import base, kaniko
+from services.api.utils.builder import base
 
 # the rootless build runs as this uid/gid regardless of the function's security-context enrichment
 # (D13): the stock quay.io/buildah/stable image ships /etc/subuid + /etc/subgid ranges for its
@@ -173,19 +173,14 @@ def make_buildah_pod(
         # if the registry was not given, infer it from the image destination
         registry = dest.partition("/")[0]
 
-    # apply the same runtime-derived pod-spec attributes Kaniko applies (node selector, affinity,
-    # tolerations, preemption, priority class, service account). The resolver is engine-agnostic -
-    # it reads the runtime spec - and lives in the kaniko module as the single source of truth.
-    extra_runtime_spec = {}
-    for attribute, handler in kaniko.get_kaniko_spec_attributes_from_runtime(
+    # runtime-derived scheduling/identity pod-spec attributes (node selector, affinity, tolerations,
+    # preemption, priority class, service account), resolved by the shared helper both backends call.
+    extra_runtime_spec = base.resolve_build_pod_spec_attributes(
         project,
         runtime_spec,
         project_default_function_node_selector,
         auth_info,
-    ).items():
-        attr_value = handler(getattr(runtime_spec, attribute, None))
-        if attr_value:
-            extra_runtime_spec[attribute] = attr_value
+    )
 
     # stage the Dockerfile (and any inline code / requirements) into the context, then bud + push.
     # everything runs in one container: the buildah image ships bash + coreutils, so no separate

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -1,0 +1,382 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pathlib
+import shlex
+from base64 import b64encode
+
+from kubernetes import client
+
+import mlrun.common.schemas
+import mlrun.errors
+import mlrun.utils
+from mlrun.config import config
+
+import framework.utils.singletons.k8s
+from services.api.utils.builder import base, kaniko
+
+# the rootless build runs as this uid/gid regardless of the function's security-context enrichment
+# (D13): the stock quay.io/buildah/stable image ships /etc/subuid + /etc/subgid ranges for its
+# "build" user (uid 1000), which is what the caps rootless model maps from.
+_BUILD_UID = 1000
+_BUILD_GID = 1000
+
+# the build image's home; buildah keeps its container store under $HOME/.local/share/containers.
+_BUILD_HOME = "/home/build"
+_CONTAINERS_STORE = f"{_BUILD_HOME}/.local/share/containers"
+
+# where the Dockerfile (and any inline code / requirements) are staged and used as the build context.
+_CONTEXT_DIR = "/empty"
+
+# static docker-config secret mount (the non-cloud registry auth path). Cloud-registry credential
+# helpers are wired in a follow-up (ML-12886); resolve_builder_backend falls back to Kaniko until then.
+_AUTHFILE_DIR = "/auth"
+_AUTHFILE_PATH = f"{_AUTHFILE_DIR}/config.json"
+
+# the AppArmor annotation is keyed by the build container's name, which BasePod hard-codes to "base".
+_BUILD_CONTAINER_NAME = "base"
+_APPARMOR_ANNOTATION = (
+    f"container.apparmor.security.beta.kubernetes.io/{_BUILD_CONTAINER_NAME}"
+)
+
+_SUPPORTED_STORAGE_DRIVERS = ("overlay", "vfs")
+
+
+class BuildahBackend:
+    """A rootless `Buildah <https://buildah.io/>`_ build backend behind the
+    :class:`~services.api.utils.builder.base.BuilderBackend` seam.
+
+    Builds the same Dockerfile as Kaniko (via :func:`base.make_dockerfile`) in a rootless,
+    non-privileged pod on the stock ``quay.io/buildah/stable`` image: ``buildah bud`` then
+    ``buildah push``, with ``BUILDAH_ISOLATION=chroot`` and the storage driver from
+    ``httpdb.builder.buildah_storage_driver``. The rootless model is fixed to the ``caps`` model
+    (``SETUID``/``SETGID`` + ``allowPrivilegeEscalation``); the ``hostUsers`` model was dropped after
+    POC-1 showed it is not viable on the target runtimes.
+
+    Scope note: this adapter handles the no-source-context build (inline code / requirements /
+    commands) and static docker-config-secret registry auth. Cloud-registry credential helpers
+    (ML-12886) and remote source acquisition (ML-12887) are not implemented here;
+    :func:`~services.api.utils.builder.resolve_builder_backend` transparently falls back to Kaniko
+    for those inputs until the follow-ups land.
+    """
+
+    def make_build_pod(
+        self, request: base.BuildRequest
+    ) -> framework.utils.singletons.k8s.BasePod:
+        """Build the rootless Buildah build pod for ``request``.
+
+        :param request: The resolved, engine-agnostic build inputs.
+        :return: The Buildah build pod.
+        :raises mlrun.errors.MLRunInvalidArgumentError: If the request carries a source needing
+            acquisition (resolve_builder_backend should have routed it to Kaniko - ML-12887).
+        """
+        # source acquisition is not implemented in this adapter yet (ML-12887). resolve_builder_backend
+        # falls back to Kaniko when a request carries such a source, so reaching here with one is a bug
+        # in the selection gate, not a user error - fail fast rather than silently drop the source.
+        loads_source_on_run = bool(
+            request.runtime_spec and request.runtime_spec.build.load_source_on_run
+        )
+        if request.source and not (request.inline_code or loads_source_on_run):
+            raise mlrun.errors.MLRunInvalidArgumentError(
+                "BuildahBackend received a build source it cannot acquire yet (ML-12887); "
+                "this should have fallen back to Kaniko in resolve_builder_backend"
+            )
+        dockerfile = base.make_dockerfile(
+            request.base_image,
+            request.commands,
+            source=None,
+            requirements_path=request.requirements_path,
+            extra=request.extra,
+            builder_env=request.builder_env_list,
+            project_secrets=request.project_secrets,
+            extra_args=request.extra_args,
+        )
+        return make_buildah_pod(
+            project=request.project,
+            dest=request.image_target,
+            dockerfile=dockerfile,
+            inline_code=request.inline_code,
+            inline_path=request.inline_path,
+            requirements=request.requirements,
+            requirements_path=request.requirements_path,
+            secret_name=request.secret_name,
+            name=request.name,
+            verbose=request.verbose,
+            builder_env=request.builder_env_list,
+            project_secrets=request.project_secrets,
+            runtime_spec=request.runtime_spec,
+            registry=request.registry,
+            extra_labels=request.labels,
+            project_default_function_node_selector=request.project_default_function_node_selector,
+            auth_info=request.auth_info,
+        )
+
+
+def make_buildah_pod(
+    project: str,
+    dest: str,
+    dockerfile: str,
+    inline_code: str | None = None,
+    inline_path: str | None = None,
+    requirements: list | None = None,
+    requirements_path: str | None = None,
+    secret_name: str | None = None,
+    name: str = "",
+    verbose: bool = False,
+    builder_env: list | None = None,
+    project_secrets: list | None = None,
+    runtime_spec=None,
+    registry: str | None = None,
+    extra_labels: dict | None = None,
+    project_default_function_node_selector: dict | None = None,
+    auth_info: mlrun.common.schemas.AuthInfo | None = None,
+) -> framework.utils.singletons.k8s.BasePod:
+    """Construct the rootless Buildah build pod (``buildah bud`` + ``push``).
+
+    :param project:            The project the build belongs to.
+    :param dest:               The fully resolved destination image reference.
+    :param dockerfile:         The rendered Dockerfile content (from :func:`base.make_dockerfile`).
+    :param inline_code:        Inline function code to stage into the build context, if any.
+    :param inline_path:        Destination filename for ``inline_code`` (default ``main.py``).
+    :param requirements:       The resolved requirements list to stage, if any.
+    :param requirements_path:  Path of the requirements file inside the build context.
+    :param secret_name:        The docker-config secret used as the push authfile, if any.
+    :param name:               The build pod's base name.
+    :param verbose:            Whether to run Buildah with ``--log-level debug``.
+    :param builder_env:        Build-time env vars, rendered as ``--build-arg`` (value read from env).
+    :param project_secrets:    Project secrets, rendered as ``--build-arg`` (value read from env).
+    :param runtime_spec:       The function's runtime spec (scheduling attributes, resources).
+    :param registry:           The target registry, when given explicitly.
+    :param extra_labels:       mlrun-internal labels to stamp on the build pod.
+    :param project_default_function_node_selector: Project-level default node selector.
+    :param auth_info:          The caller's auth info (for service-account resolution).
+    :return: The Buildah build pod.
+    """
+    storage_driver = config.httpdb.builder.buildah_storage_driver
+    if storage_driver not in _SUPPORTED_STORAGE_DRIVERS:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Unsupported buildah_storage_driver '{storage_driver}'. "
+            f"Supported drivers: {', '.join(_SUPPORTED_STORAGE_DRIVERS)}"
+        )
+
+    if not registry:
+        # if the registry was not given, infer it from the image destination
+        registry = dest.partition("/")[0]
+
+    # apply the same runtime-derived pod-spec attributes Kaniko applies (node selector, affinity,
+    # tolerations, preemption, priority class, service account). The resolver is engine-agnostic -
+    # it reads the runtime spec - and lives in the kaniko module as the single source of truth.
+    extra_runtime_spec = {}
+    for attribute, handler in kaniko.get_kaniko_spec_attributes_from_runtime(
+        project,
+        runtime_spec,
+        project_default_function_node_selector,
+        auth_info,
+    ).items():
+        attr_value = handler(getattr(runtime_spec, attribute, None))
+        if attr_value:
+            extra_runtime_spec[attribute] = attr_value
+
+    # stage the Dockerfile (and any inline code / requirements) into the context, then bud + push.
+    # everything runs in one container: the buildah image ships bash + coreutils, so no separate
+    # dockerfile-creation init container is needed (unlike Kaniko).
+    env = _build_env(
+        dockerfile=dockerfile,
+        inline_code=inline_code,
+        requirements=requirements,
+        requirements_path=requirements_path,
+        secret_name=secret_name,
+        builder_env=builder_env,
+        project_secrets=project_secrets,
+    )
+    script = _build_script(
+        dest=dest,
+        storage_driver=storage_driver,
+        verbose=verbose,
+        secret_name=secret_name,
+        inline_code=inline_code,
+        inline_path=inline_path,
+        requirements=requirements,
+        requirements_path=requirements_path,
+        build_arg_names=[env_var.name for env_var in (builder_env or [])]
+        + [env_var.name for env_var in (project_secrets or [])],
+    )
+
+    buildah_pod = framework.utils.singletons.k8s.BasePod(
+        name or "mlrun-build",
+        config.httpdb.builder.buildah_image,
+        command=["/bin/bash", "-c"],
+        args=[script],
+        kind="build",
+        project=project,
+        default_pod_spec_attributes=extra_runtime_spec,
+        resources=base.build_pod_resources(runtime_spec),
+        labels=base.resolve_builder_pod_labels(extra_labels),
+        security_context=_caps_security_context(),
+        env=env,
+    )
+
+    # the caps rootless model needs the runtime's default AppArmor profile relaxed (it blocks the
+    # mount/unshare syscalls the build performs); the annotation is keyed to the build container name.
+    apparmor_profile = config.httpdb.builder.buildah_apparmor_profile
+    if apparmor_profile:
+        buildah_pod.add_annotation(_APPARMOR_ANNOTATION, apparmor_profile)
+
+    # a writable containers store (overlay/vfs data) off the read-only image layers.
+    buildah_pod.mount_empty(name="context", mount_path=_CONTEXT_DIR)
+    buildah_pod.mount_empty(name="containers", mount_path=_CONTAINERS_STORE)
+
+    if config.is_pip_ca_configured():
+        _mount_pip_ca(buildah_pod)
+
+    if secret_name:
+        # mount the docker-config secret as the push authfile (static-credential registries).
+        buildah_pod.mount_secret(
+            secret_name,
+            _AUTHFILE_DIR,
+            items=[{"key": ".dockerconfigjson", "path": "config.json"}],
+        )
+
+    mlrun.utils.logger.debug(
+        "Resolved buildah build pod",
+        project=project,
+        image=dest,
+        storage_driver=storage_driver,
+        apparmor_profile=apparmor_profile or None,
+    )
+    return buildah_pod
+
+
+def _caps_security_context() -> client.V1SecurityContext:
+    # the caps rootless model (POC-1-validated): run as the image's non-root build user and add only
+    # SETUID/SETGID (+ allowPrivilegeEscalation) so buildah can run newuidmap/newgidmap to set up its
+    # subuid/subgid mapping. Not privileged. The hostUsers model was dropped (not viable per POC-1).
+    return client.V1SecurityContext(
+        run_as_user=_BUILD_UID,
+        run_as_group=_BUILD_GID,
+        run_as_non_root=True,
+        allow_privilege_escalation=True,
+        privileged=False,
+        capabilities=client.V1Capabilities(add=["SETUID", "SETGID"]),
+    )
+
+
+def _build_env(
+    dockerfile: str,
+    inline_code: str | None,
+    requirements: list | None,
+    requirements_path: str | None,
+    secret_name: str | None,
+    builder_env: list | None,
+    project_secrets: list | None,
+) -> list[client.V1EnvVar]:
+    # base64 the staged files into env vars (decoded in the container) to avoid shell-quoting the
+    # contents into the build script - the same convention Kaniko's create-dockerfile init uses.
+    env = [
+        client.V1EnvVar(name="BUILDAH_ISOLATION", value="chroot"),
+        client.V1EnvVar(name="HOME", value=_BUILD_HOME),
+        client.V1EnvVar(name="MLRUN_DOCKERFILE", value=_b64(dockerfile)),
+    ]
+    if secret_name:
+        env.append(client.V1EnvVar(name="REGISTRY_AUTH_FILE", value=_AUTHFILE_PATH))
+    if inline_code:
+        env.append(client.V1EnvVar(name="MLRUN_INLINE_CODE", value=_b64(inline_code)))
+    # gate on the same condition _build_script decodes it (requirements need a target path), so the
+    # env var and the decode stay in lock-step - no dead env var, no un-staged requirements.
+    if requirements and requirements_path:
+        requirements_content = "{}\n".format("\n".join(requirements))
+        env.append(
+            client.V1EnvVar(name="MLRUN_REQUIREMENTS", value=_b64(requirements_content))
+        )
+    # build-args are referenced by name only in the script; their values are read from the pod env,
+    # so the plain builder-env values and the secret-backed (valueFrom) vars must both be present.
+    env += list(builder_env or []) + list(project_secrets or [])
+    return env
+
+
+def _build_script(
+    dest: str,
+    storage_driver: str,
+    verbose: bool,
+    secret_name: str | None,
+    inline_code: str | None,
+    inline_path: str | None,
+    requirements: list | None,
+    requirements_path: str | None,
+    build_arg_names: list[str],
+) -> str:
+    dockerfile_path = f"{_CONTEXT_DIR}/Dockerfile"
+    lines = [
+        "set -e",
+        f"echo ${{MLRUN_DOCKERFILE}} | base64 -d > {shlex.quote(dockerfile_path)}",
+    ]
+    if inline_code:
+        inline_target = f"{_CONTEXT_DIR}/{inline_path or 'main.py'}"
+        lines.append(
+            f"echo ${{MLRUN_INLINE_CODE}} | base64 -d > {shlex.quote(inline_target)}"
+        )
+    if requirements and requirements_path:
+        lines.append(
+            f"echo ${{MLRUN_REQUIREMENTS}} | base64 -d > {shlex.quote(requirements_path)}"
+        )
+
+    # buildah global options precede the subcommand.
+    global_opts = ["buildah"]
+    if verbose:
+        global_opts += ["--log-level", "debug"]
+    global_opts += ["--storage-driver", storage_driver]
+
+    bud = global_opts + ["bud"]
+    bud += _tls_verify_flag(
+        config.httpdb.builder.insecure_pull_registry_mode, secret_name
+    )
+    for arg_name in build_arg_names:
+        bud += ["--build-arg", arg_name]
+    bud += ["--tag", dest, "--file", dockerfile_path, _CONTEXT_DIR]
+
+    push = global_opts + ["push"]
+    push += _tls_verify_flag(
+        config.httpdb.builder.insecure_push_registry_mode, secret_name
+    )
+    push += ["--retry", str(config.httpdb.builder.buildah_push_retry)]
+    if secret_name:
+        push += ["--authfile", _AUTHFILE_PATH]
+    push += [dest, f"docker://{dest}"]
+
+    lines.append(shlex.join(bud))
+    lines.append(shlex.join(push))
+    return "\n".join(lines)
+
+
+def _tls_verify_flag(mode: str, secret_name: str | None) -> list[str]:
+    # mirror Kaniko's insecure-registry resolution: "enabled" always, "auto" when there is no
+    # docker-config secret, "disabled" never. Buildah expresses it as --tls-verify=false.
+    if mode == "enabled" or (mode == "auto" and not secret_name):
+        return ["--tls-verify=false"]
+    return []
+
+
+def _mount_pip_ca(buildah_pod: framework.utils.singletons.k8s.BasePod) -> None:
+    # mirror Kaniko: stage the pip CA cert into the build context so the Dockerfile's COPY (added by
+    # base.make_dockerfile when a pip CA is configured) resolves.
+    ca_filename = pathlib.Path(config.httpdb.builder.pip_ca_path).name
+    buildah_pod.mount_secret(
+        config.httpdb.builder.pip_ca_secret_name,
+        str(pathlib.Path(_CONTEXT_DIR) / ca_filename),
+        items=[{"key": config.httpdb.builder.pip_ca_secret_key, "path": ca_filename}],
+        sub_path=ca_filename,
+    )
+
+
+def _b64(content: str) -> str:
+    return b64encode(content.encode("utf-8")).decode("utf-8")

--- a/server/py/services/api/utils/builder/kaniko.py
+++ b/server/py/services/api/utils/builder/kaniko.py
@@ -28,7 +28,6 @@ import mlrun.runtimes.pod
 import mlrun.runtimes.utils
 import mlrun.utils
 from mlrun.config import config
-from mlrun.k8s_utils import enrich_preemption_mode
 
 import framework.utils.helpers
 import framework.utils.singletons.k8s
@@ -75,21 +74,18 @@ def make_kaniko_pod(
     *,
     source_to_fetch: str | None = None,
 ):
-    extra_runtime_spec = {}
     if not registry:
         # if registry was not given, infer it from the image destination
         registry = dest.partition("/")[0]
 
-    # set kaniko's spec attributes from the runtime spec
-    for attribute, handler in get_kaniko_spec_attributes_from_runtime(
+    # runtime-derived scheduling/identity pod-spec attributes, shared with every backend so they
+    # can't drift between engines (see base.resolve_build_pod_spec_attributes).
+    extra_runtime_spec = base.resolve_build_pod_spec_attributes(
         project,
         runtime_spec,
         project_default_fucntion_node_selector,
         auth_info,
-    ).items():
-        attr_value = handler(getattr(runtime_spec, attribute, None))
-        if attr_value:
-            extra_runtime_spec[attribute] = attr_value
+    )
 
     if not dockertext and not dockerfile:
         raise ValueError("docker file or text must be specified")
@@ -482,76 +478,6 @@ class KanikoBackend:
             access_key=access_key,
             user=username,
         )
-
-
-def get_kaniko_spec_attributes_from_runtime(
-    project,
-    runtime_spec,
-    project_default_fucntion_node_selector,
-    auth_info: mlrun.common.schemas.AuthInfo = None,
-):
-    """Get the names of Kaniko spec attributes that are defined for runtime but should also be applied to Kaniko."""
-    # preemption mode scheduling constraints cache
-    _preemption_enrichment_result = {}
-
-    def service_account_handler(attr_value):
-        from framework.api.utils import resolve_project_service_account_details
-
-        (
-            allowed_service_accounts,
-            forbidden_service_accounts,
-            default_service_account,
-        ) = resolve_project_service_account_details(project, auth_info=auth_info)
-        if attr_value:
-            runtime_spec.validate_service_account(
-                allowed_service_accounts, forbidden_service_accounts
-            )
-        else:
-            attr_value = default_service_account
-        return attr_value
-
-    def get_merged_node_selector(attr_value):
-        attr_value = mlrun.utils.to_non_empty_values_dict(
-            mlrun.utils.helpers.merge_dicts_with_precedence(
-                mlrun.mlconf.get_default_function_node_selector(),
-                project_default_fucntion_node_selector,
-                attr_value,
-            )
-        )
-        return attr_value
-
-    def preemption_mode_handler(key):
-        if key not in _preemption_enrichment_result:
-            keys = ["node_selector", "tolerations", "affinity"]
-            values = enrich_preemption_mode(
-                preemption_mode=runtime_spec.preemption_mode,
-                node_selector=get_merged_node_selector(runtime_spec.node_selector),
-                affinity=runtime_spec.affinity,
-                tolerations=runtime_spec.tolerations,
-            )
-            _preemption_enrichment_result.update(dict(zip(keys, values)))
-        return _preemption_enrichment_result[key]
-
-    def node_selector_handler(attr_value):
-        return preemption_mode_handler("node_selector")
-
-    def affinity_handler(attr_value):
-        return preemption_mode_handler("affinity")
-
-    def tolerations_handler(attr_value):
-        return preemption_mode_handler("tolerations")
-
-    def identity_handler(attr_value):
-        return attr_value
-
-    return {
-        "node_name": identity_handler,
-        "node_selector": node_selector_handler,
-        "affinity": affinity_handler,
-        "tolerations": tolerations_handler,
-        "priority_class_name": identity_handler,
-        "service_account": service_account_handler,
-    }
 
 
 def _needs_source_fetch_init_container(source: str) -> bool:

--- a/server/py/services/api/utils/builder/kaniko.py
+++ b/server/py/services/api/utils/builder/kaniko.py
@@ -19,7 +19,6 @@ from urllib.parse import urlparse
 from kubernetes import client
 
 import mlrun.common.constants
-import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.model
@@ -125,42 +124,13 @@ def make_kaniko_pod(
         args, builder_env, project_secrets, extra_args
     )
 
-    # While requests mainly affect scheduling, setting a limit may prevent Kaniko
-    # from finishing successfully (destructive), since we're not allowing to override the default
-    # specifically for the Kaniko pod, we're setting only the requests
-    # we cannot specify gpu requests without specifying gpu limits, so we set requests without gpu field
-    default_requests = config.get_default_function_pod_requirement_resources(
-        "requests", with_gpu=False
-    )
-    resources = {
-        "requests": mlrun.runtimes.utils.generate_resources(
-            mem=default_requests.get("memory"), cpu=default_requests.get("cpu")
-        )
-    }
-    # Some cloud providers add a toleration when a GPU limit is set.
-    # If the Kaniko pod inherits a GPU-related node selector from the function
-    # but lacks a GPU limit, it may get stuck in a pending state due to unsatisfiable scheduling.
-    # Setting GPU limits to zero ensures tolerations are applied while preventing GPU allocation.
-    if runtime_spec:
-        gpu_resources = mlrun.utils.get_enriched_gpu_limits(
-            runtime_spec.resources.get("limits", {})
-        )
-        if gpu_resources:
-            resources["limits"] = gpu_resources
+    # requests-only + GPU-limit-zero, shared with every other builder backend so the policy
+    # can't drift between engines (see base.build_pod_resources for the rationale).
+    resources = base.build_pod_resources(runtime_spec)
 
-    # apply the configured builder pod labels (e.g. the azure.workload.identity/use label that lets the
-    # Azure workload-identity webhook inject ACR push credentials into the builder pod).
-    # these platform-level labels are the lowest-precedence layer: mlrun's own internal labels
-    # (mlrun/class, mlrun/project, etc., set by BasePod and the call site) must never be clobbered by them.
-    configured_pod_labels = {
-        key: value
-        for key, value in config.get_builder_pod_labels().items()
-        if key not in mlrun_constants.MLRunInternalLabels.all()
-    }
-    extra_labels = mlrun.utils.helpers.merge_dicts_with_precedence(
-        configured_pod_labels,
-        extra_labels or {},
-    )
+    # merge the configured builder pod labels (e.g. azure.workload.identity/use) under the
+    # caller's labels, shared with every backend so the precedence can't drift.
+    extra_labels = base.resolve_builder_pod_labels(extra_labels)
 
     kaniko_pod = framework.utils.singletons.k8s.BasePod(
         name or "mlrun-build",


### PR DESCRIPTION
### 📝 Description

Adds `BuildahBackend`, the second builder engine behind the `BuilderBackend` seam introduced by ML-12884 (#9920, this PR's base branch). It builds function images in a **rootless, non-privileged** pod on the stock `quay.io/buildah/stable` image — `buildah bud` + `push`, `BUILDAH_ISOLATION=chroot`, storage driver from config, the caps rootless securityContext (uid 1000 + `SETUID`/`SETGID` + `allowPrivilegeEscalation`), `insecure→--tls-verify=false`, push `--retry`, and an optional AppArmor annotation.

Buildah is **opt-in** (`httpdb.builder.builder_backend`); Kaniko stays the byte-identical default. The `hostUsers` rootless model was dropped after POC-1 showed it non-viable on the target runtimes, so `caps` is the only model and AppArmor defaults to `unconfined` (required wherever the runtime enforces its default profile, e.g. GKE/AKS; a no-op where AppArmor isn't loaded).

Source: ML-12427 Backend HLD + POC-1 Runbook.

---

### 🛠️ Changes Made
- **`BuildahBackend` / `make_buildah_pod`** (`builder/buildah.py`, new) — rootless caps pod, bud+push, chroot, storage driver, tls-verify/retry/log-level, AppArmor annotation, static docker-config-secret authfile.
- **`BasePod`** (`framework/utils/singletons/k8s.py`) — additive/optional container `security_context` and `env` kwargs. Absent by default → existing build pods unchanged.
- **Shared `base` helpers** — `build_pod_resources` (requests-only + GPU-limit-zero), `resolve_builder_pod_labels`, and `resolve_build_pod_spec_attributes` (runtime→pod-spec scheduling/identity), so the policy can't drift between engines; **Kaniko refactored to call them** (behaviour-preserving). `buildah` depends only on `base`, not on `kaniko`.
- **`resolve_builder_backend`** — registers `buildah` and adds transparent Kaniko fallbacks for inputs Buildah can't handle yet: cloud-registry credential-helper auth (ML-12886) and source acquisition (ML-12887). Each guard is commented with the ticket that removes it.
- **Config** — new `httpdb.builder` keys: `buildah_image`, `buildah_storage_driver`, `buildah_apparmor_profile`, `buildah_push_retry`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- **191 unit tests pass** (`server/py/services/api/tests/unit/utils/test_builder.py` + `test_builder_backend.py`), run with `MLRUN_DBPATH` unset.
- 24 new tests cover: config-flip selection, both Kaniko fallback guards, the caps securityContext, storage-driver × isolation, the AppArmor annotation (unconfined / localhost / none), bud+push args (tls-verify/retry/log-level), the docker-config authfile mount, inline-code/requirements staging, build-args, and the additive `BasePod` kwargs.
- The 167 existing Kaniko tests stay green, confirming the resource/label/spec-attribute extraction is behaviour-preserving.
- **Validated on lab `vmdev122ig4`:** patched `mlrun-api` with this branch, set `builder_backend=buildah`, and ran a real function build. It built **rootless** on the stock `quay.io/buildah/stable` (uid 1000, `SETUID`/`SETGID`, `allowPrivilegeEscalation`, **not** privileged, AppArmor `Unconfined`, `BUILDAH_ISOLATION=chroot`, `overlay` driver) and **pushed to the lab registry** — pod phase `Succeeded`. This is the POC-1 caps model, now driven by the adapter code.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12885
- Design docs links: Backend HLD (ML-12427), POC-1 Runbook, Assumptions & Decisions Log (IRG space)
- External links: builds on #9920 (ML-12884 seam); follow-ups ML-12886 (registry auth), ML-12887 (source parity), ML-12888 (--layers cache), ML-12889 (parity tests)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Every change is additive: Kaniko stays the default and byte-identical, only new config keys are added, and the `BasePod` fields are optional/absent-by-default.

---

### 🔍️ Additional Notes
- **Base branch is `feature/buildah`, not `development`** — this stacks on the merged ML-12884 seam.
- `builder_backend=buildah` transparently falls back to Kaniko for cloud registries (ML-12886) and remote/local sources needing acquisition (ML-12887); those guards are removed as the follow-ups land.
