### PR TITLE
[Secrets] Skip redundant token revocation once Orca self-revokes

### DIFF
--- a/mlrun/config.py
+++ b/mlrun/config.py
@@ -94,6 +94,7 @@ default_config = {
     "kfp_image": "mlrun/mlrun-kfp",  # image to use for KFP runner
     "dask_kfp_image": "mlrun/mlrun",  # image to use for dask KFP runner
     "igz_version": "",  # the version of the iguazio system the API is running on
+    "orca_version": "",  # resolved lazily from Orca's own info API, see resolve_orca_version()
     "iguazio_api_url": "",  # the url to iguazio api (internal / external access with priority to internal)
     "iguazio_api_url_ingress": "",  # the url to iguazio api ingress (for external access)
     "iguazio_api_ssl_verify": True,  # verify ssl certificate of iguazio api

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -645,6 +645,7 @@ class AsyncClient(BaseAsyncClient, Client):
 
     pass
 
+
 # if orca version specified on mlrun config set it likewise,
 # if not specified, get it from Orca's own info API
 # since this is a heavy operation (sending requests to API), and it's unlikely that the version

--- a/server/py/framework/utils/clients/iguazio/v4.py
+++ b/server/py/framework/utils/clients/iguazio/v4.py
@@ -30,7 +30,8 @@ import mlrun.common.formatters
 import mlrun.common.schemas
 import mlrun.common.types
 import mlrun.errors
-from mlrun.utils import get_in
+from mlrun.config import config
+from mlrun.utils import get_in, logger
 
 import framework.utils.clients.helpers as clients_helpers
 import framework.utils.clients.service_account_token as service_account_token
@@ -156,6 +157,24 @@ class Client(BaseClient, project_follower.Member):
             mlrun.errors.MLRunUnauthorizedError,
             "Failed to revoke offline token from Iguazio",
             auth_headers=request_headers,
+        )
+
+    def get_orca_version(self) -> str:
+        """
+        Fetch Orca's own release version from its system-info API.
+
+        :return: Orca's version string (e.g. "1.2.0").
+        :raises mlrun.errors.MLRunRuntimeError: If the request to Orca fails.
+        """
+
+        def _get_orca_version():
+            system_info = self._client.get_system_info()
+            return system_info.metadata.version.oris_version
+
+        return self._try_callback_with_httpx_exceptions(
+            _get_orca_version,
+            mlrun.errors.MLRunRuntimeError,
+            "Failed to get Orca version from its system-info API",
         )
 
     def get_user_id_by_username(
@@ -625,3 +644,18 @@ class AsyncClient(BaseAsyncClient, Client):
     """Asynchronous implementation of the Iguazio V4 client. Inherits logic from Client and BaseAsyncClient."""
 
     pass
+
+# if orca version specified on mlrun config set it likewise,
+# if not specified, get it from Orca's own info API
+# since this is a heavy operation (sending requests to API), and it's unlikely that the version
+# will change - only fetch it once
+def resolve_orca_version() -> str:
+    if not config.orca_version and config.iguazio_api_url:
+        try:
+            config.orca_version = Client().get_orca_version()
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve Orca version", exc=mlrun.errors.err_to_str(exc)
+            )
+
+    return config.orca_version

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -19,6 +19,7 @@ import typing
 import uuid
 from collections import defaultdict
 
+import semver
 from fastapi.concurrency import run_in_threadpool
 
 import mlrun.auth.utils
@@ -48,6 +49,11 @@ class SecretsClientType(enum.StrEnum):
     hub = "hub"
     notifications = "notifications"
     datastore_profiles = "datastore-profiles"
