### PR TITLE
[Project Sync] Add MLRun follower endpoints for Orca 2PC sync

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -572,14 +572,12 @@ default_config = {
             "stale_resource_ttl_create": "2 minutes",
             "stale_resource_ttl_update": "2 minutes",
             "stale_resource_ttl_delete": "10 minutes",
-            # Enterprise project-sync (ML-12901): MLRun as a follower of the Orca leader.
-            # Unused unless something actually calls the /follower/projects surface.
-            "follower": {
-                # Expected service-account identity (AuthInfo.username) of the configured
-                # project leader. Inbound /follower/projects calls are rejected with 403
-                # unless the caller is a service account matching this identity.
-                "leader_identity": "",
-            },
+            # Expected service-account identity (AuthInfo.username) of the configured
+            # project leader when MLRun is a follower (distinct from "followers" above,
+            # which is the list MLRun fans out to when it's the leader). Inbound
+            # /follower/projects calls are rejected with 403 unless the caller is a
+            # service account matching this identity.
+            "follower_leader_identity": "",
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",

--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -567,6 +567,14 @@ default_config = {
             "stale_resource_ttl_create": "2 minutes",
             "stale_resource_ttl_update": "2 minutes",
             "stale_resource_ttl_delete": "10 minutes",
+            # Enterprise project-sync (ML-12901): MLRun as a follower of the Orca leader.
+            # Unused unless something actually calls the /follower/projects surface.
+            "follower": {
+                # Expected service-account identity (AuthInfo.username) of the configured
+                # project leader. Inbound /follower/projects calls are rejected with 403
+                # unless the caller is a service account matching this identity.
+                "leader_identity": "",
+            },
         },
         # The API needs to know what is its k8s svc url so it could enrich it in the jobs it creates
         "api_url": "",

--- a/server/py/framework/api/deps.py
+++ b/server/py/framework/api/deps.py
@@ -52,13 +52,13 @@ async def authenticate_leader_request(
     request: Request,
 ) -> mlrun.common.schemas.AuthInfo:
     """
-    Auth for the `/follower/projects` surface (ML-12901): the caller must be the
-    configured project leader's service account (subject == `ProjectLeaderIdentity`),
-    never a user. Builds on the existing igz auth (the same session-verification flow
-    `authenticate_request` uses) rather than a separate machine-identity mechanism.
+    Auth for the `/follower/projects` surface: the caller must be the configured project
+    leader's service account (subject == `ProjectLeaderIdentity`), never a user. Builds
+    on the existing igz auth (the same session-verification flow `authenticate_request`
+    uses) rather than a separate machine-identity mechanism.
     """
     auth_info = await authenticate_request(request)
-    leader_identity = mlrun.mlconf.httpdb.projects.follower.leader_identity
+    leader_identity = mlrun.mlconf.httpdb.projects.follower_leader_identity
     if not auth_info.is_service_account() or auth_info.username != leader_identity:
         raise mlrun.errors.MLRunAccessDeniedError(
             "This endpoint accepts only the configured project leader's service account"

--- a/server/py/framework/api/deps.py
+++ b/server/py/framework/api/deps.py
@@ -48,6 +48,24 @@ async def authenticate_request(request: Request) -> mlrun.common.schemas.AuthInf
     )
 
 
+async def authenticate_leader_request(
+    request: Request,
+) -> mlrun.common.schemas.AuthInfo:
+    """
+    Auth for the `/follower/projects` surface (ML-12901): the caller must be the
+    configured project leader's service account (subject == `ProjectLeaderIdentity`),
+    never a user. Builds on the existing igz auth (the same session-verification flow
+    `authenticate_request` uses) rather than a separate machine-identity mechanism.
+    """
+    auth_info = await authenticate_request(request)
+    leader_identity = mlrun.mlconf.httpdb.projects.follower.leader_identity
+    if not auth_info.is_service_account() or auth_info.username != leader_identity:
+        raise mlrun.errors.MLRunAccessDeniedError(
+            "This endpoint accepts only the configured project leader's service account"
+        )
+    return auth_info
+
+
 def verify_api_state(request: Request):
     path_with_query_string = uvicorn.protocols.utils.get_path_with_query_string(
         request.scope

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3545,17 +3545,10 @@ class SQLDB(DBInterface):
     ) -> mlrun.common.schemas.ProjectsOutput:
         """
         :param keyset_after: opt-in keyset-pagination lower bound, exclusive, as
-            ``(updated_at, name)`` — used by the ML-12901 follower list-states read to
-            page through large result sets at the DB layer instead of loading
-            everything into memory. Unused by every other caller.
+            ``(updated_at, name)``. Unused by every other caller.
         :param limit: paired with ``keyset_after``; caps rows returned by this query.
         :param for_update: same ``SELECT ... FOR UPDATE`` as `_get_project_record`'s
-            own `for_update` — used by the ML-12901 follower hooks' CAS pre-check
-            (`crud.projects.Projects.get_follower_project_snapshot`) so a concurrent
-            read-decide-write for the same project blocks instead of racing on stale
-            data. No-ops on SQLite (no row-level locking support there); effective on
-            Postgres/MySQL, which is what the enterprise-only Orca-leader deployments
-            this guards actually run.
+            own `for_update`. No-op on SQLite (no row-level locking support there).
         """
         # if format is a custom selection, query only the requested columns
         # bypassing the full ORM model load and pickle deserialization

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3555,7 +3555,12 @@ class SQLDB(DBInterface):
     ) -> mlrun.common.schemas.ProjectsOutput:
         """
         :param keyset_after: opt-in keyset-pagination lower bound, exclusive, as
-            ``(updated_at, name)``. Unused by every other caller.
+            ``(updated_at, name)``. Unused by every other caller. Keyset rather than
+            offset (``Paginator``/``_calculate_offset_and_limit``): that mechanism is
+            built for cached, page-numbered listing scoped to a user's `auth_info`, and
+            an offset window shifts under concurrent writes to the same rows it's
+            paging through — exactly what happens here, since projects keep getting
+            created/updated while a caller pages through this list.
         :param limit: paired with ``keyset_after``; caps rows returned by this query.
         :param for_update: same ``SELECT ... FOR UPDATE`` as `_get_project_record`'s
             own `for_update`. No-op on SQLite (no row-level locking support there).

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3541,6 +3541,7 @@ class SQLDB(DBInterface):
         updated_after: datetime | None = None,
         keyset_after: tuple[datetime, str] | None = None,
         limit: int | None = None,
+        for_update: bool = False,
     ) -> mlrun.common.schemas.ProjectsOutput:
         """
         :param keyset_after: opt-in keyset-pagination lower bound, exclusive, as
@@ -3548,6 +3549,13 @@ class SQLDB(DBInterface):
             page through large result sets at the DB layer instead of loading
             everything into memory. Unused by every other caller.
         :param limit: paired with ``keyset_after``; caps rows returned by this query.
