### PR TITLE
[Builder] Fix Buildah rejecting mixed-media-type base images

### DIFF
--- a/server/py/services/api/tests/unit/utils/test_base_image_compat.py
+++ b/server/py/services/api/tests/unit/utils/test_base_image_compat.py
@@ -1,0 +1,426 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for the Buildah base-image compatibility check (ML-12990): buildah bud rejects a base
+# image whose manifest mixes OCI and Docker layer media types, so this is detected before
+# scheduling a Buildah pod. Fails open by design - any inconclusive case (missing/unusable
+# credentials, network error, disallowed host) must return None, never raise.
+
+import json
+import unittest.mock
+
+import pytest
+import requests
+
+import framework.utils.singletons.k8s
+import services.api.utils.builder.base_image_compat as base_image_compat
+
+_OCI_CONFIG = "application/vnd.oci.image.config.v1+json"
+_OCI_LAYER = "application/vnd.oci.image.layer.v1.tar+gzip"
+_DOCKER_CONFIG = "application/vnd.docker.container.image.v1+json"
+_DOCKER_LAYER = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+
+
+def _manifest(config_media_type, layer_media_types, media_type=None, manifests=None):
+    body = {"config": {"mediaType": config_media_type}}
+    if layer_media_types is not None:
+        body["layers"] = [{"mediaType": mt} for mt in layer_media_types]
+    if media_type:
+        body["mediaType"] = media_type
+    if manifests is not None:
+        body["manifests"] = manifests
+    return body
+
+
+def _response(status_code=200, json_body=None, headers=None):
+    response = unittest.mock.Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    response.headers = headers or {}
+    response.json.return_value = json_body or {}
+    return response
+
+
+# --- base_image_uses_mixed_media_types: the leaf-manifest cases -----------------------------------
+
+
+def test_mixed_oci_and_docker_layers_is_detected(monkeypatch):
+    manifest = _manifest(_OCI_CONFIG, [_OCI_LAYER, _DOCKER_LAYER])
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _response(json_body=manifest))
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is True
+    )
+
+
+def test_homogeneous_oci_manifest_is_compatible(monkeypatch):
+    manifest = _manifest(_OCI_CONFIG, [_OCI_LAYER, _OCI_LAYER])
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _response(json_body=manifest))
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is False
+    )
+
+
+def test_homogeneous_docker_manifest_is_compatible(monkeypatch):
+    manifest = _manifest(_DOCKER_CONFIG, [_DOCKER_LAYER, _DOCKER_LAYER])
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _response(json_body=manifest))
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is False
+    )
+
+
+def test_config_family_mismatch_against_layers_is_detected(monkeypatch):
+    # deliberately conservative: an OCI config with all-Docker layers is flagged too (see the
+    # comment on _has_mixed_media_types for why erring towards over-flagging is the safe side).
+    manifest = _manifest(_OCI_CONFIG, [_DOCKER_LAYER, _DOCKER_LAYER])
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _response(json_body=manifest))
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is True
+    )
+
+
+# --- manifest-list / index resolution --------------------------------------------------------------
+
+
+def test_manifest_list_resolves_amd64_linux_entry_then_checks_it(monkeypatch):
+    index = _manifest(
+        None,
+        None,
+        media_type="application/vnd.oci.image.index.v1+json",
+        manifests=[
+            {
+                "platform": {"architecture": "arm64", "os": "linux"},
+                "digest": "sha256:arm",
+            },
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:amd",
+            },
+        ],
+    )
+    leaf = _manifest(_OCI_CONFIG, [_OCI_LAYER])
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        return _response(json_body=leaf if "sha256:amd" in url else index)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    result = base_image_compat.base_image_uses_mixed_media_types(
+        "reg.example.com/repo", None
+    )
+    assert result is False
+    assert calls[0].endswith("manifests/latest")
+    assert any("sha256:amd" in c for c in calls[1:])
+
+
+def test_manifest_list_without_amd64_linux_entry_is_inconclusive(monkeypatch):
+    index = _manifest(
+        None,
+        None,
+        media_type="application/vnd.docker.distribution.manifest.list.v2+json",
+        manifests=[
+            {
+                "platform": {"architecture": "arm64", "os": "linux"},
+                "digest": "sha256:arm",
+            }
+        ],
+    )
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _response(json_body=index))
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is None
+    )
+
+
+def test_index_without_self_declared_media_type_is_still_detected_via_manifests_key(
+    monkeypatch,
+):
+    # some registries omit the top-level "mediaType" on an index - the presence of "manifests"
+    # (only ever on an index, never a leaf manifest) is the fallback signal.
+    index = _manifest(
+        None,
+        None,
+        manifests=[
+            {
+                "platform": {"architecture": "amd64", "os": "linux"},
+                "digest": "sha256:amd",
+            }
+        ],
+    )
+    leaf = _manifest(_OCI_CONFIG, [_DOCKER_LAYER])
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda url, **k: _response(
+            json_body=index if "sha256:amd" not in url else leaf
+        ),
+    )
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is True
+    )
+
+
+# --- fails open: credentials, network, and disallowed hosts ---------------------------------------
+
+
+def test_no_credentials_and_401_is_inconclusive(monkeypatch):
+    monkeypatch.setattr(
+        requests, "get", lambda *a, **k: _response(status_code=401, headers={})
+    )
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is None
+    )
+
+
+def test_bearer_challenge_token_exchange_then_retry_succeeds(monkeypatch):
+    manifest = _manifest(_OCI_CONFIG, [_OCI_LAYER])
+    challenge = _response(
+        status_code=401,
+        headers={
+            "Www-Authenticate": (
+                'Bearer realm="https://auth.example.com/token",'
+                'service="reg.example.com",scope="repository:repo:pull"'
+            )
+        },
+    )
+    token_response = _response(json_body={"token": "minted-token"})
+    manifest_response = _response(json_body=manifest)
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs.get("headers", {}).get("Authorization")))
+        if "auth.example.com" in url:
+            return token_response
+        if len(calls) == 1:
+            return challenge
+        return manifest_response
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is False
+    )
+    assert calls[-1][1] == "Bearer minted-token"
+
+
+def test_bearer_challenge_with_http_realm_is_rejected(monkeypatch):
+    challenge = _response(
+        status_code=401,
+        headers={"Www-Authenticate": 'Bearer realm="http://auth.example.com/token"'},
+    )
+    monkeypatch.setattr(requests, "get", lambda *a, **k: challenge)
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is None
+    )
+
+
+def test_bearer_challenge_with_metadata_realm_is_rejected(monkeypatch):
+    challenge = _response(
+        status_code=401,
+        headers={"Www-Authenticate": 'Bearer realm="https://169.254.169.254/token"'},
+    )
+    monkeypatch.setattr(requests, "get", lambda *a, **k: challenge)
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "base_image",
+    [
+        "localhost/repo",
+        "127.0.0.1/repo",
+        "169.254.169.254/repo",
+        "metadata.google.internal/repo",
+    ],
+)
+def test_disallowed_host_never_makes_a_request(monkeypatch, base_image):
+    get = unittest.mock.Mock()
+    monkeypatch.setattr(requests, "get", get)
+    assert base_image_compat.base_image_uses_mixed_media_types(base_image, None) is None
+    get.assert_not_called()
+
+
+def test_network_error_is_inconclusive_not_raised(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "get",
+        unittest.mock.Mock(side_effect=requests.ConnectionError("boom")),
+    )
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is None
+    )
+
+
+def test_timeout_is_inconclusive_not_raised(monkeypatch):
+    monkeypatch.setattr(
+        requests, "get", unittest.mock.Mock(side_effect=requests.Timeout("boom"))
+    )
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", None
+        )
+        is None
+    )
+
+
+# --- static docker-config secret auth --------------------------------------------------------------
+
+
+def _patch_secret(monkeypatch, dockerconfig, expected_namespace=None):
+    helper = unittest.mock.Mock()
+
+    def get_secret_data(secret_name, namespace):
+        if expected_namespace is not None:
+            assert namespace == expected_namespace
+        return {".dockerconfigjson": json.dumps(dockerconfig)}
+
+    helper.get_secret_data = unittest.mock.Mock(side_effect=get_secret_data)
+    monkeypatch.setattr(
+        framework.utils.singletons.k8s, "get_k8s_helper", lambda **kwargs: helper
+    )
+
+
+def test_static_secret_matching_host_port_registry_is_used(monkeypatch):
+    # regression for the .hostname-vs-.netloc bug: a host:port registry must still match its own
+    # docker-config entry.
+    _patch_secret(
+        monkeypatch, {"auths": {"registry.local:5000": {"auth": "dXNlcjpwYXNz"}}}
+    )
+    manifest = _manifest(_OCI_CONFIG, [_OCI_LAYER])
+    captured_headers = {}
+
+    def fake_get(url, headers=None, **kwargs):
+        captured_headers.update(headers or {})
+        return _response(json_body=manifest)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    result = base_image_compat.base_image_uses_mixed_media_types(
+        "registry.local:5000/proj/img", "my-secret"
+    )
+    assert result is False
+    assert captured_headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+
+def test_static_secret_namespace_is_threaded_through(monkeypatch):
+    # regression for the namespace-defaulting bug: the caller's namespace, not the k8s helper's
+    # global default, must be used to look up the secret.
+    _patch_secret(
+        monkeypatch,
+        {"auths": {"reg.example.com": {"auth": "dXNlcjpwYXNz"}}},
+        expected_namespace="some-other-namespace",
+    )
+    manifest = _manifest(_OCI_CONFIG, [_OCI_LAYER])
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _response(json_body=manifest))
+    result = base_image_compat.base_image_uses_mixed_media_types(
+        "reg.example.com/repo", "my-secret", "some-other-namespace"
+    )
+    assert result is False
+
+
+def test_static_secret_without_matching_host_falls_back_to_anonymous(monkeypatch):
+    _patch_secret(
+        monkeypatch, {"auths": {"unrelated-registry.example.com": {"auth": "x"}}}
+    )
+    manifest = _manifest(_OCI_CONFIG, [_OCI_LAYER])
+    captured_headers = {}
+
+    def fake_get(url, headers=None, **kwargs):
+        captured_headers.update(headers or {})
+        return _response(json_body=manifest)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    base_image_compat.base_image_uses_mixed_media_types(
+        "reg.example.com/repo", "my-secret"
+    )
+    assert "Authorization" not in captured_headers
+
+
+def test_unreadable_secret_falls_back_to_anonymous_instead_of_aborting(monkeypatch):
+    helper = unittest.mock.Mock()
+    helper.get_secret_data = unittest.mock.Mock(
+        side_effect=RuntimeError("k8s api down")
+    )
+    monkeypatch.setattr(
+        framework.utils.singletons.k8s, "get_k8s_helper", lambda **kwargs: helper
+    )
+    manifest = _manifest(_OCI_CONFIG, [_OCI_LAYER])
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _response(json_body=manifest))
+    # the secret lookup failed, but the anonymous attempt below it still gets a chance to run.
+    assert (
+        base_image_compat.base_image_uses_mixed_media_types(
+            "reg.example.com/repo", "my-secret"
+        )
+        is False
+    )
+
+
+# --- image-reference parsing ------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "base_image,expected",
+    [
+        (
+            "registry.local:5000/proj/img:tag",
+            ("registry.local:5000", "proj/img", "tag"),
+        ),
+        ("registry.local:5000/proj/img", ("registry.local:5000", "proj/img", "latest")),
+        ("mlrun/mlrun:1.9", ("registry-1.docker.io", "mlrun/mlrun", "1.9")),
+        ("python:3.11-slim", ("registry-1.docker.io", "library/python", "3.11-slim")),
+        ("localhost/myimage:latest", ("localhost", "myimage", "latest")),
+        ("localhost:5000/myimage", ("localhost:5000", "myimage", "latest")),
+        (
+            "registry.local/proj/img@sha256:" + "a" * 64,
+            ("registry.local", "proj/img", "sha256:" + "a" * 64),
+        ),
+        (
+            "registry.local/proj/img@sha512:" + "b" * 128,
+            ("registry.local", "proj/img", "sha512:" + "b" * 128),
+        ),
+    ],
+)
+def test_parse_image_reference(base_image, expected):
+    assert base_image_compat._parse_image_reference(base_image) == expected

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -132,6 +132,7 @@ def _make_build_request(**overrides) -> services.api.utils.builder.BuildRequest:
         project_secrets=[],
         extra_args={},
         secret_name=None,
