### PR TITLE
[Pagination] Fix pagination-cache conflict dropping model-monitoring batches [1.12.x]

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -8108,6 +8108,7 @@ class SQLDB(DBInterface):
         )
 
     # --- Pagination ---
+    @retry_on_conflict
     def store_paginated_query_cache_record(
         self,
         session,
@@ -8131,7 +8132,12 @@ class SQLDB(DBInterface):
             f"{user}/{function}/{page_size}/{kwargs}".encode()
         ).hexdigest()
         if not pagination_cache_record:
-            # in this case, we just lock for update to make sure no one else is writing to it
+            # Lock for update in case a record for this key already exists, so a concurrent
+            # request updating it can't be lost. This does NOT protect the insert branch below:
+            # if two concurrent callers both see zero rows here, both build a fresh
+            # PaginationCache and one of the two inserts collides on the `key` primary key.
+            # @retry_on_conflict closes that gap by retrying this whole method on conflict, so
+            # the retry's SELECT sees the row the other caller just committed.
             pagination_cache_record = self.get_paginated_query_cache_record(
                 session, key=key, for_update=True
             )

--- a/server/py/services/api/tests/unit/api/test_functions.py
+++ b/server/py/services/api/tests/unit/api/test_functions.py
@@ -492,6 +492,57 @@ async def test_multiple_store_function_race_condition(
     )
 
 
+@pytest.mark.asyncio
+async def test_concurrent_fresh_pagination_requests_do_not_conflict(
+    db: sqlalchemy.orm.Session, async_client: httpx.AsyncClient
+):
+    """
+    Regression test for ML-13001: two concurrent, fresh (no page-token) paginated list requests
+    with identical parameters hash to the same pagination-cache key. Before @retry_on_conflict was
+    added to store_paginated_query_cache_record, the losing request's insert raised an uncaught
+    MLRunConflictError instead of retrying - see the decorator's docstring for the general case
+    this is testing.
+    """
+    await services.api.tests.unit.api.utils.create_project_async(async_client, PROJECT)
+    # Make the pagination cache lookup return None (not found) on the first two calls, forcing
+    # both concurrent requests to take the fresh-insert branch and race on the same cache key
+    get_cache_record_mock = tests.conftest.MockSpecificCalls(
+        framework.utils.singletons.db.get_db().get_paginated_query_cache_record,
+        [1, 2],
+        None,
+    ).mock_function
+    framework.utils.singletons.db.get_db().get_paginated_query_cache_record = (
+        unittest.mock.Mock(side_effect=get_cache_record_mock)
+    )
+
+    request1_task = asyncio.create_task(
+        async_client.get(
+            f"projects/{PROJECT}/functions",
+            params={"page": 1, "page-size": 10},
+        )
+    )
+    request2_task = asyncio.create_task(
+        async_client.get(
+            f"projects/{PROJECT}/functions",
+            params={"page": 1, "page-size": 10},
+        )
+    )
+    response1, response2 = await asyncio.gather(
+        request1_task,
+        request2_task,
+    )
+
+    assert response1.status_code == HTTPStatus.OK.value
+    assert response2.status_code == HTTPStatus.OK.value
+    # 2 times for the two concurrent lookups + at least 1 retry lookup for the loser, but no more
+    # than 5 times, as retry should not be that excessive
+    assert (
+        3
+        <= framework.utils.singletons.db.get_db().get_paginated_query_cache_record.call_count
+        < 5
+    )
+
+
 def test_redirection_from_worker_to_chief_only_if_serving_function_with_track_models(
     db: sqlalchemy.orm.Session,
     client: fastapi.testclient.TestClient,

--- a/server/py/services/api/tests/unit/crud/test_pagination_cache.py
+++ b/server/py/services/api/tests/unit/crud/test_pagination_cache.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import time
+import unittest.mock
 
 import pytest
 import sqlalchemy.orm
@@ -22,7 +23,9 @@ from mlrun import mlconf
 from mlrun.utils import logger
 
 import framework.utils.pagination_cache
+import framework.utils.singletons.db
 import services.api.crud
+import tests.conftest
 from framework.db.sqldb.db import MAX_INT_32
 
 
@@ -497,3 +500,63 @@ def test_store_paginated_query_cache_record_out_of_range(
         framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
             db, "user_name", method, page, page_size, kwargs
         )
+
+
+def test_store_paginated_query_cache_record_retries_on_fresh_insert_conflict(
+    db: sqlalchemy.orm.Session,
+):
+    """
+    Regression test for ML-13001. SELECT ... FOR UPDATE only locks rows that already exist, so it
+    cannot stop two concurrent callers that both see zero matching rows from both trying to insert
+    the same primary key. Simulate the losing side of that race deterministically: force the
+    internal "does a record already exist" lookup to report "not found" on a store call whose key
+    already has a persisted row, so the insert collides for real. @retry_on_conflict must retry
+    the whole call - on retry, the lookup finds the row and updates it instead of raising
+    MLRunConflictError.
+    """
+    method = services.api.crud.Projects().list_projects
+    page_size = 10
+    kwargs = {}
+
+    key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+        db, "user_name", method, 1, page_size, kwargs
+    )
+
+    # Force only the very next lookup (inside the second store call below) to report "not found",
+    # even though a record for this key already exists - this reproduces the exact collision a
+    # real concurrent request would hit.
+    get_cache_record_mock = tests.conftest.MockSpecificCalls(
+        framework.utils.singletons.db.get_db().get_paginated_query_cache_record,
+        [1],
+        None,
+    ).mock_function
+    framework.utils.singletons.db.get_db().get_paginated_query_cache_record = (
+        unittest.mock.Mock(side_effect=get_cache_record_mock)
+    )
+
+    second_key = (
+        framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+            db, "user_name", method, 2, page_size, kwargs
+        )
+    )
+
+    assert second_key == key
+    assert (
+        framework.utils.singletons.db.get_db().get_paginated_query_cache_record.call_count
+        == 2
+    )
+    stored_record = (
+        framework.utils.pagination_cache.PaginationCache().get_pagination_cache_record(
+            db, key
+        )
+    )
+    assert stored_record is not None
+    assert stored_record.current_page == 2
+    assert (
+        len(
+            framework.utils.pagination_cache.PaginationCache().list_pagination_cache_records(
+                db
+            )
+        )
+        == 1
+    )

