### PR TITLE
[CI] Pin manusa/actions-setup-minikube action to a commit SHA on 1.7.x (#9875)

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Freeing up disk space
         run: |
           "${GITHUB_WORKSPACE}/automation/scripts/github_workflow_free_space.sh"
-      - uses: manusa/actions-setup-minikube@v2.11.0
+      - uses: manusa/actions-setup-minikube@92af4db914ab207f837251cd53eb7060e6477614  # v2.11.0
         with:
           minikube version: "v1.28.0"
           kubernetes version: "v1.25.3"


### PR DESCRIPTION
### Description
This backports a fix already merged on the default branch to release branch 1.7.x. The go ci workflow referenced manusa/actions-setup-minikube by a mutable version tag, which the zizmor scanner flags because the action owner could move the tag to point at different code later. This pins the action to the exact commit SHA for the version already in use, so nothing else about the job changes.

### Changes Made
- Pinned manusa/actions-setup-minikube in .github/workflows/go-ci.yaml to its commit SHA, with the version kept as a trailing comment for readability.

### Checklist
- [x] I have tested the changes in this PR
- [ ] Documentation update not applicable
- [ ] Not covered by system tests (CI workflow file only)

### Testing
Verified the SHA matches the official v2.11.0 tag through the GitHub API before pinning. Confirmed the branch still had the unpinned reference at HEAD prior to this change.

### References
- Ticket link: #9875

### Breaking Changes?
- [x] No

### Additional Notes
Companion PRs apply the same fix on 1.8.x and 1.9.x, pinned to v2.13.1's SHA on both.
