### PR TITLE
[Log collector] Always build with the latest Go patch version

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -46,9 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Determine Go minor version
+        id: go-version
+        run: |
+          echo "version=$(grep -m1 '^go ' server/go/go.mod | awk '{split($2,a,"."); print a[1]"."a[2]}')" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@v7
         with:
-          go-version-file: "server/go/go.mod"
+          # use the major.minor from go.mod but let setup-go resolve the latest patch,
+          # so lint/test always run on the same patch used to build the log-collector image
+          go-version: ${{ steps.go-version.outputs.version }}
           cache-dependency-path: "server/go/go.sum"
           cache: true
       - name: Install protobuf compiler

--- a/server/go/services/logcollector/cmd/docker/Dockerfile
+++ b/server/go/services/logcollector/cmd/docker/Dockerfile
@@ -16,6 +16,10 @@ ARG GO_VERSION=1.26
 
 FROM gcr.io/iguazio/golang:${GO_VERSION} AS build-binary
 
+# always build with whatever Go patch is baked into the base image, never let the go
+# toolchain silently fetch a different patch over the network to satisfy go.mod's `go` directive
+ENV GOTOOLCHAIN=local
+
 RUN mkdir /app
 WORKDIR /app
 


### PR DESCRIPTION
### 📝 Description
The log-collector's Docker base image (`gcr.io/iguazio/golang:1.26`) resolves to the latest 1.26.x patch via a floating tag, but the `go-lint` CI job pinned its Go toolchain to the exact patch declared in `go.mod`'s `go` directive (`1.26.4`) via `go-version-file`, and the actual image build had no safeguard against Go's default `GOTOOLCHAIN=auto` silently downloading a different patch over the network to satisfy that same directive. Both paths now track whatever patch the base image actually provides instead of the pinned floor.

---

### 🛠️ Changes Made
- `go-lint` CI job now derives only the major/minor from `go.mod` and passes it to `actions/setup-go`, which resolves the latest available patch, instead of pinning to the exact patch via `go-version-file`.
- Log-collector Dockerfile now sets `GOTOOLCHAIN=local`, so `go build` always uses the Go toolchain already baked into the base image rather than potentially fetching a different patch to satisfy the `go.mod` floor.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Built `mlrun/log-collector:unstable` locally, extracted the compiled binary from the distroless final image, and ran `go version -m` on it — confirmed it was built with `go1.26.5`, newer than `go.mod`'s `1.26.4` floor, verifying the base image already provides a newer patch and the build correctly uses it.
- Confirmed locally that a bare `go 1.26` directive (no patch) in `go.mod` breaks `go build` against the installed toolchain, which is why `go.mod`'s pinned floor is left unchanged in this PR.

---

### 🔗 References
- Ticket link: Not applicable
- Design docs links: Not applicable
- External links: Not applicable

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- `go.mod`'s `go 1.26.4` directive is intentionally left as-is: it now only acts as a minimum-version floor, not what's actually used to build.
