### PR TITLE
[utils] Fix in-cluster detection false negative when SA token automount is disabled

### DIFF
--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -697,7 +697,7 @@ class HTTPRunDB(RunDBInterface):
                     # TODO: change to os.getenv("MLRUN_RUNTIME_KIND")
                     # when https://github.com/mlrun/mlrun/pull/9121 is done.
                     if (
-                        mlrun.k8s_utils.is_running_inside_kubernetes_cluster()
+                        mlrun.k8s_utils.is_running_in_kubernetes_pod()
                         and not os.environ.get("JPY_SESSION_NAME")
                     ):
                         user_token_file = os.path.join(
@@ -708,7 +708,7 @@ class HTTPRunDB(RunDBInterface):
                     config.auth_with_oauth_token.token_file = user_token_file
 
                 # if running inside kubernetes, use the internal endpoint, otherwise use the external endpoint
-                if mlrun.k8s_utils.is_running_inside_kubernetes_cluster():
+                if mlrun.k8s_utils.is_running_in_kubernetes_pod():
                     config.auth_token_endpoint = server_cfg.get(
                         "oauth_internal_token_endpoint"
                     )

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -694,12 +694,7 @@ class HTTPRunDB(RunDBInterface):
                     user_token_file = os.path.expanduser("~/.igz.yml")
 
                     # runtimes
-                    # TODO: change to os.getenv("MLRUN_RUNTIME_KIND")
-                    # when https://github.com/mlrun/mlrun/pull/9121 is done.
-                    if (
-                        mlrun.k8s_utils.is_running_in_kubernetes_pod()
-                        and not os.environ.get("JPY_SESSION_NAME")
-                    ):
+                    if mlrun.utils.helpers.is_running_in_runtime():
                         user_token_file = os.path.join(
                             mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
                             mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,

--- a/mlrun/k8s_utils.py
+++ b/mlrun/k8s_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import os
 import re
 import typing
 import warnings
@@ -31,7 +32,16 @@ SanitizedK8sObj = dict[str, typing.Any]
 K8sObjList = typing.Union[list[K8sObj], list[SanitizedK8sObj]]
 
 
-def is_running_inside_kubernetes_cluster():
+def has_incluster_kubernetes_client_config() -> bool:
+    """
+    Check whether a working, credentialed in-cluster Kubernetes client config can be loaded.
+
+    Depends on the service-account token being mounted; returns False even inside a real pod when
+    automountServiceAccountToken is disabled. Use is_running_in_kubernetes_pod() instead when the
+    caller only needs "am I in a pod" and does not need to talk to the k8s API.
+
+    :return: True if a working in-cluster k8s client config could be loaded, False otherwise.
+    """
     global _running_inside_kubernetes_cluster
     if _running_inside_kubernetes_cluster is None:
         try:
@@ -40,6 +50,24 @@ def is_running_inside_kubernetes_cluster():
         except kubernetes.config.ConfigException:
             _running_inside_kubernetes_cluster = False
     return _running_inside_kubernetes_cluster
+
+
+def is_running_in_kubernetes_pod() -> bool:
+    """
+    Check whether the current process is running inside a Kubernetes pod.
+
+    Checks only the KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT env vars the kubelet
+    injects into every pod via service links, regardless of automountServiceAccountToken — the
+    same first signal kubernetes.config.incluster_config and Go's client-go rest.InClusterConfig()
+    check before ever touching the service-account token. Use this instead of
+    has_incluster_kubernetes_client_config() when the caller only needs "am I in a pod" and does
+    not need a working k8s API client.
+
+    :return: True if running inside a Kubernetes pod, False otherwise.
+    """
+    return bool(os.environ.get("KUBERNETES_SERVICE_HOST")) and bool(
+        os.environ.get("KUBERNETES_SERVICE_PORT")
+    )
 
 
 def generate_preemptible_node_selector_requirements(

--- a/mlrun/runtimes/daskjob.py
+++ b/mlrun/runtimes/daskjob.py
@@ -202,7 +202,7 @@ class DaskCluster(KubejobRuntime):
     def __init__(self, spec=None, metadata=None):
         super().__init__(spec, metadata)
         self._cluster = None
-        self.use_remote = not mlrun.k8s_utils.is_running_inside_kubernetes_cluster()
+        self.use_remote = not mlrun.k8s_utils.is_running_in_kubernetes_pod()
         self.spec.build.base_image = (
             self.spec.build.base_image or mlrun.mlconf.default_base_image
         )

--- a/mlrun/runtimes/nuclio/function.py
+++ b/mlrun/runtimes/nuclio/function.py
@@ -1748,7 +1748,7 @@ class RemoteRuntime(KubeResource):
         if (
             not force_external_address
             and self.status.internal_invocation_urls
-            and mlrun.k8s_utils.is_running_inside_kubernetes_cluster()
+            and mlrun.k8s_utils.is_running_in_kubernetes_pod()
         ):
             url = mlrun.utils.helpers.join_urls(
                 f"http://{self.status.internal_invocation_urls[0]}", path

--- a/server/py/framework/utils/runtimes/mpijob.py
+++ b/server/py/framework/utils/runtimes/mpijob.py
@@ -54,7 +54,8 @@ def _resolve_mpijob_crd_version_best_effort():
     if config.mpijob_crd_version:
         return config.mpijob_crd_version
 
-    if not mlrun.k8s_utils.is_running_inside_kubernetes_cluster():
+    # needs a working k8s client below (list_pods), so stays on the SA-token-backed check
+    if not mlrun.k8s_utils.has_incluster_kubernetes_client_config():
         return None
 
     k8s_helper = framework.utils.singletons.k8s.get_k8s_helper()

--- a/server/py/services/api/tests/unit/runtimes/test_nuclio.py
+++ b/server/py/services/api/tests/unit/runtimes/test_nuclio.py
@@ -2222,7 +2222,7 @@ class TestNuclioRuntime(TestRuntimeBase):
             ):
                 with unittest.mock.patch.object(
                     mlrun.k8s_utils,
-                    "is_running_inside_kubernetes_cluster",
+                    "is_running_in_kubernetes_pod",
                     return_value=inside_k8s,
                 ):
                     if expected_exception:

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -532,9 +532,7 @@ def test_iguazio_v4_oauth_config_is_applied_before_token_provider_init(
     }
 
     # Ensure deterministic endpoint selection (external) regardless of env/CI kubernetes detection
-    monkeypatch.setattr(
-        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: False
-    )
+    monkeypatch.setattr(mlrun.k8s_utils, "is_running_in_kubernetes_pod", lambda: False)
 
     with _mock_httpdb_connect(server_cfg):
         db = HTTPRunDB("http://some-server:1919")
@@ -572,9 +570,7 @@ def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
         "oauth_internal_token_endpoint": internal_token_endpoint,
     }
 
-    monkeypatch.setattr(
-        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: True
-    )
+    monkeypatch.setattr(mlrun.k8s_utils, "is_running_in_kubernetes_pod", lambda: True)
     monkeypatch.setattr(
         mlrun.auth.utils,
         "read_secret_tokens_file",
@@ -601,6 +597,56 @@ def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
             mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
         )
         assert mlrun.mlconf.auth_with_oauth_token.token_file == expected_token_file
+
+
+def test_iguazio_v4_oauth_token_file_uses_secret_path_without_sa_token_automount(
+    requests_mock: requests_mock_package.Mocker, monkeypatch
+):
+    """
+    Regression test for ML-13003: a job pod with automountServiceAccountToken disabled has no SA
+    token file, so kubernetes.config.load_incluster_config() would raise even though the pod is
+    genuinely in-cluster. connect() must still pick the job's secret-volume token path, driven
+    only by the KUBERNETES_SERVICE_HOST/KUBERNETES_SERVICE_PORT env vars the kubelet injects
+    regardless of automount.
+    """
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    monkeypatch.delenv("JPY_SESSION_NAME", raising=False)
+
+    internal_token_endpoint = "https://dashboard.default-tenant.svc.cluster.local/api/v1/authentication/refresh-access-token"
+    iat = int(time.time())
+    exp = iat + 3600
+    jwt_token = _encode_jwt({"iat": iat, "exp": exp})
+    requests_mock.post(
+        internal_token_endpoint, json={"spec": {"accessToken": jwt_token}}
+    )
+
+    server_cfg = {
+        "version": mlrun.mlconf.version,
+        "authentication_mode": mlrun.common.types.AuthenticationMode.IGUAZIO_V4.value,
+        "oauth_enabled": True,
+        "oauth_external_token_endpoint": "https://dashboard.default-tenant.app.example.com/api/v1/authentication/refresh-access-token",
+        "oauth_internal_token_endpoint": internal_token_endpoint,
+    }
+
+    monkeypatch.setattr(
+        mlrun.auth.utils,
+        "read_secret_tokens_file",
+        lambda raise_on_error: {
+            "secretTokens": [{"name": "default", "token": "offline"}]
+        },
+    )
+
+    with _mock_httpdb_connect(server_cfg):
+        db = HTTPRunDB("http://some-server:1919")
+        db.connect()
+
+    expected_token_file = os.path.join(
+        mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_PATH,
+        mlrun.common.constants.MLRUN_JOB_AUTH_SECRET_FILE,
+    )
+    assert mlrun.mlconf.auth_with_oauth_token.token_file == expected_token_file
+    assert mlrun.mlconf.auth_token_endpoint == internal_token_endpoint
 
 
 @pytest.mark.parametrize(
@@ -654,9 +700,7 @@ def test_iguazio_v4_oauth_token_file_auto_initialization(
     }
 
     # Mock kubernetes detection
-    monkeypatch.setattr(
-        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: is_k8s
-    )
+    monkeypatch.setattr(mlrun.k8s_utils, "is_running_in_kubernetes_pod", lambda: is_k8s)
 
     # Set or clear Jupyter environment variable
     if has_jupyter_env:
@@ -713,9 +757,7 @@ def test_connect_preserves_explicit_credentials_in_iguazio_v4(monkeypatch):
         "oauth_external_token_endpoint": "https://dashboard.example.com/refresh",
     }
     # deterministic endpoint selection
-    monkeypatch.setattr(
-        mlrun.k8s_utils, "is_running_inside_kubernetes_cluster", lambda: False
-    )
+    monkeypatch.setattr(mlrun.k8s_utils, "is_running_in_kubernetes_pod", lambda: False)
 
     token = "sa-bearer-token"
     credentials = mlrun.Credentials(token=token)

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -47,6 +47,7 @@ import mlrun.common.types
 import mlrun.errors
 import mlrun.projects.project
 import mlrun.secrets
+import mlrun.utils.helpers
 from mlrun import RunObject
 from mlrun.auth.providers import IGTokenProvider, StaticTokenProvider
 from mlrun.db.httpdb import HTTPRunDB
@@ -571,6 +572,7 @@ def test_iguazio_v4_oauth_config_uses_internal_endpoint_in_cluster(
     }
 
     monkeypatch.setattr(mlrun.k8s_utils, "is_running_in_kubernetes_pod", lambda: True)
+    monkeypatch.setattr(mlrun.utils.helpers, "is_running_in_runtime", lambda: True)
     monkeypatch.setattr(
         mlrun.auth.utils,
         "read_secret_tokens_file",
@@ -605,13 +607,14 @@ def test_iguazio_v4_oauth_token_file_uses_secret_path_without_sa_token_automount
     """
     Regression test for ML-13003: a job pod with automountServiceAccountToken disabled has no SA
     token file, so kubernetes.config.load_incluster_config() would raise even though the pod is
-    genuinely in-cluster. connect() must still pick the job's secret-volume token path, driven
-    only by the KUBERNETES_SERVICE_HOST/KUBERNETES_SERVICE_PORT env vars the kubelet injects
-    regardless of automount.
+    genuinely in-cluster. connect() must still pick the internal endpoint and the job's
+    secret-volume token path, driven only by env vars the kubelet/mlrun inject regardless of
+    automount: KUBERNETES_SERVICE_HOST/KUBERNETES_SERVICE_PORT for the endpoint, MLRUN_RUNTIME_KIND
+    for the token file.
     """
     monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
     monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
-    monkeypatch.delenv("JPY_SESSION_NAME", raising=False)
+    monkeypatch.setenv("MLRUN_RUNTIME_KIND", "job")
 
     internal_token_endpoint = "https://dashboard.default-tenant.svc.cluster.local/api/v1/authentication/refresh-access-token"
     iat = int(time.time())
@@ -650,30 +653,30 @@ def test_iguazio_v4_oauth_token_file_uses_secret_path_without_sa_token_automount
 
 
 @pytest.mark.parametrize(
-    "is_k8s,has_jupyter_env,preconfigured_token_file,expected_token_file_suffix",
+    "is_k8s,is_runtime,preconfigured_token_file,expected_token_file_suffix",
     [
-        # Running in k8s (not Jupyter) - should use k8s secret path
-        (True, False, None, "/var/mlrun-secrets/auth/.igz.yml"),
-        # Running in k8s under Jupyter - should use user home token file
-        (True, True, None, "~/.igz.yml"),
-        # Running locally (not k8s) - should use user home token file
+        # Running in k8s as an mlrun runtime (job/dask/nuclio) - should use k8s secret path
+        (True, True, None, "/var/mlrun-secrets/auth/.igz.yml"),
+        # Running in k8s but not as an mlrun runtime (e.g. Jupyter) - should use user home token file
+        (True, False, None, "~/.igz.yml"),
+        # Running locally (not k8s, not a runtime) - should use user home token file
         (False, False, None, "~/.igz.yml"),
         # Token file already configured - should not change it
-        (True, False, "/custom/path/token.yml", "/custom/path/token.yml"),
+        (True, True, "/custom/path/token.yml", "/custom/path/token.yml"),
     ],
 )
 def test_iguazio_v4_oauth_token_file_auto_initialization(
     requests_mock: requests_mock_package.Mocker,
     monkeypatch,
     is_k8s,
-    has_jupyter_env,
+    is_runtime,
     preconfigured_token_file,
     expected_token_file_suffix,
 ):
     """
     Test that token_file is correctly auto-initialized based on environment:
-    - In k8s (not Jupyter): uses /var/mlrun-secrets/auth/.igz.yml
-    - In k8s under Jupyter: uses ~/.igz.yml
+    - In k8s, as an mlrun runtime: uses /var/mlrun-secrets/auth/.igz.yml
+    - In k8s, not an mlrun runtime (e.g. Jupyter): uses ~/.igz.yml
     - Locally: uses ~/.igz.yml
     - Pre-configured: preserves the existing value
     """
@@ -699,14 +702,11 @@ def test_iguazio_v4_oauth_token_file_auto_initialization(
         "oauth_internal_token_endpoint": internal_token_endpoint,
     }
 
-    # Mock kubernetes detection
+    # Mock kubernetes detection and mlrun-runtime detection independently
     monkeypatch.setattr(mlrun.k8s_utils, "is_running_in_kubernetes_pod", lambda: is_k8s)
-
-    # Set or clear Jupyter environment variable
-    if has_jupyter_env:
-        monkeypatch.setenv("JPY_SESSION_NAME", "jupyter-session")
-    else:
-        monkeypatch.delenv("JPY_SESSION_NAME", raising=False)
+    monkeypatch.setattr(
+        mlrun.utils.helpers, "is_running_in_runtime", lambda: is_runtime
+    )
 
     # Mock secret tokens reading for k8s environments
     monkeypatch.setattr(

--- a/tests/runtimes/test_dask.py
+++ b/tests/runtimes/test_dask.py
@@ -16,6 +16,7 @@ import pytest
 
 import mlrun
 import mlrun.errors
+import mlrun.k8s_utils
 from mlrun import new_function, new_task
 from mlrun.common.types import AuthenticationMode
 from tests.conftest import tag_test, verify_state
@@ -92,3 +93,14 @@ def test_dask_run_raises_in_iguazio_v4(monkeypatch):
         mlrun.errors.MLRunBadRequestError, match="not supported on this system"
     ):
         new_function(kind="dask").run(handler=my_func)
+
+
+@pytest.mark.parametrize("in_cluster", [True, False])
+def test_dask_use_remote_reflects_in_cluster_detection(monkeypatch, in_cluster):
+    monkeypatch.setattr(
+        mlrun.k8s_utils, "is_running_in_kubernetes_pod", lambda: in_cluster
+    )
+
+    function = new_function(kind="dask")
+
+    assert function.use_remote is not in_cluster

--- a/tests/test_k8s_utils.py
+++ b/tests/test_k8s_utils.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from contextlib import nullcontext as does_not_raise
+from unittest import mock
 
+import kubernetes.config
 import pytest
 
 import mlrun.errors
@@ -142,3 +144,48 @@ def test_verify_label_key(label_key, exception):
 def test_validate_node_selectors(node_selectors, expected):
     with expected:
         mlrun.k8s_utils.validate_node_selectors(node_selectors)
+
+
+@pytest.mark.parametrize(
+    "service_host, service_port, expected",
+    [
+        ("10.0.0.1", "443", True),
+        (None, None, False),
+        ("10.0.0.1", None, False),
+        (None, "443", False),
+        ("", "", False),
+    ],
+)
+def test_is_running_in_kubernetes_pod(
+    monkeypatch, service_host, service_port, expected
+):
+    for name, value in (
+        ("KUBERNETES_SERVICE_HOST", service_host),
+        ("KUBERNETES_SERVICE_PORT", service_port),
+    ):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    assert mlrun.k8s_utils.is_running_in_kubernetes_pod() is expected
+
+
+@pytest.mark.parametrize(
+    "load_incluster_config_side_effect, expected",
+    [
+        (None, True),
+        (kubernetes.config.ConfigException("no token file"), False),
+    ],
+)
+def test_has_incluster_kubernetes_client_config(
+    monkeypatch, load_incluster_config_side_effect, expected
+):
+    monkeypatch.setattr(mlrun.k8s_utils, "_running_inside_kubernetes_cluster", None)
+    monkeypatch.setattr(
+        kubernetes.config,
+        "load_incluster_config",
+        mock.Mock(side_effect=load_incluster_config_side_effect),
+    )
+
+    assert mlrun.k8s_utils.has_incluster_kubernetes_client_config() is expected


### PR DESCRIPTION
### 📝 Description
Job pods running with `automountServiceAccountToken: false` (a common security-hardening posture) crashed at `import mlrun` time with `mlrun.errors.MLRunRuntimeError: Failed to fetch a valid access token. Authentication procedure stopped.`

Root cause: `mlrun.k8s_utils.is_running_inside_kubernetes_cluster()` (renamed here to `has_incluster_kubernetes_client_config()`) determined "am I in a Kubernetes pod" by calling `kubernetes.config.load_incluster_config()`, which requires the pod's service-account token file to exist. When automount is disabled, that file is absent, so the check raised and the function wrongly reported `False` - even though the pod genuinely was running in-cluster.

That false negative sent job pods down the wrong branch in `mlrun/db/httpdb.py`: instead of using the job's mounted secret-volume token path (`/var/mlrun-secrets/auth/.igz.yml`), it fell back to `~/.igz.yml`. In these hardened, non-root pods `HOME=/`, so that path resolved to `/.igz.yml`, which never exists - every retry over the 120s budget failed identically, and mlrun raised before any user code ran.

---

### 🛠️ Changes Made
- Added `mlrun.k8s_utils.is_running_in_kubernetes_pod()` — checks only the `KUBERNETES_SERVICE_HOST`/`KUBERNETES_SERVICE_PORT` env vars the kubelet injects into every pod regardless of SA-token automount
- Renamed `is_running_inside_kubernetes_cluster()` → `has_incluster_kubernetes_client_config()` to make its actual semantics explicit: it verifies a *working, credentialed* k8s client can be built (token-dependent), not merely "am I in a pod". 
- Switched 3 call sites that only need "am I in a pod", not real k8s API access, to the new function:
  - `mlrun/db/httpdb.py` (OAuth internal/external endpoint selection)
  - `mlrun/runtimes/nuclio/function.py` (internal-vs-external invocation URL preference)
  - `mlrun/runtimes/daskjob.py` (`DaskCluster.use_remote` initialization)
- Switched the token-file-path selection in `mlrun/db/httpdb.py` to `mlrun.utils.helpers.is_running_in_runtime()` (checks `MLRUN_RUNTIME_KIND`, added in #9121, now merged)
- Left `server/py/framework/utils/runtimes/mpijob.py` on `has_incluster_kubernetes_client_config()` (renamed call site only, no logic change) since it guards a real `k8s_helper.list_pods(...)` call immediately after and genuinely needs the SA-token-backed check; added a comment explaining why. Confirmed this call site runs only in the API server process (which needs real k8s credentials to function at all) and degrades gracefully to a default CRD version on a negative result — it cannot hit the crash this PR fixes.
- Added docstrings + `-> bool` return types to both `k8s_utils.py` functions, cross-referencing each other.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — n/a, no doc page referenced this behavior
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `tests/test_k8s_utils.py` — new parametrized unit tests for both `is_running_in_kubernetes_pod()` (env-var combinations) and `has_incluster_kubernetes_client_config()` (previously untested; mocks `load_incluster_config` success/`ConfigException`).
- `tests/rundb/test_httpdb.py` — retargeted 4 existing mocks to the renamed/new function; added `test_iguazio_v4_oauth_token_file_uses_secret_path_without_sa_token_automount`, a direct regression test for ML-13003 that sets the `KUBERNETES_SERVICE_HOST`/`PORT` and `MLRUN_RUNTIME_KIND` env vars (no SA token file, no mocking of either detector) and asserts both the OAuth endpoint and the token file resolve correctly; also re-parametrized `test_iguazio_v4_oauth_token_file_auto_initialization` on `is_k8s`/`is_runtime` independently, replacing the old `has_jupyter_env` dimension now that `MLRUN_RUNTIME_KIND` makes the Jupyter carve-out unnecessary.
- `tests/runtimes/test_dask.py` — added coverage for `DaskCluster.use_remote`, previously untested.
- `server/py/services/api/tests/unit/runtimes/test_nuclio.py` — retargeted existing mock to the renamed function (verified by AST parse only — this repo's server-side test deps have a local pydantic 1.x/2.x mismatch in my sandbox unrelated to this change, so I could not execute it directly; flagging honestly rather than claiming a run that didn't happen).
- Verified live on lab vmdev110ig4: a job pod running the patched image with automountServiceAccountToken: false (no SA token mounted) completed successfully, while the same pod spec on the pre-fix mlrun:1.13.0-rc4 image reproduced the exact reported crash (Configured token file not found: /.igz.yml → Failed to fetch a valid access token), confirming the fix end-to-end against a real cluster.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13003
- Design docs links: n/a
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- The `is_running_inside_kubernetes_cluster()` name still exists elsewhere in the codebase as an unrelated `K8sHelper` **instance method** (`server/py/framework/utils/singletons/k8s.py`) — that is a different class/state used only inside the API service (which still has a real SA token) and is out of scope for this fix.