+
+# TODO: Update to 2.1.1 during ML-13070
+# The first Orca release that ships RevokeOfflineSession and self-revokes the
+# Keycloak session before calling this endpoint.
+MIN_ORCA_VERSION_WITH_SELF_REVOKE = "2.1.0"
 
 
 class Secrets(
@@ -552,8 +558,7 @@ class Secrets(
         :param skip_revocation: If True, skip revoking the token via Iguazio and only delete
                                 the K8s secret. Used in bulk delete during user deletion flow
                                 since tokens are invalidated when the user is deleted anyway,
-                                and for service-account callers (e.g. Orca) that already own
-                                revocation themselves.
+                                and once Orca is recent enough to already own revocation itself.
         :raises mlrun.errors.MLRunNotFoundError: If the token is not found.
         :raises mlrun.errors.MLRunRuntimeError: If K8s deletion fails after revocation.
         """
@@ -588,6 +593,29 @@ class Secrets(
             )
             raise mlrun.errors.MLRunRuntimeError(err_msg) from exc
 
+    def _orca_owns_revocation(self) -> bool:
+        """
+        Returns whether the Orca deployment paired with this cluster already revokes the
+        Keycloak session itself before calling this endpoint. Orca's version is resolved once
+        via its own info API (see framework.utils.clients.iguazio.v4.resolve_orca_version).
+        A missing or unparseable version is treated as a recent Orca, since an older Orca
+        predates this version check entirely and would otherwise never resolve to one.
+        """
+        orca_version = framework.utils.clients.iguazio.v4.resolve_orca_version()
+        if not orca_version:
+            return True
+        try:
+            parsed_version = semver.VersionInfo.parse(orca_version)
+            parsed_version = semver.VersionInfo.parse(
+                f"{parsed_version.major}.{parsed_version.minor}.{parsed_version.patch}"
+            )
+        except ValueError:
+            logger.warning("Unable to parse Orca version", orca_version=orca_version)
+            return True
+        return parsed_version >= semver.VersionInfo.parse(
+            MIN_ORCA_VERSION_WITH_SELF_REVOKE
+        )
+
     def delete_secret_token(
         self,
         token_name: str,
@@ -598,10 +626,7 @@ class Secrets(
         Delete a stored offline token for a user and its corresponding Kubernetes secret.
 
         This method performs two actions:
-        1. Calls the Iguazio management service to revoke the offline token, unless the
-           caller is a service account (e.g. Orca) — Orca is now the source of truth for
-           offline-token revocation and already revokes the Keycloak session itself before
-           calling this endpoint, so revoking again here would be redundant.
+        1. (Only if Oris < 2.1.1) - Calls the Iguazio management service to revoke the Keycloak session itself
         2. Removes the Kubernetes secret associated with the token.
 
         :param token_name:
@@ -635,7 +660,7 @@ class Secrets(
                 token_name=token_name,
                 iguazio_client=iguazio_client,
                 request_headers=auth_info.request_headers,
-                skip_revocation=auth_info.is_service_account(),
+                skip_revocation=self._orca_owns_revocation(),
             )
         except mlrun.errors.MLRunNotFoundError:
             logger.warning(

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -551,7 +551,9 @@ class Secrets(
         :param request_headers: Request headers for authenticating with Iguazio.
         :param skip_revocation: If True, skip revoking the token via Iguazio and only delete
                                 the K8s secret. Used in bulk delete during user deletion flow
-                                since tokens are invalidated when the user is deleted anyway.
+                                since tokens are invalidated when the user is deleted anyway,
+                                and for service-account callers (e.g. Orca) that already own
+                                revocation themselves.
         :raises mlrun.errors.MLRunNotFoundError: If the token is not found.
         :raises mlrun.errors.MLRunRuntimeError: If K8s deletion fails after revocation.
         """
@@ -596,7 +598,10 @@ class Secrets(
         Delete a stored offline token for a user and its corresponding Kubernetes secret.
 
         This method performs two actions:
-        1. Calls the Iguazio management service to revoke the offline token.
+        1. Calls the Iguazio management service to revoke the offline token, unless the
+           caller is a service account (e.g. Orca) — Orca is now the source of truth for
+           offline-token revocation and already revokes the Keycloak session itself before
+           calling this endpoint, so revoking again here would be redundant.
         2. Removes the Kubernetes secret associated with the token.
 
         :param token_name:
@@ -630,6 +635,7 @@ class Secrets(
                 token_name=token_name,
                 iguazio_client=iguazio_client,
                 request_headers=auth_info.request_headers,
+                skip_revocation=auth_info.is_service_account(),
             )
         except mlrun.errors.MLRunNotFoundError:
             logger.warning(

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -627,7 +627,7 @@ class Secrets(
         Delete a stored offline token for a user and its corresponding Kubernetes secret.
 
         This method performs two actions:
-        1. (Only if Oris < 2.1.1) - Calls the Iguazio management service to revoke the Keycloak session itself
+        1. (Only if Orca < 2.1.0) - Calls the Iguazio management service to revoke the Keycloak session itself
         2. Removes the Kubernetes secret associated with the token.
 
         :param token_name:

--- a/server/py/services/api/crud/secrets.py
+++ b/server/py/services/api/crud/secrets.py
@@ -50,6 +50,7 @@ class SecretsClientType(enum.StrEnum):
     notifications = "notifications"
     datastore_profiles = "datastore-profiles"
 
+
 # TODO: Update to 2.1.1 during ML-13070
 # The first Orca release that ships RevokeOfflineSession and self-revokes the
 # Keycloak session before calling this endpoint.

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -951,7 +951,10 @@ def test_list_secret_tokens_returns_tokens():
     )
 
 
-def test_delete_secret_token_success(mock_iguazio_client):
+def test_delete_secret_token_success(mock_iguazio_client, monkeypatch):
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4, "resolve_orca_version", lambda: "1.0.0"
+    )
     request_headers = {
         mlrun.common.schemas.HeaderNames.authorization: f"{mlrun.common.schemas.AuthorizationHeaderPrefixes.bearer}123",
     }
@@ -1091,7 +1094,10 @@ def test_delete_secret_token_orca_below_threshold_still_revokes(
     )
 
 
-def test_delete_secret_token_not_found(mock_iguazio_client):
+def test_delete_secret_token_not_found(mock_iguazio_client, monkeypatch):
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4, "resolve_orca_version", lambda: "1.0.0"
+    )
     auth_info = mlrun.common.schemas.AuthInfo(
         username="dummy-user", user_id="user-id-123"
     )
@@ -1112,7 +1118,10 @@ def test_delete_secret_token_not_found(mock_iguazio_client):
     assert result.username == auth_info.username
 
 
-def test_delete_secret_token_iguazio_failure(mock_iguazio_client):
+def test_delete_secret_token_iguazio_failure(mock_iguazio_client, monkeypatch):
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4, "resolve_orca_version", lambda: "1.0.0"
+    )
     auth_info = mlrun.common.schemas.AuthInfo(
         username="dummy-user", user_id="user-id-123"
     )
@@ -1131,7 +1140,10 @@ def test_delete_secret_token_iguazio_failure(mock_iguazio_client):
         )
 
 
