### PR TITLE
 [Sec] Fix test prints

### DIFF
--- a/tests/runtimes/test_base.py
+++ b/tests/runtimes/test_base.py
@@ -297,7 +297,7 @@ class TestAutoMount:
         mlconf.storage.auto_mount_params = ",".join(
             [f"{key}={value}" for key, value in expected_env.items()]
         )
-        print(f"Auto mount params: {mlconf.storage.auto_mount_params}")
+        print("Auto mount params configured")
         runtime = self._generate_runtime()
         self._execute_run(runtime)
         rundb_mock.assert_env_variables(expected_env)
@@ -305,7 +305,7 @@ class TestAutoMount:
         # Try with a base64 json dictionary
         pvc_params_str = base64.b64encode(json.dumps(expected_env).encode())
         mlconf.storage.auto_mount_params = pvc_params_str
-        print(f"Auto mount params: {mlconf.storage.auto_mount_params}")
+        print("Auto mount params configured")
         runtime = self._generate_runtime()
         rundb_mock.reset()
         self._execute_run(runtime)


### PR DESCRIPTION
Potential fix for [https://github.com/mlrun/mlrun/security/code-scanning/150](https://github.com/mlrun/mlrun/security/code-scanning/150)

The best fix is to stop printing the raw `mlconf.storage.auto_mount_params` value and replace it with a non-sensitive diagnostic message.  
In this file, the only required change is in `tests/runtimes/test_base.py` within `test_auto_mount_env` at the two `print(...)` lines (around lines 300 and 308).

Implement by:
- Replacing `print(f"Auto mount params: {mlconf.storage.auto_mount_params}")`
- With a constant/sanitized message that does not include parameter contents, e.g. `print("Auto mount params configured")`.

This preserves test functionality (assertions and runtime behavior are unchanged) while removing clear-text logging of potentially sensitive content. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
