### PR TITLE
[Projects] Fix context-dir creation race in get_or_create_project

### DIFF
--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -431,8 +431,9 @@ def load_project(
         elif url.startswith("db://") or "://" not in url:
             project = _load_project_from_db(url, secrets, user_project)
             project.spec.context = context
-            if not path.isdir(context):
-                makedirs(context)
+            # exist_ok=True avoids a TOCTOU race between concurrent get_or_create_project
+            # calls targeting the same new context dir.
+            makedirs(context, exist_ok=True)
             project.spec.subpath = subpath or project.spec.subpath
             from_db = True
         else:

--- a/tests/projects/test_project.py
+++ b/tests/projects/test_project.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import concurrent.futures
 import os
 import os.path
 import pathlib
@@ -2557,6 +2558,54 @@ def test_get_or_create_project_no_db(monkeypatch):
     project_name = "project-name"
     project = mlrun.get_or_create_project(project_name, allow_cross_project=True)
     assert project.name == project_name
+
+
+def test_get_or_create_project_concurrent_context_creation(rundb_mock, context):
+    # concurrent get_or_create_project calls sharing one not-yet-existing context dir
+    # must not race on directory creation.
+    project_name = "concurrent-context-project"
+    rundb_mock.create_project({"metadata": {"name": project_name}})
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
+        futures = [
+            pool.submit(mlrun.get_or_create_project, project_name, context=str(context))
+            for _ in range(10)
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+
+    assert os.path.isdir(context)
+
+
+def test_get_or_create_project_context_dir_race_guard(rundb_mock, context, monkeypatch):
+    # deterministically simulate the TOCTOU window: another thread/process creates the
+    # context dir the instant this call's makedirs executes. A bare check-then-act
+    # makedirs would raise FileExistsError here; the exist_ok=True fix must not.
+    project_name = "existing-context-project"
+    rundb_mock.create_project({"metadata": {"name": project_name}})
+    real_makedirs = os.makedirs
+
+    def racy_makedirs(name, *args, **kwargs):
+        real_makedirs(name, exist_ok=True)
+        return real_makedirs(name, *args, **kwargs)
+
+    monkeypatch.setattr(mlrun.projects.project, "makedirs", racy_makedirs)
+
+    project = mlrun.get_or_create_project(project_name, context=str(context))
+
+    assert project.name == project_name
+
+
+def test_get_or_create_project_context_path_is_file(rundb_mock, context):
+    # a context path that collides with an existing plain file (not a directory) must
+    # still fail loudly, not be silently accepted.
+    project_name = "file-collision-project"
+    rundb_mock.create_project({"metadata": {"name": project_name}})
+    os.makedirs(context.parent, exist_ok=True)
+    context.touch()
+
+    with pytest.raises(FileExistsError):
+        mlrun.get_or_create_project(project_name, context=str(context))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description
`mlrun.get_or_create_project(name, context=...)` could raise an unhandled `FileExistsError` when multiple threads or processes called it concurrently with the same not-yet-existing `context` directory, for a project that already exists in the DB — e.g. several app-function deployments sharing one project. The cause was a check-then-act race in `load_project`: `if not path.isdir(context): makedirs(context)`. Two callers could both see the directory missing, then both call `makedirs`; the loser raised `FileExistsError`.

A lock was deliberately not used to fix this: `get_or_create_project` always calls this code path with `save=False`, so nothing else writes into `context` here, and the reported concurrency source (threads/Jupyter kernels) is typically cross-process, which an in-process lock wouldn't cover anyway.

---

### 🛠️ Changes Made
- `mlrun/projects/project.py`: replaced the check-then-act `path.isdir`/`makedirs` pair with a single atomic `makedirs(context, exist_ok=True)` call in `load_project`'s DB-name-resolution branch. Unchanged behavior: it still raises if `context` collides with an existing file (verified by a new test).
- `tests/projects/test_project.py`: added 3 regression tests — a multi-threaded repro that calls `get_or_create_project` concurrently against one shared context dir, a deterministic test that injects the race window without relying on thread timing, and a test locking in that a file colliding with `context` still raises `FileExistsError`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Full `tests/projects/test_project.py` run: 270 passed, including the 3 new tests. 7 pre-existing failures (`test_sync_functions`, `test_set_source`, `test_project_build_image[...]`) were confirmed present identically on the unmodified baseline — unrelated to this change.
- The originating NAIPI/Jenkins regression suite (`test_mlrun_app_runtime_simultaneous`) could not be re-run in this environment; the new unit tests are a local stand-in for that repro.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12952
- Design docs links: n/a — bugfix
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Scope was deliberately limited to this one call site: a sweep of every other `makedirs`/`mkdir` call in this file and its direct helpers found they already use `exist_ok=True` or an equivalent atomic pattern.