### PR TITLE
[Tests] Fix list_feature_sets missing project in teardown

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -170,7 +170,7 @@ class TestMLRunSystem:
 
         self._logger.debug("Removing test data from database")
         if self._should_clean_resources():
-            fsets = self._run_db.list_feature_sets()
+            fsets = self._run_db.list_feature_sets(project=self.project_name)
             if fsets:
                 for fset in fsets:
                     fset.purge_targets()


### PR DESCRIPTION
### 📝 Description
PR https://github.com/mlrun/mlrun/pull/9997 introduced `reuse_project_across_tests` which skips `get_or_create_project` in `setup_method`.
The `teardown_method` was implicitly relying on that to populate the project for `list_feature_sets()`, causing a 404 with empty project name.   

---

### 🛠️ Changes Made
- Pass `project=self.project_name` explicitly to `list_feature_sets()` in teardown in `tests/system/base.py`                                                       


---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
