### PR TITLE
[Jupyter] Fix base env CVEs and drop the conda package cache

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -39,22 +39,39 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
     mv kubectl /usr/local/bin/
 
 # Create and activate mlrun conda environment
+# every conda step drops its package cache in the same layer it fills it - image scanners read
+# every layer, so a cache removed only at the end of the build is still reported from the earlier
+# ones. `conda clean` keeps extracted package directories that are linked into an env, hence the
+# explicit rm; env contents are hardlinks, so dropping the cache leaves the envs intact
 RUN conda create -y -n mlrun python=${MLRUN_PYTHON_VERSION} && \
     echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate mlrun" >> ~/.bashrc && \
-    chown -R $NB_UID:$NB_GID /opt/conda/envs/mlrun
+    chown -R $NB_UID:$NB_GID /opt/conda/envs/mlrun && \
+    conda clean -a -y && rm -rf /opt/conda/pkgs ~/.conda/pkgs
 
 USER $NB_UID
 
 # Ensure uv uses mlrun conda env
 ENV PATH="/opt/conda/envs/mlrun/bin:$PATH"
 
+# the packages below carry known CVEs and live in the base env, where locked-requirements.txt has
+# no reach. `conda update --all` normally picks them up, but it silently holds packages back when
+# the solver cannot move them, so these floors act as a tripwire that fails the build instead of
+# shipping a vulnerable version. keep them lower bounds only - an upper bound here would downgrade
+# whatever `conda update --all` just resolved
 RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION} && \
-    conda update --all --yes
+    conda update -n base --all --yes && \
+    conda install -n base -y \
+      'pillow>=12.3.0' \
+      'jupyterlab>=4.5.10' \
+      'jupyterlab-git>=0.54.0' \
+      'nodejs>=24.19.0' && \
+    conda clean -a -y && rm -rf /opt/conda/pkgs ~/.conda/pkgs
 
 # Add Jupyter kernel for mlrun environment
 RUN conda install -n mlrun ipykernel -y && \
-    python -m ipykernel install --user --name=mlrun --display-name "mlrun"
+    python -m ipykernel install --user --name=mlrun --display-name "mlrun" && \
+    conda clean -a -y && rm -rf /opt/conda/pkgs ~/.conda/pkgs
 
 WORKDIR $HOME
 

--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -63,7 +63,7 @@ RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION} && \
     conda update -n base --all --yes && \
     conda install -n base -y \
       'pillow>=12.3.0' \
-      'jupyterlab>=4.5.10' \
+      'jupyterlab>=4.6.2' \
       'jupyterlab-git>=0.54.0' \
       'nodejs>=24.19.0' && \
     conda clean -a -y && rm -rf /opt/conda/pkgs ~/.conda/pkgs


### PR DESCRIPTION
### 📝 Description

A vulnerability scan on `mlrun/jupyter` (image `mlrun-development-0d00fa149-1.11.0`) raised two
tickets. Most of the findings live in the `mlrun` conda env and were already resolved by the
automated lock bump in #10034, so they clear on the next rebuild with no code change.

This PR covers the remainder — the findings that `locked-requirements.txt` cannot reach:

1. Packages in the **base jupyter conda env** inherited from `quay.io/jupyter/scipy-notebook`
   (`pillow`, `jupyterlab`, `jupyterlab-git`, `nodejs` and its bundled npm dependencies).
2. The **conda package cache**, which shipped ~2.1 GB of downloaded and extracted packages in the
   image. The scanner reports CVEs against those cached artifacts, including test fixtures embedded
   in unrelated packages (`Jinja2 3.1.2` inside `unearth`, `flask 0.11.1` inside `conda-index`).
   These were previously assumed unfixable; removing the cache eliminates them.

---

### 🛠️ Changes Made

