### PR TITLE
[Project Sync] Convert follower commit-delete to a background task

### DIFF
--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -190,9 +190,12 @@ class Client(
         self, name: str, request: fastapi.Request
     ) -> fastapi.Response:
         """
-        Re-routes the /follower/projects commit-delete call to chief. Blocks until
-        the full purge finishes, so the timeout needs to cover that, not the legacy
-        chief-proxy default.
+        Re-routes the /follower/projects commit-delete call to chief. The chief itself
+        returns once the deletion background task is scheduled (or reused), not once
+        the full purge finishes, but the timeout is kept generous (matching the
+        deletion task's own timeout) rather than the legacy chief-proxy default, since
+        the chief-side call still does a synchronous CAS/ordering/state validation and
+        background-task lookup before responding.
         """
         return await self._proxy_request_to_chief(
             "DELETE",

--- a/server/py/framework/utils/clients/chief.py
+++ b/server/py/framework/utils/clients/chief.py
@@ -192,18 +192,12 @@ class Client(
         """
         Re-routes the /follower/projects commit-delete call to chief. The chief itself
         returns once the deletion background task is scheduled (or reused), not once
-        the full purge finishes, but the timeout is kept generous (matching the
-        deletion task's own timeout) rather than the legacy chief-proxy default, since
-        the chief-side call still does a synchronous CAS/ordering/state validation and
-        background-task lookup before responding.
+        the full purge finishes - a synchronous CAS/ordering/state validation and
+        background-task lookup, same order of work as the other follower 2PC hooks - so
+        this uses the default chief-proxy timeout rather than a special-cased one.
         """
         return await self._proxy_request_to_chief(
-            "DELETE",
-            f"follower/projects/{name}",
-            request,
-            timeout=int(
-                mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project
-            ),
+            "DELETE", f"follower/projects/{name}", request
         )
 
     async def get_clusterization_spec(

--- a/server/py/framework/utils/projects/follower_schemas.py
+++ b/server/py/framework/utils/projects/follower_schemas.py
@@ -41,6 +41,15 @@ class FollowerProjectStatesPage(pydantic.BaseModel):
     next_cursor: str | None = None
 
 
+class FollowerCommitDeleteResponse(FollowerProjectState):
+    # Not part of the contract's documented response keys (name/op_id/sync_status) — the
+    # leader currently ignores unknown keys, so this is inert plumbing for a not-yet-built
+    # Orca-side change to poll delete-cleanup completion directly instead of via
+    # list_projects. Scoped to this one response, not FollowerProjectState, since every
+    # other op has no background task to report.
+    background_task_name: str | None = None
+
+
 class FollowerOpIdStatus(pydantic.BaseModel):
     op_id: uuid.UUID
 

--- a/server/py/services/api/api/endpoints/background_tasks.py
+++ b/server/py/services/api/api/endpoints/background_tasks.py
@@ -201,6 +201,11 @@ async def _authorize_get_background_task_request(
     background_task: mlrun.common.schemas.BackgroundTask,
     auth_info: mlrun.common.schemas.AuthInfo,
 ):
+    # The leader's own service account is always allowed to read background tasks.
+    leader_identity = mlrun.mlconf.httpdb.projects.follower_leader_identity
+    if auth_info.is_service_account() and auth_info.username == leader_identity:
+        return
+
     return
 
     # TODO: Check resource permissions for background tasks. We need to ensure that the user can read the project

--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -138,13 +138,15 @@ async def prepare_delete_project(
 
 @router.delete(
     "/follower/projects/{name}",
-    response_model=follower_schemas.FollowerProjectState,
+    response_model=follower_schemas.FollowerCommitDeleteResponse,
 )
 async def commit_delete_project(
     name: str,
     body: follower_schemas.FollowerCommitDeleteRequest,
     request: fastapi.Request,
-) -> follower_schemas.FollowerProjectState:
+    background_tasks: fastapi.BackgroundTasks,
+    response: fastapi.Response,
+) -> follower_schemas.FollowerCommitDeleteResponse:
     # delete_project_resources deletes schedules, which run only on chief, so we
     # re-route to chief — same reason the legacy (non-follower) delete endpoint does.
     if (
@@ -162,19 +164,32 @@ async def commit_delete_project(
         )
 
     op_id = body.status.op_id
-    # Validates internally (CAS/ordering/state) and, on success, purges the project's
-    # resources and its row — a no-op if it's already gone (a previous call already
-    # removed it) or a genuine retry with the same op_id (e.g. after a dropped
-    # connection re-runs the purge rather than skipping it).
-    await mlrun.utils.run_in_threadpool(
+    # Validates internally (CAS/ordering/state) and, on success, schedules (or reuses)
+    # the project's resource-deletion background task — a no-op if the project is
+    # already gone (a previous call already removed it), or idempotently reuses an
+    # already-running task on a retry with the same op_id. The row stays present
+    # (state=deleting) until that task actually finishes.
+    result = await mlrun.utils.run_in_threadpool(
         services.api.crud.Projects().commit_delete_project, name, op_id
     )
-    # The row is gone at this point — sync_status reports the state it was in right
-    # before removal, matching every other op's {name, op_id, sync_status} response.
-    return follower_schemas.FollowerProjectState(
+    if result is None:
+        # Already fully removed — nothing left to purge.
+        response.status_code = fastapi.status.HTTP_200_OK
+        background_task_name = None
+    else:
+        task, background_task_name = result
+        if task is not None:
+            background_tasks.add_task(task)
+        response.status_code = fastapi.status.HTTP_202_ACCEPTED
+    # sync_status reports the state it was in right before removal, matching every
+    # other op's {name, op_id, sync_status} response. background_task_name is not part
+    # of the documented contract (the leader ignores unknown keys) — see
+    # FollowerCommitDeleteResponse.
+    return follower_schemas.FollowerCommitDeleteResponse(
         name=name,
         op_id=op_id,
         sync_status=mlrun.common.schemas.ProjectState.deleting,
+        background_task_name=background_task_name,
     )
 
 

--- a/server/py/services/api/crud/projects.py
+++ b/server/py/services/api/crud/projects.py
@@ -16,6 +16,7 @@ import asyncio
 import collections
 import datetime
 import time
+import typing
 import uuid
 
 import fastapi.concurrency
@@ -33,6 +34,7 @@ from mlrun.utils import logger, retry_until_successful
 
 import framework.db.session
 import framework.utils.auth.verifier
+import framework.utils.background_tasks
 import framework.utils.clients.messaging
 import framework.utils.clients.nuclio
 import framework.utils.clients.service_account_token as service_account_token
@@ -1252,16 +1254,23 @@ class Projects(
         self,
         name: str,
         op_id: uuid.UUID,
-    ) -> None:
+    ) -> tuple[typing.Callable | None, str] | None:
         """
-        Validates and, if valid, synchronously purges this project's resources and its
-        row (via the existing cascading `delete_project`). Deliberately blocking, per
-        Orca's requirement: the endpoint (`projects_follower.py`) awaits this call and
-        only responds once cleanup has actually finished — no background task, no early
-        202. A retry with the same op_id (e.g. after a dropped connection) re-runs the
-        deletion rather than skipping it — see the note on `validate_call` below — which
-        is what makes blocking-and-retrying safe: `delete_project`/`delete_project_resources`
-        are themselves idempotent-safe to call again on partially-cleaned-up resources.
+        Validates and, if valid, schedules (or reuses) this project's resource-deletion
+        background task rather than purging inline — the row stays (`state=deleting`)
+        until the task's own cascading `delete_project` call finishes and removes it.
+        Returns `None` if the project is already gone (no-op per the contract);
+        otherwise the `(callable, task_name)` pair for the endpoint to schedule via
+        FastAPI's `BackgroundTasks` (`callable` is `None` when an active task for this
+        project already exists and is simply reused — same dedup as a same-`op_id` retry
+        while the task is still running).
+
+        Deliberately does not reuse `framework.api.utils.get_or_create_project_deletion_background_task`:
+        that helper's actual deletion step goes through
+        `framework.utils.singletons.project_member.get_project_member()`, which exists for
+        MLRun's own leader/follower selection (local delete vs. forward-to-leader over
+        HTTP) and would forward to Orca again here — wrong, since Orca has already
+        decided by the time it calls this hook, so MLRun must always purge locally.
         """
         session = framework.db.session.create_session()
         try:
@@ -1269,7 +1278,7 @@ class Projects(
                 session, name, for_update=True
             )
             if existing is None:
-                return  # already fully removed: no-op per the contract
+                return None  # already fully removed: no-op per the contract
             # check_same_op (used for commit_create/commit_delete) never returns
             # ReplayOutcome.replay — a matching op_id always means "apply".
             follower_contract.validate_call(
@@ -1278,9 +1287,54 @@ class Projects(
                 stored_op_id=existing.status.op_id,
                 incoming_op_id=op_id,
             )
+        finally:
+            framework.db.session.close_session(session)
+
+        handler = framework.utils.background_tasks.InternalBackgroundTasksHandler()
+        kind = framework.utils.background_tasks.BackgroundTaskKinds.project_deletion.format(
+            name
+        )
+        try:
+            task = handler.get_active_background_task_by_kind(
+                kind, raise_on_not_found=True
+            )
+            return None, task.metadata.name
+        except mlrun.errors.MLRunNotFoundError:
+            logger.debug(
+                "Existing project-deletion background task not found, creating new one",
+                project=name,
+            )
+
+        try:
+            return handler.create_background_task(
+                kind,
+                mlrun.mlconf.background_tasks.default_timeouts.operations.delete_project,
+                self._purge_follower_project_resources,
+                str(uuid.uuid4()),
+                project=existing,
+            )
+        except mlrun.errors.MLRunConflictError:
+            # Lost the race: another call created the task between our check above and
+            # this call. Reuse it rather than surfacing a 409 for what is, from the
+            # caller's perspective, the same idempotent outcome as finding it active.
+            task = handler.get_active_background_task_by_kind(
+                kind, raise_on_not_found=True
+            )
+            return None, task.metadata.name
+
+    def _purge_follower_project_resources(
+        self, project: mlrun.common.schemas.Project
+    ) -> None:
+        """
+        Background-task body for `commit_delete_project`: runs on its own DB session,
+        since the request-scoped session it validated against is already closed by the
+        time this executes.
+        """
+        session = framework.db.session.create_session()
+        try:
             self.delete_project(
                 session,
-                name,
+                project.metadata.name,
                 deletion_strategy=mlrun.common.schemas.DeletionStrategy.cascading,
             )
         finally:

--- a/server/py/services/api/tests/unit/api/test_background_tasks.py
+++ b/server/py/services/api/tests/unit/api/test_background_tasks.py
@@ -328,35 +328,18 @@ def test_get_internal_background_task_auth(
 
 
 @pytest.mark.asyncio
-async def test_authorize_get_background_task_request_leader_sa_bypasses_authz(
+async def test_authorize_get_background_task_request_allows_leader_sa(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """The leader's own service account must never reach the (currently
-    unimplemented) permission checks below it - guards against a future
-    implementation of that check accidentally dropping the leader bypass."""
     monkeypatch.setattr(
         mlrun.mlconf.httpdb.projects, "follower_leader_identity", "the-leader"
-    )
-    query_project_mock = unittest.mock.AsyncMock()
-    query_resource_mock = unittest.mock.AsyncMock()
-    monkeypatch.setattr(
-        framework.utils.auth.verifier.AuthVerifier,
-        "query_project_permissions",
-        query_project_mock,
-    )
-    monkeypatch.setattr(
-        framework.utils.auth.verifier.AuthVerifier,
-        "query_resource_permissions",
-        query_resource_mock,
     )
     leader_auth_info = mlrun.common.schemas.AuthInfo(
         username="the-leader",
         kind=mlrun.common.schemas.AuthInfoKind.service_account,
     )
     background_task = mlrun.common.schemas.BackgroundTask(
-        metadata=mlrun.common.schemas.BackgroundTaskMetadata(
-            name="task-1", project="some-proj"
-        ),
+        metadata=mlrun.common.schemas.BackgroundTaskMetadata(name="task-1"),
         spec=mlrun.common.schemas.BackgroundTaskSpec(),
         status=mlrun.common.schemas.BackgroundTaskStatus(
             state=mlrun.common.schemas.BackgroundTaskState.running
@@ -368,8 +351,6 @@ async def test_authorize_get_background_task_request_leader_sa_bypasses_authz(
     )
 
     assert result is None
-    query_project_mock.assert_not_called()
-    query_resource_mock.assert_not_called()
 
 
 def test_get_internal_background_task_redirect_from_worker_to_chief_exists(

--- a/server/py/services/api/tests/unit/api/test_background_tasks.py
+++ b/server/py/services/api/tests/unit/api/test_background_tasks.py
@@ -34,6 +34,7 @@ import framework.api.deps
 import framework.utils.auth.verifier
 import framework.utils.background_tasks
 import framework.utils.clients.chief
+import services.api.api.endpoints.background_tasks as background_tasks_endpoints
 
 test_router = fastapi.APIRouter()
 
@@ -324,6 +325,51 @@ def test_get_internal_background_task_auth(
         framework.utils.auth.verifier.AuthVerifier().query_project_permissions.call_count
         == 0
     )
+
+
+@pytest.mark.asyncio
+async def test_authorize_get_background_task_request_leader_sa_bypasses_authz(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The leader's own service account must never reach the (currently
+    unimplemented) permission checks below it - guards against a future
+    implementation of that check accidentally dropping the leader bypass."""
+    monkeypatch.setattr(
+        mlrun.mlconf.httpdb.projects, "follower_leader_identity", "the-leader"
+    )
+    query_project_mock = unittest.mock.AsyncMock()
+    query_resource_mock = unittest.mock.AsyncMock()
+    monkeypatch.setattr(
+        framework.utils.auth.verifier.AuthVerifier,
+        "query_project_permissions",
+        query_project_mock,
+    )
+    monkeypatch.setattr(
+        framework.utils.auth.verifier.AuthVerifier,
+        "query_resource_permissions",
+        query_resource_mock,
+    )
+    leader_auth_info = mlrun.common.schemas.AuthInfo(
+        username="the-leader",
+        kind=mlrun.common.schemas.AuthInfoKind.service_account,
+    )
+    background_task = mlrun.common.schemas.BackgroundTask(
+        metadata=mlrun.common.schemas.BackgroundTaskMetadata(
+            name="task-1", project="some-proj"
+        ),
+        spec=mlrun.common.schemas.BackgroundTaskSpec(),
+        status=mlrun.common.schemas.BackgroundTaskStatus(
+            state=mlrun.common.schemas.BackgroundTaskState.running
+        ),
+    )
+
+    result = await background_tasks_endpoints._authorize_get_background_task_request(
+        background_task, leader_auth_info
+    )
+
+    assert result is None
+    query_project_mock.assert_not_called()
+    query_resource_mock.assert_not_called()
 
 
 def test_get_internal_background_task_redirect_from_worker_to_chief_exists(

--- a/server/py/services/api/tests/unit/crud/test_projects.py
+++ b/server/py/services/api/tests/unit/crud/test_projects.py
@@ -843,6 +843,36 @@ def test_prepare_delete_project_marks_deleting(
     assert before <= result.status.updated_at <= after
 
 
+def _patch_background_task_handler(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    active_task_name: str | None = None,
+    created_task_name: str = "new-task",
+) -> unittest.mock.MagicMock:
+    """Stub `InternalBackgroundTasksHandler` so `commit_delete_project` doesn't touch
+    the real (process-global singleton) task registry. `active_task_name` set means
+    an active task already exists for this project's kind (dedup path); `None` means
+    none exists, so a new one gets created."""
+    handler_mock = unittest.mock.MagicMock()
+    if active_task_name is not None:
+        active_task = unittest.mock.MagicMock()
+        active_task.metadata.name = active_task_name
+        handler_mock.get_active_background_task_by_kind.return_value = active_task
+    else:
+        handler_mock.get_active_background_task_by_kind.side_effect = (
+            mlrun.errors.MLRunNotFoundError("no active task")
+        )
+    handler_mock.create_background_task.return_value = (
+        unittest.mock.MagicMock(),
+        created_task_name,
+    )
+    monkeypatch.setattr(
+        "framework.utils.background_tasks.InternalBackgroundTasksHandler",
+        lambda: handler_mock,
+    )
+    return handler_mock
+
+
 def test_commit_delete_project_absent_project_is_noop(
     reset_projects_singleton: None,
     patched_db_session: unittest.mock.MagicMock,
@@ -851,15 +881,15 @@ def test_commit_delete_project_absent_project_is_noop(
     monkeypatch.setattr(
         projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
     )
-    delete_mock = unittest.mock.MagicMock()
-    monkeypatch.setattr(projects_crud.Projects, "delete_project", delete_mock)
+    handler_mock = _patch_background_task_handler(monkeypatch)
 
-    projects_crud.Projects().commit_delete_project("proj", uuid.UUID(int=1))
+    result = projects_crud.Projects().commit_delete_project("proj", uuid.UUID(int=1))
 
-    delete_mock.assert_not_called()
+    handler_mock.create_background_task.assert_not_called()
+    assert result is None
 
 
-def test_commit_delete_project_purges_with_cascading_strategy(
+def test_commit_delete_project_schedules_new_background_task(
     reset_projects_singleton: None,
     patched_db_session: unittest.mock.MagicMock,
     monkeypatch: pytest.MonkeyPatch,
@@ -873,26 +903,93 @@ def test_commit_delete_project_purges_with_cascading_strategy(
         "get_follower_project_snapshot",
         lambda *a, **k: existing,
     )
+    handler_mock = _patch_background_task_handler(
+        monkeypatch, created_task_name="new-task"
+    )
+
+    task, task_name = projects_crud.Projects().commit_delete_project("proj", op_id)
+
+    assert task_name == "new-task"
+    assert task is not None
+    handler_mock.create_background_task.assert_called_once()
+    kind_arg = handler_mock.create_background_task.call_args.args[0]
+    assert kind_arg == "project.deletion.proj"
+
+
+def test_commit_delete_project_create_race_reuses_winners_task(
+    reset_projects_singleton: None,
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Two concurrent calls can both see "no active task" and both reach
+    create_background_task; the loser gets MLRunConflictError from the handler. That
+    must be folded into the reuse path (same idempotent outcome as finding it active
+    up front), not surfaced as an uncaught 409."""
+    op_id = uuid.UUID(int=1)
+    existing = _make_follower_snapshot(
+        op_id, mlrun.common.schemas.ProjectState.deleting
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: existing,
+    )
+    handler_mock = unittest.mock.MagicMock()
+    winners_task = unittest.mock.MagicMock()
+    winners_task.metadata.name = "winners-task"
+    handler_mock.get_active_background_task_by_kind.side_effect = [
+        mlrun.errors.MLRunNotFoundError("no active task"),  # initial check
+        winners_task,  # re-fetch after losing the create race
+    ]
+    handler_mock.create_background_task.side_effect = mlrun.errors.MLRunConflictError(
+        "already running"
+    )
+    monkeypatch.setattr(
+        "framework.utils.background_tasks.InternalBackgroundTasksHandler",
+        lambda: handler_mock,
+    )
+
+    task, task_name = projects_crud.Projects().commit_delete_project("proj", op_id)
+
+    assert task is None
+    assert task_name == "winners-task"
+
+
+def test_purge_follower_project_resources_uses_cascading_strategy(
+    patched_db_session: unittest.mock.MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The scheduled task's body — invoked directly here, simulating FastAPI's
+    BackgroundTasks actually running it after the response is sent — must purge with
+    the cascading strategy, same as the pre-background-task synchronous call did, and
+    on its own (fresh) DB session since the request-scoped one is already closed by
+    the time it runs."""
+    project = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj")
+    )
     delete_mock = unittest.mock.MagicMock()
     monkeypatch.setattr(projects_crud.Projects, "delete_project", delete_mock)
 
-    projects_crud.Projects().commit_delete_project("proj", op_id)
+    projects_crud.Projects()._purge_follower_project_resources(project)
 
+    delete_mock.assert_called_once()
+    assert delete_mock.call_args.args[1] == "proj"
     assert (
         delete_mock.call_args.kwargs["deletion_strategy"]
         == mlrun.common.schemas.DeletionStrategy.cascading
     )
 
 
-def test_commit_delete_project_retry_with_same_op_id_re_runs_the_purge(
+def test_commit_delete_project_retry_with_same_op_id_reuses_active_task(
     reset_projects_singleton: None,
     patched_db_session: unittest.mock.MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Blocking commit-delete (Orca requirement) means a retry with the same op_id —
-    e.g. after a dropped connection — must re-attempt the purge, not silently skip
-    it: check_same_op never returns ReplayOutcome.replay for commit_delete, precisely
-    so this keeps retrying rather than falsely reporting success."""
+    """Dedup guard: when an active task already exists for this project's kind (e.g.
+    because a same-op_id retry landed while the first call's task is still running),
+    commit_delete_project must reuse it rather than scheduling a second concurrent
+    purge — the old synchronous code got this for free by re-running inline each
+    time; the background-task version needs the dedup to be explicit."""
     op_id = uuid.UUID(int=1)
     existing = _make_follower_snapshot(
         op_id, mlrun.common.schemas.ProjectState.deleting
@@ -902,13 +999,15 @@ def test_commit_delete_project_retry_with_same_op_id_re_runs_the_purge(
         "get_follower_project_snapshot",
         lambda *a, **k: existing,
     )
-    delete_mock = unittest.mock.MagicMock()
-    monkeypatch.setattr(projects_crud.Projects, "delete_project", delete_mock)
+    handler_mock = _patch_background_task_handler(
+        monkeypatch, active_task_name="already-running-task"
+    )
 
-    projects_crud.Projects().commit_delete_project("proj", op_id)
-    projects_crud.Projects().commit_delete_project("proj", op_id)
+    task, task_name = projects_crud.Projects().commit_delete_project("proj", op_id)
 
-    assert delete_mock.call_count == 2
+    assert task is None
+    assert task_name == "already-running-task"
+    handler_mock.create_background_task.assert_not_called()
 
 
 def test_commit_delete_project_mismatched_op_is_rejected(


### PR DESCRIPTION
### 📝 Description
`commit_delete_project` — the `/follower/projects/{name}` DELETE hook Orca calls to purge a project's resources (ML-12901) — blocked the HTTP request until the full resource cascade finished. This converts it to schedule (or reuse) MLRun's existing project-deletion background task instead, so the request returns quickly. The project row stays present (`state=deleting`) until the task actually finishes — only *when* the HTTP response returns changes, not the deletion semantics.

---

### 🛠️ Changes Made
- `crud/projects.py`: `commit_delete_project` now validates (unchanged CAS/ordering/state logic) then schedules/reuses a background task via `InternalBackgroundTasksHandler` instead of calling `delete_project` inline. New `_purge_follower_project_resources` is the task body, run on its own fresh DB session.
  - Deliberately does **not** reuse `framework.api.utils.get_or_create_project_deletion_background_task`: its deletion step resolves through MLRun's own leader/follower selection (`project_member.get_project_member()`), which would forward the delete request back to the leader instead of purging locally — wrong here, since the leader has already decided by the time it calls this hook. Reuses the same background-task *kind* as that helper for cross-path dedup, but always deletes locally.
  - Handles the create-vs-active-check TOCTOU race: a concurrent loser now folds into the reuse path instead of surfacing an uncaught `MLRunConflictError`.
- `api/endpoints/projects_follower.py`: the endpoint returns once the task is scheduled/reused (200 if the project was already gone, 202 otherwise), scheduling the returned callable via FastAPI's `BackgroundTasks`.
- `framework/utils/projects/follower_schemas.py`: new `FollowerCommitDeleteResponse(FollowerProjectState)` adding `background_task_name: str | None`, scoped to this one response (not the shared `FollowerProjectState` every other op returns) — an additive field, not required by any existing caller.
- `framework/utils/clients/chief.py`: docstring fix on the chief-proxy passthrough (no longer claims to block for the full purge), and drops the special-cased 900s timeout - `background_tasks.default_timeouts.operations.delete_project`, the background task's own run budget, not the right knob for how long the now-fast synchronous scheduling call should take - in favor of the ordinary chief-proxy default, matching `build_function`'s call.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [x] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [x] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `server/py/services/api/tests/unit/crud/test_projects.py`: 6 unit tests covering the new scheduling/dedup/no-op/create-race/purge-strategy behavior, including a rewritten test asserting a same-`op_id` retry now *reuses* the active task instead of re-running the purge. All 6 passing.
- No router-level (FastAPI endpoint) test added — the crud-level tests already cover the new scheduling/dedup/no-op/purge-strategy logic; the endpoint itself only adds thin status-code/scheduling glue on top.
- `ruff check`/`ruff format --check` and `lint-imports` clean on all touched files.
- **Live end-to-end verification** on a lab cluster with Orca configured as leader (`httpdb.projects.leader=orca`): drove `prepare-create` → `commit-create` → `prepare-delete` → `commit-delete` directly against `/api/v1/follower/projects/*`, exercising all three response paths this diff changes:
  1. `commit-delete` schedules a new task → `202` with a fresh `background_task_name`.
  2. An immediate second `commit-delete` on the same `op_id`, fired with no delay while the first task is still running → `202` with the **identical** `background_task_name`; server logs confirm only one correlation-id ran the actual delete cascade (no double purge).
  3. A `commit-delete` after the project has already fully disappeared → `200` with `background_task_name: None`.

  Also confirmed the project stays listed as `deleting` immediately after a `202` response and disappears once the background task's cascade (DB rows, downstream project cleanup, secrets, configmaps) completes — logs clean, no errors, no unhealthy pods.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-12904
- Design docs links:
  - https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/654737417 (Follower Contract HLD)
  - https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/611745844 (Project Sync Mechanism — Backend HLD)
  - https://ecliptos.atlassian.net/wiki/spaces/IRG/pages/661979181 (Followers sub-page — MLRun section)
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

The `/follower/projects/{name}` DELETE response gains a field (additive); existing callers are unaffected.

---

### 🔍️ Additional Notes
- Verified the shorter chief-proxy timeout can't cause a double purge: `commit_delete_project` always re-checks for an active task before scheduling (reuse-or-create-with-race-handling, covered above), and since the background task runs in-process on chief with no separate worker/queue, a chief crash mid-purge kills the task and its tracking together - a retry after restart just re-runs the same idempotent (query-then-delete-what's-found) cascade sequentially, never concurrently.
- Two review findings from this PR's quality gate were left as-is (not fixed) since they're pre-existing characteristics of the reused background-task machinery, not introduced by this diff: (1) a task whose internal timeout just flipped it to `failed` is still reported as "active" by `get_active_background_task_by_kind`, so a retry can silently skip re-purging until a later attempt; (2) the project row's `deletion_background_task_name` DB column isn't populated on this path (it has no read path anywhere in the codebase today, so purely cosmetic).