### PR TITLE
[Partitioning] Fix Postgres partition overlap after missed rotation

### DIFF
--- a/server/py/framework/db/sqldb/partition_bootstrapper.py
+++ b/server/py/framework/db/sqldb/partition_bootstrapper.py
@@ -301,28 +301,6 @@ class PartitionBootstrapperMySQL(PartitionBootstrapper):
 
 
 class PartitionBootstrapperPostgres(PartitionBootstrapper):
-    def _get_existing_child_partition_names(
-        self,
-        session: sqlalchemy.orm.Session,
-        table_name: str,
-    ) -> set[str]:
-        """
-        Return names of existing child partitions for a PostgreSQL parent table.
-        """
-        sql = sqlalchemy.text(
-            """
-            SELECT c.relname AS partition_name
-            FROM pg_inherits
-            JOIN pg_class c ON c.oid = pg_inherits.inhrelid
-            JOIN pg_class p ON p.oid = pg_inherits.inhparent
-            JOIN pg_namespace n ON n.oid = p.relnamespace
-            WHERE n.nspname = current_schema()
-              AND p.relname = :table_name
-            """
-        )
-        result = session.execute(sql, {"table_name": table_name})
-        return {row.partition_name for row in result}
-
     def bootstrap(
         self,
         session: sqlalchemy.orm.Session,
@@ -332,6 +310,14 @@ class PartitionBootstrapperPostgres(PartitionBootstrapper):
     ):
         """
         Create missing range partitions for a PostgreSQL partitioned table.
+
+        Each new partition is anchored on the highest upper bound already present
+        in the database rather than on its position in the freshly generated batch.
+        This keeps partitions contiguous even when one or more intervals were
+        missed (e.g. the periodic task did not run for a while): the first new
+        partition simply extends from the newest existing bound and spans the gap,
+        instead of re-emitting a ``MINVALUE`` lower bound that would overlap the
+        original partition and abort the whole create/drop transaction.
         """
         partition_list = self._get_partition_list(
             table_name=table_name,
@@ -347,24 +333,43 @@ class PartitionBootstrapperPostgres(PartitionBootstrapper):
             sample_partition=partition_list[0][0],
         )
 
-        existing_children = self._get_existing_child_partition_names(
+        existing_partitions = self._get_existing_partition_boundaries(
             session=session,
             table_name=table_name,
+        )
+        # Highest upper bound covered so far (existing + just-created). Each new
+        # partition uses it as its lower bound, so partitions stay contiguous and
+        # never overlap an existing one after a missed rotation. None means the
+        # table has no partitions yet (genuine initial bootstrap).
+        highest_covered_boundary = max(
+            (boundary for _, boundary in existing_partitions),
+            default=None,
         )
 
         mlrun.utils.logger.info(
             "Creating partitions (PostgreSQL)",
             requested_partitions=len(partition_list),
-            existing_partitions=len(existing_children),
+            existing_partitions=len(existing_partitions),
+            highest_covered_boundary=highest_covered_boundary,
             table_name=table_name,
         )
 
-        for index, (partition_name, boundary_value) in enumerate(partition_list):
-            if partition_name in existing_children:
+        for partition_name, boundary_value in partition_list:
+            upper_bound_value = int(boundary_value)
+
+            # Skip anything already covered (by upper bound, not by name): this
+            # keeps the run idempotent and avoids the range overlap that anchoring
+            # on batch position — rather than on the DB — used to cause after a gap.
+            if (
+                highest_covered_boundary is not None
+                and upper_bound_value <= highest_covered_boundary
+            ):
                 mlrun.utils.logger.debug(
-                    "Partition already exists, skipping creation",
+                    "Partition range already covered, skipping creation",
                     table_name=table_name,
                     partition_name=partition_name,
+                    upper_bound=upper_bound_value,
+                    covered_up_to=highest_covered_boundary,
                 )
                 continue
 
@@ -374,17 +379,57 @@ class PartitionBootstrapperPostgres(PartitionBootstrapper):
                 table_name=table_name,
             )
             lower_bound = (
-                "MINVALUE" if index == 0 else str(int(partition_list[index - 1][1]))
+                "MINVALUE"
+                if highest_covered_boundary is None
+                else str(highest_covered_boundary)
             )
