### PR TITLE
[Telemetry] Remove system_id from local REST/inventory metrics

### DIFF
--- a/docs/server-cfg/server-metrics.md
+++ b/docs/server-cfg/server-metrics.md
@@ -29,30 +29,30 @@ MLRUN_TELEMETRY__ENABLED=true
 ```
 
 ## Server metrics description
-Every metric carries a system_id attribute (MLRun installation UUID). Project-scoped metrics additionally carry a project name. 
+Project-scoped metrics carry a project name attribute.
 
 ### Metrics and their attributes
 |Metric name |Attributes       |Meaning       |
 |---------------------|--------------------------------|--------------------------------------------------------------------------------|
-|mlrun_projects|system_id|Current number of projects in the installation|
-|mlrun_functions|system_id, project, kind ∈ {job, serving, application, dask, mpijob, spark, nuclio, …}|Current number of functions of a given kind in a given project. Consolidates the original separate serving_functions / app_runtime_functions metrics via the kind attribute.|
-|mlrun_workflows|system_id, project|Current number of workflow definitions in the project  |
-|mlrun_artifacts|system_id, project, kind ∈ {model, dataset, document, llm_prompt, other}|Current number of artifacts of a given kind in the project  |
-|mlrun_runs|system_id, project, state ∈ {running, completed, failed, aborted}|Current number of runs in the project in each state (snapshot view)  |
-|mlrun_pipeline_executions|system_id, project, state ∈ {running, completed, failed, aborted}|Current number of pipeline executions in the project in each state  |
-|mlrun_alert_configurations|system_id, project|Current number of alert configurations in the project  |
-|mlrun_alert_activations|system_id, project |Current number of active alert activations in the project|
-|mlrun_model_endpoints|system_id, project, kind ∈ {realtime, batch}|Current number of registered model endpoints of a given kind. Consolidates the original separate realtime_endpoints / batch_endpoints metrics via the kind attribute.  |
-|mlrun_model_monitoring_applications|system_id, project|Current number of model-monitoring applications in the project.  |
+|mlrun_projects|(none)|Current number of projects in the installation|
+|mlrun_functions|project, kind ∈ {job, serving, application, dask, mpijob, spark, nuclio, …}|Current number of functions of a given kind in a given project. Consolidates the original separate serving_functions / app_runtime_functions metrics via the kind attribute.|
+|mlrun_workflows|project|Current number of workflow definitions in the project  |
+|mlrun_artifacts|project, kind ∈ {model, dataset, document, llm_prompt, other}|Current number of artifacts of a given kind in the project  |
+|mlrun_runs|project, state ∈ {running, completed, failed, aborted}|Current number of runs in the project in each state (snapshot view)  |
+|mlrun_pipeline_executions|project, state ∈ {running, completed, failed, aborted}|Current number of pipeline executions in the project in each state  |
+|mlrun_alert_configurations|project|Current number of alert configurations in the project  |
+|mlrun_alert_activations|project |Current number of active alert activations in the project|
+|mlrun_model_endpoints|project, kind ∈ {realtime, batch}|Current number of registered model endpoints of a given kind. Consolidates the original separate realtime_endpoints / batch_endpoints metrics via the kind attribute.  |
+|mlrun_model_monitoring_applications|project|Current number of model-monitoring applications in the project.  |
 
 ### Example output
 ```
