### PR TITLE
[Tests] Fix remaining reused-project system test failures

### DIFF
--- a/tests/system/base.py
+++ b/tests/system/base.py
@@ -33,6 +33,7 @@ import yaml
 from deepdiff import DeepDiff
 
 import mlrun.common.schemas
+import mlrun.projects.project
 from mlrun import get_run_db, mlconf
 from mlrun.utils import create_test_logger
 
@@ -142,9 +143,12 @@ class TestMLRunSystem:
 
         if not self._skip_set_environment():
             if self.reuse_project_across_tests:
-                # _setup_env's mlconf.reload() above wipes active_project; the
-                # class-level project already exists, so just restore it.
-                mlrun.mlconf.active_project = self.project_name
+                # _setup_env's mlconf.reload() above, and the autouse
+                # config_test_base fixture (tests/common_fixtures.py), wipe
+                # active_project and pipeline_context.project on every test;
+                # the class-level project already exists, so just restore both,
+                # the same way new_project()/load_project() would.
+                mlrun.projects.project._set_as_current_active_project(self.project)
             else:
                 self.project = mlrun.get_or_create_project(
                     self.project_name, "./", allow_cross_project=True

--- a/tests/system/runtimes/test_application.py
+++ b/tests/system/runtimes/test_application.py
@@ -158,7 +158,9 @@ class TestApplicationRuntime(tests.system.base.TestMLRunSystem):
         self._upload_code_to_cluster()
 
         self._logger.debug("Creating application")
-        function, source = self._create_vizro_application()
+        # dedicated name: "vizro-app" is redeployed by other tests in this class
+        # with a default gateway, which would leak into this test's gateway-count asserts
+        function, source = self._create_vizro_application(name="vizro-app-custom-gw")
 
         self._logger.debug("Deploying vizro application")
         function.deploy(with_mlrun=False, create_default_api_gateway=False)

--- a/tests/system/runtimes/test_kubejob.py
+++ b/tests/system/runtimes/test_kubejob.py
@@ -965,7 +965,10 @@ def print_df(df):
         with pytest.raises(mlrun.runtimes.utils.RunError):
             function.run(verbose=True, retry=retry)
 
-        runs = self._run_db.list_runs(project=self.project_name, name="raise-func")
+        # the run name defaults to "<function-name>-<handler>" when unset
+        runs = self._run_db.list_runs(
+            project=self.project_name, name="raise-func-handler"
+        )
         assert len(runs) == 1
         run = mlrun.RunObject.from_dict(runs[0])
         assert run.status.retry_count is None
@@ -976,7 +979,9 @@ def print_df(df):
         assert f"Run failed attempt 1 of {max_attempts}" in run.status.status_text
 
         def _assert_retry_info():
-            runs = self._run_db.list_runs(project=self.project_name, name="raise-func")
+            runs = self._run_db.list_runs(
+                project=self.project_name, name="raise-func-handler"
+            )
             assert len(runs) == 1
             run = mlrun.RunObject.from_dict(runs[0])
             assert run.status.retry_count == 3, (

--- a/tests/system/runtimes/test_notifications.py
+++ b/tests/system/runtimes/test_notifications.py
@@ -238,7 +238,10 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
             )
 
         # Validate that the run in pending retry state
-        runs = self._run_db.list_runs(project=self.project_name, name="test-func")
+        # the run name defaults to "<function-name>-<handler>" when unset
+        runs = self._run_db.list_runs(
+            project=self.project_name, name="test-func-handler"
+        )
         assert len(runs) == 1
         run = mlrun.RunObject.from_dict(runs[0])
         assert run.status.retry_count is None
@@ -249,7 +252,7 @@ class TestNotifications(tests.system.base.TestMLRunSystem):
         def _assert_notification_received():
             runs = self._run_db.list_runs(
                 project=self.project_name,
-                name="test-func",
+                name="test-func-handler",
                 with_notifications=True,
             )
             assert len(runs) == 1


### PR DESCRIPTION
### 📝 Description
Follow-up to #10015. That PR restored `mlrun.mlconf.active_project` for `reuse_project_across_tests` classes and dropped the `Test runtimes [development]` job's failures from 41 to 7 ([run 31347559281, job 93333929903](https://github.com/mlrun/mlrun/actions/runs/31347559281/job/93333929903)). This PR fixes all 7 remaining failures, in two unrelated groups.

**Group 1 — 4 failures share a related-but-distinct cause to #10015:** `mlrun.get_current_project()` (used by `deploy_reverse_proxy_image()` and KFP pipeline runs) doesn't read `mlconf.active_project` at all — it reads a separate global, `pipeline_context.project`. That global is set by the same production code path (`new_project()`/`load_project()` via `_set_as_current_active_project`) that sets `active_project`, but it's independently wiped on every test by the autouse `config_test_base` fixture in `tests/common_fixtures.py` (`pipeline_context.set(None)`), which applies session-wide (including system tests) since `tests/conftest.py` registers it via `pytest_plugins`. #10015's fix only restored `active_project`, so anything relying on `pipeline_context.project` (`test_deploy_reverse_proxy_base_image`, `test_kfp_with_mount`, `test_kfp_without_image`, `test_kfp_retry`) still failed for reused-project classes.

**Group 2 — the remaining 3 failures are independent bugs, unrelated to the active_project/pipeline_context globals:**
- `test_kubejob.py::test_retry_job_exhausted` and `test_notifications.py::test_run_notifications_with_retries` filtered `list_runs()` by the *function* name (`"raise-func"`, `"test-func"`), but a run's default `metadata.name` is `"<function-name>-<handler>"` — the actual run names, confirmed in the job log, are `raise-func-handler` and `test-func-handler`. The filter never matched, so `len(runs)` was always `0`. This is a pre-existing bug in #9997's own rescoping fix (both filters were introduced by that PR), not a timing flake — it failed identically before and after #10015.
- `test_application.py::test_deploy_application_with_custom_api_gateway` reuses the class's default function name `"vizro-app"`, which 3 other tests in the same class redeploy with a default API gateway (`create_default_api_gateway=True`). With the project now shared across the class's test methods (#9997), that stale gateway leaks into this test's `external_invocation_urls` count assertion (`assert len(...) == 1` saw `2`).

---

### 🛠️ Changes Made
- `tests/system/base.py`: `setup_method` now calls `mlrun.projects.project._set_as_current_active_project(self.project)` for `reuse_project_across_tests` classes, restoring both `active_project` and `pipeline_context.project` the same way `new_project()`/`load_project()` do, instead of only setting `active_project` directly. There's no public SDK utility for "mark this project as current" — this private helper is the single place that keeps both globals in sync, and `tests/common_fixtures.py` already reaches into the same private module (`pipeline_context.set(None)`), so calling it here avoids re-duplicating its logic and drifting out of sync if a third global is ever added to it.
- `tests/system/runtimes/test_kubejob.py` and `tests/system/runtimes/test_notifications.py`: fixed the `list_runs(name=...)` filters to match the run's actual auto-generated name (`"<function>-handler"`) instead of the function's own name.
- `tests/system/runtimes/test_application.py`: gave `test_deploy_application_with_custom_api_gateway`'s function a dedicated name (`vizro-app-custom-gw`) instead of the class's shared `"vizro-app"`, decoupling it from other tests' gateway state.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `ruff check`/`ruff format` and `python -m py_compile` pass on all changed files.
- Not yet run against a live lab — needs a `tests/system/runtimes` run against a real cluster to confirm all 7 are resolved.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: follow-up to #10015; job under investigation — https://github.com/mlrun/mlrun/actions/runs/31347559281/job/93333929903

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Group 2's bugs predate this PR (introduced by #9997) but were masked by the #10015-era `active_project` failures until those were fixed, which is why they only surfaced once the job's failure count dropped to 7.