### PR TITLE
[Tests] Restore active_project for reused-project test classes

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -140,10 +140,15 @@ class TestMLRunSystem:
         )
         self._files_to_upload = []
 
-        if not self._skip_set_environment() and not self.reuse_project_across_tests:
-            self.project = mlrun.get_or_create_project(
-                self.project_name, "./", allow_cross_project=True
-            )
+        if not self._skip_set_environment():
+            if self.reuse_project_across_tests:
+                # _setup_env's mlconf.reload() above wipes active_project; the
+                # class-level project already exists, so just restore it.
+                mlrun.mlconf.active_project = self.project_name
+            else:
+                self.project = mlrun.get_or_create_project(
+                    self.project_name, "./", allow_cross_project=True
+                )
 
         self.custom_setup()
 


### PR DESCRIPTION
### 📝 Description
While investigating why the `Test runtimes [development]` job in the scheduled `System Tests Enterprise` workflow ([run 31232479036, job 93040153943](https://github.com/mlrun/mlrun/actions/runs/31232479036/job/93040153943)) ended with 41 failures, the common thread was every implicit-project SDK call resolving to an empty project (`projects//functions`, `MLRunMissingProjectError('Project must be provided')`, etc.), starting from the very first test in each affected class.

The cause: `setup_method` always calls `_setup_env(...)`, which ends with `mlconf.reload()` and wipes `mlrun.mlconf.active_project` back to `""`. Previously this was harmless because the very next line in `setup_method` recreated the project via `get_or_create_project(...)`, which re-sets `active_project`. #9997 added `reuse_project_across_tests` and skipped that recreation for opted-in classes (project is now created once in `setup_class`), but nothing restores `active_project` afterward, so every test in those classes runs with no active project.

---

### 🛠️ Changes Made
- `setup_method` now restores `mlrun.mlconf.active_project` to the class's project name when `reuse_project_across_tests` is set, instead of skipping project setup entirely.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `ruff check`/`ruff format` and `python -m py_compile` pass on the changed file.
- Not yet run against a live lab — needs a `tests/system/runtimes` run against a real cluster to confirm, since this is exactly the kind of regression that only shows up there.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: originating investigation — https://github.com/mlrun/mlrun/actions/runs/31232479036/job/93040153943; regression introduced in #9997

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Affects the 15 `tests/system/runtimes/` classes that opted into `reuse_project_across_tests` in #9997: `test_application.py`, `test_applications_store_uri.py`, `test_archives.py`, `test_jobs_store_uri.py`, `test_kfp.py`, `test_kubejob.py`, `test_notifications.py`, `test_nuclio.py` (six classes), `test_nuclio_store_uri.py`, `test_serving.py`.