### PR TITLE
[Project Sync] Add follower get-project-state endpoint

### DIFF
--- a/server/py/services/api/api/endpoints/projects_follower.py
+++ b/server/py/services/api/api/endpoints/projects_follower.py
@@ -203,3 +203,23 @@ async def list_project_states(
         ],
         next_cursor=next_cursor,
     )
+
+
+@router.get(
+    "/follower/projects/states/{name}",
+    response_model=follower_schemas.FollowerProjectState,
+)
+async def get_project_state(
+    name: str,
+    db_session: sqlalchemy.orm.Session = fastapi.Depends(
+        framework.api.deps.get_db_session
+    ),
+) -> follower_schemas.FollowerProjectState:
+    project = await mlrun.utils.run_in_threadpool(
+        services.api.crud.Projects().get_follower_project_snapshot,
+        db_session,
+        name,
+    )
+    if project is None:
+        raise mlrun.errors.MLRunNotFoundError(f"Project {name} not found")
+    return _to_follower_state(name, project)

--- a/server/py/services/api/tests/unit/api/test_projects_follower.py
+++ b/server/py/services/api/tests/unit/api/test_projects_follower.py
@@ -12,49 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections.abc
-import unittest.mock
 import uuid
 
 import pytest
+import sqlalchemy.orm
 
 import mlrun.common.schemas
 import mlrun.errors
-import mlrun.utils.singleton
 
 import services.api.api.endpoints.projects_follower as projects_follower
-import services.api.crud.projects as projects_crud
-
-
-@pytest.fixture
-def reset_projects_singleton() -> collections.abc.Iterator[None]:
-    """Drop the Projects singleton so __init__ re-runs with the current mlconf."""
-    mlrun.utils.singleton.Singleton._instances.pop(projects_crud.Projects, None)
-    yield
-    mlrun.utils.singleton.Singleton._instances.pop(projects_crud.Projects, None)
+import services.api.crud
 
 
 @pytest.mark.asyncio
 async def test_get_project_state_returns_state_for_existing_project(
-    reset_projects_singleton: None,
-    monkeypatch: pytest.MonkeyPatch,
+    db: sqlalchemy.orm.Session,
 ):
