### PR TITLE
[Builder] Fix Buildah RUN steps missing the build context

### DIFF
--- a/server/py/services/api/tests/unit/api/test_background_tasks.py
+++ b/server/py/services/api/tests/unit/api/test_background_tasks.py
@@ -388,15 +388,19 @@ async def test_internal_background_task_already_running(
     db: sqlalchemy.orm.Session, async_client: httpx.AsyncClient
 ):
     timeout = 3
+    kind = "long_bump_counter"
     curr_call_counter = call_counter
+    handler = framework.utils.background_tasks.InternalBackgroundTasksHandler()
 
     # if we await the first future before sending the second request, the second request will be sent after the whole
-    # background task is finished because of how httpx.AsyncClient works. To avoid this, we send both requests and
-    # await them together. This way, the second request will be sent before the first background task is finished and
-    # will be rejected.
+    # background task is finished because of how httpx.AsyncClient works. To avoid this, we send the first request
+    # then wait for it to actually lock the "long_bump_counter" kind before sending the second - this way the second
+    # request is guaranteed to be sent while the first background task is still running and gets rejected.
     first_future = await async_client.post(
         f"/test/long-internal-background-tasks/{timeout}"
     )
+    while not handler.get_active_background_task_by_kind(kind):
+        await asyncio.sleep(0.05)
     second_future = await async_client.post(
         f"/test/long-internal-background-tasks/{timeout}"
     )

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -412,6 +412,26 @@ def test_make_buildah_pod_stages_inline_code_and_requirements():
     assert "/empty/requirements.txt" in container.args[0]
 
 
+def test_make_buildah_pod_bud_mounts_context_dir_for_run_steps():
+    # Buildah's RUN steps execute in an isolated build sandbox, unlike Kaniko's (which share the
+    # pod's own filesystem) - without this mount, a RUN referencing a context-staged file (e.g. the
+    # requirements.txt written to /empty by this same script) can't see it.
+    script = (
+        _make_buildah_pod(
+            requirements=["pandas==2.0.0"],
+            requirements_path="/empty/requirements.txt",
+        )
+        .pod.spec.containers[0]
+        .args[0]
+    )
+    bud_line = next(
+        line
+        for line in script.splitlines()
+        if line.startswith("buildah") and " bud " in line
+    )
+    assert "--volume /empty:/empty" in bud_line
+
+
 def test_make_buildah_pod_renders_build_args():
     container = _make_buildah_pod(
         builder_env=[client.V1EnvVar(name="ARG1", value="v1")],

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -476,10 +476,8 @@ def _build_script(
 
     bud = global_opts + ["bud"]
     # unlike Kaniko - whose RUN steps execute directly on the build pod's own filesystem - Buildah's
-    # RUN steps run inside a real, isolated build sandbox that only sees the image layers being
-    # built. Bind-mount the context dir back in at the same path so RUN instructions that reference
-    # a staged file (e.g. `pip install -r {requirements_path}`) can see it, same as COPY/ADD already
-    # can via the positional context arg below.
+    # RUN steps run in a real, isolated build sandbox that can't see files staged into the context
+    # dir (e.g. requirements.txt) unless it's bind-mounted back in.
     bud += ["--volume", f"{_CONTEXT_DIR}:{_CONTEXT_DIR}"]
     # pull auth is intentionally scoped to secret_name, not cloud_provider: it's about arbitrary
     # base-image registries, unrelated to the *destination*'s cloud classification.

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -475,6 +475,12 @@ def _build_script(
     lines += gar_credential_exchange
 
     bud = global_opts + ["bud"]
+    # unlike Kaniko - whose RUN steps execute directly on the build pod's own filesystem - Buildah's
+    # RUN steps run inside a real, isolated build sandbox that only sees the image layers being
+    # built. Bind-mount the context dir back in at the same path so RUN instructions that reference
+    # a staged file (e.g. `pip install -r {requirements_path}`) can see it, same as COPY/ADD already
+    # can via the positional context arg below.
+    bud += ["--volume", f"{_CONTEXT_DIR}:{_CONTEXT_DIR}"]
     # pull auth is intentionally scoped to secret_name, not cloud_provider: it's about arbitrary
     # base-image registries, unrelated to the *destination*'s cloud classification.
     bud += _tls_verify_flag(


### PR DESCRIPTION
### 📝 Description
MLRun's opt-in Buildah image-builder backend (`httpdb.builder.builder_backend=buildah`) fails every kubejob build that specifies `requirements=[...]`: the requirements file is staged into the build pod's `/empty` emptyDir, but Buildah's `RUN` instructions execute inside an isolated build sandbox that can't see it, so `RUN cat/pip install -r /empty/requirements.txt` fails with "No such file or directory". Kaniko doesn't hit this because its `RUN` steps execute directly on the pod's own filesystem.

---

### 🛠️ Changes Made
- Bind-mount the build context directory back into the `buildah bud` sandbox at the same path (`--volume /empty:/empty`) in `_build_script`, so `RUN` instructions see the requirements file already staged there — the same thing Kaniko gets implicitly.
- Added a unit test asserting the `bud` command includes the `--volume /empty:/empty` mount.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the Deprecation Guidelines
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run Smoke-tests workflow, providing it the PR number as input

---

### 🧪 Testing
- Added `test_make_buildah_pod_bud_mounts_context_dir_for_run_steps`, asserting the `bud` invocation carries `--volume /empty:/empty`.
- Verified live end-to-end on a test lab: rebuilt `mlrun-api` with this fix, deployed a kubejob function with `requirements=["requests"]`, and confirmed the Buildah build pod completed successfully (previously failed with the missing-file error) and the resulting job ran and imported `requests` at runtime.

---

### 🔗 References
Not applicable.

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- An earlier version of this fix staged the file via a Dockerfile `COPY` instruction added to the shared Kaniko/Buildah Dockerfile-rendering function. This version instead scopes the fix entirely to `buildah.py` via the bind-mount, avoiding any change to code shared with the Kaniko backend.