### PR TITLE
[DB] Fix non-deterministic order in partitioned queries

### DIFF
--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -1981,6 +1981,13 @@ class SQLDB(DBInterface):
                 partition_order,
                 with_tagged=True,
             )
+            # _create_partitioned_query() now applies its own ORDER BY for determinism.
+            # Query.order_by() appends rather than replaces, so left unreset it would
+            # silently become the leading sort key for order_criteria below and change
+            # which rows survive limit/offset for non-default partition_sort_by/order.
+            # This function already orders deterministically via order_criteria and the
+            # outer query's order_by(), so reset it here.
+            query = query.order_by(None)
         if parent_uri:
             query = self._add_artifact_parent_query(query=query, parent_uri=parent_uri)
 
@@ -4965,8 +4972,15 @@ class SQLDB(DBInterface):
                     subquery.c.tag_name,
                     subquery.c.tag_id,
                 )
-            result_query = result_query.join(subquery, cls.id == subquery.c.id).filter(
-                subquery.c.row_number <= rows_per_partition
+            result_query = (
+                result_query.join(subquery, cls.id == subquery.c.id)
+                .filter(subquery.c.row_number <= rows_per_partition)
+                # The join above doesn't preserve the row_number window function's
+                # implicit order, so without an explicit ORDER BY the result order is
+                # undefined by the SQL standard.
+                .order_by(
+                    partition_order.to_order_by_predicate(sort_by_field), cls.id.desc()
+                )
             )
             return result_query
 
@@ -4986,6 +5000,9 @@ class SQLDB(DBInterface):
             session.query(cls)
             .join(subquery, cls.id == subquery.c.id)
             .filter(subquery.c.partition_rank <= max_partitions)
+            # Same ordering gap as the max_partitions == 0 branch above: rank the
+            # partitions by recency, then rows within a partition by their row_number.
+            .order_by(subquery.c.partition_rank, subquery.c.row_number, cls.id.desc())
         )
         return result_query
 

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -1965,14 +1965,14 @@ class TestArtifacts(TestDatabaseBase):
             )
 
     def test_list_artifacts_partition_by_with_limit_and_non_default_sort_field(self):
-        # Regression test for ML-13004: _create_partitioned_query now applies its own
-        # ORDER BY for determinism. _find_artifacts calls query.order_by(*order_criteria)
-        # on that same query object when `limit` is set - since SQLAlchemy's order_by()
-        # appends rather than replaces, a non-default partition_sort_by/partition_order
-        # could otherwise leak in as the *leading* sort key for the limit's row selection,
-        # picking a different artifact than _find_artifacts's own (updated desc, id desc)
-        # criteria intends. Two single-version artifacts, with `created` and `updated`
-        # deliberately disagreeing on which one is "first", make that leak observable.
+        # _create_partitioned_query applies its own ORDER BY, and _find_artifacts then
+        # calls query.order_by(*order_criteria) on that same query object when `limit`
+        # is set. Since SQLAlchemy's order_by() appends rather than replaces, a
+        # non-default partition_sort_by/partition_order could leak in as the *leading*
+        # sort key for the limit's row selection, picking a different artifact than
+        # _find_artifacts's own (updated desc, id desc) criteria intends. Two
+        # single-version artifacts, with `created` and `updated` deliberately
+        # disagreeing on which one is "first", make that leak observable.
         artifact_key_a = "artifact-a"
         artifact_key_b = "artifact-b"
         self._db.store_artifact(

--- a/server/py/services/api/tests/unit/db/test_artifacts.py
+++ b/server/py/services/api/tests/unit/db/test_artifacts.py
@@ -1964,6 +1964,66 @@ class TestArtifacts(TestDatabaseBase):
                 f"Expected {expected_name}, got {artifact_name}"
             )
 
