### PR TITLE
[Tests] Reuse project across test methods in runtimes system tests

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -41,6 +41,10 @@ logger = create_test_logger(name="test-system")
 
 class TestMLRunSystem:
     project_name = "system-test-project"
+    # Opt-in: skips the per-method project recreate/cascading-delete in favor of
+    # once per class. Only safe for classes that don't assume the project starts
+    # empty for every test (e.g. assertions counting all runs/artifacts/endpoints).
+    reuse_project_across_tests = False
     root_path = pathlib.Path(__file__).absolute().parent.parent.parent
     env_file_path = root_path / "tests" / "system" / "env.yml"
     results_path = root_path / "tests" / "test_results" / "system"
@@ -95,6 +99,11 @@ class TestMLRunSystem:
 
         cls.uploaded_code = False
 
+        if cls.reuse_project_across_tests and not cls._skip_set_environment():
+            cls.project = mlrun.get_or_create_project(
+                cls.project_name, "./", allow_cross_project=True
+            )
+
         if "MLRUN_IGUAZIO_API_URL" in env and "V3IO_ACCESS_KEY" in env:
             cls._igz_mgmt_client = igz_mgmt.Client(
                 endpoint=env["MLRUN_IGUAZIO_API_URL"],
@@ -131,7 +140,7 @@ class TestMLRunSystem:
         )
         self._files_to_upload = []
 
-        if not self._skip_set_environment():
+        if not self._skip_set_environment() and not self.reuse_project_across_tests:
             self.project = mlrun.get_or_create_project(
                 self.project_name, "./", allow_cross_project=True
             )
@@ -146,10 +155,11 @@ class TestMLRunSystem:
     def _should_clean_resources():
         return os.environ.get("MLRUN_SYSTEM_TESTS_CLEAN_RESOURCES") != "false"
 
