### PR TITLE
[Dockerfiles] Migrate to dockerhub [1.12.x]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ MLRUN_ML_DOCKER_IMAGE_NAME_PREFIX ?= ml-
 MLRUN_PYTHON_VERSION ?= 3.11
 
 # Centralized MySQL image tag for tests and tooling (overridable)
-MLRUN_MYSQL_IMAGE ?= gcr.io/iguazio/mlrun-mysql:8.4
-MLRUN_POSTGRES_IMAGE = gcr.io/iguazio/postgres:17
+MLRUN_MYSQL_IMAGE ?= mysql:8.4
+MLRUN_POSTGRES_IMAGE = postgres:18
 
 MLRUN_SKIP_COMPILE_SCHEMAS ?=
 INCLUDE_PYTHON_VERSION_SUFFIX ?=

--- a/dockerfiles/common/Dockerfile
+++ b/dockerfiles/common/Dockerfile
@@ -15,7 +15,7 @@
 ARG MLRUN_PYTHON_VERSION=3.11
 ARG DOCKER_DEFAULT_PLATFORM=linux/amd64
 
-FROM --platform=${DOCKER_DEFAULT_PLATFORM} gcr.io/iguazio/python:${MLRUN_PYTHON_VERSION}-slim
+FROM --platform=${DOCKER_DEFAULT_PLATFORM} python:${MLRUN_PYTHON_VERSION}-slim
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     DEBIAN_FRONTEND=noninteractive apt-get update -q && \
     apt-get -y upgrade -o Acquire::Check-Valid-Until=false && \

--- a/dockerfiles/gpu/prebaked.Dockerfile
+++ b/dockerfiles/gpu/prebaked.Dockerfile
@@ -15,7 +15,7 @@
 ARG CUDA_VER=12.8.1-cudnn-devel-ubuntu22.04
 
 # CUDA Based image (including cudnn and cuda-toolkit):
-FROM gcr.io/iguazio/nvidia/cuda:$CUDA_VER
+FROM nvidia/cuda:$CUDA_VER
 
 # Update apt:
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/server/common/builder/schemas_compiler/docker/Dockerfile
+++ b/server/common/builder/schemas_compiler/docker/Dockerfile
@@ -15,9 +15,9 @@
 ARG PYTHON_VERSION=3.11
 ARG GO_VERSION=1.26
 
-FROM gcr.io/iguazio/golang:${GO_VERSION}-alpine AS golang
+FROM golang:${GO_VERSION}-alpine AS golang
 
-FROM gcr.io/iguazio/python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_VERSION}-alpine
 
 ARG PROTOC_GEN_GO_VERSION=v1.36.11
 ARG PROTOC_GEN_GO_GRPC_VERSION=v1.6.1

--- a/server/go/services/logcollector/cmd/docker/Dockerfile
+++ b/server/go/services/logcollector/cmd/docker/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION=1.26
 
-FROM gcr.io/iguazio/golang:${GO_VERSION} AS build-binary
+FROM golang:${GO_VERSION} AS build-binary
 
 # always build with whatever Go patch is baked into the base image, never let the go
 # toolchain silently fetch a different patch over the network to satisfy go.mod's `go` directive

--- a/server/py/framework/tests/integration/conftest.py
+++ b/server/py/framework/tests/integration/conftest.py
@@ -43,7 +43,7 @@ _postgres_engine = pytest_mock_resources.create_postgres_fixture(
 @pytest.fixture(scope="session")
 def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
     return pytest_mock_resources.MysqlConfig(
-        image=os.getenv("MLRUN_MYSQL_IMAGE", "gcr.io/iguazio/mlrun-mysql:8.4"),
+        image=os.getenv("MLRUN_MYSQL_IMAGE", "mysql:8.4"),
         port=3306,
         username="root",
         password="pass",
@@ -54,7 +54,7 @@ def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
 @pytest.fixture(scope="session")
 def pmr_postgres_config() -> pytest_mock_resources.PostgresConfig:
     return pytest_mock_resources.PostgresConfig(
-        image=os.getenv("MLRUN_POSTGRES_IMAGE", "gcr.io/iguazio/postgres:17"),
+        image=os.getenv("MLRUN_POSTGRES_IMAGE", "postgres:18"),
         port=5432,
         username="root",
         password="pass",

--- a/server/py/framework/tests/integration/db/conftest.py
+++ b/server/py/framework/tests/integration/db/conftest.py
@@ -29,7 +29,7 @@ def pmr_mysql_config(complex_mysql_password) -> pytest_mock_resources.MysqlConfi
     # against a MySQL container whose root password contains every char the
     # backup/restore code paths must escape correctly.
     return pytest_mock_resources.MysqlConfig(
-        image=os.getenv("MLRUN_MYSQL_IMAGE", "gcr.io/iguazio/mlrun-mysql:8.4"),
+        image=os.getenv("MLRUN_MYSQL_IMAGE", "mysql:8.4"),
         port=3306,
         username="root",
         password=complex_mysql_password,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,7 @@ def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
 @pytest.fixture(scope="session")
 def pmr_postgres_config() -> pytest_mock_resources.PostgresConfig:
     return pytest_mock_resources.PostgresConfig(
-        image=os.getenv("MLRUN_POSTGRES_IMAGE", "gcr.io/iguazio/postgres:17"),
+        image=os.getenv("MLRUN_POSTGRES_IMAGE", "postgres:18"),
         port=5432,
         username="root",
         password="pass",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,7 +41,7 @@ def pmr_mysql_container(
 @pytest.fixture(scope="session")
 def pmr_mysql_config() -> pytest_mock_resources.MysqlConfig:
     return pytest_mock_resources.MysqlConfig(
-        image=os.getenv("MLRUN_MYSQL_IMAGE", "gcr.io/iguazio/mlrun-mysql:8.4"),
+        image=os.getenv("MLRUN_MYSQL_IMAGE", "mysql:8.4"),
         port=3306,
         username="root",
         password="pass",


### PR DESCRIPTION

### 📝 Description

This pull request updates the project to use standard public Docker images for Python, MySQL, Postgres, and Golang instead of the previously used `gcr.io/iguazio` images. This change affects various Dockerfiles and test configurations, ensuring broader compatibility and easier access to base images.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
