### PR TITLE
[Builder] Fix overly permissive authfile chmod flagged by CodeQL

### DIFF
--- a/mlrun/utils/registry_auth.py
+++ b/mlrun/utils/registry_auth.py
@@ -141,8 +141,10 @@ def _merge_auth_entry(authfile_path: str, registry: str, auth: str) -> None:
         json.dump(doc, fh)
     # the previous writer's UID is never guaranteed to match this process's (init containers get no
     # explicit security context - see append_secret_authfile_init_container in the server-side
-    # registry_auth.py), so the file must stay writable for whoever merges into it next.
-    os.chmod(authfile_path, 0o666)
+    # registry_auth.py), so the file must stay writable for whoever merges into it next. The pod's
+    # fsGroup (see make_buildah_pod) makes every writer's file group-owned by the same GID
+    # regardless of its own UID, so group-write is enough - no need for world-writable.
+    os.chmod(authfile_path, 0o660)
 
 
 def _ecr_repo_name(dest: str) -> str:

--- a/server/py/services/api/tests/unit/utils/test_builder_backend.py
+++ b/server/py/services/api/tests/unit/utils/test_builder_backend.py
@@ -426,16 +426,18 @@ def test_make_buildah_pod_tls_verify_disabled(monkeypatch):
 
 def test_make_buildah_pod_authfile_when_secret():
     buildah_pod = _make_buildah_pod(secret_name="my-docker-secret")
-    container = buildah_pod.pod.spec.containers[0]
+    pod = buildah_pod.pod
+    container = pod.spec.containers[0]
     assert "--authfile /auth/config.json" in container.args[0]
     env = {env_var.name: env_var.value for env_var in container.env}
     assert env["REGISTRY_AUTH_FILE"] == "/auth/config.json"
     mounted_secrets = {
-        volume.secret.secret_name
-        for volume in buildah_pod.pod.spec.volumes
-        if volume.secret
+        volume.secret.secret_name for volume in pod.spec.volumes if volume.secret
     }
     assert "my-docker-secret" in mounted_secrets
