### PR TITLE
[Jupyter] Shrink basehome.tar to fix slow cold start [1.12.x]

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -119,7 +119,10 @@ ENV JUPYTER_ENABLE_LAB=yes \
     MLRUN_HTTPDB__PORT=8080
 
 # backup home since it will be deleted when using pvc
-RUN mkdir data && tar -cvf /tmp/basehome.tar $HOME
+# exclude the conda package cache - it dominates the tarball size and is not user data,
+# so including it turns first-mount extraction on NFS-backed PVCs into a 30-60 min stall
+RUN conda clean -a -y || true && \
+    mkdir data && tar -cf /tmp/basehome.tar --exclude='.conda/pkgs' --exclude='.cache' $HOME
 
 ARG MLRUN_GIT_COMMIT
 LABEL org.opencontainers.image.revision=$MLRUN_GIT_COMMIT

--- a/dockerfiles/jupyter/mlce-start.sh
+++ b/dockerfiles/jupyter/mlce-start.sh
@@ -6,7 +6,7 @@ if [ -f "$file_path" ]; then
 else
     # Perform actions when the file does not exist
     echo "Base data does not exist, extracting home backup..."
-    cd / ; tar -xvf /tmp/basehome.tar
+    cd / ; tar -xf /tmp/basehome.tar
     echo "1" > $file_path
 fi
 


### PR DESCRIPTION
### 📝 Description
On MLRun CE on-prem, the `mlrun-jupyter` pod can take 30-60+ minutes before Jupyter serves `/lab` on first start with an empty PVC. The pod is marked K8s Ready in ~1s (no startup/readiness probe in the CE chart), so deploy health checks pass while downstream QA gets 502s hitting `/lab` during that window.

Root cause: the cold-start path extracts `basehome.tar` into the PVC-backed `$HOME` on first mount. The tarball is dominated by the conda package cache (~78,528 of 78,758 entries, 99.7%) — not user data — and extraction is bottlenecked by NFS per-file latency (~79k round-trips), not bandwidth.

---

### 🛠️ Changes Made
- `dockerfiles/jupyter/Dockerfile`: run `conda clean -a -y` (failures tolerated via `|| true`, so a clean failure doesn't break the image build) and exclude `.conda/pkgs` and `.cache` when building `basehome.tar`, expected to drop it from ~78,758 entries to roughly the ~230 non-cache entries. Also drops the `-v` verbose flag from the tar creation (`-cvf` → `-cf`).
- `dockerfiles/jupyter/mlce-start.sh`: drop the `-v` verbose flag from the tar extraction (`-xvf` → `-xf`).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Manual: `tar -tf /tmp/basehome.tar | wc -l` should drop from ~78,758 to under 1,000 with no `.conda/pkgs` entries (matches the ticket's acceptance criterion).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12950
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This implements proposed fixes 1 & 2 from ML-12950. Proposed fix 3 (adding K8s `startupProbe`/`readinessProbe` to the CE chart) lives in the separate `mlrun/ce` repo and is out of scope here.