### PR TITLE
[Spark] Fix driver service-account token automount

### DIFF
--- a/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
+++ b/server/py/services/api/runtime_handlers/sparkjob/spark3job.py
@@ -680,6 +680,16 @@ with ctx:
             "spec.executor.serviceAccount",
             runtime.spec.service_account or "sparkapp",
         )
+        # The driver needs Kubernetes API access to create and manage executors.
+        # Enable token automount explicitly in case the service account disables it.
+        update_in(
+            job,
+            "spec.driver.template.spec",
+            {
+                "automountServiceAccountToken": True,
+                "containers": [{"name": "spark-kubernetes-driver"}],
+            },
+        )
         # Spark's pod-template loader NPEs without a named executor container.
         # Keep the template minimal and only disable token automount.
         update_in(

--- a/server/py/services/api/tests/unit/runtimes/test_spark.py
+++ b/server/py/services/api/tests/unit/runtimes/test_spark.py
@@ -1344,24 +1344,27 @@ class TestSpark3Runtime(services.api.tests.unit.runtimes.base.TestRuntimeBase):
             f"Actual volumes: {volumes}"
         )
 
-    def test_executor_service_account_token_not_mounted(
+    def test_service_account_token_mounting(
         self, db: sqlalchemy.orm.Session, k8s_secrets_mock
     ):
-        """Executor pods must not mount the service-account token."""
+        """Driver pods must mount the service-account token, while executors must not."""
         runtime: mlrun.runtimes.Spark3Runtime = self._generate_runtime()
         self.execute_function(runtime)
 
         body = self._get_custom_object_creation_body()
 
+        driver_template_spec = body["spec"]["driver"]["template"]["spec"]
+        assert driver_template_spec["automountServiceAccountToken"] is True, (
+            "Driver SA token must be mounted"
+        )
+        assert driver_template_spec["containers"] == [
+            {"name": "spark-kubernetes-driver"}
+        ], "Driver template must name the Spark driver container"
+
         executor_template_spec = body["spec"]["executor"]["template"]["spec"]
         assert executor_template_spec["automountServiceAccountToken"] is False, (
             "Executor SA token must not be mounted"
         )
-        # The named container prevents Spark's pod-template loader from failing.
         assert executor_template_spec["containers"] == [
             {"name": "spark-kubernetes-executor"}
         ], "Executor template must name the spark executor container"
-        # Driver keeps its token, so no token-disabling pod template is added.
-        assert "template" not in body["spec"]["driver"], (
-            "Driver must keep its SA token (no token-disabling pod template)"
-        )


### PR DESCRIPTION
### 📝 Description

Fix Spark driver startup on Kubernetes installations where the `sparkapp` service account has `automountServiceAccountToken: false`.

Spark drivers require Kubernetes API access to create and manage executor pods. Without an explicit pod-level override, the driver inherits the service-account setting and does not receive the cluster CA certificate or API token. This causes Fabric8 to fail Kubernetes API TLS validation with `sun.security.validator.ValidatorException`.

---

### 🛠️ Changes Made

- Add a minimal Spark driver pod template that explicitly enables `automountServiceAccountToken`.
- Name the template container `spark-kubernetes-driver`, as required by Spark's pod-template loader.
- Keep service-account token automount disabled for executor pods.
- Update unit coverage to assert the driver and executor behavior independently.

---

### ✅ Checklist

- [x] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [x] This PR does not introduce a deprecation
- [x] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing

- `ruff format` passed for the changed Python files.
- `ruff check` passed for the changed Python files.
- Updated `test_service_account_token_mounting` to verify:
  - driver token automount is explicitly enabled;
  - executor token automount remains disabled;
  - both pod templates contain Spark's required container names.
- `MLRUN_IS_API_SERVER=true PYTHONPATH="$(pwd):$(pwd)/server/py" .venv/bin/python -m pytest -q server/py/services/api/tests/unit/runtimes/test_spark.py::TestSpark3Runtime::test_service_account_token_mounting` passed.
- The original AWS/EKS system scenario, `test_mlrun_spark_operator[dataframe-type-tests-not_set]`, still needs to be rerun with service-account token automount disabled.

---

### 🔗 References

- Ticket: ML-13047
- Related security configuration: ORIS-2990
- RCA: `rca.md`

---

### 🚨 Breaking Changes?

- [ ] Yes
- [x] No

---

### 🔍️ Additional Notes

This preserves the intended least-privilege boundary: the Spark driver receives Kubernetes API credentials because it manages executors, while executor pods remain tokenless.