### PR TITLE
[Project Sync] MLRun SDK: talk to Orca directly for project CUD

### DIFF
--- a/dockerfiles/gpu/locked-requirements.txt
+++ b/dockerfiles/gpu/locked-requirements.txt
@@ -1370,6 +1370,10 @@ grpcio-tools==1.81.1 \
     --hash=sha256:f8cb64f87c45ccca8234fa47e6b21f09e43801ff11b556deecb461b3b3e9f292 \
     --hash=sha256:fc3d2a41a7a4467fa03b391394fffada9291fe8feebc8679b526f6bc36942b25
     # via v3io-frames
+humanfriendly==10.0 \
+    --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
+    --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
+    # via -r requirements.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -3093,6 +3097,10 @@ pyparsing==3.3.2 \
     --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d \
     --hash=sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc
     # via matplotlib
+pyreadline3==3.5.6 ; sys_platform == 'win32' \
+    --hash=sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf \
+    --hash=sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d
+    # via humanfriendly
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427

--- a/dockerfiles/jupyter/locked-requirements.txt
+++ b/dockerfiles/jupyter/locked-requirements.txt
@@ -1338,6 +1338,10 @@ grpcio-tools==1.81.1 \
     --hash=sha256:f8cb64f87c45ccca8234fa47e6b21f09e43801ff11b556deecb461b3b3e9f292 \
     --hash=sha256:fc3d2a41a7a4467fa03b391394fffada9291fe8feebc8679b526f6bc36942b25
     # via v3io-frames
+humanfriendly==10.0 \
+    --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
+    --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
+    # via -r requirements.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -2850,6 +2854,10 @@ pyparsing==3.3.2 \
     --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d \
     --hash=sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc
     # via matplotlib
+pyreadline3==3.5.6 ; sys_platform == 'win32' \
+    --hash=sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf \
+    --hash=sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d
+    # via humanfriendly
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427

--- a/dockerfiles/mlrun-api/locked-requirements.txt
+++ b/dockerfiles/mlrun-api/locked-requirements.txt
@@ -1262,7 +1262,9 @@ httpx==0.28.1 \
 humanfriendly==10.0 \
     --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
     --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
-    # via -r dockerfiles/mlrun-api/requirements.txt
+    # via
+    #   -r dockerfiles/mlrun-api/requirements.txt
+    #   -r requirements.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848

--- a/dockerfiles/mlrun-kfp/locked-requirements.txt
+++ b/dockerfiles/mlrun-kfp/locked-requirements.txt
@@ -1234,6 +1234,10 @@ httplib2==0.32.0 \
     # via
     #   google-api-python-client
     #   google-auth-httplib2
+humanfriendly==10.0 \
+    --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
+    --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
+    # via -r requirements.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -2411,6 +2415,10 @@ pyparsing==3.3.2 \
     --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d \
     --hash=sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc
     # via httplib2
+pyreadline3==3.5.6 ; sys_platform == 'win32' \
+    --hash=sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf \
+    --hash=sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d
+    # via humanfriendly
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427

--- a/dockerfiles/mlrun/locked-requirements.txt
+++ b/dockerfiles/mlrun/locked-requirements.txt
@@ -1370,6 +1370,10 @@ grpcio-tools==1.81.1 \
     --hash=sha256:f8cb64f87c45ccca8234fa47e6b21f09e43801ff11b556deecb461b3b3e9f292 \
     --hash=sha256:fc3d2a41a7a4467fa03b391394fffada9291fe8feebc8679b526f6bc36942b25
     # via v3io-frames
+humanfriendly==10.0 \
+    --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
+    --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
+    # via -r requirements.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -3093,6 +3097,10 @@ pyparsing==3.3.2 \
     --hash=sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d \
     --hash=sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc
     # via matplotlib
+pyreadline3==3.5.6 ; sys_platform == 'win32' \
+    --hash=sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf \
+    --hash=sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d
+    # via humanfriendly
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427

--- a/dockerfiles/test/locked-requirements-client.txt
+++ b/dockerfiles/test/locked-requirements-client.txt
@@ -1924,6 +1924,10 @@ huggingface-hub==0.36.2 \
     # via
     #   tokenizers
     #   transformers
+humanfriendly==10.0 \
+    --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
+    --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
+    # via -r requirements.txt
 hypothesis==6.165.5 \
     --hash=sha256:05e7e8288b2f5fbb34a30b45c9df72a5ce9da0d5ce90705c76b28dda75aac984 \
     --hash=sha256:0a5004c3fe761b642ca556abf4551bc9a94d190320bcf7ce118cf8b792eaf71c \
@@ -3794,6 +3798,10 @@ pyparsing==3.3.2 \
     # via
     #   httplib2
     #   matplotlib
+pyreadline3==3.5.6 ; sys_platform == 'win32' \
+    --hash=sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf \
+    --hash=sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d
+    # via humanfriendly
 pytest==9.1.1 \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
     --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c

--- a/dockerfiles/test/locked-requirements-server.txt
+++ b/dockerfiles/test/locked-requirements-server.txt
@@ -1929,7 +1929,9 @@ huggingface-hub==0.36.2 \
 humanfriendly==10.0 \
     --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
     --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
-    # via -r dockerfiles/mlrun-api/requirements.txt
+    # via
+    #   -r dockerfiles/mlrun-api/requirements.txt
+    #   -r requirements.txt
 hypothesis==6.165.5 \
     --hash=sha256:05e7e8288b2f5fbb34a30b45c9df72a5ce9da0d5ce90705c76b28dda75aac984 \
     --hash=sha256:0a5004c3fe761b642ca556abf4551bc9a94d190320bcf7ce118cf8b792eaf71c \

--- a/mlrun/common/schemas/_v1/client_spec.py
+++ b/mlrun/common/schemas/_v1/client_spec.py
@@ -68,6 +68,9 @@ class ClientSpec(pydantic.v1.BaseModel):
     system_id: str | None
     model_endpoint_monitoring_store_prefixes: dict[str, str] | None
     authentication_mode: str | None
+    # The project-sync leader ("mlrun", "iguazio", "nop", or "orca") - lets the SDK know when
+    # it's safe to bypass the API and talk to Orca directly (see mlrun.db.orca).
+    projects_leader: str | None
     # Iguazio V4 OAuth token provider configuration
     oauth_internal_token_endpoint: str | None
     oauth_external_token_endpoint: str | None

--- a/mlrun/common/schemas/_v2/client_spec.py
+++ b/mlrun/common/schemas/_v2/client_spec.py
@@ -93,6 +93,9 @@ class ClientSpec(pydantic.BaseModel):
     system_id: str | None = None
     model_endpoint_monitoring_store_prefixes: dict[str, str] | None = None
     authentication_mode: str | None = None
+    # The project-sync leader ("mlrun", "iguazio", "nop", or "orca") - lets the SDK know when
+    # it's safe to bypass the API and talk to Orca directly (see mlrun.db.orca).
+    projects_leader: str | None = None
     # Iguazio V4 OAuth token provider configuration
     oauth_internal_token_endpoint: str | None = None
     oauth_external_token_endpoint: str | None = None

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -370,7 +370,6 @@ class RunDBInterface(ABC):
         self,
         name: str,
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
-        wait_for_completion: bool = True,
     ):
         pass
 
@@ -379,7 +378,6 @@ class RunDBInterface(ABC):
         self,
         name: str,
         project: mlrun.common.schemas.Project,
-        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 
@@ -389,7 +387,6 @@ class RunDBInterface(ABC):
         name: str,
         project: dict,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
-        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 
@@ -397,7 +394,6 @@ class RunDBInterface(ABC):
     def create_project(
         self,
         project: mlrun.common.schemas.Project,
-        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 

--- a/mlrun/db/base.py
+++ b/mlrun/db/base.py
@@ -370,6 +370,7 @@ class RunDBInterface(ABC):
         self,
         name: str,
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
+        wait_for_completion: bool = True,
     ):
         pass
 
@@ -378,6 +379,7 @@ class RunDBInterface(ABC):
         self,
         name: str,
         project: mlrun.common.schemas.Project,
+        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 
@@ -387,6 +389,7 @@ class RunDBInterface(ABC):
         name: str,
         project: dict,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
+        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 
@@ -394,6 +397,7 @@ class RunDBInterface(ABC):
     def create_project(
         self,
         project: mlrun.common.schemas.Project,
+        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -40,6 +40,7 @@ import mlrun.common.schemas
 import mlrun.common.schemas.model_monitoring.constants as mm_constants
 import mlrun.common.schemas.model_monitoring.model_endpoints as mm_endpoints
 import mlrun.common.types
+import mlrun.db.orca
 import mlrun.k8s_utils
 import mlrun.platforms
 import mlrun.projects
@@ -136,6 +137,7 @@ class HTTPRunDB(RunDBInterface):
     def __init__(self, url, *, credentials: "mlrun.client.Credentials | None" = None):
         self.server_version = ""
         self.session = None
+        self._orca_projects_client = None
         self._wait_for_project_terminal_state_retry_interval = 3
         self._wait_for_background_task_terminal_state_retry_interval = 3
         self._wait_for_project_deletion_interval = 3
@@ -280,36 +282,10 @@ class HTTPRunDB(RunDBInterface):
                 ("params", params),
                 ("data", body),
                 ("json", json),
-                ("headers", headers),
             )
             if value is not None
         }
-
-        if self.user:
-            kw["auth"] = (self.user, self.password)
-        elif self.token_provider:
-            token = self.token_provider.get_token()
-            if token:
-                # Iguazio auth doesn't support passing token through bearer, so use cookie instead
-                if self.token_provider.is_iguazio_session():
-                    session_cookie = f'j:{{"sid": "{token}"}}'
-                    cookies = {
-                        "session": session_cookie,
-                    }
-                    kw["cookies"] = cookies
-                else:
-                    if (
-                        mlrun.common.schemas.HeaderNames.authorization
-                        not in kw.setdefault("headers", {})
-                    ):
-                        kw["headers"].update(
-                            {
-                                mlrun.common.schemas.HeaderNames.authorization: (
-                                    mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer
-                                    + token
-                                )
-                            }
-                        )
+        kw.update(self._auth_request_kwargs(headers))
 
         if mlrun.common.schemas.HeaderNames.client_version not in kw.setdefault(
             "headers", {}
@@ -374,6 +350,45 @@ class HTTPRunDB(RunDBInterface):
             mlrun.errors.raise_for_status(response, error)
 
         return response
+
+    def _auth_request_kwargs(self, headers: dict | None = None) -> dict:
+        """Build the auth-related request kwargs (``auth``/``cookies``/``headers``) for the
+        credentials this instance was configured with. Shared by calls to MLRun's own API
+        (``api_call``) and, in enterprise mode, calls made directly to Orca - which trusts the
+        same IG4 session/token (see :class:`mlrun.db.clients.orca.OrcaProjectsClient`).
+
+        :param headers: Extra headers to merge the auth header into, if any.
+        :return: Request kwargs (a subset of ``auth``/``cookies``/``headers``) to pass to
+            ``requests``.
+        """
+        kw = {}
+        if headers is not None:
+            kw["headers"] = headers
+        if self.user:
+            kw["auth"] = (self.user, self.password)
+        elif self.token_provider:
+            token = self.token_provider.get_token()
+            if token:
+                # Iguazio auth doesn't support passing token through bearer, so use cookie instead
+                if self.token_provider.is_iguazio_session():
+                    session_cookie = f'j:{{"sid": "{token}"}}'
+                    kw["cookies"] = {
+                        "session": session_cookie,
+                    }
+                else:
+                    if (
+                        mlrun.common.schemas.HeaderNames.authorization
+                        not in kw.setdefault("headers", {})
+                    ):
+                        kw["headers"].update(
+                            {
+                                mlrun.common.schemas.HeaderNames.authorization: (
+                                    mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer
+                                    + token
+                                )
+                            }
+                        )
+        return kw
 
     def paginated_api_call(
         self,
@@ -3369,6 +3384,19 @@ class HTTPRunDB(RunDBInterface):
             for project_dict in response.json()["projects"]
         ]
 
+    def _orca_direct_mode(self) -> bool:
+        """Whether project CUD should bypass the MLRun API and talk to Orca directly - the SDK
+        side of the enterprise (IG4/Orca-led) project-sync mechanism (ML-12903). MLRun's own API
+        remains the transport for everyone else: CE, and enterprise deployments where Orca's
+        address isn't configured client-side yet.
+        """
+        return bool(mlrun.mlconf.is_iguazio_v4_mode() and mlrun.mlconf.iguazio_api_url)
+
+    def _orca_projects_client_instance(self) -> mlrun.db.orca.OrcaProjectsClient:
+        if self._orca_projects_client is None:
+            self._orca_projects_client = mlrun.db.orca.OrcaProjectsClient(self)
+        return self._orca_projects_client
+
     def get_project(self, name: str) -> "mlrun.MlrunProject":
         """Get details for a specific project."""
 
@@ -3386,7 +3414,8 @@ class HTTPRunDB(RunDBInterface):
         deletion_strategy: Union[
             str, mlrun.common.schemas.DeletionStrategy
         ] = mlrun.common.schemas.DeletionStrategy.default(),
-    ) -> None:
+        wait_for_completion: bool = True,
+    ) -> UUID | None:
         """Delete a project.
 
         :param name: Name of the project to delete.
@@ -3395,7 +3424,17 @@ class HTTPRunDB(RunDBInterface):
             - ``restrict`` (default) - Project must not have any related resources when deleted. If using
               this mode while related resources exist, the operation will fail.
             - ``cascade`` - Automatically delete all related resources when deleting the project.
+        :param wait_for_completion: Block until the delete operation reaches a terminal state. If
+            ``False``, return the operation's ``op_id`` immediately instead, if it is still
+            converging. Only honored when talking to Orca directly (enterprise); when proxied
+            through the MLRun API this call is always synchronous.
+        :return: The operation's ``op_id`` if the delete is still converging and
+            ``wait_for_completion`` is ``False``, otherwise ``None``.
         """
+        if self._orca_direct_mode():
+            return self._orca_projects_client_instance().delete_project(
+                name, wait_for_completion=wait_for_completion
+            )
 
         headers = {
             mlrun.common.schemas.HeaderNames.deletion_strategy: deletion_strategy
@@ -3431,8 +3470,19 @@ class HTTPRunDB(RunDBInterface):
         self,
         name: str,
         project: Union[dict, mlrun.projects.MlrunProject, mlrun.common.schemas.Project],
-    ) -> mlrun.projects.MlrunProject:
-        """Store a project in the DB. This operation will overwrite existing project of the same name if exists."""
+        wait_for_completion: bool = True,
+    ) -> Union[mlrun.projects.MlrunProject, UUID]:
+        """Store a project in the DB. This operation will overwrite existing project of the same name if exists.
+
+        :param wait_for_completion: Block until the store operation reaches a terminal state and
+            return the resulting project. If ``False``, return the operation's ``op_id``
+            immediately instead. Only honored when talking to Orca directly (enterprise); when
+            proxied through the MLRun API this call is always synchronous.
+        """
+        if self._orca_direct_mode():
+            return self._orca_projects_client_instance().update_project(
+                name, project, wait_for_completion=wait_for_completion
+            )
 
         path = f"projects/{name}"
         error_message = f"Failed storing project {name}"
@@ -3457,14 +3507,26 @@ class HTTPRunDB(RunDBInterface):
         patch_mode: Union[
             str, mlrun.common.schemas.PatchMode
         ] = mlrun.common.schemas.PatchMode.replace,
-    ) -> mlrun.projects.MlrunProject:
+        wait_for_completion: bool = True,
+    ) -> Union[mlrun.projects.MlrunProject, UUID]:
         """Patch an existing project object.
 
         :param name: Name of project to patch.
         :param project: The actual changes to the project object.
         :param patch_mode: The strategy for merging the changes with the existing object. Can be either ``replace``
             or ``additive``.
+        :param wait_for_completion: Block until the patch operation reaches a terminal state and
+            return the resulting project. If ``False``, return the operation's ``op_id``
+            immediately instead. Only honored when talking to Orca directly (enterprise); when
+            proxied through the MLRun API this call is always synchronous.
         """
+        if self._orca_direct_mode():
+            return self._orca_projects_client_instance().patch_project(
+                name,
+                project,
+                patch_mode=mlrun.common.schemas.PatchMode(patch_mode),
+                wait_for_completion=wait_for_completion,
+            )
 
         path = f"projects/{name}"
         headers = {mlrun.common.schemas.HeaderNames.patch_mode: patch_mode}
@@ -3477,8 +3539,19 @@ class HTTPRunDB(RunDBInterface):
     def create_project(
         self,
         project: Union[dict, mlrun.projects.MlrunProject, mlrun.common.schemas.Project],
-    ) -> mlrun.projects.MlrunProject:
-        """Create a new project. A project with the same name must not exist prior to creation."""
+        wait_for_completion: bool = True,
+    ) -> Union[mlrun.projects.MlrunProject, UUID]:
+        """Create a new project. A project with the same name must not exist prior to creation.
+
+        :param wait_for_completion: Block until the create operation reaches a terminal state and
+            return the resulting project. If ``False``, return the operation's ``op_id``
+            immediately instead. Only honored when talking to Orca directly (enterprise); when
+            proxied through the MLRun API this call is always synchronous.
+        """
+        if self._orca_direct_mode():
+            return self._orca_projects_client_instance().create_project(
+                project, wait_for_completion=wait_for_completion
+            )
 
         if isinstance(project, mlrun.common.schemas.Project):
             project = project.dict()

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -355,7 +355,7 @@ class HTTPRunDB(RunDBInterface):
         """Build the auth-related request kwargs (``auth``/``cookies``/``headers``) for the
         credentials this instance was configured with. Shared by calls to MLRun's own API
         (``api_call``) and, in enterprise mode, calls made directly to Orca - which trusts the
-        same IG4 session/token (see :class:`mlrun.db.clients.orca.OrcaProjectsClient`).
+        same IG4 session/token (see :class:`mlrun.db.orca.OrcaProjectsClient`).
 
         :param headers: Extra headers to merge the auth header into, if any.
         :return: Request kwargs (a subset of ``auth``/``cookies``/``headers``) to pass to
@@ -3414,8 +3414,7 @@ class HTTPRunDB(RunDBInterface):
         deletion_strategy: Union[
             str, mlrun.common.schemas.DeletionStrategy
         ] = mlrun.common.schemas.DeletionStrategy.default(),
-        wait_for_completion: bool = True,
-    ) -> UUID | None:
+    ) -> None:
         """Delete a project.
 
         :param name: Name of the project to delete.
