### PR TITLE
[Datastore] Add mlrun user agent to S3 datastore boto3 clients

### DIFF
--- a/docs/store/datastore.md
+++ b/docs/store/datastore.md
@@ -343,6 +343,13 @@ feature_set.ingest(..., run_config=run_config)
   file. This option should be used for local development where AWS credentials already exist (created by `aws` CLI, for
   example)
   
+```{note}
+Setting an endpoint lets one S3 datastore configuration target any S3-compatible object store, including Amazon S3,
+Backblaze B2, Cloudflare R2, and MinIO. Use `AWS_ENDPOINT_URL_S3`, or the `endpoint_url` parameter of
+`DatastoreProfileS3`, with a value such as `https://your-s3-endpoint.example.com`. Credentials and bucket paths are
+configured the same way regardless of the endpoint.
+```
+
 ### S3 datastore profile
 
 ```python

--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -16,6 +16,7 @@ import time
 from urllib.parse import urlparse
 
 import boto3
+import botocore.config
 import botocore.exceptions
 from boto3.s3.transfer import TransferConfig
 from fsspec.registry import get_filesystem_class
@@ -53,10 +54,18 @@ class S3Store(DataStore):
             multipart_chunksize=1024 * 1024 * 25,
         )
 
+        # Neutral user-agent appended to (not replacing) botocore's default.
+        client_config = botocore.config.Config(
+            user_agent_extra=f"mlrun/{mlrun.__version__}"
+        )
+
         # If user asks to assume a role, this needs to go through the STS client and retrieve temporary creds
         if assume_role_arn:
             client = boto3.client(
-                "sts", aws_access_key_id=access_key_id, aws_secret_access_key=secret_key
+                "sts",
+                aws_access_key_id=access_key_id,
+                aws_secret_access_key=secret_key,
+                config=client_config,
             )
             self._temp_credentials = client.assume_role(
                 RoleArn=assume_role_arn, RoleSessionName="assumeRoleSession"
@@ -73,6 +82,7 @@ class S3Store(DataStore):
                 aws_secret_access_key=self._temp_credentials["SecretAccessKey"],
                 aws_session_token=self._temp_credentials["SessionToken"],
                 endpoint_url=endpoint_url,
+                config=client_config,
             )
             return
 
@@ -84,6 +94,7 @@ class S3Store(DataStore):
                 "s3",
                 region_name=region,
                 endpoint_url=endpoint_url,
+                config=client_config,
             )
             return
 
@@ -94,12 +105,16 @@ class S3Store(DataStore):
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=secret_key,
                 endpoint_url=endpoint_url,
+                config=client_config,
             )
         else:
             # No explicit credentials provided. Let boto3 use the default
             # credential chain (env vars, instance profile, IRSA, etc.).
             self.s3 = boto3.resource(
-                "s3", region_name=region, endpoint_url=endpoint_url
+                "s3",
+                region_name=region,
+                endpoint_url=endpoint_url,
+                config=client_config,
             )
             if not token_file and not self._has_default_credentials():
                 # No credentials available through any provider — fall back to


### PR DESCRIPTION
### 📝 Description
`S3Store` builds its boto3 `s3` resource and its STS client with botocore's default user agent, so requests originating from MLRun are indistinguishable from any other boto3 caller in object store request logs. This PR passes a `botocore.config.Config` with `user_agent_extra="mlrun/<version>"` to every client the store constructs. `user_agent_extra` appends to botocore's default user agent instead of replacing it, so the existing SDK/platform tokens are preserved and Amazon S3 (and other S3-compatible stores) simply record an extra `mlrun/<version>` token, which helps attribute traffic when debugging access, permissions, or throttling.

The second commit is docs only: it records that the S3 datastore's existing endpoint setting is what lets one configuration target a non-AWS S3-compatible store, which is context readers currently have to infer from the env var name.

---

### 🛠️ Changes Made
- `mlrun/datastore/s3.py`: import `botocore.config`, build a single `botocore.config.Config(user_agent_extra=f"mlrun/{mlrun.__version__}")` in `S3Store.__init__`, and pass it as `config=` to all five construction sites: the STS client used for `assume_role`, the assumed-role `s3` resource, the `boto3.session.Session` profile resource, the explicit-credentials resource, and the default-credential-chain resource.
- No change to credential resolution, endpoint handling, `TransferConfig`, or the anonymous-access fallback; the only new argument is `config=`.
- `docs/store/datastore.md`: add a note to the S3 datastore section explaining that setting an endpoint (`AWS_ENDPOINT_URL_S3`, or the `endpoint_url` parameter of `DatastoreProfileS3`) lets the same S3 datastore configuration target any S3-compatible object store, listing Amazon S3, Backblaze B2, Cloudflare R2, and MinIO as examples and using a placeholder endpoint value.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- No new tests are included. The diff adds a `config=` argument at existing client construction sites and changes no branching or credential logic.
- The touched construction paths are already exercised by the unit tests in `tests/datastore/test_s3.py` and end to end by `tests/system/datastore/test_aws_s3.py`; the latter needs live credentials and a live bucket, so it was not run for this change. Reviewers should treat CI as the verification for this diff.
- If you would like an assertion that the resolved user agent contains `mlrun/<version>`, I am happy to add a unit test in `tests/datastore/test_s3.py`.

---

### 🔗 References
- Ticket link: N/A (external contribution, no Jira ticket)
- Design docs links: N/A
- External links: [botocore `user_agent_extra`](https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

The user agent string sent to the object store changes (one token is appended). Nothing in MLRun parses it, and signing, credentials, and endpoints are unaffected.

---

### 🔍️ Additional Notes
- Scope is the boto3 side of the store only. `get_storage_options()` (the fsspec/s3fs path) is untouched, so s3fs traffic keeps its default user agent. Extending it there would mean threading a `config` into `storage_options`, which seemed worth a separate discussion.
- The token is derived from `mlrun.__version__` and is not configurable. Let me know if a config option (for example under `mlrun.mlconf`) would be preferred over a fixed value.
