### PR TITLE
[Security] Fix critical CodeQL findings

### DIFF
--- a/.github/workflows/post-coverage-comment.yaml
+++ b/.github/workflows/post-coverage-comment.yaml
@@ -57,12 +57,13 @@ jobs:
       - name: Get PR number
         id: pr
         shell: bash
-        env:
-          REPO: ${{ github.repository }}
-          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
+
+          # Define variables for readability
+          REPO="${{ github.repository }}"
+          HEAD_OWNER="${{ github.event.workflow_run.head_repository.owner.login }}"
+          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
 
           echo "Searching for PR from $HEAD_OWNER:$HEAD_BRANCH in $REPO..."
 

--- a/.github/workflows/post-coverage-comment.yaml
+++ b/.github/workflows/post-coverage-comment.yaml
@@ -57,13 +57,12 @@ jobs:
       - name: Get PR number
         id: pr
         shell: bash
+        env:
+          REPO: ${{ github.repository }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-
-          # Define variables for readability
-          REPO="${{ github.repository }}"
-          HEAD_OWNER="${{ github.event.workflow_run.head_repository.owner.login }}"
-          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
 
           echo "Searching for PR from $HEAD_OWNER:$HEAD_BRANCH in $REPO..."
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -71,10 +71,16 @@ jobs:
         id: resolve
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_EVENT: ${{ github.event.workflow_run.event }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPOSITORY: ${{ github.repository }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           # workflow_dispatch: always run; resolve PR number from input
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUM="${{ inputs.pr_number }}"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            PR_NUM="${INPUT_PR_NUMBER}"
             echo "pr_number=${PR_NUM}" >> $GITHUB_OUTPUT
             echo "should_run=true" >> $GITHUB_OUTPUT
             if [ -z "$PR_NUM" ]; then
@@ -82,19 +88,17 @@ jobs:
             fi
           else
             # workflow_run: only run on a pull_request event
-            if [ "${{ github.event.workflow_run.event }}" != "pull_request" ]; then
+            if [ "${WORKFLOW_EVENT}" != "pull_request" ]; then
               echo "Not a PR event, skipping"
               echo "should_run=false" >> $GITHUB_OUTPUT
               echo "pr_number=" >> $GITHUB_OUTPUT
               exit 0
             fi
 
-            HEAD_OWNER="${{ github.event.workflow_run.head_repository.owner.login }}"
-            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
             PR_NUM=$(curl -sS \
               -H "Authorization: token ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls?head=${HEAD_OWNER}:${HEAD_BRANCH}&state=all" \
+              "https://api.github.com/repos/${REPOSITORY}/pulls?head=${HEAD_OWNER}:${HEAD_BRANCH}&state=all" \
               | jq -r '.[0].number // empty')
             if [ -z "$PR_NUM" ]; then
               echo "No PR found for ${HEAD_OWNER}:${HEAD_BRANCH}, skipping"
@@ -108,7 +112,7 @@ jobs:
             NON_DOC_COUNT=$(curl -sS \
               -H "Authorization: token ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUM}/files?per_page=100" \
+              "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUM}/files?per_page=100" \
               | jq '[.[] | select(.filename | endswith(".md") | not)] | length')
             if [ "$NON_DOC_COUNT" = "0" ]; then
               echo "PR #${PR_NUM} contains only documentation (*.md) changes, skipping smoke tests"
@@ -127,25 +131,25 @@ jobs:
           PR_JSON=$(curl -sS \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUM}")
+            "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUM}")
           PR_HEAD_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
           BASE_REF=$(echo "$PR_JSON" | jq -r '.base.ref')
           BASE_SHA=$(curl -sS \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/${BASE_REF}" \
+            "https://api.github.com/repos/${REPOSITORY}/commits/${BASE_REF}" \
             | jq -r '.sha')
 
           # Count base-branch commits since the PR's merge-base (the real "sync point").
           MERGE_BASE_SHA=$(curl -sS \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/compare/${BASE_REF}...${PR_HEAD_SHA}" \
+            "https://api.github.com/repos/${REPOSITORY}/compare/${BASE_REF}...${PR_HEAD_SHA}" \
             | jq -r '.merge_base_commit.sha')
           BASE_COMMITS_SINCE_SYNC=$(curl -sS \
             -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/compare/${MERGE_BASE_SHA}...${BASE_SHA}" \
+            "https://api.github.com/repos/${REPOSITORY}/compare/${MERGE_BASE_SHA}...${BASE_SHA}" \
             | jq -r '.ahead_by // 0')
 
           echo "PR #${PR_NUM} @ ${PR_HEAD_SHA:0:8} | base: ${BASE_REF} @ ${BASE_SHA:0:8} (${BASE_COMMITS_SINCE_SYNC} commits since sync)"

--- a/mlrun/serving/remote.py
+++ b/mlrun/serving/remote.py
@@ -163,7 +163,7 @@ class RemoteStep(storey.SendToHttp):
             kwargs["timeout"] = aiohttp.ClientTimeout(total=self.timeout)
         try:
             resp = await self._client_session.request(
-                method, url, headers=headers, data=body, ssl=False, **kwargs
+                method, url, headers=headers, data=body, ssl=_aiohttp_ssl(), **kwargs
             )
             if resp.status >= 500:
                 text = await resp.text()
@@ -415,7 +415,12 @@ class BatchHttpRequests(_ConcurrentJobExecution):
 
     async def _submit(self, method, url, headers, body):
         async with self._client_session.request(
-            method, url, headers=headers, data=body, ssl=False, **self._request_args
+            method,
+            url,
+            headers=headers,
+            data=body,
+            ssl=_aiohttp_ssl(),
+            **self._request_args,
         ) as future:
             if future.status >= 500:
                 text = await future.text()
@@ -462,6 +467,16 @@ class BatchHttpRequests(_ConcurrentJobExecution):
         ) and isinstance(data, str | bytes):
             data = json.loads(data)
         return data
+
+
+def _aiohttp_ssl() -> bool | None:
+    """Map ``httpdb.http.verify`` to aiohttp's ``ssl`` argument.
+
+    ``ssl=False`` skips certificate validation. ``ssl=None`` uses aiohttp's
+    default SSL context (verify). The sync RemoteStep path already honors the
+    same config via ``requests`` ``verify=``.
+    """
+    return None if mlrun.mlconf.httpdb.http.verify else False
 
 
 class MLRunAPIRemoteStep(RemoteStep):

--- a/mlrun/utils/azure_vault.py
+++ b/mlrun/utils/azure_vault.py
@@ -13,14 +13,54 @@
 # limitations under the License.
 
 import os
+import re
 from os.path import expanduser
+from urllib.parse import urlparse
+
+import mlrun.errors
 
 from ..config import config as mlconf
 from .helpers import logger
 
+# Azure Key Vault names: 3-24 chars, start with a letter, end with a letter or
+# digit, and otherwise only letters, digits, and hyphens.
+# https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name
+_AZURE_VAULT_NAME_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9-]{1,22}[A-Za-z0-9]$")
+
+
+def build_azure_vault_url(vault_name: str) -> str:
+    """Build the Azure Key Vault URL after validating the vault name.
+
+    Rejects names that can change the URL host (for example ``evil.com/x``),
+    which would otherwise turn ``https://{name}.vault.azure.net`` into a
+    request to an attacker-controlled host.
+
+    :param vault_name: Azure Key Vault name interpolated into the URL template.
+    :return: Vault URL from the configured template.
+    """
+    if not vault_name or not _AZURE_VAULT_NAME_PATTERN.fullmatch(vault_name):
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Invalid Azure Key Vault name. Names must be 3-24 characters, "
+            "start with a letter, end with a letter or digit, and contain "
+            "only letters, digits, and hyphens."
+        )
+    url = mlconf.secret_stores.azure_vault.url.format(name=vault_name)
+    parsed = urlparse(url)
+    hostname_labels = (parsed.hostname or "").split(".")
+    hostname_matches_vault = hostname_labels[0] == vault_name.lower()
+    if parsed.scheme not in ("https", "http") or not hostname_matches_vault:
+        raise mlrun.errors.MLRunInvalidArgumentError(
+            "Azure Key Vault URL hostname does not match the validated vault name"
+        )
+    return url
+
 
 class AzureVaultStore:
     def __init__(self, vault_name):
