### PR TITLE
[Builder] Add Buildah/Kaniko parity test matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,22 @@ make fmt
     make test-integration-dockerized
     ```
 
+  The Buildah/Kaniko parity integration tests
+  (`server/py/services/api/tests/integration/k8s/test_builder_parity.py`) additionally need the
+  [`container-diff`](https://github.com/GoogleContainerTools/container-diff) CLI on `PATH` to
+  compare the two engines' output images (config/files/pip/apt - not byte-for-byte, since
+  timestamps and filesystem metadata always differ between engines). Install it locally with:
+    ```shell script
+    # macOS
+    brew install container-diff
+    # Linux
+    curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64 && \
+      chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff
+    ```
+  If it isn't installed, that test module skips itself rather than failing. Wiring it into CI
+  (installing it on the `test-integration` runner) is tracked separately - `.github/workflows/*.yaml`
+  changes need maintainer review.
+
 * System tests - see dedicated section below
 
 ## Pull requests

--- a/server/py/services/api/tests/integration/k8s/conftest.py
+++ b/server/py/services/api/tests/integration/k8s/conftest.py
@@ -23,11 +23,25 @@ import yaml
 import framework.utils.singletons.k8s
 
 if typing.TYPE_CHECKING:
+    import testcontainers.core.container
+    import testcontainers.core.network
     import testcontainers.k3s
 
 
 @pytest.fixture(scope="session")
-def k3s():
+def _test_network() -> "testcontainers.core.network.Network":
+    # ML-12889: a shared Docker network so pods inside k3s can route to the sibling
+    # registry container by IP (they get their own netns via flannel, so they can't reach
+    # the registry through the host's loopback the way the test process itself can).
+    import testcontainers.core.network
+
+    network = testcontainers.core.network.Network()
+    with network:
+        yield network
+
+
+@pytest.fixture(scope="session")
+def k3s(_test_network: "testcontainers.core.network.Network"):
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("testcontainers").setLevel(logging.DEBUG)
 
@@ -36,11 +50,70 @@ def k3s():
     os.environ["TESTCONTAINERS_HOST_OVERRIDE"] = "host.docker.internal"
     import testcontainers.k3s
 
-    container = testcontainers.k3s.K3SContainer().with_kwargs(
-        privileged=True,
+    container = (
+        testcontainers.k3s.K3SContainer()
+        .with_kwargs(privileged=True)
+        .with_network(_test_network)
     )
     with container:
         yield container
+
+
+@pytest.fixture(scope="session")
+def registry_container(
+    _test_network: "testcontainers.core.network.Network",
+    k3s: "testcontainers.k3s.K3SContainer",  # not used directly - ordering only, see docstring
+) -> "testcontainers.core.container.DockerContainer":
+    """A plain ``registry:2`` container the build pods push to, on the same Docker network
+    as ``k3s`` so pods scheduled inside it can reach the registry by IP.
+
+    ML-12889: shared by the Buildah/Kaniko parity integration tests - both backends push
+    here so their output images can be compared with ``container-diff``. Whether a k3s pod's
+    egress actually routes to a sibling container's bridge IP depends on the cluster's CNI
+    backend (flannel's default vxlan/host-gw backends SNAT pod egress through the node's own
+    interface, which is on this same bridge network) - this is the standard testcontainers
+    multi-container topology, but hasn't been run against real Docker in this session; verify
+    reachability first if pods can't reach ``registry_endpoint`` below.
+    """
+    import testcontainers.core.container
+
+    container = testcontainers.core.container.DockerContainer("registry:2")
+    container.with_exposed_ports(5000)
+    container.with_network(_test_network)
+    with container:
+        yield container
+
+
+@pytest.fixture
+def registry_endpoint(
+    registry_container: "testcontainers.core.container.DockerContainer",
+) -> str:
+    """The registry's address as reachable *from a pod scheduled inside the k3s cluster*:
+    its IP on the shared Docker network (pods can't resolve Docker network aliases - they use
+    the cluster's own CoreDNS, not the Docker embedded DNS)."""
+    ip = registry_container.get_wrapped_container().attrs["NetworkSettings"][
+        "Networks"
+    ][_test_network_name(registry_container)]["IPAddress"]
+    return f"{ip}:5000"
+
+
+@pytest.fixture
+def registry_host_endpoint(
+    registry_container: "testcontainers.core.container.DockerContainer",
+) -> str:
+    """The registry's address as reachable *from the test process itself* (host-published
+    port), for pulling/diffing the images the build pods pushed."""
+    host = registry_container.get_container_host_ip()
+    port = registry_container.get_exposed_port(5000)
+    return f"{host}:{port}"
+
+
+def _test_network_name(
+    container: "testcontainers.core.container.DockerContainer",
+) -> str:
+    networks = container.get_wrapped_container().attrs["NetworkSettings"]["Networks"]
+    # the container is only ever attached to the one shared _test_network fixture.
+    return next(iter(networks))
 
 
 @pytest.fixture

--- a/server/py/services/api/tests/integration/k8s/container_diff.py
+++ b/server/py/services/api/tests/integration/k8s/container_diff.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin wrapper around the `container-diff <https://github.com/GoogleContainerTools/container-diff>`_
+CLI, used by the Buildah/Kaniko parity integration tests (ML-12889) to assert two images built by
+different engines are semantically equivalent. Byte-for-byte comparison doesn't work here - build
+timestamps and filesystem metadata always differ between engines - so equivalence is defined as "no
+diff in config, files, pip packages, or apt packages", which is what ``container-diff diff`` reports.
+
+Not installed by default; see CONTRIBUTING.md's Testing section for the local install command.
+"""
+
+import json
+import shutil
+import subprocess
+
+_DIFF_TYPES = ("file", "apt", "pip")
+
+
+def is_installed() -> bool:
+    return shutil.which("container-diff") is not None
+
+
+def assert_images_equivalent(image_a: str, image_b: str, insecure: bool = True) -> None:
+    """Run ``container-diff diff`` between two remote images and raise if any of the compared
+    dimensions (file/apt/pip) reports a difference.
+
+    :param image_a:  First image reference, e.g. ``registry:5000/some-image:tag``.
+    :param image_b:  Second image reference, same registry-reference format.
+    :param insecure: Whether the registries are plain HTTP (true for the local test registry).
+    """
+    args = [
+        "container-diff",
+        "diff",
+        f"remote://{image_a}",
+        f"remote://{image_b}",
+        "--json",
+    ]
+    for diff_type in _DIFF_TYPES:
+        args += ["--type", diff_type]
+    if insecure:
+        # container-diff has no bare "insecure" switch - it's opt-in per registry host.
+        for registry_host in {image_a.split("/")[0], image_b.split("/")[0]}:
+            args += ["--skip-tls-verify-registry", registry_host]
+
+    result = subprocess.run(args, capture_output=True, text=True, timeout=300)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"container-diff failed (exit {result.returncode}): {result.stderr}"
+        )
+
+    diffs = json.loads(result.stdout)
+    non_empty_diffs = [d for d in diffs if _diff_is_non_empty(d)]
+    if non_empty_diffs:
+        raise AssertionError(
+            f"container-diff found differences between {image_a} and {image_b}: "
+            f"{json.dumps(non_empty_diffs, indent=2)}"
+        )
+
+
+def _diff_is_non_empty(diff_report: dict) -> bool:
+    diff = diff_report.get("Diff") or {}
+    return any(
+        diff.get(key)
+        for key in ("Adds", "Dels", "Mods", "Packages1", "Packages2", "InfoDiff")
+    )

--- a/server/py/services/api/tests/integration/k8s/test_builder_parity.py
+++ b/server/py/services/api/tests/integration/k8s/test_builder_parity.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ML-12889: Buildah/Kaniko integration-tier parity - real pod builds against a k3s testcontainer,
+# pushed to a plain local registry (see conftest.py). Covers what doesn't need cloud credentials:
+# same-Dockerfile-same-image equivalence and the overlay/vfs storage drivers. Cloud-registry auth
+# (ECR/ACR/GAR) parity needs real cloud credentials and is exercised instead in the system tier,
+# against a real lab (see tests/system/runtimes/test_buildah_parity.py).
+#
+# NOTE: this module has not been run against real Docker in the session that wrote it (no Docker
+# daemon available); the k3s<->registry Docker-network wiring in conftest.py is written to the
+# standard testcontainers multi-container pattern but is unverified end-to-end. Run it first with
+# real Docker access and expect to iterate on the networking before trusting it in CI.
+
+import time
+
+import pytest
+
+import mlrun
+import mlrun.common.schemas
+from mlrun.config import config
+from mlrun.runtimes import RuntimeKinds
+
+import framework.utils.singletons.k8s
+import services.api.utils.builder
+from . import container_diff
+
+_BUILD_TIMEOUT_SECONDS = 300
+_POLL_INTERVAL_SECONDS = 5
+
+
+@pytest.fixture
+def cluster_k8s_helper(valid_kubeconfig_path, monkeypatch):
+    """Point the builder's k8s singleton at the real k3s cluster instead of the mocked helper
+    the unit tests use - build_image/build_runtime create and poll a real pod through this.
+    """
+    helper = framework.utils.singletons.k8s.K8sHelper(
+        namespace="default",
+        kube_config_path=valid_kubeconfig_path,
+        silent=False,
+        log=False,
+    )
+    monkeypatch.setattr(
+        framework.utils.singletons.k8s,
+        "get_k8s_helper",
+        lambda *args, **kwargs: helper,
+    )
+    return helper
+
+
+def _build_and_wait_for_terminal_phase(
+    function, cluster_k8s_helper, timeout_seconds=_BUILD_TIMEOUT_SECONDS
+) -> str:
+    services.api.utils.builder.build_runtime(
+        mlrun.common.schemas.AuthInfo(),
+        function,
+        with_mlrun=False,
+        interactive=False,
+        force_build=True,
+    )
+    pod_name = function.status.build_pod
+    deadline = time.time() + timeout_seconds
+    phase = "pending"
+    while time.time() < deadline:
+        phase = cluster_k8s_helper.get_pod_phase(pod_name)
+        if phase in ("succeeded", "failed"):
+            return phase
+        time.sleep(_POLL_INTERVAL_SECONDS)
+    raise TimeoutError(
+        f"Build pod {pod_name} did not reach a terminal phase: last seen {phase}"
+    )
+
+
+def _make_build_function(
+    name, backend, registry_endpoint, monkeypatch, **build_overrides
+):
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", backend)
+    monkeypatch.setattr(config.httpdb.builder, "docker_registry", registry_endpoint)
+    monkeypatch.setattr(config.httpdb.builder, "insecure_push_registry_mode", "enabled")
+    monkeypatch.setattr(config.httpdb.builder, "insecure_pull_registry_mode", "enabled")
+
+    function = mlrun.new_function(
+        name, "default", kind=RuntimeKinds.job, image="alpine:3.20"
+    )
+    function.spec.build.commands = build_overrides.get(
+        "commands", ["echo mlrun-parity-test"]
+    )
+    function.spec.build.image = f".{name}"
+    return function
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("storage_driver", ["overlay", "vfs"])
+def test_buildah_kaniko_same_dockerfile_same_image(
+    monkeypatch,
+    cluster_k8s_helper,
+    registry_endpoint,
+    registry_host_endpoint,
+    storage_driver,
+):
+    """Build the same commands-only function via both backends, push to the same local
+    registry, and assert equivalence via container-diff - not byte-identical (timestamps and
+    filesystem metadata always differ between engines), but no config/file/pip/apt diff.
+    """
+    if not container_diff.is_installed():
+        pytest.skip(
+            "container-diff is not installed - see CONTRIBUTING.md's Testing section"
+        )
+
+    monkeypatch.setattr(config.httpdb.builder, "buildah_storage_driver", storage_driver)
+
+    pushed_images = {}
+    for backend in ("kaniko", "buildah"):
+        function = _make_build_function(
+            f"parity-{backend}-{storage_driver}",
+            backend,
+            registry_endpoint,
+            monkeypatch,
+        )
+        phase = _build_and_wait_for_terminal_phase(function, cluster_k8s_helper)
+        assert phase == "succeeded", (
+            f"{backend} build did not succeed: pod phase {phase}"
+        )
+        pushed_images[backend] = (
+            f"{registry_host_endpoint}/{function.spec.build.image.lstrip('.')}"
+        )
+
+    container_diff.assert_images_equivalent(
+        pushed_images["kaniko"], pushed_images["buildah"], insecure=True
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("backend", ["kaniko", "buildah"])
+def test_failed_build_drives_function_to_error_state(
+    monkeypatch, cluster_k8s_helper, registry_endpoint, backend
+):
+    """The failure-contract invariant end-to-end, for both backends: a build that fails inside
+    the pod (here, a command that exits non-zero) must leave the pod Failed and, once the
+    caller polls the build status (see functions.py's build-status endpoint), the function
+    state resolved to `error` - not silently `ready` or stuck `deploying`.
+    """
+    function = _make_build_function(
+        f"parity-fail-{backend}",
+        backend,
+        registry_endpoint,
+        monkeypatch,
+        commands=["exit 1"],
+    )
+    phase = _build_and_wait_for_terminal_phase(function, cluster_k8s_helper)
+    assert phase == "failed"
+    assert (
+        mlrun.common.schemas.FunctionState.get_function_state_from_pod_state(phase)
+        == mlrun.common.schemas.FunctionState.error
+    )

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -22,6 +22,7 @@
 # Buildah has no native remote-context resolution the way Kaniko does.
 
 import base64
+import json
 import unittest.mock
 
 import pytest
@@ -33,6 +34,7 @@ import mlrun.errors
 from mlrun.config import config
 from mlrun.runtimes import RuntimeKinds
 
+import framework.api.utils
 import framework.utils.singletons.k8s
 import services.api.utils.builder
 import services.api.utils.builder.buildah
@@ -107,10 +109,37 @@ def _patch_k8s_helper(monkeypatch):
     get_k8s_helper_mock.get_project_secret_keys = unittest.mock.Mock(
         side_effect=lambda project, filter_internal: ["KEY"]
     )
+    get_k8s_helper_mock.get_project_secret_data = unittest.mock.Mock(
+        side_effect=lambda project, keys: {"KEY": "val"}
+    )
     monkeypatch.setattr(
         framework.utils.singletons.k8s,
         "get_k8s_helper",
         lambda *args, **kwargs: get_k8s_helper_mock,
+    )
+
+
+def _create_pod_mock_pod_spec():
+    # deliberately mirrors test_builder.py's helper of the same name rather than importing it -
+    # test modules in this directory are self-contained; keep both in sync if either changes.
+    return (
+        framework.utils.singletons.k8s.get_k8s_helper()
+        .create_pod.call_args[0][0]
+        .pod.spec
+    )
+
+
+def _mock_default_service_account(monkeypatch, service_account):
+    resolve_project_service_account_details_mock = unittest.mock.MagicMock()
+    resolve_project_service_account_details_mock.return_value = (
+        [],
+        [],
+        service_account,
+    )
+    monkeypatch.setattr(
+        framework.api.utils,
+        "resolve_project_service_account_details",
+        resolve_project_service_account_details_mock,
     )
 
 
@@ -591,3 +620,170 @@ def test_buildah_backend_inline_code_with_source_ignores_source():
     )
     assert _init_container_by_name(pod, "fetch-source") is None
     assert "ADD" not in _decoded_dockerfile(pod)
+
+
+# --- Buildah pod-spec parity (ML-12889) ------------------------------------------------------------
+#
+# resolve_build_pod_spec_attributes (base.py) resolves node/affinity/tolerations/priority/service
+# account identically for both backends; test_builder.py locks this for Kaniko via build_runtime.
+# These mirror the same scenarios end-to-end through build_runtime, with builder_backend=buildah,
+# to lock that the seam can't silently drift between engines.
+
+
+def _build_via_buildah(function, monkeypatch):
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    _patch_k8s_helper(monkeypatch)
+    config.httpdb.builder.docker_registry = "registry.hub.docker.com/username"
+    services.api.utils.builder.build_runtime(
+        mlrun.common.schemas.AuthInfo(),
+        function,
+        force_build=True,
+    )
+
+
+def test_buildah_pod_spec_default_service_account_enrichment(monkeypatch):
+    # parity with test_kaniko_pod_spec_default_service_account_enrichment (test_builder.py)
+    service_account = "my-service-account"
+    _mock_default_service_account(monkeypatch, service_account)
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    _build_via_buildah(function, monkeypatch)
+    assert _create_pod_mock_pod_spec().service_account == service_account
+
+
+def test_buildah_pod_spec_user_service_account_enrichment(monkeypatch):
+    # parity with test_kaniko_pod_spec_user_service_account_enrichment (test_builder.py)
+    _mock_default_service_account(monkeypatch, "my-default-service-account")
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    service_account = "my-actual-sa"
+    function.spec.service_account = service_account
+    _build_via_buildah(function, monkeypatch)
+    assert _create_pod_mock_pod_spec().service_account == service_account
+
+
+def test_buildah_pod_spec_node_selector_and_preemption_parity(monkeypatch):
+    # parity with test_build_runtime_use_default_node_selector_and_sets_gpu_limits_to_zero
+    # (test_builder.py), minus the GPU-limit assertion - that enrichment happens above the
+    # backend seam and is already covered there.
+    default_node_selector = {"label-1": "val1", "label-2": "val2"}
+    preemptible_selector = {"spot": "true"}
+    func_node_selector = {"label-3": "val3"}
+    mlrun.mlconf.default_function_node_selector = base64.b64encode(
+        json.dumps(default_node_selector).encode("utf-8")
+    )
+    mlrun.mlconf.preemptible_nodes.node_selector = base64.b64encode(
+        json.dumps(preemptible_selector).encode("utf-8")
+    )
+    mlrun.mlconf.preemptible_nodes.tolerations = base64.b64encode(
+        json.dumps(
+            [
+                {
+                    "key": "spot",
+                    "operator": "Equal",
+                    "value": "true",
+                    "effect": "NoSchedule",
+                }
+            ]
+        ).encode("utf-8")
+    )
+
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    function.spec.node_selector = func_node_selector | preemptible_selector
+    function.with_preemption_mode("prevent")
+    # scheduling attributes only - service-account resolution is exercised separately above
+    _mock_default_service_account(monkeypatch, None)
+    _build_via_buildah(function, monkeypatch)
+
+    pod_spec = _create_pod_mock_pod_spec()
+    expected_node_selector = {**default_node_selector, **func_node_selector}
+    assert pod_spec.node_selector == expected_node_selector
+    # preemptible tolerations are removed in 'prevent' mode
+    assert pod_spec.tolerations is None or pod_spec.tolerations == []
+
+
+def test_buildah_pod_spec_attributes_from_spec(monkeypatch):
+    # parity with test_function_build_with_attributes_from_spec (test_builder.py)
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    node_selector = {"label-1": "val1", "label-2": "val2"}
+    node_name = "node_test"
+    priority_class_name = "test-priority"
+    function.spec.node_name = node_name
+    function.spec.node_selector = node_selector
+    function.spec.priority_class_name = priority_class_name
+    # scheduling attributes only - service-account resolution is exercised separately above
+    _mock_default_service_account(monkeypatch, None)
+    _build_via_buildah(function, monkeypatch)
+
+    pod_spec = _create_pod_mock_pod_spec()
+    assert pod_spec.node_name == node_name
+    assert pod_spec.node_selector == node_selector
+    assert pod_spec.priority_class_name == priority_class_name
+
+
+def test_make_buildah_pod_mounts_pip_ca(monkeypatch):
+    # parity with production Kaniko's pip-CA handling (base.make_dockerfile's Dockerfile COPY +
+    # kaniko.py's own secret mount) - _mount_pip_ca itself is gated purely on
+    # config.is_pip_ca_configured(), not on dockerfile content, so the dockerfile passed to
+    # _make_buildah_pod below is just the helper's default and isn't asserted on here.
+    monkeypatch.setattr(config.httpdb.builder, "pip_ca_secret_name", "pip-ca-secret")
+    monkeypatch.setattr(config.httpdb.builder, "pip_ca_secret_key", "ca.crt")
+    buildah_pod = _make_buildah_pod()
+    pod = buildah_pod.pod
+    mounted_secrets = {
+        volume.secret.secret_name for volume in pod.spec.volumes if volume.secret
+    }
+    assert "pip-ca-secret" in mounted_secrets
+    ca_mount = next(
+        vm
+        for vm in pod.spec.containers[0].volume_mounts
+        if vm.mount_path.endswith("pip-ca-certificates.crt")
+    )
+    assert ca_mount.sub_path == "pip-ca-certificates.crt"
+
+
+# --- Failure-contract invariant (ML-12889) ---------------------------------------------------------
+#
+# Engine-agnostic: FunctionState.get_function_state_from_pod_state is what
+# server/py/services/api/api/endpoints/functions.py maps a build pod's phase through, for either
+# backend. Locking it here means the invariant "failed build -> pod Failed -> function error" can't
+# silently regress for either engine, independent of which one produced the failing pod.
+
+
+@pytest.mark.parametrize("pod_phase", ["failed", "error"])
+def test_failed_pod_state_maps_to_function_error(pod_phase):
+    assert (
+        mlrun.common.schemas.FunctionState.get_function_state_from_pod_state(pod_phase)
+        == mlrun.common.schemas.FunctionState.error
+    )
+
+
+def test_succeeded_pod_state_maps_to_function_ready():
+    assert (
+        mlrun.common.schemas.FunctionState.get_function_state_from_pod_state(
+            "succeeded"
+        )
+        == mlrun.common.schemas.FunctionState.ready
+    )

--- a/tests/system/runtimes/test_buildah_parity.py
+++ b/tests/system/runtimes/test_buildah_parity.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import mlrun
+import mlrun.common.schemas
+import mlrun.errors
+import tests.system.base
+
+
+@tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
+@pytest.mark.enterprise
+class TestBuildahParity(tests.system.base.TestMLRunSystem):
+    """ML-12889 system tier: rootless build under PodSecurity + end-to-end push, and the
+    pod-Failed -> function-error invariant, against a real Iguazio system.
+
+    Which builder backend actually runs is a server-side setting
+    (``config.httpdb.builder.builder_backend``), not something a system test can flip per run -
+    see the dedicated buildah-test-{azure,gcp} clusters kept patched with ``builder_backend=buildah``
+    for this purpose. Parity is established by running this same suite twice: once against a
+    Buildah-configured lab, once against a Kaniko-configured lab - both runs must pass with the
+    same assertions.
+    """
+
+    project_name = "buildah-parity-system-test"
+    image: str = "mlrun/mlrun"
+
+    def test_build_and_push_succeeds_under_pod_security(self):
+        # a real end-to-end build + push under whatever PodSecurity policy the target namespace
+        # enforces - Buildah's caps-rootless model (BuildahBackend) must build and push under the
+        # same admission constraints Kaniko already runs under, and the resulting image must run.
+        code_path = str(self.assets_path / "kubejob_function.py")
+        function = mlrun.code_to_function(
+            name="buildah-parity-rootless",
+            kind="job",
+            project=self.project_name,
+            filename=code_path,
+        )
+        function.build_config(
+            base_image=self.image, commands=["echo buildah-parity-rootless"]
+        )
+        function.deploy()
+        run = function.run()
+        assert run.state() == "completed", f"Unexpected state: {run.state()}"
+
+    def test_failed_build_drives_function_to_error_state(self):
+        # the failure-contract invariant (ML-12889): a build that fails inside the pod must
+        # leave the pod Failed -> function state error, and deploy() must raise - independent
+        # of which builder backend produced the failure.
+        code_path = str(self.assets_path / "kubejob_function.py")
+        function = mlrun.code_to_function(
+            name="buildah-parity-failed-build",
+            kind="job",
+            project=self.project_name,
+            filename=code_path,
+        )
+        function.build_config(base_image=self.image, commands=["exit 1"])
+        with pytest.raises(mlrun.errors.MLRunRuntimeError):
+            function.deploy()
+        assert function.status.state == mlrun.common.schemas.FunctionState.error


### PR DESCRIPTION
### 📝 Description
Closes the ML-12889 test-coverage gap between the Buildah and Kaniko builder backends: a unit/integration/system matrix proving Buildah behaves equivalently to Kaniko, plus a locked failure-contract invariant (a failed build pod always drives the owning function to `error` state, regardless of backend).

---

### 🛠️ Changes Made
- **Unit** (`test_builder_backend.py`): extended with pip-CA mount parity, node-selector/affinity/preemption/priority-class parity, service-account enrichment parity (mirrors the existing Kaniko coverage in `test_builder.py`), and an engine-agnostic test for `FunctionState.get_function_state_from_pod_state` on the failed/error pod phases.
- **Integration** (new `server/py/services/api/tests/integration/k8s/`): `container_diff.py` wraps the `container-diff` CLI for semantic image-equivalence checks (config/files/pip/apt — not byte-for-byte, since timestamps/metadata always differ between engines); `test_builder_parity.py` builds the same function via both backends against a real k3s testcontainer + local registry and diffs the pushed images, plus the failure-contract invariant end-to-end. `conftest.py` gained the k3s↔registry Docker-network fixtures.
- **System** (new `tests/system/runtimes/test_buildah_parity.py`): `TestMLRunSystem` suite for rootless-build-under-PodSecurity + end-to-end push and the failure-contract invariant, gated by `skip_test_if_env_not_configured` / `@pytest.mark.enterprise`. Which backend actually runs is a server-side lab setting, not something the suite flips — parity is running this same file against both a Buildah- and a Kaniko-configured lab.
- `CONTRIBUTING.md`: documents local `container-diff` install for the integration tier.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit tier: `pytest server/py/services/api/tests/unit/utils/test_builder_backend.py` — 48/48 pass, `ruff format --check` / `ruff check` clean.
- Integration and system tiers were written and collect cleanly under pytest, but **could not be executed** in the environment that authored them (no Docker daemon available for the k3s/registry testcontainers, no lab access for the system suite). They need a first real run — expect to iterate on the k3s↔registry Docker networking in `conftest.py` once that happens.
- An independent review caught and this PR fixes one real bug found before any execution: `container_diff.py` initially used a nonexistent `--insecure-registry` flag; corrected to the real `--skip-tls-verify-registry <host>` per container-diff's actual CLI.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12889
- Design docs links:
- External links: https://github.com/GoogleContainerTools/container-diff

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Depends on ML-12885/86/87 (all already merged into `feature/buildah`); this PR targets `feature/buildah`, not `development`.
- Follow-up: wiring `container-diff` installation into CI (`.github/workflows/*.yaml`) needs separate maintainer review — intentionally left out of this PR's scope.
- First real run of the integration/system tiers should happen with real Docker/lab access before trusting them as a merge gate.