@@ -3424,17 +3423,12 @@ class HTTPRunDB(RunDBInterface):
             - ``restrict`` (default) - Project must not have any related resources when deleted. If using
               this mode while related resources exist, the operation will fail.
             - ``cascade`` - Automatically delete all related resources when deleting the project.
-        :param wait_for_completion: Block until the delete operation reaches a terminal state. If
-            ``False``, return the operation's ``op_id`` immediately instead, if it is still
-            converging. Only honored when talking to Orca directly (enterprise); when proxied
-            through the MLRun API this call is always synchronous.
-        :return: The operation's ``op_id`` if the delete is still converging and
-            ``wait_for_completion`` is ``False``, otherwise ``None``.
         """
         if self._orca_direct_mode():
-            return self._orca_projects_client_instance().delete_project(
-                name, wait_for_completion=wait_for_completion
+            self._orca_projects_client_instance().delete_project(
+                name, wait_for_completion=True
             )
+            return
 
         headers = {
             mlrun.common.schemas.HeaderNames.deletion_strategy: deletion_strategy
@@ -3470,18 +3464,11 @@ class HTTPRunDB(RunDBInterface):
         self,
         name: str,
         project: Union[dict, mlrun.projects.MlrunProject, mlrun.common.schemas.Project],
-        wait_for_completion: bool = True,
-    ) -> Union[mlrun.projects.MlrunProject, UUID]:
-        """Store a project in the DB. This operation will overwrite existing project of the same name if exists.
-
-        :param wait_for_completion: Block until the store operation reaches a terminal state and
-            return the resulting project. If ``False``, return the operation's ``op_id``
-            immediately instead. Only honored when talking to Orca directly (enterprise); when
-            proxied through the MLRun API this call is always synchronous.
-        """
+    ) -> mlrun.projects.MlrunProject:
+        """Store a project in the DB. This operation will overwrite existing project of the same name if exists."""
         if self._orca_direct_mode():
             return self._orca_projects_client_instance().update_project(
-                name, project, wait_for_completion=wait_for_completion
+                name, project, wait_for_completion=True
             )
 
         path = f"projects/{name}"
@@ -3507,25 +3494,20 @@ class HTTPRunDB(RunDBInterface):
         patch_mode: Union[
             str, mlrun.common.schemas.PatchMode
         ] = mlrun.common.schemas.PatchMode.replace,
-        wait_for_completion: bool = True,
-    ) -> Union[mlrun.projects.MlrunProject, UUID]:
+    ) -> mlrun.projects.MlrunProject:
         """Patch an existing project object.
 
         :param name: Name of project to patch.
         :param project: The actual changes to the project object.
         :param patch_mode: The strategy for merging the changes with the existing object. Can be either ``replace``
             or ``additive``.
-        :param wait_for_completion: Block until the patch operation reaches a terminal state and
-            return the resulting project. If ``False``, return the operation's ``op_id``
-            immediately instead. Only honored when talking to Orca directly (enterprise); when
-            proxied through the MLRun API this call is always synchronous.
         """
         if self._orca_direct_mode():
             return self._orca_projects_client_instance().patch_project(
                 name,
                 project,
                 patch_mode=mlrun.common.schemas.PatchMode(patch_mode),
-                wait_for_completion=wait_for_completion,
+                wait_for_completion=True,
             )
 
         path = f"projects/{name}"
@@ -3539,18 +3521,11 @@ class HTTPRunDB(RunDBInterface):
     def create_project(
         self,
         project: Union[dict, mlrun.projects.MlrunProject, mlrun.common.schemas.Project],
-        wait_for_completion: bool = True,
-    ) -> Union[mlrun.projects.MlrunProject, UUID]:
-        """Create a new project. A project with the same name must not exist prior to creation.
-
-        :param wait_for_completion: Block until the create operation reaches a terminal state and
-            return the resulting project. If ``False``, return the operation's ``op_id``
-            immediately instead. Only honored when talking to Orca directly (enterprise); when
-            proxied through the MLRun API this call is always synchronous.
-        """
+    ) -> mlrun.projects.MlrunProject:
+        """Create a new project. A project with the same name must not exist prior to creation."""
         if self._orca_direct_mode():
             return self._orca_projects_client_instance().create_project(
-                project, wait_for_completion=wait_for_completion
+                project, wait_for_completion=True
             )
 
         if isinstance(project, mlrun.common.schemas.Project):

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -694,6 +694,9 @@ class HTTPRunDB(RunDBInterface):
                 server_cfg.get("authentication_mode")
                 or config.httpdb.authentication.mode
             )
+            config.httpdb.projects.leader = (
+                server_cfg.get("projects_leader") or config.httpdb.projects.leader
+            )
 
             config.httpdb.authorization.namespaces.mlrun = (
                 server_cfg.get("authorization_namespaces_mlrun")
@@ -3387,10 +3390,17 @@ class HTTPRunDB(RunDBInterface):
     def _orca_direct_mode(self) -> bool:
         """Whether project CUD should bypass the MLRun API and talk to Orca directly - the SDK
         side of the enterprise (IG4/Orca-led) project-sync mechanism (ML-12903). MLRun's own API
-        remains the transport for everyone else: CE, and enterprise deployments where Orca's
-        address isn't configured client-side yet.
+        remains the transport for everyone else: CE, enterprise deployments where Orca's
+        address isn't configured client-side yet, and deployments where the API server hasn't
+        (yet) cut project-sync leadership over to Orca - ``projects_leader`` is synced from the
+        server's own ``httpdb.projects.leader`` via ``connect()``'s client-spec, since that's
+        the one fact the client can't determine on its own.
         """
-        return bool(mlrun.mlconf.is_iguazio_v4_mode() and mlrun.mlconf.iguazio_api_url)
+        return bool(
+            mlrun.mlconf.is_iguazio_v4_mode()
+            and mlrun.mlconf.iguazio_api_url
+            and mlrun.mlconf.httpdb.projects.leader == "orca"
+        )
 
     def _orca_projects_client_instance(self) -> mlrun.db.orca.OrcaProjectsClient:
         if self._orca_projects_client is None:

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -3389,7 +3389,7 @@ class HTTPRunDB(RunDBInterface):
 
     def _orca_direct_mode(self) -> bool:
         """Whether project CUD should bypass the MLRun API and talk to Orca directly - the SDK
-        side of the enterprise (IG4/Orca-led) project-sync mechanism (ML-12903). MLRun's own API
+        side of the enterprise (IG4/Orca-led) project-sync mechanism. MLRun's own API
         remains the transport for everyone else: CE, enterprise deployments where Orca's
         address isn't configured client-side yet, and deployments where the API server hasn't
         (yet) cut project-sync leadership over to Orca - ``projects_leader`` is synced from the

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -315,24 +315,18 @@ class NopDB(RunDBInterface):
         self,
         name: str,
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
-        wait_for_completion: bool = True,
     ):
         pass
 
     def create_project(
-        self,
-        project: mlrun.common.schemas.Project | dict,
-        wait_for_completion: bool = True,
+        self, project: mlrun.common.schemas.Project | dict
     ) -> mlrun.common.schemas.Project:
         if isinstance(project, dict):
             project = mlrun.projects.MlrunProject.from_dict(project)
         return project
 
     def store_project(
-        self,
-        name: str,
-        project: mlrun.common.schemas.Project | dict,
-        wait_for_completion: bool = True,
+        self, name: str, project: mlrun.common.schemas.Project | dict
     ) -> mlrun.common.schemas.Project:
         return self.create_project(project)
 
@@ -341,7 +335,6 @@ class NopDB(RunDBInterface):
         name: str,
         project: dict,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
-        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 

--- a/mlrun/db/nopdb.py
+++ b/mlrun/db/nopdb.py
@@ -315,18 +315,24 @@ class NopDB(RunDBInterface):
         self,
         name: str,
         deletion_strategy: mlrun.common.schemas.DeletionStrategy = mlrun.common.schemas.DeletionStrategy.default(),
+        wait_for_completion: bool = True,
     ):
         pass
 
     def create_project(
-        self, project: mlrun.common.schemas.Project | dict
+        self,
+        project: mlrun.common.schemas.Project | dict,
+        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         if isinstance(project, dict):
             project = mlrun.projects.MlrunProject.from_dict(project)
         return project
 
     def store_project(
-        self, name: str, project: mlrun.common.schemas.Project | dict
+        self,
+        name: str,
+        project: mlrun.common.schemas.Project | dict,
+        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         return self.create_project(project)
 
@@ -335,6 +341,7 @@ class NopDB(RunDBInterface):
         name: str,
         project: dict,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
+        wait_for_completion: bool = True,
     ) -> mlrun.common.schemas.Project:
         pass
 

--- a/mlrun/db/orca.py
+++ b/mlrun/db/orca.py
@@ -1,0 +1,304 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SDK-direct client for Orca's user-facing project endpoints.
+
+In enterprise (IG4/Orca-led) deployments, this bypasses the MLRun API entirely for project
+create/update/patch/delete: it calls Orca with the SDK's own user credentials (Orca authorizes
+the user itself, via OPA), then polls to a terminal state the same way MLRun's own backward-
+compatibility proxy does server-side (``server/py/framework/utils/clients/iguazio/v4.py``,
+mlrun#10043) - see :mod:`mlrun.utils.orca_projects` for the wire protocol shared between the two.
+"""
+
+import types
+import typing
+import uuid
+
+import humanfriendly
+import mergedeep
+import requests
+
+import mlrun.common.schemas
+import mlrun.errors
+import mlrun.utils
+import mlrun.utils.helpers
+import mlrun.utils.orca_projects as orca_projects
+from mlrun.utils import logger
+
+if typing.TYPE_CHECKING:
+    import mlrun.db.httpdb
+
+
+def _as_project_like(project):
+    """Normalize ``project`` into something with ``.metadata``/``.spec``/``.status`` attribute
+    access - the shape :mod:`mlrun.utils.orca_projects`'s wire functions expect.
+
+    Accepts a dict, :class:`~mlrun.projects.MlrunProject`, or
+    :class:`mlrun.common.schemas.Project` - all three are already used interchangeably by
+    MLRun's own project CUD API (see ``HTTPRunDB.create_project``/``store_project``/
+    ``patch_project``). A dict may be partial (``patch_project``'s body only carries the changed
+    fields, and never ``metadata.name`` - that comes from the separate ``name`` argument), so
+    missing fields become ``None`` rather than raising - matching the wire functions' own
+    ``if project.spec.owner:``-style optional-field handling.
+    """
+    if not isinstance(project, dict):
+        return project
+    metadata = project.get("metadata") or {}
+    spec = project.get("spec") or {}
+    status = project.get("status") or {}
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(
+            name=metadata.get("name"),
+            labels=metadata.get("labels"),
+            annotations=metadata.get("annotations"),
+        ),
+        spec=types.SimpleNamespace(
+            owner=spec.get("owner"),
+            description=spec.get("description"),
+        ),
+        status=types.SimpleNamespace(op_id=status.get("op_id") or status.get("opId")),
+    )
+
+
+class OrcaProjectsClient:
+    """Talks to Orca's user-facing project endpoints directly, using the credentials of the
+    :class:`~mlrun.db.httpdb.HTTPRunDB` instance it is attached to - the same credentials that
+    instance uses to talk to the MLRun API, since Orca and the MLRun API trust the same IG4
+    session/token.
+    """
+
+    def __init__(self, run_db: "mlrun.db.httpdb.HTTPRunDB"):
+        self._run_db = run_db
+        self._session = mlrun.utils.HTTPSessionWithRetry(
+            retry_on_exception=(
+                mlrun.mlconf.httpdb.projects.retry_leader_request_on_exception
+                == mlrun.common.schemas.HTTPSessionRetryMode.enabled.value
+            ),
+            verbose=True,
+        )
+        self._poll_interval_seconds = humanfriendly.parse_timespan(
+            mlrun.mlconf.httpdb.projects.iguazio_project_states_poll_interval
+        )
+        self._poll_timeout_seconds = humanfriendly.parse_timespan(
+            mlrun.mlconf.httpdb.projects.iguazio_project_states_poll_timeout
+        )
+
+    def create_project(
+        self, project, wait_for_completion: bool = True
+    ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
+        """Create a project directly in Orca.
+
+        :param project: The project to create - a :class:`~mlrun.projects.MlrunProject`,
+            :class:`mlrun.common.schemas.Project`, or an equivalent dict.
+        :param wait_for_completion: Block until Orca's create operation reaches a terminal state
+            and return the resulting project. If ``False``, return the operation's ``op_id``
+            immediately instead.
+        :return: The created project, or the operation's ``op_id`` if ``wait_for_completion`` is
+            ``False``.
+        """
+        project = _as_project_like(project)
+        name = project.metadata.name
+        response = self._send_request(
+            "POST",
+            orca_projects.PROJECTS_ENDPOINT,
+            f"Failed creating project {name} in Orca",
+            json=orca_projects.create_project_wire(project),
+        )
+        return self._settle(name, response, wait_for_completion)
+
+    def update_project(
+        self, name: str, project, wait_for_completion: bool = True
+    ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
+        """Update (``PUT``) a project directly in Orca. See :meth:`create_project`."""
+        project = _as_project_like(project)
+        prev_op_id = self._resolve_prev_op_id(name, project)
+        response = self._send_request(
+            "PUT",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed updating project {name} in Orca",
+            json=orca_projects.update_project_wire(project, prev_op_id),
+        )
+        return self._settle(name, response, wait_for_completion)
+
+    def patch_project(
+        self,
+        name: str,
+        project,
+        patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
+        wait_for_completion: bool = True,
+    ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
+        """Patch (partial update) a project directly in Orca.
+
+        Orca's ``PATCH`` is full-replace, not merge (same required fields, same semantics as its
+        ``PUT`` - see orca SDK PR #1059), unlike MLRun's own ``patch_project``, which merges only
+        the given fields into the existing stored project. To preserve that partial-patch
+        contract, this reads the project's current common-set fields from Orca first, merges
+        ``project``'s changes into them the same way MLRun's own server does
+        (:mod:`mergedeep`, keyed by ``patch_mode``), and sends the merged result to Orca's
+        ``PATCH`` as a full object.
+        """
+        project = _as_project_like(project)
+        current = self.get_project(name)
+        merged_common = {
+            "labels": dict(current.metadata.labels or {}),
+            "annotations": dict(current.metadata.annotations or {}),
+            "owner": current.spec.owner,
+            "description": current.spec.description,
+        }
+        patch_common = {
+            "labels": project.metadata.labels,
+            "annotations": project.metadata.annotations,
+            "owner": project.spec.owner,
+            "description": project.spec.description,
+        }
+        patch_common = {k: v for k, v in patch_common.items() if v is not None}
+        mergedeep.merge(
+            merged_common, patch_common, strategy=patch_mode.to_mergedeep_strategy()
+        )
+        merged_project = types.SimpleNamespace(
+            metadata=types.SimpleNamespace(
+                name=name,
+                labels=merged_common["labels"],
+                annotations=merged_common["annotations"],
+            ),
+            spec=types.SimpleNamespace(
+                owner=merged_common["owner"],
+                description=merged_common["description"],
+            ),
+        )
+        response = self._send_request(
+            "PATCH",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed patching project {name} in Orca",
+            json=orca_projects.update_project_wire(
+                merged_project, current.status.op_id
+            ),
+        )
+        return self._settle(name, response, wait_for_completion)
+
+    def delete_project(
+        self, name: str, wait_for_completion: bool = True
+    ) -> uuid.UUID | None:
+        """Delete a project directly in Orca.
+
+        :param name: Name of the project to delete.
+        :param wait_for_completion: Block until Orca's delete operation reaches a terminal state.
+        :return: The operation's ``op_id`` if the delete is still converging and
+            ``wait_for_completion`` is ``False``, otherwise ``None``.
+        """
+        response = self._send_request(
+            "DELETE",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed deleting project {name} in Orca",
+        )
+        if response.status_code != requests.codes.accepted:
+            return None
+        op_id = response.json()["status"]["opId"]
+        if not wait_for_completion:
+            return op_id
+        self._wait_for_op(name, op_id)
+        return None
+
+    def get_project(self, name: str) -> "mlrun.common.schemas.Project":
+        """Get a project directly from Orca."""
+        response = self._send_request(
+            "GET",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed getting project {name} from Orca",
+        )
+        return orca_projects.project_from_wire(response.json())
+
+    def _settle(
+        self, name: str, response: requests.Response, wait_for_completion: bool
+    ) -> typing.Union["mlrun.common.schemas.Project", uuid.UUID]:
+        # update/patch may settle synchronously (200 - "all ack -> clear phase -> 200" per the
+        # HLD) rather than go through the async 202 + poll path create always takes. A 200 has
+        # already reached its terminal state, and - unlike 202 - has no trackable-action record
+        # to poll for, so it must be handled before any polling is attempted.
+        if response.status_code != requests.codes.accepted:
+            return orca_projects.project_from_wire(response.json())
+        op_id = response.json()["status"]["opId"]
+        if not wait_for_completion:
+            return op_id
+        self._wait_for_op(name, op_id)
+        return self.get_project(name)
+
+    def _resolve_prev_op_id(self, name: str, project) -> uuid.UUID | None:
+        # The CAS witness Orca requires for an update is the last op_id the caller observed; if
+        # the caller didn't supply one, read the current state from Orca first (matches the
+        # HLD's "client reads the project, then PUT/PATCH with prev_op_id" contract). A missing
+        # project (store_project's upsert-create case: PUT on a project that doesn't exist yet)
+        # has no prior op_id to CAS against - fall through with None.
+        prev_op_id = getattr(getattr(project, "status", None), "op_id", None)
+        if prev_op_id:
+            return prev_op_id
+        try:
+            return self.get_project(name).status.op_id
+        except mlrun.errors.MLRunNotFoundError:
+            return None
+
+    def _wait_for_op(self, name: str, op_id: uuid.UUID | str) -> None:
+        logger.debug(
+            "Waiting for Orca sync-project action to reach a terminal state",
+            name=name,
+            op_id=op_id,
+        )
+        try:
+            mlrun.utils.helpers.retry_until_successful(
+                self._poll_interval_seconds,
+                self._poll_timeout_seconds,
+                logger,
+                False,
+                self._verify_op_terminal,
+                name,
+                op_id,
+                fatal_exceptions=(orca_projects.OrcaActionFailedError,),
+            )
+        except orca_projects.OrcaActionFailedError as exc:
+            raise mlrun.errors.MLRunRuntimeError(str(exc)) from exc
+
+    def _verify_op_terminal(self, name: str, op_id: uuid.UUID | str) -> None:
+        response = self._send_request(
+            "GET",
+            orca_projects.ACTION_EXECUTIONS_ENDPOINT,
+            "Failed getting Orca sync-project action execution",
+            params=orca_projects.action_execution_query_params(op_id),
+        )
+        orca_projects.verify_action_execution_terminal(response.json(), name, op_id)
+
+    def _send_request(
+        self, method: str, path: str, error_message: str, **kwargs
+    ) -> requests.Response:
+        if not mlrun.mlconf.iguazio_api_url:
+            raise mlrun.errors.MLRunRuntimeError(
+                "Cannot talk to Orca directly: iguazio_api_url is not configured"
+            )
+        url = f"{mlrun.mlconf.iguazio_api_url}/api/{path}"
+        kwargs.update(self._run_db._auth_request_kwargs(kwargs.pop("headers", None)))
+        try:
+            response = self._session.request(
+                method,
+                url,
+                timeout=20,
+                verify=mlrun.mlconf.iguazio_api_ssl_verify,
+                **kwargs,
+            )
+        except requests.RequestException as exc:
+            raise mlrun.errors.MLRunRuntimeError(
+                f"{mlrun.errors.err_to_str(exc)}: {error_message}"
+            ) from exc
+        # Orca's error response body shape is unverified (same caveat mlrun#10043 flagged for the
+        # server-side proxy), so this doesn't try to extract error details from it - just the
+        # status-code-to-exception mapping raise_for_status already gives for free.
+        mlrun.errors.raise_for_status(response, error_message)
+        return response

--- a/mlrun/db/orca.py
+++ b/mlrun/db/orca.py
@@ -98,6 +98,14 @@ class OrcaProjectsClient:
             mlrun.mlconf.httpdb.projects.iguazio_project_states_poll_timeout
         )
 
+    @typing.overload
+    def create_project(
+        self, project: ProjectInput, wait_for_completion: typing.Literal[True] = True
+    ) -> "mlrun.projects.MlrunProject": ...
+    @typing.overload
+    def create_project(
+        self, project: ProjectInput, wait_for_completion: typing.Literal[False]
+    ) -> uuid.UUID: ...
     def create_project(
         self, project: ProjectInput, wait_for_completion: bool = True
     ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
@@ -121,6 +129,20 @@ class OrcaProjectsClient:
         )
         return self._settle(name, response, wait_for_completion)
 
+    @typing.overload
+    def update_project(
+        self,
+        name: str,
+        project: ProjectInput,
+        wait_for_completion: typing.Literal[True] = True,
+    ) -> "mlrun.projects.MlrunProject": ...
+    @typing.overload
+    def update_project(
+        self,
+        name: str,
+        project: ProjectInput,
+        wait_for_completion: typing.Literal[False],
+    ) -> uuid.UUID: ...
     def update_project(
         self, name: str, project: ProjectInput, wait_for_completion: bool = True
     ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
@@ -142,6 +164,23 @@ class OrcaProjectsClient:
         )
         return self._settle(name, response, wait_for_completion)
 
+    @typing.overload
+    def patch_project(
+        self,
+        name: str,
+        project: ProjectInput,
+        patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
+        wait_for_completion: typing.Literal[True] = True,
+    ) -> "mlrun.projects.MlrunProject": ...
+    @typing.overload
+    def patch_project(
+        self,
+        name: str,
+        project: ProjectInput,
+        patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
+        *,
+        wait_for_completion: typing.Literal[False],
+    ) -> uuid.UUID: ...
     def patch_project(
         self,
         name: str,
@@ -206,6 +245,14 @@ class OrcaProjectsClient:
         )
         return self._settle(name, response, wait_for_completion)
 
+    @typing.overload
+    def delete_project(
+        self, name: str, wait_for_completion: typing.Literal[True] = True
+    ) -> None: ...
+    @typing.overload
+    def delete_project(
+        self, name: str, wait_for_completion: typing.Literal[False]
+    ) -> uuid.UUID | None: ...
     def delete_project(
         self, name: str, wait_for_completion: bool = True
     ) -> uuid.UUID | None:
@@ -258,6 +305,13 @@ class OrcaProjectsClient:
     def _settle(
         self, name: str, response: requests.Response, wait_for_completion: bool
     ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
+        # wait_for_completion=False always means "give me an identifier to check later", even if
+        # the operation has, in fact, already settled - this keeps the return type strictly a
+        # function of wait_for_completion (see the @overload signatures above) rather than also
+        # depending on response.status_code, which callers can't predict.
+        if not wait_for_completion:
+            return response.json()["status"]["opId"]
+
         # update/patch may settle synchronously (200 - "all ack -> clear phase -> 200" per the
         # HLD) rather than go through the async 202 + poll path create always takes. A 200 has
         # already reached its terminal state, and - unlike 202 - has no trackable-action record
@@ -267,8 +321,6 @@ class OrcaProjectsClient:
                 orca_projects.project_from_wire(response.json())
             )
         op_id = response.json()["status"]["opId"]
-        if not wait_for_completion:
-            return op_id
         self._wait_for_op(name, op_id)
         return self.get_project(name)
 

--- a/mlrun/db/orca.py
+++ b/mlrun/db/orca.py
@@ -30,6 +30,7 @@ import requests
 
 import mlrun.common.schemas
 import mlrun.errors
+import mlrun.projects
 import mlrun.utils
 import mlrun.utils.helpers
 import mlrun.utils.orca_projects as orca_projects
@@ -119,7 +120,14 @@ class OrcaProjectsClient:
     def update_project(
         self, name: str, project, wait_for_completion: bool = True
     ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
-        """Update (``PUT``) a project directly in Orca. See :meth:`create_project`."""
+        """Update (``PUT``) a project directly in Orca.
+
+        :param name: Name of the project to update.
+        :param project: The project's desired state - see :meth:`create_project`.
+        :param wait_for_completion: See :meth:`create_project`.
+        :return: The updated project, or the operation's ``op_id`` if ``wait_for_completion`` is
+            ``False``.
+        """
         project = _as_project_like(project)
         prev_op_id = self._resolve_prev_op_id(name, project)
         response = self._send_request(
@@ -146,9 +154,17 @@ class OrcaProjectsClient:
         ``project``'s changes into them the same way MLRun's own server does
         (:mod:`mergedeep`, keyed by ``patch_mode``), and sends the merged result to Orca's
         ``PATCH`` as a full object.
+
+        :param name: Name of the project to patch.
+        :param project: The changes to apply - only the fields present are merged in.
+        :param patch_mode: The strategy for merging the changes with the existing object. Can be
+            either ``replace`` or ``additive``.
+        :param wait_for_completion: See :meth:`create_project`.
+        :return: The patched project, or the operation's ``op_id`` if ``wait_for_completion`` is
+            ``False``.
         """
         project = _as_project_like(project)