+        namespace=None,
         registry=None,
         runtime_spec=None,
         project_default_function_node_selector={},
@@ -149,9 +150,21 @@ def _make_build_request(**overrides) -> services.api.utils.builder.BuildRequest:
 # --- Buildah backend (ML-12885) ------------------------------------------------------------------
 
 
+def _patch_base_image_compat_inconclusive(monkeypatch):
+    # these tests exercise other selection gates (registry handling, source routing), not the
+    # base-image-compatibility check (ML-12990) - stub it "inconclusive" so they stay offline and
+    # deterministic instead of making a real registry call for every Buildah-selection test.
+    monkeypatch.setattr(
+        services.api.utils.builder.base_image_compat,
+        "base_image_uses_mixed_media_types",
+        lambda *args, **kwargs: None,
+    )
+
+
 def test_resolve_builder_backend_buildah_selected(monkeypatch):
     # a buildah-configured cluster with a plain-registry, no-source build routes to the Buildah adapter
     monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    _patch_base_image_compat_inconclusive(monkeypatch)
     backend = services.api.utils.builder.resolve_builder_backend(
         _make_build_request(image_target="registry.example.com/some-image:tag")
     )
@@ -171,6 +184,7 @@ def test_resolve_builder_backend_buildah_handles_cloud_registry_directly(
 ):
     # ECR/ACR/GAR credential exchange is wired into Buildah itself (ML-12886) -> no Kaniko fallback
     monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    _patch_base_image_compat_inconclusive(monkeypatch)
     backend = services.api.utils.builder.resolve_builder_backend(
         _make_build_request(image_target=target, registry=None)
     )
