### PR TITLE
[SDK] Sync function authenticaion feature flag as part of connect

### DIFF
--- a/mlrun/common/schemas/_v1/client_spec.py
+++ b/mlrun/common/schemas/_v1/client_spec.py
@@ -77,3 +77,4 @@ class ClientSpec(pydantic.v1.BaseModel):
     telemetry_otlp_endpoint: str | None = None
     telemetry_insecure: bool | None = None
     telemetry_model_monitoring_interval: int | None = None
+    nuclio_function_authentication_enabled: bool | None = None

--- a/mlrun/common/schemas/_v2/client_spec.py
+++ b/mlrun/common/schemas/_v2/client_spec.py
@@ -102,3 +102,4 @@ class ClientSpec(pydantic.BaseModel):
     telemetry_otlp_endpoint: str | None = None
     telemetry_insecure: bool | None = None
     telemetry_model_monitoring_interval: int | None = None
+    nuclio_function_authentication_enabled: bool | None = None

--- a/mlrun/db/httpdb.py
+++ b/mlrun/db/httpdb.py
@@ -731,6 +731,10 @@ class HTTPRunDB(RunDBInterface):
                 config.telemetry.model_monitoring.interval = server_cfg[
                     "telemetry_model_monitoring_interval"
                 ]
+            if server_cfg.get("nuclio_function_authentication_enabled") is not None:
+                config.httpdb.nuclio.function_authentication_enabled = server_cfg[
+                    "nuclio_function_authentication_enabled"
+                ]
 
         except Exception as exc:
             logger.warning(

--- a/server/py/services/api/crud/client_spec.py
+++ b/server/py/services/api/crud/client_spec.py
@@ -160,6 +160,9 @@ class ClientSpec(
             telemetry_model_monitoring_interval=self._get_config_value_if_not_default(
                 "telemetry.model_monitoring.interval"
             ),
+            nuclio_function_authentication_enabled=self._get_config_value_if_not_default(
+                "httpdb.nuclio.function_authentication_enabled"
+            ),
         )
 
     @staticmethod

--- a/server/py/services/api/tests/unit/api/test_client_spec.py
+++ b/server/py/services/api/tests/unit/api/test_client_spec.py
@@ -209,6 +209,39 @@ def test_client_spec_telemetry_fields_overridden(
 
 
 @pytest.mark.parametrize(
+    "function_authentication_enabled, expected_response_value",
+    [
+        # Default (unset by the operator) -> field omitted so the SDK keeps
+        # its local value.
+        (False, None),
+        # Operator-set value propagates through /client-spec to the SDK.
+        (True, True),
+    ],
+)
+def test_client_spec_nuclio_function_authentication_enabled(
+    db: sqlalchemy.orm.Session,
+    client: fastapi.testclient.TestClient,
+    function_authentication_enabled: bool,
+    expected_response_value: bool | None,
+) -> None:
+    mlrun.mlconf.httpdb.nuclio.function_authentication_enabled = (
+        function_authentication_enabled
+    )
+    services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+    try:
+        response = client.get("client-spec")
+        assert response.status_code == http.HTTPStatus.OK.value
+        assert (
+            response.json()["nuclio_function_authentication_enabled"]
+            == expected_response_value
+        )
+    finally:
+        mlrun.mlconf.httpdb.nuclio.function_authentication_enabled = False
+        services.api.api.endpoints.client_spec.get_cached_client_spec.cache_clear()
+
+
+@pytest.mark.parametrize(
     "server_version, client_version, python_version, expected_dask_kfp",
     [
         # Server is "unstable"

--- a/tests/rundb/test_unit_httpdb.py
+++ b/tests/rundb/test_unit_httpdb.py
@@ -529,3 +529,35 @@ def test_client_spec_telemetry_sync_keeps_local_when_server_omits(requests_mock)
     mlrun.mlconf.telemetry.otlp_endpoint = ""
     mlrun.mlconf.telemetry.insecure = True
     mlrun.mlconf.telemetry.model_monitoring.interval = 60
+
+
+@pytest.mark.parametrize(
+    "local_value, server_value, expected_local_value",
+    [
+        (False, True, True),
+        (True, None, True),
+    ],
+)
+def test_client_spec_nuclio_function_authentication_enabled_sync(
+    requests_mock, local_value, server_value, expected_local_value
+):
+    mlrun.mlconf.httpdb.nuclio.function_authentication_enabled = local_value
+
+    requests_mock.get(
+        "https://fake-url/api/v1/client-spec",
+        json={
+            "version": "v1.1.0",
+            "nuclio_function_authentication_enabled": server_value,
+        },
+    )
+
+    db = mlrun.db.httpdb.HTTPRunDB("https://fake-url")
+    db.connect()
+
+    assert (
+        mlrun.mlconf.httpdb.nuclio.function_authentication_enabled
+        == expected_local_value
+    )
+
+    # Restore defaults so we don't leak into other tests.
+    mlrun.mlconf.httpdb.nuclio.function_authentication_enabled = False


### PR DESCRIPTION
### 📝 Description
Propagates the `httpdb.nuclio.function_authentication_enabled` platform flag (ML-12895 / #10032) to the SDK automatically on `connect()`, instead of requiring it to be set locally on the client. The flag is checked client-side (`function.py`, `api_gateway.py`), but mlefi only injects the env var into the mlrun-api deployments — so the SDK process never saw the platform's actual value.

---

### 🛠️ Changes Made
- Added `nuclio_function_authentication_enabled: bool | None` to `ClientSpec` (`_v1`/`_v2` schemas)
- Populated it in `ClientSpec.get_client_spec()` via `_get_config_value_if_not_default`
- Mapped it in `HTTPRunDB.connect()`, following the existing `telemetry_enabled` boolean sync pattern (`is not None` guard so `False` isn't skipped as falsy)

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
Unit tests only (parametrized, 2 cases each):
- `server/py/services/api/tests/unit/api/test_client_spec.py::test_client_spec_nuclio_function_authentication_enabled` — default → field omitted; overridden → propagates.
- `tests/rundb/test_unit_httpdb.py::test_client_spec_nuclio_function_authentication_enabled_sync` — server override propagates to local `mlconf`; server omission preserves local value.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13037
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes

