### PR TITLE
[Projects] Fix ProjectStatus.state enum mismatch on project creation

### DIFF
--- a/server/py/framework/utils/projects/leader.py
+++ b/server/py/framework/utils/projects/leader.py
@@ -468,7 +468,13 @@ class Member(
 
     @staticmethod
     def _enrich_project(project: mlrun.common.schemas.Project):
-        project.status.state = project.spec.desired_state
+        desired_state = project.spec.desired_state
+        if desired_state is None:
+            project.status.state = None
+        else:
+            project.status.state = mlrun.common.schemas.ProjectState(
+                desired_state.value
+            )
 
     @staticmethod
     def _enrich_project_patch(project_patch: dict):

--- a/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
+++ b/server/py/services/api/tests/unit/utils/projects/test_leader_member.py
@@ -733,6 +733,27 @@ async def test_ensure_project_populates_opa_owner_cache_across_replicas(
     await opa_provider._sessions.async_close()
 
 
+def test_enrich_project_converts_desired_state_to_project_state():
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+        spec=mlrun.common.schemas.ProjectSpec(
+            desired_state=mlrun.common.schemas.ProjectDesiredState.online
+        ),
+    )
+    framework.utils.projects.leader.Member._enrich_project(project)
+    assert project.status.state == mlrun.common.schemas.ProjectState.online
+    assert type(project.status.state) is mlrun.common.schemas.ProjectState
+
+
+def test_enrich_project_desired_state_none():
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="project-name"),
+        spec=mlrun.common.schemas.ProjectSpec(desired_state=None),
+    )
+    framework.utils.projects.leader.Member._enrich_project(project)
+    assert project.status.state is None
+
+
 def _assert_project_not_in_followers(followers, name):
     for follower in followers:
         assert name not in follower._projects


### PR DESCRIPTION
### 📝 Description
Every project-creation request logs a `PydanticSerializationUnexpectedValue` warning. `Leader._enrich_project` assigns `project.spec.desired_state` (a `ProjectDesiredState` enum member) directly into `project.status.state`, which is declared with the sibling `ProjectState` enum. The two enums share string values (`online`/`offline`/`archived`) but are distinct classes, so nothing crashed — this went unnoticed under pydantic v1 (which doesn't re-validate types on serialize), but the API server now runs native pydantic v2 (ML-12891), whose serializer flags the class mismatch and warns on every `project.dict()` call.

---

### 🛠️ Changes Made
- `server/py/framework/utils/projects/leader.py`: `_enrich_project` now converts `desired_state` into a genuine `ProjectState` member (by value) before assigning, instead of aliasing the `ProjectDesiredState` instance. `None` is handled explicitly (the field is `Optional`).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added two unit tests in `server/py/services/api/tests/unit/utils/projects/test_leader_member.py`: enum-conversion correctness (`_enrich_project` produces a real `ProjectState` instance) and `None`-desired-state handling.
- Ran `server/py/services/api/tests/unit/utils/projects/test_leader_member.py` (28 tests) via `make test-dockerized MLRUN_TEST_FLAVOR=server MLRUN_IS_API_SERVER=true` — the flavor that installs the API server's real pydantic v2 dependency. All 28 passed, with zero `PydanticSerializationUnexpectedValue` occurrences in the output.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12959
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The underlying bug predates this ticket (introduced in `78be4b42c`) but was silently accepted under pydantic v1; ML-12891 (native pydantic-v2 schemas for the API server) unmasked it rather than causing it.
- No SDK/API/doc impact — internal type-correctness fix only, no change to the stored string value.