@@ -180,6 +194,7 @@ def test_resolve_builder_backend_buildah_handles_cloud_registry_directly(
 def test_resolve_builder_backend_buildah_handles_source(monkeypatch):
     # source acquisition is implemented -> Buildah is selected, no fallback
     monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    _patch_base_image_compat_inconclusive(monkeypatch)
     backend = services.api.utils.builder.resolve_builder_backend(
         _make_build_request(source="git://github.com/some-org/some-repo.git#main")
     )
@@ -189,6 +204,7 @@ def test_resolve_builder_backend_buildah_handles_source(monkeypatch):
 def test_resolve_builder_backend_buildah_keeps_inline_code_with_source(monkeypatch):
     # inline_code doesn't stage a build-context source (Kaniko uses /empty too), so Buildah keeps it
     monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    _patch_base_image_compat_inconclusive(monkeypatch)
     backend = services.api.utils.builder.resolve_builder_backend(
         _make_build_request(
             source="git://github.com/some-org/some-repo.git#main",
@@ -196,6 +212,54 @@ def test_resolve_builder_backend_buildah_keeps_inline_code_with_source(monkeypat
         )
     )
     assert isinstance(backend, services.api.utils.builder.BuildahBackend)
+
+
+# --- Base-image compatibility fallback (ML-12990) ------------------------------------------------
+
+
+def test_resolve_builder_backend_falls_back_to_kaniko_on_mixed_media_types(monkeypatch):
+    # buildah bud rejects a base image whose manifest mixes OCI/Docker layer media types - route
+    # to Kaniko instead of letting the build fail inside the pod.
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    monkeypatch.setattr(
+        services.api.utils.builder.base_image_compat,
+        "base_image_uses_mixed_media_types",
+        lambda *args, **kwargs: True,
+    )
+    backend = services.api.utils.builder.resolve_builder_backend(_make_build_request())
+    assert isinstance(backend, services.api.utils.builder.KanikoBackend)
+
+
+@pytest.mark.parametrize("verdict", [False, None])
+def test_resolve_builder_backend_stays_on_buildah_when_compatible_or_inconclusive(
+    monkeypatch, verdict
+):
+    # a compatible base image (False), or one this check couldn't evaluate (None, e.g. a
+    # transient registry error or a cloud-credential-only registry) - either way, no fallback.
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    monkeypatch.setattr(
+        services.api.utils.builder.base_image_compat,
+        "base_image_uses_mixed_media_types",
+        lambda *args, **kwargs: verdict,
+    )
+    backend = services.api.utils.builder.resolve_builder_backend(_make_build_request())
+    assert isinstance(backend, services.api.utils.builder.BuildahBackend)
+
+
+def test_resolve_builder_backend_skips_check_without_base_image(monkeypatch):
+    # no base_image -> nothing to inspect; the check must not even be called.
+    monkeypatch.setattr(config.httpdb.builder, "builder_backend", "buildah")
+    check = unittest.mock.Mock()
+    monkeypatch.setattr(
+        services.api.utils.builder.base_image_compat,
+        "base_image_uses_mixed_media_types",
+        check,
+    )
+    backend = services.api.utils.builder.resolve_builder_backend(
+        _make_build_request(base_image="")
+    )
+    assert isinstance(backend, services.api.utils.builder.BuildahBackend)
+    check.assert_not_called()
 
 
 def test_make_buildah_pod_security_context_is_caps_rootless():

--- a/server/py/services/api/utils/builder/__init__.py
+++ b/server/py/services/api/utils/builder/__init__.py
@@ -22,6 +22,7 @@ import mlrun.utils
 from mlrun.config import config
 
 import framework.utils.singletons.k8s
+from services.api.utils.builder import base_image_compat
 from services.api.utils.builder.base import (
     BuilderBackend,
     BuildRequest,
@@ -127,6 +128,7 @@ def build_image(
         project_secrets=project_secrets,
         extra_args=extra_args,
         secret_name=secret_name,
+        namespace=namespace,
         registry=registry,
         runtime_spec=runtime_spec,
         project_default_function_node_selector=project_default_function_node_selector,
@@ -164,6 +166,13 @@ def resolve_builder_backend(request: BuildRequest) -> BuilderBackend:
     The engine is the one named in ``httpdb.builder.builder_backend``. The whole ``request`` is
     accepted for symmetry with the backends themselves, which each take the same ``BuildRequest``.
 
+    Buildah is routed to Kaniko instead when the base image's manifest mixes OCI and Docker layer
+    media types - ``buildah bud`` deliberately refuses to build from such an image (ML-12990).
+    Unlike the ML-12886/87 fallback guards this codebase used to carry, this one is not temporary:
+    the upstream limitation it works around isn't expected to be fixed (see
+    :mod:`services.api.utils.builder.base_image_compat`), so don't delete it once some "obvious"
+    follow-up merges.
+
     :param request: The resolved build request.
     :return: The builder backend instance for this build.
     :raises mlrun.errors.MLRunInvalidArgumentError: If the configured backend is unknown.
@@ -181,6 +190,17 @@ def resolve_builder_backend(request: BuildRequest) -> BuilderBackend:
             f"Unsupported builder backend '{backend_name}'. "
             f"Supported backends: {', '.join(sorted(backends))}"
         )
+
+    if backend_class is BuildahBackend and request.base_image:
+        if base_image_compat.base_image_uses_mixed_media_types(
+            request.base_image, request.secret_name, request.namespace
+        ):
+            mlrun.utils.logger.info(
+                "Builder backend falling back to Kaniko: base image is incompatible with Buildah",
+                requested_backend=backend_name,
+                base_image=request.base_image,
+            )
+            return KanikoBackend()
 
     return backend_class()
 

--- a/server/py/services/api/utils/builder/base.py
+++ b/server/py/services/api/utils/builder/base.py
@@ -78,6 +78,7 @@ class BuildRequest:
     :param extra_args:         Extra builder CLI arguments (validated, engine-rendered
                                inside the backend).
     :param secret_name:        The docker-config secret to authenticate the push.
+    :param namespace:          The k8s namespace ``secret_name`` lives in.
     :param registry:           The target registry, when given explicitly.
     :param runtime_spec:       The function's runtime spec (resources, scheduling,
                                security context, ``build`` config).
@@ -105,6 +106,7 @@ class BuildRequest:
     project_secrets: list[client.V1EnvVar]
     extra_args: str | dict
     secret_name: str | None
+    namespace: str | None
     registry: str | None
     runtime_spec: typing.Any
     project_default_function_node_selector: dict[str, str]

--- a/server/py/services/api/utils/builder/base_image_compat.py
+++ b/server/py/services/api/utils/builder/base_image_compat.py
@@ -1,0 +1,266 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Detect base images Buildah can't build ``FROM`` (ML-12990).
+
+``buildah bud`` deliberately refuses to build from a base image whose manifest mixes OCI
+(``application/vnd.oci.*``) and legacy-Docker (``application/vnd.docker.*``) layer media types -
+a long-open, upstream-owned limitation (buildah#5272, buildah#3668, podman#19949), not a bug in
+this repo's Buildah invocation. Such mixed manifests are a routine byproduct of modern
+``docker buildx build`` (SBOM/provenance attestations on by default since Docker 23 / buildx
+0.10) and of Kaniko, so this is checked before scheduling a Buildah pod rather than only
+discovered after a failed build.
+
+Unlike Buildah's push-side cloud-registry credential exchange (see
+:mod:`services.api.utils.builder.registry_auth`), this check runs in the API server process
+itself, before any pod exists - it can only use credentials already available there (a static
+docker-config secret) or an anonymous pull. It can't mint ECR/ACR/GAR credentials (that exchange
+needs a pod's own workload identity), so those registries are treated as inconclusive unless
+anonymous access happens to work.
+"""
+
+import json
+from urllib.parse import urlparse
+
+import requests
+
+import mlrun.errors
+import mlrun.utils
+
+import framework.utils.singletons.k8s
+
+_REQUEST_TIMEOUT_SECONDS = 5
+
+_OCI_MANIFEST = "application/vnd.oci.image.manifest.v1+json"
+_OCI_INDEX = "application/vnd.oci.image.index.v1+json"
+_DOCKER_MANIFEST = "application/vnd.docker.distribution.manifest.v2+json"
+_DOCKER_MANIFEST_LIST = "application/vnd.docker.distribution.manifest.list.v2+json"
+_MANIFEST_ACCEPT_HEADER = ", ".join(
+    [_OCI_MANIFEST, _OCI_INDEX, _DOCKER_MANIFEST, _DOCKER_MANIFEST_LIST]
+)
+_INDEX_MEDIA_TYPES = (_OCI_INDEX, _DOCKER_MANIFEST_LIST)
+
+# the platform this check evaluates when a base image resolves to a multi-arch index - mlrun's
+# own build/runtime images are amd64, and the attestation/provenance layers that typically cause
+# the media-type mix are list-level, not per-arch, so checking any one real platform entry is
+# representative even on an arm64 cluster.
+_INSPECTED_PLATFORM = {"architecture": "amd64", "os": "linux"}
+
+_DEFAULT_REGISTRY_HOST = "registry-1.docker.io"
+
+# loopback and the cloud-metadata endpoints every major provider exposes on the link-local
+# range - unlike an arbitrary internal/private registry (a legitimate, common target this check
+# must still be able to reach), there is no legitimate reason for a base image's registry to
+# resolve here. base_image is caller-supplied, so this check (like the real build pod's own pull)
+# is reachable by anyone with build permissions; this denylist keeps that reachability from
+# turning into a credential-theft primitive against the API server's own network position.
+_DISALLOWED_HOSTS = {
+    "localhost",
+    "127.0.0.1",
+    "::1",
+    "169.254.169.254",  # AWS / Azure / GCP / OpenStack metadata
+    "metadata.google.internal",
+    "100.100.100.200",  # Alibaba Cloud metadata
+}
+
+
+def base_image_uses_mixed_media_types(
+    base_image: str, secret_name: str | None, namespace: str | None = None
+) -> bool | None:
+    """Return whether ``base_image``'s manifest mixes OCI and Docker layer media types.
+
+    Fails open by design: any network error, timeout, missing/unusable credentials, or
+    unparseable response returns ``None`` ("couldn't tell") rather than raising. A build must
+    never be blocked, or mis-routed to the wrong backend, because a registry was briefly
+    unreachable or needs credentials this check can't obtain.
+
+    :param base_image: The (enriched) base image reference the Dockerfile builds ``FROM``.
+    :param secret_name: The docker-config secret used for the build's push auth, if any - reused
+        here when it also carries an entry for the base image's registry host.
+    :param namespace: The k8s namespace ``secret_name`` lives in.
+    :return: ``True`` if the manifest mixes OCI/Docker media types (Buildah will reject it),
+        ``False`` if it doesn't, or ``None`` if this couldn't be determined.
+    """
+    try:
+        registry, repository, reference = _parse_image_reference(base_image)
+        if _is_disallowed_host(urlparse(f"https://{registry}").hostname):
+            return None
+        auth_header = _resolve_static_auth_header(registry, secret_name, namespace)
+        manifest = _fetch_manifest(registry, repository, reference, auth_header)
+        if manifest is None:
+            return None
+
+        # a compliant registry echoes the index mediaType, but some don't - "manifests" (a
+        # per-platform list) only ever appears on an index/manifest-list, never on a leaf image
+        # manifest, so it's a reliable fallback signal.
+        if manifest.get("mediaType") in _INDEX_MEDIA_TYPES or "manifests" in manifest:
+            platform_digest = _select_platform_digest(manifest)
+            if platform_digest is None:
+                return None
+            manifest = _fetch_manifest(
+                registry, repository, platform_digest, auth_header
+            )
+            if manifest is None:
+                return None
+
+        return _has_mixed_media_types(manifest)
+    except Exception as exc:
+        mlrun.utils.logger.debug(
+            "Could not inspect base image manifest for Buildah compatibility",
+            base_image=base_image,
+            exc=mlrun.errors.err_to_str(exc),
+        )
+        return None
+
+
+def _parse_image_reference(base_image: str) -> tuple[str, str, str]:
+    """Split ``base_image`` into ``(registry_host, repository, reference)``.
+
+    :param base_image: A full image reference (e.g. ``registry.local:5000/proj/img:tag``, or a
+        Docker-Hub shorthand like ``mlrun/mlrun:1.9`` / ``python:3.11-slim``).
+    :return: The registry host, the repository path and the tag or ``<algo>:<hex>`` digest.
+    """
+    # '@' is reserved for the digest separator in a reference - never split the tag on it.
+    path, sep, reference = base_image.partition("@")
+    if not sep:
+        path, sep, tag = base_image.rpartition(":")
+        # no ':' at all, or the last ':' was a "host:port" separator rather than a tag (a real
+        # tag never contains '/') - either way, there's no explicit tag.
+        if not sep or "/" in tag:
+            path, reference = base_image, "latest"
+        else:
+            reference = tag
+
+    first_segment, _, rest = path.partition("/")
+    if rest and (
+        "." in first_segment or ":" in first_segment or first_segment == "localhost"
+    ):
+        return first_segment, rest, reference
+
+    repository = path if "/" in path else f"library/{path}"
+    return _DEFAULT_REGISTRY_HOST, repository, reference
+
+
+def _is_disallowed_host(hostname: str | None) -> bool:
+    if not hostname:
+        return True
+    hostname = hostname.lower()
+    return hostname in _DISALLOWED_HOSTS or hostname.startswith(("169.254.", "fe80:"))
+
+
+def _resolve_static_auth_header(
+    registry: str, secret_name: str | None, namespace: str | None
+) -> str | None:
+    if not secret_name:
+        return None
+    try:
+        secret_data = framework.utils.singletons.k8s.get_k8s_helper(
+            silent=True
+        ).get_secret_data(secret_name, namespace)
+        dockerconfig = json.loads(secret_data.get(".dockerconfigjson", "{}"))
+    except Exception:
+        return None
+
+    for host, entry in dockerconfig.get("auths", {}).items():
+        # .netloc, not .hostname: .hostname silently drops the port, which would make a
+        # host:port registry (a common self-hosted-registry pattern) never match its own
+        # docker-config entry.
+        if urlparse(f"https://{host}").netloc == registry and entry.get("auth"):
+            return f"Basic {entry['auth']}"
+    return None
+
+
+def _fetch_manifest(
+    registry: str, repository: str, reference: str, auth_header: str | None
+) -> dict | None:
+    url = f"https://{registry}/v2/{repository}/manifests/{reference}"
+    headers = {"Accept": _MANIFEST_ACCEPT_HEADER}
+    if auth_header:
+        headers["Authorization"] = auth_header
+
+    response = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+    if response.status_code == 401:
+        token = _exchange_bearer_token(response, auth_header)
+        if token is None:
+            return None
+        headers["Authorization"] = f"Bearer {token}"
+        response = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS)
+
+    if not response.ok:
+        return None
+    return response.json()
+
+
+def _exchange_bearer_token(
+    challenge_response: requests.Response, auth_header: str | None
+) -> str | None:
+    """Follow the registry's ``Www-Authenticate: Bearer`` challenge to mint a pull token."""
+    challenge = challenge_response.headers.get("Www-Authenticate", "")
+    if not challenge.lower().startswith("bearer "):
+        return None
+
+    params = {}
+    for part in challenge[len("bearer ") :].split(","):
+        key, _, value = part.strip().partition("=")
+        params[key] = value.strip('"')
+
+    realm = params.pop("realm", None)
+    # the registry (attacker-controlled, in the worst case - it's whatever the caller put in
+    # base_image) picks this URL; requiring https and rejecting the same disallowed hosts as the
+    # initial request guards against it redirecting this request - and the static secret's
+    # credentials, if any - to an unencrypted or internal-only endpoint.
+    if not realm or not realm.startswith("https://"):
+        return None
+    if _is_disallowed_host(urlparse(realm).hostname):
+        return None
+
+    headers = {"Authorization": auth_header} if auth_header else {}
+    token_response = requests.get(
+        realm, params=params, headers=headers, timeout=_REQUEST_TIMEOUT_SECONDS
+    )
+    if not token_response.ok:
+        return None
+    body = token_response.json()
+    return body.get("token") or body.get("access_token")
+
+
+def _select_platform_digest(index_manifest: dict) -> str | None:
+    for entry in index_manifest.get("manifests", []):
+        platform = entry.get("platform", {})
+        if (
+            platform.get("architecture") == _INSPECTED_PLATFORM["architecture"]
+            and platform.get("os") == _INSPECTED_PLATFORM["os"]
+        ):
+            return entry.get("digest")
+    return None
+
+
+def _has_mixed_media_types(manifest: dict) -> bool:
+    # config is included alongside layers, not just layers against each other: the real-world
+    # repro behind this check (buildah#3668) had an OCI config with mostly-Docker layers, and
+    # nalind's own read of the failure ("manifests that mark layers with types from different
+    # specs") doesn't draw a config/layer distinction either. Erring towards over-flagging here
+    # is the safe direction - a false positive costs an unnecessary Kaniko fallback, a false
+    # negative reproduces the exact build failure this check exists to prevent.
+    media_types = [manifest.get("config", {}).get("mediaType", "")]
+    media_types += [layer.get("mediaType", "") for layer in manifest.get("layers", [])]
+    families = {family for mt in media_types if (family := _media_type_family(mt))}
+    return len(families) > 1
+
+
+def _media_type_family(media_type: str) -> str | None:
+    if media_type.startswith("application/vnd.oci."):
+        return "oci"
+    if media_type.startswith("application/vnd.docker."):
+        return "docker"
+    return None


### PR DESCRIPTION
### 📝 Description
`buildah bud` deliberately refuses to build `FROM` a base image whose manifest mixes OCI
(`application/vnd.oci.*`) and legacy-Docker (`application/vnd.docker.*`) layer media types.
This is a long-open, upstream-owned limitation in buildah/containers-storage
([buildah#5272](https://github.com/containers/buildah/issues/5272),
[buildah#3668](https://github.com/containers/buildah/issues/3668),
[podman#19949](https://github.com/containers/podman/issues/19949) — all still open), not
something fixable via a CLI flag or storage-driver change. Such mixed manifests are a routine
byproduct of modern `docker buildx build` (SBOM/provenance attestations on by default since
Docker 23 / buildx 0.10) and of Kaniko itself, so this recurs for any custom/pre-built base
image rather than being a one-off broken image (root cause of ML-12990: an app-runtime deploy
failing with `unsupported MIME type for compression:
"application/vnd.docker.image.rootfs.diff.tar.gzip"`).

This PR adds a pre-flight check that inspects the base image's registry manifest before
scheduling a Buildah build pod, and routes to Kaniko instead when it's incompatible — mirroring
the fallback pattern this codebase used for the now-shipped ML-12886/87 Buildah gaps, except
this guard is permanent since the upstream limitation isn't going away.

---

### 🛠️ Changes Made
- New `server/py/services/api/utils/builder/base_image_compat.py`: fetches the base image's
  manifest via the Docker Registry v2 HTTP API (handling manifest lists/indexes and the
  `Www-Authenticate: Bearer` token-exchange flow), and checks whether `config`/`layers` media
  types mix the OCI and Docker families. Uses a static docker-config secret when available,
  otherwise attempts anonymous access; fails open (returns "inconclusive", leaves Buildah
  selected) on any network error, timeout, or credential it can't obtain.
- `server/py/services/api/utils/builder/__init__.py`: `resolve_builder_backend` calls the new
  check when Buildah is configured and a `base_image` is set; falls back to `KanikoBackend` on a
  positive match.
- `server/py/services/api/utils/builder/base.py`: added a `namespace` field to `BuildRequest` so
  the pre-flight check can look up the docker-config secret in the build's actual namespace
  (previously unavailable at this call site).
- Basic SSRF hardening: the check refuses to resolve/redirect to loopback or well-known
  cloud-metadata hosts, since `base_image` (and a malicious registry's `Www-Authenticate` realm)
  is caller-controlled input reaching the API server's own network position.
- Test updates: 4 existing Buildah-selection tests in `test_builder_backend.py` now stub the new
  check (they exercise other selection gates, not this one, and shouldn't make real network
  calls).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added `test_base_image_compat.py` (29 cases): mixed/homogeneous manifests, manifest-list/index
  platform resolution, bearer-token challenge/retry, disallowed-host (SSRF) rejection, static-secret
  auth (including a host:port registry and a non-default namespace — both regression cases for bugs
  found during review), and image-reference parsing (tags, digests, Docker Hub shorthand).
- Added 3 new cases to `test_builder_backend.py` covering the `resolve_builder_backend` fallback
  wiring itself (mixed → Kaniko, compatible/inconclusive → stays Buildah, no `base_image` → check
  not even called).
- **Caveat:** `pytest` itself currently can't run against this repo's `services/api` unit-test tree
  in my environment — the whole tree fails to import due to a pre-existing, unrelated issue (an
  in-progress schemas v1/v2 migration hitting a FastAPI/pydantic incompatibility in
  `framework/routers/alert_activations.py`; confirmed via `git stash` to reproduce identically on a
  clean `development` tip with none of this PR's changes). I verified all 74 affected test functions
  (29 new + 45 in `test_builder_backend.py`) by driving them directly with `pytest.MonkeyPatch`,
  bypassing only the broken `conftest.py` import — not a clean `pytest` run, but real execution of
  the real test code. Would appreciate a real CI run to confirm.
- The ticket's own reproducer (`test_mlrun_app_runtime_basic[pre_built-not_set]`) lives in a
  separate system-tests repo not available in my environment, so it wasn't run either way.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12990
- Design docs links:
- External links:
  - https://github.com/containers/buildah/issues/5272
  - https://github.com/containers/buildah/issues/3668
  - https://github.com/containers/podman/issues/19949

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Left one judgment call documented rather than resolved: whether Buildah's rejection is
  layers-only or also triggered by a config-vs-layers family mismatch. The check currently
  includes `config.mediaType` in the comparison (erring toward over-flagging, since a false
  positive just costs an unnecessary Kaniko fallback while a false negative reproduces the exact
  bug this PR fixes) — see the comment on `_has_mixed_media_types`.
- Extending cloud-registry credential exchange (ECR/ACR/GAR) to the base image's own registry host
  (when different from the push destination) is a separate, already-tracked gap and out of scope
  here — this check treats those registries as inconclusive unless a static secret or anonymous
  access covers them.