### PR TITLE
[Model Monitoring] Fix function_name Prometheus label collision

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -257,6 +257,9 @@ linkcheck_ignore = [
     "https://docs.confident-ai.com/docs/metrics-faithfulness",
     # ignore links to kubernetes.io, since they often block the traffic
     r"https://kubernetes.io/.*",
+    # iguazio docs and Slack return 403 to CI crawlers
+    r"https://www\.iguazio\.com/docs/.*",
+    r"https://mlopslive\.slack\.com.*",
 ]
 
 # -- Autosummary -------------------------------------------------------------

--- a/docs/model-monitoring/running-applications.md
+++ b/docs/model-monitoring/running-applications.md
@@ -47,7 +47,7 @@ Each result exposes two fixed gauges. The name is a label, not part of the metri
 - mlrun.model_monitoring.result → scraped as mlrun_model_monitoring_result (one per result)
 - mlrun.model_monitoring.metric → scraped as mlrun_model_monitoring_metric (one per metric)
 
-**Shared labels**: `project`, `app.name`, `function.name`, `endpoint.uid`, `endpoint.name` </br>
+**Shared labels**: `project`, `app.name`, `serving.function.name`, `endpoint.uid`, `endpoint.name` </br>
 **Result only**: `result.name`, `result.kind`, `result.status` </br>
 **Metric only**: `metric.name`
 

--- a/mlrun/common/schemas/_shared/model_monitoring/constants.py
+++ b/mlrun/common/schemas/_shared/model_monitoring/constants.py
@@ -260,17 +260,22 @@ class OTelMonitoringAttribute(MonitoringStrEnum):
     application results / metrics.
 
     Dot-separated naming follows the OpenTelemetry semantic-conventions
-    convention. ``project``, ``app.name``, ``function.name``,
+    convention. ``project``, ``app.name``, ``serving.function.name``,
     ``endpoint.uid``, ``endpoint.name`` are shared by every entry in a
     batch. ``result.name``, ``result.kind`` and ``result.status`` apply only
     to entries coming from a :class:`ModelMonitoringApplicationResult`;
     ``metric.name`` applies only to entries coming from a
     :class:`ModelMonitoringApplicationMetric`.
+
+    ``serving.function.name`` is the model endpoint's serving function.
+    It is not ``function.name`` so it does not collide with the collector's
+    pod-identity ``function_name`` label (from ``nuclio.io/function-name``)
+    when both are sanitized for Prometheus (ML-13034).
     """
 
     PROJECT = "project"
     APP_NAME = "app.name"
-    FUNCTION_NAME = "function.name"
+    SERVING_FUNCTION_NAME = "serving.function.name"
     ENDPOINT_UID = "endpoint.uid"
     ENDPOINT_NAME = "endpoint.name"
     RESULT_NAME = "result.name"

--- a/mlrun/model_monitoring/applications/_application_steps.py
+++ b/mlrun/model_monitoring/applications/_application_steps.py
@@ -127,7 +127,7 @@ class _PrepareOTelEvent(StepToDict):
     Attributes (shared from MonitoringApplicationContext):
         * ``project``
         * ``app.name``
-        * ``function.name``
+        * ``serving.function.name``
         * ``endpoint.uid``
         * ``endpoint.name``
 
@@ -170,7 +170,7 @@ class _PrepareOTelEvent(StepToDict):
         base_attributes = {
             attr.PROJECT.value: ctx.project_name,
             attr.APP_NAME.value: ctx.application_name,
-            attr.FUNCTION_NAME.value: ctx.model_endpoint.spec.function_name,
+            attr.SERVING_FUNCTION_NAME.value: ctx.model_endpoint.spec.function_name,
             attr.ENDPOINT_UID.value: ctx.endpoint_id,
             attr.ENDPOINT_NAME.value: ctx.endpoint_name,
         }

--- a/tests/model_monitoring/test_application_steps.py
+++ b/tests/model_monitoring/test_application_steps.py
@@ -282,7 +282,7 @@ class TestPrepareOTelEvent:
     BASE_ATTRS = {
         "project": PROJECT,
         "app.name": APP,
-        "function.name": FUNC_NAME,
+        "serving.function.name": FUNC_NAME,
         "endpoint.uid": EP_ID,
         "endpoint.name": EP_NAME,
     }
@@ -421,7 +421,7 @@ class TestPrepareOTelEvent:
         assert attrs == {
             "project": cls.PROJECT,
             "app.name": cls.APP,
-            "function.name": cls.FUNC_NAME,
+            "serving.function.name": cls.FUNC_NAME,
             "metric.name": "m",
         }
 


### PR DESCRIPTION
### 📝 Description
The gateway collector copies `nuclio.io/function-name` onto OTLP metrics as `function_name`. MLRun already emitted `function.name` (the serving function). Prometheus sanitizes both to `function_name` and joins them with `;` (ML-13034).

This PR renames the MM attribute to `serving.function.name` so the two labels no longer collide.

---

### 🛠️ Changes Made
- Rename `OTelMonitoringAttribute.FUNCTION_NAME` (`function.name`) to `SERVING_FUNCTION_NAME` (`serving.function.name`)
- Emit the new key from `_PrepareOTelEvent`
- Update docs and unit tests

---

### ✅ Checklist
- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Unit: `tests/model_monitoring/test_application_steps.py::TestPrepareOTelEvent` (6 passed)
- REG-2787 (`test_model_monitoring_scale_models_same_serv_function`) should query `serving_function_name` after this ships

---

### 🔗 References
- Ticket link: https://ecliptos.atlassian.net/browse/ML-13034
- Detected by: https://ecliptos.atlassian.net/browse/REG-2787

---

### 🚨 Breaking Changes?

- [x] Yes (explain below)
- [ ] No

Dashboards and PromQL that filter MM results by `function_name` as the serving function must switch to `serving_function_name`. `function_name` remains the collector's Nuclio pod identity.

---

### 🔍️ Additional Notes
Prometheus label is `serving_function_name` (dots become underscores).

Made with [Cursor](https://cursor.com)