### PR TITLE
[Datastore] Fix S3 anonymous fallback ignoring default credential chain

### DIFF
--- a/mlrun/datastore/s3.py
+++ b/mlrun/datastore/s3.py
@@ -188,7 +188,12 @@ class S3Store(DataStore):
             token = None
 
         storage_options = dict(
-            anon=not (force_non_anonymous or (access_key_id and secret) or token_file),
+            anon=not (
+                force_non_anonymous
+                or (access_key_id and secret)
+                or token_file
+                or self._has_default_credentials()
+            ),
             key=access_key_id,
             secret=secret,
             token=token,

--- a/tests/datastore/test_s3.py
+++ b/tests/datastore/test_s3.py
@@ -274,3 +274,50 @@ class TestS3StoreAnonymousAccessFallback:
             mock_resource.meta.client.meta.events.register.call_args[0][0]
             == "choose-signer.s3.*"
         )
+
+
+class TestS3StoreGetStorageOptions:
+    """Tests for ML-13000: get_storage_options() (used by fsspec/s3fs, e.g. for
+    context.log_dataset) must mirror __init__'s signing decision, so that default
+    credentials (IAM roles, IRSA, etc.) are honored instead of forcing anonymous
+    (unsigned) access, which fails against SSE-KMS encrypted buckets.
+    """
+
+    def test_not_anonymous_when_default_credentials_available(self) -> None:
+        """When default credentials (e.g. IRSA on EKS) exist, storage options
+        must not force anonymous access, even though no explicit AWS keys or
+        S3_NON_ANONYMOUS were provided."""
+        with (
+            patch("mlrun.datastore.s3.DataStore.__init__", return_value=None),
+            patch("mlrun.datastore.s3.S3Store._get_secret_or_env", return_value=None),
+            patch("boto3.resource"),
+            patch(
+                "mlrun.datastore.s3.S3Store._has_default_credentials",
+                return_value=True,
+            ),
+        ):
+            store = S3Store(parent=None, schema="s3", name="test", endpoint="bucket")
+            store._sanitize_options = Mock(side_effect=lambda x: x)
+
+            storage_options = store.get_storage_options()
+
+        assert storage_options["anon"] is False
+
+    def test_anonymous_when_no_credentials_available(self) -> None:
+        """When no credentials are available through any provider, storage
+        options fall back to anonymous access."""
+        with (
+            patch("mlrun.datastore.s3.DataStore.__init__", return_value=None),
+            patch("mlrun.datastore.s3.S3Store._get_secret_or_env", return_value=None),
+            patch("boto3.resource"),
+            patch(
+                "mlrun.datastore.s3.S3Store._has_default_credentials",
+                return_value=False,
+            ),
+        ):
+            store = S3Store(parent=None, schema="s3", name="test", endpoint="bucket")
+            store._sanitize_options = Mock(side_effect=lambda x: x)
+
+            storage_options = store.get_storage_options()
+
+        assert storage_options["anon"] is True


### PR DESCRIPTION
### 📝 Description
On EKS with IRSA (no explicit `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` or
`S3_NON_ANONYMOUS`), `context.log_dataset()` and other fsspec/s3fs-based S3
writes fail with:

```
OSError: [Errno 22] Requests specifying Server Side Encryption with AWS KMS
managed keys require AWS Signature Version 4.
```

`S3Store.get_storage_options()` computes `anon` independently from
`S3Store.__init__` and never calls `_has_default_credentials()`. With no
explicit credentials, it always forces `anon=True`, so s3fs sends unsigned
requests — which SSE-KMS buckets reject outright, and which also silently
drop IAM/IRSA-based permissions on private buckets in general.

`__init__` already avoids this (added in #9524 / ML-11829) for the
boto3-resource-based operations (`get`/`put`/`stat`/`listdir`/`rm`/`upload`),
but `get_storage_options()` — used by the `filesystem` property, Spark
options, and pandas dataframe writes (`log_dataset`) — was never updated to
match. The removed comment in #9524's diff literally noted the two were
meant to stay in sync ("same as anon in the storage_options when working
with fsspec").

### 🛠️ Changes Made
- `get_storage_options()` in `mlrun/datastore/s3.py` now also treats
  `S3Store._has_default_credentials()` as a signal to keep requests signed,
  mirroring the check already applied in `__init__`.
- Added regression tests in `tests/datastore/test_s3.py` covering both the
  credentials-available and no-credentials-available paths for
  `get_storage_options()`.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added `TestS3StoreGetStorageOptions` (2 tests) covering `anon=False` when
  `_has_default_credentials()` is `True`, and `anon=True` when it's `False`.
- `pytest tests/datastore/test_s3.py -v` — 11/11 pass.
- `make fmt` / `make lint` — clean.

---

### 🔗 References
- Ticket link: ML-13000
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Follow-up to #9524 (ML-11829), which fixed the boto3-resource path but
missed this parallel fsspec/s3fs path.