### PR TITLE
[Secrets] Skip redundant token revocation for service-account callers

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -94,6 +94,7 @@ default_config = {
     "kfp_image": "mlrun/mlrun-kfp",  # image to use for KFP runner
     "dask_kfp_image": "mlrun/mlrun",  # image to use for dask KFP runner
     "igz_version": "",  # the version of the iguazio system the API is running on
+    "orca_version": "",  # resolved lazily from Orca's own info API, see resolve_orca_version()
     "iguazio_api_url": "",  # the url to iguazio api (internal / external access with priority to internal)
     "iguazio_api_url_ingress": "",  # the url to iguazio api ingress (for external access)
     "iguazio_api_ssl_verify": True,  # verify ssl certificate of iguazio api

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -30,7 +30,8 @@ import mlrun.common.formatters
 import mlrun.common.schemas
 import mlrun.common.types
 import mlrun.errors
-from mlrun.utils import get_in
+from mlrun.config import config
+from mlrun.utils import get_in, logger
 
 import framework.utils.clients.helpers as clients_helpers
 import framework.utils.clients.service_account_token as service_account_token
@@ -156,6 +157,24 @@ class Client(BaseClient, project_follower.Member):
             mlrun.errors.MLRunUnauthorizedError,
             "Failed to revoke offline token from Iguazio",
             auth_headers=request_headers,
+        )
+
+    def get_orca_version(self) -> str:
+        """
+        Fetch Orca's own release version from its system-info API.
+
+        :return: Orca's version string (e.g. "1.2.0").
+        :raises mlrun.errors.MLRunRuntimeError: If the request to Orca fails.
+        """
+
+        def _get_orca_version():
+            system_info = self._client.get_system_info()
+            return system_info.metadata.version.oris_version
+
+        return self._try_callback_with_httpx_exceptions(
+            _get_orca_version,
+            mlrun.errors.MLRunRuntimeError,
+            "Failed to get Orca version from its system-info API",
         )
 
     def get_user_id_by_username(
@@ -625,3 +644,18 @@ class AsyncClient(BaseAsyncClient, Client):
     """Asynchronous implementation of the Iguazio V4 client. Inherits logic from Client and BaseAsyncClient."""
 
     pass
+
+# if orca version specified on mlrun config set it likewise,
+# if not specified, get it from Orca's own info API
+# since this is a heavy operation (sending requests to API), and it's unlikely that the version
+# will change - only fetch it once
+def resolve_orca_version() -> str:
+    if not config.orca_version and config.iguazio_api_url:
+        try:
+            config.orca_version = Client().get_orca_version()
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve Orca version", exc=mlrun.errors.err_to_str(exc)
+            )
+
+    return config.orca_version

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -19,6 +19,7 @@ import typing
 import uuid
 from collections import defaultdict
 
+import semver
 from fastapi.concurrency import run_in_threadpool
 
 import mlrun.auth.utils
@@ -48,6 +49,11 @@ class SecretsClientType(enum.StrEnum):
     hub = "hub"
     notifications = "notifications"
     datastore_profiles = "datastore-profiles"