-        current = self.get_project(name)
+        current = self._get_project_schema(name)
         merged_common = {
             "labels": dict(current.metadata.labels or {}),
             "annotations": dict(current.metadata.annotations or {}),
@@ -209,8 +225,19 @@ class OrcaProjectsClient:
         self._wait_for_op(name, op_id)
         return None
 
-    def get_project(self, name: str) -> "mlrun.common.schemas.Project":
-        """Get a project directly from Orca."""
+    def get_project(self, name: str) -> "mlrun.projects.MlrunProject":
+        """Get a project directly from Orca.
+
+        :param name: Name of the project to get.
+        :return: The project.
+        """
+        return self._to_mlrun_project(self._get_project_schema(name))
+
+    def _get_project_schema(self, name: str) -> "mlrun.common.schemas.Project":
+        # Internal, schema-typed accessor - unlike the public get_project(), this keeps fields
+        # (like status.op_id, the CAS witness) that mlrun.projects.MlrunProject's own status
+        # object doesn't carry, since those are Orca-sync plumbing, not part of the SDK's
+        # user-facing project contract.
         response = self._send_request(
             "GET",
             orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
@@ -218,15 +245,23 @@ class OrcaProjectsClient:
         )
         return orca_projects.project_from_wire(response.json())
 
+    @staticmethod
+    def _to_mlrun_project(
+        project: "mlrun.common.schemas.Project",
+    ) -> "mlrun.projects.MlrunProject":
+        return mlrun.projects.MlrunProject.from_dict(project.dict())
+
     def _settle(
         self, name: str, response: requests.Response, wait_for_completion: bool
-    ) -> typing.Union["mlrun.common.schemas.Project", uuid.UUID]:
+    ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
         # update/patch may settle synchronously (200 - "all ack -> clear phase -> 200" per the
         # HLD) rather than go through the async 202 + poll path create always takes. A 200 has
         # already reached its terminal state, and - unlike 202 - has no trackable-action record
         # to poll for, so it must be handled before any polling is attempted.
         if response.status_code != requests.codes.accepted:
-            return orca_projects.project_from_wire(response.json())
+            return self._to_mlrun_project(
+                orca_projects.project_from_wire(response.json())
+            )
         op_id = response.json()["status"]["opId"]
         if not wait_for_completion:
             return op_id
@@ -243,7 +278,7 @@ class OrcaProjectsClient:
         if prev_op_id:
             return prev_op_id
         try:
-            return self.get_project(name).status.op_id
+            return self._get_project_schema(name).status.op_id
         except mlrun.errors.MLRunNotFoundError:
             return None
 

--- a/mlrun/db/orca.py
+++ b/mlrun/db/orca.py
@@ -17,7 +17,10 @@ In enterprise (IG4/Orca-led) deployments, this bypasses the MLRun API entirely f
 create/update/patch/delete: it calls Orca with the SDK's own user credentials (Orca authorizes
 the user itself, via OPA), then polls to a terminal state the same way MLRun's own backward-
 compatibility proxy does server-side (``server/py/framework/utils/clients/iguazio/v4.py``,
-mlrun#10043) - see :mod:`mlrun.utils.orca_projects` for the wire protocol shared between the two.
+mlrun#10043). The actual request sequencing (what to call, in what order, how to poll) lives in
+:mod:`mlrun.utils.orca_client`, shared with that server-side proxy - this module only supplies
+the SDK-specific pieces: how to send an authenticated request, and how to translate results into
+the SDK's own public return types.
 """
 
 import types
@@ -25,16 +28,14 @@ import typing
 import uuid
 
 import humanfriendly
-import mergedeep
 import requests
 
 import mlrun.common.schemas
 import mlrun.errors
 import mlrun.projects
 import mlrun.utils
-import mlrun.utils.helpers
+import mlrun.utils.orca_client as orca_client
 import mlrun.utils.orca_projects as orca_projects
-from mlrun.utils import logger
 
 if typing.TYPE_CHECKING:
     import mlrun.db.httpdb
@@ -91,11 +92,15 @@ class OrcaProjectsClient:
             ),
             verbose=True,
         )
-        self._poll_interval_seconds = humanfriendly.parse_timespan(
-            mlrun.mlconf.httpdb.projects.iguazio_project_states_poll_interval
-        )
-        self._poll_timeout_seconds = humanfriendly.parse_timespan(
-            mlrun.mlconf.httpdb.projects.iguazio_project_states_poll_timeout
+        self._orchestrator = orca_client.OrcaProjectsOrchestrator(
+            self._send_request,
+            mlrun.utils.logger,
+            poll_interval_seconds=humanfriendly.parse_timespan(
+                mlrun.mlconf.httpdb.projects.iguazio_project_states_poll_interval
+            ),
+            poll_timeout_seconds=humanfriendly.parse_timespan(
+                mlrun.mlconf.httpdb.projects.iguazio_project_states_poll_timeout
+            ),
         )
 
     @typing.overload
@@ -120,14 +125,14 @@ class OrcaProjectsClient:
             ``False``.
         """
         project_like = _as_project_like(project)
-        name = project_like.metadata.name
-        response = self._send_request(
-            "POST",
-            orca_projects.PROJECTS_ENDPOINT,
-            f"Failed creating project {name} in Orca",
-            json=orca_projects.create_project_wire(project_like),
+        response, op_id = self._orchestrator.create(project_like)
+        if not wait_for_completion:
+            return op_id
+        return self._to_mlrun_project(
+            self._orchestrator.settle(
+                project_like.metadata.name, response, op_id, wait_for_completion=True
+            )
         )
-        return self._settle(name, response, wait_for_completion)
 
     @typing.overload
     def update_project(
@@ -155,14 +160,12 @@ class OrcaProjectsClient:
             ``False``.
         """
         project_like = _as_project_like(project)
-        prev_op_id = self._resolve_prev_op_id(name, project_like)
-        response = self._send_request(
-            "PUT",
-            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
-            f"Failed updating project {name} in Orca",
-            json=orca_projects.update_project_wire(project_like, prev_op_id),
+        response, op_id = self._orchestrator.update(name, project_like)
+        if not wait_for_completion:
+            return op_id
+        return self._to_mlrun_project(
+            self._orchestrator.settle(name, response, op_id, wait_for_completion=True)
         )
-        return self._settle(name, response, wait_for_completion)
 
     @typing.overload
     def patch_project(
@@ -207,43 +210,12 @@ class OrcaProjectsClient:
             ``False``.
         """
         project_like = _as_project_like(project)
-        current = self._get_project_schema(name)
-        merged_common = {
-            "labels": dict(current.metadata.labels or {}),
-            "annotations": dict(current.metadata.annotations or {}),
-            "owner": current.spec.owner,
-            "description": current.spec.description,
-        }
-        patch_common = {
-            "labels": project_like.metadata.labels,
-            "annotations": project_like.metadata.annotations,
-            "owner": project_like.spec.owner,
-            "description": project_like.spec.description,
-        }
-        patch_common = {k: v for k, v in patch_common.items() if v is not None}
-        mergedeep.merge(
-            merged_common, patch_common, strategy=patch_mode.to_mergedeep_strategy()
+        response, op_id = self._orchestrator.patch(name, project_like, patch_mode)
+        if not wait_for_completion:
+            return op_id
+        return self._to_mlrun_project(
+            self._orchestrator.settle(name, response, op_id, wait_for_completion=True)
         )
-        merged_project: orca_projects.ProjectLike = types.SimpleNamespace(
-            metadata=types.SimpleNamespace(
-                name=name,
-                labels=merged_common["labels"],
-                annotations=merged_common["annotations"],
-            ),
-            spec=types.SimpleNamespace(
-                owner=merged_common["owner"],
-                description=merged_common["description"],
-            ),
-        )
-        response = self._send_request(
-            "PATCH",
-            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
-            f"Failed patching project {name} in Orca",
-            json=orca_projects.update_project_wire(
-                merged_project, current.status.op_id
-            ),
-        )
-        return self._settle(name, response, wait_for_completion)
 
     @typing.overload
     def delete_project(
@@ -263,17 +235,13 @@ class OrcaProjectsClient:
         :return: The operation's ``op_id`` if the delete is still converging and
             ``wait_for_completion`` is ``False``, otherwise ``None``.
         """
-        response = self._send_request(
-            "DELETE",
-            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
-            f"Failed deleting project {name} in Orca",
-        )
+        response = self._orchestrator.delete(name)
         if response.status_code != requests.codes.accepted:
             return None
         op_id = response.json()["status"]["opId"]
         if not wait_for_completion:
             return op_id
-        self._wait_for_op(name, op_id)
+        self._orchestrator.wait_for_op(name, op_id)
         return None
 
     def get_project(self, name: str) -> "mlrun.projects.MlrunProject":
@@ -282,92 +250,13 @@ class OrcaProjectsClient:
         :param name: Name of the project to get.
         :return: The project.
         """
-        return self._to_mlrun_project(self._get_project_schema(name))
-
-    def _get_project_schema(self, name: str) -> "mlrun.common.schemas.Project":
-        # Internal, schema-typed accessor - unlike the public get_project(), this keeps fields
-        # (like status.op_id, the CAS witness) that mlrun.projects.MlrunProject's own status
-        # object doesn't carry, since those are Orca-sync plumbing, not part of the SDK's
-        # user-facing project contract.
-        response = self._send_request(
-            "GET",
-            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
-            f"Failed getting project {name} from Orca",
-        )
-        return orca_projects.project_from_wire(response.json())
+        return self._to_mlrun_project(self._orchestrator.get(name))
 
     @staticmethod
     def _to_mlrun_project(
         project: "mlrun.common.schemas.Project",
     ) -> "mlrun.projects.MlrunProject":
         return mlrun.projects.MlrunProject.from_dict(project.dict())
-
-    def _settle(
-        self, name: str, response: requests.Response, wait_for_completion: bool
-    ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
-        # wait_for_completion=False always means "give me an identifier to check later", even if
-        # the operation has, in fact, already settled - this keeps the return type strictly a
-        # function of wait_for_completion (see the @overload signatures above) rather than also
-        # depending on response.status_code, which callers can't predict.
-        if not wait_for_completion:
-            return response.json()["status"]["opId"]
-
-        # update/patch may settle synchronously (200 - "all ack -> clear phase -> 200" per the
-        # HLD) rather than go through the async 202 + poll path create always takes. A 200 has
-        # already reached its terminal state, and - unlike 202 - has no trackable-action record
-        # to poll for, so it must be handled before any polling is attempted.
-        if response.status_code != requests.codes.accepted:
-            return self._to_mlrun_project(
-                orca_projects.project_from_wire(response.json())
-            )
-        op_id = response.json()["status"]["opId"]
-        self._wait_for_op(name, op_id)
-        return self.get_project(name)
-
-    def _resolve_prev_op_id(
-        self, name: str, project: orca_projects.ProjectLike
-    ) -> uuid.UUID | None:
-        # The CAS witness Orca requires for an update is the last op_id the caller observed; if
-        # the caller didn't supply one, read the current state from Orca first (matches the
-        # HLD's "client reads the project, then PUT/PATCH with prev_op_id" contract). A missing
-        # project (store_project's upsert-create case: PUT on a project that doesn't exist yet)
-        # has no prior op_id to CAS against - fall through with None.
-        prev_op_id = getattr(getattr(project, "status", None), "op_id", None)
-        if prev_op_id:
-            return prev_op_id
-        try:
-            return self._get_project_schema(name).status.op_id
-        except mlrun.errors.MLRunNotFoundError:
-            return None
-
-    def _wait_for_op(self, name: str, op_id: uuid.UUID | str) -> None:
-        logger.debug(
-            "Waiting for Orca sync-project action to reach a terminal state",
-            name=name,
-            op_id=op_id,
-        )
-        try:
-            mlrun.utils.helpers.retry_until_successful(
-                self._poll_interval_seconds,
-                self._poll_timeout_seconds,
-                logger,
-                False,
-                self._verify_op_terminal,
-                name,
-                op_id,
-                fatal_exceptions=(orca_projects.OrcaActionFailedError,),
-            )
-        except orca_projects.OrcaActionFailedError as exc:
-            raise mlrun.errors.MLRunRuntimeError(str(exc)) from exc
-
-    def _verify_op_terminal(self, name: str, op_id: uuid.UUID | str) -> None:
-        response = self._send_request(
-            "GET",
-            orca_projects.ACTION_EXECUTIONS_ENDPOINT,
-            "Failed getting Orca sync-project action execution",
-            params=orca_projects.action_execution_query_params(op_id),
-        )
-        orca_projects.verify_action_execution_terminal(response.json(), name, op_id)
 
     def _send_request(
         self, method: str, path: str, error_message: str, **kwargs

--- a/mlrun/db/orca.py
+++ b/mlrun/db/orca.py
@@ -39,17 +39,21 @@ from mlrun.utils import logger
 if typing.TYPE_CHECKING:
     import mlrun.db.httpdb
 
+# The three shapes MLRun's own project CUD API already accepts interchangeably (see
+# HTTPRunDB.create_project/store_project/patch_project) - before normalization to
+# orca_projects.ProjectLike via _as_project_like().
+ProjectInput = typing.Union[
+    dict, "mlrun.projects.MlrunProject", "mlrun.common.schemas.Project"
+]
 
-def _as_project_like(project):
-    """Normalize ``project`` into something with ``.metadata``/``.spec``/``.status`` attribute
-    access - the shape :mod:`mlrun.utils.orca_projects`'s wire functions expect.
 
-    Accepts a dict, :class:`~mlrun.projects.MlrunProject`, or
-    :class:`mlrun.common.schemas.Project` - all three are already used interchangeably by
-    MLRun's own project CUD API (see ``HTTPRunDB.create_project``/``store_project``/
-    ``patch_project``). A dict may be partial (``patch_project``'s body only carries the changed
-    fields, and never ``metadata.name`` - that comes from the separate ``name`` argument), so
-    missing fields become ``None`` rather than raising - matching the wire functions' own
+def _as_project_like(project: ProjectInput) -> orca_projects.ProjectLike:
+    """Normalize ``project`` into something with ``.metadata``/``.spec`` attribute access - the
+    shape :mod:`mlrun.utils.orca_projects`'s wire functions expect.
+
+    A dict input may be partial (``patch_project``'s body only carries the changed fields, and
+    never ``metadata.name`` - that comes from the separate ``name`` argument), so missing fields
+    become ``None`` rather than raising - matching the wire functions' own
     ``if project.spec.owner:``-style optional-field handling.
     """
     if not isinstance(project, dict):
@@ -95,7 +99,7 @@ class OrcaProjectsClient:
         )
 
     def create_project(
-        self, project, wait_for_completion: bool = True
+        self, project: ProjectInput, wait_for_completion: bool = True
     ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
         """Create a project directly in Orca.
 
@@ -107,18 +111,18 @@ class OrcaProjectsClient:
         :return: The created project, or the operation's ``op_id`` if ``wait_for_completion`` is
             ``False``.
         """
-        project = _as_project_like(project)
-        name = project.metadata.name
+        project_like = _as_project_like(project)
+        name = project_like.metadata.name
         response = self._send_request(
             "POST",
             orca_projects.PROJECTS_ENDPOINT,
             f"Failed creating project {name} in Orca",
-            json=orca_projects.create_project_wire(project),
+            json=orca_projects.create_project_wire(project_like),
         )
         return self._settle(name, response, wait_for_completion)
 
     def update_project(
-        self, name: str, project, wait_for_completion: bool = True
+        self, name: str, project: ProjectInput, wait_for_completion: bool = True
     ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
         """Update (``PUT``) a project directly in Orca.
 
@@ -128,20 +132,20 @@ class OrcaProjectsClient:
         :return: The updated project, or the operation's ``op_id`` if ``wait_for_completion`` is
             ``False``.
         """
-        project = _as_project_like(project)
-        prev_op_id = self._resolve_prev_op_id(name, project)
+        project_like = _as_project_like(project)
+        prev_op_id = self._resolve_prev_op_id(name, project_like)
         response = self._send_request(
             "PUT",
             orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
             f"Failed updating project {name} in Orca",
-            json=orca_projects.update_project_wire(project, prev_op_id),
+            json=orca_projects.update_project_wire(project_like, prev_op_id),
         )
         return self._settle(name, response, wait_for_completion)
 
     def patch_project(
         self,
         name: str,
-        project,
+        project: ProjectInput,
         patch_mode: mlrun.common.schemas.PatchMode = mlrun.common.schemas.PatchMode.replace,
         wait_for_completion: bool = True,
     ) -> typing.Union["mlrun.projects.MlrunProject", uuid.UUID]:
@@ -163,7 +167,7 @@ class OrcaProjectsClient:
         :return: The patched project, or the operation's ``op_id`` if ``wait_for_completion`` is
             ``False``.
         """
-        project = _as_project_like(project)
+        project_like = _as_project_like(project)
         current = self._get_project_schema(name)
         merged_common = {
             "labels": dict(current.metadata.labels or {}),
@@ -172,16 +176,16 @@ class OrcaProjectsClient:
             "description": current.spec.description,
         }
         patch_common = {
-            "labels": project.metadata.labels,
-            "annotations": project.metadata.annotations,
-            "owner": project.spec.owner,
-            "description": project.spec.description,
+            "labels": project_like.metadata.labels,
+            "annotations": project_like.metadata.annotations,
+            "owner": project_like.spec.owner,
+            "description": project_like.spec.description,
         }
         patch_common = {k: v for k, v in patch_common.items() if v is not None}
         mergedeep.merge(
             merged_common, patch_common, strategy=patch_mode.to_mergedeep_strategy()
         )
-        merged_project = types.SimpleNamespace(
+        merged_project: orca_projects.ProjectLike = types.SimpleNamespace(
             metadata=types.SimpleNamespace(
                 name=name,
                 labels=merged_common["labels"],
@@ -268,7 +272,9 @@ class OrcaProjectsClient:
         self._wait_for_op(name, op_id)
         return self.get_project(name)
 
-    def _resolve_prev_op_id(self, name: str, project) -> uuid.UUID | None:
+    def _resolve_prev_op_id(
+        self, name: str, project: orca_projects.ProjectLike
+    ) -> uuid.UUID | None:
         # The CAS witness Orca requires for an update is the last op_id the caller observed; if
         # the caller didn't supply one, read the current state from Orca first (matches the
         # HLD's "client reads the project, then PUT/PATCH with prev_op_id" contract). A missing

--- a/mlrun/db/orca.py
+++ b/mlrun/db/orca.py
@@ -194,7 +194,7 @@ class OrcaProjectsClient:
         """Patch (partial update) a project directly in Orca.
 
         Orca's ``PATCH`` is full-replace, not merge (same required fields, same semantics as its
-        ``PUT`` - see orca SDK PR #1059), unlike MLRun's own ``patch_project``, which merges only
+        ``PUT``), unlike MLRun's own ``patch_project``, which merges only
         the given fields into the existing stored project. To preserve that partial-patch
         contract, this reads the project's current common-set fields from Orca first, merges
         ``project``'s changes into them the same way MLRun's own server does

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1311,11 +1311,12 @@ class ProjectSpec(ModelObj):
 
 
 class ProjectStatus(ModelObj):
+    """Project state as last synced from the leader. ``op_id`` is the CAS witness Orca's
+    project-sync expects back on the next update/patch (see ``mlrun.utils.orca_client``).
+    """
+
     def __init__(self, state=None, op_id=None):
         self.state = state
-        # The CAS witness Orca's project-sync expects back on the next update/patch as
-        # prev_op_id (see mlrun.utils.orca_client) - must round-trip through
-        # get_project()/save() unchanged, not just carry within a single request/response.
         self.op_id = op_id
 
 

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1311,8 +1311,12 @@ class ProjectSpec(ModelObj):
 
 
 class ProjectStatus(ModelObj):
-    def __init__(self, state=None):
+    def __init__(self, state=None, op_id=None):
         self.state = state
+        # The CAS witness Orca's project-sync expects back on the next update/patch as
+        # prev_op_id (see mlrun.utils.orca_client) - must round-trip through
+        # get_project()/save() unchanged, not just carry within a single request/response.
+        self.op_id = op_id
 
 
 class MlrunProject(ModelObj):

--- a/mlrun/projects/project.py
+++ b/mlrun/projects/project.py
@@ -1319,6 +1319,19 @@ class ProjectStatus(ModelObj):
         self.state = state
         self.op_id = op_id
 
+    @property
+    def op_id(self) -> str | None:
+        return self._op_id
+
+    @op_id.setter
+    def op_id(self, op_id):
+        # normalized to str (not left as a uuid.UUID) so this round-trips through
+        # to_yaml()/to_dict() like every other MlrunProject field - yaml.safe_dump has no
+        # representer for UUID. A property (not just __init__ normalization) because
+        # ModelObj.from_dict() reconstructs via cls() + setattr() per field, bypassing
+        # __init__ entirely.
+        self._op_id = str(op_id) if op_id else None
+
 
 class MlrunProject(ModelObj):
     kind = "project"

--- a/mlrun/utils/orca_client.py
+++ b/mlrun/utils/orca_client.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared orchestration for Orca's project-sync operations.
+
+The sequence of requests create/update/patch/delete/get make, and how each polls to a terminal
+state - shared between MLRun's server-side Orca leader-proxy
+(``server/py/framework/utils/clients/iguazio/v4.py``) and MLRun's SDK-direct-to-Orca client
+(``mlrun/db/orca.py``), so neither maintains its own copy of "what request to make when". The
+two callers only differ in how they actually send an authenticated request - the SDK uses its
+own held credentials, the leader-proxy relays the acting user's identity - so that's the one
+thing each supplies via :class:`RequestSender`. See :mod:`mlrun.utils.orca_projects` for the
+wire protocol these requests carry.
+"""
+
+import types
+import typing
+import uuid
+
+import mergedeep
+import requests
+
+import mlrun.common.schemas
+import mlrun.errors
+import mlrun.utils.helpers
+import mlrun.utils.orca_projects as orca_projects
+
+
+class RequestSender(typing.Protocol):
+    """Sends one authenticated request to an Orca endpoint and returns the response, having
+    already applied the caller's own status-code-to-exception mapping. Each caller of
+    :class:`OrcaProjectsOrchestrator` supplies its own - see
+    ``mlrun.db.orca.OrcaProjectsClient._send_request`` (SDK, own credentials) and
+    ``server/py/framework/utils/clients/iguazio/v4.py``'s ``Client._send_project_request``
+    (server, relays the acting user's identity).
+    """
+
+    def __call__(
+        self, method: str, path: str, error_message: str, **kwargs
+    ) -> requests.Response: ...
+
+
+class OrcaProjectsOrchestrator:
+    """The sequence of Orca requests behind create/update/patch/delete/get, and how each polls
+    to completion. Returns raw pieces (responses, op_ids, schema objects) rather than any one
+    caller's own public return contract - callers adapt those into whatever shape their own
+    interface promises (e.g. the SDK returns ``mlrun.projects.MlrunProject``/``op_id``; the
+    server-side leader-proxy returns ``bool``/``None`` per ``project_leader.Member``).
+    """
+
+    def __init__(
+        self,
+        send_request: RequestSender,
+        logger,
+        poll_interval_seconds: float,
+        poll_timeout_seconds: float,
+    ):
+        self._send_request = send_request
+        self._logger = logger
+        self._poll_interval_seconds = poll_interval_seconds
+        self._poll_timeout_seconds = poll_timeout_seconds
+
+    def create(
+        self, project: orca_projects.ProjectLike
+    ) -> tuple[requests.Response, uuid.UUID | str]:
+        """``POST`` a new project - always async per the HLD (no synchronous-create case).
+
+        :return: The raw response, and the minted ``op_id``.
+        """
+        name = project.metadata.name
+        self._logger.debug("Creating project in Orca", project=name)
+        response = self._send_request(
+            "POST",
+            orca_projects.PROJECTS_ENDPOINT,
+            f"Failed creating project {name} in Orca",
+            json=orca_projects.create_project_wire(project),
+        )
+        return response, response.json()["status"]["opId"]
+
+    def update(
+        self, name: str, project: orca_projects.ProjectLike
+    ) -> tuple[requests.Response, uuid.UUID | str]:
+        """``PUT`` a project's desired state. Resolves the CAS witness (``prev_op_id``) first
+        if the caller didn't supply one. May settle synchronously (200) or asynchronously (202)
+        per the HLD.
+
+        :return: The raw response, and the ``op_id`` this update minted.
+        """
+        prev_op_id = self.resolve_prev_op_id(name, project)
+        self._logger.debug("Updating project in Orca", name=name, prev_op_id=prev_op_id)
+        response = self._send_request(
+            "PUT",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed updating project {name} in Orca",
+            json=orca_projects.update_project_wire(project, prev_op_id),
+        )
+        return response, response.json()["status"]["opId"]
+
+    def patch(
+        self,
+        name: str,
+        project: orca_projects.ProjectLike,
+        patch_mode: mlrun.common.schemas.PatchMode,
+    ) -> tuple[requests.Response, uuid.UUID | str]:
+        """``PATCH`` a project. Orca's ``PATCH`` is full-replace, not merge (see
+        :mod:`mlrun.utils.orca_projects`), so this reads the project's current state first and
+        merges ``project``'s changes into it (:mod:`mergedeep`, keyed by ``patch_mode``) before
+        sending the merged result as a full object.
+
+        :return: The raw response, and the ``op_id`` this patch minted.
+        """
+        current = self.get(name)
+        merged = _merge_for_patch(current, project, patch_mode)
+        response = self._send_request(
+            "PATCH",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed patching project {name} in Orca",
+            json=orca_projects.update_project_wire(merged, current.status.op_id),
+        )
+        return response, response.json()["status"]["opId"]
+
+    def delete(self, name: str) -> requests.Response:
+        """``DELETE`` a project. Callers handle any deletion-strategy short-circuit themselves
+        before calling this - Orca's ``DeleteProjectOptions`` has no strategy concept yet.
+        """
+        self._logger.debug("Deleting project in Orca", name=name)
+        return self._send_request(
+            "DELETE",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed deleting project {name} in Orca",
+        )
+
+    def get(self, name: str) -> mlrun.common.schemas.Project:
+        """``GET`` a project."""
+        response = self._send_request(
+            "GET",
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            f"Failed getting project {name} from Orca",
+        )
+        return orca_projects.project_from_wire(response.json())
+
+    def settle(
+        self,
+        name: str,
+        response: requests.Response,
+        op_id: uuid.UUID | str,
+        wait_for_completion: bool,
+    ) -> mlrun.common.schemas.Project | None:
+        """Decide whether a create/update/patch response needs polling, and return the final
+        project once it's known - or ``None`` if the caller didn't ask to wait.
+
+        ``wait_for_completion=False`` always returns ``None`` immediately, regardless of how the
+        response actually settled - callers that asked not to wait get nothing further to look
+        at here; ``op_id`` (already returned by :meth:`create`/:meth:`update`/:meth:`patch`) is
+        their handle to check later. A synchronous (non-202) response is already terminal, so
+        this fetches nothing further and parses the project out of it directly; a 202 is polled
+        to a terminal state via :meth:`wait_for_op`, then the final project is fetched fresh.
+        """
+        if not wait_for_completion:
+            return None
+        if response.status_code != requests.codes.accepted:
+            return orca_projects.project_from_wire(response.json())
+        self.wait_for_op(name, op_id)
+        return self.get(name)
+
+    def resolve_prev_op_id(
+        self, name: str, project: orca_projects.ProjectLike
+    ) -> uuid.UUID | str | None:
+        # The CAS witness Orca requires for an update is the last op_id the caller observed; if
+        # the caller didn't supply one, read the current state from Orca first (matches the
+        # HLD's "client reads the project, then PUT/PATCH with prev_op_id" contract). A missing
+        # project (an upsert-create case: PUT on a project that doesn't exist yet) has no prior
+        # op_id to CAS against - fall through with None.
+        prev_op_id = getattr(getattr(project, "status", None), "op_id", None)
+        if prev_op_id:
+            return prev_op_id
+        try:
+            return self.get(name).status.op_id
+        except mlrun.errors.MLRunNotFoundError:
+            return None
+
+    def wait_for_op(self, name: str, op_id: uuid.UUID | str) -> None:
+        """Poll the sync-project trackable action for ``op_id`` to a terminal state.
+
+        :raises mlrun.errors.MLRunRuntimeError: if the action fails or the poll times out.
+        """
+        self._logger.debug(
+            "Waiting for Orca sync-project action to reach a terminal state",
+            name=name,
+            op_id=op_id,
+        )
+        try:
+            mlrun.utils.helpers.retry_until_successful(
+                self._poll_interval_seconds,
+                self._poll_timeout_seconds,
+                self._logger,
+                False,
+                self._verify_op_terminal,
+                name,
+                op_id,
+                fatal_exceptions=(orca_projects.OrcaActionFailedError,),
+            )
+        except orca_projects.OrcaActionFailedError as exc:
+            raise mlrun.errors.MLRunRuntimeError(str(exc)) from exc
+
+    def _verify_op_terminal(self, name: str, op_id: uuid.UUID | str) -> None:
+        response = self._send_request(
+            "GET",
+            orca_projects.ACTION_EXECUTIONS_ENDPOINT,
+            "Failed getting Orca sync-project action execution",
+            params=orca_projects.action_execution_query_params(op_id),
+        )
+        orca_projects.verify_action_execution_terminal(response.json(), name, op_id)
+
+
+def _merge_for_patch(
+    current: mlrun.common.schemas.Project,
+    project: orca_projects.ProjectLike,
+    patch_mode: mlrun.common.schemas.PatchMode,
+) -> orca_projects.ProjectLike:
+    merged_common = {
+        "labels": dict(current.metadata.labels or {}),
+        "annotations": dict(current.metadata.annotations or {}),
+        "owner": current.spec.owner,
+        "description": current.spec.description,
+    }
+    patch_common = {
+        "labels": project.metadata.labels,
+        "annotations": project.metadata.annotations,
+        "owner": project.spec.owner,
+        "description": project.spec.description,
+    }
+    patch_common = {k: v for k, v in patch_common.items() if v is not None}
+    mergedeep.merge(
+        merged_common, patch_common, strategy=patch_mode.to_mergedeep_strategy()
+    )
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(
+            name=current.metadata.name,
+            labels=merged_common["labels"],
+            annotations=merged_common["annotations"],
+        ),
+        spec=types.SimpleNamespace(
+            owner=merged_common["owner"],
+            description=merged_common["description"],
+        ),
+    )

--- a/mlrun/utils/orca_client.py
+++ b/mlrun/utils/orca_client.py
@@ -73,7 +73,7 @@ class OrcaProjectsOrchestrator:
     def create(
         self, project: orca_projects.ProjectLike
     ) -> tuple[requests.Response, uuid.UUID | str]:
-        """``POST`` a new project - always async per the HLD (no synchronous-create case).
+        """``POST`` a new project - always async (no synchronous-create case).
 
         :return: The raw response, and the minted ``op_id``.
         """
@@ -91,8 +91,7 @@ class OrcaProjectsOrchestrator:
         self, name: str, project: orca_projects.ProjectLike
     ) -> tuple[requests.Response, uuid.UUID | str]:
         """``PUT`` a project's desired state. Resolves the CAS witness (``prev_op_id``) first
-        if the caller didn't supply one. May settle synchronously (200) or asynchronously (202)
-        per the HLD.
+        if the caller didn't supply one. May settle synchronously (200) or asynchronously (202).
 
         :return: The raw response, and the ``op_id`` this update minted.
         """
@@ -177,8 +176,8 @@ class OrcaProjectsOrchestrator:
         self, name: str, project: orca_projects.ProjectLike
     ) -> uuid.UUID | str | None:
         # The CAS witness Orca requires for an update is the last op_id the caller observed; if
-        # the caller didn't supply one, read the current state from Orca first (matches the
-        # HLD's "client reads the project, then PUT/PATCH with prev_op_id" contract). A missing
+        # the caller didn't supply one, read the current state from Orca first (client reads
+        # the project, then PUT/PATCH with prev_op_id). A missing
         # project (an upsert-create case: PUT on a project that doesn't exist yet) has no prior
         # op_id to CAS against - fall through with None.
         prev_op_id = getattr(getattr(project, "status", None), "op_id", None)

--- a/mlrun/utils/orca_projects.py
+++ b/mlrun/utils/orca_projects.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Orca projects wire protocol, shared between MLRun's server-side Orca leader-proxy
 (server/py/framework/utils/clients/iguazio/v4.py) and MLRun's SDK-direct-to-Orca project client
-(mlrun/db/clients/orca.py). Kept here rather than in either caller so neither implementation can
-drift from Orca's actual contract.
+(mlrun/db/orca.py). Kept here rather than in either caller so neither implementation can drift
+from Orca's actual contract.
 """
 
 import uuid
@@ -41,7 +41,11 @@ class OrcaActionFailedError(Exception):
 
 def create_project_wire(project: mlrun.common.schemas.Project) -> dict:
     """Build Orca's flat CreateProjectOptions body: name is required, everything else - owner
-    included, Orca derives it from the authenticated caller when omitted - is optional."""
+    included, Orca derives it from the authenticated caller when omitted - is optional.
+
+    :param project: The project to create.
+    :return: The JSON-serializable request body for Orca's ``POST /projects`` endpoint.
+    """
     wire = {"name": project.metadata.name}
     if project.spec.owner:
         wire["owner"] = project.spec.owner
@@ -58,7 +62,13 @@ def update_project_wire(
     project: mlrun.common.schemas.Project, prev_op_id: uuid.UUID | None
 ) -> dict:
     """Build Orca's flat UpdateProjectOptions body: prevOpId/owner are required by Orca's contract,
-    so a missing value is sent through as-is and surfaces as a real validation error from Orca."""
+    so a missing value is sent through as-is and surfaces as a real validation error from Orca.
+
+    :param project: The project's desired state to update to.
+    :param prev_op_id: The CAS witness - the ``op_id`` last observed by the caller, or ``None``
+        for a PUT that upserts a project that doesn't exist yet.
+    :return: The JSON-serializable request body for Orca's ``PUT``/``PATCH /projects/{name}``.
+    """
     wire = {
         "prevOpId": str(prev_op_id) if prev_op_id else None,
         "owner": project.spec.owner,
@@ -75,7 +85,11 @@ def update_project_wire(
 def project_from_wire(body: dict) -> mlrun.common.schemas.Project:
     """Parse an Orca project response body. Orca's wire format is camelCase (the SDK schemas
     camelize every field), so this can't just pydantic-validate the body directly - op_id/updated_at
-    need explicit remapping."""
+    need explicit remapping.
+
+    :param body: The parsed JSON body of an Orca project response.
+    :return: The equivalent :class:`mlrun.common.schemas.Project`.
+    """
     metadata = body.get("metadata", {})
     spec = body.get("spec", {})
     status = body.get("status", {})
@@ -99,7 +113,11 @@ def project_from_wire(body: dict) -> mlrun.common.schemas.Project:
 
 def action_execution_query_params(op_id: uuid.UUID | str) -> dict:
     """Query params for ``GET .../trackable-actions/executions`` to find the sync-project action for
-    ``op_id``."""
+    ``op_id``.
+
+    :param op_id: The operation id to filter the trackable-action execution by.
+    :return: The query params for the request.
+    """
     return {
         "correlationId": str(op_id),
         "actionType": PROJECT_SYNC_ACTION_TYPE,
@@ -117,6 +135,10 @@ def verify_action_execution_terminal(
     :class:`mlrun.errors.MLRunRuntimeError` if it hasn't reached a terminal state yet (including "not
     observed yet") - callers drive the retry/poll loop and treat that as still-in-progress, not
     failure.
+
+    :param body: The parsed JSON body of a ``GET .../trackable-actions/executions`` response.
+    :param name: The project name, for error messages only.
+    :param op_id: The operation id being awaited, for error messages only.
     """
     items = body.get("items", [])
     if not items:

--- a/mlrun/utils/orca_projects.py
+++ b/mlrun/utils/orca_projects.py
@@ -60,6 +60,13 @@ class ProjectLike(typing.Protocol):
     :class:`~mlrun.projects.MlrunProject`, :class:`mlrun.common.schemas.Project`, and the
     ``types.SimpleNamespace`` :func:`mlrun.db.orca._as_project_like` builds from a dict - the
     three shapes MLRun's own project CUD API already accepts interchangeably.
+
+    Deliberately duck-typed rather than always coercing to a real
+    :class:`mlrun.common.schemas.Project` (e.g. via pydantic's validation-skipping
+    ``Model.construct()``): this package binds the pydantic-v1 face of that schema in the SDK
+    but the API server binds native pydantic-v2 (see ``mlrun.common.schemas._dispatch``) - CI
+    guarantees the two faces have the same fields, but not that every pydantic-version-specific
+    API behaves identically across them, so this avoids leaning on one at all.
     """
 
     metadata: ProjectMetadataLike

--- a/mlrun/utils/orca_projects.py
+++ b/mlrun/utils/orca_projects.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Orca projects wire protocol, shared between MLRun's server-side Orca leader-proxy
+(server/py/framework/utils/clients/iguazio/v4.py) and MLRun's SDK-direct-to-Orca project client
+(mlrun/db/clients/orca.py). Kept here rather than in either caller so neither implementation can
+drift from Orca's actual contract.
+"""
+
+import uuid
+
+import mlrun.common.schemas
+import mlrun.errors
+
+# Orca's project endpoints - reached via the same iguazio_api_url used for auth/token operations. The
+# path is doubled ("projects/projects") because Orca's route registry combines the "projects"
+# subdomain with that subdomain's own "/projects" resource path.
+PROJECTS_ENDPOINT = "v1/projects/projects"
+PROJECT_ENDPOINT_TEMPLATE = "v1/projects/projects/{name}"
+ACTION_EXECUTIONS_ENDPOINT = "v1/trackable-actions/executions"
+
+# The project-sync driver publishes a "sync-project" trackable action, keyed by op_id as its
+# correlation_id, on the "projects" subdomain's ActionRunner - see orca SDK PR #1059.
+PROJECT_SYNC_ACTION_TYPE = "sync-project"
+PROJECT_SYNC_SUBDOMAIN = "projects"
+
+
+class OrcaActionFailedError(Exception):
+    """Raised when the sync-project trackable action for an op_id reaches a terminal 'failed' state."""
+
+
+def create_project_wire(project: mlrun.common.schemas.Project) -> dict:
+    """Build Orca's flat CreateProjectOptions body: name is required, everything else - owner
+    included, Orca derives it from the authenticated caller when omitted - is optional."""
+    wire = {"name": project.metadata.name}
+    if project.spec.owner:
+        wire["owner"] = project.spec.owner
+    if project.spec.description:
+        wire["description"] = project.spec.description
+    if project.metadata.labels:
+        wire["labels"] = project.metadata.labels
+    if project.metadata.annotations:
+        wire["annotations"] = project.metadata.annotations
+    return wire
+
+
+def update_project_wire(
+    project: mlrun.common.schemas.Project, prev_op_id: uuid.UUID | None
+) -> dict:
+    """Build Orca's flat UpdateProjectOptions body: prevOpId/owner are required by Orca's contract,
+    so a missing value is sent through as-is and surfaces as a real validation error from Orca."""
+    wire = {
+        "prevOpId": str(prev_op_id) if prev_op_id else None,
+        "owner": project.spec.owner,
+    }
+    if project.spec.description:
+        wire["description"] = project.spec.description
+    if project.metadata.labels:
+        wire["labels"] = project.metadata.labels
+    if project.metadata.annotations:
+        wire["annotations"] = project.metadata.annotations
+    return wire
+
+
+def project_from_wire(body: dict) -> mlrun.common.schemas.Project:
+    """Parse an Orca project response body. Orca's wire format is camelCase (the SDK schemas
+    camelize every field), so this can't just pydantic-validate the body directly - op_id/updated_at
+    need explicit remapping."""
+    metadata = body.get("metadata", {})
+    spec = body.get("spec", {})
+    status = body.get("status", {})
+    return mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(
+            name=metadata["name"],
+            labels=metadata.get("labels") or {},
+            annotations=metadata.get("annotations") or {},
+        ),
+        spec=mlrun.common.schemas.ProjectSpec(
+            owner=spec.get("owner"),
+            description=spec.get("description"),
+        ),
+        status=mlrun.common.schemas.ProjectStatus(
+            state=status.get("state"),
+            op_id=status.get("opId"),
+            updated_at=status.get("updatedAt"),
+        ),
+    )
+
+
+def action_execution_query_params(op_id: uuid.UUID | str) -> dict:
+    """Query params for ``GET .../trackable-actions/executions`` to find the sync-project action for
+    ``op_id``."""
+    return {
+        "correlationId": str(op_id),
+        "actionType": PROJECT_SYNC_ACTION_TYPE,
+        "subdomain": PROJECT_SYNC_SUBDOMAIN,
+        "limit": 1,
+    }
+
+
+def verify_action_execution_terminal(
+    body: dict, name: str, op_id: uuid.UUID | str
+) -> None:
+    """Interpret a trackable-action executions response body for one sync-project op_id.
+
+    Raises :class:`OrcaActionFailedError` if the action failed. Raises
+    :class:`mlrun.errors.MLRunRuntimeError` if it hasn't reached a terminal state yet (including "not
+    observed yet") - callers drive the retry/poll loop and treat that as still-in-progress, not
+    failure.
+    """
+    items = body.get("items", [])
+    if not items:
+        raise mlrun.errors.MLRunRuntimeError(
+            f"No Orca sync-project action observed yet for project {name} (op_id={op_id})"
+        )
+    state = items[0].get("status", {}).get("state")
+    if state == "failed":
+        raise OrcaActionFailedError(
+            f"Orca sync-project action for project {name} (op_id={op_id}) failed"
+        )
+    if state != "succeeded":
+        raise mlrun.errors.MLRunRuntimeError(
+            f"Orca sync-project action for project {name} (op_id={op_id}) is still in "
+            f"progress (state={state})"
+        )

--- a/mlrun/utils/orca_projects.py
+++ b/mlrun/utils/orca_projects.py
@@ -17,6 +17,7 @@
 from Orca's actual contract.
 """
 
+import typing
 import uuid
 
 import mlrun.common.schemas
@@ -39,7 +40,33 @@ class OrcaActionFailedError(Exception):
     """Raised when the sync-project trackable action for an op_id reaches a terminal 'failed' state."""
 
 
-def create_project_wire(project: mlrun.common.schemas.Project) -> dict:
+class ProjectMetadataLike(typing.Protocol):
+    """Structural shape of a project's ``metadata`` this module's wire functions need."""
+
+    name: str | None
+    labels: dict | None
+    annotations: dict | None
+
+
+class ProjectSpecLike(typing.Protocol):
+    """Structural shape of a project's ``spec`` this module's wire functions need."""
+
+    owner: str | None
+    description: str | None
+
+
+class ProjectLike(typing.Protocol):
+    """Structural shape ``create_project_wire``/``update_project_wire`` need. Satisfied by
+    :class:`~mlrun.projects.MlrunProject`, :class:`mlrun.common.schemas.Project`, and the
+    ``types.SimpleNamespace`` :func:`mlrun.db.orca._as_project_like` builds from a dict - the
+    three shapes MLRun's own project CUD API already accepts interchangeably.
+    """
+
+    metadata: ProjectMetadataLike
+    spec: ProjectSpecLike
+
+
+def create_project_wire(project: ProjectLike) -> dict:
     """Build Orca's flat CreateProjectOptions body: name is required, everything else - owner
     included, Orca derives it from the authenticated caller when omitted - is optional.
 
@@ -58,9 +85,7 @@ def create_project_wire(project: mlrun.common.schemas.Project) -> dict:
     return wire
 
 
-def update_project_wire(
-    project: mlrun.common.schemas.Project, prev_op_id: uuid.UUID | None
-) -> dict:
+def update_project_wire(project: ProjectLike, prev_op_id: uuid.UUID | None) -> dict:
     """Build Orca's flat UpdateProjectOptions body: prevOpId/owner are required by Orca's contract,
     so a missing value is sent through as-is and surfaces as a real validation error from Orca.
 

--- a/mlrun/utils/orca_projects.py
+++ b/mlrun/utils/orca_projects.py
@@ -31,7 +31,7 @@ PROJECT_ENDPOINT_TEMPLATE = "v1/projects/projects/{name}"
 ACTION_EXECUTIONS_ENDPOINT = "v1/trackable-actions/executions"
 
 # The project-sync driver publishes a "sync-project" trackable action, keyed by op_id as its
-# correlation_id, on the "projects" subdomain's ActionRunner - see orca SDK PR #1059.
+# correlation_id, on the "projects" subdomain's ActionRunner.
 PROJECT_SYNC_ACTION_TYPE = "sync-project"
 PROJECT_SYNC_SUBDOMAIN = "projects"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,5 @@ pyjwt~=2.10
 jsonpath-ng~=1.7
 uuid_utils~=0.14.1
 cachetools~=6.2
+# used to parse human-friendly duration config values (e.g. "2 seconds") for the SDK-direct Orca client
+humanfriendly~=10.0

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -393,13 +393,9 @@ class Client(BaseClient, project_leader.Member):
     def _orca_orchestrator(
         self, auth_info: mlrun.common.schemas.AuthInfo
     ) -> orca_client.OrcaProjectsOrchestrator:
-        # The actual sequence of Orca requests (what to call, in what order, how to poll to a
-        # terminal state) is shared with mlrun's SDK-direct-to-Orca client
-        # (mlrun/db/orca.py) - see mlrun.utils.orca_client. The two differ only in how they
-        # send an authenticated request: this relays the acting user's identity (auth_info),
-        # which changes per call, so a fresh orchestrator is built per call rather than cached
-        # on self like _session/_poll_interval_seconds - it's a cheap object holding no I/O
-        # state of its own.
+        # auth_info changes per call (this relays the acting user's identity), so a fresh
+        # orchestrator is built per call rather than cached on self like _session/
+        # _poll_interval_seconds - it's a cheap object holding no I/O state of its own.
         return orca_client.OrcaProjectsOrchestrator(
             lambda method, path, error_message, **kwargs: self._send_project_request(
                 method, path, error_message, auth_info, **kwargs

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -14,7 +14,6 @@
 import datetime
 import tempfile
 import typing
-import uuid
 
 import httpx
 import humanfriendly
@@ -31,6 +30,7 @@ import mlrun.common.types
 import mlrun.errors
 import mlrun.utils
 import mlrun.utils.helpers
+import mlrun.utils.orca_projects as orca_projects
 from mlrun.utils import get_in
 
 import framework.utils.clients.helpers as clients_helpers
@@ -40,23 +40,6 @@ from framework.utils.clients.iguazio.base import BaseAsyncClient, BaseClient
 
 _GROUP_TYPE_KEY = "@type"
 _GROUP_TYPE_VALUE = "type.googleapis.com/usergroup.Group"
-
-# Orca's project endpoints - Orca is the IG4/Oris API service, reached via the same iguazio_api_url
-# this client already uses for auth/token operations. The path is doubled ("projects/projects") because
-# the route registry combines the "projects" subdomain with that subdomain's own "/projects" resource path.
-PROJECTS_ENDPOINT = "v1/projects/projects"
-PROJECT_ENDPOINT_TEMPLATE = "v1/projects/projects/{name}"
-ACTION_EXECUTIONS_ENDPOINT = "v1/trackable-actions/executions"
-
-# The project-sync driver publishes a "sync-project" trackable action, keyed by op_id as its
-# correlation_id, on the "projects" subdomain's ActionRunner - see orca SDK PR #1059.
-PROJECT_SYNC_ACTION_TYPE = "sync-project"
-PROJECT_SYNC_SUBDOMAIN = "projects"
-
-
-class _OrcaActionFailedError(Exception):
-    """Internal marker so _wait_for_op can stop polling immediately instead of waiting out the full
-    timeout on an action that has already terminally failed."""
 
 
 class Client(BaseClient, project_leader.Member):
@@ -302,10 +285,10 @@ class Client(BaseClient, project_leader.Member):
         self._logger.debug("Creating project in Orca", project=project.metadata.name)
         response = self._send_project_request(
             mlrun.common.types.HTTPMethod.POST,
-            PROJECTS_ENDPOINT,
+            orca_projects.PROJECTS_ENDPOINT,
             "Failed creating project in Orca",
             auth_info,
-            json=self._create_project_wire(project),
+            json=orca_projects.create_project_wire(project),
         )
 
         if not wait_for_completion:
@@ -332,10 +315,10 @@ class Client(BaseClient, project_leader.Member):
         self._logger.debug("Updating project in Orca", name=name, prev_op_id=prev_op_id)
         response = self._send_project_request(
             mlrun.common.types.HTTPMethod.PUT,
-            PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
             "Failed updating project in Orca",
             auth_info,
-            json=self._update_project_wire(project, prev_op_id),
+            json=orca_projects.update_project_wire(project, prev_op_id),
         )
 
         # the shared leader-client interface has no wait_for_completion for update, so always settle here to
@@ -360,7 +343,7 @@ class Client(BaseClient, project_leader.Member):
         )
         response = self._send_project_request(
             mlrun.common.types.HTTPMethod.DELETE,
-            PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
             "Failed deleting project in Orca",
             auth_info,
         )
@@ -382,11 +365,11 @@ class Client(BaseClient, project_leader.Member):
     ) -> mlrun.common.schemas.Project:
         response = self._send_project_request(
             mlrun.common.types.HTTPMethod.GET,
-            PROJECT_ENDPOINT_TEMPLATE.format(name=name),
+            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
             "Failed getting project from Orca",
             auth_info,
         )
-        return self._wire_to_project(response.json())
+        return orca_projects.project_from_wire(response.json())
 
     def list_projects(
         self,
@@ -465,9 +448,9 @@ class Client(BaseClient, project_leader.Member):
                 name,
                 op_id,
                 auth_info,
-                fatal_exceptions=(_OrcaActionFailedError,),
+                fatal_exceptions=(orca_projects.OrcaActionFailedError,),
             )
-        except _OrcaActionFailedError as exc:
+        except orca_projects.OrcaActionFailedError as exc:
             raise mlrun.errors.MLRunRuntimeError(str(exc)) from exc
 
     def _verify_op_terminal(
@@ -478,89 +461,12 @@ class Client(BaseClient, project_leader.Member):
     ) -> None:
         response = self._send_project_request(
             mlrun.common.types.HTTPMethod.GET,
-            ACTION_EXECUTIONS_ENDPOINT,
+            orca_projects.ACTION_EXECUTIONS_ENDPOINT,
             "Failed getting Orca sync-project action execution",
             auth_info,
-            params={
-                "correlationId": str(op_id),
-                "actionType": PROJECT_SYNC_ACTION_TYPE,
-                "subdomain": PROJECT_SYNC_SUBDOMAIN,
-                "limit": 1,
-            },
+            params=orca_projects.action_execution_query_params(op_id),
         )
-        items = response.json().get("items", [])
-        if not items:
-            raise mlrun.errors.MLRunRuntimeError(
-                f"No Orca sync-project action observed yet for project {name} (op_id={op_id})"
-            )
-        state = items[0].get("status", {}).get("state")
-        if state == "failed":
-            raise _OrcaActionFailedError(
-                f"Orca sync-project action for project {name} (op_id={op_id}) failed"
-            )
-        if state != "succeeded":
-            raise mlrun.errors.MLRunRuntimeError(
-                f"Orca sync-project action for project {name} (op_id={op_id}) is still in "
-                f"progress (state={state})"
-            )
-
-    @staticmethod
-    def _create_project_wire(project: mlrun.common.schemas.Project) -> dict:
-        # Matches Orca's flat CreateProjectOptions: name is required, everything else - owner included,
-        # the server derives it from the authenticated caller when omitted - is optional.
-        wire = {"name": project.metadata.name}
-        if project.spec.owner:
-            wire["owner"] = project.spec.owner
-        if project.spec.description:
-            wire["description"] = project.spec.description
-        if project.metadata.labels:
-            wire["labels"] = project.metadata.labels
-        if project.metadata.annotations:
-            wire["annotations"] = project.metadata.annotations
-        return wire
-
-    @staticmethod
-    def _update_project_wire(
-        project: mlrun.common.schemas.Project, prev_op_id: uuid.UUID | None
-    ) -> dict:
-        # Matches Orca's flat UpdateProjectOptions: prevOpId/owner are required by Orca's contract, so a
-        # missing value is sent through as-is and surfaces as a real validation error from Orca. The rest
-        # is optional.
-        wire = {
-            "prevOpId": str(prev_op_id) if prev_op_id else None,
-            "owner": project.spec.owner,
-        }
-        if project.spec.description:
-            wire["description"] = project.spec.description
-        if project.metadata.labels:
-            wire["labels"] = project.metadata.labels
-        if project.metadata.annotations:
-            wire["annotations"] = project.metadata.annotations
-        return wire
-
-    @staticmethod
-    def _wire_to_project(body: dict) -> mlrun.common.schemas.Project:
-        # Orca's wire format is camelCase (the SDK schemas camelize every field), so this can't just
-        # pydantic-validate the body directly - op_id/updated_at need explicit remapping.
-        metadata = body.get("metadata", {})
-        spec = body.get("spec", {})
-        status = body.get("status", {})
-        return mlrun.common.schemas.Project(
-            metadata=mlrun.common.schemas.ProjectMetadata(
-                name=metadata["name"],
-                labels=metadata.get("labels") or {},
-                annotations=metadata.get("annotations") or {},
-            ),
-            spec=mlrun.common.schemas.ProjectSpec(
-                owner=spec.get("owner"),
-                description=spec.get("description"),
-            ),
-            status=mlrun.common.schemas.ProjectStatus(
-                state=status.get("state"),
-                op_id=status.get("opId"),
-                updated_at=status.get("updatedAt"),
-            ),
-        )
+        orca_projects.verify_action_execution_terminal(response.json(), name, op_id)
 
     def _extract_response_error(
         self, response: httpx.Response

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -29,8 +29,7 @@ import mlrun.common.schemas
 import mlrun.common.types
 import mlrun.errors
 import mlrun.utils
-import mlrun.utils.helpers
-import mlrun.utils.orca_projects as orca_projects
+import mlrun.utils.orca_client as orca_client
 from mlrun.utils import get_in
 
 import framework.utils.clients.helpers as clients_helpers
@@ -282,20 +281,14 @@ class Client(BaseClient, project_leader.Member):
         :return: whether the operation is still running in the background (Orca is always async, so this
             is ``True`` unless the caller asked to wait and the operation already reached a terminal state).
         """
-        self._logger.debug("Creating project in Orca", project=project.metadata.name)
-        response = self._send_project_request(
-            mlrun.common.types.HTTPMethod.POST,
-            orca_projects.PROJECTS_ENDPOINT,
-            "Failed creating project in Orca",
-            auth_info,
-            json=orca_projects.create_project_wire(project),
-        )
-
+        orchestrator = self._orca_orchestrator(auth_info)
+        _, op_id = orchestrator.create(project)
         if not wait_for_completion:
             return True
-
-        op_id = response.json()["status"]["opId"]
-        self._wait_for_op(project.metadata.name, op_id, auth_info)
+        # this leader-proxy only ever needs to know the operation settled, not the resulting
+        # project (unlike the SDK-direct client, which returns it) - wait_for_op alone, not
+        # settle(), which would also fetch it via an extra, unneeded GET.
+        orchestrator.wait_for_op(project.metadata.name, op_id)
         return False
 
     def update_project(
@@ -305,26 +298,13 @@ class Client(BaseClient, project_leader.Member):
         project: mlrun.common.schemas.Project,
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ):
-        # the CAS witness Orca requires for an update is the last op_id the caller observed; if the caller
-        # didn't supply one, read the current state from Orca first (matches the HLD's "client reads the
-        # project, then PUT/PATCH with prev_op_id" contract)
-        prev_op_id = (
-            project.status.op_id
-            or self.get_project(session, name, auth_info).status.op_id
-        )
-        self._logger.debug("Updating project in Orca", name=name, prev_op_id=prev_op_id)
-        response = self._send_project_request(
-            mlrun.common.types.HTTPMethod.PUT,
-            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
-            "Failed updating project in Orca",
-            auth_info,
-            json=orca_projects.update_project_wire(project, prev_op_id),
-        )
-
-        # the shared leader-client interface has no wait_for_completion for update, so always settle here to
-        # match the legacy synchronous contract the caller expects
-        op_id = response.json()["status"]["opId"]
-        self._wait_for_op(name, op_id, auth_info)
+        orchestrator = self._orca_orchestrator(auth_info)
+        response, op_id = orchestrator.update(name, project)
+        # the shared leader-client interface has no wait_for_completion for update, so always wait here
+        # to match the legacy synchronous contract the caller expects. A synchronous (non-202) response
+        # is already terminal - nothing to poll for.
+        if response.status_code == requests.codes.accepted:
+            orchestrator.wait_for_op(name, op_id)
 
     def delete_project(
         self,
@@ -338,22 +318,15 @@ class Client(BaseClient, project_leader.Member):
             # Orca's DeleteProjectOptions has no strategy concept yet - a plain DELETE always deletes,
             # so a "check-only" caller must not fall through to that below.
             return False
-        self._logger.debug(
-            "Deleting project in Orca", name=name, deletion_strategy=deletion_strategy
-        )
-        response = self._send_project_request(
-            mlrun.common.types.HTTPMethod.DELETE,
-            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
-            "Failed deleting project in Orca",
-            auth_info,
-        )
+        orchestrator = self._orca_orchestrator(auth_info)
+        response = orchestrator.delete(name)
 
         if response.status_code == requests.codes.accepted:
             # 202: accepted, still converging - poll for completion
             if not wait_for_completion:
                 return True
             op_id = response.json()["status"]["opId"]
-            self._wait_for_op(name, op_id, auth_info)
+            orchestrator.wait_for_op(name, op_id)
 
         return False
 
@@ -363,13 +336,7 @@ class Client(BaseClient, project_leader.Member):
         name: str,
         auth_info: mlrun.common.schemas.AuthInfo = mlrun.common.schemas.AuthInfo(),
     ) -> mlrun.common.schemas.Project:
-        response = self._send_project_request(
-            mlrun.common.types.HTTPMethod.GET,
-            orca_projects.PROJECT_ENDPOINT_TEMPLATE.format(name=name),
-            "Failed getting project from Orca",
-            auth_info,
-        )
-        return orca_projects.project_from_wire(response.json())
+        return self._orca_orchestrator(auth_info).get(name)
 
     def list_projects(
         self,
@@ -423,50 +390,24 @@ class Client(BaseClient, project_leader.Member):
         kwargs.setdefault("timeout", 20)
         return self._send_request_to_api(method, path, error_message, **kwargs)
 
-    def _wait_for_op(
-        self,
-        name: str,
-        op_id: str,
-        auth_info: mlrun.common.schemas.AuthInfo,
-    ) -> None:
-        # The 2PC driver runs the whole operation (both phases, for create/delete) inside one dispatch of
-        # the "sync-project" trackable action, keyed by op_id as its correlation_id - so the action's own
-        # terminal state is a precise, direct done/failed signal. No need to re-fetch the project and infer
-        # completion from status.op_id/status.state (see orca SDK PR #1059's wait_for_completion).
-        self._logger.debug(
-            "Waiting for Orca sync-project action to reach a terminal state",
-            name=name,
-            op_id=op_id,
+    def _orca_orchestrator(
+        self, auth_info: mlrun.common.schemas.AuthInfo
+    ) -> orca_client.OrcaProjectsOrchestrator:
+        # The actual sequence of Orca requests (what to call, in what order, how to poll to a
+        # terminal state) is shared with mlrun's SDK-direct-to-Orca client
+        # (mlrun/db/orca.py) - see mlrun.utils.orca_client. The two differ only in how they
+        # send an authenticated request: this relays the acting user's identity (auth_info),
+        # which changes per call, so a fresh orchestrator is built per call rather than cached
+        # on self like _session/_poll_interval_seconds - it's a cheap object holding no I/O
+        # state of its own.
+        return orca_client.OrcaProjectsOrchestrator(
+            lambda method, path, error_message, **kwargs: self._send_project_request(
+                method, path, error_message, auth_info, **kwargs
+            ),
+            self._logger,
+            self._poll_interval_seconds,
+            self._poll_timeout_seconds,
         )
-        try:
-            mlrun.utils.helpers.retry_until_successful(
-                self._poll_interval_seconds,
-                self._poll_timeout_seconds,
-                self._logger,
-                False,
-                self._verify_op_terminal,
-                name,
-                op_id,
-                auth_info,
-                fatal_exceptions=(orca_projects.OrcaActionFailedError,),
-            )
-        except orca_projects.OrcaActionFailedError as exc:
-            raise mlrun.errors.MLRunRuntimeError(str(exc)) from exc
-
-    def _verify_op_terminal(
-        self,
-        name: str,
-        op_id: str,
-        auth_info: mlrun.common.schemas.AuthInfo,
-    ) -> None:
-        response = self._send_project_request(
-            mlrun.common.types.HTTPMethod.GET,
-            orca_projects.ACTION_EXECUTIONS_ENDPOINT,
-            "Failed getting Orca sync-project action execution",
-            auth_info,
-            params=orca_projects.action_execution_query_params(op_id),
-        )
-        orca_projects.verify_action_execution_terminal(response.json(), name, op_id)
 
     def _extract_response_error(
         self, response: httpx.Response

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -140,6 +140,9 @@ class ClientSpec(
             authentication_mode=self._get_config_value_if_not_default(
                 "httpdb.authentication.mode"
             ),
+            projects_leader=self._get_config_value_if_not_default(
+                "httpdb.projects.leader"
+            ),
             authorization_namespaces_mlrun=self._get_config_value_if_not_default(
                 "httpdb.authorization.namespaces.mlrun"
             ),

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -369,6 +369,23 @@ def test_client_spec_kfp_default_workflow_timeout(
     assert response.json()["kfp_default_workflow_timeout"] == "3600"
 
 
+def test_client_spec_includes_projects_leader_when_not_default(
+    db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
+) -> None:
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    assert response.json()["projects_leader"] is None
+
+    mlrun.mlconf.httpdb.projects.leader = "orca"
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    response = client.get("client-spec")
+    assert response.status_code == http.HTTPStatus.OK.value
+    assert response.json()["projects_leader"] == "orca"
+
+
 def test_client_spec_does_not_include_oauth_config_when_not_iguazio_v4_mode(
     db: sqlalchemy.orm.Session, client: fastapi.testclient.TestClient
 ) -> None:

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -699,8 +699,8 @@ def test_connect_invokes_init_token_provider_from_env():
 
 def test_connect_syncs_projects_leader_from_client_spec():
     """``connect()`` syncs the server's project-sync leader, so ``_orca_direct_mode()`` can
-    tell whether the API server has actually cut project CUD over to Orca (ML-12903) - the SDK
-    has no other way to observe that.
+    tell whether the API server has actually cut project CUD over to Orca - the SDK has no
+    other way to observe that.
     """
     mlrun.mlconf.httpdb.projects.leader = "mlrun"
     server_cfg = {"version": mlrun.mlconf.version, "projects_leader": "orca"}

--- a/tests/rundb/test_httpdb.py
+++ b/tests/rundb/test_httpdb.py
@@ -697,6 +697,19 @@ def test_connect_invokes_init_token_provider_from_env():
         db.connect()
 
 
+def test_connect_syncs_projects_leader_from_client_spec():
+    """``connect()`` syncs the server's project-sync leader, so ``_orca_direct_mode()`` can
+    tell whether the API server has actually cut project CUD over to Orca (ML-12903) - the SDK
+    has no other way to observe that.
+    """
+    mlrun.mlconf.httpdb.projects.leader = "mlrun"
+    server_cfg = {"version": mlrun.mlconf.version, "projects_leader": "orca"}
+    with _mock_httpdb_connect(server_cfg):
+        db = HTTPRunDB("http://some-server:1919")
+        db.connect()
+    assert mlrun.mlconf.httpdb.projects.leader == "orca"
+
+
 def test_connect_preserves_explicit_credentials_in_iguazio_v4(monkeypatch):
     """
     Explicit ``Credentials(token=...)`` own auth for the instance: ``connect()``

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -332,12 +332,15 @@ class TestHTTPRunDBOrcaGate:
         )
 
         with unittest.mock.patch.object(db, "api_call") as mock_api_call:
-            getattr(db, method_name)(*call_args, wait_for_completion=False)
+            getattr(db, method_name)(*call_args)
             assert not mock_api_call.called
 
+        # HTTPRunDB itself has no wait_for_completion knob (see ML-12903 discussion: no known
+        # SDK caller needs async project creation, and exposing it would only work in this one
+        # mode) - it always asks the Orca client to block until the operation settles.
         orca_method = getattr(fake_client, orca_method_name)
         orca_method.assert_called_once()
-        assert orca_method.call_args.kwargs["wait_for_completion"] is False
+        assert orca_method.call_args.kwargs["wait_for_completion"] is True
 
     def test_orca_direct_mode_patch_project_coerces_patch_mode(self, db):
         mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -313,9 +313,9 @@ class TestOrcaProjectsClient:
         )
 
         # a failed action is fatal - it should stop polling immediately, not retry until
-        # timeout (matches the identical, already-merged-and-CI-passing behavior of
-        # server/py/framework/utils/clients/iguazio/v4.py's _wait_for_op for the same case:
-        # retry_until_successful wraps a fatal_exceptions hit in MLRunRetryExhaustedError).
+        # timeout: OrcaProjectsOrchestrator.wait_for_op passes OrcaActionFailedError as a
+        # fatal_exception, so retry_until_successful wraps it in MLRunRetryExhaustedError
+        # instead of retrying.
         with pytest.raises(mlrun.errors.MLRunRetryExhaustedError):
             orca_client.delete_project("p8")
 
@@ -403,9 +403,9 @@ class TestHTTPRunDBOrcaGate:
             getattr(db, method_name)(*call_args)
             assert not mock_api_call.called
 
-        # HTTPRunDB itself has no wait_for_completion knob (see ML-12903 discussion: no known
-        # SDK caller needs async project creation, and exposing it would only work in this one
-        # mode) - it always asks the Orca client to block until the operation settles.
+        # HTTPRunDB itself has no wait_for_completion knob (ML-12903: no known SDK caller
+        # needs async project creation, and exposing it would only work in this one mode) -
+        # it always asks the Orca client to block until the operation settles.
         orca_method = getattr(fake_client, orca_method_name)
         orca_method.assert_called_once()
         assert orca_method.call_args.kwargs["wait_for_completion"] is True

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -173,6 +173,31 @@ class TestOrcaProjectsClient:
         ]
         assert not poll_requests, "a synchronous 200 has nothing to poll for"
 
+    def test_update_project_async_returns_op_id_even_if_settled_synchronously(
+        self, requests_mock, orca_client
+    ):
+        # regression guard: wait_for_completion=False must always return an op_id, never the
+        # project object - even when Orca happens to answer with a synchronous 200 (e.g. all
+        # followers acked within the request). The return type must depend only on the caller's
+        # wait_for_completion flag, never on a response detail the caller can't predict; a caller
+        # relying on getting back an identifier to poll on later must not silently receive a
+        # project object instead.
+        op_id = str(uuid.uuid4())
+        requests_mock.put(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p5b",
+            json=_project_wire_body("p5b", op_id, "online"),
+            status_code=200,
+        )
+
+        project = mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="p5b"),
+            spec=mlrun.common.schemas.ProjectSpec(owner="jsmith"),
+            status=mlrun.common.schemas.ProjectStatus(op_id=uuid.uuid4()),
+        )
+        result = orca_client.update_project("p5b", project, wait_for_completion=False)
+
+        assert result == op_id
+
     def test_patch_project_merges_with_current_state(self, requests_mock, orca_client):
         op_id = str(uuid.uuid4())
         current_body = {

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -46,8 +46,8 @@ def orca_client() -> mlrun.db.orca.OrcaProjectsClient:
     db = mlrun.db.httpdb.HTTPRunDB("https://fake-mlrun-url")
     client = mlrun.db.orca.OrcaProjectsClient(db)
     # keep polling fast in tests
-    client._poll_interval_seconds = 0.01
-    client._poll_timeout_seconds = 1
+    client._orchestrator._poll_interval_seconds = 0.01
+    client._orchestrator._poll_timeout_seconds = 1
     return client
 
 

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -72,11 +72,11 @@ class TestOrcaProjectsClient:
         result = orca_client.create_project(project)
 
         # regression guard: the public contract must return mlrun.projects.MlrunProject
-        # (matching the legacy MLRun-API path), not the internal wire-schema type - op_id is
-        # Orca-sync plumbing and deliberately absent from MlrunProject's own status object.
+        # (matching the legacy MLRun-API path), not the internal wire-schema type - and must
+        # still carry status.op_id, so a later save() can send it back as the CAS witness.
         assert isinstance(result, mlrun.projects.MlrunProject)
         assert result.metadata.name == "p1"
-        assert not hasattr(result.status, "op_id")
+        assert str(result.status.op_id) == op_id
 
         create_request = requests_mock.request_history[0]
         assert create_request.json() == {"name": "p1", "owner": "jsmith"}
@@ -149,6 +149,49 @@ class TestOrcaProjectsClient:
 
         put_request = [r for r in requests_mock.request_history if r.method == "PUT"][0]
         assert put_request.json()["prevOpId"] == op_id
+
+    def test_update_project_round_trip_preserves_op_id_from_get(
+        self, requests_mock, orca_client
+    ):
+        # regression guard: MlrunProject.status must round-trip op_id through
+        # get_project() -> mutate -> save(), so update_project sends the CAS witness the caller
+        # actually observed at fetch time - not one freshly re-resolved from Orca right before
+        # the write, which would defeat conflict detection entirely.
+        fetched_op_id = str(uuid.uuid4())
+        new_op_id = str(uuid.uuid4())
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p3b",
+            json=_project_wire_body("p3b", fetched_op_id, "online"),
+        )
+        requests_mock.put(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p3b",
+            json={"status": {"opId": new_op_id}},
+            status_code=202,
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/trackable-actions/executions",
+            json={"items": [{"status": {"state": "succeeded"}}]},
+        )
+
+        project = orca_client.get_project("p3b")
+        assert isinstance(project, mlrun.projects.MlrunProject)
+        assert str(project.status.op_id) == fetched_op_id
+        project.spec.description = "updated"
+
+        orca_client.update_project("p3b", project.to_dict())
+
+        history = requests_mock.request_history
+        put_index = next(i for i, r in enumerate(history) if r.method == "PUT")
+        gets_before_put = [
+            r
+            for r in history[:put_index]
+            if r.method == "GET" and "trackable-actions" not in r.url
+        ]
+        # exactly the original get_project() GET - resolve_prev_op_id must not need another one,
+        # since the mutated project already carried the op_id it observed
+        assert len(gets_before_put) == 1
+        put_request = history[put_index]
+        assert put_request.json()["prevOpId"] == fetched_op_id
 
     def test_update_project_synchronous_200_does_not_poll(
         self, requests_mock, orca_client

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -1,0 +1,368 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest.mock
+import uuid
+
+import pytest
+
+import mlrun.common.schemas
+import mlrun.db.httpdb
+import mlrun.db.orca
+import mlrun.errors
+import mlrun.projects.project
+
+ORCA_API_URL = "https://igz-api.example.com"
+
+
+def _project_wire_body(name: str, op_id: str, state: str) -> dict:
+    return {
+        "metadata": {"name": name, "labels": {}, "annotations": {}},
+        "spec": {"owner": "jsmith", "description": "desc"},
+        "status": {"state": state, "opId": op_id, "updatedAt": None},
+    }
+
+
+def _mlrun_project(name: str, owner: str | None = None) -> mlrun.projects.MlrunProject:
+    return mlrun.projects.MlrunProject(
+        metadata=mlrun.projects.project.ProjectMetadata(name=name),
+        spec=mlrun.projects.project.ProjectSpec(owner=owner),
+    )
+
+
+@pytest.fixture
+def orca_client() -> mlrun.db.orca.OrcaProjectsClient:
+    mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-mlrun-url")
+    client = mlrun.db.orca.OrcaProjectsClient(db)
+    # keep polling fast in tests
+    client._poll_interval_seconds = 0.01
+    client._poll_timeout_seconds = 1
+    return client
+
+
+class TestOrcaProjectsClient:
+    def test_create_project_waits_for_completion(self, requests_mock, orca_client):
+        op_id = str(uuid.uuid4())
+        requests_mock.post(
+            f"{ORCA_API_URL}/api/v1/projects/projects",
+            json={"status": {"opId": op_id}},
+            status_code=202,
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/trackable-actions/executions",
+            json={"items": [{"status": {"state": "succeeded"}}]},
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p1",
+            json=_project_wire_body("p1", op_id, "online"),
+        )
+
+        project = _mlrun_project("p1", owner="jsmith")
+        result = orca_client.create_project(project)
+
+        # regression guard: the public contract must return mlrun.projects.MlrunProject
+        # (matching the legacy MLRun-API path), not the internal wire-schema type - op_id is
+        # Orca-sync plumbing and deliberately absent from MlrunProject's own status object.
+        assert isinstance(result, mlrun.projects.MlrunProject)
+        assert result.metadata.name == "p1"
+        assert not hasattr(result.status, "op_id")
+
+        create_request = requests_mock.request_history[0]
+        assert create_request.json() == {"name": "p1", "owner": "jsmith"}
+
+    def test_create_project_async_returns_op_id_without_polling(
+        self, requests_mock, orca_client
+    ):
+        op_id = str(uuid.uuid4())
+        requests_mock.post(
+            f"{ORCA_API_URL}/api/v1/projects/projects",
+            json={"status": {"opId": op_id}},
+            status_code=202,
+        )
+
+        result = orca_client.create_project(
+            _mlrun_project("p2"), wait_for_completion=False
+        )
+
+        assert result == op_id
+        assert len(requests_mock.request_history) == 1
+
+    def test_update_project_uses_prev_op_id_from_status(
+        self, requests_mock, orca_client
+    ):
+        op_id = str(uuid.uuid4())
+        prev_op_id = uuid.uuid4()
+        requests_mock.put(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p3",
+            json={"status": {"opId": op_id}},
+            status_code=202,
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/trackable-actions/executions",
+            json={"items": [{"status": {"state": "succeeded"}}]},
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p3",
+            json=_project_wire_body("p3", op_id, "online"),
+        )
+
+        project = mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="p3"),
+            spec=mlrun.common.schemas.ProjectSpec(owner="jsmith"),
+            status=mlrun.common.schemas.ProjectStatus(op_id=prev_op_id),
+        )
+        orca_client.update_project("p3", project)
+
+        put_request = [r for r in requests_mock.request_history if r.method == "PUT"][0]
+        assert put_request.json()["prevOpId"] == str(prev_op_id)
+
+    def test_update_project_resolves_prev_op_id_via_get_when_missing(
+        self, requests_mock, orca_client
+    ):
+        op_id = str(uuid.uuid4())
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p4",
+            json=_project_wire_body("p4", op_id, "online"),
+        )
+        requests_mock.put(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p4",
+            json=_project_wire_body("p4", op_id, "online"),
+            status_code=200,
+        )
+
+        project = mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="p4"),
+            spec=mlrun.common.schemas.ProjectSpec(owner="jsmith"),
+        )
+        orca_client.update_project("p4", project)
+
+        put_request = [r for r in requests_mock.request_history if r.method == "PUT"][0]
+        assert put_request.json()["prevOpId"] == op_id
+
+    def test_update_project_synchronous_200_does_not_poll(
+        self, requests_mock, orca_client
+    ):
+        op_id = str(uuid.uuid4())
+        requests_mock.put(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p5",
+            json=_project_wire_body("p5", op_id, "online"),
+            status_code=200,
+        )
+
+        project = mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="p5"),
+            spec=mlrun.common.schemas.ProjectSpec(owner="jsmith"),
+            status=mlrun.common.schemas.ProjectStatus(op_id=uuid.uuid4()),
+        )
+        result = orca_client.update_project("p5", project)
+
+        assert isinstance(result, mlrun.projects.MlrunProject)
+        poll_requests = [
+            r for r in requests_mock.request_history if "trackable-actions" in r.url
+        ]
+        assert not poll_requests, "a synchronous 200 has nothing to poll for"
+
+    def test_patch_project_merges_with_current_state(self, requests_mock, orca_client):
+        op_id = str(uuid.uuid4())
+        current_body = {
+            "metadata": {
+                "name": "p6",
+                "labels": {"team": "ds"},
+                "annotations": {"note": "x"},
+            },
+            "spec": {"owner": "jsmith", "description": "old desc"},
+            "status": {"state": "online", "opId": op_id, "updatedAt": None},
+        }
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p6", json=current_body
+        )
+        requests_mock.patch(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p6",
+            json={"status": {"opId": op_id}},
+            status_code=202,
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/trackable-actions/executions",
+            json={"items": [{"status": {"state": "succeeded"}}]},
+        )
+
+        # only touches description and adds one label - owner, annotations, and the existing
+        # "team" label must survive the merge untouched (Orca's PATCH is full-replace, not
+        # merge, so a naive pass-through of this partial patch would wipe them - see orca#1059).
+        patch_body = {
+            "metadata": {"labels": {"env": "prod"}},
+            "spec": {"description": "new desc"},
+        }
+        orca_client.patch_project("p6", patch_body)
+
+        patch_request = [
+            r for r in requests_mock.request_history if r.method == "PATCH"
+        ][0]
+        sent = patch_request.json()
+        assert sent["owner"] == "jsmith"
+        assert sent["description"] == "new desc"
+        assert sent["labels"] == {"team": "ds", "env": "prod"}
+        assert sent["annotations"] == {"note": "x"}
+        assert sent["prevOpId"] == op_id
+
+    def test_delete_project_waits_for_completion(self, requests_mock, orca_client):
+        op_id = str(uuid.uuid4())
+        requests_mock.delete(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p7",
+            json={"status": {"opId": op_id}},
+            status_code=202,
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/trackable-actions/executions",
+            json={"items": [{"status": {"state": "succeeded"}}]},
+        )
+
+        assert orca_client.delete_project("p7") is None
+
+    def test_delete_project_action_failed_raises_without_retrying(
+        self, requests_mock, orca_client
+    ):
+        op_id = str(uuid.uuid4())
+        requests_mock.delete(
+            f"{ORCA_API_URL}/api/v1/projects/projects/p8",
+            json={"status": {"opId": op_id}},
+            status_code=202,
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/trackable-actions/executions",
+            json={"items": [{"status": {"state": "failed"}}]},
+        )
+
+        # a failed action is fatal - it should stop polling immediately, not retry until
+        # timeout (matches the identical, already-merged-and-CI-passing behavior of
+        # server/py/framework/utils/clients/iguazio/v4.py's _wait_for_op for the same case:
+        # retry_until_successful wraps a fatal_exceptions hit in MLRunRetryExhaustedError).
+        with pytest.raises(mlrun.errors.MLRunRetryExhaustedError):
+            orca_client.delete_project("p8")
+
+        poll_requests = [
+            r for r in requests_mock.request_history if "trackable-actions" in r.url
+        ]
+        assert len(poll_requests) == 1
+
+    def test_create_project_poll_timeout_is_not_treated_as_failure(
+        self, requests_mock, orca_client
+    ):
+        op_id = str(uuid.uuid4())
+        requests_mock.post(
+            f"{ORCA_API_URL}/api/v1/projects/projects",
+            json={"status": {"opId": op_id}},
+            status_code=202,
+        )
+        requests_mock.get(
+            f"{ORCA_API_URL}/api/v1/trackable-actions/executions",
+            json={"items": [{"status": {"state": "running"}}]},
+        )
+
+        with pytest.raises(mlrun.errors.MLRunRetryExhaustedError) as exc_info:
+            orca_client.create_project(_mlrun_project("p9"))
+        assert "still in" in str(exc_info.value)
+
+
+class TestHTTPRunDBOrcaGate:
+    """HTTPRunDB.create_project/store_project/patch_project/delete_project gate on
+    _orca_direct_mode() and delegate to OrcaProjectsClient - or fall through to the legacy
+    MLRun-API path unchanged - depending on it.
+    """
+
+    @pytest.fixture
+    def db(self) -> mlrun.db.httpdb.HTTPRunDB:
+        return mlrun.db.httpdb.HTTPRunDB("https://fake-mlrun-url")
+
+    def test_ce_mode_falls_through_to_api_call(self, db):
+        mlrun.mlconf.httpdb.authentication.mode = "none"
+        mlrun.mlconf.iguazio_api_url = ""
+        assert db._orca_direct_mode() is False
+
+        with unittest.mock.patch.object(db, "api_call") as mock_api_call:
+            mock_api_call.return_value.status_code = 200
+            mock_api_call.return_value.json.return_value = _mlrun_project(
+                "gated"
+            ).to_dict()
+            db.create_project(_mlrun_project("gated"))
+            assert mock_api_call.called
+
+    def test_orca_direct_mode_without_configured_url_falls_through(self, db):
+        mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
+        mlrun.mlconf.iguazio_api_url = ""
+        assert db._orca_direct_mode() is False
+
+    @pytest.mark.parametrize(
+        "method_name,args,orca_method_name,orca_args",
+        [
+            ("create_project", (), "create_project", ()),
+            ("store_project", ("gated",), "update_project", ("gated",)),
+            ("delete_project", ("gated",), "delete_project", ("gated",)),
+        ],
+    )
+    def test_orca_direct_mode_delegates_and_skips_api_call(
+        self, db, method_name, args, orca_method_name, orca_args
+    ):
+        mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
+        mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+        assert db._orca_direct_mode() is True
+
+        fake_client = unittest.mock.Mock()
+        db._orca_projects_client = fake_client
+
+        project = _mlrun_project("gated")
+        call_args = (
+            (project,)
+            if method_name in ("create_project",)
+            else (
+                *args,
+                project,
+            )
+        )
+
+        with unittest.mock.patch.object(db, "api_call") as mock_api_call:
+            getattr(db, method_name)(*call_args, wait_for_completion=False)
+            assert not mock_api_call.called
+
+        orca_method = getattr(fake_client, orca_method_name)
+        orca_method.assert_called_once()
+        assert orca_method.call_args.kwargs["wait_for_completion"] is False
+
+    def test_orca_direct_mode_patch_project_coerces_patch_mode(self, db):
+        mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
+        mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+
+        fake_client = unittest.mock.Mock()
+        db._orca_projects_client = fake_client
+
+        db.patch_project("gated", {"spec": {"description": "d"}}, patch_mode="additive")
+
+        fake_client.patch_project.assert_called_once()
+        assert (
+            fake_client.patch_project.call_args.kwargs["patch_mode"]
+            == mlrun.common.schemas.PatchMode.additive
+        )
+
+    def test_get_project_is_not_gated(self, db):
+        # get_project is explicitly out of scope for this ticket (reads stay on the legacy
+        # MLRun-API path) - it must not check _orca_direct_mode at all.
+        mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
+        mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+
+        with unittest.mock.patch.object(db, "api_call") as mock_api_call:
+            mock_api_call.return_value.json.return_value = _mlrun_project(
+                "gated"
+            ).to_dict()
+            db.get_project("gated")
+            assert mock_api_call.called

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -356,6 +356,7 @@ class TestHTTPRunDBOrcaGate:
     def test_ce_mode_falls_through_to_api_call(self, db):
         mlrun.mlconf.httpdb.authentication.mode = "none"
         mlrun.mlconf.iguazio_api_url = ""
+        mlrun.mlconf.httpdb.projects.leader = "mlrun"
         assert db._orca_direct_mode() is False
 
         with unittest.mock.patch.object(db, "api_call") as mock_api_call:
@@ -369,6 +370,17 @@ class TestHTTPRunDBOrcaGate:
     def test_orca_direct_mode_without_configured_url_falls_through(self, db):
         mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
         mlrun.mlconf.iguazio_api_url = ""
+        mlrun.mlconf.httpdb.projects.leader = "orca"
+        assert db._orca_direct_mode() is False
+
+    def test_orca_direct_mode_requires_leader_orca(self, db):
+        # is_iguazio_v4_mode()/iguazio_api_url alone aren't enough - both are also true for a
+        # v4-auth deployment that hasn't cut project-sync leadership over to Orca yet (they're
+        # already used for e.g. oauth token endpoints regardless of leader). Only the server's
+        # own httpdb.projects.leader, synced via connect()'s client-spec, can confirm that.
+        mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
+        mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+        mlrun.mlconf.httpdb.projects.leader = "mlrun"
         assert db._orca_direct_mode() is False
 
     @pytest.mark.parametrize(
@@ -384,6 +396,7 @@ class TestHTTPRunDBOrcaGate:
     ):
         mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
         mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+        mlrun.mlconf.httpdb.projects.leader = "orca"
         assert db._orca_direct_mode() is True
 
         fake_client = unittest.mock.Mock()
@@ -413,6 +426,7 @@ class TestHTTPRunDBOrcaGate:
     def test_orca_direct_mode_patch_project_coerces_patch_mode(self, db):
         mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
         mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+        mlrun.mlconf.httpdb.projects.leader = "orca"
 
         fake_client = unittest.mock.Mock()
         db._orca_projects_client = fake_client
@@ -430,6 +444,7 @@ class TestHTTPRunDBOrcaGate:
         # MLRun-API path) - it must not check _orca_direct_mode at all.
         mlrun.mlconf.httpdb.authentication.mode = "iguazio-v4"
         mlrun.mlconf.iguazio_api_url = ORCA_API_URL
+        mlrun.mlconf.httpdb.projects.leader = "orca"
 
         with unittest.mock.patch.object(db, "api_call") as mock_api_call:
             mock_api_call.return_value.json.return_value = _mlrun_project(

--- a/tests/rundb/test_orca.py
+++ b/tests/rundb/test_orca.py
@@ -267,7 +267,7 @@ class TestOrcaProjectsClient:
 
         # only touches description and adds one label - owner, annotations, and the existing
         # "team" label must survive the merge untouched (Orca's PATCH is full-replace, not
-        # merge, so a naive pass-through of this partial patch would wipe them - see orca#1059).
+        # merge, so a naive pass-through of this partial patch would wipe them).
         patch_body = {
             "metadata": {"labels": {"env": "prod"}},
             "spec": {"description": "new desc"},
@@ -416,9 +416,9 @@ class TestHTTPRunDBOrcaGate:
             getattr(db, method_name)(*call_args)
             assert not mock_api_call.called
 
-        # HTTPRunDB itself has no wait_for_completion knob (ML-12903: no known SDK caller
-        # needs async project creation, and exposing it would only work in this one mode) -
-        # it always asks the Orca client to block until the operation settles.
+        # HTTPRunDB itself has no wait_for_completion knob - no known SDK caller needs async
+        # project creation, and exposing it would only work in this one mode - so it always
+        # asks the Orca client to block until the operation settles.
         orca_method = getattr(fake_client, orca_method_name)
         orca_method.assert_called_once()
         assert orca_method.call_args.kwargs["wait_for_completion"] is True

--- a/tests/utils/test_orca_projects.py
+++ b/tests/utils/test_orca_projects.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import uuid
+
+import pytest
+
+import mlrun.common.schemas
+import mlrun.errors
+import mlrun.projects.project
+import mlrun.utils.orca_projects as orca_projects
+
+
+def _project(owner=None, description=None, labels=None, annotations=None):
+    return mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(
+            name="p1", labels=labels, annotations=annotations
+        ),
+        spec=mlrun.common.schemas.ProjectSpec(owner=owner, description=description),
+    )
+
+
+def test_create_project_wire_minimal():
+    assert orca_projects.create_project_wire(_project()) == {"name": "p1"}
+
+
+def test_create_project_wire_does_not_leak_mlrun_only_spec_fields():
+    # a real MlrunProject carries ~20 MLRun-specific spec fields (functions, artifacts,
+    # workflows, build, ...) that aren't part of Orca's contract (the common set only:
+    # name/labels/annotations/owner/description). create_project_wire/update_project_wire only
+    # ever read the common-set attributes by name, so passing the richer MlrunProject object
+    # directly (as mlrun/db/orca.py does) must never leak those extra fields onto the wire.
+    project = mlrun.projects.project.MlrunProject(
+        metadata=mlrun.projects.project.ProjectMetadata(name="p1"),
+        spec=mlrun.projects.project.ProjectSpec(
+            owner="jsmith",
+            goals="win",
+            params={"a": "b"},
+            source="git://example.com/repo.git",
+        ),
+    )
+    wire = orca_projects.create_project_wire(project)
+    assert wire == {"name": "p1", "owner": "jsmith"}
+
+
+def test_create_project_wire_full():
+    project = _project(
+        owner="jsmith",
+        description="desc",
+        labels={"a": "b"},
+        annotations={"c": "d"},
+    )
+    assert orca_projects.create_project_wire(project) == {
+        "name": "p1",
+        "owner": "jsmith",
+        "description": "desc",
+        "labels": {"a": "b"},
+        "annotations": {"c": "d"},
+    }
+
+
+@pytest.mark.parametrize("prev_op_id", [uuid.uuid4(), None])
+def test_update_project_wire_prev_op_id(prev_op_id):
+    project = _project(owner="jsmith")
+    wire = orca_projects.update_project_wire(project, prev_op_id)
+    assert wire["prevOpId"] == (str(prev_op_id) if prev_op_id else None)
+    assert wire["owner"] == "jsmith"
+
+
+def test_project_from_wire_round_trip():
+    op_id = uuid.uuid4()
+    body = {
+        "metadata": {"name": "p1", "labels": {"a": "b"}, "annotations": {"c": "d"}},
+        "spec": {"owner": "jsmith", "description": "desc"},
+        "status": {"state": "online", "opId": str(op_id), "updatedAt": None},
+    }
+    project = orca_projects.project_from_wire(body)
+    assert project.metadata.name == "p1"
+    assert project.metadata.labels == {"a": "b"}
+    assert project.metadata.annotations == {"c": "d"}
+    assert project.spec.owner == "jsmith"
+    assert project.spec.description == "desc"
+    assert project.status.state == "online"
+    assert project.status.op_id == op_id
+
+
+def test_action_execution_query_params():
+    op_id = uuid.uuid4()
+    assert orca_projects.action_execution_query_params(op_id) == {
+        "correlationId": str(op_id),
+        "actionType": "sync-project",
+        "subdomain": "projects",
+        "limit": 1,
+    }
+
+
+def test_verify_action_execution_terminal_succeeded():
+    # no exception raised
+    orca_projects.verify_action_execution_terminal(
+        {"items": [{"status": {"state": "succeeded"}}]}, "p1", "op-id"
+    )
+
+
+def test_verify_action_execution_terminal_failed_raises_fatal():
+    with pytest.raises(orca_projects.OrcaActionFailedError):
+        orca_projects.verify_action_execution_terminal(
+            {"items": [{"status": {"state": "failed"}}]}, "p1", "op-id"
+        )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"items": [{"status": {"state": "running"}}]},
+        {"items": []},
+    ],
+)
+def test_verify_action_execution_terminal_not_yet_terminal_raises_retryable(body):
+    # not-observed-yet and still-in-progress are both retryable (not fatal like "failed"),
+    # so callers driving a poll loop must be able to distinguish them from OrcaActionFailedError.
+    with pytest.raises(mlrun.errors.MLRunRuntimeError):
+        orca_projects.verify_action_execution_terminal(body, "p1", "op-id")