+        :param for_update: same ``SELECT ... FOR UPDATE`` as `_get_project_record`'s
+            own `for_update` — used by the ML-12901 follower hooks' CAS pre-check
+            (`crud.projects.Projects.get_follower_project_snapshot`) so a concurrent
+            read-decide-write for the same project blocks instead of racing on stale
+            data. No-ops on SQLite (no row-level locking support there); effective on
+            Postgres/MySQL, which is what the enterprise-only Orca-leader deployments
+            this guards actually run.
         """
         # if format is a custom selection, query only the requested columns
         # bypassing the full ORM model load and pickle deserialization
@@ -3600,6 +3608,8 @@ class SQLDB(DBInterface):
             query = query.order_by(updated_at_col, Project.name)
         if limit is not None:
             query = query.limit(limit)
+        if for_update:
+            query = query.with_for_update()
 
         project_records = query.all()
         return mlrun.common.schemas.ProjectsOutput(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -223,6 +223,11 @@ def retry_on_conflict(function):
     return wrapper
 
 
+# Sort/filter floor for list_projects()'s keyset pagination when a project's
+# updated_at predates that column's existence and is still NULL.
+_KEYSET_PAGINATION_EPOCH = datetime.min.replace(tzinfo=UTC)
+
+
 class SQLDB(DBInterface):
     def __new__(cls, dsn: str | None = None):
         if dsn is None:
@@ -3534,8 +3539,16 @@ class SQLDB(DBInterface):
         state: mlrun.common.schemas.ProjectState = None,
         names: list[str] | None = None,
         updated_after: datetime | None = None,
+        keyset_after: tuple[datetime, str] | None = None,
+        limit: int | None = None,
     ) -> mlrun.common.schemas.ProjectsOutput:
-
+        """
+        :param keyset_after: opt-in keyset-pagination lower bound, exclusive, as
+            ``(updated_at, name)`` — used by the ML-12901 follower list-states read to
+            page through large result sets at the DB layer instead of loading
+            everything into memory. Unused by every other caller.
+        :param limit: paired with ``keyset_after``; caps rows returned by this query.
+        """
         # if format is a custom selection, query only the requested columns
         # bypassing the full ORM model load and pickle deserialization
         if isinstance(
@@ -3561,6 +3574,32 @@ class SQLDB(DBInterface):
             query = query.filter(Project.name.in_(names))
         if updated_after is not None:
             query = query.filter(Project.updated_at >= updated_after)
+        if keyset_after is not None or limit is not None:
+            # Coalesce NULL updated_at (pre-existing rows from before this column
+            # existed) to a fixed floor — NULL comparisons are always NULL/false in
+            # SQL, which would silently drop those rows from every keyset-paginated
+            # page and sort them inconsistently across SQLite/Postgres/MySQL's
+            # differing default NULL-ordering rules.
+            updated_at_col = func.coalesce(Project.updated_at, _KEYSET_PAGINATION_EPOCH)
+            if keyset_after is not None:
+                after_updated_at, after_name = keyset_after
+                # Portable keyset predicate (works identically on SQLite/Postgres/MySQL)
+                # — avoids row-value comparison syntax some dialects handle inconsistently.
+                query = query.filter(
+                    or_(
+                        updated_at_col > after_updated_at,
+                        and_(
+                            updated_at_col == after_updated_at,
+                            Project.name > after_name,
+                        ),
+                    )
+                )
+            # A stable order is required for keyset pagination to mean anything — the
+            # very first page (keyset_after=None) still needs it, so the boundary row
+            # a caller computes its next cursor from is consistent across pages.
+            query = query.order_by(updated_at_col, Project.name)
+        if limit is not None:
+            query = query.limit(limit)
 
         project_records = query.all()
         return mlrun.common.schemas.ProjectsOutput(

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3430,6 +3430,9 @@ class SQLDB(DBInterface):
             description=project.spec.description,
             source=project.spec.source,
             state=project.status.state,
+            op_id=project.status.op_id,
+            phase=project.status.phase,
+            updated_at=project.status.updated_at,
             created=created,
             owner=project.spec.owner,
             default_function_node_selector=project.spec.default_function_node_selector,
@@ -4395,6 +4398,9 @@ class SQLDB(DBInterface):
         project_record.source = project.spec.source
         project_record.owner = project.spec.owner
         project_record.state = project.status.state
+        project_record.op_id = project.status.op_id
+        project_record.phase = project.status.phase
+        project_record.updated_at = project.status.updated_at
         project_record.default_function_node_selector = (
             project.spec.default_function_node_selector
         )

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -3583,15 +3583,15 @@ class SQLDB(DBInterface):
             query = self._add_labels_filter(session, query, Project, labels)
         if names is not None:
             query = query.filter(Project.name.in_(names))
+        # Coalesce NULL updated_at (pre-existing rows from before this column existed)
+        # to a fixed floor — NULL comparisons are always NULL/false in SQL, which would
+        # silently drop those rows from an updated_after filter and from every
+        # keyset-paginated page, and sort them inconsistently across SQLite/Postgres/
+        # MySQL's differing default NULL-ordering rules.
+        updated_at_col = func.coalesce(Project.updated_at, _KEYSET_PAGINATION_EPOCH)
         if updated_after is not None:
-            query = query.filter(Project.updated_at >= updated_after)
+            query = query.filter(updated_at_col >= updated_after)
         if keyset_after is not None or limit is not None:
-            # Coalesce NULL updated_at (pre-existing rows from before this column
-            # existed) to a fixed floor — NULL comparisons are always NULL/false in
-            # SQL, which would silently drop those rows from every keyset-paginated
-            # page and sort them inconsistently across SQLite/Postgres/MySQL's
-            # differing default NULL-ordering rules.
-            updated_at_col = func.coalesce(Project.updated_at, _KEYSET_PAGINATION_EPOCH)
             if keyset_after is not None:
                 after_updated_at, after_name = keyset_after
                 # Portable keyset predicate (works identically on SQLite/Postgres/MySQL)

--- a/server/py/framework/tests/unit/api/__init__.py
+++ b/server/py/framework/tests/unit/api/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/server/py/framework/tests/unit/api/test_deps.py
+++ b/server/py/framework/tests/unit/api/test_deps.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock
+
+import pytest
+
+import mlrun
+import mlrun.common.schemas as schemas
+import mlrun.errors
+
+import framework.api.deps as deps
+import framework.utils.auth.verifier
+
+
+@pytest.fixture
+def leader_identity(monkeypatch: pytest.MonkeyPatch) -> str:
+    identity = "system:serviceaccount:orca:project-leader"
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.projects.follower, "leader_identity", identity
+    )
+    return identity
+
+
+def _mock_authenticate_request(
+    monkeypatch: pytest.MonkeyPatch, auth_info: schemas.AuthInfo
+) -> None:
+    async def _fake_authenticate_request(self, request):
+        return auth_info
+
+    monkeypatch.setattr(
+        framework.utils.auth.verifier.AuthVerifier,
+        "authenticate_request",
+        _fake_authenticate_request,
+    )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_leader_request_accepts_matching_service_account(
+    leader_identity: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    auth_info = schemas.AuthInfo(
+        username=leader_identity, kind=schemas.AuthInfoKind.service_account
+    )
+    _mock_authenticate_request(monkeypatch, auth_info)
+
+    result = await deps.authenticate_leader_request(unittest.mock.MagicMock())
+
+    assert result is auth_info
+
+
+@pytest.mark.asyncio
+async def test_authenticate_leader_request_rejects_user_caller(
+    leader_identity: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A regular user token — even one that happens to share the configured leader
+    identity string as a username — must never be accepted: only a service account
+    may call this surface."""
+    auth_info = schemas.AuthInfo(
+        username=leader_identity, kind=schemas.AuthInfoKind.user
+    )
+    _mock_authenticate_request(monkeypatch, auth_info)
+
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        await deps.authenticate_leader_request(unittest.mock.MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_authenticate_leader_request_rejects_wrong_service_account_identity(
+    leader_identity: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A service account that isn't the configured leader must be rejected — this is
+    what stops any other SA (or a follower's own SA) from driving this surface."""
+    auth_info = schemas.AuthInfo(
+        username="system:serviceaccount:some-other-namespace:some-other-sa",
+        kind=schemas.AuthInfoKind.service_account,
+    )
+    _mock_authenticate_request(monkeypatch, auth_info)
+
+    with pytest.raises(mlrun.errors.MLRunAccessDeniedError):
+        await deps.authenticate_leader_request(unittest.mock.MagicMock())

--- a/server/py/framework/tests/unit/api/test_deps.py
+++ b/server/py/framework/tests/unit/api/test_deps.py
@@ -28,7 +28,7 @@ import framework.utils.auth.verifier
 def leader_identity(monkeypatch: pytest.MonkeyPatch) -> str:
     identity = "system:serviceaccount:orca:project-leader"
     monkeypatch.setattr(
-        mlrun.mlconf.httpdb.projects.follower, "leader_identity", identity
+        mlrun.mlconf.httpdb.projects, "follower_leader_identity", identity
     )
     return identity
 

--- a/server/py/framework/tests/unit/utils/projects/__init__.py
+++ b/server/py/framework/tests/unit/utils/projects/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
+++ b/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import uuid
 
 import pytest
-from uuid_utils.compat import uuid7
 
 import mlrun.common.schemas
 import mlrun.errors
@@ -28,24 +26,6 @@ _STORED = uuid.UUID(int=100)
 _NEW = uuid.UUID(int=200)
 
 _STATE = mlrun.common.schemas.ProjectState
-
-
-# ----- op_id_timestamp -------------------------------------------------------
-
-
-def test_op_id_timestamp_extracts_the_embedded_mint_time():
-    before = datetime.datetime.now(tz=datetime.UTC)
-    op_id = uuid7()
-    after = datetime.datetime.now(tz=datetime.UTC)
-
-    timestamp = follower_contract.op_id_timestamp(op_id)
-
-    assert before - datetime.timedelta(milliseconds=1) <= timestamp <= after
-
-
-def test_op_id_timestamp_rejects_a_non_v7_uuid():
-    with pytest.raises(ValueError, match="UUIDv7"):
-        follower_contract.op_id_timestamp(_STORED)
 
 
 # ----- check_ordering -------------------------------------------------------

--- a/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
+++ b/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
@@ -1,0 +1,305 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+import pytest
+
+import mlrun.common.schemas
+import mlrun.errors
+
+import framework.utils.projects.follower_contract as follower_contract
+
+_OLD = uuid.UUID(int=50)
+_STORED = uuid.UUID(int=100)
+_NEW = uuid.UUID(int=200)
+
+_STATE = mlrun.common.schemas.ProjectState
+
+
+# ----- check_ordering -------------------------------------------------------
+
+
+def test_check_ordering_applies_on_first_call_with_no_stored_op():
+    assert (
+        follower_contract.check_ordering(None, _STORED)
+        == follower_contract.ReplayOutcome.apply
+    )
+
+
+def test_check_ordering_applies_on_newer_incoming_op():
+    assert (
+        follower_contract.check_ordering(_STORED, _NEW)
+        == follower_contract.ReplayOutcome.apply
+    )
+
+
+def test_check_ordering_replays_on_equal_op():
+    assert (
+        follower_contract.check_ordering(_STORED, _STORED)
+        == follower_contract.ReplayOutcome.replay
+    )
+
+
+def test_check_ordering_rejects_stale_incoming_op():
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        follower_contract.check_ordering(_STORED, _OLD)
+
+
+# ----- check_cas -------------------------------------------------------------
+
+
+def test_check_cas_requires_prev_op_id():
+    with pytest.raises(mlrun.errors.MLRunBadRequestError):
+        follower_contract.check_cas(_STORED, None)
+
+
+def test_check_cas_rejects_mismatched_witness():
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        follower_contract.check_cas(_STORED, _OLD)
+
+
+def test_check_cas_accepts_matching_witness():
+    follower_contract.check_cas(_STORED, _STORED)  # does not raise
+
+
+# ----- check_same_op (commit_create / commit_delete) ------------------------
+
+
+def test_check_same_op_rejects_when_nothing_in_flight():
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.check_same_op(None, _STORED)
+
+
+def test_check_same_op_rejects_mismatched_op():
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        follower_contract.check_same_op(_STORED, _NEW)
+
+
+def test_check_same_op_replays_on_matching_op():
+    assert (
+        follower_contract.check_same_op(_STORED, _STORED)
+        == follower_contract.ReplayOutcome.apply
+    )
+
+
+# ----- check_transition: per-op valid/invalid starting states ---------------
+
+
+@pytest.mark.parametrize(
+    "current_state",
+    [None, _STATE.creating],
+)
+def test_check_transition_prepare_create_accepts_valid_states(current_state):
+    follower_contract.check_transition(
+        current_state, follower_contract.FollowerOp.prepare_create
+    )
+
+
+@pytest.mark.parametrize(
+    "current_state",
+    [_STATE.online, _STATE.deleting, _STATE.archived],
+)
+def test_check_transition_prepare_create_rejects_invalid_states(current_state):
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.check_transition(
+            current_state, follower_contract.FollowerOp.prepare_create
+        )
+
+
+@pytest.mark.parametrize("current_state", [_STATE.creating, _STATE.online])
+def test_check_transition_commit_create_accepts_valid_states(current_state):
+    follower_contract.check_transition(
+        current_state, follower_contract.FollowerOp.commit_create
+    )
+
+
+@pytest.mark.parametrize("current_state", [None, _STATE.deleting, _STATE.archived])
+def test_check_transition_commit_create_rejects_invalid_states(current_state):
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.check_transition(
+            current_state, follower_contract.FollowerOp.commit_create
+        )
+
+
+@pytest.mark.parametrize("current_state", [_STATE.online, _STATE.archived])
+def test_check_transition_update_accepts_valid_states(current_state):
+    follower_contract.check_transition(
+        current_state, follower_contract.FollowerOp.update
+    )
+
+
+def test_check_transition_update_rejects_absent_project_as_not_found():
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        follower_contract.check_transition(None, follower_contract.FollowerOp.update)
+
+
+@pytest.mark.parametrize("current_state", [_STATE.creating, _STATE.deleting])
+def test_check_transition_update_rejects_other_invalid_states(current_state):
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.check_transition(
+            current_state, follower_contract.FollowerOp.update
+        )
+
+
+@pytest.mark.parametrize(
+    "current_state", [None, _STATE.online, _STATE.archived, _STATE.deleting]
+)
+def test_check_transition_prepare_delete_accepts_valid_states(current_state):
+    follower_contract.check_transition(
+        current_state, follower_contract.FollowerOp.prepare_delete
+    )
+
+
+def test_check_transition_prepare_delete_rejects_creating():
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.check_transition(
+            _STATE.creating, follower_contract.FollowerOp.prepare_delete
+        )
+
+
+@pytest.mark.parametrize("current_state", [None, _STATE.deleting])
+def test_check_transition_commit_delete_accepts_valid_states(current_state):
+    follower_contract.check_transition(
+        current_state, follower_contract.FollowerOp.commit_delete
+    )
+
+
+@pytest.mark.parametrize(
+    "current_state", [_STATE.creating, _STATE.online, _STATE.archived]
+)
+def test_check_transition_commit_delete_rejects_invalid_states(current_state):
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.check_transition(
+            current_state, follower_contract.FollowerOp.commit_delete
+        )
+
+
+# ----- validate_call: integrated per-op sequences ----------------------------
+
+
+def test_validate_call_prepare_create_first_call_applies():
+    outcome = follower_contract.validate_call(
+        follower_contract.FollowerOp.prepare_create,
+        current_state=None,
+        stored_op_id=None,
+        incoming_op_id=_STORED,
+    )
+    assert outcome == follower_contract.ReplayOutcome.apply
+
+
+def test_validate_call_prepare_create_replay_after_commit_create_does_not_reject():
+    """
+    Regression: a prepare-create retry (lost response, leader re-sends the exact same
+    op_id) arriving after commit-create has already flipped the project to `online`
+    must be treated as a safe replay, not rejected for being in the "wrong" state.
+    """
+    outcome = follower_contract.validate_call(
+        follower_contract.FollowerOp.prepare_create,
+        current_state=_STATE.online,
+        stored_op_id=_STORED,
+        incoming_op_id=_STORED,
+    )
+    assert outcome == follower_contract.ReplayOutcome.replay
+
+
+def test_validate_call_prepare_create_new_op_on_online_project_still_rejected():
+    """
+    The replay-skips-transition-check fix must not open a hole: a genuinely new
+    (newer, non-matching) create op_id arriving on an already-online project is a
+    real "already exists" conflict, not a replay, and must still be rejected.
+    """
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.validate_call(
+            follower_contract.FollowerOp.prepare_create,
+            current_state=_STATE.online,
+            stored_op_id=_STORED,
+            incoming_op_id=_NEW,
+        )
+
+
+def test_validate_call_commit_create_requires_provisioned():
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        follower_contract.validate_call(
+            follower_contract.FollowerOp.commit_create,
+            current_state=None,
+            stored_op_id=None,
+            incoming_op_id=_STORED,
+        )
+
+
+def test_validate_call_update_cas_mismatch_rejected():
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        follower_contract.validate_call(
+            follower_contract.FollowerOp.update,
+            current_state=_STATE.online,
+            stored_op_id=_STORED,
+            incoming_op_id=_NEW,
+            prev_op_id=_OLD,
+        )
+
+
+def test_validate_call_update_stale_ordering_rejected():
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        follower_contract.validate_call(
+            follower_contract.FollowerOp.update,
+            current_state=_STATE.online,
+            stored_op_id=_STORED,
+            incoming_op_id=_OLD,
+            prev_op_id=_STORED,
+        )
+
+
+def test_validate_call_update_valid_cas_and_ordering_applies():
+    outcome = follower_contract.validate_call(
+        follower_contract.FollowerOp.update,
+        current_state=_STATE.online,
+        stored_op_id=_STORED,
+        incoming_op_id=_NEW,
+        prev_op_id=_STORED,
+    )
+    assert outcome == follower_contract.ReplayOutcome.apply
+
+
+def test_validate_call_prepare_delete_replay_of_in_flight_delete():
+    """A repeated mark-delete call (leader resends the same op) while already
+    `deleting` is an idempotent no-op, not an error."""
+    outcome = follower_contract.validate_call(
+        follower_contract.FollowerOp.prepare_delete,
+        current_state=_STATE.deleting,
+        stored_op_id=_STORED,
+        incoming_op_id=_STORED,
+        prev_op_id=_STORED,
+    )
+    assert outcome == follower_contract.ReplayOutcome.replay
+
+
+def test_validate_call_commit_delete_matching_op_applies():
+    outcome = follower_contract.validate_call(
+        follower_contract.FollowerOp.commit_delete,
+        current_state=_STATE.deleting,
+        stored_op_id=_STORED,
+        incoming_op_id=_STORED,
+    )
+    assert outcome == follower_contract.ReplayOutcome.apply
+
+
+def test_validate_call_commit_delete_mismatched_op_rejected():
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        follower_contract.validate_call(
+            follower_contract.FollowerOp.commit_delete,
+            current_state=_STATE.deleting,
+            stored_op_id=_STORED,
+            incoming_op_id=_NEW,
+        )

--- a/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
+++ b/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
@@ -60,8 +60,11 @@ def test_check_ordering_rejects_stale_incoming_op():
 # ----- check_cas -------------------------------------------------------------
 
 
-def test_check_cas_requires_prev_op_id():
-    with pytest.raises(mlrun.errors.MLRunBadRequestError):
+def test_check_cas_rejects_missing_witness_against_a_known_op():
+    """A project MLRun already has an op_id for, but the caller sends no witness at
+    all, is a real CAS mismatch (409) — not a special "missing witness" 400. Only
+    `stored == prev_op_id` matters, and `None != _STORED`."""
+    with pytest.raises(mlrun.errors.MLRunConflictError):
         follower_contract.check_cas(_STORED, None)
 
 
@@ -72,6 +75,13 @@ def test_check_cas_rejects_mismatched_witness():
 
 def test_check_cas_accepts_matching_witness():
     follower_contract.check_cas(_STORED, _STORED)  # does not raise
+
+
+def test_check_cas_accepts_no_witness_against_a_project_with_no_prior_op():
+    """A project that existed before this follower interface has op_id=NULL — the
+    leader's first touch of it legitimately has no witness to offer either, and that
+    must be accepted, not rejected as a missing-witness error."""
+    follower_contract.check_cas(None, None)  # does not raise
 
 
 # ----- check_same_op (commit_create / commit_delete) ------------------------
@@ -237,6 +247,20 @@ def test_validate_call_commit_create_requires_provisioned():
             stored_op_id=None,
             incoming_op_id=_STORED,
         )
+
+
+def test_validate_call_update_first_touch_with_no_prior_op_id_applies():
+    """Migration scenario: a project that predates this follower interface has
+    op_id=None; the leader observes that and sends prev_op_id=None to match — this
+    must apply, not be rejected as a missing witness."""
+    outcome = follower_contract.validate_call(
+        follower_contract.FollowerOp.update,
+        current_state=_STATE.online,
+        stored_op_id=None,
+        incoming_op_id=_STORED,
+        prev_op_id=None,
+    )
+    assert outcome == follower_contract.ReplayOutcome.apply
 
 
 def test_validate_call_update_cas_mismatch_rejected():

--- a/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
+++ b/server/py/framework/tests/unit/utils/projects/test_follower_contract.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import uuid
 
 import pytest
+from uuid_utils.compat import uuid7
 
 import mlrun.common.schemas
 import mlrun.errors
@@ -26,6 +28,24 @@ _STORED = uuid.UUID(int=100)
 _NEW = uuid.UUID(int=200)
 
 _STATE = mlrun.common.schemas.ProjectState
+
+
+# ----- op_id_timestamp -------------------------------------------------------
+
+
+def test_op_id_timestamp_extracts_the_embedded_mint_time():
+    before = datetime.datetime.now(tz=datetime.UTC)
+    op_id = uuid7()
+    after = datetime.datetime.now(tz=datetime.UTC)
+
+    timestamp = follower_contract.op_id_timestamp(op_id)
+
+    assert before - datetime.timedelta(milliseconds=1) <= timestamp <= after
+
+
+def test_op_id_timestamp_rejects_a_non_v7_uuid():
+    with pytest.raises(ValueError, match="UUIDv7"):
+        follower_contract.op_id_timestamp(_STORED)
 
 
 # ----- check_ordering -------------------------------------------------------

--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -198,7 +198,9 @@ class Client(
             "DELETE",
             f"follower/projects/{name}",
             request,
-            timeout=mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
+            timeout=int(
+                mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project
+            ),
         )
 
     async def get_clusterization_spec(

--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -186,6 +186,16 @@ class Client(
             "DELETE", f"projects/{name}", request, timeout=120, version=api_version
         )
 
+    async def proxy_follower_project_request(
+        self, method: str, path: str, request: fastapi.Request
+    ) -> fastapi.Response:
+        """
+        The ML-12901 /follower/projects endpoints mutate project state via the
+        chief-only InternalBackgroundTasksHandler bookkeeping, same as project CUD —
+        re-route from a worker to chief rather than handling the call locally.
+        """
+        return await self._proxy_request_to_chief(method, path, request, timeout=120)
+
     async def get_clusterization_spec(
         self, return_fastapi_response: bool = True, raise_on_failure: bool = False
     ) -> typing.Union[fastapi.Response, mlrun.common.schemas.ClusterizationSpec]:

--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -190,11 +190,25 @@ class Client(
         self, method: str, path: str, request: fastapi.Request
     ) -> fastapi.Response:
         """
-        The ML-12901 /follower/projects endpoints mutate project state via the
-        chief-only InternalBackgroundTasksHandler bookkeeping, same as project CUD —
-        re-route from a worker to chief rather than handling the call locally.
+        Re-routes a worker's ML-12901 /follower/projects call to chief. Only
+        commit-delete actually needs chief (delete_project_resources deletes
+        schedules, which are chief-only); the other 5 routes are cheap DB writes
+        that would work locally too, but proxying them all uniformly is simpler
+        than branching on method/path.
+
+        commit-delete blocks until the full project purge finishes (per Orca's
+        requirement — see projects_follower.commit_delete_project), so this hop's
+        timeout must cover the same worst case the deletion background task was
+        already sized for, not the legacy chief-proxy default: a purge that
+        finishes on chief after this times out would report a false failure to
+        Orca even though the deletion actually succeeds.
         """
-        return await self._proxy_request_to_chief(method, path, request, timeout=120)
+        return await self._proxy_request_to_chief(
+            method,
+            path,
+            request,
+            timeout=mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
+        )
 
     async def get_clusterization_spec(
         self, return_fastapi_response: bool = True, raise_on_failure: bool = False

--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -186,26 +186,17 @@ class Client(
             "DELETE", f"projects/{name}", request, timeout=120, version=api_version
         )
 
-    async def proxy_follower_project_request(
-        self, method: str, path: str, request: fastapi.Request
+    async def commit_delete_follower_project(
+        self, name: str, request: fastapi.Request
     ) -> fastapi.Response:
         """
-        Re-routes a worker's ML-12901 /follower/projects call to chief. Only
-        commit-delete actually needs chief (delete_project_resources deletes
-        schedules, which are chief-only); the other 5 routes are cheap DB writes
-        that would work locally too, but proxying them all uniformly is simpler
-        than branching on method/path.
-
-        commit-delete blocks until the full project purge finishes (per Orca's
-        requirement — see projects_follower.commit_delete_project), so this hop's
-        timeout must cover the same worst case the deletion background task was
-        already sized for, not the legacy chief-proxy default: a purge that
-        finishes on chief after this times out would report a false failure to
-        Orca even though the deletion actually succeeds.
+        Re-routes the /follower/projects commit-delete call to chief. Blocks until
+        the full purge finishes, so the timeout needs to cover that, not the legacy
+        chief-proxy default.
         """
         return await self._proxy_request_to_chief(
-            method,
-            path,
+            "DELETE",
+            f"follower/projects/{name}",
             request,
             timeout=mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
         )

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -14,7 +14,6 @@
 import datetime
 import tempfile
 import typing
-import uuid
 
 import httpx
 import iguazio
@@ -402,42 +401,6 @@ class Client(BaseClient, project_follower.Member):
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ) -> mlrun.common.schemas.ProjectSummary:
         raise NotImplementedError("Get project summary is not supported")
-
-    def prepare_create_project(
-        self,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def commit_create_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def prepare_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def commit_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def update_project_follower(
-        self,
-        name: str,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
 
     def _project_policies_exist(
         self, project: str, auth_info: mlrun.common.schemas.AuthInfo

--- a/server/py/framework/utils/clients/nuclio.py
+++ b/server/py/framework/utils/clients/nuclio.py
@@ -16,7 +16,6 @@ import copy
 import datetime
 import enum
 import http
-import uuid
 
 import requests.adapters
 import requests.auth
@@ -215,42 +214,6 @@ class Client(
         response = self._send_request_to_api("GET", "versions")
         response_body = response.json()
         return response_body["dashboard"]["label"]
-
-    def prepare_create_project(
-        self,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def commit_create_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def prepare_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def commit_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def update_project_follower(
-        self,
-        name: str,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
 
     def _get_project_from_nuclio(
         self, name, auth_info: mlrun.common.schemas.AuthInfo = None

--- a/server/py/framework/utils/clients/service_account_token.py
+++ b/server/py/framework/utils/clients/service_account_token.py
@@ -43,15 +43,18 @@ class Client(
     def __init__(self) -> None:
         self._token_cache = None
 
-    def escalate_request_headers(self, headers: dict[str, str]) -> dict[str, str]:
+    def escalate_request_headers(
+        self, headers: dict[str, str] | None
+    ) -> dict[str, str]:
         """
         Add service account authentication headers to the given headers.
 
-        :param headers: Original request headers.
+        :param headers: Original request headers, if any (e.g. a service-account-origin
+            caller, such as a leader's follower call, has none to carry forward).
         :return: Headers with added service account authentication.
         """
         auth_headers = self.auth_headers
-        combined_headers = headers.copy()
+        combined_headers = (headers or {}).copy()
         combined_headers.update(auth_headers)
         return combined_headers
 

--- a/server/py/framework/utils/projects/follower.py
+++ b/server/py/framework/utils/projects/follower.py
@@ -162,7 +162,9 @@ class Member(
                     commit_before_get=True,
                 )
             else:
-                self._leader_client.update_project(auth_info.session, name, project)
+                self._leader_client.update_project(
+                    auth_info.session, name, project, auth_info
+                )
                 return framework.db.session.run_function_with_new_db_session(
                     self.get_project, name, auth_info
                 ), False

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -14,7 +14,7 @@
 
 """
 CAS + UUIDv7-ordering + state-machine checks for the leader -> follower 2PC project-sync
-contract (see the "Follower Contract HLD" Confluence page, ML-12901).
+contract.
 
 Deliberately dependency-free (no DB session, no FastAPI, no SQLAlchemy types) so the
 contract logic stays decoupled from MLRun's own storage/transport and can be lifted into a
@@ -93,8 +93,8 @@ def check_cas(stored_op_id: uuid.UUID | None, prev_op_id: uuid.UUID | None) -> N
     before this follower interface has `op_id = NULL` (nothing auto-fills it at migration
     time), so the leader's *first* touch of such a project legitimately has no witness to
     offer either — it observes `None` via `list_projects` and sends that back as
-    `prev_op_id`. (The "`prev_op_id` missing -> 400" rule in the Backend HLD applies only
-    to the client<->leader boundary, not leader<->follower — there is no such rule here.)
+    `prev_op_id`. (Rejecting a missing `prev_op_id` with 400 is a client<->leader boundary
+    rule; there is no such rule for leader<->follower.)
     """
     if stored_op_id != prev_op_id:
         raise mlrun.errors.MLRunConflictError(

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -191,7 +191,12 @@ def validate_call(
     replay of yesterday's already-valid one.
     """
     if op in _CAS_OPS:
-        check_cas(stored_op_id, prev_op_id)
+        # ORIS-4336: the leader doesn't send prev_op_id yet on update/prepare_delete —
+        # a follower must tolerate that and fall back to the ordering check alone,
+        # rather than treating the witness as mandatory (see the Follower Contract
+        # HLD's "Implementation status" note).
+        if prev_op_id is not None:
+            check_cas(stored_op_id, prev_op_id)
         outcome = check_ordering(stored_op_id, incoming_op_id)
     elif op in _SAME_OP_OPS:
         outcome = check_same_op(stored_op_id, incoming_op_id)

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+CAS + UUIDv7-ordering + state-machine checks for the leader -> follower 2PC project-sync
+contract (see the "Follower Contract HLD" Confluence page, ML-12901).
+
+Deliberately dependency-free (no DB session, no FastAPI, no SQLAlchemy types) so the
+contract logic stays decoupled from MLRun's own storage/transport and can be lifted into a
+shared cross-follower library later without rework. Callers translate their own storage
+(DB row, CRD labels, ...) into plain `op_id`/`ProjectState` values before calling in, and
+back again afterward.
+"""
+
+import enum
+import uuid
+
+import mlrun.common.schemas
+import mlrun.errors
+
+
+class FollowerOp(enum.Enum):
+    """The six leader -> follower operations in the project-sync 2PC contract."""
+
+    prepare_create = "prepare_create"
+    commit_create = "commit_create"
+    update = "update"
+    prepare_delete = "prepare_delete"
+    commit_delete = "commit_delete"
+
+
+class ReplayOutcome(enum.Enum):
+    apply = "apply"
+    replay = "replay"
+
+
+# Ops that carry a `prev_op_id` CAS witness distinct from their own new `op_id`.
+_CAS_OPS = frozenset({FollowerOp.update, FollowerOp.prepare_delete})
+# Ops that reuse the same op_id minted by their matching prepare step (equality, not
+# ordering) rather than a freshly minted one.
+_SAME_OP_OPS = frozenset({FollowerOp.commit_create, FollowerOp.commit_delete})
+
+# Valid current states per op, per the Follower Contract's request grid. `None` means "no
+# project row exists yet" and is listed explicitly where that's a valid starting point.
+_VALID_STATES: dict[FollowerOp, frozenset] = {
+    FollowerOp.prepare_create: frozenset(
+        {None, mlrun.common.schemas.ProjectState.creating}
+    ),
+    FollowerOp.commit_create: frozenset(
+        {
+            mlrun.common.schemas.ProjectState.creating,
+            mlrun.common.schemas.ProjectState.online,
+        }
+    ),
+    FollowerOp.update: frozenset(
+        {
+            mlrun.common.schemas.ProjectState.online,
+            mlrun.common.schemas.ProjectState.archived,
+        }
+    ),
+    FollowerOp.prepare_delete: frozenset(
+        {
+            None,
+            mlrun.common.schemas.ProjectState.online,
+            mlrun.common.schemas.ProjectState.archived,
+            mlrun.common.schemas.ProjectState.deleting,
+        }
+    ),
+    FollowerOp.commit_delete: frozenset(
+        {None, mlrun.common.schemas.ProjectState.deleting}
+    ),
+}
+
+
+def check_cas(stored_op_id: uuid.UUID | None, prev_op_id: uuid.UUID | None) -> None:
+    """
+    Enforce the CAS witness for `update` and `prepare_delete`: the caller's `prev_op_id`
+    must match what's currently stored. `prepare_create`/`commit_create`/`commit_delete`
+    don't call this — they have no separate witness (see `check_ordering`/`check_same_op`).
+    """
+    if prev_op_id is None:
+        raise mlrun.errors.MLRunBadRequestError(
+            "prev_op_id is required for this operation"
+        )
+    if stored_op_id != prev_op_id:
+        raise mlrun.errors.MLRunConflictError(
+            f"CAS mismatch: stored op_id {stored_op_id} does not match "
+            f"prev_op_id {prev_op_id}"
+        )
+
+
+def check_ordering(
+    stored_op_id: uuid.UUID | None, incoming_op_id: uuid.UUID
+) -> ReplayOutcome:
+    """
+    Enforce UUIDv7 time-ordering for `prepare_create` and `update`/`prepare_delete` (after
+    CAS passes): the incoming op_id must be newer than, or equal to, what's stored.
+
+    Equal op_id is an idempotent replay (safe no-op). An incoming op_id older than stored
+    is a stale/out-of-order call and is rejected.
+    """
+    if stored_op_id is None or incoming_op_id > stored_op_id:
+        return ReplayOutcome.apply
+    if incoming_op_id == stored_op_id:
+        return ReplayOutcome.replay
+    raise mlrun.errors.MLRunConflictError(
+        f"Stale operation: incoming op_id {incoming_op_id} is older than "
+        f"stored op_id {stored_op_id}"
+    )
+
+
+def check_same_op(
+    stored_op_id: uuid.UUID | None, incoming_op_id: uuid.UUID
+) -> ReplayOutcome:
+    """
+    For `commit_create`/`commit_delete`: the incoming op_id must equal the in-flight op
+    exactly. Unlike `update`/`prepare_delete`, these steps reuse the op_id minted by their
+    matching prepare step rather than a freshly minted one, so this is an equality check,
+    not an ordering one.
+    """
+    if stored_op_id is None:
+        raise mlrun.errors.MLRunPreconditionFailedError(
+            "No in-flight operation to commit against"
+        )
+    if incoming_op_id == stored_op_id:
+        return ReplayOutcome.apply
+    raise mlrun.errors.MLRunConflictError(
+        f"op_id mismatch: incoming {incoming_op_id} does not match "
+        f"the in-flight op {stored_op_id}"
+    )
+
+
+def check_transition(
+    current_state: mlrun.common.schemas.ProjectState | None, op: FollowerOp
+) -> None:
+    """
+    Validate that `current_state` allows `op`, per the Follower Contract's request grid.
+    Raises the error class the contract's status-code table calls for on an invalid
+    transition. Does not distinguish "apply" from "no-op replay" — that's `check_ordering`/
+    `check_same_op`'s job; this only rejects transitions that are never valid.
+    """
+    if current_state in _VALID_STATES[op]:
+        return
+    if (
+        op in (FollowerOp.prepare_delete, FollowerOp.commit_delete)
+        and current_state is None
+    ):
+        return  # absent project: caller treats this as a no-op, not an error
+    if op == FollowerOp.update and current_state is None:
+        raise mlrun.errors.MLRunNotFoundError("Project not found")
+    raise mlrun.errors.MLRunPreconditionFailedError(
+        f"Project is not in a valid state for {op.value} (state={current_state})"
+    )
+
+
+def validate_call(
+    op: FollowerOp,
+    current_state: mlrun.common.schemas.ProjectState | None,
+    stored_op_id: uuid.UUID | None,
+    incoming_op_id: uuid.UUID,
+    prev_op_id: uuid.UUID | None = None,
+) -> ReplayOutcome:
+    """
+    Run the full per-call validation order the contract specifies: CAS -> ordering ->
+    valid transition. Returns whether the caller should apply the mutation or treat this
+    as an idempotent no-op replay.
+
+    `check_transition` only runs when the outcome is `apply`. A `replay` means the
+    incoming op_id exactly matches what's stored, i.e. nothing has changed since that
+    exact op was already validated and applied — the current state may have since moved
+    on via a later, unrelated op (e.g. a `prepare_create` retry arriving after
+    `commit_create` already flipped the project to `online`), so re-running a transition
+    check meant for a *new* mutation against today's state would reject a legitimate
+    replay of yesterday's already-valid one.
+    """
+    if op in _CAS_OPS:
+        check_cas(stored_op_id, prev_op_id)
+        outcome = check_ordering(stored_op_id, incoming_op_id)
+    elif op in _SAME_OP_OPS:
+        outcome = check_same_op(stored_op_id, incoming_op_id)
+    else:
+        outcome = check_ordering(stored_op_id, incoming_op_id)
+    if outcome == ReplayOutcome.apply:
+        check_transition(current_state, op)
+    return outcome

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -53,7 +53,7 @@ _SAME_OP_OPS = frozenset({FollowerOp.commit_create, FollowerOp.commit_delete})
 
 # Valid current states per op, per the Follower Contract's request grid. `None` means "no
 # project row exists yet" and is listed explicitly where that's a valid starting point.
-_VALID_STATES: dict[FollowerOp, frozenset] = {
+_VALID_STATES: dict[FollowerOp, frozenset[mlrun.common.schemas.ProjectState | None]] = {
     FollowerOp.prepare_create: frozenset(
         {None, mlrun.common.schemas.ProjectState.creating}
     ),
@@ -88,11 +88,14 @@ def check_cas(stored_op_id: uuid.UUID | None, prev_op_id: uuid.UUID | None) -> N
     Enforce the CAS witness for `update` and `prepare_delete`: the caller's `prev_op_id`
     must match what's currently stored. `prepare_create`/`commit_create`/`commit_delete`
     don't call this — they have no separate witness (see `check_ordering`/`check_same_op`).
+
+    `None == None` is a valid match, not a missing-witness error: a project that existed
+    before this follower interface has `op_id = NULL` (nothing auto-fills it at migration
+    time), so the leader's *first* touch of such a project legitimately has no witness to
+    offer either — it observes `None` via `list_projects` and sends that back as
+    `prev_op_id`. (The "`prev_op_id` missing -> 400" rule in the Backend HLD applies only
+    to the client<->leader boundary, not leader<->follower — there is no such rule here.)
     """
-    if prev_op_id is None:
-        raise mlrun.errors.MLRunBadRequestError(
-            "prev_op_id is required for this operation"
-        )
     if stored_op_id != prev_op_id:
         raise mlrun.errors.MLRunConflictError(
             f"CAS mismatch: stored op_id {stored_op_id} does not match "
@@ -151,12 +154,15 @@ def check_transition(
     `check_same_op`'s job; this only rejects transitions that are never valid.
     """
     if current_state in _VALID_STATES[op]:
+        # Covers, among others, the absent-project (current_state=None) case for
+        # prepare_delete/commit_delete: that's a valid no-op starting point for both,
+        # not an error, per the contract's absent-project semantics.
         return
-    if (
-        op in (FollowerOp.prepare_delete, FollowerOp.commit_delete)
-        and current_state is None
-    ):
-        return  # absent project: caller treats this as a no-op, not an error
+    # The contract specifies a different status per op for "doesn't exist": update -> 404
+    # (explicit in its status table); everything else that reaches here (e.g. commit_create
+    # on an absent project) falls through to the generic 412 below, per its own status
+    # table (403/409/412, no 404). Don't generalize this to "state is None -> 404" — that
+    # would wrongly turn commit_create's 412 into a 404.
     if op == FollowerOp.update and current_state is None:
         raise mlrun.errors.MLRunNotFoundError("Project not found")
     raise mlrun.errors.MLRunPreconditionFailedError(

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -191,12 +191,7 @@ def validate_call(
     replay of yesterday's already-valid one.
     """
     if op in _CAS_OPS:
-        # ORIS-4336: the leader doesn't send prev_op_id yet on update/prepare_delete —
-        # a follower must tolerate that and fall back to the ordering check alone,
-        # rather than treating the witness as mandatory (see the Follower Contract
-        # HLD's "Implementation status" note).
-        if prev_op_id is not None:
-            check_cas(stored_op_id, prev_op_id)
+        check_cas(stored_op_id, prev_op_id)
         outcome = check_ordering(stored_op_id, incoming_op_id)
     elif op in _SAME_OP_OPS:
         outcome = check_same_op(stored_op_id, incoming_op_id)

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -23,6 +23,7 @@ shared cross-follower library later without rework. Callers translate their own 
 back again afterward.
 """
 
+import datetime
 import enum
 import uuid
 
@@ -81,6 +82,18 @@ _VALID_STATES: dict[FollowerOp, frozenset[mlrun.common.schemas.ProjectState | No
         {None, mlrun.common.schemas.ProjectState.deleting}
     ),
 }
+
+
+def op_id_timestamp(op_id: uuid.UUID) -> datetime.datetime:
+    """
+    Extract the millisecond-precision timestamp UUIDv7 embeds in its 48 high bits —
+    Orca's mint time for this operation. `updated_at` isn't on the wire for any of the
+    six follower ops (confirmed against Orca's actual follower client), so every hook
+    derives it from `op_id` instead of trusting a request field.
+    """
+    if op_id.version != 7:
+        raise ValueError("op_id must be a UUIDv7")
+    return datetime.datetime.fromtimestamp((op_id.int >> 80) / 1000, tz=datetime.UTC)
 
 
 def check_cas(stored_op_id: uuid.UUID | None, prev_op_id: uuid.UUID | None) -> None:

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -23,7 +23,6 @@ shared cross-follower library later without rework. Callers translate their own 
 back again afterward.
 """
 
-import datetime
 import enum
 import uuid
 
@@ -82,18 +81,6 @@ _VALID_STATES: dict[FollowerOp, frozenset[mlrun.common.schemas.ProjectState | No
         {None, mlrun.common.schemas.ProjectState.deleting}
     ),
 }
-
-
-def op_id_timestamp(op_id: uuid.UUID) -> datetime.datetime:
-    """
-    Extract the millisecond-precision timestamp UUIDv7 embeds in its 48 high bits —
-    Orca's mint time for this operation. `updated_at` isn't on the wire for any of the
-    six follower ops (confirmed against Orca's actual follower client), so every hook
-    derives it from `op_id` instead of trusting a request field.
-    """
-    if op_id.version != 7:
-        raise ValueError("op_id must be a UUIDv7")
-    return datetime.datetime.fromtimestamp((op_id.int >> 80) / 1000, tz=datetime.UTC)
 
 
 def check_cas(stored_op_id: uuid.UUID | None, prev_op_id: uuid.UUID | None) -> None:

--- a/server/py/framework/utils/projects/follower_contract.py
+++ b/server/py/framework/utils/projects/follower_contract.py
@@ -163,6 +163,12 @@ def check_transition(
     # on an absent project) falls through to the generic 412 below, per its own status
     # table (403/409/412, no 404). Don't generalize this to "state is None -> 404" — that
     # would wrongly turn commit_create's 412 into a 404.
+    #
+    # Unreachable from MLRun's own call path today: crud.Projects.update_project_follower
+    # already raises 404 before calling validate_call when the project is absent, so
+    # current_state can't be None here for update in practice. Kept anyway as the
+    # contract's own source of truth for a caller that doesn't pre-guard absence the
+    # way MLRun's crud layer happens to (e.g. a future follower implementation).
     if op == FollowerOp.update and current_state is None:
         raise mlrun.errors.MLRunNotFoundError("Project not found")
     raise mlrun.errors.MLRunPreconditionFailedError(

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -57,7 +57,12 @@ class FollowerOpIdStatus(pydantic.BaseModel):
 
 
 class FollowerPrepareCreateRequest(pydantic.BaseModel):
-    project: mlrun.common.schemas.Project
+    # Flat body per the Follower Contract HLD: the leader sends the common set
+    # (metadata + spec) and status.op_id directly at the top level — there is no
+    # "project" wrapper key on the wire.
+    metadata: mlrun.common.schemas.ProjectMetadata
+    spec: mlrun.common.schemas.ProjectSpec = mlrun.common.schemas.ProjectSpec()
+    status: FollowerOpIdStatus
 
 
 class FollowerCommitCreateRequest(pydantic.BaseModel):
@@ -65,7 +70,9 @@ class FollowerCommitCreateRequest(pydantic.BaseModel):
 
 
 class FollowerUpdateRequest(pydantic.BaseModel):
-    project: mlrun.common.schemas.Project
+    metadata: mlrun.common.schemas.ProjectMetadata
+    spec: mlrun.common.schemas.ProjectSpec = mlrun.common.schemas.ProjectSpec()
+    status: FollowerOpIdStatus
     # None is a valid CAS witness for a project with no op_id yet (see
     # follower_contract.check_cas) — the leader omits this field entirely rather than
     # sending an explicit null when it has no witness to offer.

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 """
-Wire request/response shapes for the leader -> follower 2PC project-sync contract (see
-the "Follower Contract HLD" Confluence page, ML-12901).
+Wire request/response shapes for the leader -> follower 2PC project-sync contract.
 
 Not in `mlrun.common.schemas`: that package is the public SDK<->server contract, and the
 SDK never talks to this surface. Kept dependency-free like `follower_contract.py` (only
@@ -57,9 +56,6 @@ class FollowerOpIdStatus(pydantic.BaseModel):
 
 
 class FollowerPrepareCreateRequest(pydantic.BaseModel):
-    # Flat body per the Follower Contract HLD: the leader sends the common set
-    # (metadata + spec) and status.op_id directly at the top level — there is no
-    # "project" wrapper key on the wire.
     metadata: mlrun.common.schemas.ProjectMetadata
     spec: mlrun.common.schemas.ProjectSpec = mlrun.common.schemas.ProjectSpec()
     status: FollowerOpIdStatus

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Wire request/response shapes for the leader -> follower 2PC project-sync contract (see
+the "Follower Contract HLD" Confluence page, ML-12901).
+
+Not in `mlrun.common.schemas`: that package is the public SDK<->server contract, and the
+SDK never talks to this surface. Kept dependency-free like `follower_contract.py` (only
+`pydantic` + `mlrun.common.schemas`, no FastAPI/SQLAlchemy) for the same reason — these
+shapes are as portable as the validation rules and could move into a shared
+cross-follower library alongside them.
+"""
+
+import typing
+import uuid
+
+import pydantic
+
+import mlrun.common.schemas
+
+
+class FollowerProjectState(pydantic.BaseModel):
+    name: str
+    op_id: uuid.UUID | None = None
+    state: mlrun.common.schemas.ProjectState | None = None
+
+
+class FollowerProjectStatesPage(pydantic.BaseModel):
+    projects: list[FollowerProjectState]
+    next_cursor: str | None = None
+
+
+class FollowerDeleteResult(pydantic.BaseModel):
+    name: str
+    op_id: uuid.UUID
+    result: typing.Literal["removed", "removal-scheduled"]
+
+
+class FollowerPrepareCreateRequest(pydantic.BaseModel):
+    project: mlrun.common.schemas.Project
+
+
+class FollowerCommitCreateRequest(pydantic.BaseModel):
+    op_id: uuid.UUID
+
+
+class FollowerUpdateRequest(pydantic.BaseModel):
+    project: mlrun.common.schemas.Project
+    # Optional: None is a valid CAS witness for a project with no op_id yet (see
+    # follower_contract.check_cas). Required-but-nullable, not omittable — the leader
+    # always sends this field, its value is what can legitimately be None.
+    prev_op_id: uuid.UUID | None = None
+
+
+class FollowerPrepareDeleteRequest(pydantic.BaseModel):
+    op_id: uuid.UUID
+    prev_op_id: uuid.UUID | None = None
+
+
+class FollowerCommitDeleteRequest(pydantic.BaseModel):
+    op_id: uuid.UUID

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -22,7 +22,6 @@ shapes are as portable as the validation rules and could move into a shared
 cross-follower library alongside them.
 """
 
-import typing
 import uuid
 
 import pydantic
@@ -40,15 +39,6 @@ class FollowerProjectState(pydantic.BaseModel):
 class FollowerProjectStatesPage(pydantic.BaseModel):
     projects: list[FollowerProjectState]
     next_cursor: str | None = None
-
-
-class FollowerDeleteResult(pydantic.BaseModel):
-    name: str
-    op_id: uuid.UUID
-    # Always "removed": commit-delete blocks until the purge actually finishes (Orca
-    # requirement) — there is no async/scheduled outcome to represent. A call that
-    # can't complete raises an HTTP error instead of returning a soft in-progress state.
-    result: typing.Literal["removed"]
 
 
 class FollowerOpIdStatus(pydantic.BaseModel):

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -45,7 +45,10 @@ class FollowerProjectStatesPage(pydantic.BaseModel):
 class FollowerDeleteResult(pydantic.BaseModel):
     name: str
     op_id: uuid.UUID
-    result: typing.Literal["removed", "removal-scheduled"]
+    # Always "removed": commit-delete blocks until the purge actually finishes (Orca
+    # requirement) — there is no async/scheduled outcome to represent. A call that
+    # can't complete raises an HTTP error instead of returning a soft in-progress state.
+    result: typing.Literal["removed"]
 
 
 class FollowerPrepareCreateRequest(pydantic.BaseModel):

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -23,7 +23,6 @@ shapes are as portable as the validation rules and could move into a shared
 cross-follower library alongside them.
 """
 
-import datetime
 import typing
 import uuid
 
@@ -35,7 +34,8 @@ import mlrun.common.schemas
 class FollowerProjectState(pydantic.BaseModel):
     name: str
     op_id: uuid.UUID | None = None
-    state: mlrun.common.schemas.ProjectState | None = None
+    # Wire name is sync_status, not state, matching Orca's FollowerProjectState struct.
+    sync_status: mlrun.common.schemas.ProjectState | None = None
 
 
 class FollowerProjectStatesPage(pydantic.BaseModel):
@@ -52,28 +52,30 @@ class FollowerDeleteResult(pydantic.BaseModel):
     result: typing.Literal["removed"]
 
 
+class FollowerOpIdStatus(pydantic.BaseModel):
+    op_id: uuid.UUID
+
+
 class FollowerPrepareCreateRequest(pydantic.BaseModel):
     project: mlrun.common.schemas.Project
 
 
 class FollowerCommitCreateRequest(pydantic.BaseModel):
-    op_id: uuid.UUID
-    updated_at: datetime.datetime
+    status: FollowerOpIdStatus
 
 
 class FollowerUpdateRequest(pydantic.BaseModel):
     project: mlrun.common.schemas.Project
-    # Optional: None is a valid CAS witness for a project with no op_id yet (see
-    # follower_contract.check_cas). Required-but-nullable, not omittable — the leader
-    # always sends this field, its value is what can legitimately be None.
+    # None is a valid CAS witness for a project with no op_id yet (see
+    # follower_contract.check_cas) — the leader omits this field entirely rather than
+    # sending an explicit null when it has no witness to offer.
     prev_op_id: uuid.UUID | None = None
 
 
 class FollowerPrepareDeleteRequest(pydantic.BaseModel):
-    op_id: uuid.UUID
-    updated_at: datetime.datetime
+    status: FollowerOpIdStatus
     prev_op_id: uuid.UUID | None = None
 
 
 class FollowerCommitDeleteRequest(pydantic.BaseModel):
-    op_id: uuid.UUID
+    status: FollowerOpIdStatus

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -23,6 +23,7 @@ shapes are as portable as the validation rules and could move into a shared
 cross-follower library alongside them.
 """
 
+import datetime
 import typing
 import uuid
 
@@ -57,6 +58,7 @@ class FollowerPrepareCreateRequest(pydantic.BaseModel):
 
 class FollowerCommitCreateRequest(pydantic.BaseModel):
     op_id: uuid.UUID
+    updated_at: datetime.datetime
 
 
 class FollowerUpdateRequest(pydantic.BaseModel):
@@ -69,6 +71,7 @@ class FollowerUpdateRequest(pydantic.BaseModel):
 
 class FollowerPrepareDeleteRequest(pydantic.BaseModel):
     op_id: uuid.UUID
+    updated_at: datetime.datetime
     prev_op_id: uuid.UUID | None = None
 
 

--- a/server/py/framework/utils/projects/remotes/follower.py
+++ b/server/py/framework/utils/projects/remotes/follower.py
@@ -115,13 +115,19 @@ class Member(abc.ABC):
     # request-driven and reconciliation-driven invocations are equivalent —
     # no per-request session, no per-request auth_info. Concrete followers
     # authenticate using their own service-account credentials.
+    #
+    # Each returns the project's resulting (name, op_id, state) — implementers
+    # already have this in hand from the write they just did, so callers that need
+    # to report it back (e.g. an HTTP response) don't have to re-query for it.
+    # commit_delete_project is the exception: on success there is no project left
+    # to describe.
 
     @abc.abstractmethod
     def prepare_create_project(
         self,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         pass
 
     @abc.abstractmethod
@@ -129,7 +135,7 @@ class Member(abc.ABC):
         self,
         name: str,
         op_id: uuid.UUID,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         pass
 
     @abc.abstractmethod
@@ -138,7 +144,7 @@ class Member(abc.ABC):
         name: str,
         op_id: uuid.UUID,
         prev_op_id: uuid.UUID | None = None,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         pass
 
     @abc.abstractmethod
@@ -156,5 +162,5 @@ class Member(abc.ABC):
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
         prev_op_id: uuid.UUID | None = None,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         pass

--- a/server/py/framework/utils/projects/remotes/follower.py
+++ b/server/py/framework/utils/projects/remotes/follower.py
@@ -110,11 +110,15 @@ class Member(abc.ABC):
         pass
 
     # ----- 2PC follower hooks ----------------------------------------------
-    # Invoked by the 2PC orchestrator on each remote follower as part of
-    # parallel fan-out. They take only data persisted on the project row, so
-    # request-driven and reconciliation-driven invocations are equivalent —
-    # no per-request session, no per-request auth_info. Concrete followers
-    # authenticate using their own service-account credentials.
+    # Invoked by the 2PC leader on a follower as part of its create/update/delete
+    # flow. They take only data persisted on the project row, so request-driven
+    # and reconciliation-driven invocations are equivalent — no per-request
+    # session, no per-request auth_info. Authenticating/authorizing the caller as
+    # leader-origin is the transport layer's job, done before a hook is ever
+    # invoked — not this interface's (see e.g. MLRun's SA-gated
+    # `/follower/projects` HTTP surface, which calls `crud.projects.Projects`'
+    # implementation of these hooks only after `authenticate_leader_request`
+    # passes).
     #
     # Each returns the project's resulting (name, op_id, state) — implementers
     # already have this in hand from the write they just did, so callers that need

--- a/server/py/framework/utils/projects/remotes/follower.py
+++ b/server/py/framework/utils/projects/remotes/follower.py
@@ -14,7 +14,6 @@
 
 import abc
 import datetime
-import uuid
 
 import sqlalchemy.orm
 
@@ -107,64 +106,4 @@ class Member(abc.ABC):
         name: str,
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ) -> mlrun.common.schemas.ProjectSummary:
-        pass
-
-    # ----- 2PC follower hooks ----------------------------------------------
-    # Invoked by the 2PC leader on a follower as part of its create/update/delete
-    # flow. They take only data persisted on the project row, so request-driven
-    # and reconciliation-driven invocations are equivalent — no per-request
-    # session, no per-request auth_info. Authenticating/authorizing the caller as
-    # leader-origin is the transport layer's job, done before a hook is ever
-    # invoked — not this interface's (see e.g. MLRun's SA-gated
-    # `/follower/projects` HTTP surface, which calls `crud.projects.Projects`'
-    # implementation of these hooks only after `authenticate_leader_request`
-    # passes).
-    #
-    # Each returns the project's resulting (name, op_id, state) — implementers
-    # already have this in hand from the write they just did, so callers that need
-    # to report it back (e.g. an HTTP response) don't have to re-query for it.
-    # commit_delete_project is the exception: on success there is no project left
-    # to describe.
-
-    @abc.abstractmethod
-    def prepare_create_project(
-        self,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-    ) -> mlrun.common.schemas.Project | None:
-        pass
-
-    @abc.abstractmethod
-    def commit_create_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> mlrun.common.schemas.Project | None:
-        pass
-
-    @abc.abstractmethod
-    def prepare_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-        prev_op_id: uuid.UUID | None = None,
-    ) -> mlrun.common.schemas.Project | None:
-        pass
-
-    @abc.abstractmethod
-    def commit_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        pass
-
-    @abc.abstractmethod
-    def update_project_follower(
-        self,
-        name: str,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-        prev_op_id: uuid.UUID | None = None,
-    ) -> mlrun.common.schemas.Project | None:
         pass

--- a/server/py/framework/utils/projects/remotes/follower.py
+++ b/server/py/framework/utils/projects/remotes/follower.py
@@ -137,6 +137,7 @@ class Member(abc.ABC):
         self,
         name: str,
         op_id: uuid.UUID,
+        prev_op_id: uuid.UUID | None = None,
     ) -> None:
         pass
 
@@ -154,5 +155,6 @@ class Member(abc.ABC):
         name: str,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
+        prev_op_id: uuid.UUID | None = None,
     ) -> None:
         pass

--- a/server/py/framework/utils/projects/remotes/nop_follower.py
+++ b/server/py/framework/utils/projects/remotes/nop_follower.py
@@ -153,22 +153,21 @@ class Member(project_follower.Member):
         self,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
-    ) -> mlrun.common.schemas.Project | None:
+    ) -> None:
         raise NotImplementedError
 
     def commit_create_project(
         self,
         name: str,
         op_id: uuid.UUID,
-    ) -> mlrun.common.schemas.Project | None:
+    ) -> None:
         raise NotImplementedError
 
     def prepare_delete_project(
         self,
         name: str,
         op_id: uuid.UUID,
-        prev_op_id: uuid.UUID | None = None,
-    ) -> mlrun.common.schemas.Project | None:
+    ) -> None:
         raise NotImplementedError
 
     def commit_delete_project(
@@ -183,6 +182,5 @@ class Member(project_follower.Member):
         name: str,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
-        prev_op_id: uuid.UUID | None = None,
-    ) -> mlrun.common.schemas.Project | None:
+    ) -> None:
         raise NotImplementedError

--- a/server/py/framework/utils/projects/remotes/nop_follower.py
+++ b/server/py/framework/utils/projects/remotes/nop_follower.py
@@ -153,14 +153,14 @@ class Member(project_follower.Member):
         self,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         raise NotImplementedError
 
     def commit_create_project(
         self,
         name: str,
         op_id: uuid.UUID,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         raise NotImplementedError
 
     def prepare_delete_project(
@@ -168,7 +168,7 @@ class Member(project_follower.Member):
         name: str,
         op_id: uuid.UUID,
         prev_op_id: uuid.UUID | None = None,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         raise NotImplementedError
 
     def commit_delete_project(
@@ -184,5 +184,5 @@ class Member(project_follower.Member):
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
         prev_op_id: uuid.UUID | None = None,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         raise NotImplementedError

--- a/server/py/framework/utils/projects/remotes/nop_follower.py
+++ b/server/py/framework/utils/projects/remotes/nop_follower.py
@@ -167,6 +167,7 @@ class Member(project_follower.Member):
         self,
         name: str,
         op_id: uuid.UUID,
+        prev_op_id: uuid.UUID | None = None,
     ) -> None:
         raise NotImplementedError
 
@@ -182,5 +183,6 @@ class Member(project_follower.Member):
         name: str,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
+        prev_op_id: uuid.UUID | None = None,
     ) -> None:
         raise NotImplementedError

--- a/server/py/framework/utils/projects/remotes/nop_follower.py
+++ b/server/py/framework/utils/projects/remotes/nop_follower.py
@@ -14,7 +14,6 @@
 
 
 import datetime
-import uuid
 
 import mergedeep
 import sqlalchemy.orm
@@ -148,39 +147,3 @@ class Member(project_follower.Member):
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ) -> mlrun.common.schemas.ProjectSummary:
         raise NotImplementedError("Get project summary is not supported")
-
-    def prepare_create_project(
-        self,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def commit_create_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def prepare_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def commit_delete_project(
-        self,
-        name: str,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError
-
-    def update_project_follower(
-        self,
-        name: str,
-        project: mlrun.common.schemas.Project,
-        op_id: uuid.UUID,
-    ) -> None:
-        raise NotImplementedError

--- a/server/py/services/api/api/api.py
+++ b/server/py/services/api/api/api.py
@@ -47,6 +47,7 @@ from services.api.api.endpoints import (
     pipelines,
     project_secrets,
     projects,
+    projects_follower,
     projects_v2,
     runs,
     runtime_resources,
@@ -204,6 +205,11 @@ api_router.include_router(
     alert_activations.router,
     tags=["alert-activations"],
     dependencies=[Depends(deps.authenticate_request)],
+)
+api_router.include_router(
+    projects_follower.router,
+    tags=["projects-follower"],
+    dependencies=[Depends(deps.authenticate_leader_request)],
 )
 
 # v2 Router

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -1,0 +1,311 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The ML-12901 follower surface: leader (Orca) -> MLRun-as-follower calls.
+
+Dedicated from the user-facing `/api/v1/projects` endpoints on purpose (see the Follower
+Contract HLD) — this router takes no user token, only the configured leader's service
+account (enforced by `deps.authenticate_leader_request`), so machine-origin auth never
+mixes with user auth. Enterprise-only in practice: nothing calls this without an Orca
+leader configured, but it stays always-registered rather than feature-gated.
+"""
+
+import datetime
+import typing
+import uuid
+
+import fastapi
+import pydantic
+import sqlalchemy.orm
+from fastapi import status
+
+import mlrun
+import mlrun.common.schemas
+import mlrun.errors
+import mlrun.utils
+
+import framework.api.deps
+import framework.utils.background_tasks
+import framework.utils.clients.chief
+import framework.utils.projects.follower_contract as follower_contract
+import services.api.crud
+
+router = fastapi.APIRouter()
+
+
+class FollowerProjectState(pydantic.BaseModel):
+    name: str
+    op_id: uuid.UUID | None = None
+    state: mlrun.common.schemas.ProjectState | None = None
+
+
+class FollowerProjectStatesPage(pydantic.BaseModel):
+    projects: list[FollowerProjectState]
+    next_cursor: str | None = None
+
+
+class FollowerDeleteResult(pydantic.BaseModel):
+    name: str
+    op_id: uuid.UUID
+    result: typing.Literal["removed", "removal-scheduled"]
+
+
+class FollowerPrepareCreateRequest(pydantic.BaseModel):
+    project: mlrun.common.schemas.Project
+
+
+class FollowerCommitCreateRequest(pydantic.BaseModel):
+    op_id: uuid.UUID
+
+
+class FollowerUpdateRequest(pydantic.BaseModel):
+    project: mlrun.common.schemas.Project
+    prev_op_id: uuid.UUID
+
+
+class FollowerPrepareDeleteRequest(pydantic.BaseModel):
+    op_id: uuid.UUID
+    prev_op_id: uuid.UUID
+
+
+class FollowerCommitDeleteRequest(pydantic.BaseModel):
+    op_id: uuid.UUID
+
+
+def _project_op_id(project: mlrun.common.schemas.Project) -> uuid.UUID:
+    if project.status.op_id is None:
+        raise mlrun.errors.MLRunBadRequestError("project.status.op_id is required")
+    return project.status.op_id
+
+
+def _to_follower_state(
+    name: str, snapshot: mlrun.common.schemas.Project | None
+) -> FollowerProjectState:
+    if snapshot is None:
+        return FollowerProjectState(name=name)
+    return FollowerProjectState(
+        name=snapshot.metadata.name,
+        op_id=snapshot.status.op_id,
+        state=snapshot.status.state,
+    )
+
+
+async def _reroute_to_chief_if_worker(
+    request: fastapi.Request, method: str, path: str
+) -> fastapi.Response | None:
+    """
+    Used only by `commit_delete_project` — the one route in this router that touches
+    `InternalBackgroundTasksHandler`, which is chief-only. A worker replica re-routes
+    that call to chief rather than handling it itself.
+    """
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        == mlrun.common.schemas.ClusterizationRole.chief
+    ):
+        return None
+    return await framework.utils.clients.chief.Client().proxy_follower_project_request(
+        method, path, request
+    )
+
+
+@router.post(
+    "/follower/projects/{name}/prepare-create",
+    response_model=FollowerProjectState,
+)
+async def prepare_create_project(
+    name: str,
+    body: FollowerPrepareCreateRequest,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
+) -> FollowerProjectState:
+    project = body.project
+    if project.metadata.name != name:
+        raise mlrun.errors.MLRunBadRequestError(
+            "Path project name does not match project.metadata.name"
+        )
+    op_id = _project_op_id(project)
+    await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().prepare_create_project, project, op_id
+    )
+    snapshot = await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
+    )
+    return _to_follower_state(name, snapshot)
+
+
+@router.post(
+    "/follower/projects/{name}/commit-create",
+    response_model=FollowerProjectState,
+)
+async def commit_create_project(
+    name: str,
+    body: FollowerCommitCreateRequest,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
+) -> FollowerProjectState:
+    await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().commit_create_project, name, body.op_id
+    )
+    snapshot = await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
+    )
+    return _to_follower_state(name, snapshot)
+
+
+@router.put(
+    "/follower/projects/{name}",
+    response_model=FollowerProjectState,
+)
+async def update_project(
+    name: str,
+    body: FollowerUpdateRequest,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
+) -> FollowerProjectState:
+    project = body.project
+    if project.metadata.name != name:
+        raise mlrun.errors.MLRunBadRequestError(
+            "Path project name does not match project.metadata.name"
+        )
+    op_id = _project_op_id(project)
+    await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().update_project_follower,
+        name,
+        project,
+        op_id,
+        body.prev_op_id,
+    )
+    snapshot = await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
+    )
+    return _to_follower_state(name, snapshot)
+
+
+@router.post(
+    "/follower/projects/{name}/prepare-delete",
+    response_model=FollowerProjectState,
+)
+async def prepare_delete_project(
+    name: str,
+    body: FollowerPrepareDeleteRequest,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
+) -> FollowerProjectState:
+    await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().prepare_delete_project,
+        name,
+        body.op_id,
+        body.prev_op_id,
+    )
+    snapshot = await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
+    )
+    return _to_follower_state(name, snapshot)
+
+
+@router.delete(
+    "/follower/projects/{name}",
+    response_model=FollowerDeleteResult,
+)
+async def commit_delete_project(
+    name: str,
+    body: FollowerCommitDeleteRequest,
+    response: fastapi.Response,
+    request: fastapi.Request,
+    background_tasks: fastapi.BackgroundTasks,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
+) -> FollowerDeleteResult:
+    # Only this endpoint reroutes to chief: it's the one call in this router that
+    # touches InternalBackgroundTasksHandler, which is chief-only — the other 4 do
+    # plain project DB writes, same as the legacy (non-rerouted) project CUD endpoints.
+    if proxied := await _reroute_to_chief_if_worker(
+        request, "DELETE", f"follower/projects/{name}"
+    ):
+        return proxied
+
+    op_id = body.op_id
+    snapshot = await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
+    )
+    if snapshot is None:
+        # Already fully removed by a previous call — idempotent no-op per the contract.
+        return FollowerDeleteResult(name=name, op_id=op_id, result="removed")
+
+    # Fail fast on an invalid call (stale/mismatched op_id, wrong state) before
+    # scheduling anything — commit_delete_project() re-runs this same check when the
+    # background task actually executes, which is then a safe, cheap no-op.
+    follower_contract.validate_call(
+        follower_contract.FollowerOp.commit_delete,
+        current_state=snapshot.status.state,
+        stored_op_id=snapshot.status.op_id,
+        incoming_op_id=op_id,
+    )
+
+    kind = framework.utils.background_tasks.BackgroundTaskKinds.project_deletion.format(
+        name
+    )
+    handler = framework.utils.background_tasks.InternalBackgroundTasksHandler()
+    existing_task = handler.get_active_background_task_by_kind(kind)
+    response.status_code = status.HTTP_202_ACCEPTED
+    if existing_task is None:
+        # No active task for this project: either the first call, or the previous
+        # attempt already finished (`InternalBackgroundTasksHandler` clears the active
+        # slot on both success and failure) and `snapshot` above being non-None means
+        # that attempt failed — either way, kicking off a fresh one is the right retry.
+        task, _ = handler.create_background_task(
+            kind,
+            mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
+            services.api.crud.Projects().commit_delete_project,
+            None,  # background task's own id — let it generate one
+            name,
+            op_id,
+        )
+        background_tasks.add_task(task)
+    # else: an active task exists and is still running (a just-succeeded/failed task
+    # would already have been cleared from the active slot, per the note above).
+    return FollowerDeleteResult(name=name, op_id=op_id, result="removal-scheduled")
+
+
+@router.get(
+    "/follower/projects/states",
+    response_model=FollowerProjectStatesPage,
+)
+async def list_project_states(
+    updated_after: datetime.datetime | None = None,
+    cursor: str | None = None,
+    page_size: int = 200,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
+) -> FollowerProjectStatesPage:
+    projects, next_cursor = await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().list_project_states,
+        db_session,
+        updated_after,
+        cursor,
+        page_size,
+    )
+    return FollowerProjectStatesPage(
+        projects=[
+            _to_follower_state(project.metadata.name, project) for project in projects
+        ],
+        next_cursor=next_cursor,
+    )

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -48,6 +48,14 @@ def _project_op_id(project: mlrun.common.schemas.Project) -> uuid.UUID:
     return project.status.op_id
 
 
+def _project_updated_at(
+    project: mlrun.common.schemas.Project,
+) -> datetime.datetime:
+    if project.status.updated_at is None:
+        raise mlrun.errors.MLRunBadRequestError("project.status.updated_at is required")
+    return project.status.updated_at
+
+
 def _to_follower_state(
     name: str, snapshot: mlrun.common.schemas.Project | None
 ) -> follower_schemas.FollowerProjectState:
@@ -74,8 +82,12 @@ async def prepare_create_project(
             "Path project name does not match project.metadata.name"
         )
     op_id = _project_op_id(project)
+    updated_at = _project_updated_at(project)
     result = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().prepare_create_project, project, op_id
+        services.api.crud.Projects().prepare_create_project,
+        project,
+        op_id,
+        updated_at,
     )
     return _to_follower_state(name, result)
 
@@ -89,7 +101,10 @@ async def commit_create_project(
     body: follower_schemas.FollowerCommitCreateRequest,
 ) -> follower_schemas.FollowerProjectState:
     result = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().commit_create_project, name, body.op_id
+        services.api.crud.Projects().commit_create_project,
+        name,
+        body.op_id,
+        body.updated_at,
     )
     return _to_follower_state(name, result)
 
@@ -108,11 +123,13 @@ async def update_project(
             "Path project name does not match project.metadata.name"
         )
     op_id = _project_op_id(project)
+    updated_at = _project_updated_at(project)
     result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().update_project_follower,
         name,
         project,
         op_id,
+        updated_at,
         body.prev_op_id,
     )
     return _to_follower_state(name, result)
@@ -130,6 +147,7 @@ async def prepare_delete_project(
         services.api.crud.Projects().prepare_delete_project,
         name,
         body.op_id,
+        body.updated_at,
         body.prev_op_id,
     )
     return _to_follower_state(name, result)

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -32,6 +32,7 @@ import mlrun
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils
+from mlrun.utils import logger
 
 import framework.api.deps
 import framework.utils.clients.chief
@@ -56,24 +57,6 @@ def _to_follower_state(
         name=snapshot.metadata.name,
         op_id=snapshot.status.op_id,
         state=snapshot.status.state,
-    )
-
-
-async def _reroute_to_chief_if_worker(
-    request: fastapi.Request, method: str, path: str
-) -> fastapi.Response | None:
-    """
-    Used only by `commit_delete_project` — the one route in this router whose work
-    (`delete_project_resources`, via `delete_schedules`) is chief-only. A worker
-    replica re-routes that call to chief rather than handling it itself.
-    """
-    if (
-        mlrun.mlconf.httpdb.clusterization.role
-        == mlrun.common.schemas.ClusterizationRole.chief
-    ):
-        return None
-    return await framework.utils.clients.chief.Client().proxy_follower_project_request(
-        method, path, request
     )
 
 
@@ -188,14 +171,21 @@ async def commit_delete_project(
         framework.api.deps.get_db_session
     ),
 ) -> follower_schemas.FollowerDeleteResult:
-    # Deliberately blocking, per Orca's requirement: this call does not return until
-    # the purge has actually finished — no background task, no early 202. Still
-    # reroutes to chief: delete_project_resources() deletes schedules, which are
-    # chief-only, same reason the legacy (non-follower) delete endpoint reroutes.
-    if proxied := await _reroute_to_chief_if_worker(
-        request, "DELETE", f"follower/projects/{name}"
+    # delete_project_resources deletes schedules, which run only on chief, so we
+    # re-route to chief — same reason the legacy (non-follower) delete endpoint does.
+    if (
+        mlrun.mlconf.httpdb.clusterization.role
+        != mlrun.common.schemas.ClusterizationRole.chief
     ):
-        return proxied
+        logger.info(
+            "Requesting to commit-delete follower project, re-routing to chief",
+            project=name,
+        )
+        return (
+            await framework.utils.clients.chief.Client().commit_delete_follower_project(
+                name=name, request=request
+            )
+        )
 
     op_id = body.op_id
     snapshot = await mlrun.utils.run_in_threadpool(

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -67,9 +67,6 @@ def _to_follower_state(
 async def prepare_create_project(
     name: str,
     body: follower_schemas.FollowerPrepareCreateRequest,
-    db_session: sqlalchemy.orm.Session = fastapi.Depends(
-        framework.api.deps.get_db_session
-    ),
 ) -> follower_schemas.FollowerProjectState:
     project = body.project
     if project.metadata.name != name:
@@ -77,13 +74,10 @@ async def prepare_create_project(
             "Path project name does not match project.metadata.name"
         )
     op_id = _project_op_id(project)
-    await mlrun.utils.run_in_threadpool(
+    result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().prepare_create_project, project, op_id
     )
-    snapshot = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
-    )
-    return _to_follower_state(name, snapshot)
+    return _to_follower_state(name, result)
 
 
 @router.post(
@@ -93,17 +87,11 @@ async def prepare_create_project(
 async def commit_create_project(
     name: str,
     body: follower_schemas.FollowerCommitCreateRequest,
-    db_session: sqlalchemy.orm.Session = fastapi.Depends(
-        framework.api.deps.get_db_session
-    ),
 ) -> follower_schemas.FollowerProjectState:
-    await mlrun.utils.run_in_threadpool(
+    result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().commit_create_project, name, body.op_id
     )
-    snapshot = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
-    )
-    return _to_follower_state(name, snapshot)
+    return _to_follower_state(name, result)
 
 
 @router.put(
@@ -113,9 +101,6 @@ async def commit_create_project(
 async def update_project(
     name: str,
     body: follower_schemas.FollowerUpdateRequest,
-    db_session: sqlalchemy.orm.Session = fastapi.Depends(
-        framework.api.deps.get_db_session
-    ),
 ) -> follower_schemas.FollowerProjectState:
     project = body.project
     if project.metadata.name != name:
@@ -123,17 +108,14 @@ async def update_project(
             "Path project name does not match project.metadata.name"
         )
     op_id = _project_op_id(project)
-    await mlrun.utils.run_in_threadpool(
+    result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().update_project_follower,
         name,
         project,
         op_id,
         body.prev_op_id,
     )
-    snapshot = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
-    )
-    return _to_follower_state(name, snapshot)
+    return _to_follower_state(name, result)
 
 
 @router.post(
@@ -143,20 +125,14 @@ async def update_project(
 async def prepare_delete_project(
     name: str,
     body: follower_schemas.FollowerPrepareDeleteRequest,
-    db_session: sqlalchemy.orm.Session = fastapi.Depends(
-        framework.api.deps.get_db_session
-    ),
 ) -> follower_schemas.FollowerProjectState:
-    await mlrun.utils.run_in_threadpool(
+    result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().prepare_delete_project,
         name,
         body.op_id,
         body.prev_op_id,
     )
-    snapshot = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
-    )
-    return _to_follower_state(name, snapshot)
+    return _to_follower_state(name, result)
 
 
 @router.delete(

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -143,9 +143,6 @@ async def commit_delete_project(
     name: str,
     body: follower_schemas.FollowerCommitDeleteRequest,
     request: fastapi.Request,
-    db_session: sqlalchemy.orm.Session = fastapi.Depends(
-        framework.api.deps.get_db_session
-    ),
 ) -> follower_schemas.FollowerDeleteResult:
     # delete_project_resources deletes schedules, which run only on chief, so we
     # re-route to chief — same reason the legacy (non-follower) delete endpoint does.
@@ -163,24 +160,15 @@ async def commit_delete_project(
             )
         )
 
-    op_id = body.op_id
-    snapshot = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().get_follower_project_snapshot, db_session, name
-    )
-    if snapshot is None:
-        # Already fully removed by a previous call — idempotent no-op per the contract.
-        return follower_schemas.FollowerDeleteResult(
-            name=name, op_id=op_id, result="removed"
-        )
-
     # Validates internally (CAS/ordering/state) and, on success, purges the project's
-    # resources and its row before returning — a genuine retry with the same op_id
-    # (e.g. after a dropped connection) re-runs the purge rather than skipping it.
+    # resources and its row — a no-op if it's already gone (a previous call already
+    # removed it) or a genuine retry with the same op_id (e.g. after a dropped
+    # connection re-runs the purge rather than skipping it).
     await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().commit_delete_project, name, op_id
+        services.api.crud.Projects().commit_delete_project, name, body.op_id
     )
     return follower_schemas.FollowerDeleteResult(
-        name=name, op_id=op_id, result="removed"
+        name=name, op_id=body.op_id, result="removed"
     )
 
 

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -27,7 +27,6 @@ import uuid
 
 import fastapi
 import sqlalchemy.orm
-from fastapi import status
 
 import mlrun
 import mlrun.common.schemas
@@ -35,9 +34,7 @@ import mlrun.errors
 import mlrun.utils
 
 import framework.api.deps
-import framework.utils.background_tasks
 import framework.utils.clients.chief
-import framework.utils.projects.follower_contract as follower_contract
 import framework.utils.projects.follower_schemas as follower_schemas
 import services.api.crud
 
@@ -66,9 +63,9 @@ async def _reroute_to_chief_if_worker(
     request: fastapi.Request, method: str, path: str
 ) -> fastapi.Response | None:
     """
-    Used only by `commit_delete_project` — the one route in this router that touches
-    `InternalBackgroundTasksHandler`, which is chief-only. A worker replica re-routes
-    that call to chief rather than handling it itself.
+    Used only by `commit_delete_project` — the one route in this router whose work
+    (`delete_project_resources`, via `delete_schedules`) is chief-only. A worker
+    replica re-routes that call to chief rather than handling it itself.
     """
     if (
         mlrun.mlconf.httpdb.clusterization.role
@@ -186,16 +183,15 @@ async def prepare_delete_project(
 async def commit_delete_project(
     name: str,
     body: follower_schemas.FollowerCommitDeleteRequest,
-    response: fastapi.Response,
     request: fastapi.Request,
-    background_tasks: fastapi.BackgroundTasks,
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),
 ) -> follower_schemas.FollowerDeleteResult:
-    # Only this endpoint reroutes to chief: it's the one call in this router that
-    # touches InternalBackgroundTasksHandler, which is chief-only — the other 4 do
-    # plain project DB writes, same as the legacy (non-rerouted) project CUD endpoints.
+    # Deliberately blocking, per Orca's requirement: this call does not return until
+    # the purge has actually finished — no background task, no early 202. Still
+    # reroutes to chief: delete_project_resources() deletes schedules, which are
+    # chief-only, same reason the legacy (non-follower) delete endpoint reroutes.
     if proxied := await _reroute_to_chief_if_worker(
         request, "DELETE", f"follower/projects/{name}"
     ):
@@ -211,40 +207,14 @@ async def commit_delete_project(
             name=name, op_id=op_id, result="removed"
         )
 
-    # Fail fast on an invalid call (stale/mismatched op_id, wrong state) before
-    # scheduling anything — commit_delete_project() re-runs this same check when the
-    # background task actually executes, which is then a safe, cheap no-op.
-    follower_contract.validate_call(
-        follower_contract.FollowerOp.commit_delete,
-        current_state=snapshot.status.state,
-        stored_op_id=snapshot.status.op_id,
-        incoming_op_id=op_id,
+    # Validates internally (CAS/ordering/state) and, on success, purges the project's
+    # resources and its row before returning — a genuine retry with the same op_id
+    # (e.g. after a dropped connection) re-runs the purge rather than skipping it.
+    await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().commit_delete_project, name, op_id
     )
-
-    kind = framework.utils.background_tasks.BackgroundTaskKinds.project_deletion.format(
-        name
-    )
-    handler = framework.utils.background_tasks.InternalBackgroundTasksHandler()
-    existing_task = handler.get_active_background_task_by_kind(kind)
-    response.status_code = status.HTTP_202_ACCEPTED
-    if existing_task is None:
-        # No active task for this project: either the first call, or the previous
-        # attempt already finished (`InternalBackgroundTasksHandler` clears the active
-        # slot on both success and failure) and `snapshot` above being non-None means
-        # that attempt failed — either way, kicking off a fresh one is the right retry.
-        task, _ = handler.create_background_task(
-            kind,
-            mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
-            services.api.crud.Projects().commit_delete_project,
-            None,  # background task's own id — let it generate one
-            name,
-            op_id,
-        )
-        background_tasks.add_task(task)
-    # else: an active task exists and is still running (a just-succeeded/failed task
-    # would already have been cleared from the active slot, per the note above).
     return follower_schemas.FollowerDeleteResult(
-        name=name, op_id=op_id, result="removal-scheduled"
+        name=name, op_id=op_id, result="removed"
     )
 
 

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -23,7 +23,6 @@ leader configured, but it stays always-registered rather than feature-gated.
 """
 
 import datetime
-import uuid
 
 import fastapi
 import sqlalchemy.orm
@@ -40,12 +39,6 @@ import framework.utils.projects.follower_schemas as follower_schemas
 import services.api.crud
 
 router = fastapi.APIRouter()
-
-
-def _project_op_id(project: mlrun.common.schemas.Project) -> uuid.UUID:
-    if project.status.op_id is None:
-        raise mlrun.errors.MLRunBadRequestError("project.status.op_id is required")
-    return project.status.op_id
 
 
 def _to_follower_state(
@@ -68,14 +61,19 @@ async def prepare_create_project(
     name: str,
     body: follower_schemas.FollowerPrepareCreateRequest,
 ) -> follower_schemas.FollowerProjectState:
-    project = body.project
-    if project.metadata.name != name:
+    if body.metadata.name != name:
         raise mlrun.errors.MLRunBadRequestError(
-            "Path project name does not match project.metadata.name"
+            "Path project name does not match metadata.name"
         )
-    op_id = _project_op_id(project)
+    project = mlrun.common.schemas.Project(
+        metadata=body.metadata,
+        spec=body.spec,
+        status=mlrun.common.schemas.ProjectStatus(op_id=body.status.op_id),
+    )
     result = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().prepare_create_project, project, op_id
+        services.api.crud.Projects().prepare_create_project,
+        project,
+        body.status.op_id,
     )
     return _to_follower_state(name, result)
 
@@ -102,17 +100,20 @@ async def update_project(
     name: str,
     body: follower_schemas.FollowerUpdateRequest,
 ) -> follower_schemas.FollowerProjectState:
-    project = body.project
-    if project.metadata.name != name:
+    if body.metadata.name != name:
         raise mlrun.errors.MLRunBadRequestError(
-            "Path project name does not match project.metadata.name"
+            "Path project name does not match metadata.name"
         )
-    op_id = _project_op_id(project)
+    project = mlrun.common.schemas.Project(
+        metadata=body.metadata,
+        spec=body.spec,
+        status=mlrun.common.schemas.ProjectStatus(op_id=body.status.op_id),
+    )
     result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().update_project_follower,
         name,
         project,
-        op_id,
+        body.status.op_id,
         body.prev_op_id,
     )
     return _to_follower_state(name, result)

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -23,11 +23,9 @@ leader configured, but it stays always-registered rather than feature-gated.
 """
 
 import datetime
-import typing
 import uuid
 
 import fastapi
-import pydantic
 import sqlalchemy.orm
 from fastapi import status
 
@@ -40,48 +38,10 @@ import framework.api.deps
 import framework.utils.background_tasks
 import framework.utils.clients.chief
 import framework.utils.projects.follower_contract as follower_contract
+import framework.utils.projects.follower_schemas as follower_schemas
 import services.api.crud
 
 router = fastapi.APIRouter()
-
-
-class FollowerProjectState(pydantic.BaseModel):
-    name: str
-    op_id: uuid.UUID | None = None
-    state: mlrun.common.schemas.ProjectState | None = None
-
-
-class FollowerProjectStatesPage(pydantic.BaseModel):
-    projects: list[FollowerProjectState]
-    next_cursor: str | None = None
-
-
-class FollowerDeleteResult(pydantic.BaseModel):
-    name: str
-    op_id: uuid.UUID
-    result: typing.Literal["removed", "removal-scheduled"]
-
-
-class FollowerPrepareCreateRequest(pydantic.BaseModel):
-    project: mlrun.common.schemas.Project
-
-
-class FollowerCommitCreateRequest(pydantic.BaseModel):
-    op_id: uuid.UUID
-
-
-class FollowerUpdateRequest(pydantic.BaseModel):
-    project: mlrun.common.schemas.Project
-    prev_op_id: uuid.UUID
-
-
-class FollowerPrepareDeleteRequest(pydantic.BaseModel):
-    op_id: uuid.UUID
-    prev_op_id: uuid.UUID
-
-
-class FollowerCommitDeleteRequest(pydantic.BaseModel):
-    op_id: uuid.UUID
 
 
 def _project_op_id(project: mlrun.common.schemas.Project) -> uuid.UUID:
@@ -92,10 +52,10 @@ def _project_op_id(project: mlrun.common.schemas.Project) -> uuid.UUID:
 
 def _to_follower_state(
     name: str, snapshot: mlrun.common.schemas.Project | None
-) -> FollowerProjectState:
+) -> follower_schemas.FollowerProjectState:
     if snapshot is None:
-        return FollowerProjectState(name=name)
-    return FollowerProjectState(
+        return follower_schemas.FollowerProjectState(name=name)
+    return follower_schemas.FollowerProjectState(
         name=snapshot.metadata.name,
         op_id=snapshot.status.op_id,
         state=snapshot.status.state,
@@ -122,15 +82,15 @@ async def _reroute_to_chief_if_worker(
 
 @router.post(
     "/follower/projects/{name}/prepare-create",
-    response_model=FollowerProjectState,
+    response_model=follower_schemas.FollowerProjectState,
 )
 async def prepare_create_project(
     name: str,
-    body: FollowerPrepareCreateRequest,
+    body: follower_schemas.FollowerPrepareCreateRequest,
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),
-) -> FollowerProjectState:
+) -> follower_schemas.FollowerProjectState:
     project = body.project
     if project.metadata.name != name:
         raise mlrun.errors.MLRunBadRequestError(
@@ -148,15 +108,15 @@ async def prepare_create_project(
 
 @router.post(
     "/follower/projects/{name}/commit-create",
-    response_model=FollowerProjectState,
+    response_model=follower_schemas.FollowerProjectState,
 )
 async def commit_create_project(
     name: str,
-    body: FollowerCommitCreateRequest,
+    body: follower_schemas.FollowerCommitCreateRequest,
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),
-) -> FollowerProjectState:
+) -> follower_schemas.FollowerProjectState:
     await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().commit_create_project, name, body.op_id
     )
@@ -168,15 +128,15 @@ async def commit_create_project(
 
 @router.put(
     "/follower/projects/{name}",
-    response_model=FollowerProjectState,
+    response_model=follower_schemas.FollowerProjectState,
 )
 async def update_project(
     name: str,
-    body: FollowerUpdateRequest,
+    body: follower_schemas.FollowerUpdateRequest,
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),
-) -> FollowerProjectState:
+) -> follower_schemas.FollowerProjectState:
     project = body.project
     if project.metadata.name != name:
         raise mlrun.errors.MLRunBadRequestError(
@@ -198,15 +158,15 @@ async def update_project(
 
 @router.post(
     "/follower/projects/{name}/prepare-delete",
-    response_model=FollowerProjectState,
+    response_model=follower_schemas.FollowerProjectState,
 )
 async def prepare_delete_project(
     name: str,
-    body: FollowerPrepareDeleteRequest,
+    body: follower_schemas.FollowerPrepareDeleteRequest,
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),
-) -> FollowerProjectState:
+) -> follower_schemas.FollowerProjectState:
     await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().prepare_delete_project,
         name,
@@ -221,18 +181,18 @@ async def prepare_delete_project(
 
 @router.delete(
     "/follower/projects/{name}",
-    response_model=FollowerDeleteResult,
+    response_model=follower_schemas.FollowerDeleteResult,
 )
 async def commit_delete_project(
     name: str,
-    body: FollowerCommitDeleteRequest,
+    body: follower_schemas.FollowerCommitDeleteRequest,
     response: fastapi.Response,
     request: fastapi.Request,
     background_tasks: fastapi.BackgroundTasks,
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),
-) -> FollowerDeleteResult:
+) -> follower_schemas.FollowerDeleteResult:
     # Only this endpoint reroutes to chief: it's the one call in this router that
     # touches InternalBackgroundTasksHandler, which is chief-only — the other 4 do
     # plain project DB writes, same as the legacy (non-rerouted) project CUD endpoints.
@@ -247,7 +207,9 @@ async def commit_delete_project(
     )
     if snapshot is None:
         # Already fully removed by a previous call — idempotent no-op per the contract.
-        return FollowerDeleteResult(name=name, op_id=op_id, result="removed")
+        return follower_schemas.FollowerDeleteResult(
+            name=name, op_id=op_id, result="removed"
+        )
 
     # Fail fast on an invalid call (stale/mismatched op_id, wrong state) before
     # scheduling anything — commit_delete_project() re-runs this same check when the
@@ -281,12 +243,14 @@ async def commit_delete_project(
         background_tasks.add_task(task)
     # else: an active task exists and is still running (a just-succeeded/failed task
     # would already have been cleared from the active slot, per the note above).
-    return FollowerDeleteResult(name=name, op_id=op_id, result="removal-scheduled")
+    return follower_schemas.FollowerDeleteResult(
+        name=name, op_id=op_id, result="removal-scheduled"
+    )
 
 
 @router.get(
     "/follower/projects/states",
-    response_model=FollowerProjectStatesPage,
+    response_model=follower_schemas.FollowerProjectStatesPage,
 )
 async def list_project_states(
     updated_after: datetime.datetime | None = None,
@@ -295,7 +259,7 @@ async def list_project_states(
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),
-) -> FollowerProjectStatesPage:
+) -> follower_schemas.FollowerProjectStatesPage:
     projects, next_cursor = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().list_project_states,
         db_session,
@@ -303,7 +267,7 @@ async def list_project_states(
         cursor,
         page_size,
     )
-    return FollowerProjectStatesPage(
+    return follower_schemas.FollowerProjectStatesPage(
         projects=[
             _to_follower_state(project.metadata.name, project) for project in projects
         ],

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -48,14 +48,6 @@ def _project_op_id(project: mlrun.common.schemas.Project) -> uuid.UUID:
     return project.status.op_id
 
 
-def _project_updated_at(
-    project: mlrun.common.schemas.Project,
-) -> datetime.datetime:
-    if project.status.updated_at is None:
-        raise mlrun.errors.MLRunBadRequestError("project.status.updated_at is required")
-    return project.status.updated_at
-
-
 def _to_follower_state(
     name: str, snapshot: mlrun.common.schemas.Project | None
 ) -> follower_schemas.FollowerProjectState:
@@ -64,7 +56,7 @@ def _to_follower_state(
     return follower_schemas.FollowerProjectState(
         name=snapshot.metadata.name,
         op_id=snapshot.status.op_id,
-        state=snapshot.status.state,
+        sync_status=snapshot.status.state,
     )
 
 
@@ -82,12 +74,8 @@ async def prepare_create_project(
             "Path project name does not match project.metadata.name"
         )
     op_id = _project_op_id(project)
-    updated_at = _project_updated_at(project)
     result = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().prepare_create_project,
-        project,
-        op_id,
-        updated_at,
+        services.api.crud.Projects().prepare_create_project, project, op_id
     )
     return _to_follower_state(name, result)
 
@@ -101,10 +89,7 @@ async def commit_create_project(
     body: follower_schemas.FollowerCommitCreateRequest,
 ) -> follower_schemas.FollowerProjectState:
     result = await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().commit_create_project,
-        name,
-        body.op_id,
-        body.updated_at,
+        services.api.crud.Projects().commit_create_project, name, body.status.op_id
     )
     return _to_follower_state(name, result)
 
@@ -123,13 +108,11 @@ async def update_project(
             "Path project name does not match project.metadata.name"
         )
     op_id = _project_op_id(project)
-    updated_at = _project_updated_at(project)
     result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().update_project_follower,
         name,
         project,
         op_id,
-        updated_at,
         body.prev_op_id,
     )
     return _to_follower_state(name, result)
@@ -146,8 +129,7 @@ async def prepare_delete_project(
     result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().prepare_delete_project,
         name,
-        body.op_id,
-        body.updated_at,
+        body.status.op_id,
         body.prev_op_id,
     )
     return _to_follower_state(name, result)
@@ -178,15 +160,16 @@ async def commit_delete_project(
             )
         )
 
+    op_id = body.status.op_id
     # Validates internally (CAS/ordering/state) and, on success, purges the project's
     # resources and its row — a no-op if it's already gone (a previous call already
     # removed it) or a genuine retry with the same op_id (e.g. after a dropped
     # connection re-runs the purge rather than skipping it).
     await mlrun.utils.run_in_threadpool(
-        services.api.crud.Projects().commit_delete_project, name, body.op_id
+        services.api.crud.Projects().commit_delete_project, name, op_id
     )
     return follower_schemas.FollowerDeleteResult(
-        name=name, op_id=body.op_id, result="removed"
+        name=name, op_id=op_id, result="removed"
     )
 
 
@@ -197,7 +180,7 @@ async def commit_delete_project(
 async def list_project_states(
     updated_after: datetime.datetime | None = None,
     cursor: str | None = None,
-    page_size: int = 200,
+    page_size: int = fastapi.Query(200, alias="limit"),
     db_session: sqlalchemy.orm.Session = fastapi.Depends(
         framework.api.deps.get_db_session
     ),

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 """
-The ML-12901 follower surface: leader (Orca) -> MLRun-as-follower calls.
+The follower surface: leader (Orca) -> MLRun-as-follower calls.
 
-Dedicated from the user-facing `/api/v1/projects` endpoints on purpose (see the Follower
-Contract HLD) — this router takes no user token, only the configured leader's service
-account (enforced by `deps.authenticate_leader_request`), so machine-origin auth never
-mixes with user auth. Enterprise-only in practice: nothing calls this without an Orca
-leader configured, but it stays always-registered rather than feature-gated.
+Dedicated from the user-facing `/api/v1/projects` endpoints on purpose — this router
+takes no user token, only the configured leader's service account (enforced by
+`deps.authenticate_leader_request`), so machine-origin auth never mixes with user auth.
+Enterprise-only in practice: nothing calls this without an Orca leader configured, but
+it stays always-registered rather than feature-gated.
 """
 
 import datetime

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -15,7 +15,7 @@
 """
 The follower surface: leader (Orca) -> MLRun-as-follower calls.
 
-Dedicated from the user-facing `/api/v1/projects` endpoints on purpose — this router
+this router
 takes no user token, only the configured leader's service account (enforced by
 `deps.authenticate_leader_request`), so machine-origin auth never mixes with user auth.
 Enterprise-only in practice: nothing calls this without an Orca leader configured, but

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -113,8 +113,8 @@ async def update_project(
         services.api.crud.Projects().update_project_follower,
         name,
         project,
-        body.status.op_id,
-        body.prev_op_id,
+        op_id=body.status.op_id,
+        prev_op_id=body.prev_op_id,
     )
     return _to_follower_state(name, result)
 
@@ -130,21 +130,21 @@ async def prepare_delete_project(
     result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().prepare_delete_project,
         name,
-        body.status.op_id,
-        body.prev_op_id,
+        op_id=body.status.op_id,
+        prev_op_id=body.prev_op_id,
     )
     return _to_follower_state(name, result)
 
 
 @router.delete(
     "/follower/projects/{name}",
-    response_model=follower_schemas.FollowerDeleteResult,
+    response_model=follower_schemas.FollowerProjectState,
 )
 async def commit_delete_project(
     name: str,
     body: follower_schemas.FollowerCommitDeleteRequest,
     request: fastapi.Request,
-) -> follower_schemas.FollowerDeleteResult:
+) -> follower_schemas.FollowerProjectState:
     # delete_project_resources deletes schedules, which run only on chief, so we
     # re-route to chief — same reason the legacy (non-follower) delete endpoint does.
     if (
@@ -169,8 +169,12 @@ async def commit_delete_project(
     await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().commit_delete_project, name, op_id
     )
-    return follower_schemas.FollowerDeleteResult(
-        name=name, op_id=op_id, result="removed"
+    # The row is gone at this point — sync_status reports the state it was in right
+    # before removal, matching every other op's {name, op_id, sync_status} response.
+    return follower_schemas.FollowerProjectState(
+        name=name,
+        op_id=op_id,
+        sync_status=mlrun.common.schemas.ProjectState.deleting,
     )
 
 

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1136,7 +1136,7 @@ class Projects(
         self,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
             name = project.metadata.name
@@ -1148,7 +1148,9 @@ class Projects(
                 incoming_op_id=op_id,
             )
             if outcome == follower_contract.ReplayOutcome.replay:
-                return
+                # Ordering only replays against a stored op_id, so a project must
+                # already exist to reach this branch.
+                return existing
             project = project.copy(deep=True)
             project.status.state = mlrun.common.schemas.ProjectState.creating
             project.status.op_id = op_id
@@ -1156,6 +1158,7 @@ class Projects(
                 self.store_project(session, name, project)
             else:
                 self.create_project(session, project)
+            return project
         finally:
             framework.db.session.close_session(session)
 
@@ -1163,13 +1166,15 @@ class Projects(
         self,
         name: str,
         op_id: uuid.UUID,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
             existing = self.get_follower_project_snapshot(session, name)
             # check_same_op (used for commit_create/commit_delete) never returns
             # ReplayOutcome.replay — a matching op_id always means "apply", since
             # re-running these two mutations on a retry is a safe no-op either way.
+            # It also requires a stored op_id to match against, so existing is
+            # guaranteed non-None once validation passes.
             follower_contract.validate_call(
                 follower_contract.FollowerOp.commit_create,
                 current_state=existing.status.state if existing else None,
@@ -1181,6 +1186,8 @@ class Projects(
                 name,
                 {"status": {"state": mlrun.common.schemas.ProjectState.online}},
             )
+            existing.status.state = mlrun.common.schemas.ProjectState.online
+            return existing
         finally:
             framework.db.session.close_session(session)
 
@@ -1189,12 +1196,12 @@ class Projects(
         name: str,
         op_id: uuid.UUID,
         prev_op_id: uuid.UUID | None = None,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project | None:
         session = framework.db.session.create_session()
         try:
             existing = self.get_follower_project_snapshot(session, name)
             if existing is None:
-                return  # absent project: no-op per the contract
+                return None  # absent project: no-op per the contract
             outcome = follower_contract.validate_call(
                 follower_contract.FollowerOp.prepare_delete,
                 current_state=existing.status.state,
@@ -1203,7 +1210,7 @@ class Projects(
                 prev_op_id=prev_op_id,
             )
             if outcome == follower_contract.ReplayOutcome.replay:
-                return
+                return existing
             self.patch_project(
                 session,
                 name,
@@ -1214,6 +1221,9 @@ class Projects(
                     }
                 },
             )
+            existing.status.state = mlrun.common.schemas.ProjectState.deleting
+            existing.status.op_id = op_id
+            return existing
         finally:
             framework.db.session.close_session(session)
 
@@ -1259,7 +1269,7 @@ class Projects(
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
         prev_op_id: uuid.UUID | None = None,
-    ) -> None:
+    ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
             existing = self.get_follower_project_snapshot(session, name)
@@ -1275,7 +1285,7 @@ class Projects(
                 prev_op_id=prev_op_id,
             )
             if outcome == follower_contract.ReplayOutcome.replay:
-                return
+                return existing
             # The common set only — labels/annotations/owner/description. Everything else
             # is MLRun-specific spec the leader never sends and never syncs (see the
             # Backend HLD's "store labels/annotations/description?" decision).
@@ -1291,6 +1301,8 @@ class Projects(
                 "status": {"op_id": op_id},
             }
             self.patch_project(session, name, common_set_patch)
+            existing.status.op_id = op_id
+            return existing
         finally:
             framework.db.session.close_session(session)
 

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -470,16 +470,16 @@ class Projects(
     ) -> tuple[list[mlrun.common.schemas.Project], str | None]:
         """
         Slim (name, op_id, state, updated_at) projection for follower reconciliation —
-        the "list states" op of the ML-12901 follower contract. `updated_after` is pushed
-        down to the DB query (via the existing `list_projects`/`updated_after` support) so
-        a leader polling for drift never full-scans the projects table. Pagination on top
-        of that filtered set is a keyset cursor computed here rather than in the DB layer:
-        the filtered set this endpoint deals with (projects that changed since the last
-        poll) is small even at scale, so adding cursor/limit to the shared `list_projects`
-        interface — used by every follower implementer — isn't warranted for this one
-        reconciliation-only read.
+        the "list states" op of the ML-12901 follower contract. Both `updated_after` and
+        the keyset cursor/page-size are pushed down to the DB query (via `list_projects`'s
+        opt-in `keyset_after`/`limit` params — unused by every other caller, so this
+        doesn't change behavior anywhere else) rather than loading the full result set
+        into memory: a follower reconnecting after a long gap, or doing its very first
+        sync with no `updated_after` at all, is exactly the "1000+ projects" case ML-12472
+        exists to avoid full-scanning.
         """
-        projects_output = self.list_projects(
+        keyset_after = self._decode_project_states_cursor(cursor) if cursor else None
+        projects_output = framework.utils.singletons.db.get_db().list_projects(
             session,
             format_=framework.utils.project_formats.ProjectFormatCustomSelection(
                 [
@@ -490,25 +490,18 @@ class Projects(
                 ]
             ),
             updated_after=updated_after,
+            keyset_after=keyset_after,
+            # fetch one extra row to know whether a further page follows
+            limit=page_size + 1,
         )
-        projects = sorted(
-            projects_output.projects,
-            key=lambda project: self._project_states_sort_key(project),
-        )
-        if cursor:
-            cursor_key = self._decode_project_states_cursor(cursor)
-            projects = [
-                project
-                for project in projects
-                if self._project_states_sort_key(project) > cursor_key
-            ]
-        page = projects[:page_size]
+        projects = projects_output.projects
         next_cursor = None
         if len(projects) > page_size:
             next_cursor = self._encode_project_states_cursor(
-                self._project_states_sort_key(page[-1])
+                self._project_states_sort_key(projects[page_size - 1])
             )
-        return page, next_cursor
+            projects = projects[:page_size]
+        return projects, next_cursor
 
     def _emit_project_lifecycle_event(
         self,

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1140,7 +1140,9 @@ class Projects(
         session = framework.db.session.create_session()
         try:
             name = project.metadata.name
-            existing = self.get_follower_project_snapshot(session, name)
+            existing = self.get_follower_project_snapshot(
+                session, name, for_update=True
+            )
             outcome = follower_contract.validate_call(
                 follower_contract.FollowerOp.prepare_create,
                 current_state=existing.status.state if existing else None,
@@ -1169,7 +1171,9 @@ class Projects(
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
-            existing = self.get_follower_project_snapshot(session, name)
+            existing = self.get_follower_project_snapshot(
+                session, name, for_update=True
+            )
             # check_same_op (used for commit_create/commit_delete) never returns
             # ReplayOutcome.replay — a matching op_id always means "apply", since
             # re-running these two mutations on a retry is a safe no-op either way.
@@ -1199,7 +1203,9 @@ class Projects(
     ) -> mlrun.common.schemas.Project | None:
         session = framework.db.session.create_session()
         try:
-            existing = self.get_follower_project_snapshot(session, name)
+            existing = self.get_follower_project_snapshot(
+                session, name, for_update=True
+            )
             if existing is None:
                 return None  # absent project: no-op per the contract
             outcome = follower_contract.validate_call(
@@ -1244,7 +1250,9 @@ class Projects(
         """
         session = framework.db.session.create_session()
         try:
-            existing = self.get_follower_project_snapshot(session, name)
+            existing = self.get_follower_project_snapshot(
+                session, name, for_update=True
+            )
             if existing is None:
                 return  # already fully removed: no-op per the contract
             # check_same_op (used for commit_create/commit_delete) never returns
@@ -1272,7 +1280,9 @@ class Projects(
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
-            existing = self.get_follower_project_snapshot(session, name)
+            existing = self.get_follower_project_snapshot(
+                session, name, for_update=True
+            )
             if existing is None:
                 # Unlike prepare_delete/commit_delete, "absent" isn't a no-op for update
                 # — there's nothing to CAS against, and the contract calls for 404 here.
@@ -1307,10 +1317,27 @@ class Projects(
             framework.db.session.close_session(session)
 
     def get_follower_project_snapshot(
-        self, session: sqlalchemy.orm.Session, name: str
+        self,
+        session: sqlalchemy.orm.Session,
+        name: str,
+        for_update: bool = False,
     ) -> mlrun.common.schemas.Project | None:
-        """(name, op_id, state) snapshot used by the 2PC hooks' CAS/ordering checks."""
-        projects_output = self.list_projects(
+        """
+        (name, op_id, state) snapshot used by the 2PC hooks' CAS/ordering checks.
+
+        :param for_update: locks the row (``SELECT ... FOR UPDATE``) for the
+            caller's transaction, so a concurrent read-decide-write for the same
+            project blocks instead of both sides racing on the same stale read —
+            pass this from every mutating hook's own pre-check, never from a plain
+            read (e.g. the endpoint's absent-project fast path has no write of its
+            own to protect and would just hold a pointless lock).
+
+        Goes straight to the DB layer rather than through ``self.list_projects``
+        (the abstract-interface-facing passthrough every follower implementer
+        provides) since ``for_update`` is specific to this CAS pre-check, not a
+        general list_projects capability.
+        """
+        projects_output = framework.utils.singletons.db.get_db().list_projects(
             session,
             format_=framework.utils.project_formats.ProjectFormatCustomSelection(
                 [
@@ -1320,6 +1347,7 @@ class Projects(
                 ]
             ),
             names=[name],
+            for_update=for_update,
         )
         return projects_output.projects[0] if projects_output.projects else None
 

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1377,6 +1377,9 @@ class Projects(
 
     @staticmethod
     def _encode_project_states_cursor(key: tuple[datetime.datetime, str]) -> str:
+        # `|` is a safe delimiter: project names are constrained to mlrun.utils.regex's
+        # DNS-1123-label pattern (lowercase alphanumerics and hyphens only) and can't
+        # contain it.
         updated_at, name = key
         return f"{updated_at.isoformat()}|{name}"
 

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1134,6 +1134,7 @@ class Projects(
         self,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
+        updated_at: datetime.datetime,
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
@@ -1154,6 +1155,7 @@ class Projects(
             project = project.copy(deep=True)
             project.status.state = mlrun.common.schemas.ProjectState.creating
             project.status.op_id = op_id
+            project.status.updated_at = updated_at
             if existing:
                 self.store_project(session, name, project)
             else:
@@ -1166,6 +1168,7 @@ class Projects(
         self,
         name: str,
         op_id: uuid.UUID,
+        updated_at: datetime.datetime,
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
@@ -1186,9 +1189,15 @@ class Projects(
             self.patch_project(
                 session,
                 name,
-                {"status": {"state": mlrun.common.schemas.ProjectState.online}},
+                {
+                    "status": {
+                        "state": mlrun.common.schemas.ProjectState.online,
+                        "updated_at": updated_at,
+                    }
+                },
             )
             existing.status.state = mlrun.common.schemas.ProjectState.online
+            existing.status.updated_at = updated_at
             return existing
         finally:
             framework.db.session.close_session(session)
@@ -1197,6 +1206,7 @@ class Projects(
         self,
         name: str,
         op_id: uuid.UUID,
+        updated_at: datetime.datetime,
         prev_op_id: uuid.UUID | None = None,
     ) -> mlrun.common.schemas.Project | None:
         session = framework.db.session.create_session()
@@ -1222,11 +1232,13 @@ class Projects(
                     "status": {
                         "state": mlrun.common.schemas.ProjectState.deleting,
                         "op_id": op_id,
+                        "updated_at": updated_at,
                     }
                 },
             )
             existing.status.state = mlrun.common.schemas.ProjectState.deleting
             existing.status.op_id = op_id
+            existing.status.updated_at = updated_at
             return existing
         finally:
             framework.db.session.close_session(session)
@@ -1274,6 +1286,7 @@ class Projects(
         name: str,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
+        updated_at: datetime.datetime,
         prev_op_id: uuid.UUID | None = None,
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
@@ -1306,10 +1319,11 @@ class Projects(
                     "owner": project.spec.owner,
                     "description": project.spec.description,
                 },
-                "status": {"op_id": op_id},
+                "status": {"op_id": op_id, "updated_at": updated_at},
             }
             self.patch_project(session, name, common_set_patch)
             existing.status.op_id = op_id
+            existing.status.updated_at = updated_at
             return existing
         finally:
             framework.db.session.close_session(session)

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -36,6 +36,8 @@ import framework.utils.auth.verifier
 import framework.utils.clients.messaging
 import framework.utils.clients.nuclio
 import framework.utils.clients.service_account_token as service_account_token
+import framework.utils.project_formats
+import framework.utils.projects.follower_contract as follower_contract
 import framework.utils.projects.remotes.follower as project_follower
 import framework.utils.singletons.db
 import services.alerts.crud
@@ -48,6 +50,9 @@ from framework.utils.singletons.k8s import get_k8s_helper
 
 # Persistable function kinds, zero-filled per project in ``mlrun_functions``.
 _FUNCTION_INVENTORY_KINDS = mlrun.runtimes.constants.RuntimeKinds.all()
+
+# Sort/cursor floor for list_project_states() when a project has no updated_at yet.
+_PROJECT_STATES_EPOCH = datetime.datetime.min.replace(tzinfo=datetime.UTC)
 
 
 class Projects(
@@ -455,6 +460,55 @@ class Projects(
             session,
             project=name,
         )
+
+    def list_project_states(
+        self,
+        session: sqlalchemy.orm.Session,
+        updated_after: datetime.datetime | None = None,
+        cursor: str | None = None,
+        page_size: int = 200,
+    ) -> tuple[list[mlrun.common.schemas.Project], str | None]:
+        """
+        Slim (name, op_id, state, updated_at) projection for follower reconciliation —
+        the "list states" op of the ML-12901 follower contract. `updated_after` is pushed
+        down to the DB query (via the existing `list_projects`/`updated_after` support) so
+        a leader polling for drift never full-scans the projects table. Pagination on top
+        of that filtered set is a keyset cursor computed here rather than in the DB layer:
+        the filtered set this endpoint deals with (projects that changed since the last
+        poll) is small even at scale, so adding cursor/limit to the shared `list_projects`
+        interface — used by every follower implementer — isn't warranted for this one
+        reconciliation-only read.
+        """
+        projects_output = self.list_projects(
+            session,
+            format_=framework.utils.project_formats.ProjectFormatCustomSelection(
+                [
+                    framework.utils.project_formats.ProjectFormatCustom.name,
+                    framework.utils.project_formats.ProjectFormatCustom.op_id,
+                    framework.utils.project_formats.ProjectFormatCustom.state,
+                    framework.utils.project_formats.ProjectFormatCustom.updated_at,
+                ]
+            ),
+            updated_after=updated_after,
+        )
+        projects = sorted(
+            projects_output.projects,
+            key=lambda project: self._project_states_sort_key(project),
+        )
+        if cursor:
+            cursor_key = self._decode_project_states_cursor(cursor)
+            projects = [
+                project
+                for project in projects
+                if self._project_states_sort_key(project) > cursor_key
+            ]
+        page = projects[:page_size]
+        next_cursor = None
+        if len(projects) > page_size:
+            next_cursor = self._encode_project_states_cursor(
+                self._project_states_sort_key(page[-1])
+            )
+        return page, next_cursor
 
     def _emit_project_lifecycle_event(
         self,
@@ -1079,59 +1133,209 @@ class Projects(
             session, name, project_patch
         )
 
-    # ----- 2PC follower-interface stubs ------------------------------------
-    # mlrun is the 2PC leader, so these per-follower hooks (called by the
-    # orchestrator on every remote follower) must never run on mlrun itself.
-    # They are present only to satisfy the abstract follower interface and
-    # to fail loudly if the orchestrator ever fans out incorrectly.
+    # ----- 2PC follower hooks (ML-12901) ------------------------------------
+    # Leader -> MLRun-as-follower calls, reachable only through the SA-gated
+    # /follower/projects surface (enterprise, leader=orca). In CE there is no Orca to
+    # call these, so this code path is unreached there. Each hook validates the call
+    # against follower_contract's CAS/ordering/state-machine rules before mutating.
 
     def prepare_create_project(
         self,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
     ) -> None:
-        raise NotImplementedError(
-            "MLRun is the leader of the 2PC project sync flow, not a follower; "
-            "this hook must not be invoked on the mlrun follower"
-        )
+        session = framework.db.session.create_session()
+        try:
+            name = project.metadata.name
+            existing = self.get_follower_project_snapshot(session, name)
+            outcome = follower_contract.validate_call(
+                follower_contract.FollowerOp.prepare_create,
+                current_state=existing.status.state if existing else None,
+                stored_op_id=existing.status.op_id if existing else None,
+                incoming_op_id=op_id,
+            )
+            if outcome == follower_contract.ReplayOutcome.replay:
+                return
+            project = project.copy(deep=True)
+            project.status.state = mlrun.common.schemas.ProjectState.creating
+            project.status.op_id = op_id
+            if existing:
+                self.store_project(session, name, project)
+            else:
+                self.create_project(session, project)
+        finally:
+            framework.db.session.close_session(session)
 
     def commit_create_project(
         self,
         name: str,
         op_id: uuid.UUID,
     ) -> None:
-        raise NotImplementedError(
-            "MLRun is the leader of the 2PC project sync flow, not a follower; "
-            "this hook must not be invoked on the mlrun follower"
-        )
+        session = framework.db.session.create_session()
+        try:
+            existing = self.get_follower_project_snapshot(session, name)
+            outcome = follower_contract.validate_call(
+                follower_contract.FollowerOp.commit_create,
+                current_state=existing.status.state if existing else None,
+                stored_op_id=existing.status.op_id if existing else None,
+                incoming_op_id=op_id,
+            )
+            if outcome == follower_contract.ReplayOutcome.replay:
+                return
+            self.patch_project(
+                session,
+                name,
+                {"status": {"state": mlrun.common.schemas.ProjectState.online}},
+            )
+        finally:
+            framework.db.session.close_session(session)
 
     def prepare_delete_project(
         self,
         name: str,
         op_id: uuid.UUID,
+        prev_op_id: uuid.UUID | None = None,
     ) -> None:
-        raise NotImplementedError(
-            "MLRun is the leader of the 2PC project sync flow, not a follower; "
-            "this hook must not be invoked on the mlrun follower"
-        )
+        session = framework.db.session.create_session()
+        try:
+            existing = self.get_follower_project_snapshot(session, name)
+            if existing is None:
+                return  # absent project: no-op per the contract
+            outcome = follower_contract.validate_call(
+                follower_contract.FollowerOp.prepare_delete,
+                current_state=existing.status.state,
+                stored_op_id=existing.status.op_id,
+                incoming_op_id=op_id,
+                prev_op_id=prev_op_id,
+            )
+            if outcome == follower_contract.ReplayOutcome.replay:
+                return
+            self.patch_project(
+                session,
+                name,
+                {
+                    "status": {
+                        "state": mlrun.common.schemas.ProjectState.deleting,
+                        "op_id": op_id,
+                    }
+                },
+            )
+        finally:
+            framework.db.session.close_session(session)
 
     def commit_delete_project(
         self,
         name: str,
         op_id: uuid.UUID,
     ) -> None:
-        raise NotImplementedError(
-            "MLRun is the leader of the 2PC project sync flow, not a follower; "
-            "this hook must not be invoked on the mlrun follower"
-        )
+        """
+        Validates and, if valid, synchronously purges this project's resources and its
+        row (via the existing cascading `delete_project`). Blocking by design — the
+        endpoint layer (`projects_follower.py`) is the one that decides whether to run
+        this inline or hand it to a background task and reply 202, since only it has
+        the request/response lifecycle; this hook stays a plain, re-entrant, idempotent
+        unit of work either way.
+        """
+        session = framework.db.session.create_session()
+        try:
+            existing = self.get_follower_project_snapshot(session, name)
+            if existing is None:
+                return  # already fully removed: no-op per the contract
+            outcome = follower_contract.validate_call(
+                follower_contract.FollowerOp.commit_delete,
+                current_state=existing.status.state,
+                stored_op_id=existing.status.op_id,
+                incoming_op_id=op_id,
+            )
+            if outcome == follower_contract.ReplayOutcome.replay:
+                # A previous call already triggered (or finished) the purge; nothing new
+                # to do here — the endpoint layer checks the background task's own state.
+                return
+            self.delete_project(
+                session,
+                name,
+                deletion_strategy=mlrun.common.schemas.DeletionStrategy.cascading,
+            )
+        finally:
+            framework.db.session.close_session(session)
 
     def update_project_follower(
         self,
         name: str,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
+        prev_op_id: uuid.UUID | None = None,
     ) -> None:
-        raise NotImplementedError(
-            "MLRun is the leader of the 2PC project sync flow, not a follower; "
-            "this hook must not be invoked on the mlrun follower"
+        session = framework.db.session.create_session()
+        try:
+            existing = self.get_follower_project_snapshot(session, name)
+            if existing is None:
+                # Unlike prepare_delete/commit_delete, "absent" isn't a no-op for update
+                # — there's nothing to CAS against, and the contract calls for 404 here.
+                raise mlrun.errors.MLRunNotFoundError(f"Project {name} not found")
+            outcome = follower_contract.validate_call(
+                follower_contract.FollowerOp.update,
+                current_state=existing.status.state,
+                stored_op_id=existing.status.op_id,
+                incoming_op_id=op_id,
+                prev_op_id=prev_op_id,
+            )
+            if outcome == follower_contract.ReplayOutcome.replay:
+                return
+            # The common set only — labels/annotations/owner/description. Everything else
+            # is MLRun-specific spec the leader never sends and never syncs (see the
+            # Backend HLD's "store labels/annotations/description?" decision).
+            common_set_patch = {
+                "metadata": {
+                    "labels": project.metadata.labels,
+                    "annotations": project.metadata.annotations,
+                },
+                "spec": {
+                    "owner": project.spec.owner,
+                    "description": project.spec.description,
+                },
+                "status": {"op_id": op_id},
+            }
+            self.patch_project(session, name, common_set_patch)
+        finally:
+            framework.db.session.close_session(session)
+
+    def get_follower_project_snapshot(
+        self, session: sqlalchemy.orm.Session, name: str
+    ) -> mlrun.common.schemas.Project | None:
+        """(name, op_id, state) snapshot used by the 2PC hooks' CAS/ordering checks."""
+        projects_output = self.list_projects(
+            session,
+            format_=framework.utils.project_formats.ProjectFormatCustomSelection(
+                [
+                    framework.utils.project_formats.ProjectFormatCustom.name,
+                    framework.utils.project_formats.ProjectFormatCustom.op_id,
+                    framework.utils.project_formats.ProjectFormatCustom.state,
+                ]
+            ),
+            names=[name],
         )
+        return projects_output.projects[0] if projects_output.projects else None
+
+    @staticmethod
+    def _project_states_sort_key(
+        project: mlrun.common.schemas.Project,
+    ) -> tuple[datetime.datetime, str]:
+        updated_at = project.status.updated_at or _PROJECT_STATES_EPOCH
+        return updated_at, project.metadata.name
+
+    @staticmethod
+    def _encode_project_states_cursor(key: tuple[datetime.datetime, str]) -> str:
+        updated_at, name = key
+        return f"{updated_at.isoformat()}|{name}"
+
+    @staticmethod
+    def _decode_project_states_cursor(cursor: str) -> tuple[datetime.datetime, str]:
+        updated_at_str, _, name = cursor.partition("|")
+        try:
+            updated_at = datetime.datetime.fromisoformat(updated_at_str)
+        except ValueError as exc:
+            raise mlrun.errors.MLRunBadRequestError(
+                f"Invalid list-states cursor: {cursor}"
+            ) from exc
+        return updated_at, name

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1134,7 +1134,6 @@ class Projects(
         self,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
-        updated_at: datetime.datetime,
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
@@ -1155,7 +1154,9 @@ class Projects(
             project = project.copy(deep=True)
             project.status.state = mlrun.common.schemas.ProjectState.creating
             project.status.op_id = op_id
-            project.status.updated_at = updated_at
+            # Not on the wire for this op (Orca's request has no updated_at field at
+            # all) — derive it from op_id's own UUIDv7 mint time instead.
+            project.status.updated_at = follower_contract.op_id_timestamp(op_id)
             if existing:
                 self.store_project(session, name, project)
             else:
@@ -1168,7 +1169,6 @@ class Projects(
         self,
         name: str,
         op_id: uuid.UUID,
-        updated_at: datetime.datetime,
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
         try:
@@ -1186,6 +1186,9 @@ class Projects(
                 stored_op_id=existing.status.op_id if existing else None,
                 incoming_op_id=op_id,
             )
+            # No project payload on this call, and updated_at isn't on the wire at
+            # all — derive it from op_id's own UUIDv7 mint time.
+            updated_at = follower_contract.op_id_timestamp(op_id)
             self.patch_project(
                 session,
                 name,
@@ -1206,7 +1209,6 @@ class Projects(
         self,
         name: str,
         op_id: uuid.UUID,
-        updated_at: datetime.datetime,
         prev_op_id: uuid.UUID | None = None,
     ) -> mlrun.common.schemas.Project | None:
         session = framework.db.session.create_session()
@@ -1225,6 +1227,9 @@ class Projects(
             )
             if outcome == follower_contract.ReplayOutcome.replay:
                 return existing
+            # No project payload on this call, and updated_at isn't on the wire at
+            # all — derive it from op_id's own UUIDv7 mint time.
+            updated_at = follower_contract.op_id_timestamp(op_id)
             self.patch_project(
                 session,
                 name,
@@ -1286,7 +1291,6 @@ class Projects(
         name: str,
         project: mlrun.common.schemas.Project,
         op_id: uuid.UUID,
-        updated_at: datetime.datetime,
         prev_op_id: uuid.UUID | None = None,
     ) -> mlrun.common.schemas.Project:
         session = framework.db.session.create_session()
@@ -1307,6 +1311,9 @@ class Projects(
             )
             if outcome == follower_contract.ReplayOutcome.replay:
                 return existing
+            # No updated_at on the wire for this op either — derive it from op_id's
+            # own UUIDv7 mint time.
+            updated_at = follower_contract.op_id_timestamp(op_id)
             # The common set only — labels/annotations/owner/description. Everything else
             # is MLRun-specific spec the leader never sends and never syncs (see the
             # Backend HLD's "store labels/annotations/description?" decision).

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -470,7 +470,7 @@ class Projects(
     ) -> tuple[list[mlrun.common.schemas.Project], str | None]:
         """
         Slim (name, op_id, state, updated_at) projection for follower reconciliation —
-        the "list states" op of the ML-12901 follower contract. Both `updated_after` and
+        the "list states" op of the follower contract. Both `updated_after` and
         the keyset cursor/page-size are pushed down to the DB query (via `list_projects`'s
         opt-in `keyset_after`/`limit` params) rather than loading the full result set into
         memory, since a follower reconnecting after a long gap, or doing its very first
@@ -1124,7 +1124,7 @@ class Projects(
             session, name, project_patch
         )
 
-    # ----- 2PC follower hooks (ML-12901) ------------------------------------
+    # ----- 2PC follower hooks -------------------------------------------
     # Leader -> MLRun-as-follower calls, reachable only through the SA-gated
     # /follower/projects surface (enterprise, leader=orca). In CE there is no Orca to
     # call these, so this code path is unreached there. Each hook validates the call
@@ -1315,8 +1315,7 @@ class Projects(
             # local time for when it applied the change.
             updated_at = datetime.datetime.now(datetime.UTC)
             # The common set only — labels/annotations/owner/description. Everything else
-            # is MLRun-specific spec the leader never sends and never syncs (see the
-            # Backend HLD's "store labels/annotations/description?" decision).
+            # is MLRun-specific spec the leader never sends and never syncs.
             common_set_patch = {
                 "metadata": {
                     "labels": project.metadata.labels,

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1167,14 +1167,15 @@ class Projects(
         session = framework.db.session.create_session()
         try:
             existing = self.get_follower_project_snapshot(session, name)
-            outcome = follower_contract.validate_call(
+            # check_same_op (used for commit_create/commit_delete) never returns
+            # ReplayOutcome.replay — a matching op_id always means "apply", since
+            # re-running these two mutations on a retry is a safe no-op either way.
+            follower_contract.validate_call(
                 follower_contract.FollowerOp.commit_create,
                 current_state=existing.status.state if existing else None,
                 stored_op_id=existing.status.op_id if existing else None,
                 incoming_op_id=op_id,
             )
-            if outcome == follower_contract.ReplayOutcome.replay:
-                return
             self.patch_project(
                 session,
                 name,
@@ -1223,27 +1224,27 @@ class Projects(
     ) -> None:
         """
         Validates and, if valid, synchronously purges this project's resources and its
-        row (via the existing cascading `delete_project`). Blocking by design — the
-        endpoint layer (`projects_follower.py`) is the one that decides whether to run
-        this inline or hand it to a background task and reply 202, since only it has
-        the request/response lifecycle; this hook stays a plain, re-entrant, idempotent
-        unit of work either way.
+        row (via the existing cascading `delete_project`). Deliberately blocking, per
+        Orca's requirement: the endpoint (`projects_follower.py`) awaits this call and
+        only responds once cleanup has actually finished — no background task, no early
+        202. A retry with the same op_id (e.g. after a dropped connection) re-runs the
+        deletion rather than skipping it — see the note on `validate_call` below — which
+        is what makes blocking-and-retrying safe: `delete_project`/`delete_project_resources`
+        are themselves idempotent-safe to call again on partially-cleaned-up resources.
         """
         session = framework.db.session.create_session()
         try:
             existing = self.get_follower_project_snapshot(session, name)
             if existing is None:
                 return  # already fully removed: no-op per the contract
-            outcome = follower_contract.validate_call(
+            # check_same_op (used for commit_create/commit_delete) never returns
+            # ReplayOutcome.replay — a matching op_id always means "apply".
+            follower_contract.validate_call(
                 follower_contract.FollowerOp.commit_delete,
                 current_state=existing.status.state,
                 stored_op_id=existing.status.op_id,
                 incoming_op_id=op_id,
             )
-            if outcome == follower_contract.ReplayOutcome.replay:
-                # A previous call already triggered (or finished) the purge; nothing new
-                # to do here — the endpoint layer checks the background task's own state.
-                return
             self.delete_project(
                 session,
                 name,

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -472,11 +472,9 @@ class Projects(
         Slim (name, op_id, state, updated_at) projection for follower reconciliation —
         the "list states" op of the ML-12901 follower contract. Both `updated_after` and
         the keyset cursor/page-size are pushed down to the DB query (via `list_projects`'s
-        opt-in `keyset_after`/`limit` params — unused by every other caller, so this
-        doesn't change behavior anywhere else) rather than loading the full result set
-        into memory: a follower reconnecting after a long gap, or doing its very first
-        sync with no `updated_after` at all, is exactly the "1000+ projects" case ML-12472
-        exists to avoid full-scanning.
+        opt-in `keyset_after`/`limit` params) rather than loading the full result set into
+        memory, since a follower reconnecting after a long gap, or doing its very first
+        sync with no `updated_after` at all, needs to page through every project.
         """
         keyset_after = self._decode_project_states_cursor(cursor) if cursor else None
         projects_output = framework.utils.singletons.db.get_db().list_projects(
@@ -1327,10 +1325,9 @@ class Projects(
 
         :param for_update: locks the row (``SELECT ... FOR UPDATE``) for the
             caller's transaction, so a concurrent read-decide-write for the same
-            project blocks instead of both sides racing on the same stale read —
-            pass this from every mutating hook's own pre-check, never from a plain
-            read (e.g. the endpoint's absent-project fast path has no write of its
-            own to protect and would just hold a pointless lock).
+            project blocks instead of both sides racing on the same stale read.
+            Pass this from a mutating hook's own pre-check; leave it off for a
+            plain read that has no write of its own to protect.
 
         Goes straight to the DB layer rather than through ``self.list_projects``
         (the abstract-interface-facing passthrough every follower implementer

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1155,8 +1155,8 @@ class Projects(
             project.status.state = mlrun.common.schemas.ProjectState.creating
             project.status.op_id = op_id
             # Not on the wire for this op (Orca's request has no updated_at field at
-            # all) — derive it from op_id's own UUIDv7 mint time instead.
-            project.status.updated_at = follower_contract.op_id_timestamp(op_id)
+            # all) — MLRun stamps its own local time for when it applied the change.
+            project.status.updated_at = datetime.datetime.now(datetime.UTC)
             if existing:
                 self.store_project(session, name, project)
             else:
@@ -1187,8 +1187,8 @@ class Projects(
                 incoming_op_id=op_id,
             )
             # No project payload on this call, and updated_at isn't on the wire at
-            # all — derive it from op_id's own UUIDv7 mint time.
-            updated_at = follower_contract.op_id_timestamp(op_id)
+            # all — MLRun stamps its own local time for when it applied the change.
+            updated_at = datetime.datetime.now(datetime.UTC)
             self.patch_project(
                 session,
                 name,
@@ -1228,8 +1228,8 @@ class Projects(
             if outcome == follower_contract.ReplayOutcome.replay:
                 return existing
             # No project payload on this call, and updated_at isn't on the wire at
-            # all — derive it from op_id's own UUIDv7 mint time.
-            updated_at = follower_contract.op_id_timestamp(op_id)
+            # all — MLRun stamps its own local time for when it applied the change.
+            updated_at = datetime.datetime.now(datetime.UTC)
             self.patch_project(
                 session,
                 name,
@@ -1311,9 +1311,9 @@ class Projects(
             )
             if outcome == follower_contract.ReplayOutcome.replay:
                 return existing
-            # No updated_at on the wire for this op either — derive it from op_id's
-            # own UUIDv7 mint time.
-            updated_at = follower_contract.op_id_timestamp(op_id)
+            # No updated_at on the wire for this op either — MLRun stamps its own
+            # local time for when it applied the change.
+            updated_at = datetime.datetime.now(datetime.UTC)
             # The common set only — labels/annotations/owner/description. Everything else
             # is MLRun-specific spec the leader never sends and never syncs (see the
             # Backend HLD's "store labels/annotations/description?" decision).

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -1377,9 +1377,10 @@ class Projects(
 
     @staticmethod
     def _encode_project_states_cursor(key: tuple[datetime.datetime, str]) -> str:
-        # `|` is a safe delimiter: project names are constrained to mlrun.utils.regex's
-        # DNS-1123-label pattern (lowercase alphanumerics and hyphens only) and can't
-        # contain it.
+        # `|` is a safe delimiter even though the name isn't constrained against it:
+        # decode only splits on the *first* `|` (str.partition), so everything after
+        # it — the whole name, `|` or not — comes back intact. What actually matters
+        # is that datetime.isoformat() never produces a `|` itself.
         updated_at, name = key
         return f"{updated_at.isoformat()}|{name}"
 

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -499,9 +499,8 @@ def test_get_follower_project_snapshot_defaults_to_no_lock(
     reset_projects_singleton: None,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """A plain read (e.g. the commit-delete endpoint's absent-project fast path,
-    which has no write of its own to protect) must not take a lock it doesn't
-    need."""
+    """A plain read with no write of its own to protect must not take a lock it
+    doesn't need."""
     db_mock = unittest.mock.MagicMock()
     db_mock.list_projects.return_value = mlrun.common.schemas.ProjectsOutput(
         projects=[]

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -20,14 +20,12 @@ import unittest.mock
 import uuid
 
 import pytest
-from uuid_utils.compat import uuid7
 
 import mlrun
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.singleton
 
-import framework.utils.projects.follower_contract as follower_contract
 import services.api.crud.projects as projects_crud
 
 
@@ -529,19 +527,21 @@ def test_prepare_create_project_creates_new_row(
     store_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "store_project", store_mock)
 
-    op_id = uuid7()
+    op_id = uuid.UUID(int=1)
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
     )
 
+    before = datetime.datetime.now(tz=datetime.UTC)
     result = projects_crud.Projects().prepare_create_project(project, op_id)
+    after = datetime.datetime.now(tz=datetime.UTC)
 
     store_mock.assert_not_called()
     created_project = create_mock.call_args.args[1]
     assert created_project.status.state == mlrun.common.schemas.ProjectState.creating
     assert created_project.status.op_id == op_id
-    # updated_at isn't on the wire for this op: derived from op_id's own timestamp.
-    assert created_project.status.updated_at == follower_contract.op_id_timestamp(op_id)
+    # updated_at isn't on the wire for this op: MLRun stamps its own local time.
+    assert before <= created_project.status.updated_at <= after
     # The endpoint builds its response from this return value directly, with no
     # follow-up query — it must reflect exactly what was just persisted.
     assert result is created_project
@@ -624,7 +624,7 @@ def test_commit_create_project_flips_to_online(
     patched_db_session: unittest.mock.MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    op_id = uuid7()
+    op_id = uuid.UUID(int=1)
     existing = _make_follower_snapshot(
         op_id, mlrun.common.schemas.ProjectState.creating
     )
@@ -636,18 +636,19 @@ def test_commit_create_project_flips_to_online(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
+    before = datetime.datetime.now(tz=datetime.UTC)
     result = projects_crud.Projects().commit_create_project("proj", op_id)
+    after = datetime.datetime.now(tz=datetime.UTC)
 
     patched_dict = patch_mock.call_args.args[2]
     assert patched_dict["status"]["state"] == mlrun.common.schemas.ProjectState.online
-    # No project payload on this call: updated_at comes from op_id's own timestamp.
-    expected_updated_at = follower_contract.op_id_timestamp(op_id)
-    assert patched_dict["status"]["updated_at"] == expected_updated_at
+    # No project payload on this call: MLRun stamps its own local time.
+    assert before <= patched_dict["status"]["updated_at"] <= after
     # The endpoint builds its response from this return value with no follow-up
     # query, so it must already reflect the new state.
     assert result.status.state == mlrun.common.schemas.ProjectState.online
     assert result.status.op_id == op_id
-    assert result.status.updated_at == expected_updated_at
+    assert before <= result.status.updated_at <= after
 
 
 def test_update_project_follower_absent_project_is_not_found(
@@ -722,21 +723,22 @@ def test_update_project_follower_first_touch_with_no_prior_op_id_applies(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    new_op_id = uuid7()
+    new_op_id = uuid.UUID(int=1)
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj", labels={"a": "b"}),
         spec=mlrun.common.schemas.ProjectSpec(owner="jsmith"),
     )
 
+    before = datetime.datetime.now(tz=datetime.UTC)
     projects_crud.Projects().update_project_follower(
         "proj", project, new_op_id, prev_op_id=None
     )
+    after = datetime.datetime.now(tz=datetime.UTC)
 
     patched_dict = patch_mock.call_args.args[2]
-    assert patched_dict["status"] == {
-        "op_id": new_op_id,
-        "updated_at": follower_contract.op_id_timestamp(new_op_id),
-    }
+    assert patched_dict["status"]["op_id"] == new_op_id
+    # No updated_at on the wire for this op: MLRun stamps its own local time.
+    assert before <= patched_dict["status"]["updated_at"] <= after
 
 
 def test_update_project_follower_applies_common_set_only(
@@ -756,7 +758,7 @@ def test_update_project_follower_applies_common_set_only(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    new_op_id = uuid7()
+    new_op_id = uuid.UUID(int=2)
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(
             name="proj", labels={"team": "ml"}, annotations={"a": "b"}
@@ -764,21 +766,25 @@ def test_update_project_follower_applies_common_set_only(
         spec=mlrun.common.schemas.ProjectSpec(owner="jsmith", description="desc"),
     )
 
+    before = datetime.datetime.now(tz=datetime.UTC)
     result = projects_crud.Projects().update_project_follower(
         "proj", project, new_op_id, prev_op_id=stored_op_id
     )
+    after = datetime.datetime.now(tz=datetime.UTC)
 
-    expected_updated_at = follower_contract.op_id_timestamp(new_op_id)
     patched_dict = patch_mock.call_args.args[2]
-    assert patched_dict == {
-        "metadata": {"labels": {"team": "ml"}, "annotations": {"a": "b"}},
-        "spec": {"owner": "jsmith", "description": "desc"},
-        "status": {"op_id": new_op_id, "updated_at": expected_updated_at},
+    assert patched_dict["metadata"] == {
+        "labels": {"team": "ml"},
+        "annotations": {"a": "b"},
     }
+    assert patched_dict["spec"] == {"owner": "jsmith", "description": "desc"}
+    assert patched_dict["status"]["op_id"] == new_op_id
+    # No updated_at on the wire for this op: MLRun stamps its own local time.
+    assert before <= patched_dict["status"]["updated_at"] <= after
     # The endpoint builds its response from this return value with no follow-up
     # query — state doesn't change on update, but op_id must reflect the new one.
     assert result.status.op_id == new_op_id
-    assert result.status.updated_at == expected_updated_at
+    assert before <= result.status.updated_at <= after
     assert result.status.state == mlrun.common.schemas.ProjectState.online
 
 
@@ -818,26 +824,23 @@ def test_prepare_delete_project_marks_deleting(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    new_op_id = uuid7()
+    new_op_id = uuid.UUID(int=2)
+    before = datetime.datetime.now(tz=datetime.UTC)
     result = projects_crud.Projects().prepare_delete_project(
         "proj", new_op_id, prev_op_id=stored_op_id
     )
+    after = datetime.datetime.now(tz=datetime.UTC)
 
-    expected_updated_at = follower_contract.op_id_timestamp(new_op_id)
     patched_dict = patch_mock.call_args.args[2]
-    # No project payload on this call: updated_at comes from op_id's own timestamp.
-    assert patched_dict == {
-        "status": {
-            "state": mlrun.common.schemas.ProjectState.deleting,
-            "op_id": new_op_id,
-            "updated_at": expected_updated_at,
-        }
-    }
+    # No project payload on this call: MLRun stamps its own local time.
+    assert patched_dict["status"]["state"] == mlrun.common.schemas.ProjectState.deleting
+    assert patched_dict["status"]["op_id"] == new_op_id
+    assert before <= patched_dict["status"]["updated_at"] <= after
     # The endpoint builds its response from this return value with no follow-up
     # query, so it must already reflect the new state.
     assert result.status.state == mlrun.common.schemas.ProjectState.deleting
     assert result.status.op_id == new_op_id
-    assert result.status.updated_at == expected_updated_at
+    assert before <= result.status.updated_at <= after
 
 
 def test_commit_delete_project_absent_project_is_noop(

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -20,12 +20,14 @@ import unittest.mock
 import uuid
 
 import pytest
+from uuid_utils.compat import uuid7
 
 import mlrun
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.utils.singleton
 
+import framework.utils.projects.follower_contract as follower_contract
 import services.api.crud.projects as projects_crud
 
 
@@ -455,9 +457,6 @@ def test_wait_for_nuclio_project_deletion_keeps_user_auth_when_not_iguazio_v4(
 # ----- 2PC follower hooks (ML-12901) ----------------------------------------
 
 
-_UPDATED_AT = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
-
-
 def _make_follower_snapshot(
     op_id: uuid.UUID, state: mlrun.common.schemas.ProjectState
 ) -> mlrun.common.schemas.Project:
@@ -530,50 +529,22 @@ def test_prepare_create_project_creates_new_row(
     store_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "store_project", store_mock)
 
-    op_id = uuid.UUID(int=1)
+    op_id = uuid7()
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
     )
 
-    result = projects_crud.Projects().prepare_create_project(
-        project, op_id, _UPDATED_AT
-    )
+    result = projects_crud.Projects().prepare_create_project(project, op_id)
 
     store_mock.assert_not_called()
     created_project = create_mock.call_args.args[1]
     assert created_project.status.state == mlrun.common.schemas.ProjectState.creating
     assert created_project.status.op_id == op_id
-    assert created_project.status.updated_at == _UPDATED_AT
+    # updated_at isn't on the wire for this op: derived from op_id's own timestamp.
+    assert created_project.status.updated_at == follower_contract.op_id_timestamp(op_id)
     # The endpoint builds its response from this return value directly, with no
     # follow-up query — it must reflect exactly what was just persisted.
     assert result is created_project
-
-
-def test_prepare_create_project_updated_at_comes_from_the_explicit_param(
-    reset_projects_singleton: None,
-    patched_db_session: unittest.mock.MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """The endpoint validates project.status.updated_at is present and passes it
-    to the hook explicitly, the same way it already does for op_id — the hook must
-    use that argument, not re-read the (possibly stale) field off `project`."""
-    monkeypatch.setattr(
-        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
-    )
-    create_mock = unittest.mock.MagicMock()
-    monkeypatch.setattr(projects_crud.Projects, "create_project", create_mock)
-
-    op_id = uuid.UUID(int=1)
-    decoy_updated_at = _UPDATED_AT + datetime.timedelta(days=1)
-    project = mlrun.common.schemas.Project(
-        metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
-        status=mlrun.common.schemas.ProjectStatus(updated_at=decoy_updated_at),
-    )
-
-    projects_crud.Projects().prepare_create_project(project, op_id, _UPDATED_AT)
-
-    created_project = create_mock.call_args.args[1]
-    assert created_project.status.updated_at == _UPDATED_AT
 
 
 def test_prepare_create_project_idempotent_replay_does_not_mutate(
@@ -598,9 +569,7 @@ def test_prepare_create_project_idempotent_replay_does_not_mutate(
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
     )
-    result = projects_crud.Projects().prepare_create_project(
-        project, op_id, _UPDATED_AT
-    )
+    result = projects_crud.Projects().prepare_create_project(project, op_id)
 
     create_mock.assert_not_called()
     store_mock.assert_not_called()
@@ -632,9 +601,7 @@ def test_prepare_create_project_stale_op_is_rejected(
     )
 
     with pytest.raises(mlrun.errors.MLRunConflictError):
-        projects_crud.Projects().prepare_create_project(
-            project, stale_op_id, _UPDATED_AT
-        )
+        projects_crud.Projects().prepare_create_project(project, stale_op_id)
 
     store_mock.assert_not_called()
 
@@ -649,9 +616,7 @@ def test_commit_create_project_requires_provisioned_project(
     )
 
     with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
-        projects_crud.Projects().commit_create_project(
-            "proj", uuid.UUID(int=1), _UPDATED_AT
-        )
+        projects_crud.Projects().commit_create_project("proj", uuid.UUID(int=1))
 
 
 def test_commit_create_project_flips_to_online(
@@ -659,7 +624,7 @@ def test_commit_create_project_flips_to_online(
     patched_db_session: unittest.mock.MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    op_id = uuid.UUID(int=1)
+    op_id = uuid7()
     existing = _make_follower_snapshot(
         op_id, mlrun.common.schemas.ProjectState.creating
     )
@@ -671,17 +636,18 @@ def test_commit_create_project_flips_to_online(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    result = projects_crud.Projects().commit_create_project("proj", op_id, _UPDATED_AT)
+    result = projects_crud.Projects().commit_create_project("proj", op_id)
 
     patched_dict = patch_mock.call_args.args[2]
     assert patched_dict["status"]["state"] == mlrun.common.schemas.ProjectState.online
-    # No project payload on this call: updated_at comes from the explicit param.
-    assert patched_dict["status"]["updated_at"] == _UPDATED_AT
+    # No project payload on this call: updated_at comes from op_id's own timestamp.
+    expected_updated_at = follower_contract.op_id_timestamp(op_id)
+    assert patched_dict["status"]["updated_at"] == expected_updated_at
     # The endpoint builds its response from this return value with no follow-up
     # query, so it must already reflect the new state.
     assert result.status.state == mlrun.common.schemas.ProjectState.online
     assert result.status.op_id == op_id
-    assert result.status.updated_at == _UPDATED_AT
+    assert result.status.updated_at == expected_updated_at
 
 
 def test_update_project_follower_absent_project_is_not_found(
@@ -701,7 +667,6 @@ def test_update_project_follower_absent_project_is_not_found(
             "proj",
             project,
             uuid.UUID(int=2),
-            _UPDATED_AT,
             prev_op_id=uuid.UUID(int=1),
         )
 
@@ -733,7 +698,6 @@ def test_update_project_follower_cas_mismatch_is_rejected(
             "proj",
             project,
             uuid.UUID(int=2),
-            _UPDATED_AT,
             prev_op_id=wrong_prev_op_id,
         )
 
@@ -758,18 +722,21 @@ def test_update_project_follower_first_touch_with_no_prior_op_id_applies(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    new_op_id = uuid.UUID(int=1)
+    new_op_id = uuid7()
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj", labels={"a": "b"}),
         spec=mlrun.common.schemas.ProjectSpec(owner="jsmith"),
     )
 
     projects_crud.Projects().update_project_follower(
-        "proj", project, new_op_id, _UPDATED_AT, prev_op_id=None
+        "proj", project, new_op_id, prev_op_id=None
     )
 
     patched_dict = patch_mock.call_args.args[2]
-    assert patched_dict["status"] == {"op_id": new_op_id, "updated_at": _UPDATED_AT}
+    assert patched_dict["status"] == {
+        "op_id": new_op_id,
+        "updated_at": follower_contract.op_id_timestamp(new_op_id),
+    }
 
 
 def test_update_project_follower_applies_common_set_only(
@@ -789,7 +756,7 @@ def test_update_project_follower_applies_common_set_only(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    new_op_id = uuid.UUID(int=2)
+    new_op_id = uuid7()
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(
             name="proj", labels={"team": "ml"}, annotations={"a": "b"}
@@ -798,55 +765,21 @@ def test_update_project_follower_applies_common_set_only(
     )
 
     result = projects_crud.Projects().update_project_follower(
-        "proj", project, new_op_id, _UPDATED_AT, prev_op_id=stored_op_id
+        "proj", project, new_op_id, prev_op_id=stored_op_id
     )
 
+    expected_updated_at = follower_contract.op_id_timestamp(new_op_id)
     patched_dict = patch_mock.call_args.args[2]
     assert patched_dict == {
         "metadata": {"labels": {"team": "ml"}, "annotations": {"a": "b"}},
         "spec": {"owner": "jsmith", "description": "desc"},
-        "status": {"op_id": new_op_id, "updated_at": _UPDATED_AT},
+        "status": {"op_id": new_op_id, "updated_at": expected_updated_at},
     }
     # The endpoint builds its response from this return value with no follow-up
     # query — state doesn't change on update, but op_id must reflect the new one.
     assert result.status.op_id == new_op_id
-    assert result.status.updated_at == _UPDATED_AT
+    assert result.status.updated_at == expected_updated_at
     assert result.status.state == mlrun.common.schemas.ProjectState.online
-
-
-def test_update_project_follower_updated_at_comes_from_the_explicit_param(
-    reset_projects_singleton: None,
-    patched_db_session: unittest.mock.MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """Same guarantee as prepare_create's: the hook must use the explicitly passed
-    updated_at, not re-read the (possibly stale) field off `project`."""
-    stored_op_id = uuid.UUID(int=1)
-    existing = _make_follower_snapshot(
-        stored_op_id, mlrun.common.schemas.ProjectState.online
-    )
-    monkeypatch.setattr(
-        projects_crud.Projects,
-        "get_follower_project_snapshot",
-        lambda *a, **k: existing,
-    )
-    patch_mock = unittest.mock.MagicMock()
-    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
-
-    new_op_id = uuid.UUID(int=2)
-    decoy_updated_at = _UPDATED_AT + datetime.timedelta(days=1)
-    project = mlrun.common.schemas.Project(
-        metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
-        status=mlrun.common.schemas.ProjectStatus(updated_at=decoy_updated_at),
-    )
-
-    result = projects_crud.Projects().update_project_follower(
-        "proj", project, new_op_id, _UPDATED_AT, prev_op_id=stored_op_id
-    )
-
-    patched_dict = patch_mock.call_args.args[2]
-    assert patched_dict["status"]["updated_at"] == _UPDATED_AT
-    assert result.status.updated_at == _UPDATED_AT
 
 
 def test_prepare_delete_project_absent_project_is_noop(
@@ -861,7 +794,7 @@ def test_prepare_delete_project_absent_project_is_noop(
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
     result = projects_crud.Projects().prepare_delete_project(
-        "proj", uuid.UUID(int=1), _UPDATED_AT, prev_op_id=uuid.UUID(int=1)
+        "proj", uuid.UUID(int=1), prev_op_id=uuid.UUID(int=1)
     )
 
     patch_mock.assert_not_called()
@@ -885,25 +818,26 @@ def test_prepare_delete_project_marks_deleting(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    new_op_id = uuid.UUID(int=2)
+    new_op_id = uuid7()
     result = projects_crud.Projects().prepare_delete_project(
-        "proj", new_op_id, _UPDATED_AT, prev_op_id=stored_op_id
+        "proj", new_op_id, prev_op_id=stored_op_id
     )
 
+    expected_updated_at = follower_contract.op_id_timestamp(new_op_id)
     patched_dict = patch_mock.call_args.args[2]
-    # No project payload on this call: updated_at comes from the explicit param.
+    # No project payload on this call: updated_at comes from op_id's own timestamp.
     assert patched_dict == {
         "status": {
             "state": mlrun.common.schemas.ProjectState.deleting,
             "op_id": new_op_id,
-            "updated_at": _UPDATED_AT,
+            "updated_at": expected_updated_at,
         }
     }
     # The endpoint builds its response from this return value with no follow-up
     # query, so it must already reflect the new state.
     assert result.status.state == mlrun.common.schemas.ProjectState.deleting
     assert result.status.op_id == new_op_id
-    assert result.status.updated_at == _UPDATED_AT
+    assert result.status.updated_at == expected_updated_at
 
 
 def test_commit_delete_project_absent_project_is_noop(

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -640,6 +640,38 @@ def test_update_project_follower_cas_mismatch_is_rejected(
     patch_mock.assert_not_called()
 
 
+def test_update_project_follower_first_touch_with_no_prior_op_id_applies(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Migration scenario: a project that predates this follower interface has
+    op_id=None on its row. The leader observes that (e.g. via list-states) and sends
+    prev_op_id=None to match it — this must apply, not be rejected as a missing
+    witness (see follower_contract.check_cas)."""
+    existing = _make_follower_snapshot(None, mlrun.common.schemas.ProjectState.online)
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    patch_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
+
+    new_op_id = uuid.UUID(int=1)
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj", labels={"a": "b"}),
+        spec=mlrun.common.schemas.ProjectSpec(owner="jsmith"),
+    )
+
+    projects_crud.Projects().update_project_follower(
+        "proj", project, new_op_id, prev_op_id=None
+    )
+
+    patched_dict = patch_mock.call_args.args[2]
+    assert patched_dict["status"] == {"op_id": new_op_id}
+
+
 def test_update_project_follower_applies_common_set_only(
     reset_projects_singleton: None,
     patched_db_session: unittest.mock.MagicMock,
@@ -790,6 +822,41 @@ def test_commit_delete_project_mismatched_op_is_rejected(
     delete_mock.assert_not_called()
 
 
+def _patch_db_list_projects(
+    monkeypatch: pytest.MonkeyPatch, projects: list[mlrun.common.schemas.Project]
+) -> None:
+    """
+    list_project_states() now pushes updated_after/keyset pagination down to
+    framework.utils.singletons.db.get_db().list_projects() (ML-12901) rather than
+    filtering/paginating in memory — this fakes that DB-layer behavior faithfully
+    enough to exercise the crud method's own cursor encode/decode and
+    "fetch page_size+1 to detect a next page" logic for real.
+    """
+
+    def _fake_list_projects(
+        session, format_=None, updated_after=None, keyset_after=None, limit=None, **_
+    ):
+        result = list(projects)
+        if updated_after is not None:
+            result = [p for p in result if p.status.updated_at >= updated_after]
+        result.sort(key=lambda p: (p.status.updated_at, p.metadata.name))
+        if keyset_after is not None:
+            after_updated_at, after_name = keyset_after
+            result = [
+                p
+                for p in result
+                if (p.status.updated_at, p.metadata.name)
+                > (after_updated_at, after_name)
+            ]
+        if limit is not None:
+            result = result[:limit]
+        return mlrun.common.schemas.ProjectsOutput(projects=result)
+
+    db_mock = unittest.mock.MagicMock()
+    db_mock.list_projects = _fake_list_projects
+    monkeypatch.setattr("framework.utils.singletons.db.get_db", lambda: db_mock)
+
+
 def test_list_project_states_filters_by_updated_after(
     reset_projects_singleton: None,
     monkeypatch: pytest.MonkeyPatch,
@@ -805,16 +872,7 @@ def test_list_project_states_filters_by_updated_after(
         metadata=mlrun.common.schemas.ProjectMetadata(name="fresh"),
         status=mlrun.common.schemas.ProjectStatus(updated_at=now),
     )
-
-    def _list_projects(self, session, format_=None, updated_after=None, **kwargs):
-        # Mimic the DB layer's own updated_after filtering (see db.py:list_projects)
-        # so this test exercises the same contract list_project_states relies on.
-        projects = [old_project, fresh_project]
-        if updated_after is not None:
-            projects = [p for p in projects if p.status.updated_at >= updated_after]
-        return mlrun.common.schemas.ProjectsOutput(projects=projects)
-
-    monkeypatch.setattr(projects_crud.Projects, "list_projects", _list_projects)
+    _patch_db_list_projects(monkeypatch, [old_project, fresh_project])
 
     page, next_cursor = projects_crud.Projects().list_project_states(
         unittest.mock.MagicMock(), updated_after=now - datetime.timedelta(hours=1)
@@ -838,11 +896,7 @@ def test_list_project_states_paginates_with_keyset_cursor(
         )
         for i, name in enumerate(["a", "b", "c"])
     ]
-
-    def _list_projects(self, session, **kwargs):
-        return mlrun.common.schemas.ProjectsOutput(projects=projects)
-
-    monkeypatch.setattr(projects_crud.Projects, "list_projects", _list_projects)
+    _patch_db_list_projects(monkeypatch, projects)
 
     crud = projects_crud.Projects()
     first_page, cursor = crud.list_project_states(

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -799,6 +799,33 @@ def test_commit_delete_project_purges_with_cascading_strategy(
     )
 
 
+def test_commit_delete_project_retry_with_same_op_id_re_runs_the_purge(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Blocking commit-delete (Orca requirement) means a retry with the same op_id —
+    e.g. after a dropped connection — must re-attempt the purge, not silently skip
+    it: check_same_op never returns ReplayOutcome.replay for commit_delete, precisely
+    so this keeps retrying rather than falsely reporting success."""
+    op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        op_id, mlrun.common.schemas.ProjectState.deleting
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    delete_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "delete_project", delete_mock)
+
+    projects_crud.Projects().commit_delete_project("proj", op_id)
+    projects_crud.Projects().commit_delete_project("proj", op_id)
+
+    assert delete_mock.call_count == 2
+
+
 def test_commit_delete_project_mismatched_op_is_rejected(
     reset_projects_singleton: None,
     patched_db_session: unittest.mock.MagicMock,

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -17,6 +17,7 @@ import collections.abc
 import datetime
 import types
 import unittest.mock
+import uuid
 
 import pytest
 
@@ -449,3 +450,409 @@ def test_wait_for_nuclio_project_deletion_keeps_user_auth_when_not_iguazio_v4(
 
     polled_auth_info = nuclio_client_mock.get_project.call_args.kwargs["auth_info"]
     assert polled_auth_info is user_auth_info
+
+
+# ----- 2PC follower hooks (ML-12901) ----------------------------------------
+
+
+def _make_follower_snapshot(
+    op_id: uuid.UUID, state: mlrun.common.schemas.ProjectState
+) -> mlrun.common.schemas.Project:
+    return mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
+        status=mlrun.common.schemas.ProjectStatus(op_id=op_id, state=state),
+    )
+
+
+@pytest.fixture
+def patched_db_session(monkeypatch: pytest.MonkeyPatch) -> unittest.mock.MagicMock:
+    """The 2PC hooks open/close their own DB session internally; stub both so
+    tests don't need a real database."""
+    session_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr("framework.db.session.create_session", lambda: session_mock)
+    monkeypatch.setattr("framework.db.session.close_session", lambda session: None)
+    return session_mock
+
+
+def test_prepare_create_project_creates_new_row(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
+    )
+    create_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "create_project", create_mock)
+    store_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "store_project", store_mock)
+
+    op_id = uuid.UUID(int=1)
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
+    )
+
+    projects_crud.Projects().prepare_create_project(project, op_id)
+
+    store_mock.assert_not_called()
+    created_project = create_mock.call_args.args[1]
+    assert created_project.status.state == mlrun.common.schemas.ProjectState.creating
+    assert created_project.status.op_id == op_id
+
+
+def test_prepare_create_project_idempotent_replay_does_not_mutate(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        op_id, mlrun.common.schemas.ProjectState.creating
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    create_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "create_project", create_mock)
+    store_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "store_project", store_mock)
+
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
+    )
+    projects_crud.Projects().prepare_create_project(project, op_id)
+
+    create_mock.assert_not_called()
+    store_mock.assert_not_called()
+
+
+def test_prepare_create_project_stale_op_is_rejected(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    newer_op_id = uuid.UUID(int=2)
+    existing = _make_follower_snapshot(
+        newer_op_id, mlrun.common.schemas.ProjectState.creating
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    store_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "store_project", store_mock)
+
+    stale_op_id = uuid.UUID(int=1)
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
+    )
+
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        projects_crud.Projects().prepare_create_project(project, stale_op_id)
+
+    store_mock.assert_not_called()
+
+
+def test_commit_create_project_requires_provisioned_project(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
+    )
+
+    with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
+        projects_crud.Projects().commit_create_project("proj", uuid.UUID(int=1))
+
+
+def test_commit_create_project_flips_to_online(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        op_id, mlrun.common.schemas.ProjectState.creating
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    patch_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
+
+    projects_crud.Projects().commit_create_project("proj", op_id)
+
+    patched_dict = patch_mock.call_args.args[2]
+    assert patched_dict["status"]["state"] == mlrun.common.schemas.ProjectState.online
+
+
+def test_update_project_follower_absent_project_is_not_found(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
+    )
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
+    )
+
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        projects_crud.Projects().update_project_follower(
+            "proj", project, uuid.UUID(int=2), prev_op_id=uuid.UUID(int=1)
+        )
+
+
+def test_update_project_follower_cas_mismatch_is_rejected(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stored_op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        stored_op_id, mlrun.common.schemas.ProjectState.online
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    patch_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
+
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
+    )
+    wrong_prev_op_id = uuid.UUID(int=99)
+
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        projects_crud.Projects().update_project_follower(
+            "proj", project, uuid.UUID(int=2), prev_op_id=wrong_prev_op_id
+        )
+
+    patch_mock.assert_not_called()
+
+
+def test_update_project_follower_applies_common_set_only(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stored_op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        stored_op_id, mlrun.common.schemas.ProjectState.online
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    patch_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
+
+    new_op_id = uuid.UUID(int=2)
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(
+            name="proj", labels={"team": "ml"}, annotations={"a": "b"}
+        ),
+        spec=mlrun.common.schemas.ProjectSpec(owner="jsmith", description="desc"),
+    )
+
+    projects_crud.Projects().update_project_follower(
+        "proj", project, new_op_id, prev_op_id=stored_op_id
+    )
+
+    patched_dict = patch_mock.call_args.args[2]
+    assert patched_dict == {
+        "metadata": {"labels": {"team": "ml"}, "annotations": {"a": "b"}},
+        "spec": {"owner": "jsmith", "description": "desc"},
+        "status": {"op_id": new_op_id},
+    }
+
+
+def test_prepare_delete_project_absent_project_is_noop(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
+    )
+    patch_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
+
+    projects_crud.Projects().prepare_delete_project(
+        "proj", uuid.UUID(int=1), prev_op_id=uuid.UUID(int=1)
+    )
+
+    patch_mock.assert_not_called()
+
+
+def test_prepare_delete_project_marks_deleting(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stored_op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        stored_op_id, mlrun.common.schemas.ProjectState.online
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    patch_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
+
+    new_op_id = uuid.UUID(int=2)
+    projects_crud.Projects().prepare_delete_project(
+        "proj", new_op_id, prev_op_id=stored_op_id
+    )
+
+    patched_dict = patch_mock.call_args.args[2]
+    assert patched_dict == {
+        "status": {
+            "state": mlrun.common.schemas.ProjectState.deleting,
+            "op_id": new_op_id,
+        }
+    }
+
+
+def test_commit_delete_project_absent_project_is_noop(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
+    )
+    delete_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "delete_project", delete_mock)
+
+    projects_crud.Projects().commit_delete_project("proj", uuid.UUID(int=1))
+
+    delete_mock.assert_not_called()
+
+
+def test_commit_delete_project_purges_with_cascading_strategy(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        op_id, mlrun.common.schemas.ProjectState.deleting
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    delete_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "delete_project", delete_mock)
+
+    projects_crud.Projects().commit_delete_project("proj", op_id)
+
+    assert (
+        delete_mock.call_args.kwargs["deletion_strategy"]
+        == mlrun.common.schemas.DeletionStrategy.cascading
+    )
+
+
+def test_commit_delete_project_mismatched_op_is_rejected(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stored_op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        stored_op_id, mlrun.common.schemas.ProjectState.deleting
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    delete_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "delete_project", delete_mock)
+
+    with pytest.raises(mlrun.errors.MLRunConflictError):
+        projects_crud.Projects().commit_delete_project("proj", uuid.UUID(int=99))
+
+    delete_mock.assert_not_called()
+
+
+def test_list_project_states_filters_by_updated_after(
+    reset_projects_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    now = datetime.datetime.now(tz=datetime.UTC)
+    old_project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="old"),
+        status=mlrun.common.schemas.ProjectStatus(
+            updated_at=now - datetime.timedelta(days=1)
+        ),
+    )
+    fresh_project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="fresh"),
+        status=mlrun.common.schemas.ProjectStatus(updated_at=now),
+    )
+
+    def _list_projects(self, session, format_=None, updated_after=None, **kwargs):
+        # Mimic the DB layer's own updated_after filtering (see db.py:list_projects)
+        # so this test exercises the same contract list_project_states relies on.
+        projects = [old_project, fresh_project]
+        if updated_after is not None:
+            projects = [p for p in projects if p.status.updated_at >= updated_after]
+        return mlrun.common.schemas.ProjectsOutput(projects=projects)
+
+    monkeypatch.setattr(projects_crud.Projects, "list_projects", _list_projects)
+
+    page, next_cursor = projects_crud.Projects().list_project_states(
+        unittest.mock.MagicMock(), updated_after=now - datetime.timedelta(hours=1)
+    )
+
+    assert [p.metadata.name for p in page] == ["fresh"]
+    assert next_cursor is None
+
+
+def test_list_project_states_paginates_with_keyset_cursor(
+    reset_projects_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    now = datetime.datetime.now(tz=datetime.UTC)
+    projects = [
+        mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name=name),
+            status=mlrun.common.schemas.ProjectStatus(
+                updated_at=now + datetime.timedelta(seconds=i)
+            ),
+        )
+        for i, name in enumerate(["a", "b", "c"])
+    ]
+
+    def _list_projects(self, session, **kwargs):
+        return mlrun.common.schemas.ProjectsOutput(projects=projects)
+
+    monkeypatch.setattr(projects_crud.Projects, "list_projects", _list_projects)
+
+    crud = projects_crud.Projects()
+    first_page, cursor = crud.list_project_states(
+        unittest.mock.MagicMock(), page_size=2
+    )
+    assert [p.metadata.name for p in first_page] == ["a", "b"]
+    assert cursor is not None
+
+    second_page, next_cursor = crud.list_project_states(
+        unittest.mock.MagicMock(), cursor=cursor, page_size=2
+    )
+    assert [p.metadata.name for p in second_page] == ["c"]
+    assert next_cursor is None

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -492,12 +492,15 @@ def test_prepare_create_project_creates_new_row(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
     )
 
-    projects_crud.Projects().prepare_create_project(project, op_id)
+    result = projects_crud.Projects().prepare_create_project(project, op_id)
 
     store_mock.assert_not_called()
     created_project = create_mock.call_args.args[1]
     assert created_project.status.state == mlrun.common.schemas.ProjectState.creating
     assert created_project.status.op_id == op_id
+    # The endpoint builds its response from this return value directly, with no
+    # follow-up query — it must reflect exactly what was just persisted.
+    assert result is created_project
 
 
 def test_prepare_create_project_idempotent_replay_does_not_mutate(
@@ -522,10 +525,13 @@ def test_prepare_create_project_idempotent_replay_does_not_mutate(
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
     )
-    projects_crud.Projects().prepare_create_project(project, op_id)
+    result = projects_crud.Projects().prepare_create_project(project, op_id)
 
     create_mock.assert_not_called()
     store_mock.assert_not_called()
+    # A replay still needs to return the current state — the endpoint has no other
+    # way to build its response, since it no longer re-queries.
+    assert result is existing
 
 
 def test_prepare_create_project_stale_op_is_rejected(
@@ -586,10 +592,14 @@ def test_commit_create_project_flips_to_online(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    projects_crud.Projects().commit_create_project("proj", op_id)
+    result = projects_crud.Projects().commit_create_project("proj", op_id)
 
     patched_dict = patch_mock.call_args.args[2]
     assert patched_dict["status"]["state"] == mlrun.common.schemas.ProjectState.online
+    # The endpoint builds its response from this return value with no follow-up
+    # query, so it must already reflect the new state.
+    assert result.status.state == mlrun.common.schemas.ProjectState.online
+    assert result.status.op_id == op_id
 
 
 def test_update_project_follower_absent_project_is_not_found(
@@ -697,7 +707,7 @@ def test_update_project_follower_applies_common_set_only(
         spec=mlrun.common.schemas.ProjectSpec(owner="jsmith", description="desc"),
     )
 
-    projects_crud.Projects().update_project_follower(
+    result = projects_crud.Projects().update_project_follower(
         "proj", project, new_op_id, prev_op_id=stored_op_id
     )
 
@@ -707,6 +717,10 @@ def test_update_project_follower_applies_common_set_only(
         "spec": {"owner": "jsmith", "description": "desc"},
         "status": {"op_id": new_op_id},
     }
+    # The endpoint builds its response from this return value with no follow-up
+    # query — state doesn't change on update, but op_id must reflect the new one.
+    assert result.status.op_id == new_op_id
+    assert result.status.state == mlrun.common.schemas.ProjectState.online
 
 
 def test_prepare_delete_project_absent_project_is_noop(
@@ -720,11 +734,12 @@ def test_prepare_delete_project_absent_project_is_noop(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    projects_crud.Projects().prepare_delete_project(
+    result = projects_crud.Projects().prepare_delete_project(
         "proj", uuid.UUID(int=1), prev_op_id=uuid.UUID(int=1)
     )
 
     patch_mock.assert_not_called()
+    assert result is None
 
 
 def test_prepare_delete_project_marks_deleting(
@@ -745,7 +760,7 @@ def test_prepare_delete_project_marks_deleting(
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
     new_op_id = uuid.UUID(int=2)
-    projects_crud.Projects().prepare_delete_project(
+    result = projects_crud.Projects().prepare_delete_project(
         "proj", new_op_id, prev_op_id=stored_op_id
     )
 
@@ -756,6 +771,10 @@ def test_prepare_delete_project_marks_deleting(
             "op_id": new_op_id,
         }
     }
+    # The endpoint builds its response from this return value with no follow-up
+    # query, so it must already reflect the new state.
+    assert result.status.state == mlrun.common.schemas.ProjectState.deleting
+    assert result.status.op_id == new_op_id
 
 
 def test_commit_delete_project_absent_project_is_noop(

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -474,6 +474,47 @@ def patched_db_session(monkeypatch: pytest.MonkeyPatch) -> unittest.mock.MagicMo
     return session_mock
 
 
+def test_get_follower_project_snapshot_for_update_reaches_the_db_layer(
+    reset_projects_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The CAS pre-check's `for_update=True` must actually reach
+    SQLDB.list_projects() as a `SELECT ... FOR UPDATE` — a race between two
+    concurrent read-decide-write calls for the same project is exactly what this
+    guards against, so a silently-dropped kwarg here would be a real regression."""
+    db_mock = unittest.mock.MagicMock()
+    db_mock.list_projects.return_value = mlrun.common.schemas.ProjectsOutput(
+        projects=[]
+    )
+    monkeypatch.setattr("framework.utils.singletons.db.get_db", lambda: db_mock)
+
+    projects_crud.Projects().get_follower_project_snapshot(
+        unittest.mock.MagicMock(), "proj", for_update=True
+    )
+
+    assert db_mock.list_projects.call_args.kwargs["for_update"] is True
+
+
+def test_get_follower_project_snapshot_defaults_to_no_lock(
+    reset_projects_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A plain read (e.g. the commit-delete endpoint's absent-project fast path,
+    which has no write of its own to protect) must not take a lock it doesn't
+    need."""
+    db_mock = unittest.mock.MagicMock()
+    db_mock.list_projects.return_value = mlrun.common.schemas.ProjectsOutput(
+        projects=[]
+    )
+    monkeypatch.setattr("framework.utils.singletons.db.get_db", lambda: db_mock)
+
+    projects_crud.Projects().get_follower_project_snapshot(
+        unittest.mock.MagicMock(), "proj"
+    )
+
+    assert db_mock.list_projects.call_args.kwargs["for_update"] is False
+
+
 def test_prepare_create_project_creates_new_row(
     reset_projects_singleton: None,
     patched_db_session: unittest.mock.MagicMock,

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -452,7 +452,7 @@ def test_wait_for_nuclio_project_deletion_keeps_user_auth_when_not_iguazio_v4(
     assert polled_auth_info is user_auth_info
 
 
-# ----- 2PC follower hooks (ML-12901) ----------------------------------------
+# ----- 2PC follower hooks ---------------------------------------------------
 
 
 def _make_follower_snapshot(
@@ -938,8 +938,8 @@ def _patch_db_list_projects(
     monkeypatch: pytest.MonkeyPatch, projects: list[mlrun.common.schemas.Project]
 ) -> None:
     """
-    list_project_states() now pushes updated_after/keyset pagination down to
-    framework.utils.singletons.db.get_db().list_projects() (ML-12901) rather than
+    list_project_states() pushes updated_after/keyset pagination down to
+    framework.utils.singletons.db.get_db().list_projects() rather than
     filtering/paginating in memory — this fakes that DB-layer behavior faithfully
     enough to exercise the crud method's own cursor encode/decode and
     "fetch page_size+1 to detect a next page" logic for real.

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -455,6 +455,9 @@ def test_wait_for_nuclio_project_deletion_keeps_user_auth_when_not_iguazio_v4(
 # ----- 2PC follower hooks (ML-12901) ----------------------------------------
 
 
+_UPDATED_AT = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+
+
 def _make_follower_snapshot(
     op_id: uuid.UUID, state: mlrun.common.schemas.ProjectState
 ) -> mlrun.common.schemas.Project:
@@ -532,15 +535,45 @@ def test_prepare_create_project_creates_new_row(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
     )
 
-    result = projects_crud.Projects().prepare_create_project(project, op_id)
+    result = projects_crud.Projects().prepare_create_project(
+        project, op_id, _UPDATED_AT
+    )
 
     store_mock.assert_not_called()
     created_project = create_mock.call_args.args[1]
     assert created_project.status.state == mlrun.common.schemas.ProjectState.creating
     assert created_project.status.op_id == op_id
+    assert created_project.status.updated_at == _UPDATED_AT
     # The endpoint builds its response from this return value directly, with no
     # follow-up query — it must reflect exactly what was just persisted.
     assert result is created_project
+
+
+def test_prepare_create_project_updated_at_comes_from_the_explicit_param(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The endpoint validates project.status.updated_at is present and passes it
+    to the hook explicitly, the same way it already does for op_id — the hook must
+    use that argument, not re-read the (possibly stale) field off `project`."""
+    monkeypatch.setattr(
+        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
+    )
+    create_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "create_project", create_mock)
+
+    op_id = uuid.UUID(int=1)
+    decoy_updated_at = _UPDATED_AT + datetime.timedelta(days=1)
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
+        status=mlrun.common.schemas.ProjectStatus(updated_at=decoy_updated_at),
+    )
+
+    projects_crud.Projects().prepare_create_project(project, op_id, _UPDATED_AT)
+
+    created_project = create_mock.call_args.args[1]
+    assert created_project.status.updated_at == _UPDATED_AT
 
 
 def test_prepare_create_project_idempotent_replay_does_not_mutate(
@@ -565,7 +598,9 @@ def test_prepare_create_project_idempotent_replay_does_not_mutate(
     project = mlrun.common.schemas.Project(
         metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
     )
-    result = projects_crud.Projects().prepare_create_project(project, op_id)
+    result = projects_crud.Projects().prepare_create_project(
+        project, op_id, _UPDATED_AT
+    )
 
     create_mock.assert_not_called()
     store_mock.assert_not_called()
@@ -597,7 +632,9 @@ def test_prepare_create_project_stale_op_is_rejected(
     )
 
     with pytest.raises(mlrun.errors.MLRunConflictError):
-        projects_crud.Projects().prepare_create_project(project, stale_op_id)
+        projects_crud.Projects().prepare_create_project(
+            project, stale_op_id, _UPDATED_AT
+        )
 
     store_mock.assert_not_called()
 
@@ -612,7 +649,9 @@ def test_commit_create_project_requires_provisioned_project(
     )
 
     with pytest.raises(mlrun.errors.MLRunPreconditionFailedError):
-        projects_crud.Projects().commit_create_project("proj", uuid.UUID(int=1))
+        projects_crud.Projects().commit_create_project(
+            "proj", uuid.UUID(int=1), _UPDATED_AT
+        )
 
 
 def test_commit_create_project_flips_to_online(
@@ -632,14 +671,17 @@ def test_commit_create_project_flips_to_online(
     patch_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
-    result = projects_crud.Projects().commit_create_project("proj", op_id)
+    result = projects_crud.Projects().commit_create_project("proj", op_id, _UPDATED_AT)
 
     patched_dict = patch_mock.call_args.args[2]
     assert patched_dict["status"]["state"] == mlrun.common.schemas.ProjectState.online
+    # No project payload on this call: updated_at comes from the explicit param.
+    assert patched_dict["status"]["updated_at"] == _UPDATED_AT
     # The endpoint builds its response from this return value with no follow-up
     # query, so it must already reflect the new state.
     assert result.status.state == mlrun.common.schemas.ProjectState.online
     assert result.status.op_id == op_id
+    assert result.status.updated_at == _UPDATED_AT
 
 
 def test_update_project_follower_absent_project_is_not_found(
@@ -656,7 +698,11 @@ def test_update_project_follower_absent_project_is_not_found(
 
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
         projects_crud.Projects().update_project_follower(
-            "proj", project, uuid.UUID(int=2), prev_op_id=uuid.UUID(int=1)
+            "proj",
+            project,
+            uuid.UUID(int=2),
+            _UPDATED_AT,
+            prev_op_id=uuid.UUID(int=1),
         )
 
 
@@ -684,7 +730,11 @@ def test_update_project_follower_cas_mismatch_is_rejected(
 
     with pytest.raises(mlrun.errors.MLRunConflictError):
         projects_crud.Projects().update_project_follower(
-            "proj", project, uuid.UUID(int=2), prev_op_id=wrong_prev_op_id
+            "proj",
+            project,
+            uuid.UUID(int=2),
+            _UPDATED_AT,
+            prev_op_id=wrong_prev_op_id,
         )
 
     patch_mock.assert_not_called()
@@ -715,11 +765,11 @@ def test_update_project_follower_first_touch_with_no_prior_op_id_applies(
     )
 
     projects_crud.Projects().update_project_follower(
-        "proj", project, new_op_id, prev_op_id=None
+        "proj", project, new_op_id, _UPDATED_AT, prev_op_id=None
     )
 
     patched_dict = patch_mock.call_args.args[2]
-    assert patched_dict["status"] == {"op_id": new_op_id}
+    assert patched_dict["status"] == {"op_id": new_op_id, "updated_at": _UPDATED_AT}
 
 
 def test_update_project_follower_applies_common_set_only(
@@ -748,19 +798,55 @@ def test_update_project_follower_applies_common_set_only(
     )
 
     result = projects_crud.Projects().update_project_follower(
-        "proj", project, new_op_id, prev_op_id=stored_op_id
+        "proj", project, new_op_id, _UPDATED_AT, prev_op_id=stored_op_id
     )
 
     patched_dict = patch_mock.call_args.args[2]
     assert patched_dict == {
         "metadata": {"labels": {"team": "ml"}, "annotations": {"a": "b"}},
         "spec": {"owner": "jsmith", "description": "desc"},
-        "status": {"op_id": new_op_id},
+        "status": {"op_id": new_op_id, "updated_at": _UPDATED_AT},
     }
     # The endpoint builds its response from this return value with no follow-up
     # query — state doesn't change on update, but op_id must reflect the new one.
     assert result.status.op_id == new_op_id
+    assert result.status.updated_at == _UPDATED_AT
     assert result.status.state == mlrun.common.schemas.ProjectState.online
+
+
+def test_update_project_follower_updated_at_comes_from_the_explicit_param(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Same guarantee as prepare_create's: the hook must use the explicitly passed
+    updated_at, not re-read the (possibly stale) field off `project`."""
+    stored_op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        stored_op_id, mlrun.common.schemas.ProjectState.online
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    patch_mock = unittest.mock.MagicMock()
+    monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
+
+    new_op_id = uuid.UUID(int=2)
+    decoy_updated_at = _UPDATED_AT + datetime.timedelta(days=1)
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
+        status=mlrun.common.schemas.ProjectStatus(updated_at=decoy_updated_at),
+    )
+
+    result = projects_crud.Projects().update_project_follower(
+        "proj", project, new_op_id, _UPDATED_AT, prev_op_id=stored_op_id
+    )
+
+    patched_dict = patch_mock.call_args.args[2]
+    assert patched_dict["status"]["updated_at"] == _UPDATED_AT
+    assert result.status.updated_at == _UPDATED_AT
 
 
 def test_prepare_delete_project_absent_project_is_noop(
@@ -775,7 +861,7 @@ def test_prepare_delete_project_absent_project_is_noop(
     monkeypatch.setattr(projects_crud.Projects, "patch_project", patch_mock)
 
     result = projects_crud.Projects().prepare_delete_project(
-        "proj", uuid.UUID(int=1), prev_op_id=uuid.UUID(int=1)
+        "proj", uuid.UUID(int=1), _UPDATED_AT, prev_op_id=uuid.UUID(int=1)
     )
 
     patch_mock.assert_not_called()
@@ -801,20 +887,23 @@ def test_prepare_delete_project_marks_deleting(
 
     new_op_id = uuid.UUID(int=2)
     result = projects_crud.Projects().prepare_delete_project(
-        "proj", new_op_id, prev_op_id=stored_op_id
+        "proj", new_op_id, _UPDATED_AT, prev_op_id=stored_op_id
     )
 
     patched_dict = patch_mock.call_args.args[2]
+    # No project payload on this call: updated_at comes from the explicit param.
     assert patched_dict == {
         "status": {
             "state": mlrun.common.schemas.ProjectState.deleting,
             "op_id": new_op_id,
+            "updated_at": _UPDATED_AT,
         }
     }
     # The endpoint builds its response from this return value with no follow-up
     # query, so it must already reflect the new state.
     assert result.status.state == mlrun.common.schemas.ProjectState.deleting
     assert result.status.op_id == new_op_id
+    assert result.status.updated_at == _UPDATED_AT
 
 
 def test_commit_delete_project_absent_project_is_noop(

--- a/server/py/services/api/tests/unit/db/test_projects.py
+++ b/server/py/services/api/tests/unit/db/test_projects.py
@@ -617,6 +617,38 @@ class TestProjects(TestDatabaseBase):
         )
         assert output.projects == []
 
+    def test_list_projects_filter_updated_after_treats_null_as_epoch(self):
+        # A project that predates the follower interface has updated_at=NULL. A real
+        # cutoff must still exclude it (NULL has no meaningful recency), but a cutoff
+        # at or before the epoch floor must include it too -- both sides of the filter
+        # need to agree with keyset pagination's own NULL-as-epoch coalescing.
+        self._db.create_project(
+            self._db_session,
+            mlrun.common.schemas.Project(
+                metadata=mlrun.common.schemas.ProjectMetadata(name="legacy"),
+            ),
+        )
+        record = self._db_session.query(Project).filter(Project.name == "legacy").one()
+        assert record.updated_at is None
+
+        recent_cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+            hours=1
+        )
+        output = self._db.list_projects(
+            self._db_session,
+            format_=mlrun.common.formatters.ProjectFormat.name_only,
+            updated_after=recent_cutoff,
+        )
+        assert output.projects == []
+
+        epoch = datetime.datetime.min.replace(tzinfo=datetime.UTC)
+        output = self._db.list_projects(
+            self._db_session,
+            format_=mlrun.common.formatters.ProjectFormat.name_only,
+            updated_after=epoch,
+        )
+        assert output.projects == ["legacy"]
+
     def test_list_projects_custom_selection_status_columns(self):
         # The new sync columns must be selectable through the custom format and
         # populate project.status (not just metadata/spec).


### PR DESCRIPTION
### 📝 Description
Adds the dedicated, SA-gated `/api/v1/follower/projects/*` surface (ML-12901) that lets Orca drive MLRun as a follower in the enterprise project-sync epic: a two-phase-commit create/delete, a fire-and-forget-with-CAS update, and a paginated list-states read for reconciliation, all filtered/paginated at the DB layer. Builds on the `op_id`/`phase`/`updated_at` columns already added to the projects table (data-model PR #9639) — this PR is the first to actually write and read them. Legacy user-facing `/api/v1/projects` endpoints and the CE (`leader=mlrun`) path are untouched — this surface only matters once an Orca leader is configured.

---

### 🛠️ Changes Made
- New `follower_contract.py`: a dependency-free CAS/UUIDv7-ordering/state-machine module implementing the Follower Contract's per-operation validation order and request grid — kept storage/transport-agnostic so it can move into a shared cross-follower library later.
- New `follower_schemas.py`: the wire request/response pydantic models for this surface. Not in `mlrun.common.schemas` — that package is the public SDK↔server contract, and the SDK never talks to this surface.
- New `projects_follower.py` router: `prepare-create`, `commit-create`, `update` (PUT), `prepare-delete`, `commit-delete` (DELETE), and `list-states` (GET, keyset-paginated at the DB layer).
- New `authenticate_leader_request` auth dependency (`framework/api/deps.py`) — builds on the existing igz session-verification flow (`AuthInfo.is_service_account()`), rejects anything that isn't the configured leader's service account.
- The 5 2PC hooks (`prepare_create_project`, `commit_create_project`, `prepare_delete_project`, `commit_delete_project`, `update_project_follower`) are implemented directly on `services.api.crud.projects.Projects`, not declared on the abstract `follower.Member` interface — the endpoint always calls the concrete class, never polymorphically, so the interface (and `nop_follower`/`nuclio`/`iguazio/v4`) carries no stubs for them.
- Each hook takes a row lock (`for_update`) on its CAS pre-check read, and persists `op_id`/`phase`/`updated_at` onto the project row alongside `state` (`SQLDB.create_project`/`store_project`/`patch_project`).
- `updated_at` is a required field on every op (confirmed always sent by Orca per the Follower Contract HLD): `FollowerCommitCreateRequest`/`FollowerPrepareDeleteRequest` declare it directly; `prepare-create`/`update`'s `project` payload is validated via a new `_project_updated_at` helper, mirroring the existing `_project_op_id`.
- New `httpdb.projects.follower.leader_identity` config key; new `commit_delete_follower_project` on the chief client. `commit-delete` blocks synchronously until the purge actually finishes (confirmed requirement from the Orca feature owner) — no background task, no early 202 — so it's the one route needing chief re-routing (schedule deletion is chief-only) and a timeout sized to the full `delete_project` operation rather than the legacy chief-proxy default.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- 50 unit tests added and passing under pytest: full CAS/ordering/state-machine coverage (`test_follower_contract.py`, 47 tests) + SA-gating coverage (`test_deps.py`, 3 tests).
- 21 more unit tests for the 5 crud-level 2PC hooks, `get_follower_project_snapshot`, and `list_project_states` (`test_projects.py`), verified passing via a manual harness — they can't run under plain `pytest` in my dev venv because `services/api/tests/unit/conftest.py` imports the full app, which hits a pre-existing, unrelated pydantic v1-vs-v2 gap in that venv (confirmed pre-existing: it breaks untouched tests the same way). Should run normally in CI.
- No system tests added — this surface has no caller yet (Orca's MLRun follower client, ORIS-3535, is a separate, not-yet-merged change in the `orca` repo).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12901
- Design docs links:
  - https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/654737417 (Follower Contract HLD)
  - https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/611745844 (Project Sync Mechanism — Backend HLD)
  - https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/661979181 (Followers sub-page — MLRun section)
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Orca's MLRun follower client (ORIS-3535) depends on this branch merging first — it's the actual caller of this surface.
- ML-12902 (mode-aware backward-compatibility proxy for the legacy `/api/v1/projects` endpoints) is a separate, not-yet-started ticket; deliberately out of scope here.
- `commit-delete`'s blocking behavior was confirmed directly with the Orca feature owner, rather than assumed from the (still-open) Backend HLD question on sync-vs-background cleanup.