-    def _delete_test_project(self, name=None):
-        if self._should_clean_resources():
-            self._run_db.delete_project(
-                name or self.project_name,
+    @classmethod
+    def _delete_test_project(cls, name=None):
+        if cls._should_clean_resources():
+            cls._run_db.delete_project(
+                name or cls.project_name,
                 deletion_strategy=mlrun.common.schemas.DeletionStrategy.cascading,
             )
 
@@ -165,7 +175,8 @@ class TestMLRunSystem:
                 for fset in fsets:
                     fset.purge_targets()
 
-        self._delete_test_project()
+        if not self.reuse_project_across_tests:
+            self._delete_test_project()
 
         self.custom_teardown()
 
@@ -176,6 +187,8 @@ class TestMLRunSystem:
     @classmethod
     def teardown_class(cls):
         cls.custom_teardown_class()
+        if cls.reuse_project_across_tests:
+            cls._delete_test_project()
         cls._disconnect_ssh()
         cls._teardown_env()
 

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -32,6 +32,7 @@ import tests.system.base
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
     project_name = "application-system-test"
+    reuse_project_across_tests = True
 
     def custom_setup(self):
         super().custom_setup()

--- a/tests/system/runtimes/test_applications_store_uri.py
+++ b/tests/system/runtimes/test_applications_store_uri.py
@@ -36,6 +36,7 @@ class TestApplicationStoreUri(tests.system.base.TestMLRunSystem):
     """
 
     project_name = "application-store-uri-system-test"
+    reuse_project_across_tests = True
 
     def custom_setup(self):
         super().custom_setup()

--- a/tests/system/runtimes/test_archives.py
+++ b/tests/system/runtimes/test_archives.py
@@ -67,6 +67,7 @@ need_gcs_workload_identity = pytest.mark.skipif(
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestArchiveSources(tests.system.base.TestMLRunSystem):
     project_name = "git-tests"
+    reuse_project_across_tests = True
 
     def custom_setup(self):
         super().custom_setup()

--- a/tests/system/runtimes/test_jobs_store_uri.py
+++ b/tests/system/runtimes/test_jobs_store_uri.py
@@ -30,6 +30,7 @@ class TestJobStoreUri(tests.system.base.TestMLRunSystem):
     """
 
     project_name = "job-store-uri-system-test"
+    reuse_project_across_tests = True
 
     def custom_setup(self):
         super().custom_setup()

--- a/tests/system/runtimes/test_kfp.py
+++ b/tests/system/runtimes/test_kfp.py
@@ -30,6 +30,7 @@ from mlrun_pipelines.common.models import RunStatuses
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestKFP(tests.system.base.TestMLRunSystem):
     project_name = "kfp-system-test"
+    reuse_project_across_tests = True
 
     @pytest.mark.enterprise
     def test_kfp_with_mount(self):

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -44,6 +44,7 @@ def exec_cli(args, action="run"):
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
     project_name = "kubejob-system-test"
+    reuse_project_across_tests = True
 
     image: str = "mlrun/mlrun"
 
@@ -404,14 +405,18 @@ class TestKubejobRuntime(tests.system.base.TestMLRunSystem):
 
         # validate that the end_time is not set before the run is finished
         assert not run.status.end_time
-        runs = mlrun.get_run_db().list_runs(project=self.project_name)
-        assert not runs[0]["status"].get("end_time")
+        fetched_run = mlrun.get_run_db().read_run(
+            uid=run.uid(), project=self.project_name
+        )
+        assert not fetched_run["status"].get("end_time")
 
         # wait for the run to finish
         run.wait_for_completion()
 
-        runs = mlrun.get_run_db().list_runs(project=self.project_name)
-        run = mlrun.RunObject.from_dict(runs[0])
+        fetched_run = mlrun.get_run_db().read_run(
+            uid=run.uid(), project=self.project_name
+        )
+        run = mlrun.RunObject.from_dict(fetched_run)
 
         assert run.status.end_time > run.status.start_time
 
@@ -960,7 +965,7 @@ def print_df(df):
         with pytest.raises(mlrun.runtimes.utils.RunError):
             function.run(verbose=True, retry=retry)
 
-        runs = self._run_db.list_runs(project=self.project_name)
+        runs = self._run_db.list_runs(project=self.project_name, name="raise-func")
         assert len(runs) == 1
         run = mlrun.RunObject.from_dict(runs[0])
         assert run.status.retry_count is None
@@ -971,7 +976,7 @@ def print_df(df):
         assert f"Run failed attempt 1 of {max_attempts}" in run.status.status_text
 
         def _assert_retry_info():
-            runs = self._run_db.list_runs(project=self.project_name)
+            runs = self._run_db.list_runs(project=self.project_name, name="raise-func")
             assert len(runs) == 1
             run = mlrun.RunObject.from_dict(runs[0])
             assert run.status.retry_count == 3, (

--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -24,6 +24,7 @@ import tests.system.base
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestNotifications(tests.system.base.TestMLRunSystem):
     project_name = "notifications-test"
+    reuse_project_across_tests = True
 
     @pytest.mark.smoke
     def test_run_notifications(self):
@@ -33,6 +34,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
         def _assert_notifications():
             runs = self._run_db.list_runs(
                 project=self.project_name,
+                uid=run.uid(),
                 with_notifications=True,
             )
             assert len(runs) == 1
@@ -104,6 +106,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
         def _assert_notification_was_sent():
             runs = self._run_db.list_runs(
                 project=self.project_name,
+                uid=run.uid(),
                 with_notifications=True,
             )
             assert len(runs) == 1
@@ -235,7 +238,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
             )
 
         # Validate that the run in pending retry state
-        runs = self._run_db.list_runs(project=self.project_name)
+        runs = self._run_db.list_runs(project=self.project_name, name="test-func")
         assert len(runs) == 1
         run = mlrun.RunObject.from_dict(runs[0])
         assert run.status.retry_count is None
@@ -246,6 +249,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
         def _assert_notification_received():
             runs = self._run_db.list_runs(
                 project=self.project_name,
+                name="test-func",
                 with_notifications=True,
             )
             assert len(runs) == 1

--- a/tests/system/runtimes/test_nuclio.py
+++ b/tests/system/runtimes/test_nuclio.py
@@ -44,6 +44,7 @@ from tests.system.runtimes.assets.function_with_model import DummyModel, MyModel
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
     project_name = "test-nuclio-runtime"
+    reuse_project_across_tests = True
 
     image: str = "mlrun/mlrun"
 
@@ -363,7 +364,14 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
         self._logger.debug("Deploying nuclio function")
         function.deploy()
 
-        assert len(self.project.list_model_endpoints().endpoints) == 1
+        assert (
+            len(
+                self.project.list_model_endpoints(
+                    names="my-model", function_name=function.metadata.name
+                ).endpoints
+            )
+            >= 1
+        )
 
     @pytest.mark.parametrize("raise_exception", [True, False])
     def test_deploy_model_runner_error_handler(self, raise_exception: bool):
@@ -1021,6 +1029,7 @@ class TestNuclioRuntime(TestMLRunSystemModelMonitoring):
 @pytest.mark.enterprise
 class TestNuclioRuntimeWithStream(tests.system.base.TestMLRunSystem):
     project_name = "stream-project"
+    reuse_project_across_tests = True
     stream_container = "bigdata"
     path_uuid_part = uuid.uuid4()
     stream_path = f"/test_nuclio/test_serving_with_child_function-{path_uuid_part}/"
@@ -1170,6 +1179,7 @@ class MyMap(MapClass):
 @pytest.mark.enterprise
 class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
     project_name = "kafka-project"
+    reuse_project_across_tests = True
     topic_uuid_part = uuid.uuid4()
     topic = f"TestNuclioRuntimeWithKafka-{topic_uuid_part}"
     topic_out = f"TestNuclioRuntimeWithKafka-out-{topic_uuid_part}"
@@ -1410,6 +1420,7 @@ class TestNuclioRuntimeWithKafka(tests.system.base.TestMLRunSystem):
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestNuclioMLRunJobs(tests.system.base.TestMLRunSystem):
     project_name = "nuclio-mlrun-jobs"
+    reuse_project_across_tests = True
 
     image: str = "mlrun/mlrun"
 
@@ -1489,6 +1500,7 @@ class TestNuclioMLRunJobs(tests.system.base.TestMLRunSystem):
 @tests.system.base.TestMLRunSystem.skip_test_if_env_not_configured
 class TestNuclioAPIGateways(tests.system.base.TestMLRunSystem):
     project_name = "nuclio-mlrun-gateways"
+    reuse_project_across_tests = True
     gw_name = "test-gateway"
 
     def custom_setup(self):
@@ -1581,6 +1593,7 @@ class TestNuclioRuntimeWithRabbitMQ(tests.system.base.TestMLRunSystem):
     """
 
     project_name = "rabbitmq-project"
+    reuse_project_across_tests = True
     exchange_uuid_part = uuid.uuid4()
     exchange_name = f"test-exchange-{exchange_uuid_part}"
     queue_name = f"test-queue-{exchange_uuid_part}"

--- a/tests/system/runtimes/test_nuclio_store_uri.py
+++ b/tests/system/runtimes/test_nuclio_store_uri.py
@@ -35,6 +35,7 @@ class TestNuclioStoreUri(tests.system.base.TestMLRunSystem):
     """
 
     project_name = "nuclio-store-uri-system-test"
+    reuse_project_across_tests = True
 
     def custom_setup(self):
         super().custom_setup()

--- a/tests/system/runtimes/test_serving.py
+++ b/tests/system/runtimes/test_serving.py
@@ -53,6 +53,7 @@ class TestServingAPIHandler(tests.system.base.TestMLRunSystem):
     """System tests for serving function API handler functionality."""
 
     project_name = "serving-api-handler"
+    reuse_project_across_tests = True
     image: str | None = None
 
     def _create_serving_function(


### PR DESCRIPTION
### 📝 Description
The `Test runtimes [development]` job in `system-tests-enterprise.yml` routinely fails to finish inside its 6-hour job timeout (e.g. [run 30729070212](https://github.com/mlrun/mlrun/actions/runs/30729070212/job/91446989186), cancelled mid-test at exactly 6h00m). A large share of that time is fixed overhead: `tests/system/base.py` recreates and cascading-deletes each test class's project before/after *every* test method, even though most `tests/system/runtimes/` classes have 7-8+ methods sharing one class-level project name. This PR makes that project lifecycle class-scoped instead of method-scoped for the classes where it's safe to do so, estimated to save ~55-60 minutes of the suite's ~6 hour total runtime.

### 🛠️ Changes Made
- Added an opt-in `reuse_project_across_tests` flag to `TestMLRunSystem` (`tests/system/base.py`): when set, the project is created once in `setup_class` and deleted once in `teardown_class` instead of on every test method. Defaults to `False`, so no other component under `tests/system/` is affected.
- Made `_delete_test_project` a classmethod so `teardown_class` can call it directly.
- Enabled the flag on 15 of the 17 test classes in `tests/system/runtimes/` (`test_application.py`, `test_applications_store_uri.py`, `test_archives.py`, `test_jobs_store_uri.py`, `test_kfp.py`, `test_kubejob.py`, `test_notifications.py`, six classes in `test_nuclio.py`, `test_nuclio_store_uri.py`, `test_serving.py`). Left `TestDatabricksRuntime` (skipped without databricks credentials, already defines its own `setup_class`/`teardown_class` overrides, and has whole-project artifact-count assertions of its own that this PR does not fix) and `TestMpiJobRuntime` (single test method — no benefit either way) on the existing per-method behavior.
- Fixed 4 call sites in `test_kubejob.py` (across `test_list_runs_with_end_time` and `test_retry_job_exhausted`) and 4 in `test_notifications.py` (across `test_run_notifications`, `test_set_run_notifications`, `test_run_notifications_with_retries`) that assumed the project starts empty on every test — unfiltered `list_runs()[0]` indexing or whole-project run counts — rescoping them to the specific run's `uid` or to a run/function `name` filter, since these would otherwise spuriously fail once the project is shared across a class's tests.
- Scoped a model-endpoint count assertion in `test_nuclio.py` (`test_deploy_function_with_model_runner_with_child_function`) to the specific model/function name instead of counting every endpoint in the project.

### ✅ Checklist
- [ ] I updated the documentation (if applicable) — not applicable, test-infra only
- [ ] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation (not applicable to this change):
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

### 🧪 Testing
- `ruff check`, `ruff format --check`, and `python -m py_compile` pass on every changed file.
- Not yet run against a live lab — this change can't be meaningfully verified by lint/compile alone, since the whole point is eliminating per-test cascading-delete/recreate calls against a real cluster. Needs a `tests/system/runtimes` run against a lab before merge.

### 🔗 References
- Ticket link:
- Design docs links:
- External links: originating investigation — https://github.com/mlrun/mlrun/actions/runs/30729070212/job/91446989186

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

### 🔍️ Additional Notes
This addresses one specific bottleneck (per-test project churn) identified while investigating why the runtimes system-test job doesn't finish inside its timeout; it is not by itself expected to halve the job's runtime, since most of that time is spent on Nuclio/image builds this PR doesn't touch.