### PR DESCRIPTION
### 📝 Description
New SDK path for project create/update/patch/delete: in enterprise mode (Orca as leader), the SDK now calls Orca's user-facing project endpoints directly with the caller's own credentials, bypassing the MLRun API entirely — instead of going through MLRun's existing backward-compatibility proxy (#10043). This is "role 3" per the Followers HLD; #10043 was role 2 (the backward-compat proxy for pre-Orca SDK clients and the UI).

The actual request orchestration (what to call, in what order, how to poll to completion) is shared between this SDK client and #10043's server-side leader-proxy — see Changes Made.

---

### 🛠️ Changes Made
- `mlrun/utils/orca_projects.py` (new) — Orca's project wire protocol (create/update wire-shape translation, response parsing, the trackable-action completion-check logic, the relevant endpoint/query constants, and `ProjectLike`/`ProjectMetadataLike`/`ProjectSpecLike` — `typing.Protocol`s describing the structural shape the wire functions need, deliberately duck-typed rather than coerced to a real pydantic `Project` — see the docstring for why), extracted out of the server-side leader-proxy (`v4.py`, #10043) so both implementations share one derivation of Orca's actual contract instead of two independently-maintained ones.
- `mlrun/utils/orca_client.py` (new) — `OrcaProjectsOrchestrator`: the actual sequence of Orca requests behind create/update/patch/delete/get, and how each polls to completion. Shared between this PR's SDK client and `v4.py`'s server-side leader-proxy, which had nearly-identical "what request to make when" logic duplicated — the only genuine difference between the two is how each sends an authenticated request (the SDK uses its own held credentials; the leader-proxy relays the acting user's identity), so that's the one thing each supplies via an injected `RequestSender` Protocol. The orchestrator returns raw pieces (response, op_id, schema objects) rather than either caller's own public return contract, since the server's `project_leader.Member` interface (`bool`/`None`/`Project`) and the SDK's own (`MlrunProject`/`op_id`) are genuinely different and interface-mandated.
- `mlrun/db/orca.py` (new) — `OrcaProjectsClient`, the SDK-direct client. Builds one `OrcaProjectsOrchestrator` (bound to its own credentials) and its public methods (create/update/patch/delete/get) are thin adapters translating orchestrator results into the SDK's own return contract. `@typing.overload` signatures make `wait_for_completion`'s effect on the return type (`MlrunProject` vs. `op_id`) explicit to type checkers.
- `v4.py` — `Client.create_project`/`update_project`/`delete_project`/`get_project` now build an orchestrator per call (identity, unlike the SDK's fixed credentials, changes per request) and delegate to it, preserving their exact `project_leader.Member` signatures/return semantics unchanged. `_wait_for_op`/`_verify_op_terminal` deleted (now in the shared orchestrator). Two small, intentional behavior improvements fall out of this: `update_project` now skips polling when Orca settles synchronously (previously it always polled, even with nothing left to wait for), and resolving the CAS witness now tolerates a project that doesn't exist yet (an upsert-create call would previously have raised instead of proceeding with `prevOpId=null`).
- `mlrun/db/httpdb.py` — `create_project`/`store_project`/`patch_project`/`delete_project` gate on a new `_orca_direct_mode()` check and delegate to `OrcaProjectsClient` when true (always blocking — no SDK caller today needs async project creation, so this doesn't add new public API surface for it); unchanged fallback to the existing MLRun-API path otherwise. These four signatures are byte-for-byte unchanged. `get_project` is deliberately left on the legacy path — out of scope for this ticket.
- `_orca_direct_mode()` requires `is_iguazio_v4_mode()`, `iguazio_api_url` being configured client-side, **and** the API server's project-sync leader actually being `"orca"` — the first two alone don't guarantee the third (a v4-auth deployment can have `iguazio_api_url` configured for unrelated reasons, e.g. oauth token endpoints, while still self-leading projects). Since the SDK had no way to observe the server's leader, added a `projects_leader` field to `mlrun.common.schemas.ClientSpec` (both pydantic faces), populated server-side from `httpdb.projects.leader`, and synced into the SDK's config during `connect()` - mirroring the existing `authentication_mode` field/sync exactly.
- Extracted `HTTPRunDB._auth_request_kwargs()` out of `api_call` (same auth-header/cookie logic, unchanged) so the new Orca client reuses it instead of duplicating it.
- `patch_project`'s Orca-direct path merges the caller's partial patch into the project's current state (`mergedeep`, mirroring the exact strategy MLRun's own server-side patch merge uses) before sending it to Orca's PATCH — Orca's PATCH is full-replace, not merge, so a naive pass-through would silently drop any field the caller didn't include.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- New unit tests: `tests/utils/test_orca_projects.py` (wire-shape translation, response parsing, all four trackable-action completion outcomes, MLRun-only spec fields never leaking onto Orca's wire) and `tests/rundb/test_orca.py` (`OrcaProjectsClient` end-to-end — create/update/patch/delete/get, `wait_for_completion` true/false, action-failed vs. poll-timeout, the synchronous-200-skips-polling case, the patch-merge preserving untouched fields — plus `HTTPRunDB`'s Orca-direct gating). 28 test cases, all passing.
- Ran the full `tests/rundb/` + `tests/utils/` suite: 961 passed, 51 failed, 2 skipped. All 51 failures are pre-existing/environmental (need a live local server or Docker, unavailable in this environment) or already-failing-and-unrelated tests in files this PR doesn't touch — none are in the changed files.
- `v4.py`'s refactor to use the shared orchestrator was verified with a standalone script driving `Client` end-to-end against `requests_mock` (create/update/delete/get, identity-relay header check, the deletion-strategy `check` short-circuit, CAS prev_op_id resolution including the new upsert-create tolerance, synchronous-vs-async delete) — server/py's own pytest suite can't run in this dev environment (unrelated local pydantic1-vs-2/FastAPI version mismatch).
- Live end-to-end verification against a real Orca-backed system (`leader=orca`): create, get, update (via `project.save()`), and delete all confirmed working through the SDK-direct path — including confirming the deleted project actually 404s afterward. Also confirmed the `projects_leader` client-spec gate against the real server (correctly reports `"orca"`, correctly activates `_orca_direct_mode()`).

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12903
- Design docs links: [Project Sync Mechanism – Backend HLD](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/611745844), [Orca as Leader HLD](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/654737409), [Followers](https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/661979181) ("New MLRun SDK → Orca directly")
- External links: #10043 (the server-side backward-compat proxy this PR shares its request orchestration with); orca#1059 (unmerged, prototypes the same contract in orca's own Python SDK)

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Orca's side of this contract lives on orca's `feature/project-sync` branch. Live-tested end-to-end against a real deployment running that branch (see Testing) — the create/read/update/delete round trip via this PR's SDK-direct path works as designed.
- `HTTPRunDB`'s project CUD methods don't expose async (`wait_for_completion=False`) at the SDK-public level yet — no known caller needs it today. If one shows up, it's a small follow-up: thread the kwarg through from `HTTPRunDB` to `OrcaProjectsClient`, which already supports it.
- Follow-up idea, not done here: once orca's own Python SDK package (`iguazio`, orca#1059) is published, revisit whether this client should depend on it instead of maintaining a parallel implementation.