+        self._vault_name = vault_name
+        self._url = build_azure_vault_url(vault_name)
+        self._client = None
+
         try:
             from azure.identity import EnvironmentCredential
             from azure.keyvault.secrets import SecretClient
@@ -28,10 +68,6 @@ class AzureVaultStore:
             raise ImportError(
                 "Azure key-vault libraries not installed, run pip install mlrun[azure-key-vault]"
             ) from exc
-
-        self._vault_name = vault_name
-        self._url = mlconf.secret_stores.azure_vault.url.format(name=vault_name)
-        self._client = None
 
         tenant_id = self._get_secret_file_contents("tenant_id")
         client_id = self._get_secret_file_contents("client_id")

--- a/tests/serving/test_remote.py
+++ b/tests/serving/test_remote.py
@@ -16,7 +16,7 @@ import re
 import time
 from http import HTTPStatus
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from urllib.parse import urlparse
 
 import pytest
@@ -528,3 +528,48 @@ def test_invoke_non_json_content_type_returns_bytes(
 
     result = nuclio_fn.invoke("/", method="GET")
     assert result == b"plain text"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("verify", "expected_ssl"), [(True, None), (False, False)])
+async def test_remote_step_async_request_follows_http_verify(
+    monkeypatch, verify, expected_ssl
+):
+    from mlrun.serving.remote import RemoteStep
+
+    step = RemoteStep(url="https://example.com", method="POST")
+    step._client_session = MagicMock()
+    step._client_session.request = AsyncMock(
+        return_value=MagicMock(status=HTTPStatus.OK)
+    )
+    step._get_event_or_body = MagicMock(return_value={})
+    step._generate_request = MagicMock(
+        return_value=("POST", "https://example.com", {}, b"", {})
+    )
+    monkeypatch.setattr(mlrun.mlconf.httpdb.http, "verify", verify)
+
+    await step._process_event(MagicMock())
+
+    assert step._client_session.request.call_args.kwargs["ssl"] is expected_ssl
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("verify", "expected_ssl"), [(True, None), (False, False)])
+async def test_batch_http_requests_follows_http_verify(
+    monkeypatch, verify, expected_ssl
+):
+    from mlrun.serving.remote import BatchHttpRequests
+
+    step = BatchHttpRequests(url="https://example.com", method="POST")
+    step._client_session = MagicMock()
+    response = MagicMock(status=HTTPStatus.OK, headers={})
+    response.read = AsyncMock(return_value=b"")
+    request_context = MagicMock()
+    request_context.__aenter__ = AsyncMock(return_value=response)
+    request_context.__aexit__ = AsyncMock(return_value=None)
+    step._client_session.request.return_value = request_context
+    monkeypatch.setattr(mlrun.mlconf.httpdb.http, "verify", verify)
+
+    await step._submit("POST", "https://example.com", {}, b"")
+
+    assert step._client_session.request.call_args.kwargs["ssl"] is expected_ssl