+    def test_list_artifacts_partition_by_with_limit_and_non_default_sort_field(self):
+        # Regression test for ML-13004: _create_partitioned_query now applies its own
+        # ORDER BY for determinism. _find_artifacts calls query.order_by(*order_criteria)
+        # on that same query object when `limit` is set - since SQLAlchemy's order_by()
+        # appends rather than replaces, a non-default partition_sort_by/partition_order
+        # could otherwise leak in as the *leading* sort key for the limit's row selection,
+        # picking a different artifact than _find_artifacts's own (updated desc, id desc)
+        # criteria intends. Two single-version artifacts, with `created` and `updated`
+        # deliberately disagreeing on which one is "first", make that leak observable.
+        artifact_key_a = "artifact-a"
+        artifact_key_b = "artifact-b"
+        self._db.store_artifact(
+            self._db_session,
+            artifact_key_a,
+            self._generate_artifact(artifact_key_a, project=self.project),
+            project=self.project,
+        )
+        self._db.store_artifact(
+            self._db_session,
+            artifact_key_b,
+            self._generate_artifact(artifact_key_b, project=self.project),
+            project=self.project,
+        )
+
+        # artifact-a: earliest `created`, oldest `updated`.
+        # artifact-b: latest `created`, newest `updated`.
+        # so "created asc" and "updated desc" pick *different* winners: "created asc"
+        # (the partitioning criterion below) would rank artifact-a first; the intended
+        # "updated desc" (_find_artifacts's own default) ranks artifact-b first.
+        self._db.update_db_object(
+            self._db_session,
+            framework.db.sqldb.models.ArtifactV2,
+            filters={"key": artifact_key_a},
+            created=datetime.datetime(2026, 1, 1),
+            updated=datetime.datetime(2026, 1, 1),
+        )
+        self._db.update_db_object(
+            self._db_session,
+            framework.db.sqldb.models.ArtifactV2,
+            filters={"key": artifact_key_b},
+            created=datetime.datetime(2026, 1, 2),
+            updated=datetime.datetime(2026, 1, 2),
+        )
+
+        artifacts = self._db.list_artifacts(
+            self._db_session,
+            project=self.project,
+            partition_by=mlrun.common.schemas.ArtifactPartitionByField.name,
+            partition_sort_by=mlrun.common.schemas.SortField.created,
+            partition_order=mlrun.common.schemas.OrderType.asc,
+            limit=1,
+        )
+
+        assert len(artifacts) == 1
+        assert artifacts[0]["metadata"]["key"] == artifact_key_b, (
+            "expected the most-recently-updated artifact under limit=1, "
+            f"got {artifacts[0]['metadata']['key']!r} - the partitioned query's "
+            "internal ORDER BY leaked into the limit's row selection"
+        )
+
     @pytest.mark.parametrize("limit", [None, 3])
     @pytest.mark.parametrize("tag", [None, "*"])
     def test_list_artifacts_orders_by_tag_id(self, limit, tag):

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -641,10 +641,10 @@ class TestRuns(TestDatabaseBase):
             )
 
     def test_list_runs_partitioned_no_max_partitions_has_explicit_order_by(self):
-        # Regression test for ML-13004: _create_partitioned_query's max_partitions=0
-        # branch (the one every "no filter" list_runs call hits) joined the ranked
-        # subquery onto the runs table with no outer ORDER BY, leaving the result
-        # order up to the DB engine instead of following partition_sort_by/order.
+        # _create_partitioned_query's max_partitions=0 branch (the one every "no
+        # filter" list_runs call hits) joins the ranked subquery onto the runs table.
+        # Without an outer ORDER BY, the result order is left up to the DB engine
+        # instead of following partition_sort_by/order.
         #
         # SQLite happens to preserve the window function's internal sort into the
         # final join for this query shape regardless of whether the fix is present,
@@ -706,9 +706,8 @@ class TestRuns(TestDatabaseBase):
         )
 
     def test_list_runs_partitioned_with_max_partitions_has_explicit_order_by(self):