+    # no cloud provider involved - the secret is mounted directly as the authfile (read-only,
+    # never written to), so there's no cross-container write-sharing to need an fsGroup for.
+    assert pod.spec.security_context is None
 
 
 @pytest.mark.parametrize(
@@ -467,7 +469,9 @@ def test_make_buildah_pod_secret_and_cloud_provider_merge(registry, provider):
     assert copy_container.command == ["/bin/sh", "-c"]
     script = copy_container.args[0]
     assert "cp /auth-secret/config.json /auth/config.json" in script
-    assert "chmod 0666 /auth/config.json" in script
+    assert "chmod 0660 /auth/config.json" in script
+    # group-writable via the pod's fsGroup, not world-writable - see make_buildah_pod
+    assert pod.spec.security_context.fs_group == 1000
     # mounted read-only elsewhere - never directly at the shared authfile path (ML-12988)
     secret_mount = next(
         mount

--- a/server/py/services/api/tests/unit/utils/test_registry_auth.py
+++ b/server/py/services/api/tests/unit/utils/test_registry_auth.py
@@ -76,8 +76,9 @@ def test_append_secret_authfile_init_container():
     # ML-12988: copies the secret in via `cp` (no soft-fail - a misconfigured secret is a real
     # error worth surfacing directly), using buildah_image since the main container always pulls it
     # anyway - never the credential-exchange image, which a GAR-only build wouldn't otherwise need.
-    # Also chmods the copy world-writable: this init container gets no explicit security context,
-    # so its UID is never guaranteed to match whichever container merges into the file next.
+    # Also chmods the copy group-writable: this init container gets no explicit security context,
+    # so its UID is never guaranteed to match whichever container merges into the file next - the
+    # pod's fsGroup (see make_buildah_pod) makes the group match regardless.
     pod = framework.utils.singletons.k8s.BasePod(task_name="t", image="img")
     registry_auth.append_secret_authfile_init_container(pod, "/auth/config.json")
 
@@ -88,7 +89,7 @@ def test_append_secret_authfile_init_container():
     assert len(container.args) == 1
     script = container.args[0]
     assert "cp /auth-secret/config.json /auth/config.json" in script
-    assert "chmod 0666 /auth/config.json" in script
+    assert "chmod 0660 /auth/config.json" in script
 
 
 def test_append_ecr_credential_exchange_init_container():

--- a/server/py/services/api/utils/builder/buildah.py
+++ b/server/py/services/api/utils/builder/buildah.py
@@ -301,6 +301,15 @@ def make_buildah_pod(
         project_default_function_node_selector,
         auth_info,
     )
+    if push_cloud_provider or pull_cloud_provider:
+        # the registry-auth emptyDir gets written to by containers with no explicit (and thus
+        # inconsistent) UID - a pod-wide fsGroup makes kubelet chown it group-owned regardless of
+        # who wrote it, so every writer can merge into it via group access (see
+        # registry_auth.append_secret_authfile_init_container / mlrun.utils.registry_auth's
+        # _merge_auth_entry, which chmod it group-writable rather than world-writable for this).
+        extra_runtime_spec["security_context"] = client.V1PodSecurityContext(
+            fs_group=_BUILD_GID
+        )
 
     # stage the Dockerfile (and any inline code / requirements) into the context, then bud + push.
     # everything runs in one container: the buildah image ships bash + coreutils, so no separate

--- a/server/py/services/api/utils/builder/registry_auth.py
+++ b/server/py/services/api/utils/builder/registry_auth.py
@@ -138,12 +138,14 @@ def append_secret_authfile_init_container(pod, authfile_path: str) -> None:
     one need to merge into that file, which a secret-backed volume mount doesn't allow. Runs first,
     so those merges land on top of the secret's own entries.
 
-    Chmods the copy to be world-writable: init containers get no explicit security context (see
+    Chmods the copy group-writable: init containers get no explicit security context (see
     :class:`~framework.utils.singletons.k8s.BasePod`), so this container's own UID depends entirely
     on ``buildah_image``'s default user, which needn't match the main container's (fixed to 1000 -
     see ``_caps_security_context`` in buildah.py) or any other credential-exchange init container's.
     Every subsequent writer merges into this same file, so it must stay writable regardless of which
-    UID wrote it last.
+    UID wrote it last - the pod's ``fsGroup`` (see ``make_buildah_pod``) makes every writer's file
+    group-owned by the same GID no matter its own UID, so group-write is enough without resorting to
+    world-writable.
 
     :param pod: The Buildah build pod being constructed.
     :param authfile_path: Where to copy the secret's docker-config content to.
@@ -157,7 +159,7 @@ def append_secret_authfile_init_container(pod, authfile_path: str) -> None:
         command=["/bin/sh", "-c"],
         args=[
             f"cp {shlex.quote(SECRET_AUTHFILE_PATH)} {shlex.quote(authfile_path)} && "
-            f"chmod 0666 {shlex.quote(authfile_path)}"
+            f"chmod 0660 {shlex.quote(authfile_path)}"
         ],
         name=_COPY_SECRET_AUTHFILE_INIT_CONTAINER_NAME,
     )

--- a/tests/utils/test_registry_auth.py
+++ b/tests/utils/test_registry_auth.py
@@ -119,11 +119,11 @@ def test_mint_ecr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     assert auths[registry]["auth"] == "token"
     assert written["credHelpers"] == {"some.other.registry": "docker-credential-helper"}
 
-    # world-writable: the authfile may already have been written by a different init container
-    # (e.g. the secret-copy one) whose UID isn't guaranteed to match this process's, and a later
-    # writer (another init container, or the main container's GAR script) must still be able to
-    # merge into it.
-    assert stat.S_IMODE(authfile.stat().st_mode) == 0o666
+    # group-writable via the pod's fsGroup (see make_buildah_pod), not world-writable: the authfile
+    # may already have been written by a different init container (e.g. the secret-copy one) whose
+    # UID isn't guaranteed to match this process's, and a later writer (another init container, or
+    # the main container's GAR script) must still be able to merge into it via the shared group.
+    assert stat.S_IMODE(authfile.stat().st_mode) == 0o660
 
 
 def test_mint_ecr_authfile_overwrites_same_registry_entry(tmp_path, monkeypatch):
@@ -229,7 +229,7 @@ def test_mint_acr_authfile_merges_existing_entry(tmp_path, monkeypatch):
     decoded = base64.b64decode(auths[registry]["auth"]).decode()
     assert decoded == "00000000-0000-0000-0000-000000000000:my-refresh-token"
     assert written["credsStore"] == "desktop"
-    assert stat.S_IMODE(authfile.stat().st_mode) == 0o666
+    assert stat.S_IMODE(authfile.stat().st_mode) == 0o660
 
 
 def test_mint_acr_authfile_overwrites_same_registry_entry(tmp_path, monkeypatch):


### PR DESCRIPTION
### 📝 Description
CodeQL flagged `mlrun/utils/registry_auth.py`'s authfile `chmod` as world-writable
([code-scanning alert #190](https://github.com/mlrun/mlrun/security/code-scanning/190),
`py/overly-permissive-file`, high severity). This landed in #10020 (already merged) as part of
fixing a real cross-container permission bug in Buildah's registry-auth flow: init containers get
no explicit security context, so their UID depends entirely on each image's own default, which
doesn't reliably match the main container's (fixed to UID 1000) or each other's - whichever
container wrote the shared authfile first could leave it unwritable to whoever needed to merge
into it next. The original fix (`chmod 0o666`) solved that, but was broader than necessary.

---

### 🛠️ Changes Made
- Set a pod-wide `fsGroup` (matching the main container's GID) on the Buildah build pod whenever
  the registry-auth `emptyDir` is actually used (push or pull credential exchange applies) -
  Kubernetes then makes every writer's file group-owned by that GID regardless of its own UID.
- Narrow both `chmod` calls (the secret-copy init container, and `_merge_auth_entry`, shared by
  `mint_ecr_authfile`/`mint_acr_authfile`) from `0o666` to `0o660` - group-writable, no longer
  world-writable.
- No change needed in the generated GAR script - it never chmods the file at all, since it always
  runs in the main container after every init container has finished, so nothing writes to the file
  afterward that could need it.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Extended existing unit tests: chmod mode assertions now check `stat.S_IMODE(...) == 0o660`, plus
  a new assertion that the pod's `spec.security_context.fs_group` is set when push/pull cloud
  provider is present, and a negative case confirming no `security_context` is added when only a
  static secret is used (no cross-container write-sharing needed there).
- Full relevant suite (`test_builder_backend.py`, both `registry_auth.py` test files, `test_cli.py`):
  104 passing.
- `ruff check`/`format` clean.
- **Live verification on a real GKE cluster** (Workload Identity enabled, `builder_backend=buildah`,
  a real Artifact Registry as the push destination): called `make_buildah_pod` directly with a
  static secret + a GAR push destination - the one combination that forces a real cross-UID write
  (the secret-copy init container writes the authfile under whatever UID `buildah_image` defaults
  to; GAR's JIT script then has to read-modify-write that same file from the main container, fixed
  at UID 1000, with no chmod of its own to fall back on). Generated the pod spec once from the
  currently-deployed code (`chmod 0o666`, no `fsGroup`) and once from this branch (`chmod 0o660` +
  `fsGroup`), applied both directly to the cluster, and let each run a full `buildah bud` + `push`
  against the real registry. Both completed successfully (every container exit code 0) - confirming
  `fsGroup` actually does what we're relying on it for on GKE, not just in the pod-spec assertions.
  This bypassed the HTTP build API/project/auth layer (mocked only `resolve_project_service_account_details`,
  which this PR doesn't touch) but exercised every line this PR actually changes, running for real.

---

### 🔗 References
- Ticket links: https://ecliptos.atlassian.net/browse/ML-12988
- Design docs links:
- External links: https://github.com/mlrun/mlrun/security/code-scanning/190

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
- Follow-up to #10020 (already merged). That PR's last commit, fixing this same cross-container
  permission bug, used `chmod 0o666`; CodeQL flagged that as world-writable after merge, so this PR
  narrows it to `0o660` via a pod-level `fsGroup` instead. #10020 was squash-merged, so this branch
  is based on latest `development` with just this one change, rather than continuing that PR's
  branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