--- a/tests/utils/test_azure_vault.py
+++ b/tests/utils/test_azure_vault.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Iguazio
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from urllib.parse import urlparse
+
+import pytest
+
+import mlrun.errors
+from mlrun.config import config as mlconf
+from mlrun.utils.azure_vault import AzureVaultStore, build_azure_vault_url
+
+
+@pytest.mark.parametrize(
+    "vault_name",
+    [
+        "abc",
+        "saar-key-vault",
+        "ab1",
+        "a" * 24,
+        "MyVault-123",
+    ],
+)
+def test_build_azure_vault_url_accepts_valid_names(vault_name):
+    url = build_azure_vault_url(vault_name)
+    parsed = urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.hostname == f"{vault_name.lower()}.vault.azure.net"
+
+
+@pytest.mark.parametrize(
+    "vault_name",
+    [
+        "",
+        "ab",
+        "1abc",
+        "abc-",
+        "a" * 25,
+        "evil.com",
+        "evil.com/x",
+        "evil.com/x.vault.azure.net",
+        "vault.azure.net",
+        "name with space",
+        "name_underscore",
+        "name@user",
+        "name:8080",
+        "../escape",
+        "a/b",
+        "a\\b",
+    ],
+)
+def test_build_azure_vault_url_rejects_invalid_names(vault_name):
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        build_azure_vault_url(vault_name)
+
+
+def test_azure_vault_store_rejects_host_rewrite_before_sdk_initialization():
+    with pytest.raises(mlrun.errors.MLRunInvalidArgumentError):
+        AzureVaultStore("evil.com/x")
+
+
+def test_rejected_name_would_escape_azure_hostname():
+    # documents the SSRF shape CodeQL flagged: an unvalidated name can move the host
+    raw = "https://{name}.vault.azure.net".format(name="evil.com/x")
+    assert urlparse(raw).hostname == "evil.com"
+
+
+def test_build_azure_vault_url_supports_custom_cloud_template(monkeypatch):
+    monkeypatch.setattr(
+        mlconf.secret_stores.azure_vault,
+        "url",
+        "https://{name}.vault.usgovcloudapi.net",
+    )
+    url = build_azure_vault_url("gov-vault")
+    assert urlparse(url).hostname == "gov-vault.vault.usgovcloudapi.net"


