### PR TITLE
[Schemas] Add L2 behavioural wire-parity suite (ML-12900)

### DIFF
--- a/mlrun/common/schemas/_v1/model_monitoring/model_endpoints.py
+++ b/mlrun/common/schemas/_v1/model_monitoring/model_endpoints.py
@@ -16,8 +16,7 @@ from datetime import datetime
 from typing import Any, Literal, TypeVar
 from uuid import UUID
 
-from pydantic import validator  # use `validator` if you’re still on Pydantic v1
-from pydantic.v1 import BaseModel, Field, constr
+from pydantic.v1 import BaseModel, Field, constr, validator
 
 from ..._shared.model_monitoring.constants import (
     FQN_REGEX,

--- a/mlrun/common/schemas/_v2/common.py
+++ b/mlrun/common/schemas/_v2/common.py
@@ -62,7 +62,14 @@ class LabelsModel(pydantic.BaseModel):
 
     labels: typing.Union[str, dict[str, str | None], list[str]] | None = None
 
-    @pydantic.field_validator("labels")
+    # mode="before": v1's field-then-validator pipeline lets the validator return any
+    # shape regardless of the declared type; v2's default "after" mode type-checks the
+    # raw input against the Union *before* the validator runs, which rejects a dict with
+    # non-str values (e.g. {"label1": 1}) that v1 happily coerced. Running before type
+    # validation reproduces the v1 leniency (the branch below already `f"{key}={value}"`
+    # -stringifies non-str values), and the `list[str]` this returns satisfies the
+    # declared Union on its own.
+    @pydantic.field_validator("labels", mode="before")
     @classmethod
     def validate(cls, labels) -> list[str]:
         if labels is None:

--- a/tests/common/test_schemas.py
+++ b/tests/common/test_schemas.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pydantic
 import pydantic.v1
 import pytest
 
@@ -74,8 +75,12 @@ def test_project_monitoring_spec_round_trip():
     [("stream_type", "not-a-real-stream"), ("tsdb_type", "not-a-real-tsdb")],
 )
 def test_project_monitoring_spec_rejects_invalid_enum(field, value):
-    """Invalid stream/tsdb type strings must fail validation."""
-    with pytest.raises(pydantic.v1.ValidationError):
+    """Invalid stream/tsdb type strings must fail validation.
+
+    The exception class differs by which schema face is dispatched (_v1 -> pydantic.v1
+    under a client install, _v2 -> pydantic under the API server), so both are accepted.
+    """
+    with pytest.raises((pydantic.ValidationError, pydantic.v1.ValidationError)):
         mlrun.common.schemas.project.ProjectMonitoringSpec(**{field: value})
 
 

