### PR TITLE
[Builder] Fix Buildah base-image cloud-registry credential exchange

### DIFF
--- a/mlrun/__main__.py
+++ b/mlrun/__main__.py
@@ -1416,18 +1416,21 @@ def load_source(source_uri, project, target):
 @click.option(
     "--dest",
     default=None,
-    help="the destination image reference (ECR only, to derive the repository name)",
+    help="the destination image reference (ECR push only, to create the repository; omit for a "
+    "pull-only/base-image exchange, which skips repository creation)",
 )
 @click.option(
     "--authfile",
     required=True,
-    help="path to write the docker-config-shaped authfile",
+    help="path to merge the docker-config-shaped authfile entry into",
 )
 def mint_registry_credentials(provider, registry, dest, authfile):
-    """Mint short-lived cloud-registry push credentials into a docker-config authfile.
+    """Mint short-lived cloud-registry credentials into a docker-config authfile.
 
     This is an internal CLI command used by Buildah build init containers to exchange the pod's
-    workload identity for a registry push credential before the main container runs.
+    workload identity for a registry credential (push destination or base-image pull) before the
+    main container runs. Merges into ``--authfile`` rather than overwriting it, so a push-side and
+    a pull-side exchange (different registries) can share the same authfile.
 
     Examples:
 
@@ -1441,11 +1444,7 @@ def mint_registry_credentials(provider, registry, dest, authfile):
     """
     try:
         if provider == CloudRegistryProvider.ECR:
-            if not dest:
-                raise mlrun.errors.MLRunInvalidArgumentError(
-                    "--dest is required for --provider ecr"
-                )
-            mint_ecr_authfile(registry, dest, authfile)
+            mint_ecr_authfile(registry, authfile, dest=dest)
         elif provider == CloudRegistryProvider.ACR:
             mint_acr_authfile(registry, authfile)
         else:

--- a/mlrun/utils/registry_auth.py
+++ b/mlrun/utils/registry_auth.py
@@ -124,10 +124,11 @@ def _merge_auth_entry(authfile_path: str, registry: str, auth: str) -> None:
     # a push-side and a pull-side credential exchange can both target this file (different
     # registries, e.g. the push destination and a differently-hosted base image) - init containers
     # run sequentially, never concurrently, so read-modify-write here is safe without locking.
-    auths = {}
     if os.path.exists(authfile_path):
         with open(authfile_path) as fh:
             auths = json.load(fh).get("auths", {})
+    else:
+        auths = {}
     auths[registry] = {"auth": auth}
     with open(authfile_path, "w") as fh:
         json.dump({"auths": auths}, fh)

--- a/mlrun/utils/registry_auth.py
+++ b/mlrun/utils/registry_auth.py
@@ -126,7 +126,11 @@ def _merge_auth_entry(authfile_path: str, registry: str, auth: str) -> None:
     # static secret (ML-12988) may already be there too - init containers run sequentially, never
     # concurrently, so read-modify-write here is safe without locking. Preserves any other
     # top-level docker-config keys already in the file (credHelpers, credsStore, ...) - only the
-    # entry for this one registry is ever added or replaced.
+    # entry for this one registry is ever added or replaced. If a secret (or an earlier exchange)
+    # already had an entry for this exact registry, this mint's result wins - mirroring nuclio's own
+    # merge_authfile.py, which applies cloud tokens after secrets for the same reason: a successful
+    # mint means workload identity is actually configured for that host, so it's the fresher
+    # credential; a stale/misconfigured secret entry for the same host shouldn't shadow it.
     if os.path.exists(authfile_path):
         with open(authfile_path) as fh:
             doc = json.load(fh)
@@ -135,6 +139,10 @@ def _merge_auth_entry(authfile_path: str, registry: str, auth: str) -> None:
     doc.setdefault("auths", {})[registry] = {"auth": auth}
     with open(authfile_path, "w") as fh:
         json.dump(doc, fh)
+    # the previous writer's UID is never guaranteed to match this process's (init containers get no
+    # explicit security context - see append_secret_authfile_init_container in the server-side
+    # registry_auth.py), so the file must stay writable for whoever merges into it next.
+    os.chmod(authfile_path, 0o666)
 
 
 def _ecr_repo_name(dest: str) -> str:

--- a/mlrun/utils/registry_auth.py
+++ b/mlrun/utils/registry_auth.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""ECR/ACR push-credential minting, run inside a Buildah build's init container (ML-12886).
+"""ECR/ACR credential minting, run inside a Buildah build's init container (ML-12886, ML-12961).
 
 Invoked via ``python -m mlrun mint-registry-credentials`` by
 :mod:`services.api.utils.builder.registry_auth` (server-side) - the init container runs on the
@@ -44,46 +44,52 @@ _ACR_TOKEN_SCOPE = "https://management.azure.com/.default"
 _ACR_ANONYMOUS_USERNAME = "00000000-0000-0000-0000-000000000000"
 
 
-def mint_ecr_authfile(registry: str, dest: str, authfile_path: str) -> None:
-    """Create the target ECR repository (idempotent) and write a push authfile.
+def mint_ecr_authfile(
+    registry: str, authfile_path: str, dest: str | None = None
+) -> None:
+    """Mint an ECR authorization token and merge it into the authfile.
 
     Unlike ACR/GAR, ECR does not auto-create a repository on first push - it must exist first, or
-    the push fails outright, so this creates it up front.
+    the push fails outright. When ``dest`` is given (a push), the repository is created (idempotent)
+    up front; when it's omitted (a base-image pull), repository creation is skipped - the pod may
+    not even have create permissions on a registry it's only pulling from.
 
     Credentials come from boto3's default chain (IRSA or instance role, resolved via the build
     pod's own service account/environment) - nothing else needs to be configured.
 
     :param registry: The ECR registry host.
-    :param dest: The fully resolved destination image reference (for the repository name).
-    :param authfile_path: Where to write the docker-config-shaped authfile.
+    :param authfile_path: Where to merge the docker-config-shaped authfile entry.
+    :param dest: The fully resolved destination image reference, to derive the repository name for
+        creation. Omit for a pull-only (base-image) credential exchange.
     """
     import boto3
 
     region = registry.split(".")[3]
-    repo = _ecr_repo_name(dest)
     client = boto3.client("ecr", region_name=region)
-    try:
-        client.create_repository(repositoryName=repo)
-    except client.exceptions.RepositoryAlreadyExistsException:
-        pass
+    if dest:
+        repo = _ecr_repo_name(dest)
+        try:
+            client.create_repository(repositoryName=repo)
+        except client.exceptions.RepositoryAlreadyExistsException:
+            pass
 
     authorization_data = client.get_authorization_token()["authorizationData"][0]
     token = authorization_data["authorizationToken"]
-    with open(authfile_path, "w") as fh:
-        json.dump({"auths": {registry: {"auth": token}}}, fh)
+    _merge_auth_entry(authfile_path, registry, token)
 
 
 def mint_acr_authfile(registry: str, authfile_path: str) -> None:
-    """Exchange the pod's Azure workload identity for an ACR push credential.
+    """Exchange the pod's Azure workload identity for an ACR credential.
 
     Exchanges the pod's Azure workload identity (federated JWT, injected by the
     ``azure.workload.identity/use`` label - see
     :func:`~services.api.utils.builder.base.resolve_builder_pod_labels`) for an AAD access token via
     azure-identity, then exchanges that AAD token for an ACR refresh token via ACR's
-    ``/oauth2/exchange`` endpoint (no SDK covers this ACR-specific endpoint).
+    ``/oauth2/exchange`` endpoint (no SDK covers this ACR-specific endpoint). Used for both push and
+    base-image-pull credentials - the exchange itself is identical, only the registry host differs.
 
     :param registry: The ACR registry host.
-    :param authfile_path: Where to write the docker-config-shaped authfile.
+    :param authfile_path: Where to merge the docker-config-shaped authfile entry.
     """
     # lazy: azure-identity is only needed for ACR, not ECR/GAR - avoid requiring it unless this path
     # actually runs, same as boto3 in mint_ecr_authfile.
@@ -111,8 +117,20 @@ def mint_acr_authfile(registry: str, authfile_path: str) -> None:
     auth = base64.b64encode(
         f"{_ACR_ANONYMOUS_USERNAME}:{refresh_token}".encode()
     ).decode()
+    _merge_auth_entry(authfile_path, registry, auth)
+
+
+def _merge_auth_entry(authfile_path: str, registry: str, auth: str) -> None:
+    # a push-side and a pull-side credential exchange can both target this file (different
+    # registries, e.g. the push destination and a differently-hosted base image) - init containers
+    # run sequentially, never concurrently, so read-modify-write here is safe without locking.
+    auths = {}
+    if os.path.exists(authfile_path):
+        with open(authfile_path) as fh:
+            auths = json.load(fh).get("auths", {})
+    auths[registry] = {"auth": auth}
     with open(authfile_path, "w") as fh:
-        json.dump({"auths": {registry: {"auth": auth}}}, fh)
+        json.dump({"auths": auths}, fh)
 
 
 def _ecr_repo_name(dest: str) -> str:

--- a/mlrun/utils/registry_auth.py
+++ b/mlrun/utils/registry_auth.py
@@ -122,16 +122,19 @@ def mint_acr_authfile(registry: str, authfile_path: str) -> None:
 
 def _merge_auth_entry(authfile_path: str, registry: str, auth: str) -> None:
     # a push-side and a pull-side credential exchange can both target this file (different
-    # registries, e.g. the push destination and a differently-hosted base image) - init containers
-    # run sequentially, never concurrently, so read-modify-write here is safe without locking.
+    # registries, e.g. the push destination and a differently-hosted base image), and a copied-in
+    # static secret (ML-12988) may already be there too - init containers run sequentially, never
+    # concurrently, so read-modify-write here is safe without locking. Preserves any other
+    # top-level docker-config keys already in the file (credHelpers, credsStore, ...) - only the
+    # entry for this one registry is ever added or replaced.
     if os.path.exists(authfile_path):
         with open(authfile_path) as fh:
-            auths = json.load(fh).get("auths", {})
+            doc = json.load(fh)
     else:
-        auths = {}
-    auths[registry] = {"auth": auth}
+        doc = {}
+    doc.setdefault("auths", {})[registry] = {"auth": auth}
     with open(authfile_path, "w") as fh:
-        json.dump({"auths": auths}, fh)
+        json.dump(doc, fh)
 
 
 def _ecr_repo_name(dest: str) -> str:

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -428,6 +428,20 @@ def test_make_buildah_pod_gar_credential_exchange_is_jit_not_init_container():
     assert "--authfile /auth/config.json" in lines[push_line]
 
 
+def test_make_buildah_pod_bare_base_image_has_no_pull_side_exchange():
+    # a base image with no explicit registry (e.g. the default "mlrun/mlrun:<version>", a Docker
+    # Hub image) must not be treated as a pull-side registry needing credential exchange.
+    registry = "myregistry.azurecr.io"
+    buildah_pod = _make_buildah_pod(
+        dest=f"{registry}/some-image:tag",
+        registry=registry,
+        base_image="mlrun/mlrun:1.13.0-rc2",
+    )
+    pod = buildah_pod.pod
+    assert len(pod.spec.init_containers) == 1
+    assert pod.spec.init_containers[0].name == "registry-credential-exchange"
+
+
 def test_make_buildah_pod_gar_credential_exchange_same_registry_mints_both():
     # base image on the *same* GAR host as the push destination - pull and push are still minted
     # independently (no same-host dedup for GAR, unlike ECR/ACR's init-container skip): pull right

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -411,41 +411,48 @@ def test_make_buildah_pod_gar_credential_exchange_is_jit_not_init_container():
     assert env["REGISTRY_AUTH_FILE"] == "/auth/config.json"
     assert "MLRUN_GAR_CREDENTIAL_SCRIPT" in env
     lines = container.args[0].splitlines()
-    bud_line = next(i for i, line in enumerate(lines) if "bud" in line.split())
     push_line = next(i for i, line in enumerate(lines) if "push" in line.split())
     mint_lines = [
         i for i, line in enumerate(lines) if "MLRUN_GAR_CREDENTIAL_SCRIPT" in line
     ]
-    # minted immediately before *both* bud and push - see buildah.py::_build_script for why.
-    assert len(mint_lines) == 2
-    assert mint_lines[0] < bud_line < mint_lines[1] < push_line
+    # minted once, immediately before push - no base image here, so bud needs no push credential.
+    assert len(mint_lines) == 1
+    assert mint_lines[0] < push_line
+    mint_script_line = lines[push_line - 1]
     # wrapped so a failed mint (ML-12988) logs a warning and continues rather than aborting the
     # build under `set -e` - see registry_auth.soft_fail_script.
-    for mint_script_line in (lines[bud_line - 1], lines[push_line - 1]):
-        assert mint_script_line.startswith(
-            "python3 /tmp/mlrun-gar-credential-exchange.py"
-        )
-        assert mint_script_line.endswith(
-            "|| echo 'WARNING: failed to mint GAR registry credentials' >&2"
-        )
+    assert mint_script_line.startswith("python3 /tmp/mlrun-gar-credential-exchange.py")
+    assert mint_script_line.endswith(
+        "|| echo 'WARNING: failed to mint GAR registry credentials' >&2"
+    )
     assert "--authfile /auth/config.json" in lines[push_line]
 
 
-def test_make_buildah_pod_gar_credential_exchange_same_registry_skips_pull_script():
-    # base image on the *same* GAR host as the push destination - the push-side JIT script (minted
-    # before bud too) already covers it, so no separate pull script/env var is generated.
+def test_make_buildah_pod_gar_credential_exchange_same_registry_mints_both():
+    # base image on the *same* GAR host as the push destination - pull and push are still minted
+    # independently (no same-host dedup for GAR, unlike ECR/ACR's init-container skip): pull right
+    # before `bud`, push right before `push`.
     registry = "us-docker.pkg.dev"
     buildah_pod = _make_buildah_pod(
         dest=f"{registry}/proj/repo/some-image:tag",
         registry=registry,
         base_image=f"{registry}/mlrun/mlrun:1.13.0-rc2",
     )
-    env = {
-        env_var.name: env_var.value
-        for env_var in buildah_pod.pod.spec.containers[0].env
-    }
+    pod = buildah_pod.pod
+    env = {env_var.name: env_var.value for env_var in pod.spec.containers[0].env}
     assert "MLRUN_GAR_CREDENTIAL_SCRIPT" in env
-    assert "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" not in env
+    assert "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" in env
+
+    lines = pod.spec.containers[0].args[0].splitlines()
+    bud_line = next(i for i, line in enumerate(lines) if "bud" in line.split())
+    push_line = next(i for i, line in enumerate(lines) if "push" in line.split())
+    pull_mint_line = next(
+        i for i, line in enumerate(lines) if "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" in line
+    )
+    push_mint_line = next(
+        i for i, line in enumerate(lines) if "MLRUN_GAR_CREDENTIAL_SCRIPT" in line
+    )
+    assert pull_mint_line < bud_line < push_mint_line < push_line
 
 
 def test_make_buildah_pod_gar_pull_side_credential_exchange_for_different_host_base_image():
@@ -552,6 +559,16 @@ def test_make_buildah_pod_same_registry_skips_duplicate_exchange():
     init_containers = buildah_pod.pod.spec.init_containers
     assert len(init_containers) == 1
     assert init_containers[0].name == "registry-credential-exchange"
+
+    # the pull *is* credentialed (via the init container above), even though it got no init
+    # container of its own - --tls-verify=false must not be added for it in "auto" mode.
+    script = buildah_pod.pod.spec.containers[0].args[0]
+    bud_line = next(
+        line
+        for line in script.splitlines()
+        if line.startswith("buildah") and " bud " in line
+    )
+    assert "--tls-verify=false" not in bud_line
 
 
 def test_make_buildah_pod_secret_and_cloud_pull_exchange_merge():

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -319,8 +319,10 @@ def test_make_buildah_pod_secret_and_cloud_provider_merge(registry, provider):
 
     copy_container = _init_container_by_name(buildah_pod, "copy-registry-auth-secret")
     assert copy_container is not None
