### PR TITLE
[Utils] Fix dubious ownership error in source-loader git clone

### DIFF
--- a/mlrun/utils/clones.py
+++ b/mlrun/utils/clones.py
@@ -191,15 +191,33 @@ def clone_git(url: str, context: str, secrets=None, clone: bool = True):
             url = url.replace(f"#{refs}", f"#refs/heads/{refs}")
             branch = refs
 
+    # Kubernetes provisions `emptyDir` volumes as root-owned regardless of the
+    # container's securityContext, so a non-root init container (e.g. the
+    # Application runtime's source loader) cloning into one trips git's ownership
+    # check (CVE-2022-24765). `safe.directory` is only honored from git's "protected
+    # configuration" scopes (system/global/command) - not from a `clone -c ...`
+    # flag, which writes to the *new* repo's local config and is ignored for this
+    # setting. The GIT_CONFIG_COUNT/KEY/VALUE vars are the command scope, passed via
+    # GitPython's own per-call `env` (clone) and instance-scoped
+    # `custom_environment` (post-clone commands) so no process-wide state is touched.
+    safe_directory_env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "safe.directory",
+        "GIT_CONFIG_VALUE_0": os.path.realpath(context),
+    }
+
     # when using the CLI and clone path was not enriched, username/password input will be requested via shell
-    repo = Repo.clone_from(final_clone_path, context, single_branch=True, b=branch)
+    repo = Repo.clone_from(
+        final_clone_path, context, single_branch=True, b=branch, env=safe_directory_env
+    )
 
-    if is_path_enriched:
-        # override enriched clone path for security reasons
-        repo.remotes[0].set_url(clone_path, final_clone_path)
+    with repo.git.custom_environment(**safe_directory_env):
+        if is_path_enriched:
+            # override enriched clone path for security reasons
+            repo.remotes[0].set_url(clone_path, final_clone_path)
 
-    if tag_or_commit := tag or commit:
-        repo.git.checkout(tag_or_commit)
+        if tag_or_commit := tag or commit:
+            repo.git.checkout(tag_or_commit)
 
     return url, repo
 

--- a/tests/utils/test_clones.py
+++ b/tests/utils/test_clones.py
@@ -46,10 +46,47 @@ def test_clone_git_refs(ref, ref_type):
     with unittest.mock.patch("git.Repo.clone_from") as clone_from:
         _, repo_obj = mlrun.utils.clones.clone_git(url, context)
         clone_from.assert_called_once_with(
-            f"https://{repo}", context, single_branch=True, b=branch
+            f"https://{repo}",
+            context,
+            single_branch=True,
+            b=branch,
+            env={
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "safe.directory",
+                "GIT_CONFIG_VALUE_0": os.path.realpath(context),
+            },
         )
         if tag:
             repo_obj.git.checkout.assert_called_once_with(tag)
+
+
+def test_clone_git_wraps_post_clone_operations_in_safe_directory_env(tmp_path):
+    # each of set_url and checkout is its own git subprocess, run after clone_from
+    # returns, so both need the same safe.directory override as the clone itself.
+    url = "git://github.com/some-git-project/some-git-repo.git#refs/tags/v1.0"
+    context = str(tmp_path / "clone-target")
+    expected_safe_directory_env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "safe.directory",
+        "GIT_CONFIG_VALUE_0": os.path.realpath(context),
+    }
+
+    with unittest.mock.patch("git.Repo.clone_from") as clone_from:
+        repo_obj = clone_from.return_value
+        mlrun.utils.clones.clone_git(url, context, secrets={"GIT_TOKEN": "abc123"})
+
+        clone_from.assert_called_once_with(
+            "https://abc123:x-oauth-basic@github.com/some-git-project/some-git-repo.git",
+            context,
+            single_branch=True,
+            b=None,
+            env=expected_safe_directory_env,
+        )
+        repo_obj.git.custom_environment.assert_called_once_with(
+            **expected_safe_directory_env
+        )
+        repo_obj.remotes[0].set_url.assert_called_once()
+        repo_obj.git.checkout.assert_called_once_with("v1.0")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### 📝 Description
The `mlrun-source-loader` init container (used by the Application runtime to load `git://` sources) fails with `fatal: detected dubious ownership in repository at '/home/mlrun_code'`. The container now runs as non-root by default, but the Kubernetes-provisioned `emptyDir` volume it clones into is still root-owned, so git's CVE-2022-24765 ownership check rejects every git command run against it — first tripping on the `git remote set-url` call inside `clone_git()`.

---

### 🛠️ Changes Made
- `clone_git()` (`mlrun/utils/clones.py`) now scopes a `safe.directory` override (`GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0`) to the clone target directory, passed via GitPython's `Repo.clone_from(..., env=...)` for the initial clone and `repo.git.custom_environment(...)` for the subsequent `remote set-url`/`checkout` calls. `safe.directory` is only honored from git's "protected configuration" scopes (system/global/command); a `git clone -c safe.directory=...` flag, by contrast, writes to the new repo's *local* config, which git explicitly ignores for this setting — command scope (env vars) is used here since it composes cleanly per-call/per-`Repo`-instance without writing to `os.environ` or `~/.gitconfig`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added `test_clone_git_wraps_post_clone_operations_in_safe_directory_env` and updated `test_clone_git_refs` in `tests/utils/test_clones.py` to assert the new `env=`/`custom_environment` calls.
- Ran `pytest tests/utils/` — 810 passed; the one pre-existing failure (`test_logger.py::test_custom_logger`) reproduces identically on a clean `development` checkout and is unrelated to this change.
- `ruff check`/`ruff format --check` pass on both changed files.
- Not run: the real end-to-end system test (`test_mlrun_app_runtime_git_source`, tracked via REG-2734) needs an actual UID/ownership mismatch on a live cluster; a true unit-level repro would require `chown` to a different UID, which needs root and wasn't available in this environment.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12991
- Design docs links: n/a
- External links: n/a

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Related regression tracker: REG-2734 (same underlying `test_mlrun_app_runtime_git_source` failure).
- Parent Epic ORIS-2306 ("Containers must run without elevated permissions") is context only — establishes why this init container now defaults to non-root; not itself part of this diff.