-def test_delete_secret_token_k8s_delete_failure(mock_iguazio_client):
+def test_delete_secret_token_k8s_delete_failure(mock_iguazio_client, monkeypatch):
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4, "resolve_orca_version", lambda: "1.0.0"
+    )
     auth_info = mlrun.common.schemas.AuthInfo(
         username="dummy-user", user_id="user-id-123"
     )

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -27,6 +27,7 @@ import mlrun.common.schemas
 import mlrun.errors
 import mlrun.runtimes.base
 
+import framework.utils.clients.iguazio.v4
 import services.api.crud
 import services.api.tests.unit.conftest
 
@@ -986,16 +987,38 @@ def test_delete_secret_token_success(mock_iguazio_client):
     )
 
 
-def test_delete_secret_token_service_account_skips_revocation(mock_iguazio_client):
+@pytest.mark.parametrize(
+    "resolved_version,min_version",
+    [
+        ("999.0.0", "2.1.1"),  # plain release, well past the threshold
+        # PR/dev build: pre-release and build metadata are stripped before comparing, so only
+        # major.minor.patch matters - a PR build cut from a release at the threshold still skips.
+        ("2.1.0-pr-921.1.20260818115106", "2.1.0"),
+        # Unresolvable (unreachable, unconfigured, or unparseable): an old Orca predates this
+        # version check entirely and would never resolve to a version either, so this is
+        # treated as a recent Orca rather than blocking revocation from ever being skipped.
+        ("", "2.1.1"),
+    ],
+)
+def test_delete_secret_token_recent_orca_skips_revocation(
+    mock_iguazio_client, monkeypatch, resolved_version, min_version
+):
     """
-    Orca is the source of truth for offline-token revocation and revokes the Keycloak
-    session itself before calling this endpoint, so a service-account caller (e.g. Orca)
-    must not trigger a redundant revoke here - it should only delete the K8s secret.
+    A recent-enough (or unresolvable) Orca is the source of truth for offline-token revocation
+    and revokes the Keycloak session itself before calling this endpoint, so it must not
+    trigger a redundant revoke here - it should only delete the K8s secret. Orca's version is
+    resolved once via its own info API, never trusted from the (spoofable) caller.
     """