-        # Regression test for ML-13004: the max_partitions>0 branch of
-        # _create_partitioned_query has the same missing-ORDER-BY gap as the
-        # max_partitions=0 branch. See the comment in
+        # The max_partitions>0 branch of _create_partitioned_query has the same
+        # missing-ORDER-BY gap as the max_partitions=0 branch. See the comment in
         # test_list_runs_partitioned_no_max_partitions_has_explicit_order_by for why
         # the compiled-SQL assertion, not row order, is the real regression guard.
         project_name = "my-project"

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -14,7 +14,7 @@
 
 import time
 import unittest.mock
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy.dialects import mysql, postgresql, sqlite
@@ -639,6 +639,143 @@ class TestRuns(TestDatabaseBase):
             assert run_name == expected_name, (
                 f"Expected {expected_name}, got {run_name}"
             )
+
+    def test_list_runs_partitioned_no_max_partitions_has_explicit_order_by(self):
+        # Regression test for ML-13004: _create_partitioned_query's max_partitions=0
+        # branch (the one every "no filter" list_runs call hits) joined the ranked
+        # subquery onto the runs table with no outer ORDER BY, leaving the result
+        # order up to the DB engine instead of following partition_sort_by/order.
+        #
+        # SQLite happens to preserve the window function's internal sort into the
+        # final join for this query shape regardless of whether the fix is present,
+        # so an end-to-end "is the returned row order correct" assertion can't
+        # actually distinguish fixed from broken here (verified: it passes either
+        # way). The real regression guard is inspecting the compiled SQL for an
+        # explicit ORDER BY - this is what MySQL's optimizer needs to produce a
+        # deterministic result, and it's what the fix actually adds.
+        project_name = "my-project"
+        query = self._db._find_runs(self._db_session, None, project_name)
+        partitioned_query = self._db._create_partitioned_query(
+            self._db_session,
+            query,
+            framework.db.sqldb.models.Run,
+            mlrun.common.schemas.RunPartitionByField.project_and_name,
+            rows_per_partition=5,
+            partition_sort_by=mlrun.common.schemas.SortField.updated,
+            partition_order=mlrun.common.schemas.OrderType.desc,
+        )
+        compiled_sql = str(partitioned_query.statement.compile(dialect=mysql.dialect()))
+        # The row_number() window function's own OVER(ORDER BY ...) clause always
+        # contains the substring "ORDER BY" - that's not what's under test. A
+        # second, outer-level ORDER BY (added by the fix) is what's needed for a
+        # deterministic final result, so assert on the count, not just presence.
+        assert compiled_sql.count("ORDER BY") >= 2, (
+            "expected an explicit outer ORDER BY on the partitioned query in "
+            f"addition to the window function's own OVER(ORDER BY ...), got: {compiled_sql}"
+        )
+
+        # End-to-end sanity check: still exercises the real list_runs() path and
+        # documents the intended behaviour, even though it can't fail on SQLite.
+        run_name = "run-same-name"
+        number_of_runs = 5
+        base_time = datetime(2026, 1, 1, tzinfo=UTC)
+        for counter in range(number_of_runs):
+            uid = f"uid-{counter}"
+            self._create_new_run(project=project_name, name=run_name, uid=uid)
+            self._db.update_db_object(
+                self._db_session,
+                framework.db.sqldb.models.Run,
+                filters={"uid": uid},
+                updated=base_time + timedelta(seconds=counter),
+            )
+
+        runs = self._db.list_runs(
+            self._db_session,
+            project=project_name,
+            partition_by=mlrun.common.schemas.RunPartitionByField.project_and_name,
+            partition_sort_by=mlrun.common.schemas.SortField.updated,
+            partition_order=mlrun.common.schemas.OrderType.desc,
+            rows_per_partition=number_of_runs,
+        )
+        assert len(runs) == number_of_runs
+        expected_uids = [f"uid-{i}" for i in range(number_of_runs - 1, -1, -1)]
+        actual_uids = [run["metadata"]["uid"] for run in runs]
+        assert actual_uids == expected_uids, (
+            f"Expected runs ordered newest-updated-first {expected_uids}, "
+            f"got {actual_uids}"
+        )
+
+    def test_list_runs_partitioned_with_max_partitions_has_explicit_order_by(self):
+        # Regression test for ML-13004: the max_partitions>0 branch of
+        # _create_partitioned_query has the same missing-ORDER-BY gap as the
+        # max_partitions=0 branch. See the comment in
+        # test_list_runs_partitioned_no_max_partitions_has_explicit_order_by for why
+        # the compiled-SQL assertion, not row order, is the real regression guard.
+        project_name = "my-project"
+        query = self._db._find_runs(self._db_session, None, project_name)
+        partitioned_query = self._db._create_partitioned_query(
+            self._db_session,
+            query,
+            framework.db.sqldb.models.Run,
+            mlrun.common.schemas.RunPartitionByField.project_and_name,
+            rows_per_partition=2,
+            partition_sort_by=mlrun.common.schemas.SortField.updated,
+            partition_order=mlrun.common.schemas.OrderType.desc,
+            max_partitions=2,
+        )
+        compiled_sql = str(partitioned_query.statement.compile(dialect=mysql.dialect()))
+        # This branch already has two window functions pre-fix - row_number() and
+        # dense_rank() - each with its own OVER(ORDER BY ...), contributing 2
+        # occurrences of "ORDER BY" regardless of the fix. A third, outer-level
+        # ORDER BY (added by the fix) is what's needed for a deterministic final
+        # result, so assert on the count, not just presence.
+        assert compiled_sql.count("ORDER BY") >= 3, (
+            "expected an explicit outer ORDER BY on the partitioned query in "
+            "addition to the row_number()/dense_rank() window functions' own "
+            f"OVER(ORDER BY ...) clauses, got: {compiled_sql}"
+        )
+
+        # End-to-end sanity check: still exercises the real list_runs() path and
+        # documents the intended behaviour, even though it can't fail on SQLite.
+        base_time = datetime(2026, 1, 1, tzinfo=UTC)
+        partitions = [
+            ("run-oldest", 0),
+            ("run-newest", 20),
+            ("run-middle", 10),
+        ]
+        for run_name, offset_seconds in partitions:
+            for counter in range(2):
+                uid = f"{run_name}-uid-{counter}"
+                self._create_new_run(project=project_name, name=run_name, uid=uid)
+                self._db.update_db_object(
+                    self._db_session,
+                    framework.db.sqldb.models.Run,
+                    filters={"uid": uid},
+                    updated=base_time + timedelta(seconds=offset_seconds + counter),
+                )
+
+        runs = self._db.list_runs(
+            self._db_session,
+            project=project_name,
+            partition_by=mlrun.common.schemas.RunPartitionByField.project_and_name,
+            partition_sort_by=mlrun.common.schemas.SortField.updated,
+            partition_order=mlrun.common.schemas.OrderType.desc,
+            rows_per_partition=2,
+            max_partitions=2,
+        )
+        run_names = [run["metadata"]["name"] for run in runs]
+        assert set(run_names) == {"run-newest", "run-middle"}
+        assert len(runs) == 4
+        expected_order = [
+            "run-newest-uid-1",
+            "run-newest-uid-0",
+            "run-middle-uid-1",
+            "run-middle-uid-0",
+        ]
+        actual_order = [run["metadata"]["uid"] for run in runs]
+        assert actual_order == expected_order, (
+            f"Expected {expected_order}, got {actual_order}"
+        )
 
     def test_list_runs_with_missing_milliseconds_in_timestamp(self):
         self._create_new_run(project="my-project")