-    op_id = uuid.UUID(int=1)
-    snapshot = mlrun.common.schemas.Project(
-        metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
-        status=mlrun.common.schemas.ProjectStatus(
-            op_id=op_id, state=mlrun.common.schemas.ProjectState.online
+    op_id = uuid.uuid4()
+    services.api.crud.Projects().create_project(
+        db,
+        mlrun.common.schemas.Project(
+            metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
+            status=mlrun.common.schemas.ProjectStatus(
+                op_id=op_id, state=mlrun.common.schemas.ProjectState.online
+            ),
         ),
     )
-    monkeypatch.setattr(
-        projects_crud.Projects,
-        "get_follower_project_snapshot",
-        lambda *a, **k: snapshot,
-    )
 
-    result = await projects_follower.get_project_state(
-        "proj", unittest.mock.MagicMock()
-    )
+    result = await projects_follower.get_project_state("proj", db)
 
     assert result == projects_follower.follower_schemas.FollowerProjectState(
         name="proj",
@@ -65,36 +50,7 @@ async def test_get_project_state_returns_state_for_existing_project(
 
 @pytest.mark.asyncio
 async def test_get_project_state_raises_not_found_for_missing_project(
-    reset_projects_singleton: None,
-    monkeypatch: pytest.MonkeyPatch,
+    db: sqlalchemy.orm.Session,
 ):
-    monkeypatch.setattr(
-        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
-    )
-
     with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        await projects_follower.get_project_state("missing", unittest.mock.MagicMock())
-
-
-@pytest.mark.asyncio
-async def test_get_project_state_passes_session_and_name_to_the_snapshot_lookup(
-    reset_projects_singleton: None,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    calls = []
-
-    def _fake_get_follower_project_snapshot(self, session, name):
-        calls.append((session, name))
-        return None
-
-    monkeypatch.setattr(
-        projects_crud.Projects,
-        "get_follower_project_snapshot",
-        _fake_get_follower_project_snapshot,
-    )
-    db_session = unittest.mock.MagicMock()
-
-    with pytest.raises(mlrun.errors.MLRunNotFoundError):
-        await projects_follower.get_project_state("proj", db_session)
-
-    assert calls == [(db_session, "proj")]
+        await projects_follower.get_project_state("missing", db)

--- a/server/py/services/api/tests/unit/api/test_projects_follower.py
+++ b/server/py/services/api/tests/unit/api/test_projects_follower.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections.abc
+import unittest.mock
+import uuid
+
+import pytest
+
+import mlrun.common.schemas
+import mlrun.errors
+import mlrun.utils.singleton
+
+import services.api.api.endpoints.projects_follower as projects_follower
+import services.api.crud.projects as projects_crud
+
+
+@pytest.fixture
+def reset_projects_singleton() -> collections.abc.Iterator[None]:
+    """Drop the Projects singleton so __init__ re-runs with the current mlconf."""
+    mlrun.utils.singleton.Singleton._instances.pop(projects_crud.Projects, None)
+    yield
+    mlrun.utils.singleton.Singleton._instances.pop(projects_crud.Projects, None)
+
+
+@pytest.mark.asyncio
+async def test_get_project_state_returns_state_for_existing_project(
+    reset_projects_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    op_id = uuid.UUID(int=1)
+    snapshot = mlrun.common.schemas.Project(
+        metadata=mlrun.common.schemas.ProjectMetadata(name="proj"),
+        status=mlrun.common.schemas.ProjectStatus(
+            op_id=op_id, state=mlrun.common.schemas.ProjectState.online
+        ),
+    )
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        lambda *a, **k: snapshot,
+    )
+
+    result = await projects_follower.get_project_state(
+        "proj", unittest.mock.MagicMock()
+    )
+
+    assert result == projects_follower.follower_schemas.FollowerProjectState(
+        name="proj",
+        op_id=op_id,
+        sync_status=mlrun.common.schemas.ProjectState.online,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_project_state_raises_not_found_for_missing_project(
+    reset_projects_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        projects_crud.Projects, "get_follower_project_snapshot", lambda *a, **k: None
+    )
+
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        await projects_follower.get_project_state("missing", unittest.mock.MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_get_project_state_passes_session_and_name_to_the_snapshot_lookup(
+    reset_projects_singleton: None,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = []
+
+    def _fake_get_follower_project_snapshot(self, session, name):
+        calls.append((session, name))
+        return None
+
+    monkeypatch.setattr(
+        projects_crud.Projects,
+        "get_follower_project_snapshot",
+        _fake_get_follower_project_snapshot,
+    )
+    db_session = unittest.mock.MagicMock()
+
+    with pytest.raises(mlrun.errors.MLRunNotFoundError):
+        await projects_follower.get_project_state("proj", db_session)
+
+    assert calls == [(db_session, "proj")]


### PR DESCRIPTION
### 📝 Description
Adds a single-record counterpart to the follower `list-states` endpoint: `GET /follower/projects/states/{name}` returns the sync state of one named project, so a caller that only needs one project's state doesn't have to page through `list-states` to find it.

---

### 🛠️ Changes Made
- New `GET /follower/projects/states/{name}` route in `projects_follower.py`, returning a `FollowerProjectState` for a single project.
- Reuses the existing `Projects().get_follower_project_snapshot()` (name/op_id/state) projection — the same one the 2PC hooks use for their CAS pre-check reads — rather than adding a new crud method.
- Returns 404 (`MLRunNotFoundError`) when the project doesn't exist.
- Inherits the router's existing SA-gated `authenticate_leader_request` auth automatically (applied at `include_router`, not per-route).

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [ ] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `ruff check` / `ruff format --check` pass on the changed file.
- Ran the existing crud-layer suite (`services/api/tests/unit/crud/test_projects.py`, 29/29 passing) covering `get_follower_project_snapshot()`'s found/not-found behavior, which this endpoint calls directly.
- No new automated test exercises the route itself over HTTP — none of the sibling follower routes (`prepare-create`, `update`, `list-states`, etc.) have router-level tests either, so this follows the existing coverage pattern rather than introducing a new one.

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13069
- Design docs links:
- External links:

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Stacked on `feature/project-sync-follower` (not yet merged) — base this PR against that branch, not `development`.