--- a/tests/common/test_schemas_behavioral_parity.py
+++ b/tests/common/test_schemas_behavioral_parity.py
@@ -227,17 +227,13 @@ def test_accept_case_round_trips_both_directions(case_id, v1_model, v2_model, pa
 def test_reject_case_matches_error_loci(
     case_id, v1_model, v2_model, payload, expected_loci
 ):
-    try:
+    with pytest.raises(v1.ValidationError) as v1_exc_info:
         v1_model.parse_obj(payload)
-        pytest.fail(f"{case_id}: _v1 accepted a reject-verdict input")
-    except v1.ValidationError as exc:
-        v1_loci = _error_loci(exc)
-
-    try:
+    with pytest.raises(v2.ValidationError) as v2_exc_info:
         v2_model.model_validate(payload)
-        pytest.fail(f"{case_id}: _v2 accepted a reject-verdict input")
-    except v2.ValidationError as exc:
-        v2_loci = _error_loci(exc)
+
+    v1_loci = _error_loci(v1_exc_info.value)
+    v2_loci = _error_loci(v2_exc_info.value)
 
     assert v1_loci == expected_loci, (
         f"{case_id}: _v1 error loci {v1_loci} != expected {expected_loci}"

--- a/tests/common/test_schemas_behavioral_parity.py
+++ b/tests/common/test_schemas_behavioral_parity.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""L2 behavioural parity between the ``_v1`` (pydantic.v1) and ``_v2`` (native pydantic 2)
+schema faces (ML-12900).
+
+L1 (``test_schemas_parity.py``, ML-12891) pins the declared *shape* of every model — same
+fields, same required-ness, same defaults. It cannot express *behaviour*: how a value is
+coerced, serialised, or rejected. L2 closes that gap with a fixed, reviewable corpus of
+inputs, each carrying an explicit expected verdict — ``accept`` or ``reject``.
+
+The verdict is never inferred from "do the two faces agree" (a both-agree assertion would
+silently pass if an ``accept`` case decayed into a mutual ``reject`` as schemas evolve,
+quietly shrinking the corpus to rejection-only). Each case is asserted against its pinned
+verdict independently.
+
+* ``accept`` — both faces must accept the input, and round-trip identically: the JSON each
+  produces, parsed back to a plain value, must be equal, AND each face must be able to
+  parse the *other* face's JSON output (the actual wire scenario — a ``_v1`` client and a
+  ``_v2`` server exchanging requests/responses, per Backend HLD §2.3).
+* ``reject`` — both faces must reject, and the set of error loci (offending field paths)
+  must match. Only loci are compared, never messages or ``type`` codes — those differ
+  between Pydantic majors by construction (Backend HLD §3.1).
+
+Like L1, this runs on the Pydantic-2-only baseline and imports ``_v1``/``_v2`` directly,
+independent of the ``MLRUN_IS_API_SERVER`` dispatch gate.
+"""
+
+import json
+
+import pydantic as v2
+import pydantic.v1 as v1
+import pytest
+
+if int(v2.VERSION.split(".")[0]) < 2:
+    pytest.skip(
+        "L2 behavioural parity requires the pydantic 2 baseline",
+        allow_module_level=True,
+    )
+
+import mlrun.common.schemas._v1.alert as v1_alert
+import mlrun.common.schemas._v1.client_spec as v1_client_spec
+import mlrun.common.schemas._v1.common as v1_common
+import mlrun.common.schemas._v1.model_monitoring.model_endpoints as v1_mep
+import mlrun.common.schemas._v1.schedule as v1_schedule
+import mlrun.common.schemas._v2.alert as v2_alert
+import mlrun.common.schemas._v2.client_spec as v2_client_spec
+import mlrun.common.schemas._v2.common as v2_common
+import mlrun.common.schemas._v2.model_monitoring.model_endpoints as v2_mep
+import mlrun.common.schemas._v2.schedule as v2_schedule
+
+# (case_id, v1 model, v2 model, input payload). Grounded in real hard-conversion sites
+# found in the merged _v1/_v2 schemas, per Backend HLD §3.1's seed list (implicit-optional
+# fields, const->Literal, engine-sensitive regex, json_encoders->serializer, coercion).
+ACCEPT_CASES = [
+    (
+        "schedule_cron_trigger_all_optional_omitted",
+        v1_schedule.ScheduleCronTrigger,
+        v2_schedule.ScheduleCronTrigger,
+        {},
+    ),
+    (
+        "schedule_cron_trigger_iso_string_start_date",
+        v1_schedule.ScheduleCronTrigger,
+        v2_schedule.ScheduleCronTrigger,
+        {"start_date": "2026-01-01T00:00:00"},
+    ),
+    (
+        # regression guard for the historical bare-`Any` v1 bug (ML-12736 POC): a v1
+        # client omitting `scheduled_object` must keep working under `_v2`.
+        "schedule_input_missing_scheduled_object",
+        v1_schedule.ScheduleInput,
+        v2_schedule.ScheduleInput,
+        {"name": "s1", "kind": "job", "cron_trigger": "0 0 * * *"},
+    ),
+    (
+        "schedule_identifier_correct_kind_literal",
+        v1_schedule.ScheduleIdentifier,
+        v2_schedule.ScheduleIdentifier,
+        {"kind": "schedule", "name": "s1"},
+    ),
+    (
+        # v1 implicitly coerces non-str scalars into str-typed fields; _v2's before-
+        # validator on ClientSpec must reproduce that exactly (else existing v1 clients
+        # that send e.g. a bool for a str-typed setting would get a different value back).
+        "client_spec_bool_coerced_to_str",
+        v1_client_spec.ClientSpec,
+        v2_client_spec.ClientSpec,
+        {"scrape_metrics": True},
+    ),
+    (
+        "model_endpoint_metadata_valid_project_pattern",
+        v1_mep.ModelEndpointMetadata,
+        v2_mep.ModelEndpointMetadata,
+        {"name": "ep1", "project": "my-proj-1"},
+    ),
+    (
+        # PROJECT_PATTERN/MODEL_ENDPOINT_ID_PATTERN use a bare `$` anchor. Python's `re`
+        # module treats `$` as matching just before a trailing newline, not only at the
+        # true end of string; Pydantic 2's default (Rust) regex engine does not. `_v2`
+        # sets `regex_engine="python-re"` specifically to keep this quirk wire-identical
+        # to `_v1` (which always uses Python's `re`) -- this case guards that choice.
+        "model_endpoint_instruction_name_trailing_newline",
+        v1_mep.ModelEndpointInstruction,
+        v2_mep.ModelEndpointInstruction,
+        {"name": "myname\n"},
+    ),
+    (
+        "alert_event_entities_single_id",
+        v1_alert.EventEntities,
+        v2_alert.EventEntities,
+        {"kind": "job", "project": "p1", "ids": ["x"]},
+    ),
+    (
+        # v1's Union[str, dict[str, str|None], list[str]] coerces a non-str dict value
+        # (int -> str) before its custom validator runs; v2's default "after"-mode
+        # validator type-checks against the Union first and rejected this, until fixed
+        # to mode="before" (this case is the regression guard for that fix).
+        "labels_model_dict_with_int_value",
+        v1_common.LabelsModel,
+        v2_common.LabelsModel,
+        {"labels": {"label1": 1}},
+    ),
+]
+
+REJECT_CASES = [
+    (
+        "schedule_identifier_wrong_kind_literal",
+        v1_schedule.ScheduleIdentifier,
+        v2_schedule.ScheduleIdentifier,
+        {"kind": "not-a-schedule", "name": "s1"},
+        {("kind",)},
+    ),
+    (
+        "model_endpoint_metadata_invalid_project_pattern",
+        v1_mep.ModelEndpointMetadata,
+        v2_mep.ModelEndpointMetadata,
+        {"name": "ep1", "project": "Bad_Project!"},
+        {("project",)},
+    ),
+    (
+        "model_endpoint_instruction_name_with_space",
+        v1_mep.ModelEndpointInstruction,
+        v2_mep.ModelEndpointInstruction,
+        {"name": "bad name"},
+        {("name",)},
+    ),
+    (
+        # conlist(min_items/max_items=1) (_v1) vs conlist(min_length/max_length=1) (_v2):
+        # an empty list must violate the lower bound on both.
+        "alert_event_entities_empty_ids",
+        v1_alert.EventEntities,
+        v2_alert.EventEntities,
+        {"kind": "job", "project": "p1", "ids": []},
+        {("ids",)},
+    ),
+    (
+        "alert_event_entities_too_many_ids",
+        v1_alert.EventEntities,
+        v2_alert.EventEntities,
+        {"kind": "job", "project": "p1", "ids": ["a", "b"]},
+        {("ids",)},
+    ),
+]
+
+
+def _error_loci(exc) -> set:
+    return {tuple(error["loc"]) for error in exc.errors()}
+
+
+@pytest.mark.parametrize(
+    "case_id,v1_model,v2_model,payload",
+    ACCEPT_CASES,
+    ids=[case[0] for case in ACCEPT_CASES],
+)
+def test_accept_case_round_trips_both_directions(case_id, v1_model, v2_model, payload):
+    try:
+        v1_obj = v1_model.parse_obj(payload)
+    except v1.ValidationError as exc:
+        pytest.fail(f"{case_id}: _v1 rejected an accept-verdict input: {exc}")
+
+    try:
+        v2_obj = v2_model.model_validate(payload)
+    except v2.ValidationError as exc:
+        pytest.fail(f"{case_id}: _v2 rejected an accept-verdict input: {exc}")
+
+    v1_json = v1_obj.json()
+    v2_json = v2_obj.model_dump_json()
+    # Compared as parsed JSON, not raw strings: `.json()` (v1) and `.model_dump_json()`
+    # (v2) differ in incidental whitespace by default (v1 inserts separators, v2's Rust
+    # serializer is compact) -- neither reflects an actual wire encoding (FastAPI's
+    # JSONResponse and the client's HTTP layer both re-encode compactly regardless), so
+    # whitespace is not a wire-parity signal. Content is. Known blind spot: Python's `==`
+    # treats `True`/`1`/`1.0` as equal, so a face divergence that only swaps JSON `true`
+    # for `1` would slip through here -- none of the current corpus exercises that shape.
+    assert json.loads(v1_json) == json.loads(v2_json), (
+        f"{case_id}: dumps differ\n v1={v1_json}\n v2={v2_json}"
+    )
+
+    # both directions: each face must accept the JSON the *other* face produced -- this is
+    # the actual wire scenario (v1 client <-> v2 server, Backend HLD §2.3).
+    try:
+        v2_model.model_validate_json(v1_json)
+    except v2.ValidationError as exc:
+        pytest.fail(f"{case_id}: _v2 rejected _v1's JSON output: {exc}")
+    try:
+        v1_model.parse_raw(v2_json)
+    except v1.ValidationError as exc:
+        pytest.fail(f"{case_id}: _v1 rejected _v2's JSON output: {exc}")
+
+
+@pytest.mark.parametrize(
+    "case_id,v1_model,v2_model,payload,expected_loci",
+    REJECT_CASES,
+    ids=[case[0] for case in REJECT_CASES],
+)
+def test_reject_case_matches_error_loci(
+    case_id, v1_model, v2_model, payload, expected_loci
+):
+    try:
+        v1_model.parse_obj(payload)
+        pytest.fail(f"{case_id}: _v1 accepted a reject-verdict input")
+    except v1.ValidationError as exc:
+        v1_loci = _error_loci(exc)
+
+    try:
+        v2_model.model_validate(payload)
+        pytest.fail(f"{case_id}: _v2 accepted a reject-verdict input")
+    except v2.ValidationError as exc:
+        v2_loci = _error_loci(exc)
+
+    assert v1_loci == expected_loci, (
+        f"{case_id}: _v1 error loci {v1_loci} != expected {expected_loci}"
+    )
+    assert v2_loci == expected_loci, (
+        f"{case_id}: _v2 error loci {v2_loci} != expected {expected_loci}"
+    )
+
+
+def test_schedule_record_callable_scheduled_object_serializes_to_empty_object():
+    # The one case in this file that isn't an ACCEPT_CASES/REJECT_CASES entry: it has no
+    # _v1 side to compare against (see below), so it can't fit the accept/reject corpus
+    # shape and is asserted directly instead.
+    # _v2 only, not a _v1-vs-_v2 comparison: a `local_function` schedule holds a live
+    # Python callable server-side. The pre-migration stack rendered it as `{}` via
+    # *FastAPI's* `jsonable_encoder` (its fallback for an unencodable object), never via
+    # pydantic v1's own `.json()` -- calling that directly on a raw function raises
+    # TypeError (confirmed: pydantic v1 has no encoder for a bare function), so there is
+    # no genuine v1 behaviour to compare against here. `_v2`'s `field_serializer` on
+    # `scheduled_object` exists specifically to reproduce the old FastAPI-layer behaviour
+    # now that the server dumps via `.model_dump_json()` directly; this guards that it
+    # still does.
+    def _scheduled_object():
+        pass
+
+    v2_obj = v2_schedule.ScheduleRecord(
+        name="s1",
+        kind="local_function",
+        scheduled_object=_scheduled_object,
+        cron_trigger="0 0 * * *",
+        creation_time="2026-01-01T00:00:00",
+        project="p1",
+    )
+
+    assert json.loads(v2_obj.model_dump_json())["scheduled_object"] == {}


### PR DESCRIPTION
### 📝 Description
Second half of the ML-12736 M1 wire-parity plan, split off ML-12891 (which delivered L1 — structural parity — merged as #9934). This adds **L2**: a fixed, verdict-pinned corpus proving the `_v1`/`_v2` schema faces behave identically, not just declare identical shape. Each case's expected verdict (`accept`/`reject`) is asserted independently per face, never inferred from whether the two faces happen to agree — so an `accept` case can't silently decay into a mutual `reject` as schemas evolve without failing.

---

### 🛠️ Changes Made
- Added `tests/common/test_schemas_behavioral_parity.py`: 9 `accept` cases + 5 `reject` cases (parametrized) + 1 direct-construction case. `accept` cases assert both faces parse the input and round-trip identically in both directions (each face must also accept the *other* face's JSON output — the real client↔server wire scenario). `reject` cases assert matching error loci only (not messages/type codes, which differ by construction between Pydantic majors).
- Fixed two real pydantic-2-baseline bugs the corpus surfaced:
  - `mlrun/common/schemas/_v1/model_monitoring/model_endpoints.py` imported `validator` from top-level `pydantic` instead of `pydantic.v1` — harmless under a real pydantic-1 client install, but silently a no-op when `_v1` is loaded directly inside a pydantic-2 process (exactly what this parity suite does), so the `uid`/`mode` validators never fired there.
  - `mlrun/common/schemas/_v2/common.py`'s `LabelsModel` validator ran in pydantic 2's default "after" mode, so the raw input was type-checked against the declared `Union` *before* the validator could coerce it — rejecting a dict value (e.g. `{"label1": 1}`) that `_v1` accepted. Switched to `mode="before"`.
- Fixed a pre-existing dispatch-blind assertion in `tests/common/test_schemas.py` (`test_project_monitoring_spec_rejects_invalid_enum`) that only tolerated the `_v1` exception class and broke under the `_v2`/API-server dispatch face.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New `test_schemas_behavioral_parity.py` run on both baselines: pydantic-2 (dedicated dev venv, mirroring the CI "server" flavor) — 250 passed in `tests/common/`; pydantic-1 client baseline — 40 passed + 4 expected skips (the pydantic-2-only parity/dispatch modules).
- `tests/model_monitoring/` re-run on the pydantic-1 baseline (349 passed) to confirm the `_v1` import fix doesn't regress real client behaviour.
- `ruff format` / `ruff check` clean on all touched files.
- Independent code review (score 8/10, no blockers, ready-to-merge) verified both bug-fix claims empirically before sign-off.
- Not run: the broader `pytest server/py` suite (L3) — out of scope for this PR; its CI wiring already landed with #9934/#9937.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12900
- Design docs links: [Backend HLD §3.1](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/607780869), [Decisions Log (D_WIRE)](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/608075779)
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- No doc changes: this is internal schema/test infrastructure, no user-facing SDK/API behaviour change.
- Corpus is seeded, not exhaustive (~10 cases across 6 hard-conversion sites) — expected to grow as review/incidents find more, per the HLD's own "sampling, not proof" framing for L2.