--- a/tests/integration/sdk_api/httpdb/runs/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/runs/test_runs.py
@@ -273,13 +273,19 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
             expected_number_of_runs=5,
             project=project_name,
         )
-        # The elements are not ordered as they were originally stored because some of the elements
-        # have a start_time from the previous day, which affects their sorting order.
+        # No filter is given, so this goes through the "no filter" default
+        # (partition_by=project_and_name, partition_sort_by=updated,
+        # partition_order=desc - see crud.Runs().list_runs). Each run has a
+        # distinct name, so each is its own partition; the global order across
+        # partitions is by `updated` (real insertion wall-clock time, independent
+        # of the fake historical `start_time` values set above), most-recent
+        # first, with `id` descending as the tiebreaker for runs created within
+        # the same timestamp resolution - i.e. the reverse of creation order.
         expected_names = [
             "run-name-4",
             "run-name-3",
-            "run-name-1",
             "run-name-2",
+            "run-name-1",
             "run-name-0",
         ]
         for i, expected_name in enumerate(expected_names):

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -1361,13 +1361,18 @@ def test_paginated_list_runs(create_server):
     db, project_name = _store_runs(create_server, num_runs)
     page_size = 4
 
+    # No filter is given, so pagination goes through the "no filter" default
+    # (partition_by=project_and_name, partition_sort_by=updated,
+    # partition_order=desc - see crud.Runs().list_runs) - most-recently-updated
+    # run first, i.e. run-9 down to run-0.
+
     # First request (Page 1)
     runs, token = db.paginated_list_runs(project=project_name, page_size=page_size)
     _assert_list_response(
         runs,
         expected_results_count=page_size,
         identifier_name="name",
-        expected_first_result_name="run-0",
+        expected_first_result_name="run-9",
     )
     assert token is not None
 
