### PR TITLE
[Pipelines] Fix KFP 400 on page 2 of filtered run listing (revert #9885) [1.12.x]

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlrun-pipelines-kfp-v1-8"
-version = "0.7.3"
+version = "0.7.4"
 description = "MLRun Pipelines adapter package for providing KFP 1.8 compatibility"
 readme = "README.md"
 requires-python = ">=3.11, <3.12"

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py
@@ -1019,10 +1019,8 @@ class Client(
             runs, next_page_token = self._list_runs(
                 page_token=current_page_token,
                 page_size=page_size,
-                sort_by=sort_by,
                 experiment_id=experiment_id,
                 namespace=namespace,
-                filter_json=filter_json,
             )
             fetched_run_count += len(runs)
             current_page_token = next_page_token

--- a/pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_list_runs.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_list_runs.py
@@ -75,34 +75,3 @@ def test_list_runs_wildcard_project_does_not_short_circuit(client, monkeypatch):
 
     get_experiments_mock.assert_not_called()
     paginate_runs_mock.assert_called_once()
-
-
-def test_paginate_runs_forwards_filter_and_sort_on_every_page(client, monkeypatch):
-    """
-    _paginate_runs must resend filter_json and sort_by to KFP on every page, not
-    just the first. page_token is an opaque seek-position cursor computed against
-    the filtered/sorted query — it does not carry the filter or sort predicates
-    with it. Dropping them on later pages makes KFP fall back to an unfiltered
-    scan while still applying a token seeked into the filtered result set.
-    """
-    list_runs_mock = unittest.mock.MagicMock(
-        side_effect=[
-            (["run-1"], "page2_token"),
-            (["run-2"], None),
-        ]
-    )
-    monkeypatch.setattr(client, "_list_runs", list_runs_mock)
-
-    pages = list(
-        client._paginate_runs(
-            page_size=1,
-            sort_by="created_at desc",
-            filter_json='{"predicates": []}',
-        )
-    )
-
-    assert [runs for runs, _ in pages] == [["run-1"], ["run-2"]]
-    assert list_runs_mock.call_count == 2
-    for call in list_runs_mock.call_args_list:
-        assert call.kwargs["sort_by"] == "created_at desc"
-        assert call.kwargs["filter_json"] == '{"predicates": []}'


### PR DESCRIPTION
(cherry picked from commit dc4696815126d6ff34a25b953d3ad3ae12c29e06)

### 📝 Description

Cherry-pick of #9999 to `1.12.x`. Reverts #9885, which made `_paginate_runs` re-send `filter_json`/`sort_by` on page 2+. KFP 1.8 embeds the filter and sort inside `next_page_token` and **rejects** re-supplying them, so every filtered run listing that spans more than one page fails with:

```
400 "Failed to create list options: Invalid input error: page token does not match the
     supplied sort by and/or filtering criteria. Either specify the same criteria or
     leave the latter empty if page token is specified"
```

User-visible impact: `_calculate_pipelines_counters` catches that error and returns all-zero counters, so **every** project's `pipelines_completed_recent_count` / `pipelines_failed_recent_count` / `pipelines_running_count` in `GET /api/v1/project-summaries` becomes `0`. That is the "Last 24hrs Workflows shows 0" symptom in ML-12987.

Only triggers when the summary window exceeds one page (`PipelinesPagination.default_page_size = 200`), which is why small labs looked healthy and loaded ones did not.

---

### 🛠️ Changes Made

- `pipeline-adapters/mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/client.py`: stop passing `sort_by` and `filter_json` on the page-2+ `_list_runs` call inside `_paginate_runs`; the page token already carries both.
- `pipeline-adapters/mlrun-pipelines-kfp-v1-8/pyproject.toml`: version `0.7.3` → `0.7.4`. This is what actually lands the fix in the image — `dockerfiles/mlrun-api/Dockerfile` installs the adapters from in-repo source *after* the `locked-requirements.txt` sync, so the branch source wins over the published wheel.
- `pipeline-adapters/mlrun-pipelines-kfp-v1-8/tests/test_list_runs.py`: drop `test_paginate_runs_forwards_filter_and_sort_on_every_page`, whose premise ("page_token ... does not carry the filter or sort predicates with it") is incorrect for KFP 1.8 — see Testing below.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

Verified against a live KFP 1.8 (`kfp-server-api` 1.8.5) on vmdev48ig4, from inside `mlrun-api-chief`, with 909 pipeline runs in the 2-day window and `page_size=200`:

| call | result |
|---|---|
| page 1, no token + filter | ✅ 200 runs, returns token |
| page 2, token + **same** filter (pre-fix behavior) | ❌ **400** page-token mismatch |
| page 2, token, no filter (post-fix behavior) | ✅ 200 runs |

Decoding the `next_page_token` confirms it already carries both predicates, which is why re-sending them is rejected and why the removed test's premise was wrong:

```json
{"SortByFieldName":"CreatedAtInSec","IsDesc":false,
 "Filter":{"GTE":{"CreatedAtInSec":[1786467099]}}}
```

Corroborated in the DB on that lab: `0 of 191` projects had any `pipelines_*_count > 0` while `189 of 191` had `runs_completed_recent_count > 0` — pipeline counters specifically zeroed, runs counters fine.

Cherry-pick applied cleanly; the resulting diff is byte-identical to #9999 on `development`.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12987
- Design docs links: None — cherry-pick of a revert.
- External links: Cherry-pick of #9999, which reverts #9885.

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- `dockerfiles/*/locked-requirements.txt` on `1.12.x` already pin `mlrun-pipelines-kfp-v1-8==0.7.4`, so no lock-file regeneration is needed. Note those pins were previously inert for this package: `v1.12.0-rc26` locked `==0.7.4` but shipped **0.7.3**, because the Dockerfile's local `uv pip install ./pipeline-adapters/...` overwrites the synced wheel. This PR is what makes the pinned version and the shipped code agree.
- **Does not fully resolve ML-12987 on its own.** A second, independent defect keeps `project-summaries` stale: on a scaled deployment the chief's `_calculate_artifact_counters_by_category` query (`SELECT project, kind, count(DISTINCT key) FROM artifacts_v2 GROUP BY project, kind`) can wedge for hours — observed 8h41m on vmdev48ig4 (`artifacts_v2` 4.26M rows / 11 GB, `work_mem` 4MB, disk-spilling sort on `COLLATE utf8_bin`). Because `refresh_project_resources_counters_cache` awaits it, no counters are written at all. Its `READ UNCOMMITTED` guard is a no-op on PostgreSQL, and the `slow_counters_warn_threshold_seconds` warning logs only *after* the await, so a full stall never warns. Filed separately.
- Consequence for validation: clear that wedge (chief restart) before re-checking the workflow tile, otherwise the frozen values will make this fix look ineffective.
