### PR TITLE
[Pipeline Adapters] Add bump-version command; default to help

### DIFF
--- a/pipeline-adapters/CONTRIBUTING.md
+++ b/pipeline-adapters/CONTRIBUTING.md
@@ -11,21 +11,27 @@ Before using this Makefile, ensure you have the following installed:
 
 ## Getting Started
 
-1. **Build Packages**: Run the following command to build your Python packages:
+1. **Bump Versions**: Before building, bump the version of each package in `PACKAGES`:
+    ```bash
+    make bump-version                # bumps the patch version (default), e.g. 0.1.1 -> 0.1.2
+    make bump-version BUMP=minor     # bumps the minor version and resets patch, e.g. 0.1.1 -> 0.2.0
+    ```
+
+2. **Build Packages**: Run the following command to build your Python packages:
     ```bash
     make build
     ```
     
     This command will build each package listed in PACKAGES.
 
-2. **Release Packages**: After building, you can release the packages to PyPI by running:
+3. **Release Packages**: After building, you can release the packages to PyPI by running:
     ```bash
     make release
     ```
 
     This command will upload the built distribution files to PyPI using twine.
 
-3. **Cleaning Up**: If needed, you can clean up the build artifacts by running:
+4. **Cleaning Up**: If needed, you can clean up the build artifacts by running:
 
     ```bash
     make clean

--- a/pipeline-adapters/Makefile
+++ b/pipeline-adapters/Makefile
@@ -17,16 +17,26 @@ PACKAGES ?= mlrun-pipelines-kfp-common mlrun-pipelines-kfp-v1-8 mlrun-pipelines-
 TWINE_USERNAME ?= __token__
 TWINE_PASSWORD ?= "replace with your token"
 
-.PHONY: build release clean
+BUMP ?= patch
 
-build:
+.DEFAULT_GOAL := help
+
+.PHONY: help build release clean bump-version
+
+help: ## Display available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+bump-version: ## Bump the patch (default) or minor (BUMP=minor) version across all packages
+	@python bump_version.py $(BUMP)
+
+build: ## Build all packages
 	@for pkg in $(PACKAGES); do \
         echo "Building $$pkg"; \
         cd $$pkg && python -m build; \
         cd ..; \
     done
 
-release:
+release: ## Release all packages to PyPI
 	@set -e;\
 	for pkg in $(PACKAGES); do \
         echo "Releasing $$pkg to PyPI"; \
@@ -34,7 +44,7 @@ release:
         cd ..; \
     done
 
-clean:
+clean: ## Remove build artifacts from all packages
 	@for pkg in $(PACKAGES); do \
 	  echo "Cleaning $$pkg"; \
 	  (cd $$pkg && rm -rf dist build *.egg-info src/*.egg-info); \

--- a/pipeline-adapters/bump_version.py
+++ b/pipeline-adapters/bump_version.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import pathlib
+import re
+
+PACKAGES = [
+    "mlrun-pipelines-kfp-common",
+    "mlrun-pipelines-kfp-v1-8",
+    "mlrun-pipelines-kfp-v2",
+]
+
+VERSION_PATTERN = re.compile(r'^version = "(\d+)\.(\d+)\.(\d+)"$', re.MULTILINE)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Bump the version of every pipeline-adapters package"
+    )
+    parser.add_argument("mode", choices=["patch", "minor"])
+    args = parser.parse_args()
+
+    repo_root = pathlib.Path(__file__).parent
+    for package in PACKAGES:
+        bump_pyproject(repo_root / package / "pyproject.toml", mode=args.mode)
+
+
+def bump_pyproject(pyproject_path: pathlib.Path, mode: str) -> None:
+    content = pyproject_path.read_text()
+    match = VERSION_PATTERN.search(content)
+    if not match:
+        raise ValueError(f"could not find version in {pyproject_path}")
+
+    current_version = ".".join(match.groups())
+    new_version = _bump_version(current_version, mode=mode)
+    content = VERSION_PATTERN.sub(f'version = "{new_version}"', content, count=1)
+    pyproject_path.write_text(content)
+    print(f"{pyproject_path.parent.name}: {current_version} -> {new_version}")
+
+
+def _bump_version(version: str, mode: str) -> str:
+    major, minor, patch = (int(part) for part in version.split("."))
+    if mode == "minor":
+        minor += 1
+        patch = 0
+    else:
+        patch += 1
+    return f"{major}.{minor}.{patch}"
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-common"
-version = "0.7.1"
+version = "0.8.0"
 description = "MLRun Pipelines adapter package for providing KFP common functionality"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.7.4"
+version = "0.8.0"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v2"
-version = "0.7.0"
+version = "0.8.0"
 description = "MLRun Pipelines adapter package for providing KFP 2.* compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"


### PR DESCRIPTION
### 📝 Description
Adds a `make bump-version` command to the pipeline-adapters Makefile for bumping package versions, and sets `help` as the default Makefile target so a bare `make` prints the command list.

---

### 🛠️ Changes Made
- Added `pipeline-adapters/bump_version.py`, which bumps the patch (default) or minor (`BUMP=minor`) version in each package's `pyproject.toml`; a minor bump resets the patch to 0.
- Added a `bump-version` target to `pipeline-adapters/Makefile` that invokes the script, and documented both invocation forms in `CONTRIBUTING.md`.
- Annotated every Makefile target with `## ` help text, added a `help` target that lists them, and set `.DEFAULT_GOAL := help` so a bare `make` prints the command list.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Ran `make bump-version` (patch) and `make bump-version BUMP=minor` locally against the three packages' `pyproject.toml` files and confirmed the versions updated correctly (patch: `0.7.1 → 0.7.2`; minor: `0.7.2 → 0.8.0`), then reverted the test bumps before committing.
- Ran a bare `make` and confirmed it prints the command list via the new `help` target.

---

### 🔗 References
- Ticket link: Not applicable
- Design docs links: Not applicable
- External links: Not applicable

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Not applicable — no follow-up work.