### PR TITLE
[API] Fix DB.Connection.Failed missing on chief-startup outage

### DIFF
--- a/server/py/framework/tests/integration/db/test_db_connection_event.py
+++ b/server/py/framework/tests/integration/db/test_db_connection_event.py
@@ -28,7 +28,9 @@ no-false-positive contract for the most plausible noise sources:
 True-positive disconnect detection is covered by the unit tests
 (test_db_errors.py) and was verified end-to-end on the lab during PR review.
 Reproducing a real disconnect deterministically in a container fixture is
-brittle (it usually means killing the container mid-test).
+brittle (it usually means killing the container mid-test) — except for a
+never-established connection (host/port refuses immediately), which is
+deterministic and exercised below.
 """
 
 import threading
@@ -160,6 +162,32 @@ def test_integrity_violation_does_not_emit_event(
             conn.execute(sqlalchemy.text("DROP TABLE conn_event_integrity_test"))
 
     assert stub_events_client == [], "integrity violation must not trigger an event"
+
+
+def test_unreachable_connection_classifies_as_disconnect(
+    db_engine: sqlalchemy.engine.Engine,
+) -> None:
+    """
+    Reproduces the chief-startup-during-outage shape: a connection attempt
+    against an unreachable host/port fails before any backend ever responds
+    (no SQLSTATE, no is_disconnect flag) — this is why the bootstrap DB-init
+    path (sqlalchemy_utils.database_exists/create_database, which open their
+    own throwaway engines) needs classify_exception(), not just classify().
+    Deterministic: an unreachable port refuses immediately, unlike killing a
+    running container mid-test.
+    """
+    unreachable_engine = sqlalchemy.create_engine(
+        db_engine.url.set(host="127.0.0.1", port=1)
+    )
+    try:
+        with pytest.raises(sqlalchemy.exc.DBAPIError) as exc_info:
+            with unreachable_engine.connect():
+                pass
+    finally:
+        unreachable_engine.dispose()
+
+    category, _ = db_errors.classify_exception(exc_info.value)
+    assert category == db_errors.CATEGORY_DISCONNECT
 
 
 def _is_postgres(engine: sqlalchemy.engine.Engine) -> bool:

--- a/server/py/services/api/initial_data.py
+++ b/server/py/services/api/initial_data.py
@@ -53,6 +53,7 @@ import framework.db.sqldb.sql_session
 import framework.utils.pagination_cache
 import services.api.utils.db.alembic
 import services.api.utils.db.backup
+import services.api.utils.events.db_errors
 import services.api.utils.events.events_factory
 import services.api.utils.scheduler
 from framework.utils.db.utils import DBUtil
@@ -90,15 +91,26 @@ def _initialize_db_if_needed(engine: sqlalchemy.engine.Engine) -> bool:
     Returns True if the database needs to be created or initialized from scratch (i.e.,
     if the database does not exist or exists but has no tables).
     Returns False if the database exists and has tables (i.e., is set up and ready).
+
+    ``sqlalchemy_utils.database_exists``/``create_database`` open their own throwaway
+    engines that never go through the ``handle_error`` listener registered on the
+    long-lived singleton ``engine``, so a connection failure here would otherwise crash
+    the process without ever publishing ``MLRun.DB.Connection.Failed``.
     """
     url = engine.url
