### PR TITLE
[CI] Use singular gomod directory in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,7 @@ updates:
 
   # go modules
   - package-ecosystem: gomod
-    directories:
-      - "server/go/**/*"
+    directory: "/server/go"
     schedule:
       interval: daily
     commit-message:


### PR DESCRIPTION
### 📝 Description
The `gomod` entry in `.github/dependabot.yml` used the plural `directories:` key with a glob (`server/go/**/*`) that only ever matches one real path (`server/go` is the repo's only Go module). Using the plural key — even when it only resolves to one directory — triggers Dependabot's "group updates across directories" behavior, which overrides the PR title/branch template entirely and ignores the configured `commit-message.prefix`.

That's why [#9983](https://github.com/mlrun/mlrun/pull/9983) (bumping `google.golang.org/grpc`) got the title `Bump google.golang.org/grpc from 1.81.1 to 1.82.1 in the go_modules group across 1 directory` instead of the expected `[Dependabot-automated] Bump google.golang.org/grpc from 1.81.1 to 1.82.1` — compare to a `github-actions`-ecosystem bump like [#9974](https://github.com/mlrun/mlrun/pull/9974) (`[Dependabot-automated] Bump github/codeql-action from 4 to 4.37.3`), which uses the singular `directory:` field and gets the prefix correctly.

---

### 🛠️ Changes Made
- Switch the `gomod` entry from `directories: ["server/go/**/*"]` to the singular `directory: "/server/go"`, matching how the other three entries in this same file already declare their path.
- No behavior change intended for the explicit `kubernetes` dependency group (`k8s.io/*`, `sigs.k8s.io/*`) — those will still legitimately produce grouped-style titles; this only restores the standard prefixed title template for non-matching Go dependencies (e.g. `grpc`, `x/text`).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Validated the file parses as well-formed YAML (`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`).
- No CI to run for this file directly — the real verification is Dependabot's next `server/go` update PR title, once this merges.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: https://github.com/mlrun/mlrun/pull/9983, https://github.com/mlrun/mlrun/pull/9974

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Not under a workflow path, so it doesn't hit the `.github/workflows/*.yaml` maintainer-review guardrail, but it's shared dependency-automation config worth a look.