### PR TITLE
[Server] Bump fastapi>=0.128, starlette>=1.0.1

### DIFF
--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -692,9 +692,9 @@ executing==2.2.1 \
     --hash=sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4 \
     --hash=sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017
     # via stack-data
-fastapi==0.125.0 \
-    --hash=sha256:16b532691a33e2c5dee1dac32feb31dc6eb41a3dd4ff29a95f9487cb21c054c0 \
-    --hash=sha256:2570ec4f3aecf5cca8f0428aed2398b774fcdfee6c2116f86e80513f2f86a7a1
+fastapi==0.140.13 \
+    --hash=sha256:500172a08cf1459901f90b05c37d93060dada3b573fec8f0862445db52ba6b4b \
+    --hash=sha256:8b017110e1e9f30a95e8bdb8f71fbe2f0fe3af5717109e5b14f9e069df54f6d4
     # via -r dockerfiles/mlrun-api/requirements.txt
 fastjsonschema==2.21.2 \
     --hash=sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463 \
@@ -3111,10 +3111,12 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-starlette==0.50.0 \
-    --hash=sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca \
-    --hash=sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca
-    # via fastapi
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
+    # via
+    #   -r dockerfiles/mlrun-api/requirements.txt
+    #   fastapi
 storey==1.12.5 \
     --hash=sha256:adc2ea259e21ccd0b11dbfebab28554fd937b1d72102b1ef97f1136bf67c4aac
     # via
@@ -3217,7 +3219,9 @@ typing-extensions==4.16.0 \
 typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 tzdata==2026.3 \
     --hash=sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415 \
     --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931

--- a/dockerfiles/mlrun-api/requirements.txt
+++ b/dockerfiles/mlrun-api/requirements.txt
@@ -5,7 +5,9 @@ apscheduler>=3.11,<4
 objgraph~=3.6
 igz-mgmt~=0.4.2
 humanfriendly~=10.0
-fastapi~=0.125.0
+# starlette>=1.0.1 pinned directly (not just left to fastapi's transitive floor): CVE-2026-48710 BadHost fix.
+fastapi>=0.128,<1
+starlette>=1.0.1,<2
 sqlalchemy~=2.0
 sqlalchemy-utils~=0.41.2
 pymysql~=1.1
@@ -15,8 +17,6 @@ timelength~=1.1
 memray~=1.12; sys_platform != 'win32'
 aiosmtplib~=5.1
 # ML-12891: API server runs on pydantic 2 (client/SDK stays on pydantic 1 via the pydantic.v1 layer).
-# fastapi stays ~=0.125 here — 0.128+ rejects the pydantic.v1 models the server still serves while the
-# native _v2 face is gated off; the fastapi bump + content-type middleware is ML-12893.
 pydantic>=2,<3
 mlrun-pipelines-kfp-v1-8~=0.7.3
 iguazio~=0.0.1

--- a/dockerfiles/test/locked-requirements-server.txt
+++ b/dockerfiles/test/locked-requirements-server.txt
@@ -1054,9 +1054,9 @@ faker==40.31.0 \
     --hash=sha256:af163a937aec99dca5abaeb94dd5008c51c26c6e9af1a26c8db4b3c4e7ca4403 \
     --hash=sha256:bedc97c292a48a6a1bbe471a9076d7395a196421ede1cedde99d5719f6b91027
     # via polyfactory
-fastapi==0.125.0 \
-    --hash=sha256:16b532691a33e2c5dee1dac32feb31dc6eb41a3dd4ff29a95f9487cb21c054c0 \
-    --hash=sha256:2570ec4f3aecf5cca8f0428aed2398b774fcdfee6c2116f86e80513f2f86a7a1
+fastapi==0.140.13 \
+    --hash=sha256:500172a08cf1459901f90b05c37d93060dada3b573fec8f0862445db52ba6b4b \
+    --hash=sha256:8b017110e1e9f30a95e8bdb8f71fbe2f0fe3af5717109e5b14f9e069df54f6d4
     # via
     #   -r dockerfiles/mlrun-api/requirements.txt
     #   mlflow-skinny
@@ -4851,10 +4851,12 @@ stack-data==0.6.3 \
     --hash=sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9 \
     --hash=sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
     # via ipython