-mlrun_projects{system_id="f3a2b1c4d5e6f7a8"} 5
-mlrun_artifacts{system_id="f3a2b1c4d5e6f7a8", project="name1", kind="model"}   8
-mlrun_artifacts{system_id="f3a2b1c4d5e6f7a8", project="name2", kind="dataset"} 34
-mlrun_artifacts{system_id="f3a2b1c4d5e6f7a8", project="name3", kind="other"}   1
-mlrun_runs{system_id="f3a2b1c4d5e6f7a8", project="name4", state="completed"} 120
-mlrun_runs{system_id="f3a2b1c4d5e6f7a8", project="name5", state="failed"}     3
+mlrun_projects 5
+mlrun_artifacts{project="name1", kind="model"}   8
+mlrun_artifacts{project="name2", kind="dataset"} 34
+mlrun_artifacts{project="name3", kind="other"}   1
+mlrun_runs{project="name4", state="completed"} 120
+mlrun_runs{project="name5", state="failed"}     3
 ```
 ### Example PromQL views
 PromQL (Prometheus Query Language) is the language used to select and aggregate time series data in real time.
@@ -81,7 +81,7 @@ To disable REST metrics independently while keeping other telemetry on:
 MLRUN_TELEMETRY__REST_METRICS__ENABLED=false
 ```
 
-`system_id`, `status_code`, `resource`, and `project` are common to every instrument below. `resource` is the object type the route operates on (for example `functions`, `runs`, `artifacts`); `project` is set for project-scoped routes and empty otherwise. `project` is normally read straight from the URL path, but for a handful of routes where the project isn't part of the path — project creation, function build/start/status, job submission, and build-status polling — it's read from the request body or query string instead. Health-check (`/healthz`) requests are excluded.
+`status_code`, `resource`, and `project` are common to every instrument below. `resource` is the object type the route operates on (for example `functions`, `runs`, `artifacts`); `project` is set for project-scoped routes and empty otherwise. `project` is normally read straight from the URL path, but for a handful of routes where the project isn't part of the path — project creation, function build/start/status, job submission, and build-status polling — it's read from the request body or query string instead. Health-check (`/healthz`) requests are excluded.
 
 `method` is the real HTTP method, except a collection-returning GET is reported as the synthetic `"LIST"` value instead of `"GET"` — so list calls are distinguishable without a separate label. It's omitted entirely (not just empty) wherever it wouldn't vary: absent from `mlrun_rest_response_num_items`, since that metric only ever records `method="LIST"` calls by construction — a label that never varies within a metric adds nothing to query it by.
 
@@ -100,11 +100,11 @@ Every call is recorded — there is no sampling for these metrics.
 
 ### Example output
 ```
-mlrun_rest_request_duration_milliseconds_count{system_id="f3a2b1c4d5e6", method="LIST", status_code="200", resource="functions", project="name1"} 134
-mlrun_rest_request_duration_milliseconds_count{system_id="f3a2b1c4d5e6", method="GET", status_code="404", resource="runs", project="name1"}        2
-mlrun_rest_request_duration_milliseconds_bucket{system_id="f3a2b1c4d5e6", method="LIST", status_code="200", resource="functions", project="name1", le="5"} 96
-mlrun_rest_response_num_items_count{system_id="f3a2b1c4d5e6", status_code="200", resource="functions", project="name1"} 76
-mlrun_rest_response_num_items_sum{system_id="f3a2b1c4d5e6", status_code="200", resource="functions", project="name1"} 812
+mlrun_rest_request_duration_milliseconds_count{method="LIST", status_code="200", resource="functions", project="name1"} 134
+mlrun_rest_request_duration_milliseconds_count{method="GET", status_code="404", resource="runs", project="name1"}        2
+mlrun_rest_request_duration_milliseconds_bucket{method="LIST", status_code="200", resource="functions", project="name1", le="5"} 96
+mlrun_rest_response_num_items_count{status_code="200", resource="functions", project="name1"} 76
+mlrun_rest_response_num_items_sum{status_code="200", resource="functions", project="name1"} 812
 ```
 
 ### Example PromQL views

--- a/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
+++ b/server/py/framework/tests/unit/utils/telemetry/test_rest_metrics.py
@@ -123,10 +123,7 @@ def test_record_duration_noop_when_uninitialized(reset_state: None) -> None:
     assert telemetry_rest_metrics._duration_histogram is None
 
 