+
+# TODO: Update to 2.1.1 during ML-13070
+# The first Orca release that ships RevokeOfflineSession and self-revokes the
+# Keycloak session before calling this endpoint.
+MIN_ORCA_VERSION_WITH_SELF_REVOKE = "2.1.0"
 
 
 class Secrets(
@@ -552,8 +558,7 @@ class Secrets(
         :param skip_revocation: If True, skip revoking the token via Iguazio and only delete
                                 the K8s secret. Used in bulk delete during user deletion flow
                                 since tokens are invalidated when the user is deleted anyway,
-                                and for service-account callers (e.g. Orca) that already own
-                                revocation themselves.
+                                and once Orca is recent enough to already own revocation itself.
         :raises mlrun.errors.MLRunNotFoundError: If the token is not found.
         :raises mlrun.errors.MLRunRuntimeError: If K8s deletion fails after revocation.
         """
@@ -588,6 +593,29 @@ class Secrets(
             )
             raise mlrun.errors.MLRunRuntimeError(err_msg) from exc
 
+    def _orca_owns_revocation(self) -> bool:
+        """
+        Returns whether the Orca deployment paired with this cluster already revokes the
+        Keycloak session itself before calling this endpoint. Orca's version is resolved once
+        via its own info API (see framework.utils.clients.iguazio.v4.resolve_orca_version).
+        A missing or unparseable version is treated as a recent Orca, since an older Orca
+        predates this version check entirely and would otherwise never resolve to one.
+        """
+        orca_version = framework.utils.clients.iguazio.v4.resolve_orca_version()
+        if not orca_version:
+            return True
+        try:
+            parsed_version = semver.VersionInfo.parse(orca_version)
+            parsed_version = semver.VersionInfo.parse(
+                f"{parsed_version.major}.{parsed_version.minor}.{parsed_version.patch}"
+            )
+        except ValueError:
+            logger.warning("Unable to parse Orca version", orca_version=orca_version)
+            return True
+        return parsed_version >= semver.VersionInfo.parse(
+            MIN_ORCA_VERSION_WITH_SELF_REVOKE
+        )
+
     def delete_secret_token(
         self,
         token_name: str,
@@ -598,10 +626,7 @@ class Secrets(
         Delete a stored offline token for a user and its corresponding Kubernetes secret.
 
         This method performs two actions:
-        1. Calls the Iguazio management service to revoke the offline token, unless the
-           caller is a service account (e.g. Orca) — Orca is now the source of truth for
-           offline-token revocation and already revokes the Keycloak session itself before
-           calling this endpoint, so revoking again here would be redundant.
+        1. (Only if Oris < 2.1.1) - Calls the Iguazio management service to revoke the Keycloak session itself
         2. Removes the Kubernetes secret associated with the token.
 
         :param token_name:
@@ -635,7 +660,7 @@ class Secrets(
                 token_name=token_name,
                 iguazio_client=iguazio_client,
                 request_headers=auth_info.request_headers,
-                skip_revocation=auth_info.is_service_account(),
+                skip_revocation=self._orca_owns_revocation(),
             )
         except mlrun.errors.MLRunNotFoundError:
             logger.warning(

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -551,7 +551,9 @@ class Secrets(
         :param request_headers: Request headers for authenticating with Iguazio.
         :param skip_revocation: If True, skip revoking the token via Iguazio and only delete
                                 the K8s secret. Used in bulk delete during user deletion flow
-                                since tokens are invalidated when the user is deleted anyway.
+                                since tokens are invalidated when the user is deleted anyway,
+                                and for service-account callers (e.g. Orca) that already own
+                                revocation themselves.
         :raises mlrun.errors.MLRunNotFoundError: If the token is not found.
         :raises mlrun.errors.MLRunRuntimeError: If K8s deletion fails after revocation.
         """
@@ -596,7 +598,10 @@ class Secrets(
         Delete a stored offline token for a user and its corresponding Kubernetes secret.
 
         This method performs two actions:
-        1. Calls the Iguazio management service to revoke the offline token.
+        1. Calls the Iguazio management service to revoke the offline token, unless the
+           caller is a service account (e.g. Orca) — Orca is now the source of truth for
+           offline-token revocation and already revokes the Keycloak session itself before
+           calling this endpoint, so revoking again here would be redundant.
         2. Removes the Kubernetes secret associated with the token.
 
         :param token_name:
@@ -630,6 +635,7 @@ class Secrets(
                 token_name=token_name,
                 iguazio_client=iguazio_client,
                 request_headers=auth_info.request_headers,
+                skip_revocation=auth_info.is_service_account(),
             )
         except mlrun.errors.MLRunNotFoundError:
             logger.warning(

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -27,6 +27,7 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.base
 
+import framework.utils.clients.iguazio.v4
 import services.api.crud
 import services.api.tests.unit.conftest
 
@@ -986,16 +987,38 @@ def test_delete_secret_token_success(mock_iguazio_client):
     )
 
 
-def test_delete_secret_token_service_account_skips_revocation(mock_iguazio_client):
+@pytest.mark.parametrize(
+    "resolved_version,min_version",
+    [
+        ("999.0.0", "2.1.1"),  # plain release, well past the threshold
+        # PR/dev build: pre-release and build metadata are stripped before comparing, so only
+        # major.minor.patch matters - a PR build cut from a release at the threshold still skips.
+        ("2.1.0-pr-921.1.20260818115106", "2.1.0"),
+        # Unresolvable (unreachable, unconfigured, or unparseable): an old Orca predates this
+        # version check entirely and would never resolve to a version either, so this is
+        # treated as a recent Orca rather than blocking revocation from ever being skipped.
+        ("", "2.1.1"),
+    ],
+)
+def test_delete_secret_token_recent_orca_skips_revocation(
+    mock_iguazio_client, monkeypatch, resolved_version, min_version
+):
     """
-    Orca is the source of truth for offline-token revocation and revokes the Keycloak
-    session itself before calling this endpoint, so a service-account caller (e.g. Orca)
-    must not trigger a redundant revoke here - it should only delete the K8s secret.
+    A recent-enough (or unresolvable) Orca is the source of truth for offline-token revocation
+    and revokes the Keycloak session itself before calling this endpoint, so it must not
+    trigger a redundant revoke here - it should only delete the K8s secret. Orca's version is
+    resolved once via its own info API, never trusted from the (spoofable) caller.
     """
+    monkeypatch.setattr(
+        services.api.crud.secrets, "MIN_ORCA_VERSION_WITH_SELF_REVOKE", min_version
+    )
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4,
+        "resolve_orca_version",
+        lambda: resolved_version,
+    )
     auth_info = mlrun.common.schemas.AuthInfo(
-        username="dummy-user",
-        user_id="user-id-123",
-        kind=mlrun.common.schemas.AuthInfoKind.service_account,
+        username="dummy-user", user_id="user-id-123"
     )
     token_name = "my-token"
 
@@ -1014,6 +1037,55 @@ def test_delete_secret_token_service_account_skips_revocation(mock_iguazio_clien
 
     mock_secrets_provider.get_user_token_secret_value.assert_not_called()
     mock_iguazio_client.revoke_offline_token.assert_not_called()
+    mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
+        user_id=auth_info.user_id, token_name=token_name
+    )
+
+
+@pytest.mark.parametrize(
+    "resolved_version,min_version",
+    [
+        ("1.2.0", "5.0.0"),  # predates ORIS-4151's self-revoke behavior
+        # PR/dev build below the threshold even after stripping pre-release/build metadata.
+        ("2.1.0-pr-921.1.20260818115106", "2.1.1"),
+    ],
+)
+def test_delete_secret_token_orca_below_threshold_still_revokes(
+    mock_iguazio_client, monkeypatch, resolved_version, min_version
+):
+    """
+    A resolvable Orca version that's too old (even after stripping pre-release/build metadata)
+    must still go through the normal revoke-then-delete flow.
+    """
+    monkeypatch.setattr(
+        services.api.crud.secrets, "MIN_ORCA_VERSION_WITH_SELF_REVOKE", min_version
+    )
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4,
+        "resolve_orca_version",
+        lambda: resolved_version,
+    )
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
+    token_name = "my-token"
+    fake_token = "jwt-token-123"
+
+    mock_secrets_provider = unittest.mock.Mock()
+    services.api.crud.Secrets().secrets_provider = mock_secrets_provider
+    mock_secrets_provider.get_user_token_secret_value.return_value = fake_token
+    mock_secrets_provider.delete_user_token_secret = unittest.mock.Mock()
+
+    result = services.api.crud.Secrets().delete_secret_token(
+        token_name=token_name,
+        username=auth_info.username,
+        auth_info=auth_info,
+    )
+
+    assert result.deleted is True
+    mock_iguazio_client.revoke_offline_token.assert_called_once_with(
+        fake_token, auth_info.request_headers
+    )
     mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
         user_id=auth_info.user_id, token_name=token_name
     )

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -986,6 +986,39 @@ def test_delete_secret_token_success(mock_iguazio_client):
     )
 
 
