### PR TITLE
[Jupyter] Remediate High CVEs in Jupyter image

### DIFF
--- a/dockerfiles/jupyter/Dockerfile
+++ b/dockerfiles/jupyter/Dockerfile
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 ARG MLRUN_PYTHON_VERSION=3.11
+ARG MLRUN_BASE_PYTHON_VERSION=3.13
 ARG MLRUN_PIP_VERSION=26.0
 ARG MLRUN_UV_IMAGE=ghcr.io/astral-sh/uv:latest
 ARG MLRUN_CACHE_DATE=initial
 
 FROM ${MLRUN_UV_IMAGE} AS uv-image
-FROM quay.io/jupyter/scipy-notebook:python-${MLRUN_PYTHON_VERSION}
+FROM quay.io/jupyter/scipy-notebook:python-${MLRUN_BASE_PYTHON_VERSION}
 ARG MLRUN_PYTHON_VERSION
+ARG MLRUN_BASE_PYTHON_VERSION
 ARG MLRUN_PIP_VERSION
 USER root
 
@@ -49,8 +51,14 @@ USER $NB_UID
 # Ensure uv uses mlrun conda env
 ENV PATH="/opt/conda/envs/mlrun/bin:$PATH"
 
+# jupyterlab-git-core is a separate conda-forge package from jupyterlab-git (split since v0.50)
 RUN python -m pip install --upgrade pip~=${MLRUN_PIP_VERSION} && \
-    conda update --all --yes
+    conda update --all --yes && \
+    conda install -n base -y \
+        "jupyterlab-git>=0.54.0" \
+        "jupyterlab-git-core>=0.54.0" \
+        "pillow>=12.3.0" \
+        "tornado>=6.5.8"
 
 # Add Jupyter kernel for mlrun environment
 RUN conda install -n mlrun ipykernel -y && \
@@ -97,8 +105,8 @@ USER root
 RUN rm -rf /tmp/mlrun \
     && rm -rf $HOME/.cache \
     && rm -rf /opt/conda/envs/mlrun/lib/python${MLRUN_PYTHON_VERSION}/ensurepip \
-    && rm -rf /opt/conda/lib/python${MLRUN_PYTHON_VERSION}/ensurepip \
-    && rm -rf /usr/local/lib/python${MLRUN_PYTHON_VERSION}/ensurepip
+    && rm -rf /opt/conda/lib/python${MLRUN_BASE_PYTHON_VERSION}/ensurepip \
+    && rm -rf /usr/local/lib/python${MLRUN_BASE_PYTHON_VERSION}/ensurepip
 
 USER $NB_UID
 
@@ -119,10 +127,12 @@ ENV JUPYTER_ENABLE_LAB=yes \
     MLRUN_HTTPDB__PORT=8080
 
 # backup home since it will be deleted when using pvc
-# exclude the conda package cache - it dominates the tarball size and is not user data,
-# so including it turns first-mount extraction on NFS-backed PVCs into a 30-60 min stall
+# the conda package cache is removed explicitly before archiving: --exclude was unreliable
+# (packages still linked to the base env survive conda clean and the path pattern was
+# not consistently matched by GNU tar when the source path is absolute)
 RUN conda clean -a -y || true && \
-    mkdir data && tar -cf /tmp/basehome.tar --exclude='.conda/pkgs' --exclude='.cache' $HOME
+    rm -rf $HOME/.conda/pkgs && \
+    mkdir data && tar -cf /tmp/basehome.tar --exclude='.cache' $HOME
 
 ARG MLRUN_GIT_COMMIT
 LABEL org.opencontainers.image.revision=$MLRUN_GIT_COMMIT


### PR DESCRIPTION
### 📝 Description
security scan on `mlrun/jupyter` flagged 47 unique CVEs across multiple
dependency groups. This PR fixes all CVEs that are resolvable at the Dockerfile level.

Key root causes addressed:
- Base image was `scipy-notebook:python-3.11`; upgrading to Python 3.13 via a new
  `MLRUN_BASE_PYTHON_VERSION` ARG decouples the base image Python from the mlrun conda env
  (which remains on 3.11) and eliminates stale Python 3.11 paths from scanner findings.
- `conda update --all --yes` upgrades JupyterLab 3.x → 4.x, which removes nodejs/npm
  entirely (JupyterLab 4.x uses pre-built extensions), eliminating 19 npm CVEs.
- The conda package cache was leaking into `basehome.tar` via an unreliable `tar --exclude`
  pattern, making cached vulnerable packages visible to the scanner.

---

### 🛠️ Changes Made
- Added `ARG MLRUN_BASE_PYTHON_VERSION=3.13` to decouple the base `scipy-notebook` image
  Python version from the mlrun conda env Python version (`MLRUN_PYTHON_VERSION=3.11`)
- Changed `FROM quay.io/jupyter/scipy-notebook:python-${MLRUN_PYTHON_VERSION}` to use
  `MLRUN_BASE_PYTHON_VERSION`; updated ensurepip cleanup paths accordingly
- Added `conda install -n base` block with explicit CVE-driven package pins:
  - `jupyterlab-git>=0.54.0` and `jupyterlab-git-core>=0.54.0` — CVE-2026-54527
    (`jupyterlab-git-core` is a separate conda-forge package split from `jupyterlab-git` since v0.50)
  - `pillow>=12.3.0` — CVE-2026-54058 (base conda env)
  - `tornado>=6.5.8` — XRAY-1046607 (base conda env)
- Replaced unreliable `tar --exclude='.conda/pkgs'` with explicit `rm -rf $HOME/.conda/pkgs`
  before archiving `basehome.tar` — GNU tar did not consistently match the pattern when the
  source path was absolute, leaving cached packages inside the archive and visible to scanners

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR

---

### 🧪 Testing
Changed a current CE Jupyter deployment image and saw that everything is running as expected 

```
Checks confirmed:
- Base Python 3.13, mlrun env Python 3.11
- `jupyterlab-git` and `jupyterlab-git-core` >= 0.54.0
- `pillow` >= 12.3.0, `tornado` >= 6.5.8 in base env
- `nodejs` absent from image (all npm CVEs resolved by removal)
- `~/.conda/pkgs` absent; `basehome.tar` contains no `.conda/pkgs` entries
```
---

### 🔗 References
- Ticket link: ML-12977
---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---