### PR TITLE
[Builder] Fix chown fallback when security-context enrichment is disabled

### DIFF
--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -100,10 +100,10 @@ def test_build_image_build_request_carries_raw_unrouted_source(monkeypatch):
 def test_build_image_falls_back_to_static_security_context_when_enrichment_disabled(
     monkeypatch,
 ):
-    # ML-12960: even with enrichment disabled, a function may already carry a static
-    # non-root security context (e.g. a cluster-wide default) that will govern the job
-    # pod's actual runtime uid/gid - the build must chown the baked source dir to match
-    # it, or the pod won't be able to write into its own working directory.
+    # even with enrichment disabled, a function may already carry a static non-root
+    # security context (e.g. a cluster-wide default) that will govern the job pod's
+    # actual runtime uid/gid - the build must chown the baked source dir to match it,
+    # or the pod won't be able to write into its own working directory.
     monkeypatch.setattr(
         config.function.spec.security_context,
         "enrichment_mode",
@@ -137,6 +137,51 @@ def test_build_image_falls_back_to_static_security_context_when_enrichment_disab
     function.spec.security_context = client.V1SecurityContext(
         run_as_user=1000, run_as_group=1000, run_as_non_root=True
     )
+    services.api.utils.builder.build_runtime(
+        mlrun.common.schemas.AuthInfo(),
+        function,
+    )
+
+    request = captured["request"]
+    assert request.user_unix_id == 1000
+    assert request.enriched_group_id == 1000
+
+
+def test_build_image_static_security_context_uid_only_still_chowns(monkeypatch):
+    # a static security context may pin only the uid, leaving the group to the
+    # image's own default - the chown must still fire (using the uid as the group
+    # too), since POSIX owner permissions only need the uid to match.
+    monkeypatch.setattr(
+        config.function.spec.security_context,
+        "enrichment_mode",
+        mlrun.common.schemas.SecurityContextEnrichmentModes.disabled.value,
+    )
+
+    captured = {}
+
+    def _capture_request(self, request):
+        captured["request"] = request
+        return unittest.mock.MagicMock()
+
+    monkeypatch.setattr(
+        services.api.utils.builder.KanikoBackend, "make_build_pod", _capture_request
+    )
+    monkeypatch.setattr(
+        config.httpdb.builder,
+        "docker_registry",
+        "default.docker.registry/default-repository",
+    )
+    _patch_k8s_helper(monkeypatch)
+
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    function.spec.build.source = "/path/some-source.tar.gz"
+    function.spec.security_context = client.V1SecurityContext(run_as_user=1000)
     services.api.utils.builder.build_runtime(
         mlrun.common.schemas.AuthInfo(),
         function,

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -97,6 +97,106 @@ def test_build_image_build_request_carries_raw_unrouted_source(monkeypatch):
     assert "refs/heads" not in request.source
 
 
+def test_build_image_falls_back_to_static_security_context_when_enrichment_disabled(
+    monkeypatch,
+):
+    # ML-12960: even with enrichment disabled, a function may already carry a static
+    # non-root security context (e.g. a cluster-wide default) that will govern the job
+    # pod's actual runtime uid/gid - the build must chown the baked source dir to match
+    # it, or the pod won't be able to write into its own working directory.
+    monkeypatch.setattr(
+        config.function.spec.security_context,
+        "enrichment_mode",
+        mlrun.common.schemas.SecurityContextEnrichmentModes.disabled.value,
+    )
+
+    captured = {}
+
+    def _capture_request(self, request):
+        captured["request"] = request
+        return unittest.mock.MagicMock()
+
+    monkeypatch.setattr(
+        services.api.utils.builder.KanikoBackend, "make_build_pod", _capture_request
+    )
+    monkeypatch.setattr(
+        config.httpdb.builder,
+        "docker_registry",
+        "default.docker.registry/default-repository",
+    )
+    _patch_k8s_helper(monkeypatch)
+
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    function.spec.build.source = "/path/some-source.tar.gz"
+    function.spec.security_context = client.V1SecurityContext(
+        run_as_user=1000, run_as_group=1000, run_as_non_root=True
+    )
+    services.api.utils.builder.build_runtime(
+        mlrun.common.schemas.AuthInfo(),
+        function,
+    )
+
+    request = captured["request"]
+    assert request.user_unix_id == 1000
+    assert request.enriched_group_id == 1000
+
+
+def test_build_image_no_uid_fallback_when_no_static_security_context(monkeypatch):
+    # the common/default case: enrichment disabled and no static security context
+    # configured. An *unconfigured* cluster default decodes to "{}" (not None) via
+    # mlconf.get_default_function_security_context(), and stays an unconverted plain
+    # dict rather than a V1SecurityContext instance - the exact shape that motivated
+    # the attribute-safe getattr() in the fix. No chown target, matching today's
+    # shipped behaviour.
+    monkeypatch.setattr(
+        config.function.spec.security_context,
+        "enrichment_mode",
+        mlrun.common.schemas.SecurityContextEnrichmentModes.disabled.value,
+    )
+
+    captured = {}
+
+    def _capture_request(self, request):
+        captured["request"] = request
+        return unittest.mock.MagicMock()
+
+    monkeypatch.setattr(
+        services.api.utils.builder.KanikoBackend, "make_build_pod", _capture_request
+    )
+    monkeypatch.setattr(
+        config.httpdb.builder,
+        "docker_registry",
+        "default.docker.registry/default-repository",
+    )
+    _patch_k8s_helper(monkeypatch)
+
+    function = mlrun.new_function(
+        "some-function",
+        "some-project",
+        "some-tag",
+        image="mlrun/mlrun",
+        kind=RuntimeKinds.job,
+    )
+    function.spec.build.source = "/path/some-source.tar.gz"
+    function.spec.security_context = {}
+    assert not isinstance(function.spec.security_context, client.V1SecurityContext)
+
+    services.api.utils.builder.build_runtime(
+        mlrun.common.schemas.AuthInfo(),
+        function,
+    )
+
+    request = captured["request"]
+    assert request.user_unix_id is None
+    assert request.enriched_group_id is None
+
+
 def _patch_k8s_helper(monkeypatch):
     get_k8s_helper_mock = unittest.mock.Mock()
     get_k8s_helper_mock.create_pod = unittest.mock.Mock(

--- a/server/py/services/api/utils/builder/__init__.py
+++ b/server/py/services/api/utils/builder/__init__.py
@@ -108,14 +108,15 @@ def build_image(
         user_unix_id = runtime.spec.security_context.run_as_user
         enriched_group_id = runtime.spec.security_context.run_as_group
     else:
-        # enrichment is disabled, but the function may still carry a static non-root
-        # security context (e.g. a cluster-wide default) that will govern the job pod's
-        # actual runtime uid/gid - chown the baked source dir to match it, or the pod
-        # won't be able to write into its own working directory. security_context may
-        # be an unconverted (e.g. empty) dict rather than a V1SecurityContext instance,
-        # hence the attribute-safe getattr.
+        # a static (non-enriched) security context still needs its uid/gid chowned;
+        # security_context may be an unconverted dict, hence the safe getattr.
         user_unix_id = getattr(runtime.spec.security_context, "run_as_user", None)
         enriched_group_id = getattr(runtime.spec.security_context, "run_as_group", None)
+        if user_unix_id is not None and enriched_group_id is None:
+            # only the uid matters for the chown to grant write access (POSIX owner
+            # permissions apply once the uid matches, regardless of group), so don't
+            # skip the chown just because the group wasn't pinned.
+            enriched_group_id = user_unix_id
 
     # everything above is engine-agnostic resolution. Package it into the seam DTO,
     # then let the resolved backend own source routing, the Dockerfile source COPY

--- a/server/py/services/api/utils/builder/__init__.py
+++ b/server/py/services/api/utils/builder/__init__.py
@@ -107,6 +107,15 @@ def build_image(
         ensure_function_security_context(runtime, auth_info)
         user_unix_id = runtime.spec.security_context.run_as_user
         enriched_group_id = runtime.spec.security_context.run_as_group
+    else:
+        # enrichment is disabled, but the function may still carry a static non-root
+        # security context (e.g. a cluster-wide default) that will govern the job pod's
+        # actual runtime uid/gid - chown the baked source dir to match it, or the pod
+        # won't be able to write into its own working directory. security_context may
+        # be an unconverted (e.g. empty) dict rather than a V1SecurityContext instance,
+        # hence the attribute-safe getattr.
+        user_unix_id = getattr(runtime.spec.security_context, "run_as_user", None)
+        enriched_group_id = getattr(runtime.spec.security_context, "run_as_group", None)
 
     # everything above is engine-agnostic resolution. Package it into the seam DTO,
     # then let the resolved backend own source routing, the Dockerfile source COPY


### PR DESCRIPTION
### 📝 Description
Follow-up on ML-12960. The previous fix (merged, in `v1.13.0-rc5`) closed a narrow Buildah-vs-Kaniko parity gap, but QA re-tested `test_mlrun_source_archive_from_python_file` against that exact release and it still failed with the same `PermissionError: ... 'job.py'`.

Root cause: `server/py/services/api/utils/builder/__init__.py`'s resolution of `user_unix_id`/`enriched_group_id` (used to chown a baked source dir so a non-root job pod can write into it) was gated entirely on `function.spec.security_context.enrichment_mode != disabled`. But `KubeResource.__init__` (`mlrun/runtimes/pod.py`) unconditionally applies a **static** default security context regardless of `enrichment_mode` — and mlefi's real-world default is exactly `enrichment_mode=disabled` (deliberately, to dodge an unrelated `igz_version` startup-crash bug) combined with a non-root static default (`runAsUser=1000` etc, the whole point of mlefi PR #776). In that combination — the realistic production case — neither Kaniko nor Buildah ever chowned the directory, so the previous fix didn't cover it.

Verified with real, unmocked build pods on a live lab (not inferred from code alone):
- Reconfigured a lab to `enrichment_mode=disabled` + static `runAsUser=1000/runAsGroup=1000` (mirroring mlefi's real default).
- Pre-fix-equivalent Kaniko/Buildah builds (real `BuildRequest`, replayed through the real, unmodified backend code with `user_unix_id`/`enriched_group_id` forced back to `None`): generated Dockerfile and build pod log both show `ADD ... → ENV PYTHONPATH ...` with **no chown step**.
- Post-fix: same builds produce `ADD ... → RUN chown -R 1000:1000 ... → ENV PYTHONPATH ...`, and the chown executes cleanly in the real build pod log for both backends.
- Full end-to-end: built an image with both a baked source archive and packed inline handler code (matching QA's test), launched a pod with the built image under the real job-pod security context and `workingDir` (discovered `server/py/services/api/runtime_handlers/kubejob.py::_resolve_workdir` overrides the container's working directory to `source_code_target_dir`, regardless of the base image's own `WORKDIR`) — the previously-failing write now succeeds and the packed handler runs correctly.

---

### 🛠️ Changes Made
- `server/py/services/api/utils/builder/__init__.py`: in `build_image()`'s uid/gid resolution, fall back to the function's already-set `security_context.run_as_user`/`.run_as_group` (via attribute-safe `getattr`, since an unconfigured default decodes to an unconverted plain `{}` dict, not a `V1SecurityContext`) whenever enrichment didn't resolve a value.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added two unit tests to `test_builder_backend.py`: one asserting the fallback resolves `user_unix_id`/`enriched_group_id` from a static `V1SecurityContext`, one asserting the common unconfigured case (`security_context = {}`, an unconverted plain dict) leaves both `None` (no regression).
- Ran the full `test_builder_backend.py` + `test_builder.py` suite (223 tests) — all pass.
- `ruff check`/`ruff format --check` clean on both changed files.
- Live-lab verification on vmdev122ig4 as described above: real pre-fix and post-fix build pods for both Kaniko and Buildah, plus a full end-to-end job run reproducing and then resolving the exact QA failure.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12960 (reopened after QA regression)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Follow-up to #10019 (the first ML-12960 fix, already merged and included in `v1.13.0-rc5`, but insufficient for the `enrichment_mode=disabled` + static-default combination this PR covers).