### PR TITLE
[DB] Fix partitioned list_runs order overriding sort=True contract [1.12.x]

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -1118,7 +1118,10 @@ class HTTPRunDB(RunDBInterface):
 
         :param states: List only runs whose state is one of the provided states.
         :param sort: Whether to sort the result according to their start time. Otherwise, results will be
-            returned by their internal order in the DB (order will not be guaranteed).
+            returned by their internal order in the DB (order will not be guaranteed). Takes precedence over
+            `partition_sort_by` for the returned order - `partition_sort_by` only decides which run wins
+            *within* a partition, and, when `max_partitions` is set, which partitions are kept; it does not
+            affect the order of the final result.
         :param iter: If ``True`` return runs from all iterations. Otherwise, return only runs whose ``iter`` is 0.
         :param start_time_from: Filter by run start time in ``[start_time_from, start_time_to]``.
         :param start_time_to: Filter by run start time in ``[start_time_from, start_time_to]``.

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -5792,7 +5792,10 @@ class MlrunProject(ModelObj):
 
         :param states: List only runs whose state is one of the provided states.
         :param sort: Whether to sort the result according to their start time. Otherwise, results will be
-            returned by their internal order in the DB (order will not be guaranteed).
+            returned by their internal order in the DB (order will not be guaranteed). Takes precedence over
+            `partition_sort_by` for the returned order - `partition_sort_by` only decides which run wins
+            *within* a partition, and, when `max_partitions` is set, which partitions are kept; it does not
+            affect the order of the final result.
         :param iter: If ``True`` return runs from all iterations. Otherwise, return only runs whose ``iter`` is 0.
         :param start_time_from: Filter by run start time in ``[start_time_from, start_time_to]``.
         :param start_time_to: Filter by run start time in ``[start_time_from, start_time_to]``.

--- a/server/py/framework/db/sqldb/db.py
+++ b/server/py/framework/db/sqldb/db.py
@@ -619,6 +619,17 @@ class SQLDB(DBInterface):
                 partition_order,
                 max_partitions,
             )
+            if sort:
+                # _create_partitioned_query() orders its result by partition_sort_by
+                # (e.g. "updated" for the "no filter" default) purely to make row
+                # selection/pagination deterministic - that field governs which row
+                # wins *within* a partition, not the contract of this function's own
+                # `sort` param (order by start_time). Query.order_by() appends rather
+                # than replaces, so reset before reapplying the same sort used for the
+                # non-partitioned path above.
+                query = query.order_by(None).order_by(
+                    Run.start_time.desc(), Run.id.desc()
+                )
 
         query = self._paginate_query(query, offset, limit)
 

--- a/server/py/services/api/tests/unit/db/test_runs.py
+++ b/server/py/services/api/tests/unit/db/test_runs.py
@@ -763,17 +763,73 @@ class TestRuns(TestDatabaseBase):
             max_partitions=2,
         )
         run_names = [run["metadata"]["name"] for run in runs]
+        # Partition *selection* (which partitions/rows survive max_partitions and
+        # rows_per_partition) is still ranked by partition_sort_by ("updated" here) -
+        # that's unaffected by list_runs's `sort` param, since it happens inside the
+        # subquery before any outer ORDER BY is applied.
         assert set(run_names) == {"run-newest", "run-middle"}
         assert len(runs) == 4