--- a/server/py/services/api/tests/unit/crud/test_pagination_cache.py
+++ b/server/py/services/api/tests/unit/crud/test_pagination_cache.py
@@ -19,13 +19,13 @@ import pytest
 import sqlalchemy.orm
 
 import mlrun.errors
+import tests.conftest
 from mlrun import mlconf
 from mlrun.utils import logger
 
 import framework.utils.pagination_cache
 import framework.utils.singletons.db
 import services.api.crud
-import tests.conftest
 from framework.db.sqldb.db import MAX_INT_32
 
 
@@ -534,10 +534,8 @@ def test_store_paginated_query_cache_record_retries_on_fresh_insert_conflict(
         unittest.mock.Mock(side_effect=get_cache_record_mock)
     )
 
-    second_key = (
-        framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
-            db, "user_name", method, 2, page_size, kwargs
-        )
+    second_key = framework.utils.pagination_cache.PaginationCache().store_pagination_cache_record(
+        db, "user_name", method, 2, page_size, kwargs
     )
 
     assert second_key == key


### PR DESCRIPTION
### 📝 Description
The model-monitoring controller processes multiple model endpoints concurrently within the same batch tick. Each endpoint issues an identical, fresh (`page=1`, no page-token) paginated `list_functions` call, so concurrent requests hash to the same pagination-cache key. `store_paginated_query_cache_record` does a get-or-create, but unlike the entity `store_*` methods that guard this shape with `@retry_on_conflict` (`store_run`, `store_artifact`, `store_function`, `store_schedule`, `store_project`, `store_feature_set`, `store_feature_vector`, `store_hub_source`, `store_background_task`), it relied solely on a `SELECT ... FOR UPDATE` lookup for mutual exclusion — it is the only `FOR UPDATE` caller in the file whose critical section can insert. That relies on the assumption that a second concurrent caller would block on the `SELECT` until the first caller's insert committed, then see the row and update it instead of racing to insert. That assumption doesn't hold on PostgreSQL: `FOR UPDATE` only locks rows that already match, so if zero rows match, zero locks are taken and nothing blocks the second caller (per [PG docs](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS), confirmed in ticket discussion). MySQL's InnoDB additionally takes gap/next-key locks that happen to block inserts into non-matching ranges too, which is likely why this stayed latent there. The losing insert's `MLRunConflictError` (409) was previously uncaught, so the model-monitoring controller logged it and silently dropped that endpoint's batch. This closes the gap by adding the missing decorator — retrying on conflict is correct regardless of locking semantics, so it fixes this independent of DB dialect.

---

### 🛠️ Changes Made
- Added `@retry_on_conflict` to `store_paginated_query_cache_record` in `server/py/framework/db/sqldb/db.py`, so a conflicting insert retries the whole call instead of raising.
- Corrected the inline comment above the `FOR UPDATE` lookup to describe what it does and doesn't protect against.
- Added a regression test in `test_pagination_cache.py` that forces a real primary-key collision on the fresh-insert path and asserts the call retries instead of raising.
- Added a regression test in `test_functions.py` that fires two concurrent, identical `GET .../functions?page=1&page-size=...` requests and asserts both succeed.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added two unit tests that reproduce the race: reverting just the fix makes both fail with the exact `MLRunConflictError`/409 from the ticket; with the fix, both pass.
- Ran the pagination-cache, pagination-utils, sqldb, and functions/runs/artifacts unit-test suites (140+ tests) — all pass except one pre-existing, unrelated failure (`test_list_functions_with_time_filters`, a clock-based test) confirmed to fail identically on unmodified `1.12.x`.
- Did not run system tests (no live cluster available in this environment).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13001
- Design docs links: N/A
- External links: N/A

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The changelog's existing "Open issues" row for ML-11468 (the prior, incomplete fix for this same mechanism) becomes stale once this lands; a changelog update is left as a follow-up rather than included here, matching this repo's own precedent of shipping that kind of doc update via a separate PR.
- Whether this needs to block the 1.12.0 release is an open product decision raised on the ticket; this PR is ready to merge regardless of when it's scheduled.
- Scope note, for the broader `FOR UPDATE` concern raised in the ticket: I audited every locking call site in the repo. There are 6 `FOR UPDATE` users and no other locking primitives (no advisory locks / `GET_LOCK` / raw lock SQL). The other 5 are not exposed to this failure mode — `update_run` and `set_run_retrying_status` lock a row that must already exist (raising `MLRunNotFoundError` otherwise, so there is no insert branch), `tag_artifacts` and `_mark_best_iteration_artifact` lock artifact rows that are committed before the lock is taken (so the later contender's lock set always includes the earlier's row and they do serialize on PG), and `_get_project_record`'s `for_update` parameter is never passed `True` by any caller. Separately, several other `store_*` methods do an unguarded get-then-insert with neither a lock nor a retry (`store_datastore_profile`, `store_alert_template`, `store_alert`, `_store_notifications`, `store_time_window_tracker_record`); none carry this bug's silent-data-loss property (they would surface as a 409 on a concurrent duplicate write rather than a dropped batch), and per the ticket discussion those belong to the separate follow-up ticket rather than this PR.