@@ -1377,7 +1382,7 @@ def test_paginated_list_runs(create_server):
         runs,
         expected_results_count=page_size,
         identifier_name="name",
-        expected_first_result_name="run-4",
+        expected_first_result_name="run-5",
     )
     assert token is not None
 
@@ -1387,7 +1392,7 @@ def test_paginated_list_runs(create_server):
         runs,
         expected_results_count=2,
         identifier_name="name",
-        expected_first_result_name="run-8",
+        expected_first_result_name="run-1",
     )
     assert token is None
 
@@ -1399,7 +1404,7 @@ def test_paginated_list_runs(create_server):
         runs,
         expected_results_count=2,
         identifier_name="name",
-        expected_first_result_name="run-8",
+        expected_first_result_name="run-1",
     )
     assert token is None
 


### PR DESCRIPTION
### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->
`list_runs`/`list_artifacts`/`list_feature_sets`/`list_feature_vectors`, when called with `partition_by`, build their final result via `_create_partitioned_query`. That helper's final joined query had no outer `ORDER BY` in either the `max_partitions == 0` or `max_partitions > 0` branch, so the returned row order was left up to the DB engine instead of following `partition_sort_by`/`partition_order`. Since `list_runs`'s "no filter" default sets `partition_by=project_and_name` (hitting the `max_partitions == 0` branch on essentially every no-filter call), this showed up as non-deterministic ordering.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- Added an explicit `ORDER BY` to both branches of `_create_partitioned_query`: the `max_partitions == 0` branch orders by the same sort criterion computed for its `row_number()` window function plus `id` as a tiebreaker; the `max_partitions > 0` branch orders by its `partition_rank`/`row_number` columns (produced by its two window functions) plus `id` as a tiebreaker.
- Reset that new `ORDER BY` in `_find_artifacts` via `query.order_by(None)` right after the `_create_partitioned_query` call. `_find_artifacts` already applies its own `order_by(*order_criteria)` when `limit` is set, and since SQLAlchemy's `order_by()` appends rather than replaces, the new ordering would otherwise silently become the leading sort key for that `LIMIT`'s row selection under non-default `partition_sort_by`/`partition_order`.
- Added 3 regression tests: two for `list_runs` covering both `_create_partitioned_query` branches (asserting the compiled SQL contains the expected outer `ORDER BY`, since SQLite's window-function execution otherwise masks the bug end-to-end), and one for `list_artifacts` reproducing the `order_by()`-append hazard directly.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  
- 3 new unit tests added; full `test_runs.py` (25 tests) and `test_artifacts.py` (103 tests) suites pass.
- Each new test verified to fail without the fix and pass with it (toggled via `git stash`).
- Verified live against a real PostgreSQL-backed lab (not SQLite): scrambled `updated` timestamps on a set of runs and on a pair of artifacts, confirmed `list_runs`/`list_artifacts` (with `partition_by` + non-default sort criteria) now return the correct order/winner.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13004
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
