### PR TITLE
[Pagination] Fix event-loop deadlock in cache-record update

### DIFF
--- a/server/py/framework/utils/pagination.py
+++ b/server/py/framework/utils/pagination.py
@@ -181,7 +181,8 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
             page_size,
             method,
             method_kwargs,
-        ) = self._create_or_update_pagination_cache_record(
+        ) = await framework.utils.asyncio.await_or_call_in_threadpool(
+            self._create_or_update_pagination_cache_record,
             session,
             method,
             auth_info,


### PR DESCRIPTION
### 📝 Description
Paginated list endpoints could freeze the API server under concurrency. `Paginator.paginate_request` ran the pagination-cache read/update (`_create_or_update_pagination_cache_record`) synchronously on the asyncio event loop, where it checks out a DB connection. On a single-worker server under load the connection pool is drained by the page's list queries — which are already offloaded to the threadpool — and those connections are released only when their coroutines resume on the event loop. But the event loop is itself blocked here waiting to check out a connection, so the connections are never returned: a self-deadlock that freezes the whole server. This surfaced as the flaky `test_paginated_list_artifacts[server]` CI hang — a request frozen for ~748s that unblocked only at server teardown, with no "database is locked" logged (the loop never acquired a connection, so SQLite was never touched).

---

### 🛠️ Changes Made
- `server/py/framework/utils/pagination.py`: run `_create_or_update_pagination_cache_record` via `await_or_call_in_threadpool` instead of calling it inline on the event loop, so its DB connection checkout happens off the loop — the same offloading already applied to the page's list query on the following line. The event loop stays responsive and pooled connections are always returned.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `tests/rundb/test_httpdb.py::test_paginated_list_artifacts[server]` passes.
- Pagination unit tests pass (26).
- Local concurrency reproduction (100 concurrent clients paginating against a from-source API server on SQLite): before this change 56 requests timed out with the server frozen; after it, 0 timeouts across 3 runs (~5,000 successful ops each).

---

### 🔗 References
- Ticket link: none (latent bug found while investigating the CI failure on #9930)
- Design docs links:
- External links: surfaced by the integration-test failure on #9930

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The change is in the shared `Paginator.paginate_request`, so it covers all paginated endpoints that go through it (artifacts, functions, runs), not only artifacts.
