### PR TITLE
[Test] Fix subprocess stdout/stderr pipe deadlock in test_httpdb server fixture

### DIFF
--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -91,7 +91,19 @@ def start_server(workdir, env_config: dict):
         "server.py.services.api.main",
     ]
 
-    proc = Popen(cmd, env=env, stdout=PIPE, stderr=PIPE, cwd=project_dir_path)
+    # Redirect to files rather than PIPE: an unread pipe has a small, fixed-size OS
+    # buffer, and once the server's debug-level logging fills it, the writing thread
+    # blocks inside the stdlib logging Handler's flush() while holding its lock - which
+    # then blocks every other thread (including the event loop) the next time it tries
+    # to log anything, freezing the whole single-worker server until someone drains the
+    # pipe. Files have no such backpressure.
+    with (
+        open(os.path.join(workdir, "server-stdout.log"), "wb") as stdout_file,
+        open(os.path.join(workdir, "server-stderr.log"), "wb") as stderr_file,
+    ):
+        proc = Popen(
+            cmd, env=env, stdout=stdout_file, stderr=stderr_file, cwd=project_dir_path
+        )
     url = f"http://localhost:{port}"
 
     return proc, url
@@ -172,9 +184,12 @@ def server_fixture():
     def cleanup():
         if process:
             process.terminate()
-            stdout = process.stdout.read()
+            process.wait()
+            with open(os.path.join(workdir, "server-stdout.log"), "rb") as fh:
+                stdout = fh.read()
+            with open(os.path.join(workdir, "server-stderr.log"), "rb") as fh:
+                stderr = fh.read()
             human_readable_stdout = codecs.escape_decode(stdout)[0].decode("utf-8")
-            stderr = process.stderr.read()
             human_readable_stderr = codecs.escape_decode(stderr)[0].decode("utf-8")
             print(f"Stdout from server {human_readable_stdout}")
             print(f"Stderr from server {human_readable_stderr}")


### PR DESCRIPTION
### 📝 Description
`test_paginated_list_artifacts[server]` (and any other `[server]`-parametrized test) could intermittently freeze the from-source API subprocess in CI for minutes. `server_fixture()` launches that subprocess with `Popen(..., stdout=PIPE, stderr=PIPE)` but only drains those pipes in `cleanup()`, after `terminate()`. Under debug-level logging (headers dumped per pagination request), the OS pipe buffer fills up: the writing thread blocks inside the stdlib logging `Handler.flush()` while holding that handler's lock, and the next thread to log anything through the same handler — including the asyncio event loop itself — blocks trying to acquire that lock, freezing the whole single-worker server until `cleanup()` finally reads the pipe.

This was confirmed with `faulthandler` thread dumps captured from an actual failing CI run (via a temporary diagnostic branch, since reverted): every dump showed one thread stuck in logging `flush()` reached from `_create_or_update_pagination_cache_record`'s debug log, and the main/event-loop thread stuck in `acquire()` from the request-logging middleware — never a DB, pool, or lock-related error, consistent with the server being unable to emit its own logs once stuck. An earlier attempted fix (#9946, offloading a DB call off the event loop) did not resolve this — this hang is unrelated to that bug.

---

### 🛠️ Changes Made
- `tests/rundb/test_httpdb.py`: `start_server()` now redirects the subprocess's stdout/stderr to files under the fixture's `workdir` instead of `PIPE`. Files have no fixed-size backpressure, so the same debug-log volume can't stall the writer.
- `server_fixture().cleanup()` now reads the server's captured output from those files (after `process.wait()`) instead of `process.stdout.read()` / `process.stderr.read()`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `test_paginated_list_artifacts[server]` passes.
- A reproduction using the exact `Popen(stdout=PIPE, stderr=PIPE)` pattern plus debug-level logging hung within seconds before this change; it now completes cleanly.
- Driving the fixture directly under 20 concurrent clients for 30s with debug logging produced 3,667 successful pagination round-trips, 0 timeouts, 0 errors — the same setup deadlocked almost immediately before the fix.

---

### 🔗 References
- Ticket link: none
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Test-only change — no production code paths are affected.