### PR TITLE
[Pagination] Fix 500 on list endpoints when page-size given without page

### DIFF
--- a/server/py/framework/utils/pagination.py
+++ b/server/py/framework/utils/pagination.py
@@ -175,6 +175,11 @@ class Paginator(metaclass=mlrun.utils.singleton.Singleton):
 
         page_size = page_size or mlconf.httpdb.pagination.default_page_size
 
+        # Only default page on a fresh request (no token): with a token, leaving page as None lets
+        # _create_or_update_pagination_cache_record derive it from current_page + 1 for continuation.
+        if not token:
+            page = page or 1
+
         (
             token,
             page,

--- a/server/py/services/api/tests/unit/api/test_runs.py
+++ b/server/py/services/api/tests/unit/api/test_runs.py
@@ -614,6 +614,37 @@ def test_list_runs_with_pagination(db: Session, client: TestClient):
     assert not runs
 
 
+def test_list_runs_with_page_size_and_no_page(db: Session, client: TestClient):
+    """
+    Regression test for ML-12987: requesting page-size without page (the shape a UI takes on first
+    page load) used to 500 with a TypeError instead of defaulting page to 1.
+    """
+    number_of_runs = 5
+    project = "my_project"
+    for counter in range(number_of_runs):
+        uid = f"uid_{counter}"
+        run = {
+            "metadata": {
+                "name": f"run_{counter}",
+                "uid": uid,
+                "project": project,
+            },
+        }
+        services.api.crud.Runs().store_run(db, run, uid, project=project)
+
+    runs, pagination = _list_and_assert_objects(
+        client,
+        {
+            "page-size": 10,
+            "sort": True,
+        },
+        5,
+        project=project,
+    )
+    assert pagination["page"] == 1
+    assert pagination["page-size"] == 10
+
+
 def test_delete_runs_with_permissions(db: Session, client: TestClient):
     framework.utils.auth.verifier.AuthVerifier().query_project_resource_permissions = (
         unittest.mock.AsyncMock()

--- a/server/py/services/api/tests/unit/utils/test_pagination.py
+++ b/server/py/services/api/tests/unit/utils/test_pagination.py
@@ -180,6 +180,46 @@ async def test_paginate_request(
 
 
 @pytest.mark.asyncio
+async def test_paginate_request_defaults_page_when_only_page_size_given(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
+    """
+    Regression test for ML-12987.
+    Requesting with page_size but no page and no token (the shape a first page-load request takes)
+    must default page to 1 instead of leaving it None, which used to crash _validate_integer_max_value
+    with a TypeError comparing NoneType to int.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
+    page_size = 3
+    method_kwargs = {"total_amount": 5, "since": datetime.datetime.now()}
+
+    paginator = framework.utils.pagination.Paginator()
+
+    response, pagination_info = await paginator.paginate_request(
+        db, paginated_method, auth_info, None, None, page_size, **method_kwargs
+    )
+    _assert_paginated_response(
+        response,
+        pagination_info,
+        1,
+        page_size,
+        ["item0", "item1", "item2"],
+        method_kwargs["since"],
+    )
+
+    cache_record = (
+        framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+            db, pagination_info.page_token
+        )
+    )
+    _assert_cache_record(
+        cache_record, auth_info.user_id, paginated_method, 1, page_size
+    )
+
+
+@pytest.mark.asyncio
 async def test_paginate_other_users_token(
     mock_paginated_method,
     cleanup_pagination_cache_on_teardown,
@@ -670,6 +710,41 @@ async def test_paginate_permission_filtered_no_pagination(
     )
     assert len(response) == 5
     assert not pagination_info["page"]
+
+
+@pytest.mark.asyncio
+async def test_paginate_permission_filtered_request_defaults_page_when_only_page_size_given(
+    mock_paginated_method,
+    cleanup_pagination_cache_on_teardown,
+    db: sqlalchemy.orm.Session,
+):
+    """
+    Regression test for ML-12987, exercised through the outer permission-filtered wrapper.
+    Requesting with page_size but no page and no token must default page to 1 instead of crashing.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(user_id="user1")
+    page_size = 3
+    method_kwargs = {"total_amount": 5, "since": datetime.datetime.now()}
+
+    paginator = framework.utils.pagination.Paginator()
+
+    async def filter_(items):
+        return items
+
+    response, pagination_info = await paginator.paginate_permission_filtered_request(
+        db,
+        paginated_method,
+        filter_,
+        auth_info,
+        None,
+        None,
+        page_size,
+        **method_kwargs,
+    )
+    pagination_info = mlrun.common.schemas.PaginationInfo(**pagination_info)
+    assert len(response) == 3
+    assert pagination_info.page == 1
+    assert pagination_info.page_size == page_size
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### 📝 Description
Requesting a paginated list endpoint (e.g. `GET /runs`) with `page-size` but no `page` and no continuation token — the exact shape a UI sends on first page load — raised an unhandled 500 (`TypeError("'>' not supported between instances of 'NoneType' and 'int'")`) instead of returning page
1. `page=1&page-size=N` worked; `page-size=N` alone did not.

### 🛠️ Changes Made
- `Paginator.paginate_request` (`server/py/framework/utils/pagination.py`): default `page` to `1` when no continuation token is present, mirroring the existing `page_size` default. Guarded on `if not token` specifically so it doesn't interfere with token-based pagination continuation, which relies on `page` staying `None` so it can be derived from the cached record's `current_page + 1`.
- Added regression tests in `test_pagination.py` (unit-level, both `paginate_request` and `paginate_permission_filtered_request`) and `test_runs.py` (HTTP-level, reproducing the ticket's exact request shape).

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
- [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
- [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

### 🧪 Testing
- Added tests reproduce the exact original `TypeError` when reverted, and pass with the fix applied — verified manually, not just asserted.
- Full regression sweep: `test_pagination.py` + `test_runs.py` + `test_functions.py` + `test_artifacts.py` — 104 passed, 0 failed.
- `ruff check` + `ruff format --check` clean on all changed files.

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12987
- Design docs links: None — bugfix, no design doc.
- External links: None

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

### 🔍️ Additional Notes
- Scoped to the `1.12.x` branch only, per explicit decision. The same bug is confirmed present on `development` (byte-identical code) but is deliberately left for a separate follow-up PR, not included here.
- The fix lives in the shared `Paginator` class, so `/functions`, `/artifacts`, and `/alert-activations` (which hit the same crash today) are automatically covered without separate changes. The Python SDK already always sends `page=1` explicitly on first requests, so it never triggered this bug client-side.

(cherry picked from commit 29f94d2758af6c53f36505e9a04aa01e70e06c19)
