### PR TITLE
[Datastore] Pass key_column/timestamp_key/options through to prepare_spark

### DIFF
--- a/mlrun/datastore/targets.py
+++ b/mlrun/datastore/targets.py
@@ -1368,7 +1368,7 @@ class NoSqlBaseTarget(BaseStoreTarget):
         if is_spark_dataframe(df):
             options = self.get_spark_options(key_column, timestamp_key)
             options.update(kwargs)
-            df = self.prepare_spark_df(df)
+            df = self.prepare_spark_df(df, key_column, timestamp_key, options)
             write_format = options.pop("format", None)
             write_spark_dataframe_with_options(
                 options, df, "overwrite", write_format=write_format


### PR DESCRIPTION
## Problem

`NoSqlBaseTarget.write_dataframe` calls `prepare_spark_df` with only the frame:

```python
# mlrun/datastore/targets.py:1365
def write_dataframe(self, df, key_column=None, timestamp_key=None, chunk_id=0, **kwargs):
    if is_spark_dataframe(df):
        options = self.get_spark_options(key_column, timestamp_key)
        options.update(kwargs)
        df = self.prepare_spark_df(df)          # <-- 1 argument
```

But every one of the six `prepare_spark_df` definitions in this file has the
signature

```python
def prepare_spark_df(self, df, key_columns, timestamp_key=None, spark_options=None):
```

`key_columns` is **required**. So writing a Spark DataFrame to a `NoSqlTarget`
or a `RedisNoSqlTarget` — both of which declare `support_spark = True` and
inherit this method — raises:

```
TypeError: prepare_spark_df() missing 1 required positional argument: 'key_columns'
```

## Sibling baseline

`NoSqlBaseTarget.write_dataframe` is a near-verbatim copy of
`BaseStoreTarget.write_dataframe`, which passes all four:

```python
# mlrun/datastore/targets.py:504  (base class, correct)
df = self.prepare_spark_df(df, key_column, timestamp_key, options)
```

`mlrun/feature_store/api.py:663` independently uses the same four-argument form:

```python
df_to_write = target.prepare_spark_df(df_to_write, key_columns, timestamp_key, spark_options)
```

The one-argument call at line 1371 is the only one out of step.

This is not cosmetic: `NoSqlTarget.prepare_spark_df` actually *uses*
`key_columns` — `len(key_columns) > 2` gates the V3IO `_spark_object_name`
hashing over `key_columns[1:]`. Dropping the argument removes that logic, not
just the signature match.

## Fix

One line — mirror the base class.

## Verification

Rebuilding the real `NoSqlTarget.prepare_spark_df` signature from the source AST
and replaying each call site through `inspect.Signature.bind`:

```
NoSqlTarget.prepare_spark_df(df, key_columns, timestamp_key='<d>', spark_options='<d>')

  TypeError  NoSqlBaseTarget.write_dataframe L1371 (current): self.prepare_spark_df(df)
             -> missing a required argument: 'key_columns'
  OK         BaseStoreTarget.write_dataframe  L504 (sibling): self.prepare_spark_df(df, key_column, timestamp_key, options)
  OK         feature_store/api.py           L663 (sibling): target.prepare_spark_df(df, key_columns, timestamp_key, spark_options)
```

`ruff format --diff` and `ruff check` are clean on the patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
