### PR TITLE
[Builder] Buildah source acquisition + load-source s3/http parity

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1375,6 +1375,7 @@ def load_source(source_uri, project, target):
     - git:// URLs: Git repositories (cloned to target directory)
     - .zip files: ZIP archives (extracted to target directory)
     - .tar.gz files: Tarball archives (extracted to target directory)
+    - bare s3:// / http(s):// URLs: Single files (downloaded to target directory)
 
     Examples:
 
@@ -1382,6 +1383,7 @@ def load_source(source_uri, project, target):
         mlrun load-source store://artifacts/my-project/app.py -t /tmp/code
         mlrun load-source git://github.com/org/repo.git#main -t /tmp/code
         mlrun load-source https://example.com/source.tar.gz -t /tmp/code
+        mlrun load-source s3://my-bucket/main.py -t /tmp/code
     """
 
     try:

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -26,6 +26,11 @@ import mlrun
 
 from .helpers import is_store_uri, logger
 
+# bare (non-archive) URIs load-source can fetch as a single file, the same shape store:// artifacts
+# already support. Excludes v3io (FUSE-mounted by callers, never fetched) and any scheme without a
+# datastore implementation.
+_SINGLE_FILE_SCHEMES = frozenset({"s3", "http", "https"})
+
 
 def _remove_directory_contents(target_dir):
     for filename in os.listdir(target_dir):
@@ -249,8 +254,9 @@ def load_source_code(
     - git:// URLs: Git repositories (cloned to target directory)
     - .zip files: ZIP archives (extracted to target directory)
     - .tar.gz files: Tarball archives (extracted to target directory)
+    - bare s3:// / http(s):// URLs: Single files (downloaded to target directory)
 
-    :param source_uri: Source URI (store://, git://, or archive URL)
+    :param source_uri: Source URI (store://, git://, archive URL, or a bare s3:// / http(s):// file)
     :param target_dir: Target directory where source will be placed
     :param project:    Optional project name (used for store:// URIs)
     :param secrets:    Optional secrets used to access secured data stores
@@ -258,8 +264,8 @@ def load_source_code(
 
     :returns: ``(target_dir, file_path)``. ``target_dir`` is always set.
               ``file_path`` is the resolved local file path for ``store://``
-              single-file artifacts, and ``None`` for git/archive sources
-              where there is no canonical entry file.
+              and bare s3/http(s) single-file sources, and ``None`` for
+              git/archive sources where there is no canonical entry file.
     """
     if not source_uri:
         raise mlrun.errors.MLRunInvalidArgumentError("source_uri is required")
@@ -274,14 +280,41 @@ def load_source_code(
     if source_uri.startswith("git://"):
         return _load_git_source(source_uri, target_dir), None
 
-    # Handle archive files (.zip, .tar.gz)
+    # Handle archive files (.zip, .tar.gz) - checked before the bare-scheme branch below so an
+    # archive under s3://.../foo.tar.gz still extracts rather than downloading as a single file.
     if source_uri.endswith(".zip") or source_uri.endswith(".tar.gz"):
         return _load_archive_source(source_uri, target_dir), None
 
+    # Handle bare (non-archive) s3:// / http(s):// single files
+    if urlparse(source_uri).scheme in _SINGLE_FILE_SCHEMES:
+        return _load_single_file_source(source_uri, target_dir, secrets=secrets)
+
     raise mlrun.errors.MLRunInvalidArgumentError(
-        f"Unsupported source type: {source_uri}. "
-        "Supported types: store:// URIs, git:// URLs, .zip and .tar.gz archives"
+        f"Unsupported source type: {source_uri}. Supported types: store:// URIs, git:// URLs, "
+        ".zip and .tar.gz archives, and bare s3:// / http(s):// files"
     )
+
+
+def is_source_loadable(source_uri: str) -> bool:
+    """
+    Return whether ``load_source_code`` can resolve ``source_uri``, without downloading it.
+
+    Mirrors ``load_source_code``'s dispatch conditions so a caller that schedules work around
+    the fetch (e.g. a build pod's init container) can fail fast on an unsupported source instead
+    of scheduling work that is guaranteed to fail once ``load_source_code`` actually runs.
+
+    :param source_uri: The source URI to check.
+    :return: Whether ``load_source_code`` has a dispatch branch for ``source_uri``.
+    """
+    if not source_uri:
+        return False
+    if mlrun.datastore.is_store_uri(source_uri):
+        return True
+    if source_uri.startswith("git://"):
+        return True
+    if source_uri.endswith(".zip") or source_uri.endswith(".tar.gz"):
+        return True
+    return urlparse(source_uri).scheme in _SINGLE_FILE_SCHEMES
 
 
 def resolve_artifact_filename(artifact) -> str:
@@ -375,9 +408,21 @@ def _download_artifact_to_dir(artifact, target_dir: str, secrets) -> tuple[str, 
             "(src_path, target_path, and metadata.key are all empty or "
             "basename-empty)"
         )
+    return _download_single_file_to_dir(
+        artifact_target_path, filename, target_dir, secrets=secrets
+    )
+
+
+def _download_single_file_to_dir(
+    source_path: str, filename: str, target_dir: str, secrets
+) -> tuple[str, str]:
+    """Download ``source_path`` as ``filename`` into ``target_dir``.
+
+    :returns: ``(target_dir, local_file_path)``.
+    """
     os.makedirs(target_dir, exist_ok=True)
     local_file_path = os.path.join(target_dir, filename)
-    _download_dataitem_to(local_file_path, artifact_target_path, secrets=secrets)
+    _download_dataitem_to(local_file_path, source_path, secrets=secrets)
 
     return target_dir, local_file_path
 
@@ -558,3 +603,25 @@ def _load_archive_source(source_uri: str, target_dir: str) -> str:
         ) from exc
 
     return target_dir
+
+
+def _load_single_file_source(
+    source_uri: str, target_dir: str, secrets=None
+) -> tuple[str, str]:
+    """
+    Download a bare (non-archive) s3:// or http(s):// URI as a single file.
+
+    :param source_uri: A non-archive s3:// or http(s):// URI pointing at one file
+    :param target_dir: Target directory where the file will be placed
+    :param secrets:    Optional secrets used to access secured data stores
+
+    :returns: ``(target_dir, local_file_path)``
+    """
+    filename = os.path.basename(urlparse(source_uri).path)
+    if not filename:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Source {source_uri!r} has no resolvable filename in its path"
+        )
+    return _download_single_file_to_dir(
+        source_uri, filename, target_dir, secrets=secrets
+    )