-            upper_bound = str(int(boundary_value))
+            upper_bound = str(upper_bound_value)
             ddl = f"""
                 CREATE TABLE {quoted_partition}
                 PARTITION OF {quoted_table}
                 FOR VALUES FROM ({lower_bound}) TO ({upper_bound})
             """
             session.execute(sqlalchemy.text(ddl))
+            highest_covered_boundary = upper_bound_value
 
         session.commit()
+
+    def _get_existing_partition_boundaries(
+        self,
+        session: sqlalchemy.orm.Session,
+        table_name: str,
+    ) -> list[tuple[str, int]]:
+        """
+        Read existing PostgreSQL child partitions and their integer upper bounds.
+
+        :param session: SQLAlchemy session bound to the target database.
+        :param table_name: Parent partitioned table name.
+        :return: ``(partition_name, upper_bound)`` tuples. Rows whose upper bound
+            cannot be parsed (e.g. a ``DEFAULT``/``MAXVALUE`` partition) are skipped.
+        """
+        sql = sqlalchemy.text(
+            r"""
+            SELECT c.relname AS partition_name,
+                   (regexp_match(
+                           pg_get_expr(c.relpartbound, c.oid),
+                           'TO \((\d+)\)'
+                    ))[1]::int AS upper_bound
+            FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            JOIN pg_class p ON p.oid = i.inhparent
+            JOIN pg_namespace n ON n.oid = p.relnamespace
+            WHERE n.nspname = current_schema()
+              AND p.relname = :table_name
+              AND c.relkind = 'r'
+            """
+        )
+        result = session.execute(sql, {"table_name": table_name})
+        existing_partitions: list[tuple[str, int]] = []
+        for partition_name, upper_bound in result:
+            if upper_bound is None:
+                continue
+            existing_partitions.append((partition_name, int(upper_bound)))
+        return existing_partitions
 
 
 class PartitionBootstrapperSqlite(PartitionBootstrapper):

--- a/server/py/services/api/migrations/tests/postgres/test_partitions_postgres.py
+++ b/server/py/services/api/migrations/tests/postgres/test_partitions_postgres.py
@@ -122,3 +122,184 @@ def test_drop_partitions_postgres(postgres_db_session):
     assert parts[0][0] not in remaining  # oldest dropped
     assert cutoff_name in remaining  # cutoff kept
     postgres_db_session.close()