-    if not sqlalchemy_utils.database_exists(url):
-        mlrun.utils.logger.info(
-            "Database does not exist, creating",
-            database_url=url,
+    try:
+        if not sqlalchemy_utils.database_exists(url):
+            mlrun.utils.logger.info(
+                "Database does not exist, creating",
+                database_url=url,
+            )
+            sqlalchemy_utils.create_database(url)
+            return True
+    except sqlalchemy.exc.DBAPIError as exc:
+        services.api.utils.events.db_errors.publish_connection_failed_from_exception(
+            exc, dialect=engine.dialect.name
         )
-        sqlalchemy_utils.create_database(url)
-        return True
+        raise
 
     # db exists, lets see if it has some tables
     has_tables = bool(sqlalchemy.inspect(engine).get_table_names())

--- a/server/py/services/api/tests/unit/test_initial_data.py
+++ b/server/py/services/api/tests/unit/test_initial_data.py
@@ -15,7 +15,10 @@
 import string
 import unittest.mock
 
+import psycopg2
+import pymysql.err
 import pytest
+import sqlalchemy
 import sqlalchemy.exc
 import sqlalchemy.orm
 
@@ -30,9 +33,17 @@ import framework.db.sqldb.models
 import framework.db.sqldb.sql_session
 import framework.utils.singletons.db
 import services.api.initial_data
+import services.api.utils.events.db_errors as db_errors
 
 _UUID_V4 = "550e8400-e29b-41d4-a716-446655440000"
 _UUID_V7 = "018f6c4e-7b8a-7c2e-bf3a-5e4d1c2a8b90"
+
+
+@pytest.fixture(autouse=True)
+def _reset_db_connection_event_throttle(monkeypatch):
+    """The DB-connection-failed publish throttle is a process-wide singleton
+    (`db_errors._slot`); reset it so each test starts with a claimable slot."""
+    monkeypatch.setattr(db_errors._slot, "_last_emit_monotonic", 0.0)
 
 
 def test_add_data_version_empty_db():
@@ -828,6 +839,135 @@ def test_publish_db_migration_event_swallows_factory_errors(
         mlrun.common.schemas.MigrationEventActions.failed,
         error=RuntimeError("boom"),
     )
+
+
+def test_initialize_db_if_needed_publishes_event_on_create_database_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Ticket repro: database_exists() swallows the outage internally (as
+    sqlalchemy_utils does for Postgres) and returns False, so create_database()
+    is where the real, unhandled connection failure surfaces."""
+    engine = _engine_with_dialect(monkeypatch, "postgresql")
+    orig = psycopg2.OperationalError(
+        'connection to server at "mlrun-db" (10.43.154.75), port 5432 '
+        "failed: Connection refused"
+    )
+    monkeypatch.setattr(
+        services.api.initial_data.sqlalchemy_utils, "database_exists", lambda url: False
+    )
+    monkeypatch.setattr(
+        services.api.initial_data.sqlalchemy_utils,
+        "create_database",
+        unittest.mock.MagicMock(
+            side_effect=sqlalchemy.exc.OperationalError(
+                statement=None, params=None, orig=orig, connection_invalidated=True
+            )
+        ),
+    )
+    fake_client = _fake_events_client(monkeypatch)
+
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        services.api.initial_data._initialize_db_if_needed(engine)
+
+    fake_client.generate_db_connection_event.assert_called_once()
+    call_kwargs = fake_client.generate_db_connection_event.call_args.kwargs
+    assert call_kwargs["error_category"] == db_errors.CATEGORY_DISCONNECT
+    assert call_kwargs["dialect"] == "postgresql"
+    fake_client.emit.assert_called_once()
+
+
+def test_initialize_db_if_needed_publishes_event_on_database_exists_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """MySQL path: database_exists() has no internal swallow-loop, so the
+    connection failure surfaces directly from that call instead."""
+    engine = _engine_with_dialect(monkeypatch, "mysql")
+    orig = pymysql.err.OperationalError(
+        2003, "Can't connect to MySQL server on 'mlrun-db' (111)"
+    )
+    monkeypatch.setattr(
+        services.api.initial_data.sqlalchemy_utils,
+        "database_exists",
+        unittest.mock.MagicMock(
+            side_effect=sqlalchemy.exc.OperationalError(
+                statement=None, params=None, orig=orig
+            )
+        ),
+    )
+    fake_client = _fake_events_client(monkeypatch)
+
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        services.api.initial_data._initialize_db_if_needed(engine)
+
+    fake_client.generate_db_connection_event.assert_called_once()
+    call_kwargs = fake_client.generate_db_connection_event.call_args.kwargs
+    assert call_kwargs["error_category"] == db_errors.CATEGORY_DISCONNECT
+    assert call_kwargs["error_code"] == 2003
+    assert call_kwargs["dialect"] == "mysql"
+
+
+def test_initialize_db_if_needed_fresh_install_does_not_publish_event(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A legitimate first-ever install (DB truly doesn't exist yet, connects
+    fine to create it) must never fire MLRun.DB.Connection.Failed."""
+    engine = _engine_with_dialect(monkeypatch, "postgresql")
+    monkeypatch.setattr(
+        services.api.initial_data.sqlalchemy_utils, "database_exists", lambda url: False
+    )
+    create_database_spy = unittest.mock.MagicMock()
+    monkeypatch.setattr(
+        services.api.initial_data.sqlalchemy_utils,
+        "create_database",
+        create_database_spy,
+    )
+    fake_client = _fake_events_client(monkeypatch)
+
+    assert services.api.initial_data._initialize_db_if_needed(engine) is True
+
+    create_database_spy.assert_called_once()
+    fake_client.emit.assert_not_called()
+
+
+def test_initialize_db_if_needed_non_connection_failure_not_published(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A non-connection DBAPIError (e.g. integrity error) must still propagate,
+    but must not be misreported as a connection failure."""
+    engine = _engine_with_dialect(monkeypatch, "postgresql")
+    monkeypatch.setattr(
+        services.api.initial_data.sqlalchemy_utils,
+        "database_exists",
+        unittest.mock.MagicMock(
+            side_effect=sqlalchemy.exc.IntegrityError(
+                statement=None, params=None, orig=RuntimeError("duplicate key")
+            )
+        ),
+    )
+    fake_client = _fake_events_client(monkeypatch)
+
+    with pytest.raises(sqlalchemy.exc.IntegrityError):
+        services.api.initial_data._initialize_db_if_needed(engine)
+
+    fake_client.emit.assert_not_called()
+
+
+def _fake_events_client(monkeypatch: pytest.MonkeyPatch) -> unittest.mock.MagicMock:
+    fake_client = unittest.mock.MagicMock()
+    fake_client.generate_db_connection_event.return_value = object()
+    monkeypatch.setattr(
+        "services.api.utils.events.events_factory.EventsFactory.get_events_client",
+        lambda *a, **kw: fake_client,
+    )
+    return fake_client
+
+
+def _engine_with_dialect(
+    monkeypatch: pytest.MonkeyPatch, dialect_name: str
+) -> sqlalchemy.engine.Engine:
+    engine = sqlalchemy.create_engine("sqlite:///:memory:")
+    monkeypatch.setattr(engine.dialect, "name", dialect_name)
+    return engine
 
 
 def _initialize_db_without_schema() -> tuple[

--- a/server/py/services/api/tests/unit/utils/events/test_db_errors.py
+++ b/server/py/services/api/tests/unit/utils/events/test_db_errors.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import unittest.mock
 
+import psycopg2
 import pymysql.err
 import pytest
 import sqlalchemy
@@ -208,6 +209,121 @@ def test_classify_skips_non_fatal_errors(exc):
     category, code = db_errors.classify(_ctx(exc))
     assert category is None
     assert code is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        psycopg2.OperationalError(
+            'connection to server at "mlrun-db" (10.43.154.75), port 5432 '
+            "failed: Connection refused"
+        ),
+        psycopg2.OperationalError(
+            'could not translate host name "mlrun-db" to address: '
+            "Name or service not known"
+        ),
+        psycopg2.OperationalError(
+            "could not connect to server: Connection timed out\n\tIs the server "
+            'running on host "mlrun-db" and accepting TCP/IP connections?'
+        ),
+        psycopg2.OperationalError(
+            'connection to server at "mlrun-db" (10.43.154.75), port 5432 failed: '
+            "No route to host"
+        ),
+        psycopg2.OperationalError(
+            'connection to server at "mlrun-db" (10.43.154.75), port 5432 failed: '
+            "Network is unreachable"
+        ),
+        psycopg2.OperationalError("timeout expired"),
+    ],
+)
+def test_classify_exception_postgres_unreachable(exc):
+    """The ticket's exact repro shape: no SQLSTATE, no is_disconnect flag —
+    the connection was never established at all."""
+    category, code = db_errors.classify_exception(exc)
+    assert category == db_errors.CATEGORY_DISCONNECT
+    assert code is None
+
+
+def test_classify_exception_mysql_unreachable():
+    exc = pymysql.err.OperationalError(
+        2003, "Can't connect to MySQL server on 'mlrun-db' (111)"
+    )
+    category, code = db_errors.classify_exception(exc)
+    assert category == db_errors.CATEGORY_DISCONNECT
+    assert code == 2003
+
+
+def test_classify_exception_unwraps_sqlalchemy_wrapper():
+    """initial_data.py's except-block receives the wrapped sqlalchemy.exc
+    error, not the bare driver exception."""
+    orig = _PsycopgLikeError("08006", "server closed the connection unexpectedly")
+    wrapped = sqlalchemy.exc.OperationalError(
+        statement=None, params=None, orig=orig, connection_invalidated=True
+    )
+    category, code = db_errors.classify_exception(wrapped)
+    assert category == db_errors.CATEGORY_DISCONNECT
+    assert code == "08006"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pymysql.err.IntegrityError(1062, "Duplicate entry"),
+        _PsycopgLikeError("23505", "unique_violation"),
+        ValueError("not a db error"),
+    ],
+)
+def test_classify_exception_skips_non_connection_errors(exc):
+    category, code = db_errors.classify_exception(exc)
+    assert category is None
+    assert code is None
+
+
+def test_publish_connection_failed_from_exception_happy_path(monkeypatch):
+    publish_calls: list[dict] = []
+    monkeypatch.setattr(
+        db_errors,
+        "publish_connection_failed",
+        lambda **kw: publish_calls.append(kw) or True,
+    )
+    exc = psycopg2.OperationalError(
+        'connection to server at "mlrun-db" ... failed: Connection refused'
+    )
+    emitted = db_errors.publish_connection_failed_from_exception(
+        exc, dialect="postgresql"
+    )
+    assert emitted is True
+    assert len(publish_calls) == 1
+    assert publish_calls[0]["error"] is exc
+    assert publish_calls[0]["dialect"] == "postgresql"
+    assert publish_calls[0]["category"] == db_errors.CATEGORY_DISCONNECT
+    assert publish_calls[0]["error_code"] is None
+
+
+def test_publish_connection_failed_from_exception_skips_non_connection_error(
+    monkeypatch,
+):
+    publish_spy = unittest.mock.MagicMock()
+    monkeypatch.setattr(db_errors, "publish_connection_failed", publish_spy)
+    emitted = db_errors.publish_connection_failed_from_exception(
+        ValueError("not a db error")
+    )
+    assert emitted is False
+    publish_spy.assert_not_called()
+
+
+def test_publish_connection_failed_from_exception_swallows_classify_error(
+    monkeypatch,
+):
+    """If classify_exception raises, the caller must not see it (never raises)."""
+    monkeypatch.setattr(
+        db_errors,
+        "classify_exception",
+        unittest.mock.MagicMock(side_effect=RuntimeError("classifier broke")),
+    )
+    emitted = db_errors.publish_connection_failed_from_exception(RuntimeError("boom"))
+    assert emitted is False
 
 
 def test_publish_emits_event_via_factory(monkeypatch):

--- a/server/py/services/api/tests/unit/utils/events/test_db_errors.py
+++ b/server/py/services/api/tests/unit/utils/events/test_db_errors.py
@@ -197,6 +197,25 @@ def test_classify_postgres_unknown_sqlstate_returns_none():
     assert code is None
 
 
+def test_classify_postgres_never_connected_via_message_fallback():
+    """
+    A fresh-connect attempt against a fully unreachable Postgres server (no
+    established connection to invalidate, hence no SQLSTATE and
+    is_disconnect=False) must still classify as a disconnect. This is the
+    same shape mlrun-api-chief hits mid-session when the DB pool needs a new
+    connection and the server is down, not just at bootstrap.
+    """
+    exc = psycopg2.OperationalError(
+        'connection to server at "mlrun-db" (10.43.154.75), port 5432 '
+        "failed: Connection refused"
+    )
+    category, code = db_errors.classify(
+        _ctx(exc, is_disconnect=False, dialect_name="postgresql")
+    )
+    assert category == db_errors.CATEGORY_DISCONNECT
+    assert code is None
+
+
 @pytest.mark.parametrize(
     "exc",
     [

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -70,6 +70,19 @@ PG_CATEGORIES: dict[str, str] = {
     "28P01": CATEGORY_AUTH_FAILED,  # invalid_password
 }
 
+# psycopg2/3 raise these for connection *establishment* failures with neither
+# a SQLSTATE (no backend was ever reached to issue one) nor a message matching
+# SQLAlchemy's own disconnect heuristic (which only covers connections that
+# died *after* being established). Matched case-insensitively, substring.
+PG_UNREACHABLE_MESSAGES: tuple[str, ...] = (
+    "connection refused",
+    "could not connect to server",
+    "could not translate host name",
+    "no route to host",
+    "network is unreachable",
+    "timeout expired",
+)
+
 SUPPORTED_DIALECTS: frozenset[str] = frozenset(
     {
         mlrun.common.db.dialects.Dialects.MYSQL,
@@ -122,6 +135,46 @@ def classify(
     return None, None
 
 
+def classify_exception(
+    exc: BaseException,
+) -> tuple[str | None, int | str | None]:
+    """
+    Classify a caught exception into ``(category, driver_code)``, for call
+    sites with no ``handle_error`` :class:`ExceptionContext` available (e.g. a
+    one-off connection attempt through a throwaway engine that was never
+    registered with :func:`register`). See :func:`classify` for the return
+    contract.
+    """
+    original = getattr(exc, "orig", exc)
+
+    if getattr(exc, "connection_invalidated", False):
+        code = _extract_pg_sqlstate(original) or _extract_mysql_code(original)
+        return CATEGORY_DISCONNECT, code
+
+    if isinstance(original, sqlalchemy.exc.TimeoutError):
+        return CATEGORY_POOL_TIMEOUT, None
+
+    mysql_code = _extract_mysql_code(original)
+    if mysql_code is not None:
+        category = MYSQL_CATEGORIES.get(mysql_code)
+        if category is not None:
+            return category, mysql_code
+
+    pg_code = _extract_pg_sqlstate(original)
+    if pg_code is not None:
+        category = PG_CATEGORIES.get(pg_code)
+        if category is not None:
+            return category, pg_code
+
+    # A connection that was never established has no SQLSTATE (the backend
+    # never responded) and SQLAlchemy's own is_disconnect/connection_invalidated
+    # heuristic only covers connections that died *after* being established.
+    if _is_pg_unreachable(original):
+        return CATEGORY_DISCONNECT, None
+
+    return None, None
+
+
 def publish_connection_failed(
     error: BaseException,
     dialect: str | None,
@@ -162,6 +215,32 @@ def publish_connection_failed(
             exc_info=publish_exc,
         )
         return False
+
+
+def publish_connection_failed_from_exception(
+    exc: BaseException,
+    dialect: str | None = None,
+) -> bool:
+    """
+    Best-effort classify-and-publish for a caught exception (no
+    ``handle_error`` :class:`ExceptionContext` available). Never raises.
+
+    :return: True if an event was emitted, False if not a connection-level
+        error, throttled, or unsupported.
+    """
+    try:
+        category, code = classify_exception(exc)
+        if category is None:
+            return False
+    except Exception as classify_exc:
+        logger.warning(
+            "Failed to classify DB error for connection event, ignoring",
+            exc_info=classify_exc,
+        )
+        return False
+    return publish_connection_failed(
+        error=exc, dialect=dialect, category=category, error_code=code
+    )
 
 
 def register(engine: sqlalchemy.engine.Engine) -> None:
@@ -245,3 +324,19 @@ def _extract_pg_sqlstate(exc: BaseException | None) -> str | None:
     if isinstance(code, str) and code:
         return code
     return None
+
+
+def _is_pg_unreachable(exc: BaseException | None) -> bool:
+    """
+    True if ``exc`` is a psycopg2/3 error whose message matches a known
+    "could not establish a connection at all" phrasing (see
+    ``PG_UNREACHABLE_MESSAGES``). Module-checked the same way as
+    :func:`_extract_mysql_code`, to avoid matching an unrelated driver's
+    exception that happens to share wording.
+    """
+    if exc is None:
+        return False
+    if not type(exc).__module__.startswith(("psycopg2", "psycopg")):
+        return False
+    message = str(exc).lower()
+    return any(phrase in message for phrase in PG_UNREACHABLE_MESSAGES)

--- a/server/py/services/api/utils/events/db_errors.py
+++ b/server/py/services/api/utils/events/db_errors.py
@@ -117,22 +117,7 @@ def classify(
         code = _extract_pg_sqlstate(original) or _extract_mysql_code(original)
         return CATEGORY_DISCONNECT, code
 
-    if isinstance(original, sqlalchemy.exc.TimeoutError):
-        return CATEGORY_POOL_TIMEOUT, None
-
-    mysql_code = _extract_mysql_code(original)
-    if mysql_code is not None:
-        category = MYSQL_CATEGORIES.get(mysql_code)
-        if category is not None:
-            return category, mysql_code
-
-    pg_code = _extract_pg_sqlstate(original)
-    if pg_code is not None:
-        category = PG_CATEGORIES.get(pg_code)
-        if category is not None:
-            return category, pg_code
-
-    return None, None
+    return _classify_by_driver_code(original)
 
 
 def classify_exception(
@@ -151,28 +136,7 @@ def classify_exception(
         code = _extract_pg_sqlstate(original) or _extract_mysql_code(original)
         return CATEGORY_DISCONNECT, code
 
-    if isinstance(original, sqlalchemy.exc.TimeoutError):
-        return CATEGORY_POOL_TIMEOUT, None
-
-    mysql_code = _extract_mysql_code(original)
-    if mysql_code is not None:
-        category = MYSQL_CATEGORIES.get(mysql_code)
-        if category is not None:
-            return category, mysql_code
-
-    pg_code = _extract_pg_sqlstate(original)
-    if pg_code is not None:
-        category = PG_CATEGORIES.get(pg_code)
-        if category is not None:
-            return category, pg_code
-
-    # A connection that was never established has no SQLSTATE (the backend
-    # never responded) and SQLAlchemy's own is_disconnect/connection_invalidated
-    # heuristic only covers connections that died *after* being established.
-    if _is_pg_unreachable(original):
-        return CATEGORY_DISCONNECT, None
-
-    return None, None
+    return _classify_by_driver_code(original)
 
 
 def publish_connection_failed(
@@ -295,6 +259,39 @@ def _on_dbapi_error(ctx: sqlalchemy.engine.ExceptionContext) -> None:
             "Failed to handle DB error event, ignoring",
             exc_info=exc,
         )
+
+
+def _classify_by_driver_code(
+    original: BaseException | None,
+) -> tuple[str | None, int | str | None]:
+    """
+    Classify a DBAPI error that carries no explicit disconnect signal
+    (``is_disconnect``/``connection_invalidated``) by its driver-level error
+    code, and — for Postgres — by message text as a last resort. Shared by
+    :func:`classify` and :func:`classify_exception` so both the mid-session
+    ``handle_error`` listener and the bootstrap-time caught-exception path get
+    the same coverage, including a connection that was never established at
+    all (no SQLSTATE, since the backend never responded).
+    """
+    if isinstance(original, sqlalchemy.exc.TimeoutError):
+        return CATEGORY_POOL_TIMEOUT, None
+
+    mysql_code = _extract_mysql_code(original)
+    if mysql_code is not None:
+        category = MYSQL_CATEGORIES.get(mysql_code)
+        if category is not None:
+            return category, mysql_code
+
+    pg_code = _extract_pg_sqlstate(original)
+    if pg_code is not None:
+        category = PG_CATEGORIES.get(pg_code)
+        if category is not None:
+            return category, pg_code
+
+    if _is_pg_unreachable(original):
+        return CATEGORY_DISCONNECT, None
+
+    return None, None
 
 
 def _extract_mysql_code(exc: BaseException | None) -> int | None:


### PR DESCRIPTION
### 📝 Description
When `mlrun-db` is down and `mlrun-api-chief` restarts, the DB-existence check in `_initialize_db_if_needed()` (`services.api.initial_data`) crashes the process via `sqlalchemy_utils.database_exists()`/`create_database()` — but these open their own throwaway SQLAlchemy engines, never the singleton engine that has the `handle_error` listener publishing `MLRun.DB.Connection.Failed`. The event never fires, even though the outage is real and fatal. Separately, a raw "connection refused" psycopg2 error carries neither a SQLSTATE nor SQLAlchemy's own `is_disconnect` flag, so even a caught exception wouldn't have classified as a connection failure. This PR closes both gaps for the bootstrap path, and — since the same unclassified shape also affects the long-lived singleton engine whenever it needs a brand-new pooled connection while Postgres is totally unreachable (e.g. right after a failed pre-ping probe) — the classification fix is shared with the existing mid-session `handle_error` listener as well, so both paths now agree.

---

### 🛠️ Changes Made
- `services/api/initial_data.py`: wrap `sqlalchemy_utils.database_exists`/`create_database` in `_initialize_db_if_needed()` with `try/except sqlalchemy.exc.DBAPIError`, publishing `MLRun.DB.Connection.Failed` before always re-raising — the crash is unchanged, only the event now fires first.
- `services/api/utils/events/db_errors.py`:
  - Added `classify_exception(exc)` and `publish_connection_failed_from_exception(exc, dialect)` — siblings to the existing `classify(ctx)`/`publish_connection_failed()` for callers with a plain caught exception instead of a `handle_error` `ExceptionContext`.
  - Added `PG_UNREACHABLE_MESSAGES` + `_is_pg_unreachable()`: a Postgres-only message-matching fallback for connection-establishment failures ("connection refused", "could not connect to server", etc.) that have no SQLSTATE and no disconnect flag.
  - Extracted the shared driver-code/message classification tail into `_classify_by_driver_code()`, used by both `classify(ctx)` (the existing mid-session listener) and the new `classify_exception(exc)` — so the Postgres "never connected" fallback covers both call sites, not just the bootstrap one.
- Tests: 8 new test functions (15 parametrized cases) in `test_db_errors.py` (using real `psycopg2`/`pymysql` exceptions), 4 new unit tests in `test_initial_data.py` (Postgres `create_database` failure, MySQL `database_exists` failure, fresh-install happy path must NOT publish, non-connection error must NOT publish), and 1 new integration test in `test_db_connection_event.py` that connects to an unreachable host/port on a real container-backed engine and asserts the classifier recognizes it.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit tests: 15 new parametrized cases in `test_db_errors.py` and 4 new cases in `test_initial_data.py`, using real `psycopg2.OperationalError`/`pymysql.err.OperationalError` instances (not stand-ins). Ran locally and passed, alongside the rest of the affected test files (no regressions — the shared-helper extraction preserves every existing `classify()` test case unmodified).
- Integration test: new case in `test_db_connection_event.py`, run and verified against both a real MySQL and a real Postgres container (`MLRUN_TEST_DB=mysql|postgres`) — connects to an intentionally unreachable host/port and asserts the classifier reports it as a connection failure.
- Not run: the literal end-to-end lab reproduction (scale `mlrun-db` to 0, restart `mlrun-api-chief`, confirm the platform event lands in oris-monitoring) — no lab/cluster access from the dev environment used for this PR.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12948 (a.k.a. ORIS-3708)
- Design docs links: N/A — bugfix, no design doc
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- An earlier revision of this PR scoped the Postgres "never connected" message fallback to the bootstrap path only, to avoid touching the already-working mid-session listener. Follow-up review surfaced that the same unclassified shape (no SQLSTATE, `is_disconnect=False`) also occurs on the singleton engine mid-session whenever the pool needs a fresh connection during a total outage — so the fallback now lives in a shared `_classify_by_driver_code()` helper used by both paths.
