### PR TITLE
[DEVOPS-2054] [System Tests] Use ghcr proxy secret for enterprise registry

### DIFF
--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -73,18 +73,6 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -qqy && apt-get install -y sshpass
-    - name: Identify enterprise system-test cluster
-      run: |
-        sshpass \
-          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
-          ssh \
-          -o StrictHostKeyChecking=no \
-          -o ConnectTimeout=15 \
-          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
-          "hostname -f; hostname -I; kubectl get ingress -n default-tenant mlrun-api -o jsonpath='{.spec.rules[0].host}'; echo"
-
-        echo "::error::Intentional stop after identifying the data cluster"
-        exit 1
     - name: cleanup docker images from registries
       # SSH to datanode and delete all docker images created by the system tests by restarting the docker-registry
       # deployment and the datanode docker-registry
@@ -292,7 +280,7 @@ jobs:
           echo ${input_system_tests_clean_resources:-true})" >> $GITHUB_OUTPUT
         echo "override_iguazio_version=$INPUT_OVERRIDE_IGUAZIO_VERSION" >> $GITHUB_OUTPUT
       env:
-        SECRET_DOCKER_REGISTRY: ${{ secrets.SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY }}
+        SECRET_DOCKER_REGISTRY: ${{ secrets.SYSTEM_TESTS_ENTERPRISE_GHCR_PROXY_REGISTRY }}
         INPUT_DOCKER_REGISTRY: ${{ github.event.inputs.docker_registry }}
         INPUT_OVERRIDE_IGUAZIO_VERSION: ${{ github.event.inputs.override_iguazio_version }}
         INPUT_CLEAN_RESOURCES_IN_TEARDOWN: ${{ github.event.inputs.clean_resources_in_teardown }}

--- a/.github/workflows/system-tests-enterprise.yml
+++ b/.github/workflows/system-tests-enterprise.yml
@@ -73,6 +73,18 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -qqy && apt-get install -y sshpass
+    - name: Identify enterprise system-test cluster
+      run: |
+        sshpass \
+          -p "${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_PASSWORD }}" \
+          ssh \
+          -o StrictHostKeyChecking=no \
+          -o ConnectTimeout=15 \
+          ${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_SSH_USERNAME }}@${{ secrets.LATEST_SYSTEM_TEST_DATA_CLUSTER_IP }} \
+          "hostname -f; hostname -I; kubectl get ingress -n default-tenant mlrun-api -o jsonpath='{.spec.rules[0].host}'; echo"
+
+        echo "::error::Intentional stop after identifying the data cluster"
+        exit 1
     - name: cleanup docker images from registries
       # SSH to datanode and delete all docker images created by the system tests by restarting the docker-registry
       # deployment and the datanode docker-registry


### PR DESCRIPTION
### 📝 Description

Enterprise system tests were failing on MLRun image pulls from the old Iguazio ghcr proxy.

This PR points the enterprise workflow at the new ghcr proxy using a new GitHub secret, leaving `SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY` unchanged.

---

### 🛠️ Changes Made

- `Set computed versions params` reads `SYSTEM_TESTS_ENTERPRISE_GHCR_PROXY_REGISTRY` instead of `SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY`
- Manual `workflow_dispatch` `docker_registry` input and fallback logic unchanged

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- [System Tests Enterprise #7319](https://github.com/mlrun/mlrun/actions/runs/29912298698) on this branch
- Confirm in prepare logs that provctl pulls from `mckinsey-igz-ghcr-io-proxy.jfrog.io/mlrun/...`

---

### 🔗 References
- Ticket link: [DEVOPS-2054](https://ecliptos.atlassian.net/browse/DEVOPS-2054)
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- Rollback: point the workflow back at `SYSTEM_TESTS_ENTERPRISE_DOCKER_REGISTRY` (secret value unchanged)