+        # But list_runs's own `sort` contract (default True: order by start_time) takes
+        # precedence over partition_sort_by for the *display* order of already-selected
+        # rows - partition_sort_by ("updated") only decided which rows survived, above.
+        # Runs were created oldest -> newest -> middle, so start_time descending is
+        # middle-1, middle-0, newest-1, newest-0 (oldest's partition didn't survive).
         expected_order = [
-            "run-newest-uid-1",
-            "run-newest-uid-0",
             "run-middle-uid-1",
             "run-middle-uid-0",
+            "run-newest-uid-1",
+            "run-newest-uid-0",
         ]
         actual_order = [run["metadata"]["uid"] for run in runs]
         assert actual_order == expected_order, (
             f"Expected {expected_order}, got {actual_order}"
+        )
+
+    def test_list_runs_partitioned_sort_true_orders_by_start_time_not_partition_sort_by(
+        self,
+    ):
+        # ML-13004 reopen: the "no filter" default (server/py/services/api/crud/
+        # runs.py) sets partition_by=project_and_name, partition_sort_by=updated
+        # (with the default rows_per_partition=1, so distinctly-named runs all
+        # survive). list_runs's own `sort` param (default True) promises the
+        # *displayed* result is ordered by start_time regardless - partition_sort_by
+        # only decides which row wins *within* a partition (irrelevant here, one
+        # row per name), not the final order. Mirrors the naipi repro: runs finish
+        # (get `updated`) in a different order than they started.
+        project_name = "my-project"
+        base_time = datetime(2026, 1, 1, tzinfo=UTC)
+        run_names_by_updated_offset = [
+            ("run-a", 30),
+            ("run-b", 10),
+            ("run-c", 20),
+        ]
+        for run_name, updated_offset_seconds in run_names_by_updated_offset:
+            uid = f"{run_name}-uid"
+            self._create_new_run(project=project_name, name=run_name, uid=uid)
+            self._db.update_db_object(
+                self._db_session,
+                framework.db.sqldb.models.Run,
+                filters={"uid": uid},
+                updated=base_time + timedelta(seconds=updated_offset_seconds),
+            )
+
+        runs = self._db.list_runs(
+            self._db_session,
+            project=project_name,
+            partition_by=mlrun.common.schemas.RunPartitionByField.project_and_name,
+            partition_sort_by=mlrun.common.schemas.SortField.updated,
+            partition_order=mlrun.common.schemas.OrderType.desc,
+        )
+        assert len(runs) == 3
+        # Created run-a, run-b, run-c in that order (ascending start_time), so
+        # descending start_time order is run-c, run-b, run-a. If partition_sort_by
+        # ("updated") leaked into display order it would instead be run-a (30s),
+        # run-c (20s), run-b (10s).
+        expected_order = ["run-c-uid", "run-b-uid", "run-a-uid"]
+        actual_order = [run["metadata"]["uid"] for run in runs]
+        assert actual_order == expected_order, (
+            f"Expected start_time-ordered {expected_order}, got {actual_order} "
+            "(partition_sort_by leaking into display order?)"
         )
 
     def test_list_runs_with_missing_milliseconds_in_timestamp(self):

--- a/tests/integration/sdk_api/httpdb/runs/test_runs.py
+++ b/tests/integration/sdk_api/httpdb/runs/test_runs.py
@@ -276,16 +276,21 @@ class TestRuns(tests.integration.sdk_api.base.TestMLRunIntegration):
         # No filter is given, so this goes through the "no filter" default
         # (partition_by=project_and_name, partition_sort_by=updated,
         # partition_order=desc - see crud.Runs().list_runs). Each run has a
-        # distinct name, so each is its own partition; the global order across
-        # partitions is by `updated` (real insertion wall-clock time, independent
-        # of the fake historical `start_time` values set above), most-recent
-        # first, with `id` descending as the tiebreaker for runs created within
-        # the same timestamp resolution - i.e. the reverse of creation order.
+        # distinct name, so each is its own partition (partition_sort_by only
+        # decides row *selection* within a partition, a no-op here). The global
+        # order across partitions follows list_runs's own `sort` contract
+        # (default True: order by start_time), not partition_sort_by - see
+        # ML-13004. run-name-4 has no explicit start_time, so it defaults to
+        # real now() at store time (stored last, so latest); run-name-1/3 share
+        # the fake "now()-5h" offset and run-name-0/2 share "now()-1day", with
+        # run-name-3/run-name-2 each a hair more recent than run-name-1/run-name-0
+        # respectively, since their now() calls were evaluated later while
+        # building the `statuses` list above.
         expected_names = [
             "run-name-4",
             "run-name-3",
-            "run-name-2",
             "run-name-1",
+            "run-name-2",
             "run-name-0",
         ]
         for i, expected_name in enumerate(expected_names):