+
+
+def _create_partitioned_table(
+    session: sqlalchemy.orm.session.Session, table: str
+) -> None:
+    session.execute(
+        sqlalchemy.text(
+            f"""
+            CREATE TABLE {table} (
+                id            INTEGER NOT NULL,
+                partition_key INTEGER NOT NULL,
+                data          TEXT,
+                PRIMARY KEY (id, partition_key)
+            ) PARTITION BY RANGE (partition_key);
+            """
+        )
+    )
+
+
+def _partition_bound_expr(
+    session: sqlalchemy.orm.session.Session, partition_name: str
+) -> str:
+    return session.execute(
+        sqlalchemy.text(
+            "SELECT pg_get_expr(c.relpartbound, c.oid) "
+            "FROM pg_class c WHERE c.relname = :name"
+        ),
+        {"name": partition_name},
+    ).scalar_one()
+
+
+def _bootstrap(
+    session: sqlalchemy.orm.session.Session, table: str, partitions_count: int
+) -> None:
+    framework.db.sqldb.partition_bootstrapper.PartitionBootstrapper(
+        session.get_bind().dialect.name
+    ).bootstrap(
+        session=session,
+        table_name=table,
+        partition_interval=mlrun.common.schemas.partition_interval.PartitionInterval.DAY,
+        partitions_count=partitions_count,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("pmr_postgres_container")
+@tests.common_fixtures.freeze_datetime(datetime(2025, 6, 1))
+def test_bootstrap_after_gap_does_not_overlap(
+    postgres_db_session: sqlalchemy.orm.session.Session,
+):
+    """
+    Regression for ORIS-3709: when the periodic task misses days, the next run's
+    first new partition must anchor on the existing max bound (spanning the gap),
+    not on MINVALUE. Pre-fix this raised
+    ``psycopg2.errors.InvalidObjectDefinition: partition ... would overlap ...``.
+    """
+    table = "dyn_table_gap"
+    _create_partitioned_table(postgres_db_session, table)
+
+    # Day 0: single partition p20250601 -> [MINVALUE, 20250602).
+    _bootstrap(postgres_db_session, table, partitions_count=1)
+
+    # Skip days 2, 3, 4 entirely, then run again on day 5 (the missed-rotation gap).
+    tests.common_fixtures.FrozenDatetime._frozen_now = datetime(2025, 6, 5)
+    _bootstrap(postgres_db_session, table, partitions_count=2)  # must not raise
+
+    metadata = sqldb.PostgreSQLDB._get_partition_metadata(postgres_db_session, table)
+    assert metadata == {
+        "p20250601": 20250602,
+        "p20250605": 20250606,
+        "p20250606": 20250607,
+    }
+
+    # The gap-filler is contiguous with the existing partition (not MINVALUE),
+    # so it spans the skipped days without overlapping p20250601.
+    gap_bound = _partition_bound_expr(postgres_db_session, "p20250605")
+    assert "20250602" in gap_bound
+    assert "MINVALUE" not in gap_bound
+
+    # A row dated on a skipped gap day (2025-06-03) still has a home -> no hole.
+    postgres_db_session.execute(
+        sqlalchemy.text(
+            f"INSERT INTO {table} (id, partition_key, data) "
+            "VALUES (1, 20250603, 'gap-day')"
+        )
+    )
+    postgres_db_session.commit()
+    postgres_db_session.close()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("pmr_postgres_container")
+@tests.common_fixtures.freeze_datetime(datetime(2025, 7, 1))
+def test_bootstrap_contiguous_runs_are_idempotent(
+    postgres_db_session: sqlalchemy.orm.session.Session,
+):
+    """Repeated runs create only missing partitions; a re-run adds nothing."""
+    table = "dyn_table_contig"
+    _create_partitioned_table(postgres_db_session, table)
+
+    _bootstrap(postgres_db_session, table, partitions_count=2)
+    first = set(
+        sqldb.PostgreSQLDB._get_partition_metadata(postgres_db_session, table).keys()
+    )
+    assert first == {"p20250701", "p20250702"}
+
+    # Same "now": nothing new, no error.
+    _bootstrap(postgres_db_session, table, partitions_count=2)
+    assert (
+        set(
+            sqldb.PostgreSQLDB._get_partition_metadata(
+                postgres_db_session, table
+            ).keys()
+        )
+        == first
+    )
+
+    # One day later: exactly one new contiguous partition is added.
+    tests.common_fixtures.FrozenDatetime._frozen_now = datetime(2025, 7, 2)
+    _bootstrap(postgres_db_session, table, partitions_count=2)
+    assert set(
+        sqldb.PostgreSQLDB._get_partition_metadata(postgres_db_session, table).keys()
+    ) == {"p20250701", "p20250702", "p20250703"}
+    postgres_db_session.close()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("pmr_postgres_container")
+@tests.common_fixtures.freeze_datetime(datetime(2025, 8, 1))
+def test_bootstrap_initial_uses_minvalue(
+    postgres_db_session: sqlalchemy.orm.session.Session,
+):
+    """The very first partition of an empty table is anchored at MINVALUE."""
+    table = "dyn_table_initial"
+    _create_partitioned_table(postgres_db_session, table)
+
+    _bootstrap(postgres_db_session, table, partitions_count=2)
+
+    first_bound = _partition_bound_expr(postgres_db_session, "p20250801")
+    assert "MINVALUE" in first_bound
+    assert "20250802" in first_bound
+    # The second partition chains from the first, not from MINVALUE.
+    second_bound = _partition_bound_expr(postgres_db_session, "p20250802")
+    assert "MINVALUE" not in second_bound
+    assert "20250802" in second_bound
+    postgres_db_session.close()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("pmr_postgres_container")
+@tests.common_fixtures.freeze_datetime(datetime(2025, 9, 1))
+def test_rotation_after_gap_creates_and_drops(
+    postgres_db_session: sqlalchemy.orm.session.Session,
+):
+    """
+    End-to-end ORIS-3709: after a multi-day gap, a rotation both creates the new
+    partition (no overlap) and drops the expired one. Pre-fix the create raised,
+    so neither happened.
+    """
+    table = "dyn_table_rotate"
+    _create_partitioned_table(postgres_db_session, table)
+
+    # Day 0 partition, then a 4-day gap.
+    _bootstrap(postgres_db_session, table, partitions_count=1)
+    tests.common_fixtures.FrozenDatetime._frozen_now = datetime(2025, 9, 5)
+
+    # Create (spans the gap) then drop anything older than 1 day.
+    _bootstrap(postgres_db_session, table, partitions_count=2)
+    services.api.utils.db.partitioner.DBPartitioner().drop_partitions(
+        session=postgres_db_session,
+        table_name=table,
+        partition_interval=mlrun.common.schemas.partition_interval.PartitionInterval.DAY,
+        retention_days=1,
+    )
+
+    remaining = set(
+        sqldb.PostgreSQLDB._get_partition_metadata(postgres_db_session, table).keys()
+    )
+    assert "p20250901" not in remaining  # expired, dropped
+    assert {"p20250905", "p20250906"} <= remaining  # newly created, kept
+    postgres_db_session.close()


### PR DESCRIPTION
### 📝 Description
On PostgreSQL, `alert_activations` stopped rotating its daily partitions after a periodic partition run was missed: the expired partition was never dropped and no new one was created (ORIS-3709). The Postgres bootstrapper derived the first new partition's lower bound from its position in the freshly generated batch (`index == 0` → `MINVALUE`) instead of from the highest bound already in the database. After a gap, "today" was batch index 0 and was recreated `FROM (MINVALUE)`, overlapping the original `MINVALUE`-anchored partition; PostgreSQL raised `InvalidObjectDefinition`, and because the periodic task runs create before drop in one transaction, the whole rotation rolled back — so both symptoms came from a single cause.

---

### 🛠️ Changes Made
- `PartitionBootstrapperPostgres.bootstrap` now anchors each new partition's lower bound on the highest existing partition upper bound read from the DB (new `_get_existing_partition_boundaries` helper), replacing the previous batch-index anchor.
- Partitions already covered are skipped by upper bound rather than by name, keeping runs idempotent and preventing range overlaps.
- `MINVALUE` is used only when the table has no partitions yet; after a missed-rotation gap the first new partition spans the gap contiguously.
- Removed the now-unused name-only `_get_existing_child_partition_names` helper.
- Added Postgres integration tests for the gap overlap, contiguous-run idempotency, initial `MINVALUE` anchoring, and create+drop rotation after a gap.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added 4 integration tests against real PostgreSQL (`pmr_postgres_container`) in `test_partitions_postgres.py`: gap-overlap regression (guards the overlap the old batch-index anchoring produced), contiguous-run idempotency, initial `MINVALUE` anchoring, and rotation create+drop after a gap.
- The Postgres partition test file passes locally: 6 passed (4 new + 2 pre-existing). `make lint` passes (ruff + import-linter).
- Verified end-to-end on a live PostgreSQL-backed lab: after deploying the fix, a previously stuck `alert_activations` (single partition after a multi-day gap) rotated correctly — new daily partitions created and the expired one dropped, with no overlap error.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ORIS-3709
- Design docs links: —
- External links: —

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Change is internal to Postgres partition management: only `partition_bootstrapper.py` and its Postgres test file are touched — no schema migration, API, SDK, or config change.