-def test_record_duration_records_with_system_id_and_attributes(
-    reset_state: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(mlrun.mlconf, "system_id", "sys-xyz")
+def test_record_duration_records_with_attributes(reset_state: None) -> None:
     histogram = unittest.mock.MagicMock()
     telemetry_rest_metrics._duration_histogram = histogram
 
@@ -141,7 +138,6 @@ def test_record_duration_records_with_system_id_and_attributes(
     histogram.record.assert_called_once_with(
         0.25,
         attributes={
-            "system_id": "sys-xyz",
             "method": http.HTTPMethod.POST,
             "status_code": 201,
             "resource": "functions",
@@ -193,7 +189,6 @@ def test_record_request_size_records_with_attributes(reset_state: None) -> None:
     histogram.record.assert_called_once_with(
         2.5,
         attributes={
-            "system_id": "",
             "method": http.HTTPMethod.POST,
             "status_code": 201,
             "resource": "runs",
@@ -217,7 +212,6 @@ def test_record_response_size_records_with_attributes(reset_state: None) -> None
     histogram.record.assert_called_once_with(
         12.75,
         attributes={
-            "system_id": "",
             "method": "LIST",
             "status_code": 200,
             "resource": "artifacts",
@@ -252,7 +246,6 @@ def test_record_items_returned_records_without_method(
     histogram.record.assert_called_once_with(
         7,
         attributes={
-            "system_id": "",
             "status_code": 200,
             "resource": "runs",
             "project": "proj-a",

--- a/server/py/framework/utils/telemetry/rest_metrics.py
+++ b/server/py/framework/utils/telemetry/rest_metrics.py
@@ -15,7 +15,7 @@
 """Per-REST-call OTel telemetry for MLRun API-bearing services.
 
 Records duration, request/response size, and items-returned histograms per
-REST call, tagged with system_id/method/status_code/resource/project.
+REST call, tagged with method/status_code/resource/project.
 Collection-returning GETs report method="LIST" (see parse_method).
 
 Gated behind telemetry.enabled + telemetry.rest_metrics.enabled; init() is a
@@ -265,7 +265,6 @@ def _record(
     if record_fn is None:
         return
     attributes = {
-        "system_id": mlrun.mlconf.system_id or "",
         "status_code": status_code,
         "resource": resource,
         "project": project,

--- a/server/py/services/api/tests/unit/utils/telemetry/test_inventory.py
+++ b/server/py/services/api/tests/unit/utils/telemetry/test_inventory.py
@@ -337,12 +337,10 @@ def test_set_count_noop_when_metric_name_unknown(reset_inventory_state: None) ->
     known_gauge.set.assert_not_called()
 
 
-def test_set_count_injects_system_id_and_forwards_attributes(
+def test_set_count_forwards_attributes(
     reset_inventory_state: None,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The current mlconf.system_id is added to every emission alongside user kwargs."""
-    monkeypatch.setattr(mlrun.mlconf, "system_id", "sys-xyz")
+    """User kwargs are forwarded to the gauge as attributes."""
     gauge = unittest.mock.MagicMock()
     telemetry_inventory._gauges = {"mlrun_artifacts": gauge}
 
@@ -350,19 +348,17 @@ def test_set_count_injects_system_id_and_forwards_attributes(
 
     gauge.set.assert_called_once_with(
         7,
-        attributes={"system_id": "sys-xyz", "project": "proj-a", "kind": "model"},
+        attributes={"project": "proj-a", "kind": "model"},
     )
 
 
 def test_set_count_falls_back_to_empty_string_for_missing_values(
     reset_inventory_state: None,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """None or "" attribute values + missing system_id are normalized to "".
+    """None or "" attribute values are normalized to "".
 
     OTLP attribute values must be non-None primitives; None would break export.
     """
-    monkeypatch.setattr(mlrun.mlconf, "system_id", "")
     gauge = unittest.mock.MagicMock()
     telemetry_inventory._gauges = {"mlrun_projects": gauge}
 
@@ -370,7 +366,7 @@ def test_set_count_falls_back_to_empty_string_for_missing_values(
 
     gauge.set.assert_called_once_with(
         0,
-        attributes={"system_id": "", "project": "", "kind": ""},
+        attributes={"project": "", "kind": ""},
     )
 
 

--- a/server/py/services/api/utils/telemetry/inventory.py
+++ b/server/py/services/api/utils/telemetry/inventory.py
@@ -17,8 +17,8 @@
 Chief-only. Re-anchored to DB truth on every project-summaries cache refresh,
 so the values are immune to counter resets, pod restarts, and Prometheus
 retention windows. Exported via synchronous Gauge instruments — one per
-logical metric in ``_METRIC_NAMES``, all tagged with ``system_id`` plus any
-per-call attributes (e.g. ``project``).
+logical metric in ``_METRIC_NAMES``, tagged with any per-call attributes
+(e.g. ``project``).
 
 The OTLP exporter ticks at ``cache_interval`` * ``export_interval_multiplier``
 (default 10 * 60 s = 10 min), aligned with the cache refresh cadence so each
@@ -198,8 +198,7 @@ def set_count(metric: str, value: int, **attributes) -> None:
     """Set the current count for ``metric`` with the given attributes.
 
     No-op when the SDK was not initialized (telemetry disabled) or when
-    ``metric`` is not in ``_METRIC_NAMES``. ``system_id`` is injected from
-    ``mlrun.mlconf`` on every call so live config changes are picked up.
+    ``metric`` is not in ``_METRIC_NAMES``.
     """
     gauge = _gauges.get(metric)
     if gauge is None:
@@ -207,10 +206,7 @@ def set_count(metric: str, value: int, **attributes) -> None:
     try:
         gauge.set(
             value,
-            attributes={
-                "system_id": mlrun.mlconf.system_id or "",
-                **{k: (v or "") for k, v in attributes.items()},
-            },
+            attributes={k: (v or "") for k, v in attributes.items()},
         )
     except Exception as exc:
         mlrun.utils.logger.warning(


### PR DESCRIPTION
### 📝 Description
MLRun metrics rendered in Grafana carried a shortened system ID instead of the full system UUID shown elsewhere (UI, log bundling). `system_id` is only meant to be attached to metrics sent to external destinations (e.g. Dynatrace); metrics that stay local and are scraped directly by Prometheus — which is what Grafana renders here — don't need it, since a single-system local Prometheus has nothing to disambiguate by system.

---

### 🛠️ Changes Made
- Removed the `system_id` attribute from the REST-metrics histogram attributes (`server/py/framework/utils/telemetry/rest_metrics.py`).
- Removed the `system_id` attribute from the inventory-gauge attributes (`server/py/services/api/utils/telemetry/inventory.py`).
- Updated both files' module docstrings to drop `system_id` from their attribute descriptions.
- Updated `docs/server-cfg/server-metrics.md` (attribute tables and example output) to match.
- Updated the corresponding unit tests.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Updated unit tests in `test_rest_metrics.py` (13 passed) and `test_inventory.py` to drop `system_id`-specific assertions.
- `make lint` clean.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13049
- Design docs links: None
- External links: None

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)

Any Grafana dashboard, alert rule, or PromQL query that filters or groups by `system_id` on the REST metrics (`mlrun_rest_*`) or the inventory metrics (`mlrun_projects`, `mlrun_artifacts`, etc.) may need to drop that matcher — the label no longer exists on these series.

---

### 🔍️ Additional Notes
`test_inventory.py` can't be run through the full `services.api` pytest conftest locally due to a pre-existing, unrelated pydantic v1/v2 import mismatch (confirmed it also fails on `development` via `git stash`) — verified `set_count`'s new behavior directly against the module instead.