-starlette==0.50.0 \
-    --hash=sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca \
-    --hash=sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca
-    # via fastapi
+starlette==1.3.1 \
+    --hash=sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0 \
+    --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
+    # via
+    #   -r dockerfiles/mlrun-api/requirements.txt
+    #   fastapi
 statsmodels==0.14.6 \
     --hash=sha256:00781869991f8f02ad3610da6627fd26ebe262210287beb59761982a8fa88cae \
     --hash=sha256:0444e88557df735eda7db330806fe09d51c9f888bb1f5906cb3a61fb1a3ed4a8 \
@@ -5146,7 +5148,9 @@ typing-inspect==0.9.0 \
 typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 tzdata==2026.3 \
     --hash=sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415 \
     --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931

--- a/server/py/framework/middlewares/__init__.py
+++ b/server/py/framework/middlewares/__init__.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 from .ensure_be_version import EnsureBackendVersionMiddleware
+from .ensure_json_content_type import EnsureJsonContentTypeMiddleware
 from .request_logger import RequestLoggerMiddleware
 from .ui_clear_cache import UiClearCacheMiddleware

--- a/server/py/framework/middlewares/__init__.py
+++ b/server/py/framework/middlewares/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 from .ensure_be_version import EnsureBackendVersionMiddleware
-from .ensure_json_content_type import EnsureJsonContentTypeMiddleware
+from .ensure_json_content_type import EnsureJSONContentTypeMiddleware
 from .request_logger import RequestLoggerMiddleware
 from .ui_clear_cache import UiClearCacheMiddleware

--- a/server/py/framework/middlewares/ensure_json_content_type.py
+++ b/server/py/framework/middlewares/ensure_json_content_type.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from starlette.datastructures import MutableHeaders
+from uvicorn._types import (
+    ASGI3Application,
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    Scope,
+)
+
+
+class EnsureJsonContentTypeMiddleware:
+    def __init__(
+        self,
+        app: "ASGI3Application",
+    ) -> None:
+        self.app = app
+
+    async def __call__(
+        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ) -> None:
+        """
+        FastAPI's strict_content_type option (default on since 0.128) only parses a request body as
+        JSON when Content-Type: application/json is set. Some clients send pre-serialized JSON bodies
+        without that header, which used to parse fine under lenient older FastAPI versions. Default a
+        missing Content-Type to application/json so those requests keep working — this intentionally
+        reverts strict_content_type's protection for back-compat; FastAPI <0.128 had no such
+        protection either, so this is parity, not a new hole. Requests that already declare a content
+        type (multipart/form uploads included, since those always carry their own boundary-bearing
+        Content-Type) are left untouched.
+        """
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        headers = MutableHeaders(scope=scope)
+        headers.setdefault("content-type", "application/json")
+
+        return await self.app(scope, receive, send)

--- a/server/py/framework/middlewares/ensure_json_content_type.py
+++ b/server/py/framework/middlewares/ensure_json_content_type.py
@@ -13,38 +13,38 @@
 # limitations under the License.
 
 from starlette.datastructures import MutableHeaders
-from uvicorn._types import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    Scope,
-)
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+_BODY_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 
-class EnsureJsonContentTypeMiddleware:
-    def __init__(
-        self,
-        app: "ASGI3Application",
-    ) -> None:
+class EnsureJSONContentTypeMiddleware:
+    app: ASGIApp
+
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    async def __call__(
-        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
-    ) -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """
         FastAPI's strict_content_type option (default on since 0.128) only parses a request body as
-        JSON when Content-Type: application/json is set. Some clients send pre-serialized JSON bodies
-        without that header, which used to parse fine under lenient older FastAPI versions. Default a
-        missing Content-Type to application/json so those requests keep working — this intentionally
-        reverts strict_content_type's protection for back-compat; FastAPI <0.128 had no such
-        protection either, so this is parity, not a new hole. Requests that already declare a content
-        type (multipart/form uploads included, since those always carry their own boundary-bearing
-        Content-Type) are left untouched.
+        JSON when Content-Type: application/json is set. Some clients send pre-serialized JSON
+        bodies without that header, which used to parse fine under lenient older FastAPI versions.
+        Default a missing Content-Type to application/json for body-bearing requests so those keep
+        working — this intentionally reverts strict_content_type's protection for back-compat;
+        FastAPI <0.128 had no such protection either, so this is parity, not a new hole. Requests
+        with no body, or that already declare a content type (multipart/form uploads included),
+        are left untouched.
         """
-        if scope["type"] != "http":
-            return await self.app(scope, receive, send)
-
-        headers = MutableHeaders(scope=scope)
-        headers.setdefault("content-type", "application/json")
+        if scope["type"] == "http" and scope.get("method") in _BODY_METHODS:
+            headers = MutableHeaders(scope=scope)
+            if not headers.get("content-type") and _has_body(headers):
+                headers["content-type"] = "application/json"
 
         return await self.app(scope, receive, send)