+    monkeypatch.setattr(
+        services.api.crud.secrets, "MIN_ORCA_VERSION_WITH_SELF_REVOKE", min_version
+    )
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4,
+        "resolve_orca_version",
+        lambda: resolved_version,
+    )
     auth_info = mlrun.common.schemas.AuthInfo(
-        username="dummy-user",
-        user_id="user-id-123",
-        kind=mlrun.common.schemas.AuthInfoKind.service_account,
+        username="dummy-user", user_id="user-id-123"
     )
     token_name = "my-token"
 
@@ -1014,6 +1037,55 @@ def test_delete_secret_token_service_account_skips_revocation(mock_iguazio_clien
 
     mock_secrets_provider.get_user_token_secret_value.assert_not_called()
     mock_iguazio_client.revoke_offline_token.assert_not_called()
+    mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
+        user_id=auth_info.user_id, token_name=token_name
+    )
+
+
+@pytest.mark.parametrize(
+    "resolved_version,min_version",
+    [
+        ("1.2.0", "5.0.0"),  # predates ORIS-4151's self-revoke behavior
+        # PR/dev build below the threshold even after stripping pre-release/build metadata.
+        ("2.1.0-pr-921.1.20260818115106", "2.1.1"),
+    ],
+)
+def test_delete_secret_token_orca_below_threshold_still_revokes(
+    mock_iguazio_client, monkeypatch, resolved_version, min_version
+):
+    """
+    A resolvable Orca version that's too old (even after stripping pre-release/build metadata)
+    must still go through the normal revoke-then-delete flow.
+    """
+    monkeypatch.setattr(
+        services.api.crud.secrets, "MIN_ORCA_VERSION_WITH_SELF_REVOKE", min_version
+    )
+    monkeypatch.setattr(
+        framework.utils.clients.iguazio.v4,
+        "resolve_orca_version",
+        lambda: resolved_version,
+    )
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user", user_id="user-id-123"
+    )
+    token_name = "my-token"
+    fake_token = "jwt-token-123"
+
+    mock_secrets_provider = unittest.mock.Mock()
+    services.api.crud.Secrets().secrets_provider = mock_secrets_provider
+    mock_secrets_provider.get_user_token_secret_value.return_value = fake_token
+    mock_secrets_provider.delete_user_token_secret = unittest.mock.Mock()
+
+    result = services.api.crud.Secrets().delete_secret_token(
+        token_name=token_name,
+        username=auth_info.username,
+        auth_info=auth_info,
+    )
+
+    assert result.deleted is True
+    mock_iguazio_client.revoke_offline_token.assert_called_once_with(
+        fake_token, auth_info.request_headers
+    )
     mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
         user_id=auth_info.user_id, token_name=token_name
     )

--- a/server/py/services/api/tests/unit/crud/test_secrets.py
+++ b/server/py/services/api/tests/unit/crud/test_secrets.py
@@ -986,6 +986,39 @@ def test_delete_secret_token_success(mock_iguazio_client):
     )
 
 