+def test_delete_secret_token_service_account_skips_revocation(mock_iguazio_client):
+    """
+    Orca is the source of truth for offline-token revocation and revokes the Keycloak
+    session itself before calling this endpoint, so a service-account caller (e.g. Orca)
+    must not trigger a redundant revoke here - it should only delete the K8s secret.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user",
+        user_id="user-id-123",
+        kind=mlrun.common.schemas.AuthInfoKind.service_account,
+    )
+    token_name = "my-token"
+
+    mock_secrets_provider = unittest.mock.Mock()
+    services.api.crud.Secrets().secrets_provider = mock_secrets_provider
+    mock_secrets_provider.delete_user_token_secret = unittest.mock.Mock()
+
+    result = services.api.crud.Secrets().delete_secret_token(
+        token_name=token_name,
+        username=auth_info.username,
+        auth_info=auth_info,
+    )
+
+    assert result.deleted is True
+    assert result.username == auth_info.username
+
+    mock_secrets_provider.get_user_token_secret_value.assert_not_called()
+    mock_iguazio_client.revoke_offline_token.assert_not_called()
+    mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
+        user_id=auth_info.user_id, token_name=token_name
+    )
+
+
 def test_delete_secret_token_not_found(mock_iguazio_client):
     auth_info = mlrun.common.schemas.AuthInfo(
         username="dummy-user", user_id="user-id-123"


### PR DESCRIPTION
### 📝 Description
Deleting a stored offline token always calls Iguazio to revoke it before deleting the Kubernetes secret. For a service-account caller (e.g. Orca), that revoke call hits a pre-existing bug in Orca's legacy revoke-callback endpoint and fails - which meant the secret deletion never ran, even though the API still returned success. Orca now revokes the underlying Keycloak session itself before calling this endpoint (it's the source of truth for offline-token revocation), so the revoke call MLRun makes here is redundant for that caller anyway. This skips it for service-account callers and deletes the secret directly.

---

### 🛠️ Changes Made
- `Secrets._delete_single_token`: extend the `skip_revocation` docstring to cover the new caller (previously only the bulk user-deletion flow set it).
- `Secrets.delete_secret_token`: update the method docstring to explain the revoke call is skipped for service-account callers.
- `Secrets.delete_secret_token`: pass `skip_revocation=auth_info.is_service_account()` into `_delete_single_token`, so a service-account caller's delete goes straight to removing the K8s secret.
- Added `test_delete_secret_token_service_account_skips_revocation` (see Testing).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Added `test_delete_secret_token_service_account_skips_revocation`, asserting the revoke call is skipped and only the K8s secret delete happens for a service-account caller.
- Verified end-to-end on a live lab: before this fix, deleting a token via Orca (a service-account caller) returned success but the MLRun secret remained. After deploying this fix, the same call correctly deleted the secret - confirmed via MLRun logs going straight to "Deleting user token secret from Kubernetes" without attempting the revoke call.

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: Companion Orca-side change that exercises this fix (sends `x-igz-authenticator-kind: sa`): https://github.com/McK-Private/orca/pull/1151

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

`skip_revocation` defaults to whatever `auth_info.is_service_account()` returns; a non-service-account caller's behavior is unchanged.

---

### 🔍️ Additional Notes
- The underlying bug in Orca's legacy revoke-callback endpoint (a malformed Keycloak certs URL) is unrelated to this fix and out of scope here; it still exists, just no longer hit on this path.
- Checked the adjacent ticket ML-13036 (Orca's service account storing tokens in MLRun) for overlap: it only affects the store/create path, not the delete path this fix touches, so there's no conflict.