+
+
+def _has_body(headers: MutableHeaders) -> bool:
+    return (
+        headers.get("content-length") not in (None, "", "0")
+        or "transfer-encoding" in headers
+    )

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -260,6 +260,11 @@ class Service(ABC):
 
     def _add_middlewares(self):
         # middlewares, order matter
+        # added first, so it ends up innermost (closest to the router) once the stack is built,
+        # normalizing the request right before FastAPI's body parsing.
+        self.app.add_middleware(
+            framework.middlewares.EnsureJsonContentTypeMiddleware,
+        )
         self.app.add_middleware(
             framework.middlewares.EnsureBackendVersionMiddleware,
             backend_version=mlconf.version,

--- a/server/py/framework/service/__init__.py
+++ b/server/py/framework/service/__init__.py
@@ -263,7 +263,7 @@ class Service(ABC):
         # added first, so it ends up innermost (closest to the router) once the stack is built,
         # normalizing the request right before FastAPI's body parsing.
         self.app.add_middleware(
-            framework.middlewares.EnsureJsonContentTypeMiddleware,
+            framework.middlewares.EnsureJSONContentTypeMiddleware,
         )
         self.app.add_middleware(
             framework.middlewares.EnsureBackendVersionMiddleware,

--- a/server/py/services/api/tests/unit/api/framework/test_logging_middleware.py
+++ b/server/py/services/api/tests/unit/api/framework/test_logging_middleware.py
@@ -17,7 +17,7 @@ from collections.abc import Iterator
 from http import HTTPStatus
 
 import fastapi
-import pydantic.v1
+import pydantic
 import pytest
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.testclient import TestClient
@@ -86,7 +86,7 @@ def unhandled_exception():
     raise UnhandledError("Unhandled exception")
 
 
-class SomeScheme(pydantic.v1.BaseModel):
+class SomeScheme(pydantic.BaseModel):
     id: str
 
 

--- a/server/py/services/api/tests/unit/api/framework/test_middlewares.py
+++ b/server/py/services/api/tests/unit/api/framework/test_middlewares.py
@@ -107,14 +107,29 @@ async def _run_ensure_json_content_type_middleware(scope: dict) -> dict:
     async def downstream_app(inner_scope, receive, send):
         downstream_scope.update(inner_scope)
 
-    middleware = framework.middlewares.EnsureJsonContentTypeMiddleware(downstream_app)
+    middleware = framework.middlewares.EnsureJSONContentTypeMiddleware(downstream_app)
     await middleware(scope, _noop_receive, _noop_send)
     return downstream_scope
 
 
-async def test_ensure_json_content_type_middleware_defaults_missing_header() -> None:
+def _http_scope(method: str, headers: list[tuple[bytes, bytes]]) -> dict:
+    return {"type": "http", "method": method, "headers": headers}
+
+
+async def test_ensure_json_content_type_middleware_defaults_missing_header_with_content_length() -> (
+    None
+):
     downstream_scope = await _run_ensure_json_content_type_middleware(
-        {"type": "http", "headers": []}
+        _http_scope("POST", [(b"content-length", b"13")])
+    )
+    assert dict(downstream_scope["headers"])[b"content-type"] == b"application/json"
+
+
+async def test_ensure_json_content_type_middleware_defaults_missing_header_with_chunked_transfer_encoding() -> (
+    None
+):
+    downstream_scope = await _run_ensure_json_content_type_middleware(
+        _http_scope("PUT", [(b"transfer-encoding", b"chunked")])
     )
     assert dict(downstream_scope["headers"])[b"content-type"] == b"application/json"
 
@@ -123,17 +138,34 @@ async def test_ensure_json_content_type_middleware_does_not_override_existing_co
     None
 ):
     downstream_scope = await _run_ensure_json_content_type_middleware(
-        {
-            "type": "http",
-            "headers": [
-                (b"content-type", b"multipart/form-data; boundary=some-boundary")
+        _http_scope(
+            "POST",
+            [
+                (b"content-length", b"13"),
+                (b"content-type", b"multipart/form-data; boundary=some-boundary"),
             ],
-        }
+        )
     )
     assert (
         dict(downstream_scope["headers"])[b"content-type"]
         == b"multipart/form-data; boundary=some-boundary"
     )
+
+
+async def test_ensure_json_content_type_middleware_skips_non_body_bearing_method() -> (
+    None
+):
+    downstream_scope = await _run_ensure_json_content_type_middleware(
+        _http_scope("GET", [(b"content-length", b"13")])
+    )
+    assert dict(downstream_scope["headers"]) == {b"content-length": b"13"}
+
+
+async def test_ensure_json_content_type_middleware_skips_bodyless_request() -> None:
+    downstream_scope = await _run_ensure_json_content_type_middleware(
+        _http_scope("POST", [(b"content-length", b"0")])
+    )
+    assert dict(downstream_scope["headers"]) == {b"content-length": b"0"}
 
 
 async def test_ensure_json_content_type_middleware_skips_non_http_scope() -> None:

--- a/server/py/services/api/tests/unit/api/framework/test_middlewares.py
+++ b/server/py/services/api/tests/unit/api/framework/test_middlewares.py
@@ -12,14 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest.mock
+import uuid
+from http import HTTPStatus
 
 import fastapi.testclient
 import pytest
 import sqlalchemy.orm
 
+import mlrun.common.schemas
 import mlrun.common.schemas.constants
 import mlrun.utils.version
+
+import framework.middlewares
 
 
 @pytest.mark.parametrize(
@@ -85,3 +91,67 @@ def test_ensure_be_version_middleware(
         response.headers[mlrun.common.schemas.constants.HeaderNames.backend_version]
         == "dummy-version"
     )
+
+
+async def _noop_receive():
+    return {"type": "http.disconnect"}
+
+
+async def _noop_send(message):
+    pass
+
+
+async def _run_ensure_json_content_type_middleware(scope: dict) -> dict:
+    downstream_scope = {}
+
+    async def downstream_app(inner_scope, receive, send):
+        downstream_scope.update(inner_scope)
+
+    middleware = framework.middlewares.EnsureJsonContentTypeMiddleware(downstream_app)
+    await middleware(scope, _noop_receive, _noop_send)
+    return downstream_scope
+
+
+async def test_ensure_json_content_type_middleware_defaults_missing_header() -> None:
+    downstream_scope = await _run_ensure_json_content_type_middleware(
+        {"type": "http", "headers": []}
+    )
+    assert dict(downstream_scope["headers"])[b"content-type"] == b"application/json"
+
+
+async def test_ensure_json_content_type_middleware_does_not_override_existing_content_type() -> (
+    None
+):
+    downstream_scope = await _run_ensure_json_content_type_middleware(
+        {
+            "type": "http",
+            "headers": [
+                (b"content-type", b"multipart/form-data; boundary=some-boundary")
+            ],
+        }
+    )
+    assert (
+        dict(downstream_scope["headers"])[b"content-type"]
+        == b"multipart/form-data; boundary=some-boundary"
+    )
+
+
+async def test_ensure_json_content_type_middleware_skips_non_http_scope() -> None:
+    downstream_scope = await _run_ensure_json_content_type_middleware(
+        {"type": "websocket", "headers": []}
+    )
+    assert downstream_scope["headers"] == []
+
+
+def test_ensure_json_content_type_middleware_lets_headerless_json_body_through(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    # simulates a v1-client sending a pre-serialized JSON body without a Content-Type header
+    # (e.g. mlrun.db.httpdb.HTTPRunDB.api_call's `body=` kwarg, which requests/httpx never tag
+    # with Content-Type on their own, unlike the `json=` kwarg)
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name=f"prj-{uuid.uuid4().hex}"),
+        spec=mlrun.common.schemas.ProjectSpec(),
+    )
+    response = client.post("projects", content=json.dumps(project.dict()).encode())
+    assert response.status_code == HTTPStatus.CREATED.value

--- a/server/py/services/api/tests/unit/utils/clients/test_discovery.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_discovery.py
@@ -99,7 +99,10 @@ def test_find_service_correctness(client: fastapi.testclient.TestClient):
         "alert-activations",
     }
     for app_route in client.app.router.routes:
-        app_route: fastapi.routing.APIRoute
+        # newer FastAPI versions also list each include_router() call as a routes entry
+        # (fastapi.routing._IncludedRouter), alongside the individual leaf routes it expands to
+        if not isinstance(app_route, fastapi.routing.APIRoute):
+            continue
         for method in app_route.methods:
             path = app_route.path
             for prefix in ["/api", "/api/v1", "/api/v2", "/v1", "/v2", "/"]:

--- a/server/py/services/api/tests/unit/utils/clients/test_messaging.py
+++ b/server/py/services/api/tests/unit/utils/clients/test_messaging.py
@@ -39,7 +39,7 @@ def fastapi_request():
             "method": "GET",
             "path": "/proxy-service/success",
             "headers": [(b"host", b"http://some-other-svc/proxy-service/success")],
-            "query_string": "",
+            "query_string": b"",
             "state": {"request_id": "test"},
             "app": fastapi_app,
         }


