### PR TITLE
[Builder] Fix Buildah-built images not chowned for non-root job pods

### DIFF
--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -584,6 +584,26 @@ def test_buildah_backend_local_abs_path_source_passthrough():
     assert "ADD /opt/baked-in-source /home/mlrun_code" in _decoded_dockerfile(pod)
 
 
+def test_buildah_backend_chowns_source_dir_when_security_context_enriched():
+    # ML-12960 regression: a source-baked build on a cluster with non-root security-context
+    # enrichment enabled must chown the baked source dir to the job pod's runtime uid/gid, or a
+    # non-root job pod can't write into it at runtime. Buildah was silently skipping this
+    # (unlike Kaniko, which already threads user_unix_id/enriched_group_id through).
+    pod = _make_buildah_backend_pod(
+        source="/opt/baked-in-source",
+        user_unix_id=1000,
+        enriched_group_id=1000,
+    )
+    assert "RUN chown -R 1000:1000 /home/mlrun_code" in _decoded_dockerfile(pod)
+
+
+def test_buildah_backend_no_chown_when_security_context_not_enriched():
+    # the shipped default (enrichment disabled): no uid/gid resolved, so no chown - matches
+    # Kaniko's own behaviour for this case.
+    pod = _make_buildah_backend_pod(source="/opt/baked-in-source")
+    assert "chown" not in _decoded_dockerfile(pod)
+
+
 def test_buildah_backend_relative_path_source_raises():
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError, match="relative source"):
         _make_buildah_backend_pod(source="relative/path")

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -101,6 +101,8 @@ class BuildahBackend:
             source=source_to_copy,
             requirements_path=request.requirements_path,
             extra=request.extra,
+            user_unix_id=request.user_unix_id,
+            enriched_group_id=request.enriched_group_id,
             target_dir=request.runtime_spec.build.source_code_target_dir,
             builder_env=request.builder_env_list,
             project_secrets=request.project_secrets,


### PR DESCRIPTION
### 📝 Description
`BuildahBackend.make_build_pod()` omitted `user_unix_id`/`enriched_group_id` when calling `base.make_dockerfile()`, unlike `KanikoBackend`'s equivalent call. Since `make_dockerfile()` only emits the `chown` line for the baked source directory when both are set, Buildah-built images with baked source (e.g. via `with_source_archive(url, pull_at_runtime=False)`) never got that directory chowned. On a cluster with non-root security-context enrichment enabled, the job pod then runs as a non-root UID but the baked source dir stays root-owned, so the job's entrypoint fails writing its packed handler with `PermissionError: [Errno 13] Permission denied: 'job.py'`.

---

### 🛠️ Changes Made
- `server/py/services/api/utils/builder/buildah.py`: pass `user_unix_id=request.user_unix_id, enriched_group_id=request.enriched_group_id` into the `base.make_dockerfile(...)` call in `BuildahBackend.make_build_pod()`, mirroring `KanikoBackend`'s call exactly.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added two unit tests to `test_builder_backend.py`: `test_buildah_backend_chowns_source_dir_when_security_context_enriched` (regression case from the ticket) and `test_buildah_backend_no_chown_when_security_context_not_enriched` (confirms no behavior change for the default/disabled-enrichment case).
- Ran the full `test_builder_backend.py` (43 tests) and `test_builder.py` (167 tests, the Kaniko regression anchor) — all pass.
- `ruff check` / `ruff format --check` clean on both changed files.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12960

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
None.