-    assert copy_container.command == ["cp"]
-    assert copy_container.args == ["/auth-secret/config.json", "/auth/config.json"]
+    assert copy_container.command == ["/bin/sh", "-c"]
+    script = copy_container.args[0]
+    assert "cp /auth-secret/config.json /auth/config.json" in script
+    assert "chmod 0666 /auth/config.json" in script
     # mounted read-only elsewhere - never directly at the shared authfile path (ML-12988)
     secret_mount = next(
         mount
@@ -575,10 +577,16 @@ def test_make_buildah_pod_push_and_pull_different_acr_hosts():
     assert "system.azurecr.io" in by_name["registry-credential-exchange-pull"].args[0]
 
 
-def test_make_buildah_pod_same_registry_skips_duplicate_exchange():
-    # base image on the *same* ACR host as the push destination - the push-side exchange already
-    # writes that host's authfile entry, so no second (redundant) init container is needed.
-    registry = "myregistry.azurecr.io"
+@pytest.mark.parametrize(
+    "registry",
+    [
+        "myregistry.azurecr.io",
+        "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+    ],
+)
+def test_make_buildah_pod_same_registry_skips_duplicate_exchange(registry):
+    # base image on the *same* ACR/ECR host as the push destination - the push-side exchange
+    # already writes that host's authfile entry, so no second (redundant) init container is needed.
     buildah_pod = _make_buildah_pod(
         dest=f"{registry}/some-image:tag",
         registry=registry,

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -442,6 +442,20 @@ def test_make_buildah_pod_bare_base_image_has_no_pull_side_exchange():
     assert pod.spec.init_containers[0].name == "registry-credential-exchange"
 
 
+def test_make_buildah_pod_bare_push_destination_has_no_push_side_exchange():
+    # a push destination with no explicit registry (e.g. pushed straight to Docker Hub as
+    # "my-org/my-image:tag") must not be treated as a registry needing credential exchange -
+    # inferring one from the whole "my-org" segment would be as wrong as the base_image case above.
+    base_registry = "myregistry.azurecr.io"
+    buildah_pod = _make_buildah_pod(
+        dest="my-org/my-image:tag",
+        base_image=f"{base_registry}/mlrun/mlrun:1.13.0-rc2",
+    )
+    pod = buildah_pod.pod
+    assert len(pod.spec.init_containers) == 1
+    assert pod.spec.init_containers[0].name == "registry-credential-exchange-pull"
+
+
 def test_make_buildah_pod_gar_credential_exchange_same_registry_mints_both():
     # base image on the *same* GAR host as the push destination - pull and push are still minted
     # independently (no same-host dedup for GAR, unlike ECR/ACR's init-container skip): pull right

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -400,6 +400,56 @@ def test_make_buildah_pod_gar_credential_exchange_is_jit_not_init_container():
     assert "--authfile /auth/config.json" in lines[push_line]
 
 
+def test_make_buildah_pod_gar_credential_exchange_same_registry_skips_pull_script():
+    # base image on the *same* GAR host as the push destination - the push-side JIT script (minted
+    # before bud too) already covers it, so no separate pull script/env var is generated.
+    registry = "us-docker.pkg.dev"
+    buildah_pod = _make_buildah_pod(
+        dest=f"{registry}/proj/repo/some-image:tag",
+        registry=registry,
+        base_image=f"{registry}/mlrun/mlrun:1.13.0-rc2",
+    )
+    env = {
+        env_var.name: env_var.value
+        for env_var in buildah_pod.pod.spec.containers[0].env
+    }
+    assert "MLRUN_GAR_CREDENTIAL_SCRIPT" in env
+    assert "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" not in env
+
+
+def test_make_buildah_pod_gar_pull_side_credential_exchange_for_different_host_base_image():
+    # ML-12961: base image on a *different* GAR host than the push destination - a separate JIT
+    # script mints its credentials, merged into the same authfile, run once right before `bud`
+    # (the only step that pulls the base image).
+    push_registry = "us-docker.pkg.dev"
+    base_registry = "europe-docker.pkg.dev"
+    buildah_pod = _make_buildah_pod(
+        dest=f"{push_registry}/proj/repo/some-image:tag",
+        registry=push_registry,
+        base_image=f"{base_registry}/mlrun/mlrun:1.13.0-rc2",
+    )
+    pod = buildah_pod.pod
+
+    assert pod.spec.init_containers == []
+    container = pod.spec.containers[0]
+    env = {env_var.name: env_var.value for env_var in container.env}
+    assert "MLRUN_GAR_CREDENTIAL_SCRIPT" in env
+    assert "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" in env
+
+    lines = container.args[0].splitlines()
+    bud_line = next(i for i, line in enumerate(lines) if "bud" in line.split())
+    pull_mint_line = next(
+        i for i, line in enumerate(lines) if "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" in line
+    )
+    assert pull_mint_line < bud_line
+    assert (
+        lines[pull_mint_line + 1]
+        == "python3 /tmp/mlrun-gar-credential-exchange-pull.py"
+    )
+    # runs exactly once - only needed before the base-image pull, not before push
+    assert sum(1 for line in lines if "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" in line) == 1
+
+
 @pytest.mark.parametrize(
     "base_registry,provider",
     [

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -16,10 +16,11 @@
 # gate and the BuildRequest contract. The behaviour of the Kaniko path itself is
 # the byte-identical regression anchor covered by test_builder.py; here we lock the
 # seam, and (ML-12885) the Buildah backend: config-flip selection, ECR/ACR/GAR
-# credential exchange (ML-12886), remote source acquisition (ML-12887), and the
-# rootless pod spec. It also locks Buildah's own source routing - every remote
-# source is fetched via `mlrun load-source` or, for v3io, FUSE-mounted, since
-# Buildah has no native remote-context resolution the way Kaniko does.
+# credential exchange (ML-12886) - including the base-image (pull-side) exchange
+# added in ML-12961 - remote source acquisition (ML-12887), and the rootless pod
+# spec. It also locks Buildah's own source routing - every remote source is
+# fetched via `mlrun load-source` or, for v3io, FUSE-mounted, since Buildah has no
+# native remote-context resolution the way Kaniko does.
 
 import base64
 import unittest.mock
@@ -397,6 +398,110 @@ def test_make_buildah_pod_gar_credential_exchange_is_jit_not_init_container():
     assert lines[bud_line - 1] == "python3 /tmp/mlrun-gar-credential-exchange.py"
     assert lines[push_line - 1] == "python3 /tmp/mlrun-gar-credential-exchange.py"
     assert "--authfile /auth/config.json" in lines[push_line]
+
+
+@pytest.mark.parametrize(
+    "base_registry,provider",
+    [
+        ("system.azurecr.io", "acr"),
+        ("111111111111.dkr.ecr.us-east-1.amazonaws.com", "ecr"),
+    ],
+)
+def test_make_buildah_pod_pull_side_credential_exchange_for_different_host_base_image(
+    base_registry, provider
+):
+    # ML-12961 regression: the base image's registry needs its own credential exchange when it's a
+    # different cloud host than the push destination - this is the reported "invalid
+    # username/password" pulling a private ACR base image while pushing elsewhere.
+    buildah_pod = _make_buildah_pod(
+        dest="docker-hub/some-image:tag",
+        base_image=f"{base_registry}/mlrun/mlrun:1.13.0-rc2",
+    )
+    pod = buildah_pod.pod
+
+    init_containers = pod.spec.init_containers
+    assert len(init_containers) == 1
+    assert init_containers[0].name == "registry-credential-exchange-pull"
+    assert "--provider" in init_containers[0].args
+    assert provider in init_containers[0].args
+    assert "--registry" in init_containers[0].args
+    assert base_registry in init_containers[0].args
+    assert "--dest" not in init_containers[0].args
+
+    empty_dir_volumes = {
+        volume.name for volume in pod.spec.volumes if volume.empty_dir is not None
+    }
+    assert "registry-auth" in empty_dir_volumes
+    env = {env_var.name: env_var.value for env_var in pod.spec.containers[0].env}
+    assert env["REGISTRY_AUTH_FILE"] == "/auth/config.json"
+
+
+def test_make_buildah_pod_push_and_pull_different_acr_hosts():
+    # push destination and base image are both ACR, but different registry instances - each needs
+    # its own credential-exchange init container, writing into the same shared authfile.
+    buildah_pod = _make_buildah_pod(
+        dest="push.azurecr.io/some-image:tag",
+        registry="push.azurecr.io",
+        base_image="system.azurecr.io/mlrun/mlrun:1.13.0-rc2",
+    )
+    init_containers = buildah_pod.pod.spec.init_containers
+    assert len(init_containers) == 2
+    names = {container.name for container in init_containers}
+    assert names == {
+        "registry-credential-exchange",
+        "registry-credential-exchange-pull",
+    }
+
+    by_name = {container.name: container for container in init_containers}
+    assert "push.azurecr.io" in by_name["registry-credential-exchange"].args
+    assert "system.azurecr.io" in by_name["registry-credential-exchange-pull"].args
+
+
+def test_make_buildah_pod_same_registry_skips_duplicate_exchange():
+    # base image on the *same* ACR host as the push destination - the push-side exchange already
+    # writes that host's authfile entry, so no second (redundant) init container is needed.
+    registry = "myregistry.azurecr.io"
+    buildah_pod = _make_buildah_pod(
+        dest=f"{registry}/some-image:tag",
+        registry=registry,
+        base_image=f"{registry}/mlrun/mlrun:1.13.0-rc2",
+    )
+    init_containers = buildah_pod.pod.spec.init_containers
+    assert len(init_containers) == 1
+    assert init_containers[0].name == "registry-credential-exchange"
+
+
+def test_make_buildah_pod_static_secret_skips_cloud_pull_exchange():
+    # an explicit secret_name always wins, even when the base image (not just the push
+    # destination) lives on a recognized cloud registry - no credential-exchange init container.
+    buildah_pod = _make_buildah_pod(
+        dest="docker-hub/some-image:tag",
+        base_image="system.azurecr.io/mlrun/mlrun:1.13.0-rc2",
+        secret_name="my-docker-secret",
+    )
+    assert buildah_pod.pod.spec.init_containers == []
+
+
+def test_make_buildah_pod_pull_tls_verify_unaffected_by_unrelated_gar_push():
+    # regression guard: a GAR push destination must not, on its own, mark the *pull* as
+    # credentialed when the base image is on an unrelated (here: non-cloud/self-signed) registry -
+    # doing so would wrongly disable --tls-verify=false for that pull in "auto" mode.
+    registry = "us-docker.pkg.dev"
+    script = (
+        _make_buildah_pod(
+            dest=f"{registry}/proj/repo/some-image:tag",
+            registry=registry,
+            base_image="self-signed.internal.example.com/base:latest",
+        )
+        .pod.spec.containers[0]
+        .args[0]
+    )
+    bud_line = next(
+        line
+        for line in script.splitlines()
+        if line.startswith("buildah") and " bud " in line
+    )
+    assert "--tls-verify=false" in bud_line
 
 
 def test_make_buildah_pod_stages_inline_code_and_requirements():

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -294,29 +294,54 @@ def test_make_buildah_pod_authfile_when_secret():
 
 
 @pytest.mark.parametrize(
-    "registry",
+    "registry,provider",
     [
-        "123456789012.dkr.ecr.us-east-1.amazonaws.com",  # ECR
-        "myregistry.azurecr.io",  # ACR
-        "us-docker.pkg.dev",  # GAR
+        ("123456789012.dkr.ecr.us-east-1.amazonaws.com", "ecr"),
+        ("myregistry.azurecr.io", "acr"),
+        ("us-docker.pkg.dev", "gar"),
     ],
 )
-def test_make_buildah_pod_explicit_secret_wins_over_cloud_provider(registry):
-    # an explicit secret_name on an otherwise-cloud registry host must use the static secret as-is -
-    # no credential-exchange init container, no GAR JIT script clobbering the mounted secret's authfile
+def test_make_buildah_pod_secret_and_cloud_provider_merge(registry, provider):
+    # ML-12988: an explicit secret_name (e.g. authenticating a private base image elsewhere) must
+    # not disable cloud credential exchange for a *different* host that needs it - the secret is
+    # copied into the shared authfile first, then merged with per-host cloud auth on top.
     buildah_pod = _make_buildah_pod(
         dest=f"{registry}/some-image:tag",
         registry=registry,
         secret_name="my-docker-secret",
     )
     pod = buildah_pod.pod
-    assert pod.spec.init_containers == []
-    env = {env_var.name: env_var.value for env_var in pod.spec.containers[0].env}
-    assert "MLRUN_GAR_CREDENTIAL_SCRIPT" not in env
+
     mounted_secrets = {
         volume.secret.secret_name for volume in pod.spec.volumes if volume.secret
     }
     assert mounted_secrets == {"my-docker-secret"}
+
+    copy_container = _init_container_by_name(buildah_pod, "copy-registry-auth-secret")
+    assert copy_container is not None
+    assert copy_container.command == ["cp"]
+    assert copy_container.args == ["/auth-secret/config.json", "/auth/config.json"]
+    # mounted read-only elsewhere - never directly at the shared authfile path (ML-12988)
+    secret_mount = next(
+        mount
+        for mount in copy_container.volume_mounts
+        if mount.name == "my-docker-secret"
+    )
+    assert secret_mount.mount_path == "/auth-secret"
+    # runs first, so cloud exchange below merges on top of the secret's own entries
+    assert pod.spec.init_containers[0].name == "copy-registry-auth-secret"
+
+    init_container_names = {c.name for c in pod.spec.init_containers}
+    env = {env_var.name: env_var.value for env_var in pod.spec.containers[0].env}
+    if provider == "gar":
+        # GAR still has no credential-exchange init container - JIT in the main container
+        assert init_container_names == {"copy-registry-auth-secret"}
+        assert "MLRUN_GAR_CREDENTIAL_SCRIPT" in env
+    else:
+        assert init_container_names == {
+            "copy-registry-auth-secret",
+            "registry-credential-exchange",
+        }
 
 
 @pytest.mark.parametrize(
@@ -337,18 +362,17 @@ def test_make_buildah_pod_credential_exchange_init_container(registry, provider)
     init_containers = pod.spec.init_containers
     assert len(init_containers) == 1
     assert init_containers[0].name == "registry-credential-exchange"
-    # same python -m mlrun <subcommand> convention Kaniko's source-fetch init container uses
-    assert init_containers[0].command == ["python"]
-    assert init_containers[0].args[:3] == ["-m", "mlrun", "mint-registry-credentials"]
-    assert "--provider" in init_containers[0].args
-    assert provider in init_containers[0].args
-    assert "--authfile" in init_containers[0].args
-    assert "/auth/config.json" in init_containers[0].args
+    # same python -m mlrun <subcommand> convention Kaniko's source-fetch init container uses,
+    # wrapped so a failed mint (ML-12988) logs a warning and exits 0 instead of failing the pod
+    assert init_containers[0].command == ["/bin/sh", "-c"]
+    script = init_containers[0].args[0]
+    assert script.startswith("python -m mlrun mint-registry-credentials")
+    assert f"--provider {provider}" in script
+    assert "--authfile /auth/config.json" in script
     if provider == "ecr":
-        assert "--dest" in init_containers[0].args
-        assert f"{registry}/some-image:tag" in init_containers[0].args
+        assert f"--dest {registry}/some-image:tag" in script
     else:
-        assert "--dest" not in init_containers[0].args
+        assert "--dest" not in script
     # the mounted emptyDir is shared: BasePod attaches every volume mount to every init container
     assert any(
         mount.mount_path == "/auth" for mount in init_containers[0].volume_mounts
@@ -395,8 +419,15 @@ def test_make_buildah_pod_gar_credential_exchange_is_jit_not_init_container():
     # minted immediately before *both* bud and push - see buildah.py::_build_script for why.
     assert len(mint_lines) == 2
     assert mint_lines[0] < bud_line < mint_lines[1] < push_line
-    assert lines[bud_line - 1] == "python3 /tmp/mlrun-gar-credential-exchange.py"
-    assert lines[push_line - 1] == "python3 /tmp/mlrun-gar-credential-exchange.py"
+    # wrapped so a failed mint (ML-12988) logs a warning and continues rather than aborting the
+    # build under `set -e` - see registry_auth.soft_fail_script.
+    for mint_script_line in (lines[bud_line - 1], lines[push_line - 1]):
+        assert mint_script_line.startswith(
+            "python3 /tmp/mlrun-gar-credential-exchange.py"
+        )
+        assert mint_script_line.endswith(
+            "|| echo 'WARNING: failed to mint GAR registry credentials' >&2"
+        )
     assert "--authfile /auth/config.json" in lines[push_line]
 
 
@@ -442,9 +473,12 @@ def test_make_buildah_pod_gar_pull_side_credential_exchange_for_different_host_b
         i for i, line in enumerate(lines) if "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" in line
     )
     assert pull_mint_line < bud_line
-    assert (
-        lines[pull_mint_line + 1]
-        == "python3 /tmp/mlrun-gar-credential-exchange-pull.py"
+    pull_mint_script_line = lines[pull_mint_line + 1]
+    assert pull_mint_script_line.startswith(
+        "python3 /tmp/mlrun-gar-credential-exchange-pull.py"
+    )
+    assert pull_mint_script_line.endswith(
+        "|| echo 'WARNING: failed to mint GAR registry credentials' >&2"
     )
     # runs exactly once - only needed before the base-image pull, not before push
     assert sum(1 for line in lines if "MLRUN_GAR_PULL_CREDENTIAL_SCRIPT" in line) == 1
@@ -472,11 +506,10 @@ def test_make_buildah_pod_pull_side_credential_exchange_for_different_host_base_
     init_containers = pod.spec.init_containers
     assert len(init_containers) == 1
     assert init_containers[0].name == "registry-credential-exchange-pull"
-    assert "--provider" in init_containers[0].args
-    assert provider in init_containers[0].args
-    assert "--registry" in init_containers[0].args
-    assert base_registry in init_containers[0].args
-    assert "--dest" not in init_containers[0].args
+    script = init_containers[0].args[0]
+    assert f"--provider {provider}" in script
+    assert f"--registry {base_registry}" in script
+    assert "--dest" not in script
 
     empty_dir_volumes = {
         volume.name for volume in pod.spec.volumes if volume.empty_dir is not None
@@ -503,8 +536,8 @@ def test_make_buildah_pod_push_and_pull_different_acr_hosts():
     }
 
     by_name = {container.name: container for container in init_containers}
-    assert "push.azurecr.io" in by_name["registry-credential-exchange"].args
-    assert "system.azurecr.io" in by_name["registry-credential-exchange-pull"].args
+    assert "push.azurecr.io" in by_name["registry-credential-exchange"].args[0]
+    assert "system.azurecr.io" in by_name["registry-credential-exchange-pull"].args[0]
 
 
 def test_make_buildah_pod_same_registry_skips_duplicate_exchange():
@@ -521,15 +554,22 @@ def test_make_buildah_pod_same_registry_skips_duplicate_exchange():
     assert init_containers[0].name == "registry-credential-exchange"
 
 
-def test_make_buildah_pod_static_secret_skips_cloud_pull_exchange():
-    # an explicit secret_name always wins, even when the base image (not just the push
-    # destination) lives on a recognized cloud registry - no credential-exchange init container.
+def test_make_buildah_pod_secret_and_cloud_pull_exchange_merge():
+    # ML-12988: secret_name authenticates the push destination (a non-cloud registry here), but
+    # the base image lives on a recognized cloud registry - pull-side credential exchange must
+    # still run, merging into the authfile alongside the copied-in secret.
     buildah_pod = _make_buildah_pod(
         dest="docker-hub/some-image:tag",
         base_image="system.azurecr.io/mlrun/mlrun:1.13.0-rc2",
         secret_name="my-docker-secret",
     )
-    assert buildah_pod.pod.spec.init_containers == []
+    init_container_names = [
+        container.name for container in buildah_pod.pod.spec.init_containers
+    ]
+    assert init_container_names == [
+        "copy-registry-auth-secret",
+        "registry-credential-exchange-pull",
+    ]
 
 
 def test_make_buildah_pod_pull_tls_verify_unaffected_by_unrelated_gar_push():

--- a/server/py/services/api/tests/unit/utils/test_registry_auth.py
+++ b/server/py/services/api/tests/unit/utils/test_registry_auth.py
@@ -73,18 +73,22 @@ def _init_container(pod) -> object:
 
 
 def test_append_secret_authfile_init_container():
-    # ML-12988: copies the secret in via `cp` (no shell, no soft-fail - a misconfigured secret is a
-    # real error worth surfacing directly), using buildah_image since the main container always
-    # pulls it anyway - never the credential-exchange image, which a GAR-only build wouldn't
-    # otherwise need.
+    # ML-12988: copies the secret in via `cp` (no soft-fail - a misconfigured secret is a real
+    # error worth surfacing directly), using buildah_image since the main container always pulls it
+    # anyway - never the credential-exchange image, which a GAR-only build wouldn't otherwise need.
+    # Also chmods the copy world-writable: this init container gets no explicit security context,
+    # so its UID is never guaranteed to match whichever container merges into the file next.
     pod = framework.utils.singletons.k8s.BasePod(task_name="t", image="img")
     registry_auth.append_secret_authfile_init_container(pod, "/auth/config.json")
 
     container = _init_container(pod)
     assert container.name == "copy-registry-auth-secret"
     assert container.image == config.httpdb.builder.buildah_image
-    assert container.command == ["cp"]
-    assert container.args == ["/auth-secret/config.json", "/auth/config.json"]
+    assert container.command == ["/bin/sh", "-c"]
+    assert len(container.args) == 1
+    script = container.args[0]
+    assert "cp /auth-secret/config.json /auth/config.json" in script
+    assert "chmod 0666 /auth/config.json" in script
 
 
 def test_append_ecr_credential_exchange_init_container():

--- a/server/py/services/api/tests/unit/utils/test_registry_auth.py
+++ b/server/py/services/api/tests/unit/utils/test_registry_auth.py
@@ -195,11 +195,20 @@ def test_gar_credential_exchange_script_uses_metadata_server_only(
 
 
 def test_gar_credential_exchange_script_merges_existing_entry(tmp_path, monkeypatch):
-    # a push-side and a pull-side GAR script (different hosts, ML-12961), or an ACR/ECR init
-    # container that ran first, may already have written an entry - this must merge, not clobber it.
+    # a push-side and a pull-side GAR script (different hosts, ML-12961), an ACR/ECR init
+    # container, or a copied-in static secret (ML-12988) may already have written to this file -
+    # this must merge, not clobber it, and must preserve any other top-level docker-config keys
+    # (credHelpers, credsStore, ...) the secret may have carried, not just the sibling auths entry.
     authfile = tmp_path / "config.json"
     other_registry = "myregistry.azurecr.io"
-    authfile.write_text(json.dumps({"auths": {other_registry: {"auth": "existing"}}}))
+    authfile.write_text(
+        json.dumps(
+            {
+                "auths": {other_registry: {"auth": "existing"}},
+                "credHelpers": {"some.other.registry": "docker-credential-helper"},
+            }
+        )
+    )
 
     monkeypatch.setattr(
         "urllib.request.urlopen",
@@ -212,7 +221,9 @@ def test_gar_credential_exchange_script_merges_existing_entry(tmp_path, monkeypa
     script = registry_auth.gar_credential_exchange_script(registry, str(authfile))
     exec(script, {})  # noqa: S102 - exercising the generated script, not user input
 
-    auths = json.loads(authfile.read_text())["auths"]
+    written = json.loads(authfile.read_text())
+    auths = written["auths"]
     assert auths[other_registry]["auth"] == "existing"
     decoded = base64.b64decode(auths[registry]["auth"]).decode()
     assert decoded == "oauth2accesstoken:gcp-token"
+    assert written["credHelpers"] == {"some.other.registry": "docker-credential-helper"}

--- a/server/py/services/api/tests/unit/utils/test_registry_auth.py
+++ b/server/py/services/api/tests/unit/utils/test_registry_auth.py
@@ -55,6 +55,21 @@ def _init_container(pod) -> object:
     return pod.init_containers[0]
 
 
+def test_append_secret_authfile_init_container():
+    # ML-12988: copies the secret in via `cp` (no shell, no soft-fail - a misconfigured secret is a
+    # real error worth surfacing directly), using buildah_image since the main container always
+    # pulls it anyway - never the credential-exchange image, which a GAR-only build wouldn't
+    # otherwise need.
+    pod = framework.utils.singletons.k8s.BasePod(task_name="t", image="img")
+    registry_auth.append_secret_authfile_init_container(pod, "/auth/config.json")
+
+    container = _init_container(pod)
+    assert container.name == "copy-registry-auth-secret"
+    assert container.image == config.httpdb.builder.buildah_image
+    assert container.command == ["cp"]
+    assert container.args == ["/auth-secret/config.json", "/auth/config.json"]
+
+
 def test_append_ecr_credential_exchange_init_container():
     pod = framework.utils.singletons.k8s.BasePod(task_name="t", image="img")
     registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
@@ -67,20 +82,19 @@ def test_append_ecr_credential_exchange_init_container():
     assert container.name == "registry-credential-exchange"
     # same python -m mlrun <subcommand> convention Kaniko's source-fetch init container uses -
     # mlrun is installed on the init container's image, so there's no need to inline a script.
-    assert container.command == ["python"]
-    assert container.args == [
-        "-m",
-        "mlrun",
-        "mint-registry-credentials",
-        "--provider",
-        "ecr",
-        "--registry",
-        registry,
-        "--dest",
-        dest,
-        "--authfile",
-        "/auth/config.json",
-    ]
+    # Wrapped in a shell so a failed mint (ML-12988) logs a warning and exits 0 rather than
+    # failing the pod - see registry_auth.soft_fail_script.
+    assert container.command == ["/bin/sh", "-c"]
+    assert len(container.args) == 1
+    script = container.args[0]
+    assert script.startswith("python -m mlrun mint-registry-credentials")
+    assert "--provider ecr" in script
+    assert f"--registry {registry}" in script
+    assert f"--dest {dest}" in script
+    assert "--authfile /auth/config.json" in script
+    assert script.endswith(
+        "|| echo 'WARNING: failed to mint ECR registry credentials' >&2"
+    )
 
 
 def test_append_ecr_credential_exchange_init_container_pull_only_omits_dest():
@@ -97,18 +111,11 @@ def test_append_ecr_credential_exchange_init_container_pull_only_omits_dest():
 
     container = _init_container(pod)
     assert container.name == "registry-credential-exchange-pull"
-    assert "--dest" not in container.args
-    assert container.args == [
-        "-m",
-        "mlrun",
-        "mint-registry-credentials",
-        "--provider",
-        "ecr",
-        "--registry",
-        registry,
-        "--authfile",
-        "/auth/config.json",
-    ]
+    script = container.args[0]
+    assert "--dest" not in script
+    assert "--provider ecr" in script
+    assert f"--registry {registry}" in script
+    assert "--authfile /auth/config.json" in script
 
 
 def test_append_acr_credential_exchange_init_container():
@@ -120,18 +127,15 @@ def test_append_acr_credential_exchange_init_container():
 
     container = _init_container(pod)
     assert container.name == "registry-credential-exchange"
-    assert container.command == ["python"]
-    assert container.args == [
-        "-m",
-        "mlrun",
-        "mint-registry-credentials",
-        "--provider",
-        "acr",
-        "--registry",
-        registry,
-        "--authfile",
-        "/auth/config.json",
-    ]
+    assert container.command == ["/bin/sh", "-c"]
+    script = container.args[0]
+    assert script.startswith("python -m mlrun mint-registry-credentials")
+    assert "--provider acr" in script
+    assert f"--registry {registry}" in script
+    assert "--authfile /auth/config.json" in script
+    assert script.endswith(
+        "|| echo 'WARNING: failed to mint ACR registry credentials' >&2"
+    )
 
 
 def test_append_acr_credential_exchange_init_container_custom_container_name():

--- a/server/py/services/api/tests/unit/utils/test_registry_auth.py
+++ b/server/py/services/api/tests/unit/utils/test_registry_auth.py
@@ -50,6 +50,23 @@ def test_classify_cloud_registry(target, expected):
     assert registry_auth.classify_cloud_registry(target) == expected
 
 
+@pytest.mark.parametrize(
+    "image,expected",
+    [
+        ("us-docker.pkg.dev/some-project/some-image:tag", "us-docker.pkg.dev"),
+        ("myregistry.azurecr.io/mlrun/mlrun:1.13.0-rc2", "myregistry.azurecr.io"),
+        ("localhost:5000/some-image:tag", "localhost:5000"),
+        ("localhost/some-image:tag", "localhost"),
+        # no explicit registry - implicitly Docker Hub, per Docker's own reference-parsing rule
+        ("python:3.11-slim", None),
+        ("some-org/some-image:tag", None),
+        ("mlrun/mlrun:1.13.0-rc2", None),
+    ],
+)
+def test_registry_from_image(image, expected):
+    assert registry_auth.registry_from_image(image) == expected
+
+
 def _init_container(pod) -> object:
     assert len(pod.init_containers) == 1
     return pod.init_containers[0]

--- a/server/py/services/api/tests/unit/utils/test_registry_auth.py
+++ b/server/py/services/api/tests/unit/utils/test_registry_auth.py
@@ -21,6 +21,7 @@
 # push-side one in the same pod - see test_builder_backend.py for the make_buildah_pod-level wiring.
 
 import base64
+import io
 import json
 import unittest.mock
 
@@ -186,4 +187,28 @@ def test_gar_credential_exchange_script_uses_metadata_server_only(
 
     written = json.loads(authfile.read_text())
     decoded = base64.b64decode(written["auths"][registry]["auth"]).decode()
+    assert decoded == "oauth2accesstoken:gcp-token"
+
+
+def test_gar_credential_exchange_script_merges_existing_entry(tmp_path, monkeypatch):
+    # a push-side and a pull-side GAR script (different hosts, ML-12961), or an ACR/ECR init
+    # container that ran first, may already have written an entry - this must merge, not clobber it.
+    authfile = tmp_path / "config.json"
+    other_registry = "myregistry.azurecr.io"
+    authfile.write_text(json.dumps({"auths": {other_registry: {"auth": "existing"}}}))
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        unittest.mock.Mock(
+            return_value=io.BytesIO(json.dumps({"access_token": "gcp-token"}).encode())
+        ),
+    )
+
+    registry = "us-docker.pkg.dev"
+    script = registry_auth.gar_credential_exchange_script(registry, str(authfile))
+    exec(script, {})  # noqa: S102 - exercising the generated script, not user input
+
+    auths = json.loads(authfile.read_text())["auths"]
+    assert auths[other_registry]["auth"] == "existing"
+    decoded = base64.b64decode(auths[registry]["auth"]).decode()
     assert decoded == "oauth2accesstoken:gcp-token"

--- a/server/py/services/api/tests/unit/utils/test_registry_auth.py
+++ b/server/py/services/api/tests/unit/utils/test_registry_auth.py
@@ -16,7 +16,9 @@
 # ECR/ACR init-container wiring (they invoke `python -m mlrun mint-registry-credentials` - see
 # tests/utils/test_registry_auth.py for the actual credential-exchange logic those calls run), and
 # the generated GAR/GCR script (no mlrun installed where it runs, so it stays a generated script
-# `exec()`'d directly here with the underlying stdlib call mocked).
+# `exec()`'d directly here with the underlying stdlib call mocked). Also covers the optional `dest`
+# and `container_name` (ML-12961) that let a pull-side (base-image) exchange run alongside a
+# push-side one in the same pod - see test_builder_backend.py for the make_buildah_pod-level wiring.
 
 import base64
 import json
@@ -57,7 +59,7 @@ def test_append_ecr_credential_exchange_init_container():
     registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
     dest = f"{registry}/myrepo:latest"
     registry_auth.append_ecr_credential_exchange_init_container(
-        pod, registry, dest, "/auth/config.json"
+        pod, registry, "/auth/config.json", dest=dest
     )
 
     container = _init_container(pod)
@@ -75,6 +77,34 @@ def test_append_ecr_credential_exchange_init_container():
         registry,
         "--dest",
         dest,
+        "--authfile",
+        "/auth/config.json",
+    ]
+
+
+def test_append_ecr_credential_exchange_init_container_pull_only_omits_dest():
+    # a base-image (pull-only) exchange has no dest - no reason to create a repository, and the
+    # container name must differ so it can coexist with a push-side exchange in the same pod.
+    pod = framework.utils.singletons.k8s.BasePod(task_name="t", image="img")
+    registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    registry_auth.append_ecr_credential_exchange_init_container(
+        pod,
+        registry,
+        "/auth/config.json",
+        container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
+    )
+
+    container = _init_container(pod)
+    assert container.name == "registry-credential-exchange-pull"
+    assert "--dest" not in container.args
+    assert container.args == [
+        "-m",
+        "mlrun",
+        "mint-registry-credentials",
+        "--provider",
+        "ecr",
+        "--registry",
+        registry,
         "--authfile",
         "/auth/config.json",
     ]
@@ -101,6 +131,21 @@ def test_append_acr_credential_exchange_init_container():
         "--authfile",
         "/auth/config.json",
     ]
+
+
+def test_append_acr_credential_exchange_init_container_custom_container_name():
+    # a pull-side (base-image) exchange running alongside a push-side one in the same pod needs a
+    # distinct container name - k8s requires unique container names within a pod.
+    pod = framework.utils.singletons.k8s.BasePod(task_name="t", image="img")
+    registry = "myregistry.azurecr.io"
+    registry_auth.append_acr_credential_exchange_init_container(
+        pod,
+        registry,
+        "/auth/config.json",
+        container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
+    )
+
+    assert _init_container(pod).name == "registry-credential-exchange-pull"
 
 
 def test_credential_exchange_image_defaults_to_default_base_image(monkeypatch):

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -44,7 +44,7 @@ _CONTEXT_DIR = "/empty"
 
 # the authfile: an emptyDir populated by any combination of a copied-in static docker-config
 # secret, ECR/ACR init containers, and GAR's JIT script in this container's own bud/push script -
-# merged per host (ML-12988), not mutually exclusive, so a secret authenticating one registry
+# merged per registry (ML-12988), not mutually exclusive, so a secret authenticating one registry
 # (e.g. a private base image) coexists with cloud exchange for another (e.g. the push
 # destination). See services.api.utils.builder.registry_auth for the cloud-credential-exchange
 # implementations.
@@ -234,8 +234,8 @@ def make_buildah_pod(
     :param requirements:       The resolved requirements list to stage, if any.
     :param requirements_path:  Path of the requirements file inside the build context.
     :param secret_name:        A docker-config secret to merge into the authfile, if any - covers
-                               whichever host(s) it has entries for; a cloud provider covering a
-                               *different* host still gets credential exchange (ML-12988).
+                               whichever registries it has entries for; a cloud provider covering a
+                               *different* registry still gets credential exchange (ML-12988).
     :param name:               The build pod's base name.
     :param verbose:            Whether to run Buildah with ``--log-level debug``.
     :param builder_env:        Build-time env vars, rendered as ``--build-arg`` (value read from env).
@@ -258,21 +258,24 @@ def make_buildah_pod(
         # if the registry was not given, infer it from the image destination
         registry = dest.partition("/")[0]
 
-    # ECR/ACR/GAR need credential-exchange auth (see registry_auth); anything else (Docker Hub,
-    # private, self-signed) sticks to the static docker-config secret path. Resolved independently
-    # of secret_name (ML-12988): a secret may authenticate a *different* host than this one (e.g. a
-    # private base-image registry alongside a cloud push destination), so it must not disable cloud
-    # exchange for a host it was never meant to cover - the two are merged into the authfile instead
-    # (see the secret-copy init container below).
-    push_cloud_provider = registry_auth.classify_cloud_registry(registry)
+    base_registry = base_image.partition("/")[0] if base_image else None
 
+    # every distinct registry this build touches, and which role(s) it plays there - a secret may
+    # authenticate a *different* registry than either of these (e.g. a private base-image registry
+    # alongside a cloud push destination, ML-12988), so it's resolved independently below and
+    # merged into the authfile instead (see the secret-copy init container), never gated by this.
+    roles_by_registry: dict[str, set[str]] = {registry: {"push"}}
+    if base_registry:
+        roles_by_registry.setdefault(base_registry, set()).add("pull")
+
+    # ECR/ACR/GAR need credential-exchange auth (see registry_auth); anything else (Docker Hub,
+    # private, self-signed) sticks to the static docker-config secret path.
+    push_cloud_provider = registry_auth.classify_cloud_registry(registry)
     # the base image's registry needs its own credential exchange too (ML-12961) - e.g. a "system"
     # ACR hosting mlrun's own images vs. a per-project push target. Classified unconditionally, even
-    # when it's the same host as the push destination: GAR mints pull and push credentials
-    # independently either way (see _build_script), while ECR/ACR's pull-side init container is
-    # skipped below when the hosts match, since the push-side one already wrote that entry.
-    base_registry = base_image.partition("/")[0] if base_image else None
-    base_shares_push_registry = bool(base_registry) and base_registry == registry
+    # when it's the same registry as the push destination: GAR mints pull and push credentials
+    # independently either way (see _build_script); ECR/ACR instead dedupe on the shared registry
+    # via roles_by_registry below.
     pull_cloud_provider = (
         registry_auth.classify_cloud_registry(base_registry) if base_registry else None
     )
@@ -295,10 +298,7 @@ def make_buildah_pod(
         requirements=requirements,
         requirements_path=requirements_path,
         secret_name=secret_name,
-        push_cloud_provider=push_cloud_provider,
-        pull_cloud_provider=pull_cloud_provider,
-        registry=registry,
-        base_registry=base_registry,
+        roles_by_registry=roles_by_registry,
         builder_env=builder_env,
         project_secrets=project_secrets,
     )
@@ -307,8 +307,7 @@ def make_buildah_pod(
         storage_driver=storage_driver,
         verbose=verbose,
         secret_name=secret_name,
-        push_cloud_provider=push_cloud_provider,
-        pull_cloud_provider=pull_cloud_provider,
+        roles_by_registry=roles_by_registry,
         inline_code=inline_code,
         inline_path=inline_path,
         requirements=requirements,
@@ -364,41 +363,40 @@ def make_buildah_pod(
             registry_auth.append_secret_authfile_init_container(
                 buildah_pod, _AUTHFILE_PATH
             )
-        if push_cloud_provider == CloudRegistryProvider.ECR:
-            registry_auth.append_ecr_credential_exchange_init_container(
-                buildah_pod, registry, _AUTHFILE_PATH, dest=dest
-            )
-        elif push_cloud_provider == CloudRegistryProvider.ACR:
-            registry_auth.append_acr_credential_exchange_init_container(
-                buildah_pod, registry, _AUTHFILE_PATH
-            )
         # GAR/GCR gets no init container - the authfile is written just-in-time by this container's
         # own script (see _build_script), into the mount above rather than the root filesystem, for
         # both the push destination and the base image's registry.
-
-        # the base image's registry, when it needs its own exchange (see pull_cloud_provider above)
-        # - a distinct container name, since both can run in the same pod. Skipped when it's the same
-        # host as the push destination: the container above already wrote that host's authfile entry.
-        if (
-            pull_cloud_provider == CloudRegistryProvider.ECR
-            and not base_shares_push_registry
-        ):
-            registry_auth.append_ecr_credential_exchange_init_container(
-                buildah_pod,
-                base_registry,
-                _AUTHFILE_PATH,
-                container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
+        #
+        # ECR/ACR mint via one init container per distinct registry: a registry playing both push
+        # and pull (i.e. the push destination and base image are the same) gets exactly one,
+        # parameterized by the union of its roles - only a push role creates the destination
+        # repository, and only a pull-only registry (never a push-covering one) gets the "-pull"
+        # container name, since a push-side container can coexist with a different pull-side
+        # registry in the same pod.
+        for target_registry, roles in roles_by_registry.items():
+            provider = registry_auth.classify_cloud_registry(target_registry)
+            container_name_kwargs = (
+                {
+                    "container_name": registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME
+                }
+                if roles == {"pull"}
+                else {}
             )
-        elif (
-            pull_cloud_provider == CloudRegistryProvider.ACR
-            and not base_shares_push_registry
-        ):
-            registry_auth.append_acr_credential_exchange_init_container(
-                buildah_pod,
-                base_registry,
-                _AUTHFILE_PATH,
-                container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
-            )
+            if provider == CloudRegistryProvider.ECR:
+                registry_auth.append_ecr_credential_exchange_init_container(
+                    buildah_pod,
+                    target_registry,
+                    _AUTHFILE_PATH,
+                    dest=dest if "push" in roles else None,
+                    **container_name_kwargs,
+                )
+            elif provider == CloudRegistryProvider.ACR:
+                registry_auth.append_acr_credential_exchange_init_container(
+                    buildah_pod,
+                    target_registry,
+                    _AUTHFILE_PATH,
+                    **container_name_kwargs,
+                )
     elif secret_name:
         # no cloud provider involved - mount the secret directly as the authfile, unchanged.
         buildah_pod.mount_secret(
@@ -439,10 +437,7 @@ def _build_env(
     requirements: list | None,
     requirements_path: str | None,
     secret_name: str | None,
-    push_cloud_provider: CloudRegistryProvider | None,
-    pull_cloud_provider: CloudRegistryProvider | None,
-    registry: str,
-    base_registry: str | None,
+    roles_by_registry: dict[str, set[str]],
     builder_env: list | None,
     project_secrets: list | None,
 ) -> list[client.V1EnvVar]:
@@ -453,34 +448,41 @@ def _build_env(
         client.V1EnvVar(name="HOME", value=_BUILD_HOME),
         client.V1EnvVar(name="MLRUN_DOCKERFILE", value=_b64(dockerfile)),
     ]
-    if secret_name or push_cloud_provider or pull_cloud_provider:
+    has_cloud_registry = any(
+        registry_auth.classify_cloud_registry(registry)
+        for registry in roles_by_registry
+    )
+    if secret_name or has_cloud_registry:
         env.append(client.V1EnvVar(name="REGISTRY_AUTH_FILE", value=_AUTHFILE_PATH))
-    if push_cloud_provider == CloudRegistryProvider.GAR:
-        # minted just-in-time by this same container's push script, not an init container - see
-        # registry_auth.gar_credential_exchange_script.
-        env.append(
-            client.V1EnvVar(
-                name="MLRUN_GAR_CREDENTIAL_SCRIPT",
-                value=_b64(
-                    registry_auth.gar_credential_exchange_script(
-                        registry, _AUTHFILE_PATH
-                    )
-                ),
+    # GAR/GCR is minted just-in-time by this same container's own script (see
+    # registry_auth.gar_credential_exchange_script), never via an init container - a registry
+    # playing both push and pull still gets both scripts independently, unlike ECR/ACR's init
+    # containers above: see _build_script for why this one never dedupes on a shared registry.
+    for registry, roles in roles_by_registry.items():
+        if registry_auth.classify_cloud_registry(registry) != CloudRegistryProvider.GAR:
+            continue
+        if "push" in roles:
+            env.append(
+                client.V1EnvVar(
+                    name="MLRUN_GAR_CREDENTIAL_SCRIPT",
+                    value=_b64(
+                        registry_auth.gar_credential_exchange_script(
+                            registry, _AUTHFILE_PATH
+                        )
+                    ),
+                )
             )
-        )
-    if pull_cloud_provider == CloudRegistryProvider.GAR:
-        # the base image's own GAR host, minted separately from the push destination's script above
-        # (ML-12961) - same JIT convention, merged into the same authfile.
-        env.append(
-            client.V1EnvVar(
-                name="MLRUN_GAR_PULL_CREDENTIAL_SCRIPT",
-                value=_b64(
-                    registry_auth.gar_credential_exchange_script(
-                        base_registry, _AUTHFILE_PATH
-                    )
-                ),
+        if "pull" in roles:
+            env.append(
+                client.V1EnvVar(
+                    name="MLRUN_GAR_PULL_CREDENTIAL_SCRIPT",
+                    value=_b64(
+                        registry_auth.gar_credential_exchange_script(
+                            registry, _AUTHFILE_PATH
+                        )
+                    ),
+                )
             )
-        )
     if inline_code:
         env.append(client.V1EnvVar(name="MLRUN_INLINE_CODE", value=_b64(inline_code)))
     # gate on the same condition _build_script decodes it (requirements need a target path), so the
@@ -501,8 +503,7 @@ def _build_script(
     storage_driver: str,
     verbose: bool,
     secret_name: str | None,
-    push_cloud_provider: CloudRegistryProvider | None,
-    pull_cloud_provider: CloudRegistryProvider | None,
+    roles_by_registry: dict[str, set[str]],
     inline_code: str | None,
     inline_path: str | None,
     requirements: list | None,
@@ -530,8 +531,14 @@ def _build_script(
         global_opts += ["--log-level", "debug"]
     global_opts += ["--storage-driver", storage_driver]
 
+    # `bud`/`push` are each a single Buildah invocation, so there's exactly one pull-side and one
+    # push-side question here no matter how many registries roles_by_registry ever grows to hold -
+    # this assumes one registry per role, true for both roles today (see _role_cloud_provider).
+    push_cloud_provider = _role_cloud_provider(roles_by_registry, "push")
+    pull_cloud_provider = _role_cloud_provider(roles_by_registry, "pull")
+
     has_push_auth = bool(secret_name or push_cloud_provider)
-    # a static secret covers any host; otherwise a dedicated pull-side exchange (ML-12961) covers
+    # a static secret covers any registry; otherwise a dedicated pull-side exchange (ML-12961) covers
     # the base image's own registry - classified independently of push_cloud_provider (see
     # make_buildah_pod), so an unrelated push-side provider never wrongly asserts pull auth for a
     # self-signed/private base image and disables --tls-verify=false for it in "auto" mode.
@@ -550,8 +557,8 @@ def _build_script(
     else:
         push_gar_credential_exchange = []
 
-    # the base image's own GAR host (ML-12961) - only needed before `bud`, since that's the only
-    # step that pulls the base image.
+    # the base image's own GAR registry (ML-12961) - only needed before `bud`, since that's the
+    # only step that pulls the base image.
     if pull_cloud_provider == CloudRegistryProvider.GAR:
         pull_gar_credential_exchange = [
             f"echo ${{MLRUN_GAR_PULL_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_PULL_SCRIPT_PATH)}",
@@ -588,6 +595,19 @@ def _build_script(
     lines.append(shlex.join(push))
 
     return "\n".join(lines)
+
+
+def _role_cloud_provider(
+    roles_by_registry: dict[str, set[str]], role: str
+) -> CloudRegistryProvider | None:
+    # today's build shape has exactly one registry per role (the push destination, the base image)
+    # - if roles_by_registry ever grows a second registry for the same role (e.g. a multi-stage
+    # build with several base images), this - and how has_pull_auth/has_push_auth aggregate it -
+    # needs revisiting.
+    registry = next(
+        (r for r, roles in roles_by_registry.items() if role in roles), None
+    )
+    return registry_auth.classify_cloud_registry(registry) if registry else None
 
 
 def _tls_verify_flag(mode: str, has_registry_auth: bool) -> list[str]:

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -109,6 +109,7 @@ class BuildahBackend:
         buildah_pod = make_buildah_pod(
             project=request.project,
             dest=request.image_target,
+            base_image=request.base_image,
             dockerfile=dockerfile,
             inline_code=request.inline_code,
             inline_path=request.inline_path,
@@ -202,6 +203,7 @@ def make_buildah_pod(
     project: str,
     dest: str,
     dockerfile: str,
+    base_image: str | None = None,
     inline_code: str | None = None,
     inline_path: str | None = None,
     requirements: list | None = None,
@@ -222,6 +224,8 @@ def make_buildah_pod(
     :param project:            The project the build belongs to.
     :param dest:               The fully resolved destination image reference.
     :param dockerfile:         The rendered Dockerfile content (from :func:`base.make_dockerfile`).
+    :param base_image:         The image the Dockerfile builds ``FROM``, used to also credential
+                               the base-image pull when it's on a cloud registry (ML-12961).
     :param inline_code:        Inline function code to stage into the build context, if any.
     :param inline_path:        Destination filename for ``inline_code`` (default ``main.py``).
     :param requirements:       The resolved requirements list to stage, if any.
@@ -253,9 +257,24 @@ def make_buildah_pod(
     # private, self-signed) sticks to the static docker-config secret path, unchanged. An explicit
     # secret_name always wins - e.g. a self-hosted credential on an otherwise-cloud registry host -
     # so it must never be overridden by an inferred cloud-provider exchange.
-    cloud_provider = (
+    push_cloud_provider = (
         None if secret_name else registry_auth.classify_cloud_registry(registry)
     )
+
+    # the base image's registry needs its own credential exchange when it differs from the push
+    # destination (ML-12961) - e.g. a "system" ACR hosting mlrun's own images vs. a per-project push
+    # target. When the hosts match, the push-side exchange below already writes an authfile entry
+    # for it, so there's nothing extra to do. GAR is intentionally excluded here: its existing
+    # just-in-time re-mint before `bud` (see _build_script) already covers the common same-registry
+    # case, and a cross-registry GAR pull would need a second metadata-server call path - a larger,
+    # separate change.
+    base_registry = base_image.partition("/")[0] if base_image else None
+    base_shares_push_registry = bool(base_registry) and base_registry == registry
+    pull_cloud_provider = None
+    if secret_name is None and base_registry and not base_shares_push_registry:
+        candidate = registry_auth.classify_cloud_registry(base_registry)
+        if candidate in (CloudRegistryProvider.ACR, CloudRegistryProvider.ECR):
+            pull_cloud_provider = candidate
 
     # runtime-derived scheduling/identity pod-spec attributes (node selector, affinity, tolerations,
     # preemption, priority class, service account), resolved by the shared helper both backends call.
@@ -275,7 +294,8 @@ def make_buildah_pod(
         requirements=requirements,
         requirements_path=requirements_path,
         secret_name=secret_name,
-        cloud_provider=cloud_provider,
+        push_cloud_provider=push_cloud_provider,
+        pull_cloud_provider=pull_cloud_provider,
         registry=registry,
         builder_env=builder_env,
         project_secrets=project_secrets,
@@ -285,7 +305,9 @@ def make_buildah_pod(
         storage_driver=storage_driver,
         verbose=verbose,
         secret_name=secret_name,
-        cloud_provider=cloud_provider,
+        push_cloud_provider=push_cloud_provider,
+        pull_cloud_provider=pull_cloud_provider,
+        base_shares_push_registry=base_shares_push_registry,
         inline_code=inline_code,
         inline_path=inline_path,
         requirements=requirements,
@@ -325,35 +347,54 @@ def make_buildah_pod(
         _mount_pip_ca(buildah_pod)
 
     if secret_name:
-        # mount the docker-config secret as the push authfile (static-credential registries).
+        # mount the docker-config secret as the authfile (static-credential registries) - covers
+        # both push and pull, since a docker config can hold entries for multiple hosts.
         buildah_pod.mount_secret(
             secret_name,
             _AUTHFILE_DIR,
             items=[{"key": ".dockerconfigjson", "path": "config.json"}],
         )
-    elif cloud_provider:
+    elif push_cloud_provider or pull_cloud_provider:
         # an emptyDir, not the container's own root filesystem: confirmed on a live GKE cluster
         # that the rootless build user can't mkdir at the image's filesystem root ("/auth: Permission
         # denied") - the mount is what actually guarantees a writable path, regardless of provider.
-        # For ECR/ACR it's also how the init container below hands the authfile to this container.
+        # For ECR/ACR it's also how the init container(s) below hand the authfile to this container.
         buildah_pod.mount_empty(name="registry-auth", mount_path=_AUTHFILE_DIR)
-        if cloud_provider == CloudRegistryProvider.ECR:
+        if push_cloud_provider == CloudRegistryProvider.ECR:
             registry_auth.append_ecr_credential_exchange_init_container(
-                buildah_pod, registry, dest, _AUTHFILE_PATH
+                buildah_pod, registry, _AUTHFILE_PATH, dest=dest
             )
-        elif cloud_provider == CloudRegistryProvider.ACR:
+        elif push_cloud_provider == CloudRegistryProvider.ACR:
             registry_auth.append_acr_credential_exchange_init_container(
                 buildah_pod, registry, _AUTHFILE_PATH
             )
         # GAR/GCR gets no init container - the authfile is written just-in-time by this container's
         # own push script (see _build_script), into the mount above rather than the root filesystem.
 
+        # the base image's registry, when it needs its own exchange (see pull_cloud_provider above)
+        # - a distinct container name, since both can run in the same pod.
+        if pull_cloud_provider == CloudRegistryProvider.ECR:
+            registry_auth.append_ecr_credential_exchange_init_container(
+                buildah_pod,
+                base_registry,
+                _AUTHFILE_PATH,
+                container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
+            )
+        elif pull_cloud_provider == CloudRegistryProvider.ACR:
+            registry_auth.append_acr_credential_exchange_init_container(
+                buildah_pod,
+                base_registry,
+                _AUTHFILE_PATH,
+                container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
+            )
+
     mlrun.utils.logger.debug(
         "Resolved buildah build pod",
         project=project,
         image=dest,
         storage_driver=storage_driver,
-        cloud_provider=cloud_provider,
+        push_cloud_provider=push_cloud_provider,
+        pull_cloud_provider=pull_cloud_provider,
         apparmor_profile=apparmor_profile or None,
     )
     return buildah_pod
@@ -379,7 +420,8 @@ def _build_env(
     requirements: list | None,
     requirements_path: str | None,
     secret_name: str | None,
-    cloud_provider: CloudRegistryProvider | None,
+    push_cloud_provider: CloudRegistryProvider | None,
+    pull_cloud_provider: CloudRegistryProvider | None,
     registry: str,
     builder_env: list | None,
     project_secrets: list | None,
@@ -391,9 +433,9 @@ def _build_env(
         client.V1EnvVar(name="HOME", value=_BUILD_HOME),
         client.V1EnvVar(name="MLRUN_DOCKERFILE", value=_b64(dockerfile)),
     ]
-    if secret_name or cloud_provider:
+    if secret_name or push_cloud_provider or pull_cloud_provider:
         env.append(client.V1EnvVar(name="REGISTRY_AUTH_FILE", value=_AUTHFILE_PATH))
-    if cloud_provider == CloudRegistryProvider.GAR:
+    if push_cloud_provider == CloudRegistryProvider.GAR:
         # minted just-in-time by this same container's push script, not an init container - see
         # registry_auth.gar_credential_exchange_script.
         env.append(
@@ -426,7 +468,9 @@ def _build_script(
     storage_driver: str,
     verbose: bool,
     secret_name: str | None,
-    cloud_provider: CloudRegistryProvider | None,
+    push_cloud_provider: CloudRegistryProvider | None,
+    pull_cloud_provider: CloudRegistryProvider | None,
+    base_shares_push_registry: bool,
     inline_code: str | None,
     inline_path: str | None,
     requirements: list | None,
@@ -454,7 +498,21 @@ def _build_script(
         global_opts += ["--log-level", "debug"]
     global_opts += ["--storage-driver", storage_driver]
 
-    has_push_auth = bool(secret_name or cloud_provider)
+    has_push_auth = bool(secret_name or push_cloud_provider)
+    # pull auth: a static secret covers any host. Otherwise, either a dedicated pull-side exchange
+    # (ML-12961, different-host ACR/ECR base image) or - only when the base image actually shares
+    # the push destination's GAR host - the JIT re-mint below supplies credentials for the pull too.
+    # Unlike pull_cloud_provider, push_cloud_provider alone says nothing about the base image's own
+    # registry, so it must never assert pull auth on its own - that would wrongly disable
+    # --tls-verify=false for an unrelated (e.g. self-signed) base-image registry in "auto" mode.
+    has_pull_auth = bool(
+        secret_name
+        or pull_cloud_provider
+        or (
+            push_cloud_provider == CloudRegistryProvider.GAR
+            and base_shares_push_registry
+        )
+    )
 
     # GAR/GCR credentials are minted JIT (see registry_auth.gar_credential_exchange_script) rather
     # than by an earlier init container: the metadata server caches and reuses a token across callers
@@ -462,7 +520,7 @@ def _build_script(
     # little as ~5 minutes left, regardless of when it's minted. Minting immediately before both bud
     # (in case the base image shares the same registry) and push minimizes the gap between mint and
     # use, rather than relying on a single early mint to outlast the whole build.
-    if cloud_provider == CloudRegistryProvider.GAR:
+    if push_cloud_provider == CloudRegistryProvider.GAR:
         gar_credential_exchange = [
             f"echo ${{MLRUN_GAR_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_SCRIPT_PATH)}",
             shlex.join(["python3", _GAR_SCRIPT_PATH]),
@@ -479,10 +537,8 @@ def _build_script(
     # RUN steps run in a real, isolated build sandbox that can't see files staged into the context
     # dir (e.g. requirements.txt) unless it's bind-mounted back in.
     bud += ["--volume", f"{_CONTEXT_DIR}:{_CONTEXT_DIR}"]
-    # pull auth is intentionally scoped to secret_name, not cloud_provider: it's about arbitrary
-    # base-image registries, unrelated to the *destination*'s cloud classification.
     bud += _tls_verify_flag(
-        config.httpdb.builder.insecure_pull_registry_mode, bool(secret_name)
+        config.httpdb.builder.insecure_pull_registry_mode, has_pull_auth
     )
     for arg_name in build_arg_names:
         bud += ["--build-arg", arg_name]

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -461,21 +461,13 @@ def _build_env(
     for registry, roles in roles_by_registry.items():
         if registry_auth.classify_cloud_registry(registry) != CloudRegistryProvider.GAR:
             continue
-        if "push" in roles:
-            env.append(
-                client.V1EnvVar(
-                    name="MLRUN_GAR_CREDENTIAL_SCRIPT",
-                    value=_b64(
-                        registry_auth.gar_credential_exchange_script(
-                            registry, _AUTHFILE_PATH
-                        )
-                    ),
-                )
+        for role in roles:
+            env_var_name = (
+                f"MLRUN_GAR{'_PULL' if role == 'pull' else ''}_CREDENTIAL_SCRIPT"
             )
-        if "pull" in roles:
             env.append(
                 client.V1EnvVar(
-                    name="MLRUN_GAR_PULL_CREDENTIAL_SCRIPT",
+                    name=env_var_name,
                     value=_b64(
                         registry_auth.gar_credential_exchange_script(
                             registry, _AUTHFILE_PATH

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -50,8 +50,9 @@ _AUTHFILE_DIR = "/auth"
 _AUTHFILE_PATH = f"{_AUTHFILE_DIR}/config.json"
 
 # where the GAR/GCR JIT credential-exchange script (see registry_auth.gar_credential_exchange_script)
-# is decoded to before running it.
+# is decoded to before running it - push destination and, when it's a different GAR host, base image.
 _GAR_SCRIPT_PATH = "/tmp/mlrun-gar-credential-exchange.py"
+_GAR_PULL_SCRIPT_PATH = "/tmp/mlrun-gar-credential-exchange-pull.py"
 
 # the AppArmor profile is applied via a per-container annotation (the k8s client in the test image is
 # capped below the securityContext.appArmorProfile field by KFP v1, and the annotation is also honored
@@ -264,17 +265,12 @@ def make_buildah_pod(
     # the base image's registry needs its own credential exchange when it differs from the push
     # destination (ML-12961) - e.g. a "system" ACR hosting mlrun's own images vs. a per-project push
     # target. When the hosts match, the push-side exchange below already writes an authfile entry
-    # for it, so there's nothing extra to do. GAR is intentionally excluded here: its existing
-    # just-in-time re-mint before `bud` (see _build_script) already covers the common same-registry
-    # case, and a cross-registry GAR pull would need a second metadata-server call path - a larger,
-    # separate change.
+    # for it, so there's nothing extra to do.
     base_registry = base_image.partition("/")[0] if base_image else None
     base_shares_push_registry = bool(base_registry) and base_registry == registry
     pull_cloud_provider = None
     if secret_name is None and base_registry and not base_shares_push_registry:
-        candidate = registry_auth.classify_cloud_registry(base_registry)
-        if candidate in (CloudRegistryProvider.ACR, CloudRegistryProvider.ECR):
-            pull_cloud_provider = candidate
+        pull_cloud_provider = registry_auth.classify_cloud_registry(base_registry)
 
     # runtime-derived scheduling/identity pod-spec attributes (node selector, affinity, tolerations,
     # preemption, priority class, service account), resolved by the shared helper both backends call.
@@ -297,6 +293,7 @@ def make_buildah_pod(
         push_cloud_provider=push_cloud_provider,
         pull_cloud_provider=pull_cloud_provider,
         registry=registry,
+        base_registry=base_registry,
         builder_env=builder_env,
         project_secrets=project_secrets,
     )
@@ -369,7 +366,8 @@ def make_buildah_pod(
                 buildah_pod, registry, _AUTHFILE_PATH
             )
         # GAR/GCR gets no init container - the authfile is written just-in-time by this container's
-        # own push script (see _build_script), into the mount above rather than the root filesystem.
+        # own script (see _build_script), into the mount above rather than the root filesystem, for
+        # both the push destination and, when it differs, the base image's registry.
 
         # the base image's registry, when it needs its own exchange (see pull_cloud_provider above)
         # - a distinct container name, since both can run in the same pod.
@@ -423,6 +421,7 @@ def _build_env(
     push_cloud_provider: CloudRegistryProvider | None,
     pull_cloud_provider: CloudRegistryProvider | None,
     registry: str,
+    base_registry: str | None,
     builder_env: list | None,
     project_secrets: list | None,
 ) -> list[client.V1EnvVar]:
@@ -444,6 +443,19 @@ def _build_env(
                 value=_b64(
                     registry_auth.gar_credential_exchange_script(
                         registry, _AUTHFILE_PATH
+                    )
+                ),
+            )
+        )
+    if pull_cloud_provider == CloudRegistryProvider.GAR:
+        # the base image's own GAR host, minted separately from the push destination's script above
+        # (ML-12961) - same JIT convention, merged into the same authfile.
+        env.append(
+            client.V1EnvVar(
+                name="MLRUN_GAR_PULL_CREDENTIAL_SCRIPT",
+                value=_b64(
+                    registry_auth.gar_credential_exchange_script(
+                        base_registry, _AUTHFILE_PATH
                     )
                 ),
             )
@@ -521,16 +533,27 @@ def _build_script(
     # (in case the base image shares the same registry) and push minimizes the gap between mint and
     # use, rather than relying on a single early mint to outlast the whole build.
     if push_cloud_provider == CloudRegistryProvider.GAR:
-        gar_credential_exchange = [
+        push_gar_credential_exchange = [
             f"echo ${{MLRUN_GAR_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_SCRIPT_PATH)}",
             shlex.join(["python3", _GAR_SCRIPT_PATH]),
         ]
     else:
-        gar_credential_exchange = []
+        push_gar_credential_exchange = []
+
+    # the base image's own GAR host (ML-12961), when it differs from the push destination's - only
+    # needed before `bud`, since that's the only step that pulls the base image.
+    if pull_cloud_provider == CloudRegistryProvider.GAR:
+        pull_gar_credential_exchange = [
+            f"echo ${{MLRUN_GAR_PULL_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_PULL_SCRIPT_PATH)}",
+            shlex.join(["python3", _GAR_PULL_SCRIPT_PATH]),
+        ]
+    else:
+        pull_gar_credential_exchange = []
 
     # First we do a credential exchange to ensure we have credentials for the
     # build
-    lines += gar_credential_exchange
+    lines += pull_gar_credential_exchange
+    lines += push_gar_credential_exchange
 
     bud = global_opts + ["bud"]
     # unlike Kaniko - whose RUN steps execute directly on the build pod's own filesystem - Buildah's
@@ -546,8 +569,9 @@ def _build_script(
     lines.append(shlex.join(bud))
 
     # We do another credential exchange to ensure we have credentials for the
-    # push since it can be that the token expired during the build
-    lines += gar_credential_exchange
+    # push since it can be that the token expired during the build - only the push destination's
+    # script; the base image was already pulled by `bud` above, nothing left to credential for it.
+    lines += push_gar_credential_exchange
 
     push = global_opts + ["push"]
     push += _tls_verify_flag(

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -52,7 +52,7 @@ _AUTHFILE_DIR = "/auth"
 _AUTHFILE_PATH = f"{_AUTHFILE_DIR}/config.json"
 
 # where the GAR/GCR JIT credential-exchange script (see registry_auth.gar_credential_exchange_script)
-# is decoded to before running it - push destination and, when it's a different GAR host, base image.
+# is decoded to before running it - push destination and base image, minted independently.
 _GAR_SCRIPT_PATH = "/tmp/mlrun-gar-credential-exchange.py"
 _GAR_PULL_SCRIPT_PATH = "/tmp/mlrun-gar-credential-exchange-pull.py"
 
@@ -266,15 +266,16 @@ def make_buildah_pod(
     # (see the secret-copy init container below).
     push_cloud_provider = registry_auth.classify_cloud_registry(registry)
 
-    # the base image's registry needs its own credential exchange when it differs from the push
-    # destination (ML-12961) - e.g. a "system" ACR hosting mlrun's own images vs. a per-project push
-    # target. When the hosts match, the push-side exchange below already writes an authfile entry
-    # for it, so there's nothing extra to do.
+    # the base image's registry needs its own credential exchange too (ML-12961) - e.g. a "system"
+    # ACR hosting mlrun's own images vs. a per-project push target. Classified unconditionally, even
+    # when it's the same host as the push destination: GAR mints pull and push credentials
+    # independently either way (see _build_script), while ECR/ACR's pull-side init container is
+    # skipped below when the hosts match, since the push-side one already wrote that entry.
     base_registry = base_image.partition("/")[0] if base_image else None
     base_shares_push_registry = bool(base_registry) and base_registry == registry
-    pull_cloud_provider = None
-    if base_registry and not base_shares_push_registry:
-        pull_cloud_provider = registry_auth.classify_cloud_registry(base_registry)
+    pull_cloud_provider = (
+        registry_auth.classify_cloud_registry(base_registry) if base_registry else None
+    )
 
     # runtime-derived scheduling/identity pod-spec attributes (node selector, affinity, tolerations,
     # preemption, priority class, service account), resolved by the shared helper both backends call.
@@ -308,7 +309,6 @@ def make_buildah_pod(
         secret_name=secret_name,
         push_cloud_provider=push_cloud_provider,
         pull_cloud_provider=pull_cloud_provider,
-        base_shares_push_registry=base_shares_push_registry,
         inline_code=inline_code,
         inline_path=inline_path,
         requirements=requirements,
@@ -374,18 +374,25 @@ def make_buildah_pod(
             )
         # GAR/GCR gets no init container - the authfile is written just-in-time by this container's
         # own script (see _build_script), into the mount above rather than the root filesystem, for
-        # both the push destination and, when it differs, the base image's registry.
+        # both the push destination and the base image's registry.
 
         # the base image's registry, when it needs its own exchange (see pull_cloud_provider above)
-        # - a distinct container name, since both can run in the same pod.
-        if pull_cloud_provider == CloudRegistryProvider.ECR:
+        # - a distinct container name, since both can run in the same pod. Skipped when it's the same
+        # host as the push destination: the container above already wrote that host's authfile entry.
+        if (
+            pull_cloud_provider == CloudRegistryProvider.ECR
+            and not base_shares_push_registry
+        ):
             registry_auth.append_ecr_credential_exchange_init_container(
                 buildah_pod,
                 base_registry,
                 _AUTHFILE_PATH,
                 container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
             )
-        elif pull_cloud_provider == CloudRegistryProvider.ACR:
+        elif (
+            pull_cloud_provider == CloudRegistryProvider.ACR
+            and not base_shares_push_registry
+        ):
             registry_auth.append_acr_credential_exchange_init_container(
                 buildah_pod,
                 base_registry,
@@ -496,7 +503,6 @@ def _build_script(
     secret_name: str | None,
     push_cloud_provider: CloudRegistryProvider | None,
     pull_cloud_provider: CloudRegistryProvider | None,
-    base_shares_push_registry: bool,
     inline_code: str | None,
     inline_path: str | None,
     requirements: list | None,
@@ -525,27 +531,17 @@ def _build_script(
     global_opts += ["--storage-driver", storage_driver]
 
     has_push_auth = bool(secret_name or push_cloud_provider)
-    # pull auth: a static secret covers any host. Otherwise, either a dedicated pull-side exchange
-    # (ML-12961, different-host ACR/ECR base image) or - only when the base image actually shares
-    # the push destination's GAR host - the JIT re-mint below supplies credentials for the pull too.
-    # Unlike pull_cloud_provider, push_cloud_provider alone says nothing about the base image's own
-    # registry, so it must never assert pull auth on its own - that would wrongly disable
-    # --tls-verify=false for an unrelated (e.g. self-signed) base-image registry in "auto" mode.
-    has_pull_auth = bool(
-        secret_name
-        or pull_cloud_provider
-        or (
-            push_cloud_provider == CloudRegistryProvider.GAR
-            and base_shares_push_registry
-        )
-    )
+    # a static secret covers any host; otherwise a dedicated pull-side exchange (ML-12961) covers
+    # the base image's own registry - classified independently of push_cloud_provider (see
+    # make_buildah_pod), so an unrelated push-side provider never wrongly asserts pull auth for a
+    # self-signed/private base image and disables --tls-verify=false for it in "auto" mode.
+    has_pull_auth = bool(secret_name or pull_cloud_provider)
 
     # GAR/GCR credentials are minted JIT (see registry_auth.gar_credential_exchange_script) rather
     # than by an earlier init container: the metadata server caches and reuses a token across callers
     # until fewer than 5 minutes remain before its expiry, so any mint can hand back a token with as
-    # little as ~5 minutes left, regardless of when it's minted. Minting immediately before both bud
-    # (in case the base image shares the same registry) and push minimizes the gap between mint and
-    # use, rather than relying on a single early mint to outlast the whole build.
+    # little as ~5 minutes left, regardless of when it's minted. Pull and push are minted
+    # independently, each immediately before the one step that needs it, to minimize that gap.
     if push_cloud_provider == CloudRegistryProvider.GAR:
         push_gar_credential_exchange = [
             f"echo ${{MLRUN_GAR_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_SCRIPT_PATH)}",
@@ -554,8 +550,8 @@ def _build_script(
     else:
         push_gar_credential_exchange = []
 
-    # the base image's own GAR host (ML-12961), when it differs from the push destination's - only
-    # needed before `bud`, since that's the only step that pulls the base image.
+    # the base image's own GAR host (ML-12961) - only needed before `bud`, since that's the only
+    # step that pulls the base image.
     if pull_cloud_provider == CloudRegistryProvider.GAR:
         pull_gar_credential_exchange = [
             f"echo ${{MLRUN_GAR_PULL_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_PULL_SCRIPT_PATH)}",
@@ -565,7 +561,6 @@ def _build_script(
         pull_gar_credential_exchange = []
 
     lines += pull_gar_credential_exchange
-    lines += push_gar_credential_exchange
 
     bud = global_opts + ["bud"]
     # unlike Kaniko - whose RUN steps execute directly on the build pod's own filesystem - Buildah's
@@ -580,9 +575,6 @@ def _build_script(
     bud += ["--tag", dest, "--file", dockerfile_path, _CONTEXT_DIR]
     lines.append(shlex.join(bud))
 
-    # the token may have expired during the build - re-mint before push. Only the push
-    # destination's script; the base image was already pulled by `bud` above, nothing left to
-    # credential for it.
     lines += push_gar_credential_exchange
 
     push = global_opts + ["push"]

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -42,10 +42,12 @@ _CONTAINERS_STORE = f"{_BUILD_HOME}/.local/share/containers"
 # where the Dockerfile (and any inline code / requirements) are staged and used as the build context.
 _CONTEXT_DIR = "/empty"
 
-# the push authfile: either the mounted static docker-config secret, or - for ECR/ACR - written by
-# the registry_auth init container onto this same (emptyDir) path; GAR writes it here too, but
-# just-in-time in this container's own push script (see registry_auth for why). See
-# services.api.utils.builder.registry_auth for the cloud-credential-exchange implementations.
+# the authfile: an emptyDir populated by any combination of a copied-in static docker-config
+# secret, ECR/ACR init containers, and GAR's JIT script in this container's own bud/push script -
+# merged per host (ML-12988), not mutually exclusive, so a secret authenticating one registry
+# (e.g. a private base image) coexists with cloud exchange for another (e.g. the push
+# destination). See services.api.utils.builder.registry_auth for the cloud-credential-exchange
+# implementations.
 _AUTHFILE_DIR = "/auth"
 _AUTHFILE_PATH = f"{_AUTHFILE_DIR}/config.json"
 
@@ -231,7 +233,9 @@ def make_buildah_pod(
     :param inline_path:        Destination filename for ``inline_code`` (default ``main.py``).
     :param requirements:       The resolved requirements list to stage, if any.
     :param requirements_path:  Path of the requirements file inside the build context.
-    :param secret_name:        The docker-config secret used as the push authfile, if any.
+    :param secret_name:        A docker-config secret to merge into the authfile, if any - covers
+                               whichever host(s) it has entries for; a cloud provider covering a
+                               *different* host still gets credential exchange (ML-12988).
     :param name:               The build pod's base name.
     :param verbose:            Whether to run Buildah with ``--log-level debug``.
     :param builder_env:        Build-time env vars, rendered as ``--build-arg`` (value read from env).
@@ -255,12 +259,12 @@ def make_buildah_pod(
         registry = dest.partition("/")[0]
 
     # ECR/ACR/GAR need credential-exchange auth (see registry_auth); anything else (Docker Hub,
-    # private, self-signed) sticks to the static docker-config secret path, unchanged. An explicit
-    # secret_name always wins - e.g. a self-hosted credential on an otherwise-cloud registry host -
-    # so it must never be overridden by an inferred cloud-provider exchange.
-    push_cloud_provider = (
-        None if secret_name else registry_auth.classify_cloud_registry(registry)
-    )
+    # private, self-signed) sticks to the static docker-config secret path. Resolved independently
+    # of secret_name (ML-12988): a secret may authenticate a *different* host than this one (e.g. a
+    # private base-image registry alongside a cloud push destination), so it must not disable cloud
+    # exchange for a host it was never meant to cover - the two are merged into the authfile instead
+    # (see the secret-copy init container below).
+    push_cloud_provider = registry_auth.classify_cloud_registry(registry)
 
     # the base image's registry needs its own credential exchange when it differs from the push
     # destination (ML-12961) - e.g. a "system" ACR hosting mlrun's own images vs. a per-project push
@@ -269,7 +273,7 @@ def make_buildah_pod(
     base_registry = base_image.partition("/")[0] if base_image else None
     base_shares_push_registry = bool(base_registry) and base_registry == registry
     pull_cloud_provider = None
-    if secret_name is None and base_registry and not base_shares_push_registry:
+    if base_registry and not base_shares_push_registry:
         pull_cloud_provider = registry_auth.classify_cloud_registry(base_registry)
 
     # runtime-derived scheduling/identity pod-spec attributes (node selector, affinity, tolerations,
@@ -343,20 +347,26 @@ def make_buildah_pod(
     if config.is_pip_ca_configured():
         _mount_pip_ca(buildah_pod)
 
-    if secret_name:
-        # mount the docker-config secret as the authfile (static-credential registries) - covers
-        # both push and pull, since a docker config can hold entries for multiple hosts.
-        buildah_pod.mount_secret(
-            secret_name,
-            _AUTHFILE_DIR,
-            items=[{"key": ".dockerconfigjson", "path": "config.json"}],
-        )
-    elif push_cloud_provider or pull_cloud_provider:
+    if push_cloud_provider or pull_cloud_provider:
         # an emptyDir, not the container's own root filesystem: confirmed on a live GKE cluster
         # that the rootless build user can't mkdir at the image's filesystem root ("/auth: Permission
         # denied") - the mount is what actually guarantees a writable path, regardless of provider.
         # For ECR/ACR it's also how the init container(s) below hand the authfile to this container.
         buildah_pod.mount_empty(name="registry-auth", mount_path=_AUTHFILE_DIR)
+        if secret_name:
+            # the secret may authenticate a different host than the ones needing cloud exchange
+            # (ML-12988, e.g. a private base-image registry alongside a cloud push destination).
+            # Mount it read-only elsewhere and copy it in as the first init container, rather than
+            # directly at _AUTHFILE_PATH, since the steps below need to merge into that file and
+            # can't write into a secret-backed volume mount.
+            buildah_pod.mount_secret(
+                secret_name,
+                registry_auth.SECRET_AUTHFILE_DIR,
+                items=[{"key": ".dockerconfigjson", "path": "config.json"}],
+            )
+            registry_auth.append_secret_authfile_init_container(
+                buildah_pod, _AUTHFILE_PATH
+            )
         if push_cloud_provider == CloudRegistryProvider.ECR:
             registry_auth.append_ecr_credential_exchange_init_container(
                 buildah_pod, registry, _AUTHFILE_PATH, dest=dest
@@ -385,6 +395,13 @@ def make_buildah_pod(
                 _AUTHFILE_PATH,
                 container_name=registry_auth.PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
             )
+    elif secret_name:
+        # no cloud provider involved - mount the secret directly as the authfile, unchanged.
+        buildah_pod.mount_secret(
+            secret_name,
+            _AUTHFILE_DIR,
+            items=[{"key": ".dockerconfigjson", "path": "config.json"}],
+        )
 
     mlrun.utils.logger.debug(
         "Resolved buildah build pod",
@@ -535,7 +552,7 @@ def _build_script(
     if push_cloud_provider == CloudRegistryProvider.GAR:
         push_gar_credential_exchange = [
             f"echo ${{MLRUN_GAR_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_SCRIPT_PATH)}",
-            shlex.join(["python3", _GAR_SCRIPT_PATH]),
+            registry_auth.soft_fail_script(["python3", _GAR_SCRIPT_PATH], "GAR"),
         ]
     else:
         push_gar_credential_exchange = []
@@ -545,7 +562,7 @@ def _build_script(
     if pull_cloud_provider == CloudRegistryProvider.GAR:
         pull_gar_credential_exchange = [
             f"echo ${{MLRUN_GAR_PULL_CREDENTIAL_SCRIPT}} | base64 -d > {shlex.quote(_GAR_PULL_SCRIPT_PATH)}",
-            shlex.join(["python3", _GAR_PULL_SCRIPT_PATH]),
+            registry_auth.soft_fail_script(["python3", _GAR_PULL_SCRIPT_PATH], "GAR"),
         ]
     else:
         pull_gar_credential_exchange = []

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -228,7 +228,10 @@ def make_buildah_pod(
     :param dest:               The fully resolved destination image reference.
     :param dockerfile:         The rendered Dockerfile content (from :func:`base.make_dockerfile`).
     :param base_image:         The image the Dockerfile builds ``FROM``, used to also credential
-                               the base-image pull when it's on a cloud registry (ML-12961).
+                               the base-image pull when it's on a cloud registry (ML-12961). Pull
+                               credentials are derived from this alone - the Dockerfile
+                               (base.make_dockerfile) has exactly one ``FROM``, no separate
+                               onbuild/cache-from image with its own registry to account for.
     :param inline_code:        Inline function code to stage into the build context, if any.
     :param inline_path:        Destination filename for ``inline_code`` (default ``main.py``).
     :param requirements:       The resolved requirements list to stage, if any.

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -255,8 +255,10 @@ def make_buildah_pod(
         )
 
     if not registry:
-        # if the registry was not given, infer it from the image destination
-        registry = dest.partition("/")[0]
+        # if the registry was not given, infer it from the image destination - dest can itself be
+        # bare (e.g. pushed straight to Docker Hub as "my-org/my-image:tag") with no explicit
+        # registry at all.
+        registry = registry_auth.registry_from_image(dest)
 
     # unlike dest, base_image is very often bare (e.g. "python:3.11-slim", or a Docker Hub
     # "some-org/some-image:tag") with no explicit registry at all.
@@ -268,7 +270,9 @@ def make_buildah_pod(
     # authenticate a *different* registry than either of these (e.g. a private base-image registry
     # alongside a cloud push destination, ML-12988), so it's resolved independently below and
     # merged into the authfile instead (see the secret-copy init container), never gated by this.
-    roles_by_registry: dict[str, set[str]] = {registry: {"push"}}
+    roles_by_registry: dict[str, set[str]] = {}
+    if registry:
+        roles_by_registry.setdefault(registry, set()).add("push")
     if base_registry:
         roles_by_registry.setdefault(base_registry, set()).add("pull")
 

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -354,11 +354,8 @@ def make_buildah_pod(
         # For ECR/ACR it's also how the init container(s) below hand the authfile to this container.
         buildah_pod.mount_empty(name="registry-auth", mount_path=_AUTHFILE_DIR)
         if secret_name:
-            # the secret may authenticate a different host than the ones needing cloud exchange
-            # (ML-12988, e.g. a private base-image registry alongside a cloud push destination).
-            # Mount it read-only elsewhere and copy it in as the first init container, rather than
-            # directly at _AUTHFILE_PATH, since the steps below need to merge into that file and
-            # can't write into a secret-backed volume mount.
+            # mounted read-only elsewhere, then copied in as the first init container (ML-12988) -
+            # see registry_auth.append_secret_authfile_init_container.
             buildah_pod.mount_secret(
                 secret_name,
                 registry_auth.SECRET_AUTHFILE_DIR,
@@ -567,8 +564,6 @@ def _build_script(
     else:
         pull_gar_credential_exchange = []
 
-    # First we do a credential exchange to ensure we have credentials for the
-    # build
     lines += pull_gar_credential_exchange
     lines += push_gar_credential_exchange
 
@@ -585,9 +580,9 @@ def _build_script(
     bud += ["--tag", dest, "--file", dockerfile_path, _CONTEXT_DIR]
     lines.append(shlex.join(bud))
 
-    # We do another credential exchange to ensure we have credentials for the
-    # push since it can be that the token expired during the build - only the push destination's
-    # script; the base image was already pulled by `bud` above, nothing left to credential for it.
+    # the token may have expired during the build - re-mint before push. Only the push
+    # destination's script; the base image was already pulled by `bud` above, nothing left to
+    # credential for it.
     lines += push_gar_credential_exchange
 
     push = global_opts + ["push"]

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -258,7 +258,11 @@ def make_buildah_pod(
         # if the registry was not given, infer it from the image destination
         registry = dest.partition("/")[0]
 
-    base_registry = base_image.partition("/")[0] if base_image else None
+    # unlike dest, base_image is very often bare (e.g. "python:3.11-slim", or a Docker Hub
+    # "some-org/some-image:tag") with no explicit registry at all.
+    base_registry = (
+        registry_auth.registry_from_image(base_image) if base_image else None
+    )
 
     # every distinct registry this build touches, and which role(s) it plays there - a secret may
     # authenticate a *different* registry than either of these (e.g. a private base-image registry

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -15,8 +15,8 @@
 
 Buildah's stock image has no built-in cloud-credential support the way Kaniko's Go binary does, so
 each provider mints its own credential from the pod's existing workload identity - for both the
-push destination and, when it lives on a different ACR/ECR host, the base image being pulled
-(ML-12961; GAR's base-image case isn't covered, see :mod:`services.api.utils.builder.buildah`):
+push destination and, when it lives on a different ACR/ECR/GAR host, the base image being pulled
+(ML-12961):
 
 * **ECR** and **ACR** — an init container on the MLRun image (already carries boto3 /
   azure-identity, and mlrun itself) runs ``python -m mlrun mint-registry-credentials`` (see
@@ -30,7 +30,8 @@ push destination and, when it lives on a different ACR/ECR host, the base image 
   immediately before each Buildah step that needs it (see :mod:`services.api.utils.builder.buildah`),
   minimizes the gap between mint and use rather than trying to outlast a fixed TTL. This path can't
   use the same init-container convention as ECR/ACR: it runs inline in the Buildah main container,
-  which has no mlrun (or any cloud SDK) installed - only the stock image's python3/urllib.
+  which has no mlrun (or any cloud SDK) installed - only the stock image's python3/urllib. A
+  push-side and a pull-side (different GAR host) script both merge into the same authfile.
 
 None of the generated scripts or CLI args ever log the minted token.
 """
@@ -168,19 +169,26 @@ def gar_credential_exchange_script(registry: str, authfile_path: str) -> str:
     intercepting the metadata-server call for the build pod's service account - no federated-token
     plumbing is needed on mlrun's side.
 
+    Merges into ``authfile_path`` rather than overwriting it: a push-side and a pull-side script
+    (different GAR hosts, ML-12961), or an ACR/ECR init container that ran first, may already have
+    written an entry there.
+
     :param registry: The GAR/GCR registry host.
-    :param authfile_path: Where to write the docker-config-shaped authfile.
+    :param authfile_path: Where to merge the docker-config-shaped authfile entry.
     :return: The Python source to run (e.g. via ``python3 -c``).
     """
     # kept terse - this is base64-embedded into a pod env var, so every byte here is sent over the
     # wire. No `with` blocks: the process exits right after, so explicit close/flush isn't needed.
     lines = [
-        "import base64, json, urllib.request",
+        "import base64, json, os, urllib.request",
         f"req = urllib.request.Request({_GCP_METADATA_TOKEN_URL!r}, headers="
         "{'Metadata-Flavor': 'Google'})",
         "token = json.load(urllib.request.urlopen(req, timeout=10))['access_token']",
         "auth = base64.b64encode(b'oauth2accesstoken:' + token.encode()).decode()",
-        f"json.dump({{'auths': {{{registry!r}: {{'auth': auth}}}}}}, open({authfile_path!r}, 'w'))",
+        f"auths = json.load(open({authfile_path!r})).get('auths', {{}}) "
+        f"if os.path.exists({authfile_path!r}) else {{}}",
+        f"auths[{registry!r}] = {{'auth': auth}}",
+        f"json.dump({{'auths': auths}}, open({authfile_path!r}, 'w'))",
     ]
     return "\n".join(lines)
 

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -90,6 +90,23 @@ def classify_cloud_registry(target: str) -> CloudRegistryProvider | None:
     return None
 
 
+def registry_from_image(image: str) -> str | None:
+    """Return the explicit registry host in ``image``, or ``None`` if it has none.
+
+    Mirrors Docker's own reference-parsing rule: the segment before the first ``/`` is a registry
+    host only if it contains a ``.`` or ``:``, or is exactly ``localhost`` - otherwise (e.g.
+    ``python:3.11-slim``, or a Docker Hub ``some-org/some-image:tag``) there's no explicit registry,
+    the image is implicitly on Docker Hub.
+
+    :param image: A full image reference (``[registry/]repository[:tag]``).
+    :return: The registry host, or ``None``.
+    """
+    host, sep, _ = image.partition("/")
+    if not sep or ("." not in host and ":" not in host and host != "localhost"):
+        return None
+    return host
+
+
 def soft_fail_script(command: list[str], kind: str) -> str:
     """Wrap ``command`` so a failure logs a warning and exits 0 instead of failing the pod.
 

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -33,9 +33,23 @@ push destination and, when it lives on a different ACR/ECR/GAR host, the base im
   which has no mlrun (or any cloud SDK) installed - only the stock image's python3/urllib. A
   push-side and a pull-side (different GAR host) script both merge into the same authfile.
 
+A static docker-config secret (``secret_name``) may authenticate a *different* host than the ones
+above - e.g. a private base-image registry alongside a cloud push destination (ML-12988). It's
+copied into the shared authfile by its own init container (:func:`append_secret_authfile_init_container`)
+rather than being mounted directly at the authfile path, so the credential-exchange steps above can
+still merge into that file afterward.
+
+Every credential-exchange step - ECR/ACR's init containers and GAR's inline script alike - logs a
+warning and continues rather than failing the pod if the mint itself fails (ML-12988, matching
+nuclio's own Buildah registry-login containers, NUC-688). A cloud host's workload identity
+genuinely not being configured is not the exchange's problem to enforce: the build falls back to
+whatever a secret already provided for that host, or, if nothing covers it, buildah's own push/pull
+surfaces a clear auth error instead of an opaque credential-helper traceback.
+
 None of the generated scripts or CLI args ever log the minted token.
 """
 
+import shlex
 from urllib.parse import urlparse
 
 import mlrun.utils
@@ -47,6 +61,15 @@ _CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME = "registry-credential-exchange"
 # used when a base-image (pull) exchange runs alongside a push-side one in the same pod - container
 # names must be unique within a pod.
 PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME = "registry-credential-exchange-pull"
+
+_COPY_SECRET_AUTHFILE_INIT_CONTAINER_NAME = "copy-registry-auth-secret"
+
+# where a configured docker-config secret is mounted read-only before being copied into the shared
+# authfile (ML-12988) - never mounted directly at the authfile path once a cloud provider is also
+# involved, since the credential-exchange init containers/scripts need to merge into that file,
+# which a secret-backed volume mount doesn't allow.
+SECRET_AUTHFILE_DIR = "/auth-secret"
+SECRET_AUTHFILE_PATH = f"{SECRET_AUTHFILE_DIR}/config.json"
 
 _GCP_METADATA_TOKEN_URL = (
     "http://metadata.google.internal/computeMetadata/v1/"
@@ -72,6 +95,51 @@ def classify_cloud_registry(target: str) -> CloudRegistryProvider | None:
     return None
 
 
+def soft_fail_script(command: list[str], kind: str) -> str:
+    """Wrap ``command`` so a failure logs a warning and exits 0 instead of failing the pod.
+
+    Mirrors nuclio's own Buildah registry-login containers (NUC-688): a cloud credential mint
+    failing - e.g. workload identity genuinely isn't configured for this host - must not abort the
+    build outright (ML-12988). The build falls back to whatever a secret already provided for that
+    host, or, if nothing covers it, buildah's own push/pull surfaces a clear auth error instead of
+    an opaque credential-helper traceback. Used by ECR/ACR's init containers below and, inline, by
+    :func:`gar_credential_exchange_script`'s callers in
+    :mod:`services.api.utils.builder.buildah`.
+
+    :param command: The command to run, as argv (shell-quoted here, never shell-interpreted itself).
+    :param kind: The provider name, for the warning message (e.g. ``"ECR"``).
+    :return: A ``/bin/sh -c`` script string.
+    """
+    return (
+        f"{shlex.join(command)} || "
+        f"echo 'WARNING: failed to mint {kind} registry credentials' >&2"
+    )
+
+
+def append_secret_authfile_init_container(pod, authfile_path: str) -> None:
+    """Append the init container that copies a mounted docker-config secret into ``authfile_path``.
+
+    Used when a static secret and cloud credential exchange are both configured (ML-12988): the
+    secret must already be mounted at :data:`SECRET_AUTHFILE_DIR` (read-only) rather than directly
+    at ``authfile_path``, since the credential-exchange init containers/scripts that run after this
+    one need to merge into that file, which a secret-backed volume mount doesn't allow. Runs first,
+    so those merges land on top of the secret's own entries.
+
+    :param pod: The Buildah build pod being constructed.
+    :param authfile_path: Where to copy the secret's docker-config content to.
+    """
+    # buildah_image, not _credential_exchange_image(): the main container always pulls it anyway,
+    # so this copy step never costs an extra image pull - unlike the credential-exchange image,
+    # which a GAR-only build (no ECR/ACR init container of its own) would otherwise never need. It
+    # already ships coreutils (see BuildahBackend's docstring), so `cp` is available.
+    pod.append_init_container(
+        config.httpdb.builder.buildah_image,
+        command=["cp"],
+        args=[SECRET_AUTHFILE_PATH, authfile_path],
+        name=_COPY_SECRET_AUTHFILE_INIT_CONTAINER_NAME,
+    )
+
+
 def append_ecr_credential_exchange_init_container(
     pod,
     registry: str,
@@ -87,7 +155,8 @@ def append_ecr_credential_exchange_init_container(
     :func:`~services.api.utils.builder.base.resolve_build_pod_spec_attributes` - to mint a
     short-lived authorization token, merging it into ``authfile_path``. When ``dest`` is given
     (a push), the target ECR repository is also created (idempotent); omit it for a pull-only
-    (base-image) exchange, which skips repository creation.
+    (base-image) exchange, which skips repository creation. A failed mint logs a warning and exits
+    0 rather than failing the pod (ML-12988) - see :func:`soft_fail_script`.
 
     :param pod: The Buildah build pod being constructed.
     :param registry: The ECR registry host.
@@ -97,7 +166,7 @@ def append_ecr_credential_exchange_init_container(
     :param container_name: The init container's name - distinct names are required when both a
         push-side and a pull-side exchange run in the same pod.
     """
-    args = [
+    mint_args = [
         "-m",
         "mlrun",
         "mint-registry-credentials",
@@ -107,12 +176,12 @@ def append_ecr_credential_exchange_init_container(
         registry,
     ]
     if dest:
-        args += ["--dest", dest]
-    args += ["--authfile", authfile_path]
+        mint_args += ["--dest", dest]
+    mint_args += ["--authfile", authfile_path]
     pod.append_init_container(
         _credential_exchange_image(),
-        command=["python"],
-        args=args,
+        command=["/bin/sh", "-c"],
+        args=[soft_fail_script(["python", *mint_args], "ECR")],
         name=container_name,
     )
 
@@ -131,7 +200,8 @@ def append_acr_credential_exchange_init_container(
     :func:`~services.api.utils.builder.base.resolve_builder_pod_labels`) for an AAD access token via
     azure-identity, then exchanges that AAD token for an ACR refresh token via ACR's
     ``/oauth2/exchange`` endpoint (no SDK covers this ACR-specific endpoint), merging the result
-    into ``authfile_path``. Used for both push and base-image-pull credentials.
+    into ``authfile_path``. Used for both push and base-image-pull credentials. A failed mint logs
+    a warning and exits 0 rather than failing the pod (ML-12988) - see :func:`soft_fail_script`.
 
     :param pod: The Buildah build pod being constructed.
     :param registry: The ACR registry host.
@@ -139,20 +209,21 @@ def append_acr_credential_exchange_init_container(
     :param container_name: The init container's name - distinct names are required when both a
         push-side and a pull-side exchange run in the same pod.
     """
+    mint_args = [
+        "-m",
+        "mlrun",
+        "mint-registry-credentials",
+        "--provider",
+        CloudRegistryProvider.ACR.value,
+        "--registry",
+        registry,
+        "--authfile",
+        authfile_path,
+    ]
     pod.append_init_container(
         _credential_exchange_image(),
-        command=["python"],
-        args=[
-            "-m",
-            "mlrun",
-            "mint-registry-credentials",
-            "--provider",
-            CloudRegistryProvider.ACR.value,
-            "--registry",
-            registry,
-            "--authfile",
-            authfile_path,
-        ],
+        command=["/bin/sh", "-c"],
+        args=[soft_fail_script(["python", *mint_args], "ACR")],
         name=container_name,
     )
 

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -72,10 +72,11 @@ _GCP_METADATA_TOKEN_URL = (
 )
 
 
-def classify_cloud_registry(target: str) -> CloudRegistryProvider | None:
+def classify_cloud_registry(target: str | None) -> CloudRegistryProvider | None:
     """Return which cloud provider's registry ``target`` belongs to, or ``None``.
 
-    :param target: A registry host, or a full image reference (only the host matters).
+    :param target: A registry host, a full image reference (only the host matters), or ``None``
+        (e.g. from :func:`registry_from_image` finding no explicit registry).
     :return: The registry's :class:`CloudRegistryProvider`, or ``None`` for anything else (Docker
         Hub, a private/self-signed registry, ...).
     """
@@ -137,17 +138,27 @@ def append_secret_authfile_init_container(pod, authfile_path: str) -> None:
     one need to merge into that file, which a secret-backed volume mount doesn't allow. Runs first,
     so those merges land on top of the secret's own entries.
 
+    Chmods the copy to be world-writable: init containers get no explicit security context (see
+    :class:`~framework.utils.singletons.k8s.BasePod`), so this container's own UID depends entirely
+    on ``buildah_image``'s default user, which needn't match the main container's (fixed to 1000 -
+    see ``_caps_security_context`` in buildah.py) or any other credential-exchange init container's.
+    Every subsequent writer merges into this same file, so it must stay writable regardless of which
+    UID wrote it last.
+
     :param pod: The Buildah build pod being constructed.
     :param authfile_path: Where to copy the secret's docker-config content to.
     """
     # buildah_image, not _credential_exchange_image(): the main container always pulls it anyway,
     # so this copy step never costs an extra image pull - unlike the credential-exchange image,
     # which a GAR-only build (no ECR/ACR init container of its own) would otherwise never need. It
-    # already ships coreutils (see BuildahBackend's docstring), so `cp` is available.
+    # already ships coreutils (see BuildahBackend's docstring), so `cp`/`chmod` are available.
     pod.append_init_container(
         config.httpdb.builder.buildah_image,
-        command=["cp"],
-        args=[SECRET_AUTHFILE_PATH, authfile_path],
+        command=["/bin/sh", "-c"],
+        args=[
+            f"cp {shlex.quote(SECRET_AUTHFILE_PATH)} {shlex.quote(authfile_path)} && "
+            f"chmod 0666 {shlex.quote(authfile_path)}"
+        ],
         name=_COPY_SECRET_AUTHFILE_INIT_CONTAINER_NAME,
     )
 
@@ -256,7 +267,11 @@ def gar_credential_exchange_script(registry: str, authfile_path: str) -> str:
     (different GAR hosts, ML-12961), an ACR/ECR init container, or a copied-in static secret
     (ML-12988) may already have written to it - and any other top-level docker-config keys already
     there (``credHelpers``, ``credsStore``, ...) are preserved; only this one registry's entry is
-    ever added or replaced.
+    ever added or replaced. Unlike those writers (see :func:`append_secret_authfile_init_container`),
+    this one never needs to chmod the file afterward: it always runs in the main container, after
+    every init container has already finished, so nothing with a different UID ever writes to it
+    again - only ``buildah bud``/``push`` read it via ``--authfile``, which the default file mode
+    already allows.
 
     :param registry: The GAR/GCR registry host.
     :param authfile_path: Where to merge the docker-config-shaped authfile entry.

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -241,8 +241,10 @@ def gar_credential_exchange_script(registry: str, authfile_path: str) -> str:
     plumbing is needed on mlrun's side.
 
     Merges into ``authfile_path`` rather than overwriting it: a push-side and a pull-side script
-    (different GAR hosts, ML-12961), or an ACR/ECR init container that ran first, may already have
-    written an entry there.
+    (different GAR hosts, ML-12961), an ACR/ECR init container, or a copied-in static secret
+    (ML-12988) may already have written to it - and any other top-level docker-config keys already
+    there (``credHelpers``, ``credsStore``, ...) are preserved; only this one registry's entry is
+    ever added or replaced.
 
     :param registry: The GAR/GCR registry host.
     :param authfile_path: Where to merge the docker-config-shaped authfile entry.
@@ -256,10 +258,9 @@ def gar_credential_exchange_script(registry: str, authfile_path: str) -> str:
         "{'Metadata-Flavor': 'Google'})",
         "token = json.load(urllib.request.urlopen(req, timeout=10))['access_token']",
         "auth = base64.b64encode(b'oauth2accesstoken:' + token.encode()).decode()",
-        f"auths = json.load(open({authfile_path!r})).get('auths', {{}}) "
-        f"if os.path.exists({authfile_path!r}) else {{}}",
-        f"auths[{registry!r}] = {{'auth': auth}}",
-        f"json.dump({{'auths': auths}}, open({authfile_path!r}, 'w'))",
+        f"doc = json.load(open({authfile_path!r})) if os.path.exists({authfile_path!r}) else {{}}",
+        f"doc.setdefault('auths', {{}})[{registry!r}] = {{'auth': auth}}",
+        f"json.dump(doc, open({authfile_path!r}, 'w'))",
     ]
     return "\n".join(lines)
 

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -35,16 +35,12 @@ push destination and, when it lives on a different ACR/ECR/GAR host, the base im
 
 A static docker-config secret (``secret_name``) may authenticate a *different* host than the ones
 above - e.g. a private base-image registry alongside a cloud push destination (ML-12988). It's
-copied into the shared authfile by its own init container (:func:`append_secret_authfile_init_container`)
-rather than being mounted directly at the authfile path, so the credential-exchange steps above can
-still merge into that file afterward.
+copied into the shared authfile via its own init container rather than mounted there directly - see
+:func:`append_secret_authfile_init_container`.
 
-Every credential-exchange step - ECR/ACR's init containers and GAR's inline script alike - logs a
-warning and continues rather than failing the pod if the mint itself fails (ML-12988, matching
-nuclio's own Buildah registry-login containers, NUC-688). A cloud host's workload identity
-genuinely not being configured is not the exchange's problem to enforce: the build falls back to
-whatever a secret already provided for that host, or, if nothing covers it, buildah's own push/pull
-surfaces a clear auth error instead of an opaque credential-helper traceback.
+Every credential-exchange step - ECR/ACR's init containers and GAR's inline script alike - soft-fails
+(warns, doesn't fail the pod) on a mint failure rather than aborting the build, matching nuclio's own
+Buildah registry-login containers (NUC-688) - see :func:`soft_fail_script`.
 
 None of the generated scripts or CLI args ever log the minted token.
 """
@@ -64,10 +60,8 @@ PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME = "registry-credential-exchange-pul
 
 _COPY_SECRET_AUTHFILE_INIT_CONTAINER_NAME = "copy-registry-auth-secret"
 
-# where a configured docker-config secret is mounted read-only before being copied into the shared
-# authfile (ML-12988) - never mounted directly at the authfile path once a cloud provider is also
-# involved, since the credential-exchange init containers/scripts need to merge into that file,
-# which a secret-backed volume mount doesn't allow.
+# where a configured docker-config secret is mounted read-only before
+# append_secret_authfile_init_container copies it into the shared authfile.
 SECRET_AUTHFILE_DIR = "/auth-secret"
 SECRET_AUTHFILE_PATH = f"{SECRET_AUTHFILE_DIR}/config.json"
 

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -14,13 +14,16 @@
 """Cloud-registry credential exchange for :class:`~services.api.utils.builder.buildah.BuildahBackend`.
 
 Buildah's stock image has no built-in cloud-credential support the way Kaniko's Go binary does, so
-each provider mints its own push credential from the pod's existing workload identity:
+each provider mints its own credential from the pod's existing workload identity - for both the
+push destination and, when it lives on a different ACR/ECR host, the base image being pulled
+(ML-12961; GAR's base-image case isn't covered, see :mod:`services.api.utils.builder.buildah`):
 
 * **ECR** and **ACR** — an init container on the MLRun image (already carries boto3 /
   azure-identity, and mlrun itself) runs ``python -m mlrun mint-registry-credentials`` (see
-  :mod:`mlrun.utils.registry_auth` for the actual credential-exchange logic) and writes the result
-  to a shared authfile - the same ``python -m mlrun <subcommand>`` convention Kaniko's source-fetch
-  init container uses.
+  :mod:`mlrun.utils.registry_auth` for the actual credential-exchange logic) and merges the result
+  into a shared authfile - the same ``python -m mlrun <subcommand>`` convention Kaniko's
+  source-fetch init container uses. A push-side and a pull-side exchange (different registries) run
+  as two distinctly-named init containers against the same authfile.
 * **GAR / GCR** — no init container: GCP tokens are cached and reused by the metadata server across
   callers until fewer than 5 minutes remain before expiry, so *any* mint can hand back a token with
   as little as ~5 minutes of remaining life, regardless of its original TTL. Minting just-in-time,
@@ -40,6 +43,9 @@ from mlrun.config import config
 from mlrun.utils.registry_auth import CloudRegistryProvider
 
 _CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME = "registry-credential-exchange"
+# used when a base-image (pull) exchange runs alongside a push-side one in the same pod - container
+# names must be unique within a pod.
+PULL_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME = "registry-credential-exchange-pull"
 
 _GCP_METADATA_TOKEN_URL = (
     "http://metadata.google.internal/computeMetadata/v1/"
@@ -66,58 +72,71 @@ def classify_cloud_registry(target: str) -> CloudRegistryProvider | None:
 
 
 def append_ecr_credential_exchange_init_container(
-    pod, registry: str, dest: str, authfile_path: str
+    pod,
+    registry: str,
+    authfile_path: str,
+    dest: str | None = None,
+    container_name: str = _CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
 ) -> None:
-    """Append the init container that mints ECR push credentials for ``pod``.
+    """Append the init container that mints ECR credentials for ``pod``.
 
     Runs ``python -m mlrun mint-registry-credentials --provider ecr`` (see
     :func:`mlrun.utils.registry_auth.mint_ecr_authfile`), which uses boto3 with the pod's own AWS
     credentials - IRSA or instance role, resolved via the build pod's service account, see
-    :func:`~services.api.utils.builder.base.resolve_build_pod_spec_attributes` - to create the
-    target ECR repository (idempotent) and mint a short-lived authorization token, writing it to
-    ``authfile_path`` for the main Buildah container to push with.
+    :func:`~services.api.utils.builder.base.resolve_build_pod_spec_attributes` - to mint a
+    short-lived authorization token, merging it into ``authfile_path``. When ``dest`` is given
+    (a push), the target ECR repository is also created (idempotent); omit it for a pull-only
+    (base-image) exchange, which skips repository creation.
 
     :param pod: The Buildah build pod being constructed.
     :param registry: The ECR registry host.
-    :param dest: The fully resolved destination image reference (for the repository name).
-    :param authfile_path: Where to write the docker-config-shaped authfile.
+    :param authfile_path: Where to merge the docker-config-shaped authfile entry.
+    :param dest: The fully resolved destination image reference (for the repository name). Omit
+        for a base-image pull exchange.
+    :param container_name: The init container's name - distinct names are required when both a
+        push-side and a pull-side exchange run in the same pod.
     """
+    args = [
+        "-m",
+        "mlrun",
+        "mint-registry-credentials",
+        "--provider",
+        CloudRegistryProvider.ECR.value,
+        "--registry",
+        registry,
+    ]
+    if dest:
+        args += ["--dest", dest]
+    args += ["--authfile", authfile_path]
     pod.append_init_container(
         _credential_exchange_image(),
         command=["python"],
-        args=[
-            "-m",
-            "mlrun",
-            "mint-registry-credentials",
-            "--provider",
-            CloudRegistryProvider.ECR.value,
-            "--registry",
-            registry,
-            "--dest",
-            dest,
-            "--authfile",
-            authfile_path,
-        ],
-        name=_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
+        args=args,
+        name=container_name,
     )
 
 
 def append_acr_credential_exchange_init_container(
-    pod, registry: str, authfile_path: str
+    pod,
+    registry: str,
+    authfile_path: str,
+    container_name: str = _CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
 ) -> None:
-    """Append the init container that mints ACR push credentials for ``pod``.
+    """Append the init container that mints an ACR credential for ``pod``.
 
     Runs ``python -m mlrun mint-registry-credentials --provider acr`` (see
     :func:`mlrun.utils.registry_auth.mint_acr_authfile`), which exchanges the pod's Azure workload
     identity (federated JWT, injected by the ``azure.workload.identity/use`` label - see
     :func:`~services.api.utils.builder.base.resolve_builder_pod_labels`) for an AAD access token via
     azure-identity, then exchanges that AAD token for an ACR refresh token via ACR's
-    ``/oauth2/exchange`` endpoint (no SDK covers this ACR-specific endpoint), writing the result to
-    ``authfile_path``.
+    ``/oauth2/exchange`` endpoint (no SDK covers this ACR-specific endpoint), merging the result
+    into ``authfile_path``. Used for both push and base-image-pull credentials.
 
     :param pod: The Buildah build pod being constructed.
     :param registry: The ACR registry host.
-    :param authfile_path: Where to write the docker-config-shaped authfile.
+    :param authfile_path: Where to merge the docker-config-shaped authfile entry.
+    :param container_name: The init container's name - distinct names are required when both a
+        push-side and a pull-side exchange run in the same pod.
     """
     pod.append_init_container(
         _credential_exchange_image(),
@@ -133,7 +152,7 @@ def append_acr_credential_exchange_init_container(
             "--authfile",
             authfile_path,
         ],
-        name=_CREDENTIAL_EXCHANGE_INIT_CONTAINER_NAME,
+        name=container_name,
     )
 
 

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -15,15 +15,15 @@
 
 Buildah's stock image has no built-in cloud-credential support the way Kaniko's Go binary does, so
 each provider mints its own credential from the pod's existing workload identity - for both the
-push destination and, when it lives on a different ACR/ECR/GAR host, the base image being pulled
-(ML-12961):
+push destination and the base image being pulled (ML-12961):
 
 * **ECR** and **ACR** — an init container on the MLRun image (already carries boto3 /
   azure-identity, and mlrun itself) runs ``python -m mlrun mint-registry-credentials`` (see
   :mod:`mlrun.utils.registry_auth` for the actual credential-exchange logic) and merges the result
   into a shared authfile - the same ``python -m mlrun <subcommand>`` convention Kaniko's
-  source-fetch init container uses. A push-side and a pull-side exchange (different registries) run
-  as two distinctly-named init containers against the same authfile.
+  source-fetch init container uses. A push-side and a pull-side exchange run as two distinctly-named
+  init containers against the same authfile, unless they're the same host, in which case the
+  pull-side one is skipped as redundant.
 * **GAR / GCR** — no init container: GCP tokens are cached and reused by the metadata server across
   callers until fewer than 5 minutes remain before expiry, so *any* mint can hand back a token with
   as little as ~5 minutes of remaining life, regardless of its original TTL. Minting just-in-time,
@@ -31,7 +31,8 @@ push destination and, when it lives on a different ACR/ECR/GAR host, the base im
   minimizes the gap between mint and use rather than trying to outlast a fixed TTL. This path can't
   use the same init-container convention as ECR/ACR: it runs inline in the Buildah main container,
   which has no mlrun (or any cloud SDK) installed - only the stock image's python3/urllib. A
-  push-side and a pull-side (different GAR host) script both merge into the same authfile.
+  push-side and a pull-side script are minted independently - even when they're the same host -
+  and both merge into the same authfile.
 
 A static docker-config secret (``secret_name``) may authenticate a *different* host than the ones
 above - e.g. a private base-image registry alongside a cloud push destination (ML-12988). It's

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,3 +174,76 @@ def test_cli_load_source_custom_target():
         target_dir=custom_target,
         project=None,
     )
+
+
+def test_cli_mint_registry_credentials_ecr():
+    runner = CliRunner()
+    registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    dest = f"{registry}/my-repo:latest"
+
+    with unittest.mock.patch("mlrun.__main__.mint_ecr_authfile") as mock_mint:
+        result = runner.invoke(
+            main,
+            [
+                "mint-registry-credentials",
+                "--provider",
+                "ecr",
+                "--registry",
+                registry,
+                "--dest",
+                dest,
+                "--authfile",
+                "/auth/config.json",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Successfully minted ecr registry credentials" in result.output
+    mock_mint.assert_called_once_with(registry, "/auth/config.json", dest=dest)
+
+
+def test_cli_mint_registry_credentials_acr():
+    runner = CliRunner()
+    registry = "myregistry.azurecr.io"
+
+    with unittest.mock.patch("mlrun.__main__.mint_acr_authfile") as mock_mint:
+        result = runner.invoke(
+            main,
+            [
+                "mint-registry-credentials",
+                "--provider",
+                "acr",
+                "--registry",
+                registry,
+                "--authfile",
+                "/auth/config.json",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "Successfully minted acr registry credentials" in result.output
+    mock_mint.assert_called_once_with(registry, "/auth/config.json")
+
+
+def test_cli_mint_registry_credentials_failure():
+    runner = CliRunner()
+
+    with unittest.mock.patch(
+        "mlrun.__main__.mint_ecr_authfile",
+        side_effect=ValueError("no credentials found"),
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "mint-registry-credentials",
+                "--provider",
+                "ecr",
+                "--registry",
+                "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+                "--authfile",
+                "/auth/config.json",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "Error minting registry credentials:" in result.output

--- a/tests/utils/test_registry_auth.py
+++ b/tests/utils/test_registry_auth.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 # Tests for the ECR/ACR credential-minting functions run inside a Buildah build's init container
-# (ML-12886), invoked via `python -m mlrun mint-registry-credentials`. GAR/GCR is not here: it has
-# no mlrun installed to call into, and runs an inline script instead - see
-# server/py/services/api/tests/unit/utils/test_registry_auth.py for that path.
+# (ML-12886), invoked via `python -m mlrun mint-registry-credentials`. Also covers the merge-not-
+# overwrite behaviour and optional `dest` (ML-12961) that let a push-side and a pull-side exchange
+# share one authfile. GAR/GCR is not here: it has no mlrun installed to call into, and runs an
+# inline script instead - see server/py/services/api/tests/unit/utils/test_registry_auth.py for
+# that path.
 
 import base64
 import json
@@ -41,7 +43,7 @@ def test_mint_ecr_authfile_writes_authfile(tmp_path, monkeypatch):
 
     authfile = tmp_path / "config.json"
     registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
-    mint_ecr_authfile(registry, f"{registry}/myrepo:latest", str(authfile))
+    mint_ecr_authfile(registry, str(authfile), dest=f"{registry}/myrepo:latest")
 
     boto3.client.assert_called_once_with("ecr", region_name="us-east-1")
     fake_client.create_repository.assert_called_once_with(repositoryName="myrepo")
@@ -63,9 +65,47 @@ def test_mint_ecr_authfile_repo_create_idempotent(tmp_path, monkeypatch):
     authfile = tmp_path / "config.json"
     registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
     # must not raise even though create_repository always errors "already exists"
-    mint_ecr_authfile(registry, f"{registry}/myrepo:latest", str(authfile))
+    mint_ecr_authfile(registry, str(authfile), dest=f"{registry}/myrepo:latest")
 
     assert json.loads(authfile.read_text())["auths"][registry]["auth"] == "token"
+
+
+def test_mint_ecr_authfile_skips_repo_creation_without_dest(tmp_path, monkeypatch):
+    # a base-image (pull-only) exchange has no reason to create a repository - and may not even
+    # have permission to on a registry it's only pulling from.
+    fake_client = unittest.mock.MagicMock()
+    fake_client.get_authorization_token.return_value = {
+        "authorizationData": [{"authorizationToken": "token"}]
+    }
+    monkeypatch.setattr(boto3, "client", unittest.mock.Mock(return_value=fake_client))
+
+    authfile = tmp_path / "config.json"
+    registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    mint_ecr_authfile(registry, str(authfile))
+
+    fake_client.create_repository.assert_not_called()
+    assert json.loads(authfile.read_text())["auths"][registry]["auth"] == "token"
+
+
+def test_mint_ecr_authfile_merges_existing_entry(tmp_path, monkeypatch):
+    # a push-side exchange (different registry) may have already written to this authfile - the
+    # pull-side exchange must add its entry, not clobber the existing one.
+    authfile = tmp_path / "config.json"
+    other_registry = "myregistry.azurecr.io"
+    authfile.write_text(json.dumps({"auths": {other_registry: {"auth": "existing"}}}))
+
+    fake_client = unittest.mock.MagicMock()
+    fake_client.get_authorization_token.return_value = {
+        "authorizationData": [{"authorizationToken": "token"}]
+    }
+    monkeypatch.setattr(boto3, "client", unittest.mock.Mock(return_value=fake_client))
+
+    registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    mint_ecr_authfile(registry, str(authfile))
+
+    auths = json.loads(authfile.read_text())["auths"]
+    assert auths[other_registry]["auth"] == "existing"
+    assert auths[registry]["auth"] == "token"
 
 
 def test_mint_acr_authfile_writes_authfile(tmp_path, monkeypatch):
@@ -109,3 +149,32 @@ def test_mint_acr_authfile_requires_azure_tenant_id(tmp_path, monkeypatch):
 
     with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
         mint_acr_authfile("myregistry.azurecr.io", str(tmp_path / "config.json"))
+
+
+def test_mint_acr_authfile_merges_existing_entry(tmp_path, monkeypatch):
+    # a push-side exchange (different registry) may have already written to this authfile - the
+    # pull-side exchange must add its entry, not clobber the existing one.
+    authfile = tmp_path / "config.json"
+    other_registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    authfile.write_text(json.dumps({"auths": {other_registry: {"auth": "existing"}}}))
+
+    fake_credential = unittest.mock.MagicMock()
+    fake_credential.get_token.return_value = unittest.mock.Mock(token="aad-token")
+    monkeypatch.setattr(
+        "azure.identity.DefaultAzureCredential",
+        unittest.mock.Mock(return_value=fake_credential),
+    )
+    fake_response = unittest.mock.MagicMock()
+    fake_response.json.return_value = {"refresh_token": "my-refresh-token"}
+    monkeypatch.setattr(
+        requests, "post", unittest.mock.Mock(return_value=fake_response)
+    )
+    monkeypatch.setenv("AZURE_TENANT_ID", "tenant-123")
+
+    registry = "myregistry.azurecr.io"
+    mint_acr_authfile(registry, str(authfile))
+
+    auths = json.loads(authfile.read_text())["auths"]
+    assert auths[other_registry]["auth"] == "existing"
+    decoded = base64.b64decode(auths[registry]["auth"]).decode()
+    assert decoded == "00000000-0000-0000-0000-000000000000:my-refresh-token"

--- a/tests/utils/test_registry_auth.py
+++ b/tests/utils/test_registry_auth.py
@@ -89,10 +89,19 @@ def test_mint_ecr_authfile_skips_repo_creation_without_dest(tmp_path, monkeypatc
 
 def test_mint_ecr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     # a push-side exchange (different registry) may have already written to this authfile - the
-    # pull-side exchange must add its entry, not clobber the existing one.
+    # pull-side exchange must add its entry, not clobber the existing one. A copied-in static
+    # secret (ML-12988) may also carry other top-level docker-config keys (credHelpers,
+    # credsStore, ...) - those must survive the merge too, not just the sibling auths entry.
     authfile = tmp_path / "config.json"
     other_registry = "myregistry.azurecr.io"
-    authfile.write_text(json.dumps({"auths": {other_registry: {"auth": "existing"}}}))
+    authfile.write_text(
+        json.dumps(
+            {
+                "auths": {other_registry: {"auth": "existing"}},
+                "credHelpers": {"some.other.registry": "docker-credential-helper"},
+            }
+        )
+    )
 
     fake_client = unittest.mock.MagicMock()
     fake_client.get_authorization_token.return_value = {
@@ -103,9 +112,11 @@ def test_mint_ecr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
     mint_ecr_authfile(registry, str(authfile))
 
-    auths = json.loads(authfile.read_text())["auths"]
+    written = json.loads(authfile.read_text())
+    auths = written["auths"]
     assert auths[other_registry]["auth"] == "existing"
     assert auths[registry]["auth"] == "token"
+    assert written["credHelpers"] == {"some.other.registry": "docker-credential-helper"}
 
 
 def test_mint_acr_authfile_writes_authfile(tmp_path, monkeypatch):
@@ -153,10 +164,18 @@ def test_mint_acr_authfile_requires_azure_tenant_id(tmp_path, monkeypatch):
 
 def test_mint_acr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     # a push-side exchange (different registry) may have already written to this authfile - the
-    # pull-side exchange must add its entry, not clobber the existing one.
+    # pull-side exchange must add its entry, not clobber the existing one. A copied-in static
+    # secret (ML-12988) may also carry other top-level docker-config keys - those must survive.
     authfile = tmp_path / "config.json"
     other_registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
-    authfile.write_text(json.dumps({"auths": {other_registry: {"auth": "existing"}}}))
+    authfile.write_text(
+        json.dumps(
+            {
+                "auths": {other_registry: {"auth": "existing"}},
+                "credsStore": "desktop",
+            }
+        )
+    )
 
     fake_credential = unittest.mock.MagicMock()
     fake_credential.get_token.return_value = unittest.mock.Mock(token="aad-token")
@@ -174,7 +193,9 @@ def test_mint_acr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     registry = "myregistry.azurecr.io"
     mint_acr_authfile(registry, str(authfile))
 
-    auths = json.loads(authfile.read_text())["auths"]
+    written = json.loads(authfile.read_text())
+    auths = written["auths"]
     assert auths[other_registry]["auth"] == "existing"
     decoded = base64.b64decode(auths[registry]["auth"]).decode()
     assert decoded == "00000000-0000-0000-0000-000000000000:my-refresh-token"
+    assert written["credsStore"] == "desktop"

--- a/tests/utils/test_registry_auth.py
+++ b/tests/utils/test_registry_auth.py
@@ -21,6 +21,7 @@
 
 import base64
 import json
+import stat
 import unittest.mock
 
 import boto3
@@ -118,6 +119,35 @@ def test_mint_ecr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     assert auths[registry]["auth"] == "token"
     assert written["credHelpers"] == {"some.other.registry": "docker-credential-helper"}
 
+    # world-writable: the authfile may already have been written by a different init container
+    # (e.g. the secret-copy one) whose UID isn't guaranteed to match this process's, and a later
+    # writer (another init container, or the main container's GAR script) must still be able to
+    # merge into it.
+    assert stat.S_IMODE(authfile.stat().st_mode) == 0o666
+
+
+def test_mint_ecr_authfile_overwrites_same_registry_entry(tmp_path, monkeypatch):
+    # if a secret (or an earlier exchange) already has an entry for this *exact* registry - e.g. a
+    # secret meant to authenticate it, now coincidentally also cloud-classified - this mint's result
+    # wins. Documents the precedence explicitly: see _merge_auth_entry in mlrun/utils/registry_auth.py
+    # for why (mirrors nuclio's own merge_authfile.py, which applies cloud tokens after secrets).
+    authfile = tmp_path / "config.json"
+    registry = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    authfile.write_text(
+        json.dumps({"auths": {registry: {"auth": "stale-secret-auth"}}})
+    )
+
+    fake_client = unittest.mock.MagicMock()
+    fake_client.get_authorization_token.return_value = {
+        "authorizationData": [{"authorizationToken": "fresh-token"}]
+    }
+    monkeypatch.setattr(boto3, "client", unittest.mock.Mock(return_value=fake_client))
+
+    mint_ecr_authfile(registry, str(authfile))
+
+    written = json.loads(authfile.read_text())
+    assert written["auths"][registry]["auth"] == "fresh-token"
+
 
 def test_mint_acr_authfile_writes_authfile(tmp_path, monkeypatch):
     fake_credential = unittest.mock.MagicMock()
@@ -199,3 +229,33 @@ def test_mint_acr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     decoded = base64.b64decode(auths[registry]["auth"]).decode()
     assert decoded == "00000000-0000-0000-0000-000000000000:my-refresh-token"
     assert written["credsStore"] == "desktop"
+    assert stat.S_IMODE(authfile.stat().st_mode) == 0o666
+
+
+def test_mint_acr_authfile_overwrites_same_registry_entry(tmp_path, monkeypatch):
+    # same precedence as the ECR case above: an entry for this exact registry already present
+    # (e.g. from a secret) is overwritten by this mint's fresher result.
+    authfile = tmp_path / "config.json"
+    registry = "myregistry.azurecr.io"
+    authfile.write_text(
+        json.dumps({"auths": {registry: {"auth": "stale-secret-auth"}}})
+    )
+
+    fake_credential = unittest.mock.MagicMock()
+    fake_credential.get_token.return_value = unittest.mock.Mock(token="aad-token")
+    monkeypatch.setattr(
+        "azure.identity.DefaultAzureCredential",
+        unittest.mock.Mock(return_value=fake_credential),
+    )
+    fake_response = unittest.mock.MagicMock()
+    fake_response.json.return_value = {"refresh_token": "my-refresh-token"}
+    monkeypatch.setattr(
+        requests, "post", unittest.mock.Mock(return_value=fake_response)
+    )
+    monkeypatch.setenv("AZURE_TENANT_ID", "tenant-123")
+
+    mint_acr_authfile(registry, str(authfile))
+
+    written = json.loads(authfile.read_text())
+    decoded = base64.b64decode(written["auths"][registry]["auth"]).decode()
+    assert decoded == "00000000-0000-0000-0000-000000000000:my-refresh-token"


### PR DESCRIPTION
### 📝 Description
`buildah`'s cloud-registry credential exchange (ML-12886) only classifies the *push
destination*'s registry for ACR/ECR/GAR credential minting — never the base image's. When a
build's `FROM` base image lives on a different cloud-registry host than the push target (e.g. a
"system" ACR hosting mlrun's own images vs. a per-project push target), `buildah bud`'s implicit
pull of that base image runs with zero credentials and fails with `invalid username/password:
unauthorized` (ML-12961).

Separately, an explicit `secret_name` (e.g. authenticating a private base-image pull from an
internal registry) was unconditionally disabling GAR/ECR/ACR credential exchange for the push
destination too, even when the secret had nothing to do with that host — the root cause of
ML-12988's GKE/EKS "403 Forbidden"/"authentication required" failures.

---

### 🛠️ Changes Made
- `server/py/services/api/utils/builder/buildah.py`: classify the base image's registry for
  pull-side credential exchange independently of the push destination's, rather than only when the
  hosts differ. ECR/ACR still mint via a second, distinctly-named init container, skipped only when
  the hosts match (the push-side container already wrote that entry); GAR mints pull and push
  credentials independently and unconditionally — before `bud` and before `push` respectively —
  regardless of whether the hosts coincide. All merge into the same shared authfile. Fixes the
  `buildah bud --tls-verify` decision, which previously only considered `secret_name` and, for a
  same-host ECR/ACR base image, could wrongly disable TLS verification despite that pull actually
  being credentialed.
- `server/py/services/api/utils/builder/registry_auth.py`: the ECR/ACR init-container helpers gain
  an optional `container_name` (so a push-side and a pull-side exchange can coexist in one pod) and
  ECR's `dest` becomes optional (pull-only exchanges skip repository creation). GAR's
  `gar_credential_exchange_script` now merges its entry into the authfile instead of overwriting
  it, since it can now share the file with a pull-side script or an ACR/ECR init container.
- `mlrun/utils/registry_auth.py`: `mint_ecr_authfile`/`mint_acr_authfile` now merge their entry
  into an existing authfile instead of overwriting it, so two sequential credential-exchange init
  containers (different registries) can share one authfile.
- `mlrun/__main__.py`: the `mint-registry-credentials` CLI no longer requires `--dest` for
  `--provider ecr`.
- **(ML-12988)** Cloud-provider classification (push and pull) is now resolved independently of
  `secret_name`; a configured secret is merged into the shared authfile via a new first init
  container (`registry_auth.append_secret_authfile_init_container`) instead of being mounted
  directly at the authfile path, since the credential-exchange steps need to write into that file
  afterward.
- **(ML-12988)** Every credential-exchange step (ECR/ACR init containers, GAR's inline script) now
  soft-fails (`registry_auth.soft_fail_script`) — logs a warning and continues instead of crashing
  the pod — mirroring nuclio's own Buildah registry-login containers (NUC-688), so a secret
  intentionally covering the same host as a broken/unconfigured workload identity still wins.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the Deprecation Guidelines
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input

---

### 🧪 Testing
- Added unit tests in `test_builder_backend.py` covering: pull-side exchange for a
  different-host ACR/ECR/GAR base image, both push+pull exchanges present for two different ACR
  hosts, same-host dedup for both ACR and GAR (no redundant second container/script), and a
  regression guard for a GAR-push / unrelated-base-image case where `--tls-verify` must stay
  correct.
- Added unit tests in both `registry_auth.py` test files (SDK + server) for the authfile-merge
  behavior (ECR/ACR init-container path and the GAR JIT script), optional `dest`/`container_name`,
  and the ECR repo-creation-skip-without-dest path.
- **(ML-12988)** Rewrote the two tests that asserted the old (buggy) "secret always wins, zero
  cloud auth" behavior to assert the new merge behavior instead; added a dedicated unit test for
  the new secret-copy init container and updated the ECR/ACR/GAR command-shape assertions for the
  soft-fail wrapper.
- **(ML-12988)** Reworked the same-host GAR test to assert pull and push are still minted
  independently (each right before the step that needs it, rather than the base image's host being
  a special case), and extended the same-host ECR/ACR dedup test to assert `--tls-verify=false` is
  correctly omitted from `bud`, locking in the fix above.
- Ran the full local unit-test suite after each change (`pytest --noconftest`, which sidesteps an
  unrelated, pre-existing FastAPI/pydantic import break in the shared conftest that these unit
  tests don't actually need): 73 tests across `test_builder_backend.py` and both
  `registry_auth.py` test files, all passing. `ruff check`/`format` clean.
- Independent code review (twice, once per fix) caught and fixed real issues pre-merge: a
  GAR-push destination wrongly asserting pull-side auth for an unrelated base-image registry
  (would have disabled `--tls-verify=false` for previously-working self-signed base-image pulls in
  `insecure_pull_registry_mode=auto`, the default); and the secret/cloud-provider merge initially
  letting a same-host cloud mint clobber a secret intentionally covering that same host, fixed by
  the soft-fail change above.

---

### 🔗 References
- Ticket links: https://ecliptos.atlassian.net/browse/ML-12961, https://ecliptos.atlassian.net/browse/ML-12988
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Related Story ML-12886 (already merged) covers push-side ACR/ECR/GAR credential exchange; this
  PR extends the same mechanism to the base-image pull for all three providers (ML-12961), and
  fixes a static-secret/cloud-provider interaction gap found while investigating a live GKE/EKS
  failure report (ML-12988).
- Also encountered (but did not fix, out of scope for this ticket) a pre-existing gap in the local
  dev/test setup: `make test-dockerized`'s default (`client`) test-image flavor is missing the
  `humanfriendly` server-only dependency, and the `server` flavor's locked `fastapi==0.141.1` no
  longer supports a pydantic.v1 response model used in `framework/routers/alert_activations.py`.
  Both reproduce on unmodified `development` too — flagging for CI/maintainer attention.