### PR DESCRIPTION
### 📝 Description
Fixes two open critical CodeQL findings and corrects TLS verification behavior identified by a third finding. The changes prevent untrusted workflow data from being interpolated into the smoke-test shell script, constrain Azure Key Vault names before URL construction, and make async serving requests honor the existing TLS verification configuration.

---

### 🛠️ Changes Made
- Pass `workflow_run` branch and repository data through step environment variables in the smoke-test workflow, preventing shell template injection.
- Validate Azure Key Vault names against Azure naming rules and verify the constructed hostname before initializing the Azure client.
- Make async `RemoteStep` and `BatchHttpRequests` requests verify TLS by default and honor `httpdb.http.verify`, matching the synchronous path.
- Add regression coverage for malicious vault names, custom Azure cloud templates, and both async HTTP request paths.

---

### ✅ Checklist
- [ ] I updated the documentation (if applicable)
- [x] I have tested the changes in this PR
- [x] I confirmed whether my changes are covered by system tests
  - [ ] If yes, I ran all relevant system tests and ensured they passed before submitting this PR
  - [ ] I updated existing system tests and/or added new ones if needed to cover my changes
- [ ] If I introduced a deprecation:
  - [ ] I followed the [Deprecation Guidelines](./DEPRECATION.md)
  - [ ] I updated the relevant Jira ticket for documentation
- [ ] Please run [Smoke-tests](https://github.com/mlrun/mlrun/actions/workflows/smoke-tests.yml) workflow, providing it the PR number as input (upon success, the workflow run will add label "Smoke tests: Pass" to the PR)

---

### 🧪 Testing
- `pytest tests/serving/test_remote.py tests/utils/test_azure_vault.py`: 51 passed.
- Azure-vault-focused project and serving tests: 4 passed.
- Ruff lint and formatting checks passed for all affected Python files.
- Actionlint passed for the modified smoke-test workflow.
- `git diff --check` passed.

---

### 🔗 References
- Ticket link: GitHub CodeQL alerts [#147](https://github.com/mlrun/mlrun/security/code-scanning/147), [#161](https://github.com/mlrun/mlrun/security/code-scanning/161), and [#183](https://github.com/mlrun/mlrun/security/code-scanning/183)
- Design docs links:
- External links: [CodeQL partial SSRF guidance](https://codeql.github.com/codeql-query-help/python/py-partial-ssrf/)

---

### 🚨 Breaking Changes?
- [ ] Yes (explain below)
- [x] No

---

### 🔍️ Additional Notes
Alert #183 is dismissed because explicitly disabling TLS verification remains a supported cluster option. This PR fixes the insecure default behavior: async requests now verify certificates unless `httpdb.http.verify` is explicitly disabled. This change is awaiting confirmation from the serving owner.

The coverage-comment workflow fix was removed because it is already handled by [PR #10098](https://github.com/mlrun/mlrun/pull/10098). The remaining workflow change requires maintainer review. CodeQL will formally reevaluate the open alerts after scanning the PR branch.