### PR TITLE
[CI] Fix code injection risk in smoke-tests workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -71,6 +71,8 @@ jobs:
         id: resolve
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           # workflow_dispatch: always run; resolve PR number from input
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -89,8 +91,6 @@ jobs:
               exit 0
             fi
 
-            HEAD_OWNER="${{ github.event.workflow_run.head_repository.owner.login }}"
-            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
             PR_NUM=$(curl -sS \
               -H "Authorization: token ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
### 📝 Description
Fixes a critical CodeQL code-injection finding ([GitHub code scanning alert #161](https://github.com/mlrun/mlrun/security/code-scanning/161)) in `.github/workflows/smoke-tests.yml`. The `should-run` job's "Resolve PR number and check eligibility" step spliced `github.event.workflow_run.head_branch` and `github.event.workflow_run.head_repository.owner.login` directly into the `run:` script using `${{ }}` expression syntax. Both values are attacker-controlled (set via the PR's branch/fork name), so a maliciously crafted branch name could inject arbitrary shell commands into the workflow run, potentially exfiltrating the `GITHUB_TOKEN` or making unauthorized repo changes.

---

### 🛠️ Changes Made
- Moved `HEAD_OWNER` (`github.event.workflow_run.head_repository.owner.login`) and `HEAD_BRANCH` (`github.event.workflow_run.head_branch`) into the step's `env:` block instead of interpolating them inline via `${{ }}` in the script body.
- The script now reads them as ordinary shell variables (`$HEAD_OWNER`, `$HEAD_BRANCH`), which GitHub Actions treats as opaque string values rather than script text, closing the injection vector.

---

### ✅ Checklist
- [x] I updated the documentation (if applicable) — N/A, workflow-only change
- [x] I have tested the changes in this PR — validated YAML syntax; behavior of the step is unchanged (same values, same usage), only the injection vector is closed
- [ ] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- Validated the updated YAML parses correctly with `python3 -c "import yaml; yaml.safe_load(...)"`.
- No functional behavior change: `HEAD_OWNER`/`HEAD_BRANCH` still hold the same values and are used identically in the `curl` calls — only how they enter the shell changed (via `env:` instead of literal script interpolation).

---

### 🔗 References
- Ticket link:
- Design docs links:
- External links: https://github.com/mlrun/mlrun/security/code-scanning/161

---

### 🚨 Breaking Changes?

- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
This is a CI-workflow-only fix (`.github/workflows/*`), which per repo guardrails requires maintainer review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)