+def test_delete_secret_token_service_account_skips_revocation(mock_iguazio_client):
+    """
+    Orca is the source of truth for offline-token revocation and revokes the Keycloak
+    session itself before calling this endpoint, so a service-account caller (e.g. Orca)
+    must not trigger a redundant revoke here - it should only delete the K8s secret.
+    """
+    auth_info = mlrun.common.schemas.AuthInfo(
+        username="dummy-user",
+        user_id="user-id-123",
+        kind=mlrun.common.schemas.AuthInfoKind.service_account,
+    )
+    token_name = "my-token"
+
+    mock_secrets_provider = unittest.mock.Mock()
+    services.api.crud.Secrets().secrets_provider = mock_secrets_provider
+    mock_secrets_provider.delete_user_token_secret = unittest.mock.Mock()
+
+    result = services.api.crud.Secrets().delete_secret_token(
+        token_name=token_name,
+        username=auth_info.username,
+        auth_info=auth_info,
+    )
+
+    assert result.deleted is True
+    assert result.username == auth_info.username
+
+    mock_secrets_provider.get_user_token_secret_value.assert_not_called()
+    mock_iguazio_client.revoke_offline_token.assert_not_called()
+    mock_secrets_provider.delete_user_token_secret.assert_called_once_with(
+        user_id=auth_info.user_id, token_name=token_name
+    )
+
+
 def test_delete_secret_token_not_found(mock_iguazio_client):
     auth_info = mlrun.common.schemas.AuthInfo(
         username="dummy-user", user_id="user-id-123"


### PR DESCRIPTION
### 📝 Description
Deleting a stored offline token always calls Iguazio to revoke it before deleting the Kubernetes secret. For a caller like Orca, which now revokes the Keycloak session itself first, that call is not just redundant - it also hits a pre-existing bug in Orca's legacy revoke-callback endpoint, so the secret never actually got deleted even though the API returned success.

This fetches Orca's own version from its info API and skips the redundant revoke call once that version confirms Orca already owns revocation. `MIN_ORCA_VERSION_WITH_SELF_REVOKE` is currently a placeholder value used for live verification and will be updated to the real Orca release version (see ML-13070) once one ships.

---

### 🛠️ Changes Made
- `framework.utils.clients.iguazio.v4`: add `Client.get_orca_version()` (calls Orca's info API) and `resolve_orca_version()` (fetches and caches it once per process, mirroring `resolve_nuclio_version()`).
- `mlrun/config.py`: add the `orca_version` config field used to cache the resolved version.
- `Secrets._orca_owns_revocation()`: compares Orca's version (major.minor.patch only, ignoring pre-release/build metadata) against `MIN_ORCA_VERSION_WITH_SELF_REVOKE`. An unresolvable version (unreachable, unconfigured, or unparseable) is treated as recent, since an older Orca predates this check entirely and would never resolve to a version either.
- `Secrets.delete_secret_token`: pass `skip_revocation=self._orca_owns_revocation()` into `_delete_single_token`, replacing the previous `auth_info.is_service_account()` check.
- Tests added/updated accordingly.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit tests cover: a recent (or unresolvable) Orca version skipping revocation, and an old or pre-release Orca version still revoking.
- Verified end-to-end on a live lab: confirmed `resolve_orca_version()` fetches the real Orca version from its live info API, `_orca_owns_revocation()` evaluates correctly against it, and a real delete-token call skips the Iguazio revoke call and goes straight to deleting the K8s secret - confirmed via MLRun logs.

---

### 🔗 References
- Ticket link:
- Follow-up ticket: https://ecliptos.atlassian.net/browse/ML-13070 (set `MIN_ORCA_VERSION_WITH_SELF_REVOKE` to the real Orca release version once one ships)
- Design docs links:
- External links: Companion Orca-side change that exercises this fix: https://github.com/McK-Private/orca/pull/1151. Supersedes #10085 (closed due to a branch-rename mishap on the fork).

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

`skip_revocation` now depends on Orca's own resolved version rather than the caller's identity; a caller whose Orca isn't recent enough sees unchanged behavior.

---

### 🔍️ Additional Notes
- The underlying bug in Orca's legacy revoke-callback endpoint (a malformed Keycloak certs URL) is unrelated to this fix and out of scope here; it still exists, just no longer hit on this path.
- `MIN_ORCA_VERSION_WITH_SELF_REVOKE` is currently a placeholder/test value used for live verification; see the follow-up ticket above.
- `resolve_orca_version()` fetches Orca's version once and caches it for the process's lifetime (same pattern as `resolve_nuclio_version()`), so if Orca gets upgraded while mlrun-api is already running, mlrun-api needs to be restarted to pick up the new version. @liranbg As the mlrun upgrade component owner, do you think this can happen?