### PR DESCRIPTION
### 📝 Description
Fourth atomic step of the mlrun Pydantic-2/FastAPI migration (ML-12736 → M1). Bumps `fastapi~=0.125.0` → `fastapi>=0.128,<1`, pulling in `starlette>=1.0.1,<2` and the CVE-2026-48710 ("BadHost") Host-header auth-bypass fix (Starlette 0.8.3–1.0.0 affected, fixed in 1.0.1). The bump isn't a no-op: FastAPI ≥0.128 only parses a request body as JSON when `Content-Type: application/json` is set, and some existing callers (`mlrun/db/httpdb.py`'s pre-serialized-body call sites, e.g. `store_run`/`update_run`) never set that header, since `requests`/`httpx` only auto-set it for the `json=` kwarg, not raw `data=`/`content=`. A new middleware restores that leniency without reopening it for requests that already declare their own content type.

---

### 🛠️ Changes Made
- `dockerfiles/mlrun-api/requirements.txt` — bump `fastapi` to `>=0.128,<1`, add explicit `starlette>=1.0.1,<2` (fastapi's own transitive floor is only `starlette>=0.46.0`, which would not have picked up the CVE fix on its own). Removed a deferral comment that named this exact ticket.
- `server/py/framework/middlewares/ensure_json_content_type.py` (new) — `EnsureJsonContentTypeMiddleware`, a raw ASGI middleware (same style as `ensure_be_version.py`) that defaults a *missing* `Content-Type` to `application/json` via `MutableHeaders(scope=scope).setdefault(...)`. This is a no-op whenever any `Content-Type` is already present, so multipart/form uploads (which always declare their own boundary-bearing type) are structurally unreachable by the default.
- `server/py/framework/service/__init__.py` — registers the new middleware first in `_add_middlewares`, making it the innermost wrapper (closest to the router) so it normalizes the request immediately before FastAPI's body parsing.
- `server/py/services/api/tests/unit/api/framework/test_logging_middleware.py` — a pre-existing test declared a `pydantic.v1.BaseModel` directly as a route body model, which FastAPI ≥0.128 hard-rejects at route registration (`PydanticV1NotSupportedError`). Switched to plain `pydantic.BaseModel`; unrelated to the content-type fix but a hard blocker for the version bump.
- `dockerfiles/mlrun-api/locked-requirements.txt`, `dockerfiles/test/locked-requirements-server.txt` — regenerated via scoped `uv pip compile` (no blanket `--upgrade`); diffs are exactly fastapi 0.125.0→0.140.13 and starlette 0.50.0→1.3.1, no unrelated dependency churn.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New unit tests in `test_middlewares.py`: 3 tests drive `EnsureJsonContentTypeMiddleware` directly at the ASGI-scope level (defaults a missing header / does not override an existing one / no-ops on non-http scopes), plus one integration test through the real app proving a v1-client-style request (JSON body, no `Content-Type`) succeeds under the bumped FastAPI — verified with a negative control that it fails without the middleware.
- `server/py/services/api/tests/unit/api/framework/`: 11/11 pass.
- `server/py/services/api/tests/unit/api/`: 490 passed, 30 pre-existing failures unrelated to this change (confirmed via `git stash` that the same 30 fail identically on the unmodified base commit — an `AttributeError: forbidden_service_accounts` in `mlrun/config.py`, unrelated to fastapi/starlette).
- `tests/common/test_schemas_dispatch.py`: 25/25 pass.
- Tested in an isolated worktree-local venv, not the shared dev venv.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12893
- Design docs links: n/a — scope fixed by parent ticket ML-12736, no separate HLD
- External links: [CVE-2026-48710 (BadHost) advisory](https://badhost.org/)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Depends on ML-12890/12891/12892, already merged into `feature/api-w-pydanticv2` (PR #9934).
- fastapi/starlette pins are bounded (`<1`, `<2`) rather than left open, since this exact ticket exists because an open-ended fastapi bump silently changed body-parsing behavior — a future lock regen crossing a major version should require a deliberate re-review, not happen silently.