### PR DESCRIPTION
backport - https://github.com/mlrun/mlrun/pull/10054

### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. --> ML-13004 was reopened: the earlier fix (#10048/#10051) made `list_runs`'s "no filter" default deterministic, but deterministically wrong. That fix added an `ORDER BY` inside `_create_partitioned_query` using `partition_sort_by` (`updated`), which leaked into the *global* result order once `partition_by` was set — overriding `list_runs`'s own `sort` contract (order by `start_time`, per its docstring). `partition_sort_by`'s docstring already documents that it only decides which run wins *within* a partition, not the final order, so this fix restores that separation instead of blurring it.

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->
- `server/py/framework/db/sqldb/db.py`: in `list_runs`, after `_create_partitioned_query`, reset (`order_by(None)`) and reapply `Run.start_time.desc(), Run.id.desc()` whenever `sort=True` — the same reset-then-reapply idiom already used in `_find_artifacts` for the same class of issue (`Query.order_by()` appends rather than replaces). Row *selection* (which rows survive `rows_per_partition`/`max_partitions`) is unaffected — that happens inside the subquery, before any outer `order_by`.
- `mlrun/db/httpdb.py`, `mlrun/projects/project.py`: clarified in `sort`'s docstring that it takes precedence over `partition_sort_by` for the returned order — the ambiguity that led to the reopen.
- `server/py/services/api/tests/unit/db/test_runs.py`: corrected `test_list_runs_partitioned_with_max_partitions_has_explicit_order_by`'s expected order (it previously encoded the old, incorrect partition-rank-based order); added
`test_list_runs_partitioned_sort_true_orders_by_start_time_not_partition_sort_by` as the direct regression guard, mirroring the naipi repro (runs whose `updated` order differs from their `start_time`/creation order).

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
- [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
- [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) --> <!-- - Any special cases covered. -->
- `server/py/services/api/tests/unit/db/test_runs.py`: 26/26 passed (includes the corrected test and the new regression test).
- `server/py/services/api/tests/unit/db/test_artifacts.py`: 78/78 passed, confirming `_find_artifacts`'s existing behavior is unaffected.
- Verified the new/corrected tests are real regression guards by toggling the `db.py` fix off/on: both fail without it, pass with it.
- Could not run the API-layer `TestClient`-based `test_runs.py::test_list_runs_partition_by` locally — blocked by a pre-existing, unrelated `PydanticV1NotSupportedError` in the `alert_activations` router (reproduces identically on a clean `development` checkout). Read its assertions manually: they check only *which* rows survive partitioning, not cross-row display order, so they're unaffected by this change — not verified by an actual run.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13004
- Design docs links:
- External links: Prior fix attempts this PR builds on — https://github.com/mlrun/mlrun/pull/10048,
https://github.com/mlrun/mlrun/pull/10051

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->

(cherry picked from commit 24da82c266f8bae214a8877c24795b3d0d0794c3)

### 📝 Description
<!-- A short summary of what this PR does. -->
<!-- Include any relevant context or background information. -->

---

### 🛠️ Changes Made
<!-- - Key changes (e.g., added feature X, refactored Y, fixed Z) -->

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
<!-- - How it was tested (unit tests, manual, integration) -->  
<!-- - Any special cases covered. -->  

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [ ] No

<!-- If yes, describe what needs to be changed downstream: -->

---

### 🔍️ Additional Notes
<!-- Anything else reviewers should know (follow-up tasks, known issues, affected areas etc.). -->
<!-- ### 📸 Screenshots / Logs -->
