### PR TITLE
[REST Metrics] Fix missing project label on several REST metric calls

### DIFF
--- a/docs/server-cfg/server-metrics.md
+++ b/docs/server-cfg/server-metrics.md
@@ -81,7 +81,7 @@ To disable REST metrics independently while keeping other telemetry on:
 MLRUN_TELEMETRY__REST_METRICS__ENABLED=false
 ```
 
-`system_id`, `status_code`, `resource`, and `project` are common to every instrument below. `resource` is the object type the route operates on (for example `functions`, `runs`, `artifacts`); `project` is set for project-scoped routes and empty otherwise. Health-check (`/healthz`) requests are excluded.
+`system_id`, `status_code`, `resource`, and `project` are common to every instrument below. `resource` is the object type the route operates on (for example `functions`, `runs`, `artifacts`); `project` is set for project-scoped routes and empty otherwise. `project` is normally read straight from the URL path, but for a handful of routes where the project isn't part of the path — project creation, function build/start/status, job submission, and build-status polling — it's read from the request body or query string instead. Health-check (`/healthz`) requests are excluded.
 
 `method` is the real HTTP method, except a collection-returning GET is reported as the synthetic `"LIST"` value instead of `"GET"` — so list calls are distinguishable without a separate label. It's omitted entirely (not just empty) wherever it wouldn't vary: absent from `mlrun_rest_response_num_items`, since that metric only ever records `method="LIST"` calls by construction — a label that never varies within a metric adds nothing to query it by.
 

--- a/server/py/framework/middlewares/rest_metrics.py
+++ b/server/py/framework/middlewares/rest_metrics.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections.abc
 import http
 import json
 import re
 import time
+import urllib.parse
 
 from starlette.types import Message
 from uvicorn._types import (
@@ -24,6 +26,7 @@ from uvicorn._types import (
     Scope,
 )
 
+import mlrun.common.helpers
 import mlrun.errors
 import mlrun.utils
 
@@ -43,6 +46,11 @@ _PATH_PREFIX = re.compile(r"^/api(?:/v\d+)?")
 _BYTES_PER_KIBIBYTE = 1024
 
 
+def _path_segments(path: str) -> tuple[str, ...]:
+    stripped = _PATH_PREFIX.sub("", path)
+    return tuple(segment for segment in stripped.split("/") if segment)
+
+
 def parse_resource_and_project(path: str) -> tuple[str, str]:
     """Extract the object type and (if any) project a route operates on.
 
@@ -55,10 +63,10 @@ def parse_resource_and_project(path: str) -> tuple[str, str]:
         /api/v1/projects/{project}/functions/{name} -> ("functions", "{project}")
         /api/v1/projects/{project}                   -> ("projects", "{project}")
         /api/v1/projects                             -> ("projects", "")
+        /api/v1/project-summaries/{name}             -> ("project-summaries", "{name}")
         /api/v1/runs                                 -> ("runs", "")
     """
-    stripped = _PATH_PREFIX.sub("", path)
-    segments = [segment for segment in stripped.split("/") if segment]
+    segments = _path_segments(path)
     if not segments:
         return "", ""
     if segments[0] == "projects":
@@ -67,6 +75,9 @@ def parse_resource_and_project(path: str) -> tuple[str, str]:
             return segments[2], segments[1]
         # /projects or /projects/{project}
         return "projects", (segments[1] if len(segments) == 2 else "")
+    if segments[0] == "project-summaries":
+        # /project-summaries or /project-summaries/{name}
+        return "project-summaries", (segments[1] if len(segments) == 2 else "")
     return segments[0], ""
 
 
@@ -132,6 +143,139 @@ def parse_item_count(body: bytes) -> int | None:
     return None
 
 
+def _parse_json_object(body: bytes) -> dict | None:
+    """Parse ``body`` as JSON, returning it only if it decodes to an object.
+
+    Shared by the per-route request-body project extractors below.
+    """
+    if not body:
+        return None
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def parse_create_project_body(body: bytes) -> str:
+    """Extract the project name from a create-project request body.
+
+    Used only for ``POST /projects``, where the project name lives solely in
+    the body (``Project.metadata.name``) — unlike every other project-scoped
+    route, the URL has no project segment to parse it from.
+
+    :param body: The full, concatenated request body.
+    :return: The project name, or "" if not present.
+    """
+    parsed = _parse_json_object(body)
+    name = parsed.get("metadata", {}).get("name") if parsed else None
+    return name if isinstance(name, str) else ""
+
+
+def parse_build_function_body(body: bytes) -> str:
+    """Extract the project name from a build-function request body.
+
+    Used only for ``POST /build/function``: the function spec is nested
+    under a top-level ``function`` key.
+
+    :param body: The full, concatenated request body.
+    :return: The project name, or "" if not present.
+    """
+    parsed = _parse_json_object(body)
+    function = parsed.get("function") if parsed else None
+    if not isinstance(function, dict):
+        return ""
+    project = function.get("metadata", {}).get("project")
+    return project if isinstance(project, str) else ""
+
+
+def parse_start_function_body(body: bytes) -> str:
+    """Extract the project name from a start-function request body.
+
+    Used only for ``POST /start/function``: the project name is embedded in
+    the versioned ``functionUrl`` (``{project}/{name}[:{tag}][@{hash}]``)
+    rather than being its own field.
+
+    :param body: The full, concatenated request body.
+    :return: The project name, or "" if not present.
+    """
+    parsed = _parse_json_object(body)
+    function_url = parsed.get("functionUrl") if parsed else None
+    if not isinstance(function_url, str):
+        return ""
+    project, _, _, _ = mlrun.common.helpers.parse_versioned_object_uri(function_url)
+    return project
+
+
+def parse_status_function_body(body: bytes) -> str:
+    """Extract the project name from a function-status request body.
+
+    Used only for ``POST /status/function``, where ``project`` is a top-level
+    field.
+
+    :param body: The full, concatenated request body.
+    :return: The project name, or "" if not present.
+    """
+    parsed = _parse_json_object(body)
+    project = parsed.get("project") if parsed else None
+    return project if isinstance(project, str) else ""
+
+
+def parse_submit_body(body: bytes) -> str:
+    """Extract the project name from a submit-job request body.
+
+    Used only for ``POST /submit`` and ``POST /submit_job``: the project name
+    lives under the ``task`` key.
+
+    :param body: The full, concatenated request body.
+    :return: The project name, or "" if not present.
+    """
+    parsed = _parse_json_object(body)
+    task = parsed.get("task") if parsed else None
+    if not isinstance(task, dict):
+        return ""
+    project = task.get("metadata", {}).get("project")
+    return project if isinstance(project, str) else ""
+
+
+def parse_build_status_query(query_string: bytes) -> str:
+    """Extract the ``project`` query parameter's value.
+
+    Used only for ``GET /build/status``, which — unlike the other routes
+    handled by the extractors above — takes ``project`` as a query parameter
+    rather than a JSON body field.
+
+    :param query_string: The raw ASGI ``query_string`` bytes.
+    :return: The project name, or "" if absent.
+    """
+    if not query_string:
+        return ""
+    values = urllib.parse.parse_qs(query_string.decode()).get("project")
+    return values[0] if values else ""
+
+
+# Routes whose project name is a request-body field rather than a URL
+# segment — see parse_resource_and_project's docstring for the routes where
+# path parsing already works. Keyed by (method, path segments) so a fix here
+# can never affect any other route.
+_BODY_PROJECT_EXTRACTORS: dict[
+    tuple[str, tuple[str, ...]], collections.abc.Callable[[bytes], str]
+] = {
+    (http.HTTPMethod.POST, ("projects",)): parse_create_project_body,
+    (http.HTTPMethod.POST, ("build", "function")): parse_build_function_body,
+    (http.HTTPMethod.POST, ("start", "function")): parse_start_function_body,
+    (http.HTTPMethod.POST, ("status", "function")): parse_status_function_body,
+    (http.HTTPMethod.POST, ("submit",)): parse_submit_body,
+    (http.HTTPMethod.POST, ("submit_job",)): parse_submit_body,
+}
+
+# Routes whose project name is a query parameter rather than a URL segment or
+# body field.
+_QUERY_PROJECT_ROUTES: frozenset[tuple[str, tuple[str, ...]]] = frozenset(
+    {(http.HTTPMethod.GET, ("build", "status"))}
+)
+
+
 class RestMetricsMiddleware(BaseHTTPMiddleware):
     """
     Records per-REST-call histogram metrics, always-on regardless of any
@@ -146,17 +290,31 @@ class RestMetricsMiddleware(BaseHTTPMiddleware):
     ) -> None:
         start_time = time.perf_counter_ns()
         path = scope["path"]
+        method = scope["method"]
         should_record = not any(
             substring in path for substring in _SILENT_PATH_SUBSTRINGS
         )
+        segments = _path_segments(path)
+        body_project_extractor = (
+            _BODY_PROJECT_EXTRACTORS.get((method, segments)) if should_record else None
+        )
+        query_project = (
+            parse_build_status_query(scope.get("query_string") or b"")
+            if should_record and (method, segments) in _QUERY_PROJECT_ROUTES
+            else ""
+        )
 
         request_size_bytes = 0
+        request_body = bytearray()
 
         async def receive_wrapper() -> "Message":
             nonlocal request_size_bytes
             message = await receive()
             if should_record and message["type"] == "http.request":
-                request_size_bytes += len(message.get("body") or b"")
+                body = message.get("body") or b""
+                request_size_bytes += len(body)
+                if body_project_extractor is not None:
+                    request_body.extend(body)
             return message
 
         # Mutated by send_wrapper across calls; only meaningful once
@@ -190,16 +348,22 @@ class RestMetricsMiddleware(BaseHTTPMiddleware):
                     # Streamed body still in flight — nothing to record yet.
                     return
                 duration_ms = response_state["duration_ms"]
-                method = response_state["method"]
+                list_method = response_state["method"]
                 item_count = (
                     parse_item_count(bytes(response_state["response_body"]))
-                    if method == _LIST_METHOD
+                    if list_method == _LIST_METHOD
                     else None
+                )
+                project_override = query_project or (
+                    body_project_extractor(bytes(request_body))
+                    if body_project_extractor is not None
+                    else ""
                 )
                 self._record_call(
                     path=path,
                     duration_ms=duration_ms,
                     request_size_bytes=request_size_bytes,
+                    project_override=project_override,
                     response_state=response_state,
                     item_count=item_count,
                 )
@@ -218,11 +382,13 @@ class RestMetricsMiddleware(BaseHTTPMiddleware):
         path: str,
         duration_ms: float,
         request_size_bytes: int,
+        project_override: str,
         response_state: dict,
         item_count: int | None,
     ) -> None:
         """Record all metric instruments for one completed call."""
         resource, project = parse_resource_and_project(path)
+        project = project or project_override
         status_code = response_state["status_code"]
         method = response_state["method"]
         request_size_kib = request_size_bytes / _BYTES_PER_KIBIBYTE

--- a/server/py/framework/middlewares/rest_metrics.py
+++ b/server/py/framework/middlewares/rest_metrics.py
@@ -250,7 +250,7 @@ def parse_build_status_query(query_string: bytes) -> str:
     """
     if not query_string:
         return ""
-    values = urllib.parse.parse_qs(query_string.decode()).get("project")
+    values = urllib.parse.parse_qs(query_string.decode(errors="replace")).get("project")
     return values[0] if values else ""
 
 

--- a/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
+++ b/server/py/services/api/tests/unit/api/framework/test_rest_metrics_middleware.py
@@ -134,6 +134,125 @@ def test_parse_item_count(body: bytes, expected: int | None) -> None:
     assert framework.middlewares.rest_metrics.parse_item_count(body) == expected
 
 
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (b"", ""),
+        (b"not json", ""),
+        (json.dumps({"metadata": {"name": "proj-a"}}).encode(), "proj-a"),
+        (json.dumps({"metadata": {"name": 123}}).encode(), ""),
+        (json.dumps({"metadata": {}}).encode(), ""),
+        (json.dumps({}).encode(), ""),
+        (json.dumps([1, 2, 3]).encode(), ""),
+    ],
+)
+def test_parse_create_project_body(body: bytes, expected: str) -> None:
+    assert (
+        framework.middlewares.rest_metrics.parse_create_project_body(body) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (b"", ""),
+        (b"not json", ""),
+        (
+            json.dumps({"function": {"metadata": {"project": "proj-a"}}}).encode(),
+            "proj-a",
+        ),
+        (json.dumps({"function": {"metadata": {"project": 123}}}).encode(), ""),
+        (json.dumps({"function": {"metadata": {}}}).encode(), ""),
+        (json.dumps({"function": "not-a-dict"}).encode(), ""),
+        (json.dumps({}).encode(), ""),
+    ],
+)
+def test_parse_build_function_body(body: bytes, expected: str) -> None:
+    assert (
+        framework.middlewares.rest_metrics.parse_build_function_body(body) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (b"", ""),
+        (b"not json", ""),
+        (json.dumps({"functionUrl": "proj-a/fn-name"}).encode(), "proj-a"),
+        (json.dumps({"functionUrl": "proj-a/fn-name:tag@hash"}).encode(), "proj-a"),
+        (json.dumps({"functionUrl": "fn-name"}).encode(), ""),
+        (json.dumps({"functionUrl": 123}).encode(), ""),
+        (json.dumps({}).encode(), ""),
+    ],
+)
+def test_parse_start_function_body(body: bytes, expected: str) -> None:
+    assert (
+        framework.middlewares.rest_metrics.parse_start_function_body(body) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (b"", ""),
+        (b"not json", ""),
+        (json.dumps({"project": "proj-a"}).encode(), "proj-a"),
+        (json.dumps({"project": 123}).encode(), ""),
+        (json.dumps({}).encode(), ""),
+    ],
+)
+def test_parse_status_function_body(body: bytes, expected: str) -> None:
+    assert (
+        framework.middlewares.rest_metrics.parse_status_function_body(body) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (b"", ""),
+        (b"not json", ""),
+        (
+            json.dumps({"task": {"metadata": {"project": "proj-a"}}}).encode(),
+            "proj-a",
+        ),
+        (json.dumps({"task": {"metadata": {"project": 123}}}).encode(), ""),
+        (json.dumps({"task": {"metadata": {}}}).encode(), ""),
+        (json.dumps({"task": "not-a-dict"}).encode(), ""),
+        (json.dumps({}).encode(), ""),
+    ],
+)
+def test_parse_submit_body(body: bytes, expected: str) -> None:
+    assert framework.middlewares.rest_metrics.parse_submit_body(body) == expected
+
+
+@pytest.mark.parametrize(
+    ("query_string", "expected"),
+    [
+        (b"", ""),
+        (b"project=proj-a", "proj-a"),
+        (b"other=1&project=proj-b", "proj-b"),
+        (b"other=1", ""),
+        (b"project=proj-a&project=proj-b", "proj-a"),
+    ],
+)
+def test_parse_build_status_query(query_string: bytes, expected: str) -> None:
+    assert (
+        framework.middlewares.rest_metrics.parse_build_status_query(query_string)
+        == expected
+    )
+
+
+def test_parse_build_status_query_handles_invalid_utf8() -> None:
+    """Malformed bytes must not raise — this runs unguarded, ahead of the
+    middleware's try/except around per-call recording.
+    """
+    result = framework.middlewares.rest_metrics.parse_build_status_query(
+        b"project=\xff\xfe"
+    )
+    assert isinstance(result, str)
+
+
 def _middleware_class_names(app: fastapi.FastAPI) -> list[str]:
     return [middleware.cls.__name__ for middleware in app.user_middleware]
 
@@ -424,6 +543,38 @@ def test_rest_metrics_middleware_computes_response_size_across_chunks() -> None:
 
     response_size_kwargs = mocks["record_response_size"].call_args.kwargs
     assert response_size_kwargs["size_kib"] == pytest.approx(1024 / 1024)
+
+
+def test_rest_metrics_middleware_records_project_from_request_body() -> None:
+    """Body-derived project label (e.g. POST /submit) flows through end-to-end,
+    not just through the pure parser function.
+    """
+    body = json.dumps({"task": {"metadata": {"project": "proj-a"}}}).encode()
+
+    async def downstream_app(scope, receive, send):
+        while True:
+            message = await receive()
+            if not message.get("more_body", False):
+                break
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    receive = _make_receive(
+        [{"type": "http.request", "body": body, "more_body": False}]
+    )
+
+    with _patch_all_record_fns() as mocks:
+        asyncio.run(
+            _run_middleware(
+                downstream_app,
+                _http_scope(path="/api/v1/submit", method=http.HTTPMethod.POST),
+                receive=receive,
+            )
+        )
+
+    kwargs = mocks["record_duration"].call_args.kwargs
+    assert kwargs["resource"] == "submit"
+    assert kwargs["project"] == "proj-a"
 
 
 def test_rest_metrics_middleware_records_item_count_for_list_calls() -> None:


### PR DESCRIPTION
## Summary
- `RestMetricsMiddleware.parse_resource_and_project()` derived the `project` OTel label purely from the URL path, so calls whose project name lives in the request body, a query parameter, or under a differently-shaped path segment were always recorded with `project=""`. Since project-scoped metric access is filtered on this label, those calls' metrics were only visible to admins.
- Fixed seven routes: `POST /projects` (create), `GET /project-summaries/{name}`, `POST /build/function`, `POST /start/function`, `POST /status/function`, `POST /submit` / `/submit_job`, `GET /build/status`.
   The "function" APIs are planned to be changed: [ML-9765](https://ecliptos.atlassian.net/browse/ML-9765).
- Each fix is gated by an exact `(method, path segments)` match, so no other route's label logic is affected.

Fixes [ML-12989](https://ecliptos.atlassian.net/browse/ML-12989).

## Test plan
- [x] Existing pure-function telemetry unit tests pass (`server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py`, 13/13).
- [x] `ruff check` passes on the changed file.
- [x] Manually exercised every new/changed parser function and dispatch table against representative payloads for all seven routes, and confirmed unrelated routes (e.g. `/runs`) are unaffected.
- [x] End-to-end verified against a live deployment running this branch: sent real requests through the running middleware for all seven fixed routes, with the OTel `record_*` calls intercepted to capture the resulting `project` attribute. All seven, previously always `""`, now correctly resolve to the request's actual project name. Non-2xx statuses seen during this pass were expected (test auth had no real permissions) and unrelated to the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ML-9765]: https://iguazio.atlassian.net/browse/ML-9765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