- Install explicit version floors into the base env for `pillow`, `jupyterlab`, `jupyterlab-git`
  and `nodejs`. `conda update --all` normally picks these up, but silently holds packages back when
  the solver cannot move them, so the floors act as a tripwire that fails the build instead of
  shipping a vulnerable version. `conda install` is used rather than `conda update` because
  `conda update` rejects version specs (`CondaUpdatePackageError: only supports name-only spec`).
  The floors are deliberately lower bounds only — an upper bound would downgrade whatever
  `conda update --all` just resolved.
- Drop the conda package cache in each layer that fills it, instead of once at the end of the
  build. Image scanners read every layer, so a cache deleted in a later layer is still reported
  from the earlier ones. `conda clean` alone is insufficient: it removes downloaded tarballs but
  keeps extracted package directories that are linked into an env, which is where the test-fixture
  CVEs live. Env contents are hardlinks, so dropping the cache leaves both envs intact.
- Make the base env an explicit target (`conda update -n base --all`) so the update cannot be
  silently retargeted by a future `PATH` or `CONDA_PREFIX` change.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

No automated check builds, lints or runs this Dockerfile: `build.yaml` has no `pull_request`
trigger, the PR smoke run passes `skip_images: test,mlrun-gpu,jupyter`, and there is no Dockerfile
linter in `make lint`. Verification was therefore done by building the conda layers locally and
asserting on the result:

- Base env resolves to `pillow 12.3.0`, `jupyterlab-git 0.54.1`, `jupyterlab 4.6.3`,
  `nodejs 26.6.0`, plus `cryptography 50.0.0`, `mistune 3.3.4`, `pyjwt 2.13.0` and `tornado 6.5.8`
  from `conda update --all` — all at or above the versions the tickets ask for.
- Package cache drops from 2.1 GB to 12 KB; `/opt/conda/pkgs` is gone.
- Both envs still work after the cache removal: base imports `PIL 12.3.0` and
  `cryptography 50.0.0`, `jupyter lab 4.6.3` runs, the `@jupyterlab/git v0.54.1` extension reports
  `enabled OK`, and the `mlrun` kernel is registered with `ipykernel 7.3.0` on Python 3.11.15.
- npm's bundled dependencies are refreshed by the nodejs bump: `tar 7.5.19`, `minimatch 10.2.5`,
  `diff 8.0.4`, `brace-expansion 5.0.7`, with `cross-spawn` and `picomatch` no longer present.

Not covered locally: this exercised the conda layers only, natively on arm64, not a full
`make jupyter` on amd64. Requesting a `workflow_dispatch` run of `Build` against this branch and a
`Security Scan` run against the resulting tag before merge.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12867
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12868

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

- The image moves from `jupyterlab 4.5.x` to `4.6.x` and `nodejs 24` to `26`. This is existing
  behaviour of the `conda update --all` that already runs in this Dockerfile, not something these
  floors introduce — they only avoid capping it. The `jupyterlab-git` extension was verified
  against 4.6.3.
- Removing 2.1 GB of package cache from every layer is also a significant image size reduction,
  complementing #9991.
- Residual finding: `ip-address` resolves to 10.2.0 where ML-12868 asks for 10.3.1
  (CVE-2026-69192, score 3). It is bundled inside npm 11.18.0, so there is no conda lever for it.
- `kafka-python` CVE-2026-10142/10143 is **not** in this PR. It needs the `~=2.1.0` cap lifted in
  `dependencies.py`, `extras-requirements.txt` and the waiver in `tests/test_requirements.py`
  together, plus a regeneration of all eight lock files — that affects every image, so it belongs
  in its own `[Requirements]` PR.
- The `tar --exclude` on `basehome.tar` is intentionally untouched. It was suspected of being
  broken, but GNU tar 1.35 excludes `.conda/pkgs` correctly (patterns are unanchored), and the
  exclusion was already present in the scanned image. The `tmp/basehome.tar/...` entries in the
  report should clear now that no layer retains a package cache; the rescan will confirm.