### PR TITLE
[Pipelines] Pass function to add_default_function_resources in KFP v2 builder/deployer nodes

### DIFF
--- a/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
+++ b/pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py
@@ -352,7 +352,7 @@ def generate_image_builder_pipeline_node(
     task = container_component()
     task.set_display_name(name)
 
-    add_default_function_resources(task)
+    add_default_function_resources(task, function)
     add_function_node_selection_attributes(function, task)
     add_annotations(task, PipelineRunType.build, function, func_url)
 
@@ -396,7 +396,7 @@ def generate_deployer_pipeline_node(
     task = container_component()
     task.set_display_name(name)
 
-    add_default_function_resources(task)
+    add_default_function_resources(task, function)
     add_function_node_selection_attributes(function, task)
     add_annotations(task, PipelineRunType.deploy, function, func_url)
 


### PR DESCRIPTION
## Problem

`add_default_function_resources` in the KFP v2 adapter takes two required
positional parameters:

```python
# pipeline-adapters/mlrun-pipelines-kfp-v2/src/mlrun_pipelines/ops.py:84
def add_default_function_resources(
    task,
    function: dsl.PipelineTask,
) -> dsl.PipelineTask:
    ...
    mlrun_pipelines.common.ops._enrich_gpu_limits(function=function, task=task)
```

Two of the three generators in that file call it with one argument:

| call site | enclosing generator | call |
|---|---|---|
| `ops.py:316` | `generate_pipeline_node` | `add_default_function_resources(task, function)` ✅ |
| `ops.py:355` | `generate_image_builder_pipeline_node` | `add_default_function_resources(task)` ❌ |
| `ops.py:399` | `generate_deployer_pipeline_node` | `add_default_function_resources(task)` ❌ |

Both raise:

```
TypeError: add_default_function_resources() missing 1 required positional argument: 'function'
```

`function` is a parameter of both broken generators and is already in hand — the
next statement at each site is `add_function_node_selection_attributes(function, task)`.

The kfp-v1-8 adapter agrees: all three of its call sites
(`mlrun-pipelines-kfp-v1-8/src/mlrun_pipelines/ops.py:51/91/151`) pass
`add_default_function_resources(container_op=cop, function=function)`.

## Fix

Pass `function` at the two call sites, matching `generate_pipeline_node` and the
v1-8 adapter. Two lines, no behaviour change anywhere the call already worked.

## Verification

No mlrun/kfp runtime is needed to show the mismatch — the signature is taken
from the file itself, with the body replaced by `pass`, and the three call sites
are replayed against it:

```
signature: (task, function: object)
  line 316: binds OK
  line 355: TypeError: add_default_function_resources() missing 1 required positional argument: 'function'
  line 399: TypeError: add_default_function_resources() missing 1 required positional argument: 'function'
```

`ruff format --check` and `ruff check` (repo `pyproject.toml`) are clean on the
patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