--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -282,7 +282,10 @@ def load_source_code(
 
     # Handle archive files (.zip, .tar.gz) - checked before the bare-scheme branch below so an
     # archive under s3://.../foo.tar.gz still extracts rather than downloading as a single file.
-    if source_uri.endswith(".zip") or source_uri.endswith(".tar.gz"):
+    # Matched against the URL path, not the raw URI, so a query string (e.g. a presigned-URL
+    # token) doesn't hide the extension from detection.
+    source_path = urlparse(source_uri).path
+    if source_path.endswith(".zip") or source_path.endswith(".tar.gz"):
         return _load_archive_source(source_uri, target_dir), None
 
     # Handle bare (non-archive) s3:// / http(s):// single files
@@ -312,7 +315,16 @@ def is_source_loadable(source_uri: str) -> bool:
         return True
     if source_uri.startswith("git://"):
         return True
-    if source_uri.endswith(".zip") or source_uri.endswith(".tar.gz"):
+    source_path = urlparse(source_uri).path
+    if source_path.endswith(".zip") or source_path.endswith(".tar.gz"):
+        # archive extraction goes through mlrun.get_dataitem, which only resolves schemes
+        # mlrun.datastore actually registers - reject anything else (e.g. ftp://) up front,
+        # rather than letting Buildah schedule a pod that's guaranteed to fail once
+        # load_source_code actually runs.
+        try:
+            mlrun.datastore.datastore.schema_to_store(urlparse(source_uri).scheme)
+        except Exception:
+            return False
         return True
     return urlparse(source_uri).scheme in _SINGLE_FILE_SCHEMES
 
@@ -468,14 +480,15 @@ def _download_dataitem_to(local_file_path: str, source_path: str, secrets) -> No
 
     Wraps any failure as ``MLRunRuntimeError`` for a consistent error type,
     surfacing the underlying cause in the message so a log-only context still
-    shows why the download failed.
+    shows why the download failed. Only ``source_path``'s scheme is included -
+    the full path can embed credentials (e.g. a presigned URL's query string).
     """
     try:
         mlrun.get_dataitem(source_path, secrets=secrets).download(local_file_path)
     except Exception as exc:
         raise mlrun.errors.MLRunRuntimeError(
-            f"Failed to download artifact from {source_path} to {local_file_path}: "
-            f"{mlrun.errors.err_to_str(exc)}"
+            f"Failed to download source (scheme {urlparse(source_path).scheme!r}) "
+            f"to {local_file_path}: {mlrun.errors.err_to_str(exc)}"
         ) from exc
 
 
@@ -592,10 +605,13 @@ def _load_archive_source(source_uri: str, target_dir: str) -> str:
     """
     os.makedirs(target_dir, exist_ok=True)
 
+    # matched against the URL path, not the raw URI, so a query string doesn't hide the
+    # extension from detection (mirrors the dispatch in load_source_code).
+    source_path = urlparse(source_uri).path
     try:
-        if source_uri.endswith(".zip"):
+        if source_path.endswith(".zip"):
             clone_zip(source_uri, target_dir)
-        elif source_uri.endswith(".tar.gz"):
+        elif source_path.endswith(".tar.gz"):
             clone_tgz(source_uri, target_dir)
     except Exception as exc:
         raise mlrun.errors.MLRunRuntimeError(
@@ -620,7 +636,8 @@ def _load_single_file_source(
     filename = os.path.basename(urlparse(source_uri).path)
     if not filename:
         raise mlrun.errors.MLRunInvalidArgumentError(
-            f"Source {source_uri!r} has no resolvable filename in its path"
+            f"Source (scheme {urlparse(source_uri).scheme!r}) has no resolvable "
+            "filename in its path"
         )
     return _download_single_file_to_dir(
         source_uri, filename, target_dir, secrets=secrets

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -17,7 +17,7 @@
 # the byte-identical regression anchor covered by test_builder.py; here we lock the
 # seam, and (ML-12885) the Buildah backend: config-flip selection, the transparent
 # Kaniko fallback for inputs Buildah can't handle yet, and the rootless pod spec.
-# (ML-12887) also locks Buildah's own source routing - every remote source is fetched
+# It also locks Buildah's own source routing - every remote source is fetched
 # via `mlrun load-source` or, for v3io, FUSE-mounted, since Buildah has no native
 # remote-context resolution the way Kaniko does.
 
@@ -178,7 +178,7 @@ def test_resolve_builder_backend_buildah_falls_back_for_cloud_registry(
 
 
 def test_resolve_builder_backend_buildah_handles_source(monkeypatch):
-    # source acquisition is implemented (ML-12887) -> Buildah is selected, no fallback
+    # source acquisition is implemented -> Buildah is selected, no fallback
     monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
     backend = services.api.utils.builder.resolve_builder_backend(
         _make_build_request(source="git://github.com/some-org/some-repo.git#main")
@@ -352,7 +352,7 @@ def _make_buildah_pod(**overrides) -> framework.utils.singletons.k8s.BasePod:
         return services.api.utils.builder.buildah.make_buildah_pod(**defaults)
 
 
-# --- Buildah source routing (ML-12887) ------------------------------------------------------------
+# --- Buildah source routing -----------------------------------------------------------------------
 
 
 def _make_buildah_backend_pod(

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -352,9 +352,6 @@ def _make_buildah_pod(**overrides) -> framework.utils.singletons.k8s.BasePod:
         return services.api.utils.builder.buildah.make_buildah_pod(**defaults)
 
 
-# --- Buildah source routing -----------------------------------------------------------------------
-
-
 def _make_buildah_backend_pod(
     **overrides,
 ) -> framework.utils.singletons.k8s.BasePod:

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -425,7 +425,9 @@ def test_buildah_backend_mounts_v3io_source():
     # base.mount_v3io_source) rather than being routed through the fetch-source init container.
     pod = _make_buildah_backend_pod(
         source="v3io:///bigdata/project/code",
-        auth_info=mlrun.common.schemas.AuthInfo(username="some-user", access_key="some-key"),
+        auth_info=mlrun.common.schemas.AuthInfo(
+            username="some-user", access_key="some-key"
+        ),
     )
 
     assert _init_container_by_name(pod, "fetch-source") is None

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -17,7 +17,11 @@
 # the byte-identical regression anchor covered by test_builder.py; here we lock the
 # seam, and (ML-12885) the Buildah backend: config-flip selection, the transparent
 # Kaniko fallback for inputs Buildah can't handle yet, and the rootless pod spec.
+# (ML-12887) also locks Buildah's own source routing - every remote source is fetched
+# via `mlrun load-source` or, for v3io, FUSE-mounted, since Buildah has no native
+# remote-context resolution the way Kaniko does.
 
+import base64
 import unittest.mock
 
 import pytest
@@ -173,13 +177,13 @@ def test_resolve_builder_backend_buildah_falls_back_for_cloud_registry(
     assert isinstance(backend, services.api.utils.builder.KanikoBackend)
 
 
-def test_resolve_builder_backend_buildah_falls_back_for_source(monkeypatch):
-    # a source needing acquisition is not on Buildah yet (ML-12887) -> fall back to Kaniko
+def test_resolve_builder_backend_buildah_handles_source(monkeypatch):
+    # source acquisition is implemented (ML-12887) -> Buildah is selected, no fallback
     monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
     backend = services.api.utils.builder.resolve_builder_backend(
         _make_build_request(source="git://github.com/some-org/some-repo.git#main")
     )
-    assert isinstance(backend, services.api.utils.builder.KanikoBackend)
+    assert isinstance(backend, services.api.utils.builder.BuildahBackend)
 
 
 def test_resolve_builder_backend_buildah_keeps_inline_code_with_source(monkeypatch):
@@ -192,14 +196,6 @@ def test_resolve_builder_backend_buildah_keeps_inline_code_with_source(monkeypat
         )
     )
     assert isinstance(backend, services.api.utils.builder.BuildahBackend)
-
-
-def test_buildah_backend_rejects_unacquirable_source():
-    # the source guard in resolve_builder_backend should route this to Kaniko; if the adapter is
-    # somehow reached with an unacquirable source it must fail fast, not silently drop the source
-    request = _make_build_request(source="git://github.com/some-org/some-repo.git#main")
-    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="ML-12887"):
-        services.api.utils.builder.BuildahBackend().make_build_pod(request)
 
 
 def test_make_buildah_pod_security_context_is_caps_rootless():
@@ -354,3 +350,138 @@ def _make_buildah_pod(**overrides) -> framework.utils.singletons.k8s.BasePod:
         )
         defaults.update(overrides)
         return services.api.utils.builder.buildah.make_buildah_pod(**defaults)
+
+
+# --- Buildah source routing (ML-12887) ------------------------------------------------------------
+
+
+def _make_buildah_backend_pod(
+    **overrides,
+) -> framework.utils.singletons.k8s.BasePod:
+    """Route a BuildRequest through BuildahBackend.make_build_pod with a real runtime spec.
+
+    A real runtime_spec is required: source routing mutates
+    ``request.runtime_spec.build.source_code_target_dir``, which a bare ``_make_build_request()``
+    (``runtime_spec=None``) cannot support.
+    """
+    with unittest.mock.patch(
+        "framework.api.utils.resolve_project_service_account_details",
+        return_value=(None, None, None),
+    ):
+        function = mlrun.new_function("test", "test", kind=RuntimeKinds.job)
+        request = _make_build_request(runtime_spec=function.spec, **overrides)
+        return services.api.utils.builder.BuildahBackend().make_build_pod(request)
+
+
+def _init_container_by_name(pod: framework.utils.singletons.k8s.BasePod, name: str):
+    for container in pod.pod.spec.init_containers or []:
+        if container.name == name:
+            return container
+    return None
+
+
+def _decoded_dockerfile(pod: framework.utils.singletons.k8s.BasePod) -> str:
+    env = {env_var.name: env_var.value for env_var in pod.pod.spec.containers[0].env}
+    return base64.b64decode(env["MLRUN_DOCKERFILE"]).decode("utf-8")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "git://github.com/some-org/some-repo.git#main",
+        "s3://bucket/path/project.tar.gz",
+        "s3://bucket/path/main.py",
+        "http://example.com/main.py",
+        "https://example.com/main.py",
+    ],
+)
+def test_buildah_backend_routes_remote_source_through_fetch_init_container(source):
+    # unlike Kaniko (native --context for git/s3, Dockerfile ADD for bare http), Buildah has no
+    # native remote-context resolution - every remote source is fetched via `mlrun load-source`
+    # into the same emptyDir already mounted for Dockerfile staging.
+    pod = _make_buildah_backend_pod(source=source)
+
+    fetch_container = _init_container_by_name(pod, "fetch-source")
+    assert fetch_container is not None
+    assert fetch_container.command == ["python"]
+    assert fetch_container.args == [
+        "-m",
+        "mlrun",
+        "load-source",
+        source,
+        "--target",
+        "/empty/source",
+    ]
+    fetch_mounts = {
+        (vm.name, vm.mount_path) for vm in fetch_container.volume_mounts or []
+    }
+    assert ("context", "/empty") in fetch_mounts
+
+    assert "ADD ./source /home/mlrun_code" in _decoded_dockerfile(pod)
+
+
+def test_buildah_backend_mounts_v3io_source():
+    # v3io keeps its existing FUSE-mount mechanism (shared with Kaniko via
+    # base.mount_v3io_source) rather than being routed through the fetch-source init container.
+    pod = _make_buildah_backend_pod(
+        source="v3io:///bigdata/project/code",
+        auth_info=mlrun.common.schemas.AuthInfo(username="some-user", access_key="some-key"),
+    )
+
+    assert _init_container_by_name(pod, "fetch-source") is None
+
+    volume_mounts = {
+        (vm.name, vm.mount_path)
+        for vm in pod.pod.spec.containers[0].volume_mounts or []
+    }
+    assert ("v3io", "/empty/source") in volume_mounts
+
+    # v3io_to_vol returns a plain dict (not a V1Volume), unlike the other mount_* helpers.
+    v3io_volume = next(
+        v
+        for v in pod.pod.spec.volumes or []
+        if (v["name"] if isinstance(v, dict) else v.name) == "v3io"
+    )
+    flex_volume_options = v3io_volume["flexVolume"].options
+    assert flex_volume_options["container"] == "bigdata"
+    assert flex_volume_options["subPath"] == "/project"
+
+    assert "ADD ./source/code /home/mlrun_code" in _decoded_dockerfile(pod)
+
+
+def test_buildah_backend_local_abs_path_source_passthrough():
+    # parity with Kaniko's own edge case: an absolute local path is assumed valid inside the
+    # build image already (e.g. baked into a custom base image) - no fetch, no mount.
+    pod = _make_buildah_backend_pod(source="/opt/baked-in-source")
+
+    assert _init_container_by_name(pod, "fetch-source") is None
+    assert "ADD /opt/baked-in-source /home/mlrun_code" in _decoded_dockerfile(pod)
+
+
+def test_buildah_backend_relative_path_source_raises():
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="relative source"):
+        _make_buildah_backend_pod(source="relative/path")
+
+
+def test_buildah_backend_unsupported_scheme_raises_before_pod_construction():
+    # fails fast at BuildRequest-resolution time, before scheduling a pod that would only fail
+    # once the fetch-source init container actually runs `mlrun load-source`.
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="ftp"):
+        _make_buildah_backend_pod(source="ftp://example.com/file")
+
+
+def test_buildah_backend_no_source_has_no_fetch_container_or_mount():
+    pod = _make_buildah_backend_pod(source="")
+    assert _init_container_by_name(pod, "fetch-source") is None
+    assert "ADD" not in _decoded_dockerfile(pod)
+
+
+def test_buildah_backend_inline_code_with_source_ignores_source():
+    # inline_code takes precedence over source (Kaniko's own /empty-context rule) - no fetch,
+    # no mount, no ADD line for the ignored source.
+    pod = _make_buildah_backend_pod(
+        source="git://github.com/some-org/some-repo.git#main",
+        inline_code="print('hi')",
+    )
+    assert _init_container_by_name(pod, "fetch-source") is None
+    assert "ADD" not in _decoded_dockerfile(pod)

--- a/server/py/services/api/utils/builder/__init__.py
+++ b/server/py/services/api/utils/builder/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from base64 import b64decode
-from urllib.parse import urlparse
 
 import mlrun.common.constants as mlrun_constants
 import mlrun.common.schemas
@@ -351,31 +350,15 @@ def _buildah_fallback_reason(request: BuildRequest) -> str | None:
     :param request: The resolved build request.
     :return: A human-readable fallback reason, or ``None`` when Buildah can build the request.
     """
-    # (1) Cloud-registry credential-helper auth -> ML-12886. The Buildah adapter authenticates only
-    #     via a mounted static docker-config secret; ECR/ACR/GAR workload-identity credential
-    #     exchange is wired in ML-12886. Remove this guard when ML-12886 merges.
-    #     (The registry host is a plain hostname - safe to log; the source below is not, see below.)
+    # Cloud-registry credential-helper auth -> ML-12886. The Buildah adapter authenticates only
+    # via a mounted static docker-config secret; ECR/ACR/GAR workload-identity credential
+    # exchange is wired in ML-12886. Remove this guard when ML-12886 merges.
+    # (The registry host is a plain hostname - safe to log.)
     target = request.registry or request.image_target or ""
     if _is_cloud_registry(target):
         return (
             f"target registry '{target}' requires credential-helper auth not yet supported "
             "on Buildah (ML-12886)"
-        )
-
-    # (2) Source acquisition -> ML-12887. The adapter builds only the no-source-context case;
-    #     fetching or mounting a source into the build context (local path, v3io, remote scheme) is
-    #     added in ML-12887. inline_code and load_source_on_run don't stage a build-context source,
-    #     so they stay on Buildah. Remove this guard when ML-12887 merges.
-    #     Only the scheme is put in the reason - a source URI can embed credentials
-    #     (e.g. https://<token>@github.com/...), which must never be logged.
-    loads_source_on_run = bool(
-        request.runtime_spec and request.runtime_spec.build.load_source_on_run
-    )
-    if request.source and not (request.inline_code or loads_source_on_run):
-        source_scheme = urlparse(request.source).scheme or "local"
-        return (
-            f"source (scheme '{source_scheme}') requires acquisition not yet supported "
-            "on Buildah (ML-12887)"
         )
 
     return None

--- a/server/py/services/api/utils/builder/base.py
+++ b/server/py/services/api/utils/builder/base.py
@@ -18,6 +18,7 @@ import re
 import textwrap
 import typing
 from collections import defaultdict
+from urllib.parse import urlparse
 
 from kubernetes import client
 
@@ -36,6 +37,13 @@ from mlrun.utils.helpers import remove_image_protocol_prefix
 
 import framework.utils.helpers
 import framework.utils.singletons.k8s
+
+# subdirectory (under an engine's build-context emptyDir) that a fetch-source init container
+# writes into, and that a v3io FUSE-mount is nested under - shared so the two backends' Dockerfile
+# ``ADD``/``COPY`` source paths agree with what they actually mounted.
+FETCHED_SOURCE_SUBDIR = "source"
+
+_DEFAULT_SOURCE_FETCH_IMAGE = "mlrun/mlrun"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -504,6 +512,156 @@ def resolve_build_pod_spec_attributes(
         if attr_value:
             resolved[attribute] = attr_value
     return resolved
+
+
+def normalize_git_source_fragment(source: str) -> str:
+    """Normalize a ``git://`` source's fragment to a full ``refs/...`` ref.
+
+    A user-supplied branch/tag fragment without the ``refs/heads/``/``refs/tags/`` prefix is
+    assumed to be a branch. Shared by every backend that resolves a ``git://`` source itself
+    (rather than delegating the whole URI to the engine), so the assumption can't drift.
+
+    :param source: The raw ``git://...#<fragment>`` source descriptor.
+    :return: ``source`` with its fragment normalized, unchanged if there is no fragment or it
+        already starts with ``refs/``.
+    """
+    fragment = urlparse(source).fragment or ""
+    if fragment and not fragment.startswith("refs/"):
+        source = source.replace("#" + fragment, f"#refs/heads/{fragment}")
+    return source
+
+
+def resolve_source_code_target_dir(
+    request: BuildRequest, source_to_copy: str | None
+) -> None:
+    """Resolve the in-image source target dir (mutates the runtime build spec).
+
+    Only relevant when there is source to copy; a relative or unset target dir is anchored under
+    ``/home/mlrun_code``. Shared by every backend so the anchoring can't drift between engines.
+
+    :param request:        The build request (its ``runtime_spec`` is mutated).
+    :param source_to_copy: The routed source, or ``None`` when nothing is copied.
+    """
+    source_code_target_dir = request.runtime_spec.build.source_code_target_dir
+    if source_to_copy and (
+        not source_code_target_dir or not os.path.isabs(source_code_target_dir)
+    ):
+        relative_workdir = source_code_target_dir or ""
+        relative_workdir = relative_workdir.removeprefix("./")
+
+        request.runtime_spec.build.source_code_target_dir = os.path.join(
+            "/home/mlrun_code", relative_workdir
+        )
+
+
+def mount_v3io_source(
+    request: BuildRequest,
+    pod: "framework.utils.singletons.k8s.BasePod",
+    v3io_dir_to_mount: str,
+    mount_path: str,
+) -> None:
+    """Mount a v3io source directory into a build pod's build context.
+
+    Shared by every backend that supports a v3io source, so the credential-resolution precedence
+    (``builder_env`` overrides, falling back to ``auth_info``) can't drift between engines - only
+    the mount path (each engine's own build-context layout) is engine-specific.
+
+    :param request:           The build request (for v3io credentials).
+    :param pod:               The build pod to mount into.
+    :param v3io_dir_to_mount: The normalized v3io directory to mount.
+    :param mount_path:        Where to mount it inside the pod (engine-specific).
+    """
+    access_key = request.builder_env.get(
+        "V3IO_ACCESS_KEY",
+        request.auth_info.data_session or request.auth_info.access_key,
+    )
+    username = request.builder_env.get("V3IO_USERNAME", request.auth_info.username)
+    pod.mount_v3io(
+        remote=v3io_dir_to_mount,
+        mount_path=mount_path,
+        access_key=access_key,
+        user=username,
+    )
+
+
+def append_source_fetch_init_container(
+    pod: "framework.utils.singletons.k8s.BasePod",
+    source: str,
+    target_dir: str,
+    builder_env_list: list,
+    project_secrets: list,
+) -> None:
+    """Append a ``fetch-source`` init container that runs ``mlrun load-source``.
+
+    Fetches ``source`` into ``target_dir`` on a volume already mounted into ``pod`` (every init
+    container inherits the pod's volume mounts). Shared by every backend that stages a remote
+    source locally before its build step runs.
+
+    :param pod:              The build pod to append the init container to.
+    :param source:           The raw source URI to fetch.
+    :param target_dir:       Where ``mlrun load-source`` should write the fetched source, inside
+                             a volume the build container also has mounted.
+    :param builder_env_list: Build-time env vars (highest precedence).
+    :param project_secrets:  Project secrets exposed as build-time env vars (next precedence).
+    """
+    # Env precedence: builder_env_list > project_secrets > storage.auto_mount_params.
+    # First-write wins so caller-supplied values are not overwritten by auto-mount defaults.
+    image = config.httpdb.builder.kaniko_source_fetch_init_container_image
+    if not image:
+        image = mlrun.utils.enrich_image_url(_DEFAULT_SOURCE_FETCH_IMAGE)
+
+    args = ["-m", "mlrun", "load-source", source, "--target", target_dir]
+
+    env_list = list(builder_env_list or []) + list(project_secrets or [])
+    already_set = {env_var.name for env_var in env_list}
+    for env_var in resolve_storage_auto_mount_env():
+        if env_var.name in already_set:
+            continue
+        env_list.append(env_var)
+        already_set.add(env_var.name)
+
+    # only the scheme is logged - a source URI can embed credentials
+    # (e.g. https://<token>@github.com/... or a presigned s3/http URL), which must never be logged.
+    mlrun.utils.logger.debug(
+        "Adding source-fetch init container",
+        image=image,
+        source_scheme=urlparse(source).scheme or "local",
+        target=target_dir,
+    )
+    pod.append_init_container(
+        image,
+        command=["python"],
+        args=args,
+        env=env_list,
+        name="fetch-source",
+    )
+
+
+def resolve_storage_auto_mount_env() -> list:
+    # Gate on env_style_modifiers so mount-style outputs (volumes/volume_mounts) are
+    # not silently dropped. KubeResource.apply sanitizes spec.env to plain dicts, so
+    # rebuild V1EnvVar for callers that rely on attribute access.
+    auto_mount_type = mlrun.runtimes.pod.AutoMountType(
+        mlrun.mlconf.storage.auto_mount_type
+    )
+    modifier = auto_mount_type.get_modifier()
+    if (
+        modifier is None
+        or modifier not in mlrun.runtimes.pod.AutoMountType.env_style_modifiers()
+    ):
+        return []
+    scratch = mlrun.runtimes.KubejobRuntime()
+    scratch.try_auto_mount_based_on_config()
+    return [
+        client.V1EnvVar(
+            name=env_var["name"],
+            value=env_var.get("value"),
+            value_from=env_var.get("valueFrom"),
+        )
+        if isinstance(env_var, dict)
+        else env_var
+        for env_var in scratch.spec.env or []
+    ]
 
 
 def _generate_builder_env(

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -71,10 +71,10 @@ class BuildahBackend:
     :func:`~services.api.utils.builder.resolve_builder_backend` transparently falls back to Kaniko
     for those inputs until it lands.
 
-    Source acquisition (ML-12887): Buildah's ``bud --context`` has no native remote-context
-    resolution (unlike Kaniko's git/s3 ``--context`` and Dockerfile ``ADD``-from-URL for http), so
-    every remote source is either fetched via the ``fetch-source`` init container (git, archives,
-    s3, http(s)) or, for v3io, FUSE-mounted - both write/mount into
+    Source acquisition: Buildah's ``bud --context`` has no native remote-context resolution
+    (unlike Kaniko's git/s3 ``--context`` and Dockerfile ``ADD``-from-URL for http), so every
+    remote source is either fetched via the ``fetch-source`` init container (git, archives, s3,
+    http(s)) or, for v3io, FUSE-mounted - both write/mount into
     ``{_CONTEXT_DIR}/{base.FETCHED_SOURCE_SUBDIR}``, the same emptyDir already mounted for
     Dockerfile/inline-code staging.
     """

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os.path
 import pathlib
 import shlex
 from base64 import b64encode
+from urllib.parse import urlparse
 
 from kubernetes import client
 
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils
+import mlrun.utils.clones
 from mlrun.config import config
 
 import framework.utils.singletons.k8s
@@ -63,11 +66,17 @@ class BuildahBackend:
     (``SETUID``/``SETGID`` + ``allowPrivilegeEscalation``); the ``hostUsers`` model was dropped after
     POC-1 showed it is not viable on the target runtimes.
 
-    Scope note: this adapter handles the no-source-context build (inline code / requirements /
-    commands) and static docker-config-secret registry auth. Cloud-registry credential helpers
-    (ML-12886) and remote source acquisition (ML-12887) are not implemented here;
+    Scope note: this adapter handles static docker-config-secret registry auth only.
+    Cloud-registry credential helpers are wired in a follow-up (ML-12886);
     :func:`~services.api.utils.builder.resolve_builder_backend` transparently falls back to Kaniko
-    for those inputs until the follow-ups land.
+    for those inputs until it lands.
+
+    Source acquisition (ML-12887): Buildah's ``bud --context`` has no native remote-context
+    resolution (unlike Kaniko's git/s3 ``--context`` and Dockerfile ``ADD``-from-URL for http), so
+    every remote source is either fetched via the ``fetch-source`` init container (git, archives,
+    s3, http(s)) or, for v3io, FUSE-mounted - both write/mount into
+    ``{_CONTEXT_DIR}/{base.FETCHED_SOURCE_SUBDIR}``, the same emptyDir already mounted for
+    Dockerfile/inline-code staging.
     """
 
     def make_build_pod(
@@ -77,31 +86,22 @@ class BuildahBackend:
 
         :param request: The resolved, engine-agnostic build inputs.
         :return: The Buildah build pod.
-        :raises mlrun.errors.MLRunInvalidArgumentError: If the request carries a source needing
-            acquisition (resolve_builder_backend should have routed it to Kaniko - ML-12887).
         """
-        # source acquisition is not implemented in this adapter yet (ML-12887). resolve_builder_backend
-        # falls back to Kaniko when a request carries such a source, so reaching here with one is a bug
-        # in the selection gate, not a user error - fail fast rather than silently drop the source.
-        loads_source_on_run = bool(
-            request.runtime_spec and request.runtime_spec.build.load_source_on_run
-        )
-        if request.source and not (request.inline_code or loads_source_on_run):
-            raise mlrun.errors.MLRunInvalidArgumentError(
-                "BuildahBackend received a build source it cannot acquire yet (ML-12887); "
-                "this should have fallen back to Kaniko in resolve_builder_backend"
-            )
+        source_to_copy, source_to_fetch, v3io_dir_to_mount = self._route_source(request)
+        base.resolve_source_code_target_dir(request, source_to_copy=source_to_copy)
+
         dockerfile = base.make_dockerfile(
             request.base_image,
             request.commands,
-            source=None,
+            source=source_to_copy,
             requirements_path=request.requirements_path,
             extra=request.extra,
+            target_dir=request.runtime_spec.build.source_code_target_dir,
             builder_env=request.builder_env_list,
             project_secrets=request.project_secrets,
             extra_args=request.extra_args,
         )
-        return make_buildah_pod(
+        buildah_pod = make_buildah_pod(
             project=request.project,
             dest=request.image_target,
             dockerfile=dockerfile,
@@ -119,6 +119,77 @@ class BuildahBackend:
             extra_labels=request.labels,
             project_default_function_node_selector=request.project_default_function_node_selector,
             auth_info=request.auth_info,
+        )
+
+        if source_to_fetch:
+            base.append_source_fetch_init_container(
+                pod=buildah_pod,
+                source=source_to_fetch,
+                target_dir=f"{_CONTEXT_DIR}/{base.FETCHED_SOURCE_SUBDIR}",
+                builder_env_list=request.builder_env_list,
+                project_secrets=request.project_secrets,
+            )
+        elif v3io_dir_to_mount:
+            base.mount_v3io_source(
+                request,
+                buildah_pod,
+                v3io_dir_to_mount,
+                mount_path=f"{_CONTEXT_DIR}/{base.FETCHED_SOURCE_SUBDIR}",
+            )
+
+        return buildah_pod
+
+    @staticmethod
+    def _route_source(
+        request: base.BuildRequest,
+    ) -> tuple[str | None, str | None, str | None]:
+        """Route the raw source descriptor to the Buildah build context.
+
+        Buildah has no native remote-context resolution, so - unlike Kaniko - every remote source
+        is either fetched or FUSE-mounted; none is ever passed through as a raw remote URI.
+
+        :param request: The build request carrying the raw ``source``.
+        :return: ``(source_to_copy, source_to_fetch, v3io_dir_to_mount)``. At most one of
+            ``source_to_fetch``/``v3io_dir_to_mount`` is set.
+        """
+        source = request.source
+        loads_source_on_run = bool(
+            request.runtime_spec and request.runtime_spec.build.load_source_on_run
+        )
+        if request.inline_code or loads_source_on_run or not source:
+            return None, None, None
+
+        if source.startswith("v3io://") or source.startswith("v3ios://"):
+            v3io_path = urlparse(source).path
+            v3io_dir_to_mount, basename = os.path.split(v3io_path)
+            v3io_dir_to_mount = os.path.normpath(v3io_dir_to_mount)
+            source_to_copy = f"./{base.FETCHED_SOURCE_SUBDIR}/{basename}"
+            return source_to_copy, None, v3io_dir_to_mount
+
+        if "://" in source:
+            # fail fast, before scheduling a pod, on a scheme `mlrun load-source` can't resolve
+            # (the fetch-source init container would otherwise fail only once it actually runs).
+            # git's own ref-fragment normalization happens inside `clone_git`, which
+            # ``load-source`` calls - the raw source is handed through unchanged.
+            if not mlrun.utils.clones.is_source_loadable(source):
+                scheme = urlparse(source).scheme
+                raise mlrun.errors.MLRunInvalidArgumentError(
+                    f"Source scheme '{scheme}://' is not supported by mlrun load-source. "
+                    "Provide a store:// URI, a git:// URL, a .zip/.tar.gz archive, or a bare "
+                    "s3:// / http(s):// file"
+                )
+            return f"./{base.FETCHED_SOURCE_SUBDIR}", source, None
+
+        # no scheme: local path, same edge-case semantics Kaniko has - assumed to be a valid path
+        # already inside the build image (e.g. baked into a custom base image); relative paths are
+        # not supported at build time.
+        if os.path.isabs(source):
+            return source, None, None
+
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            f"Load of relative source ({source}) is not supported at build time "
+            "see 'mlrun.runtimes.kubejob.KubejobRuntime.with_source_archive' or "
+            "'mlrun.projects.project.MlrunProject.set_source' for more details"
         )
 
 

--- a/server/py/services/api/utils/builder/kaniko.py
+++ b/server/py/services/api/utils/builder/kaniko.py
@@ -24,7 +24,6 @@ import mlrun.errors
 import mlrun.model
 import mlrun.runtimes
 import mlrun.runtimes.mounts
-import mlrun.runtimes.pod
 import mlrun.runtimes.utils
 import mlrun.utils
 from mlrun.config import config
@@ -44,10 +43,6 @@ _FETCH_SUPPORTED_SCHEMES = frozenset({"az", "wasb", "wasbs", "ds", "oss", "gs", 
 # matches what ``mlrun load-source`` extracts.
 # TODO: support .tgz
 _FETCHABLE_ARCHIVE_EXTENSIONS = (".tar.gz", ".zip")
-
-_FETCHED_SOURCE_SUBDIR = "source"
-
-_DEFAULT_SOURCE_FETCH_IMAGE = "mlrun/mlrun"
 
 
 def make_kaniko_pod(
@@ -206,9 +201,10 @@ def make_kaniko_pod(
         kaniko_pod.mount_secret(secret_name, "/kaniko/.docker", items=items)
 
     if source_to_fetch:
-        _append_source_fetch_init_container(
-            kaniko_pod=kaniko_pod,
+        base.append_source_fetch_init_container(
+            pod=kaniko_pod,
             source=source_to_fetch,
+            target_dir=f"/empty/{base.FETCHED_SOURCE_SUBDIR}",
             builder_env_list=builder_env,
             project_secrets=project_secrets,
         )
@@ -300,7 +296,7 @@ class KanikoBackend:
             to_mount,
             needs_source_fetch_init_container,
         ) = self._route_source(request)
-        self._resolve_source_code_target_dir(request, source_to_copy=source_to_copy)
+        base.resolve_source_code_target_dir(request, source_to_copy=source_to_copy)
 
         dock = base.make_dockerfile(
             request.base_image,
@@ -342,7 +338,9 @@ class KanikoBackend:
         )
 
         if to_mount:
-            self._mount_v3io_source(request, kaniko_pod, source_dir_to_mount)
+            base.mount_v3io_source(
+                request, kaniko_pod, source_dir_to_mount, mount_path="/context"
+            )
 
         return kaniko_pod
 
@@ -385,16 +383,13 @@ class KanikoBackend:
         elif source and _needs_source_fetch_init_container(source):
             _validate_source_fetch_archive(source)
             context = "/empty"
-            source_to_copy = f"./{_FETCHED_SOURCE_SUBDIR}"
+            source_to_copy = f"./{base.FETCHED_SOURCE_SUBDIR}"
             needs_source_fetch_init_container = True
 
         # source is remote (kaniko-native)
         elif source and "://" in source and not is_v3io_source:
             if source.startswith("git://"):
-                # if the user provided branch (w/o refs/..) we add the "refs/.."
-                fragment = parsed_url.fragment or ""
-                if not fragment.startswith("refs/"):
-                    source = source.replace("#" + fragment, f"#refs/heads/{fragment}")
+                source = base.normalize_git_source_fragment(source)
 
             # set remote source as kaniko's build context and copy it
             context = source
@@ -432,53 +427,6 @@ class KanikoBackend:
             needs_source_fetch_init_container,
         )
 
-    @staticmethod
-    def _resolve_source_code_target_dir(
-        request: base.BuildRequest, source_to_copy: str | None
-    ) -> None:
-        """Resolve the in-image source target dir (mutates the runtime build spec).
-
-        Only relevant when there is source to copy; a relative or unset target dir is
-        anchored under ``/home/mlrun_code``.
-
-        :param request:        The build request (its ``runtime_spec`` is mutated).
-        :param source_to_copy: The routed source, or ``None`` when nothing is copied.
-        """
-        source_code_target_dir = request.runtime_spec.build.source_code_target_dir
-        if source_to_copy and (
-            not source_code_target_dir or not os.path.isabs(source_code_target_dir)
-        ):
-            relative_workdir = source_code_target_dir or ""
-            relative_workdir = relative_workdir.removeprefix("./")
-
-            request.runtime_spec.build.source_code_target_dir = os.path.join(
-                "/home/mlrun_code", relative_workdir
-            )
-
-    @staticmethod
-    def _mount_v3io_source(
-        request: base.BuildRequest,
-        kaniko_pod: framework.utils.singletons.k8s.BasePod,
-        source_dir_to_mount: str | None,
-    ) -> None:
-        """Mount a v3io source directory as the Kaniko build context.
-
-        :param request:             The build request (for v3io credentials).
-        :param kaniko_pod:                The build pod to mount into.
-        :param source_dir_to_mount: The normalized v3io directory to mount.
-        """
-        access_key = request.builder_env.get(
-            "V3IO_ACCESS_KEY",
-            request.auth_info.data_session or request.auth_info.access_key,
-        )
-        username = request.builder_env.get("V3IO_USERNAME", request.auth_info.username)
-        kaniko_pod.mount_v3io(
-            remote=source_dir_to_mount,
-            mount_path="/context",
-            access_key=access_key,
-            user=username,
-        )
-
 
 def _needs_source_fetch_init_container(source: str) -> bool:
     return urlparse(source).scheme in _FETCH_SUPPORTED_SCHEMES
@@ -495,71 +443,6 @@ def _validate_source_fetch_archive(source: str) -> None:
             "supported as a kaniko build context. Provide the source as an "
             f"archive ending in one of: {', '.join(_FETCHABLE_ARCHIVE_EXTENSIONS)}"
         )
-
-
-def _append_source_fetch_init_container(
-    kaniko_pod,
-    source: str,
-    builder_env_list: list,
-    project_secrets: list,
-) -> None:
-    # Env precedence: builder_env_list > project_secrets > storage.auto_mount_params.
-    # First-write wins so caller-supplied values are not overwritten by auto-mount defaults.
-    image = config.httpdb.builder.kaniko_source_fetch_init_container_image
-    if not image:
-        image = mlrun.utils.enrich_image_url(_DEFAULT_SOURCE_FETCH_IMAGE)
-
-    target_dir = f"/empty/{_FETCHED_SOURCE_SUBDIR}"
-    args = ["-m", "mlrun", "load-source", source, "--target", target_dir]
-
-    env_list = list(builder_env_list or []) + list(project_secrets or [])
-    already_set = {env_var.name for env_var in env_list}
-    for env_var in _resolve_storage_auto_mount_env():
-        if env_var.name in already_set:
-            continue
-        env_list.append(env_var)
-        already_set.add(env_var.name)
-
-    mlrun.utils.logger.debug(
-        "Adding source-fetch init container",
-        image=image,
-        source=source,
-        target=target_dir,
-    )
-    kaniko_pod.append_init_container(
-        image,
-        command=["python"],
-        args=args,
-        env=env_list,
-        name="fetch-source",
-    )
-
-
-def _resolve_storage_auto_mount_env() -> list:
-    # Gate on env_style_modifiers so mount-style outputs (volumes/volume_mounts) are
-    # not silently dropped. KubeResource.apply sanitizes spec.env to plain dicts, so
-    # rebuild V1EnvVar for callers that rely on attribute access.
-    auto_mount_type = mlrun.runtimes.pod.AutoMountType(
-        mlrun.mlconf.storage.auto_mount_type
-    )
-    modifier = auto_mount_type.get_modifier()
-    if (
-        modifier is None
-        or modifier not in mlrun.runtimes.pod.AutoMountType.env_style_modifiers()
-    ):
-        return []
-    scratch = mlrun.runtimes.KubejobRuntime()
-    scratch.try_auto_mount_based_on_config()
-    return [
-        client.V1EnvVar(
-            name=env_var["name"],
-            value=env_var.get("value"),
-            value_from=env_var.get("valueFrom"),
-        )
-        if isinstance(env_var, dict)
-        else env_var
-        for env_var in scratch.spec.env or []
-    ]
 
 
 def _add_kaniko_args_with_all_build_args(

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -195,9 +195,9 @@ def test_extract_source_store_uri_forwards_secrets():
             "s3://path",
             "target_dir is required",
         ),
-        # Unsupported source type (not store://, git://, .zip, or .tar.gz)
+        # Unsupported source type (not store://, git://, .zip/.tar.gz, or bare s3/http(s))
         (
-            "http://not-a-store/file.py",
+            "ftp://not-a-store/file.py",
             "/tmp/target",
             False,
             "s3://path",
@@ -296,6 +296,58 @@ def test_load_source_code_tgz(tmp_path):
     assert returned_dir == target_dir
     assert returned_file_path is None
     mock_clone_tgz.assert_called_once_with(source_uri, target_dir)
+
+
+@pytest.mark.parametrize(
+    "source_uri",
+    [
+        "s3://bucket/path/main.py",
+        "http://example.com/path/main.py",
+        "https://example.com/path/main.py",
+    ],
+)
+def test_load_source_code_single_file(tmp_path, source_uri):
+    target_dir = str(tmp_path / "target")
+
+    with unittest.mock.patch.object(mlrun, "get_dataitem") as mock_get_dataitem:
+        mock_download = mock_get_dataitem.return_value.download
+        returned_dir, returned_file_path = mlrun.utils.clones.load_source_code(
+            source_uri=source_uri,
+            target_dir=target_dir,
+        )
+
+    expected_file_path = os.path.join(target_dir, "main.py")
+    assert returned_dir == target_dir
+    assert returned_file_path == expected_file_path
+    mock_get_dataitem.assert_called_once_with(source_uri, secrets=None)
+    mock_download.assert_called_once_with(expected_file_path)
+    assert os.path.isdir(target_dir)
+
+
+def test_load_source_code_s3_archive_still_uses_archive_handler(tmp_path):
+    # archive detection must run before the new bare-scheme single-file check, so an archive
+    # under s3:// still extracts rather than downloading as one opaque file.
+    source_uri = "s3://bucket/path/project.tar.gz"
+    target_dir = str(tmp_path / "target")
+
+    with unittest.mock.patch.object(mlrun.utils.clones, "clone_tgz") as mock_clone_tgz:
+        returned_dir, returned_file_path = mlrun.utils.clones.load_source_code(
+            source_uri=source_uri,
+            target_dir=target_dir,
+        )
+
+    assert returned_dir == target_dir
+    assert returned_file_path is None
+    mock_clone_tgz.assert_called_once_with(source_uri, target_dir)
+
+
+def test_load_source_code_single_file_no_filename_raises(tmp_path):
+    # a trailing slash resolves to an empty basename - nothing to name the downloaded file.
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="no resolvable filename"):
+        mlrun.utils.clones.load_source_code(
+            source_uri="s3://bucket/path/",
+            target_dir=str(tmp_path / "target"),
+        )
 
 
 def test_extract_source_store_uri_delegates_to_load_source_code():

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -324,6 +324,24 @@ def test_load_source_code_single_file(tmp_path, source_uri):
     assert os.path.isdir(target_dir)
 
 
+def test_load_source_code_single_file_download_failure_does_not_leak_uri(tmp_path):
+    # a download failure must surface only the scheme in the error, never the full URI - it
+    # can embed credentials (e.g. a presigned URL's query string, or a token in the path).
+    source_uri = "https://example.com/main.py?token=super-secret"
+    target_dir = str(tmp_path / "target")
+
+    with unittest.mock.patch.object(mlrun, "get_dataitem") as mock_get_dataitem:
+        mock_get_dataitem.return_value.download.side_effect = Exception("boom")
+        with pytest.raises(mlrun.errors.MLRunRuntimeError) as exc_info:
+            mlrun.utils.clones.load_source_code(
+                source_uri=source_uri,
+                target_dir=target_dir,
+            )
+
+    assert "super-secret" not in str(exc_info.value)
+    assert "'https'" in str(exc_info.value)
+
+
 def test_load_source_code_s3_archive_still_uses_archive_handler(tmp_path):
     # archive detection must run before the new bare-scheme single-file check, so an archive
     # under s3:// still extracts rather than downloading as one opaque file.
@@ -350,6 +368,63 @@ def test_load_source_code_single_file_no_filename_raises(tmp_path):
             source_uri="s3://bucket/path/",
             target_dir=str(tmp_path / "target"),
         )
+
+
+def test_load_source_code_single_file_no_filename_does_not_leak_uri(tmp_path):
+    # the error must name only the scheme, never the full URI - it can embed credentials
+    # (e.g. a presigned URL's query string).
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError) as exc_info:
+        mlrun.utils.clones.load_source_code(
+            source_uri="s3://bucket/path/?token=super-secret",
+            target_dir=str(tmp_path / "target"),
+        )
+    assert "super-secret" not in str(exc_info.value)
+
+
+def test_load_source_code_archive_with_query_string_still_uses_archive_handler(
+    tmp_path,
+):
+    # a presigned-URL query string must not hide the .tar.gz extension from detection and
+    # cause it to fall through to the single-file branch instead of extracting.
+    source_uri = "https://example.com/path/project.tar.gz?token=abc123"
+    target_dir = str(tmp_path / "target")
+
+    with unittest.mock.patch.object(mlrun.utils.clones, "clone_tgz") as mock_clone_tgz:
+        returned_dir, returned_file_path = mlrun.utils.clones.load_source_code(
+            source_uri=source_uri,
+            target_dir=target_dir,
+        )
+
+    assert returned_dir == target_dir
+    assert returned_file_path is None
+    mock_clone_tgz.assert_called_once_with(source_uri, target_dir)
+
+
+@pytest.mark.parametrize(
+    "source_uri,expected",
+    [
+        ("", False),
+        ("store://artifacts/project/handler.py", True),
+        ("git://github.com/org/repo.git#main", True),
+        ("s3://bucket/path/project.tar.gz", True),
+        ("s3://bucket/path/project.zip", True),
+        ("s3://bucket/path/project.tar.gz?token=abc", True),
+        # bare (non-archive) single-file schemes
+        ("s3://bucket/path/main.py", True),
+        ("http://example.com/main.py", True),
+        ("https://example.com/main.py", True),
+        # an archive extension under a scheme mlrun.datastore doesn't register at all - must
+        # not be reported loadable, or a caller that fails fast on this signal (e.g. Buildah's
+        # source routing) would schedule a pod that's guaranteed to fail.
+        ("ftp://host/source.zip", False),
+        ("ftp://host/source.tar.gz", False),
+        # unsupported bare-file scheme
+        ("ftp://host/file.py", False),
+        ("relative/path", False),
+    ],
+)
+def test_is_source_loadable(source_uri, expected):
+    assert mlrun.utils.clones.is_source_loadable(source_uri) is expected
 
 
 def test_extract_source_store_uri_delegates_to_load_source_code():

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -343,7 +343,9 @@ def test_load_source_code_s3_archive_still_uses_archive_handler(tmp_path):
 
 def test_load_source_code_single_file_no_filename_raises(tmp_path):
     # a trailing slash resolves to an empty basename - nothing to name the downloaded file.
-    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="no resolvable filename"):
+    with pytest.raises(
+        mlrun.errors.MLRunInvalidArgumentError, match="no resolvable filename"
+    ):
         mlrun.utils.clones.load_source_code(
             source_uri="s3://bucket/path/",
             target_dir=str(tmp_path / "target"),


### PR DESCRIPTION
### 📝 Description

Implements ML-12887: `BuildahBackend` (ML-12885, #9930) currently refuses any build source that isn't inline code or `load_source_on_run` — `resolve_builder_backend` silently falls back to Kaniko for everything else. Buildah's `bud --context` has no native remote-context resolution the way Kaniko's executor does (no native git/s3 `--context`, no Dockerfile `ADD`-from-URL for bare http), so this PR routes **every** remote source through the existing `fetch-source` init container (`mlrun load-source`) or, for v3io, a FUSE mount — both into the pod's existing context emptyDir. That routing depends on `mlrun load-source` covering two shapes it didn't before: a bare (non-archive) `s3://` object and a bare `http(s)://` URL, single-file downloads the same shape `store://` artifacts already support.

Source: ML-12427 Backend HLD, Decision D6.

---

### 🛠️ Changes Made
- **`mlrun/utils/clones.py`** — `load_source_code` gains a dispatch branch for bare (non-archive) `s3://`/`http(s)://` single-file sources; new `is_source_loadable` predicate lets a caller fail fast on an unsupported scheme without downloading; new shared `_download_single_file_to_dir` helper (also used by the existing artifact-download path).
- **`server/py/services/api/utils/builder/buildah.py`** — `BuildahBackend._route_source` (new): fetches git/archive/s3/http(s) sources via the fetch-source init container, FUSE-mounts v3io sources, passes through a local absolute path unchanged (parity with Kaniko's own edge case), and raises `MLRunInvalidArgumentError` for an unsupported scheme *before* a pod is constructed.
- **`server/py/services/api/utils/builder/base.py`** — extracted several source-routing helpers out of `kaniko.py` so Kaniko and Buildah share one implementation (behavior-preserving move): `FETCHED_SOURCE_SUBDIR`, `resolve_source_code_target_dir`, `mount_v3io_source`, `append_source_fetch_init_container`, `resolve_storage_auto_mount_env`, `normalize_git_source_fragment`.
- **`server/py/services/api/utils/builder/__init__.py`** — removed the now-satisfied "source needs acquisition" Kaniko-fallback guard in `_buildah_fallback_reason` (the ML-12886 cloud-registry guard is untouched).
- **`server/py/services/api/utils/builder/kaniko.py`** — re-points at the moved helpers; no behavior change (existing Kaniko test suite stays green).
- Only the URI **scheme** is ever logged around source fetching, never the raw URI — a source URI can embed credentials (e.g. `https://<token>@github.com/...`, a presigned S3/HTTP URL).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New unit tests: `tests/utils/test_clones.py` (bare s3/http(s) single-file downloads, archive-before-single-file regression guard, no-resolvable-filename failure) and a new "Buildah source routing" section in `server/py/services/api/tests/unit/utils/test_builder_backend.py` (fetch-init for git/s3-archive/s3-file/http/https, v3io FUSE-mount, local-abs-path passthrough, relative-path and unsupported-scheme failures, no-source/inline-code no-ops).
- Full relevant suite (`test_clones.py`, `test_cli.py`, `test_builder.py`, `test_builder_backend.py`): 242 passed. 36 pre-existing failures are unrelated (an environment-only `forbidden_service_accounts` config `AttributeError`, reproducible on this branch's unmodified base commit) — confirmed unchanged before/after this diff.
- System-level parity testing across all source types is explicitly ML-12889's scope, not duplicated here.
- **Live-validated on lab `vmdev122ig4`** (patched `mlrun-api` with this branch, `builder_backend=buildah`): real end-to-end builds succeeded for **git://**, an **https tar.gz archive**, and a **bare https single file** — each ran the `fetch-source` init container (`Successfully loaded source to: /empty/source`), `buildah bud` built the image, and `buildah push` succeeded to the lab registry (pod phase `Completed`). **v3io://** routing was confirmed correct via a direct in-pod call (`v3io:///bigdata/x/code` → mounts `/bigdata/x`, copies `./source/code`) but the FUSE mount itself wasn't exercised live (needs an interactive v3io access-key login). **s3** wasn't live-tested (no AWS test credentials) — its code path is identical to the now-validated bare-http case (same `_load_single_file_source` → `_download_single_file_to_dir` → `mlrun.get_dataitem`, only the backing `DataStore` class differs).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12887
- Design docs links: Backend HLD (ML-12427) — Decision D6; Assumptions & Decisions Log (IRG space)
- External links: builds on #9930 (ML-12885); unblocks ML-12889 (parity test matrix)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

Every change is additive. Kaniko's own routing is untouched (byte-identical, confirmed by its existing test suite staying green); Buildah gains a capability it didn't have, gated the same way it already was (opt-in via `builder_backend`).

---

### 🔍️ Additional Notes
- **Base branch is `feature/buildah`, not `development`** — stacks on the merged ML-12885 adapter, matching that PR's own convention.
- "Documentation" here means docstrings and the `mlrun load-source` CLI `--help` text (the only user-facing surface for this change) — there's no `docs/` page about builder backends to update.
- Cloud-registry auth (ML-12886) is untouched; `resolve_builder_backend` still falls back to Kaniko for ECR/ACR/GAR targets.
